### PR TITLE
feat(agent): localize date/time in system prompt

### DIFF
--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -37,6 +37,8 @@ export async function POST(req: Request): Promise<Response> {
 
   const currentPage =
     req.headers.get("x-current-page") ?? undefined
+  const timezone =
+    req.headers.get("x-timezone") ?? undefined
 
   const model = await getAgentModel()
 
@@ -46,6 +48,7 @@ export async function POST(req: Request): Promise<Response> {
       userName: user.displayName ?? user.email,
       userRole: user.role,
       currentPage,
+      timezone,
       memories,
       pluginSections,
       mode: "full",

--- a/src/hooks/use-compass-chat.ts
+++ b/src/hooks/use-compass-chat.ts
@@ -33,7 +33,11 @@ export function useCompassChat(options?: UseCompassChatOptions) {
   const chatState = useChat({
     transport: new DefaultChatTransport({
       api: "/api/agent",
-      headers: { "x-current-page": pathname },
+      headers: {
+        "x-current-page": pathname,
+        "x-timezone":
+          Intl.DateTimeFormat().resolvedOptions().timeZone,
+      },
     }),
     onFinish: options?.onFinish,
     onError: (err) => {

--- a/src/lib/agent/system-prompt.ts
+++ b/src/lib/agent/system-prompt.ts
@@ -26,6 +26,7 @@ interface PromptContext {
   readonly userRole: string
   readonly currentPage?: string
   readonly memories?: string
+  readonly timezone?: string
   readonly pluginSections?: ReadonlyArray<PromptSection>
   readonly mode?: PromptMode
 }
@@ -216,11 +217,27 @@ function buildUserContext(
   state: DerivedState,
 ): ReadonlyArray<string> {
   if (state.mode === "none") return []
+  const tz = ctx.timezone ?? "UTC"
+  const now = new Date()
+  const date = now.toLocaleDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: tz,
+  })
+  const time = now.toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: tz,
+  })
   return [
     "## User Context",
     `- Name: ${ctx.userName}`,
     `- Role: ${ctx.userRole}`,
     `- Current page: ${state.page}`,
+    `- Current date: ${date}`,
+    `- Current time: ${time} (${tz})`,
   ]
 }
 


### PR DESCRIPTION
## Summary

- Sends the user's IANA timezone via `x-timezone` header from the chat transport (uses `Intl.DateTimeFormat().resolvedOptions().timeZone`)
- System prompt now includes localized current date and time in the user context section
- Falls back to UTC if the header is missing

The agent sees something like:
```
- Current date: Thursday, February 6, 2026
- Current time: 11:15 PM (America/New_York)
```

## Test plan

- [ ] `bun run build` passes
- [ ] Open chat, send a message — confirm agent knows the current date/time in your local timezone
- [ ] Check network tab: `x-timezone` header is present on `/api/agent` requests