### PR TITLE
ci: add branch protection, CI workflow, and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## what
+
+<!-- what does this PR do -->
+
+## why
+
+<!-- context/motivation, link to issue if applicable -->
+
+## how to test
+
+<!-- steps to verify -->
+
+## notes
+
+<!-- tradeoffs, anything reviewers should know -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun run build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$branch" = "main" ]; then
+  echo "direct commits to main are blocked."
+  echo "create a feature branch: git checkout -b <username>/<feature>"
+  exit 1
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+contributing
+===
+
+local setup
+---
+
+```bash
+git clone git@github.com:High-Performance-Structures/compass.git
+cd compass
+bun install
+bun dev
+```
+
+branching
+---
+
+branch off main using the format `<username>/<feature>`:
+
+```bash
+git checkout -b nicholai/add-gantt-zoom
+```
+
+direct commits to main are blocked by a pre-commit hook.
+
+commits
+---
+
+use conventional commits:
+
+```
+type(scope): subject
+```
+
+- types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
+- subject: imperative mood, 50 chars max
+- body: 72 chars max width, explain *why* not *what*
+
+pull requests
+---
+
+1. push your branch and open a PR against main
+2. CI runs lint + build automatically
+3. both checks must pass before merge
+4. PRs are squash-and-merged (single clean commit on main)
+
+the PR template will guide you on what to include.
+
+deployment
+---
+
+deployment to cloudflare workers happens manually via `bun deploy`.
+this is separate from the PR/merge workflow.

--- a/bun.lock
+++ b/bun.lock
@@ -71,6 +71,7 @@
         "drizzle-kit": "^0.31.8",
         "eslint": "^9",
         "eslint-config-next": "15.4.6",
+        "husky": "^9.1.7",
         "tailwindcss": "^4",
         "typescript": "^5",
         "wrangler": "^4.59.3",
@@ -1193,6 +1194,8 @@
     "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
 
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts",
 		"db:generate": "drizzle-kit generate",
 		"db:migrate:local": "wrangler d1 migrations apply compass-db --local",
-		"db:migrate:prod": "wrangler d1 migrations apply compass-db --remote"
+		"db:migrate:prod": "wrangler d1 migrations apply compass-db --remote",
+		"prepare": "husky"
 	},
 	"dependencies": {
 		"@dnd-kit/core": "^6.3.1",
@@ -82,6 +83,7 @@
 		"drizzle-kit": "^0.31.8",
 		"eslint": "^9",
 		"eslint-config-next": "15.4.6",
+		"husky": "^9.1.7",
 		"tailwindcss": "^4",
 		"typescript": "^5",
 		"wrangler": "^4.59.3"


### PR DESCRIPTION
## what

- husky pre-commit hook that blocks direct commits to main
- github actions CI with parallel lint + build jobs
- PR template for consistent descriptions
- CONTRIBUTING.md with branching/commit/PR conventions

## why

sets up a proper PR workflow so we stop committing directly to main. CI catches lint/build errors before merge.

## how to test

- confirm CI runs on this PR (lint + build should pass)
- after merge: try `git commit` on main locally, hook should block it

## notes

after this merges and CI passes, we need to run the branch protection commands:

```bash
gh repo edit High-Performance-Structures/compass \
  --enable-squash-merge \
  --disable-merge-commit \
  --disable-rebase-merge \
  --delete-branch-when-merged

gh api repos/High-Performance-Structures/compass/rulesets \
  --method POST \
  --input - <<'RULES'
{
  "name": "main-protection",
  "target": "branch",
  "enforcement": "active",
  "conditions": {
    "ref_name": {
      "include": ["refs/heads/main"],
      "exclude": []
    }
  },
  "rules": [
    {
      "type": "pull_request",
      "parameters": {
        "required_approving_review_count": 0,
        "dismiss_stale_reviews_on_push": true,
        "require_last_push_approval": false
      }
    },
    {
      "type": "required_status_checks",
      "parameters": {
        "strict_required_status_checks_policy": false,
        "required_status_checks": [
          { "context": "Lint" },
          { "context": "Build" }
        ]
      }
    }
  ]
}
RULES
```

these need to wait until after CI runs at least once so github recognizes the check names.