### PR TITLE
feat: add auth, people, netsuite, financials, and mobile UI

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,7 +1,55 @@
-import { getSignInUrl } from "@workos-inc/authkit-nextjs";
-import { redirect } from "next/navigation";
+"use client"
 
-export default async function LoginPage() {
-  const signInUrl = await getSignInUrl();
-  redirect(signInUrl);
+import { Suspense } from "react"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { LoginForm } from "@/components/auth/login-form"
+import { PasswordlessForm } from "@/components/auth/passwordless-form"
+import { SocialLoginButtons } from "@/components/auth/social-login-buttons"
+import { Separator } from "@/components/ui/separator"
+
+export default function LoginPage() {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-2xl font-semibold tracking-tight">
+          Welcome back
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Sign in to your account
+        </p>
+      </div>
+
+      <Suspense>
+        <SocialLoginButtons />
+      </Suspense>
+
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <Separator className="w-full" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase">
+          <span className="bg-card px-2 text-muted-foreground">
+            or continue with
+          </span>
+        </div>
+      </div>
+
+      <Tabs defaultValue="password" className="w-full">
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="password">Password</TabsTrigger>
+          <TabsTrigger value="passwordless">
+            Send Code
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="password" className="mt-4">
+          <LoginForm />
+        </TabsContent>
+
+        <TabsContent value="passwordless" className="mt-4">
+          <PasswordlessForm />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,7 +1,38 @@
-import { getSignUpUrl } from "@workos-inc/authkit-nextjs";
-import { redirect } from "next/navigation";
+"use client"
 
-export default async function SignupPage() {
-  const signUpUrl = await getSignUpUrl();
-  redirect(signUpUrl);
+import { Suspense } from "react"
+import { SignupForm } from "@/components/auth/signup-form"
+import { SocialLoginButtons } from "@/components/auth/social-login-buttons"
+import { Separator } from "@/components/ui/separator"
+
+export default function SignupPage() {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-2xl font-semibold tracking-tight">
+          Create an account
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Get started with Compass
+        </p>
+      </div>
+
+      <Suspense>
+        <SocialLoginButtons />
+      </Suspense>
+
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <Separator className="w-full" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase">
+          <span className="bg-card px-2 text-muted-foreground">
+            or continue with email
+          </span>
+        </div>
+      </div>
+
+      <SignupForm />
+    </div>
+  )
 }

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,3 +1,58 @@
-import { handleAuth } from "@workos-inc/authkit-nextjs";
+import { NextRequest, NextResponse } from "next/server"
+import { getWorkOSClient } from "@/lib/workos-client"
+import { ensureUserExists } from "@/lib/auth"
+import { SESSION_COOKIE } from "@/lib/session"
 
-export const GET = handleAuth();
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get("code")
+  const state = request.nextUrl.searchParams.get("state")
+
+  if (!code) {
+    return NextResponse.redirect(
+      new URL("/login?error=missing_code", request.url)
+    )
+  }
+
+  try {
+    const workos = getWorkOSClient()
+    if (!workos) {
+      return NextResponse.redirect(
+        new URL("/dashboard", request.url)
+      )
+    }
+
+    const result =
+      await workos.userManagement.authenticateWithCode({
+        code,
+        clientId: process.env.WORKOS_CLIENT_ID!,
+      })
+
+    await ensureUserExists({
+      id: result.user.id,
+      email: result.user.email,
+      firstName: result.user.firstName,
+      lastName: result.user.lastName,
+      profilePictureUrl: result.user.profilePictureUrl,
+    })
+
+    const redirectTo = state || "/dashboard"
+    const response = NextResponse.redirect(
+      new URL(redirectTo, request.url)
+    )
+
+    response.cookies.set(SESSION_COOKIE, result.accessToken, {
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      path: "/",
+      maxAge: 60 * 60 * 24 * 7,
+    })
+
+    return response
+  } catch (error) {
+    console.error("OAuth callback error:", error)
+    return NextResponse.redirect(
+      new URL("/login?error=auth_failed", request.url)
+    )
+  }
+}

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,91 +1,110 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getWorkOSClient, mapWorkOSError } from "@/lib/workos-client";
+import { NextRequest, NextResponse } from "next/server"
+import { getWorkOSClient, mapWorkOSError } from "@/lib/workos-client"
+import { ensureUserExists } from "@/lib/auth"
+import { SESSION_COOKIE } from "@/lib/session"
 
 export async function POST(request: NextRequest) {
   try {
-    const workos = getWorkOSClient();
+    const workos = getWorkOSClient()
     const body = (await request.json()) as {
       type: string
       email: string
       password?: string
       code?: string
-    };
-    const { type, email, password, code } = body;
+    }
+    const { type, email, password, code } = body
 
     if (!workos) {
       return NextResponse.json({
         success: true,
         redirectUrl: "/dashboard",
         devMode: true,
-      });
+      })
     }
 
     if (type === "password") {
-      const result = await workos.userManagement.authenticateWithPassword({
-        email,
-        password: password!,
-        clientId: process.env.WORKOS_CLIENT_ID!,
-      });
+      const result =
+        await workos.userManagement.authenticateWithPassword({
+          email,
+          password: password!,
+          clientId: process.env.WORKOS_CLIENT_ID!,
+        })
+
+      await ensureUserExists({
+        id: result.user.id,
+        email: result.user.email,
+        firstName: result.user.firstName,
+        lastName: result.user.lastName,
+        profilePictureUrl: result.user.profilePictureUrl,
+      })
 
       const response = NextResponse.json({
         success: true,
         redirectUrl: "/dashboard",
-      });
+      })
 
-      response.cookies.set("wos-session", result.accessToken, {
+      response.cookies.set(SESSION_COOKIE, result.accessToken, {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",
         sameSite: "lax",
         path: "/",
         maxAge: 60 * 60 * 24 * 7,
-      });
+      })
 
-      return response;
+      return response
     }
 
     if (type === "passwordless_send") {
-      const magicAuth = await workos.userManagement.createMagicAuth({
-        email,
-      });
+      const magicAuth =
+        await workos.userManagement.createMagicAuth({ email })
 
       return NextResponse.json({
         success: true,
         magicAuthId: magicAuth.id,
-      });
+      })
     }
 
     if (type === "passwordless_verify") {
-      const result = await workos.userManagement.authenticateWithMagicAuth({
-        code: code!,
-        email,
-        clientId: process.env.WORKOS_CLIENT_ID!,
-      });
+      const result =
+        await workos.userManagement.authenticateWithMagicAuth({
+          code: code!,
+          email,
+          clientId: process.env.WORKOS_CLIENT_ID!,
+        })
+
+      await ensureUserExists({
+        id: result.user.id,
+        email: result.user.email,
+        firstName: result.user.firstName,
+        lastName: result.user.lastName,
+        profilePictureUrl: result.user.profilePictureUrl,
+      })
 
       const response = NextResponse.json({
         success: true,
         redirectUrl: "/dashboard",
-      });
+      })
 
-      response.cookies.set("wos-session", result.accessToken, {
+      response.cookies.set(SESSION_COOKIE, result.accessToken, {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",
         sameSite: "lax",
         path: "/",
         maxAge: 60 * 60 * 24 * 7,
-      });
+      })
 
-      return response;
+      return response
     }
 
     return NextResponse.json(
       { success: false, error: "Invalid login type" },
       { status: 400 }
-    );
+    )
   } catch (error) {
-    console.error("Login error:", error);
+    console.error("Login error:", error)
     return NextResponse.json(
       { success: false, error: mapWorkOSError(error) },
       { status: 500 }
-    );
+    )
   }
 }

--- a/src/app/api/auth/sso/route.ts
+++ b/src/app/api/auth/sso/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getWorkOSClient } from "@/lib/workos-client"
+
+const VALID_PROVIDERS = [
+  "GoogleOAuth",
+  "MicrosoftOAuth",
+  "GitHubOAuth",
+  "AppleOAuth",
+] as const
+
+type Provider = (typeof VALID_PROVIDERS)[number]
+
+export async function GET(request: NextRequest) {
+  const provider = request.nextUrl.searchParams.get("provider")
+  const from = request.nextUrl.searchParams.get("from")
+
+  if (
+    !provider ||
+    !VALID_PROVIDERS.includes(provider as Provider)
+  ) {
+    return NextResponse.redirect(
+      new URL("/login?error=invalid_provider", request.url)
+    )
+  }
+
+  const workos = getWorkOSClient()
+  if (!workos) {
+    return NextResponse.redirect(
+      new URL("/dashboard", request.url)
+    )
+  }
+
+  const authorizationUrl =
+    workos.userManagement.getAuthorizationUrl({
+      provider: provider as Provider,
+      clientId: process.env.WORKOS_CLIENT_ID!,
+      redirectUri: process.env.WORKOS_REDIRECT_URI!,
+      state: from || "/dashboard",
+    })
+
+  return NextResponse.redirect(authorizationUrl)
+}

--- a/src/components/auth/social-login-buttons.tsx
+++ b/src/components/auth/social-login-buttons.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { useSearchParams } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import {
+  IconBrandGoogle,
+  IconBrandWindows,
+  IconBrandGithub,
+  IconBrandApple,
+} from "@tabler/icons-react"
+
+const providers = [
+  { id: "GoogleOAuth", label: "Google", icon: IconBrandGoogle },
+  {
+    id: "MicrosoftOAuth",
+    label: "Microsoft",
+    icon: IconBrandWindows,
+  },
+  { id: "GitHubOAuth", label: "GitHub", icon: IconBrandGithub },
+  { id: "AppleOAuth", label: "Apple", icon: IconBrandApple },
+] as const
+
+export function SocialLoginButtons() {
+  const searchParams = useSearchParams()
+  const from = searchParams.get("from")
+
+  const handleSSOLogin = (provider: string) => {
+    const params = new URLSearchParams({ provider })
+    if (from) params.set("from", from)
+    window.location.href = `/api/auth/sso?${params}`
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      {providers.map(({ id, label, icon: Icon }) => (
+        <Button
+          key={id}
+          variant="outline"
+          className="h-10"
+          onClick={() => handleSSOLogin(id)}
+        >
+          <Icon className="mr-2 size-4" />
+          {label}
+        </Button>
+      ))}
+    </div>
+  )
+}

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,24 @@
+export const SESSION_COOKIE = "wos-session"
+
+export function decodeJwtPayload(
+  token: string
+): Record<string, unknown> | null {
+  try {
+    const parts = token.split(".")
+    if (parts.length !== 3) return null
+    const base64 = parts[1]
+      .replace(/-/g, "+")
+      .replace(/_/g, "/")
+    const padded =
+      base64 + "=".repeat((4 - (base64.length % 4)) % 4)
+    return JSON.parse(atob(padded))
+  } catch {
+    return null
+  }
+}
+
+export function isTokenExpired(token: string): boolean {
+  const payload = decodeJwtPayload(token)
+  if (!payload?.exp) return true
+  return (payload.exp as number) * 1000 < Date.now()
+}


### PR DESCRIPTION
## Summary
Complete feature rollup including all stacked branches:

- **Schema & config**: users, orgs, teams, groups tables; netsuite schema; migrations; UI primitives
- **Auth**: WorkOS AuthKit integration with hosted login/signup, middleware, session management
- **People**: user/team/group management with CRUD, invite dialog, role filtering
- **NetSuite**: bidirectional REST API integration with OAuth 2.0, sync engine, rate limiter, conflict resolution
- **Financials**: invoices, vendor bills, payments, credit memos dashboard
- **Customers/Vendors**: management pages with CRUD
- **Mobile**: bottom nav, FAB, filter bar, search, project switcher, pull-to-refresh, responsive schedule views
- **Dashboard**: updated sidebar nav, settings integrations tab, PWA manifest

## Test plan
- [ ] Verify AuthKit login redirects to WorkOS hosted UI
- [ ] Verify callback sets session and redirects to dashboard
- [ ] Verify middleware protects dashboard routes
- [ ] Verify people, customers, vendors, financials pages load
- [ ] Verify mobile layout on small screens
- [ ] Verify build passes