### PR TITLE
fix(agent): improve chat message rendering

### DIFF
--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -103,6 +103,7 @@ export async function POST(req: Request): Promise<Response> {
       ...githubTools,
       ...pluginTools,
     },
+    toolChoice: "auto",
     stopWhen: stepCountIs(10),
     onError({ error }) {
       const apiErr = unwrapAPICallError(error)

--- a/src/lib/agent/system-prompt.ts
+++ b/src/lib/agent/system-prompt.ts
@@ -5,22 +5,6 @@ import type { PromptSection } from "@/lib/agent/plugins/types"
 
 type PromptMode = "full" | "minimal" | "none"
 
-type ToolCategory =
-  | "data"
-  | "navigation"
-  | "ui"
-  | "memory"
-  | "github"
-  | "skills"
-  | "feedback"
-
-interface ToolMeta {
-  readonly name: string
-  readonly summary: string
-  readonly category: ToolCategory
-  readonly adminOnly?: true
-}
-
 interface DashboardSummary {
   readonly id: string
   readonly name: string
@@ -36,6 +20,22 @@ interface PromptContext {
   readonly pluginSections?: ReadonlyArray<PromptSection>
   readonly dashboards?: ReadonlyArray<DashboardSummary>
   readonly mode?: PromptMode
+}
+
+type ToolCategory =
+  | "data"
+  | "navigation"
+  | "ui"
+  | "memory"
+  | "github"
+  | "skills"
+  | "feedback"
+
+interface ToolMeta {
+  readonly name: string
+  readonly summary: string
+  readonly category: ToolCategory
+  readonly adminOnly?: true
 }
 
 interface DerivedState {
@@ -665,6 +665,10 @@ function buildGuidelines(
 
   return [
     ...core,
+    "- Tool workflow: data requests -> queryData immediately. " +
+      "Navigation -> navigateTo, brief confirmation. " +
+      "Dashboards -> queryData first, then generateUI. " +
+      "Memories -> save proactively with rememberContext.",
     '- "How\'s development going?" means fetch repo_stats and ' +
       'recent commits right now, not "Would you like to see ' +
       'commits or PRs?"',


### PR DESCRIPTION
## Summary

- Refactored ChatMessage to use AI SDK type guards (`isTextUIPart`, `isToolUIPart`, `isReasoningUIPart`) and render parts in natural order with proper interleaving
- Reasoning/thinking content now collapsed by default (`defaultOpen={false}`) so chain-of-thought doesn't flood the screen during streaming
- Capped reasoning content height during streaming with overflow hidden
- Reduced auto-close grace period from 1000ms to 300ms
- Added tool workflow guidance to system prompt for more direct agent behavior
- Memoized ChatMessage with custom comparator to reduce unnecessary re-renders

## Test plan

- [ ] Send a message to a reasoning model (qwen3) — should see "Thinking..." collapsed, clean response below
- [ ] Click the reasoning trigger to expand — should show full thinking content
- [ ] Verify non-reasoning models show no change
- [ ] Test panel variant and page variant both render correctly
- [ ] Verify tool calls still display properly with interleaved text

🤖 Generated with [Claude Code](https://claude.com/claude-code)