### PR TITLE
fix(mobile): fix sidebar close button and scrollbar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -196,3 +196,10 @@
     @apply bg-background text-foreground;
 	}
 }
+
+[data-mobile="true"] [data-sidebar="content"] {
+  scrollbar-width: none;
+}
+[data-mobile="true"] [data-sidebar="content"]::-webkit-scrollbar {
+  display: none;
+}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -187,7 +187,7 @@ function Sidebar({
           data-sidebar="sidebar"
           data-slot="sidebar"
           data-mobile="true"
-          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:text-sidebar-foreground [&>button]:opacity-80 [&>button]:hover:opacity-100"
           style={
             {
               "--sidebar-width": SIDEBAR_WIDTH_MOBILE,


### PR DESCRIPTION
## Summary

- Make the Sheet close button (X) visible on mobile, styled to match the sidebar's color scheme
- Hide the native scrollbar inside the mobile sidebar drawer via `scrollbar-width: none` + webkit fallback
- Both fixes scoped exclusively to mobile via the existing `data-mobile="true"` attribute — desktop sidebar unchanged

## Test plan

- [ ] Open app in mobile viewport (< 768px) or Chrome DevTools mobile emulation
- [ ] Tap sidebar trigger to open — confirm X button visible in top-right
- [ ] Tap X to close — confirm sidebar closes
- [ ] Tap dark overlay backdrop — confirm sidebar closes
- [ ] Scroll sidebar content — confirm no scrollbar visible, touch scroll still works
- [ ] Resize to desktop (>= 768px) — confirm sidebar looks/behaves exactly as before