### PR TITLE
fix(ci): grant write permissions to Claude GitHub Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,11 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      contents: write      # Create branches and push commits
+      pull-requests: write # Create PRs and comments
+      issues: write        # Update issue comments
+      id-token: write      # OIDC authentication
+      actions: read        # Read CI results
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -36,8 +36,11 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
+          # Permissions passed to Claude for repository operations
           additional_permissions: |
+            contents: write
+            pull-requests: write
+            issues: write
             actions: read
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.


### PR DESCRIPTION
## Summary

Updates the Claude Code GitHub Action workflow permissions to allow Claude to create branches, push commits, and create PRs when tagged in issues or comments.

Previously, the workflow only had read permissions, preventing Claude from committing any changes it implemented.

## Changes

- `contents: read` → `contents: write` — create branches and push commits
- `pull-requests: read` → `pull-requests: write` — create PRs and comments  
- `issues: read` → `issues: write` — update issue comments
- Updated `additional_permissions` to match

## Test plan

- [ ] Merge this PR
- [ ] Create a test issue with `@claude` in the body
- [ ] Ask Claude to implement a simple fix
- [ ] Verify Claude can create a branch, push commits, and provide a PR link

## Sources

- [Claude Code GitHub Actions docs](https://code.claude.com/docs/en/github-actions)
- [claude-code-action FAQ](https://github.com/anthropics/claude-code-action/blob/main/docs/faq.md)