### PR TITLE
fix(ui): dashboard context menu works everywhere

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -51,6 +51,8 @@ export default async function DashboardLayout({
     <CommandMenuProvider>
       <BiometricGuard>
       <DesktopShell>
+      <FeedbackWidget>
+      <DashboardContextMenu>
       <SidebarProvider
         defaultOpen={false}
         className="h-screen overflow-hidden"
@@ -61,21 +63,17 @@ export default async function DashboardLayout({
         }
       >
         <AppSidebar variant="inset" projects={projectList} dashboards={dashboardList} user={user} />
-        <FeedbackWidget>
-          <SidebarInset className="overflow-hidden">
-            <DesktopOfflineBanner />
-            <OfflineBanner />
-            <SiteHeader user={user} />
-            <div className="flex min-h-0 flex-1 overflow-hidden">
-              <DashboardContextMenu>
-                <MainContent>
-                  {children}
-                </MainContent>
-              </DashboardContextMenu>
-              <ChatPanelShell />
-            </div>
-          </SidebarInset>
-        </FeedbackWidget>
+        <SidebarInset className="overflow-hidden">
+          <DesktopOfflineBanner />
+          <OfflineBanner />
+          <SiteHeader user={user} />
+          <div className="flex min-h-0 flex-1 overflow-hidden">
+            <MainContent>
+              {children}
+            </MainContent>
+            <ChatPanelShell />
+          </div>
+        </SidebarInset>
         <MobileBottomNav />
         <NativeShell />
         <PushNotificationRegistrar />
@@ -84,6 +82,8 @@ export default async function DashboardLayout({
         </p>
         <Toaster position="bottom-right" />
       </SidebarProvider>
+      </DashboardContextMenu>
+      </FeedbackWidget>
       </DesktopShell>
       </BiometricGuard>
     </CommandMenuProvider>

--- a/src/components/agent/main-content.tsx
+++ b/src/components/agent/main-content.tsx
@@ -6,9 +6,9 @@ import { useRenderState } from "./chat-provider"
 
 export function MainContent({
   children,
-}: {
-  readonly children: React.ReactNode
-}) {
+  className: classNameProp,
+  ...rest
+}: React.ComponentPropsWithRef<"div">) {
   const pathname = usePathname()
   const { spec, isRendering } = useRenderState()
   const hasRenderedUI = !!spec?.root || isRendering
@@ -18,6 +18,7 @@ export function MainContent({
 
   return (
     <div
+      {...rest}
       className={cn(
         "flex flex-col overflow-x-hidden min-w-0",
         "transition-[flex,opacity] duration-300 ease-in-out",
@@ -25,7 +26,8 @@ export function MainContent({
           ? "flex-[0_0_0%] opacity-0 overflow-hidden pointer-events-none"
           : isConversations
             ? "flex-1 overflow-hidden"
-            : "flex-1 overflow-y-auto pb-14 md:pb-0"
+            : "flex-1 overflow-y-auto pb-14 md:pb-0",
+        classNameProp
       )}
     >
       <div className={cn(

--- a/src/components/nav-files.tsx
+++ b/src/components/nav-files.tsx
@@ -11,7 +11,7 @@ import {
 import Link from "next/link"
 import { usePathname, useSearchParams } from "next/navigation"
 
-import { useFiles } from "@/hooks/use-files"
+import { useFilesOptional } from "@/hooks/use-files"
 import { StorageIndicator } from "@/components/files/storage-indicator"
 import {
   SidebarGroup,
@@ -49,7 +49,8 @@ export function NavFiles() {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const activeView = searchParams.get("view") ?? "my-files"
-  const { storageUsage } = useFiles()
+  const files = useFilesOptional()
+  const storageUsage = files?.storageUsage
 
   return (
     <>
@@ -102,9 +103,11 @@ export function NavFiles() {
           </SidebarMenu>
         </SidebarGroupContent>
       </SidebarGroup>
-      <div className="mt-auto px-3 pb-3">
-        <StorageIndicator usage={storageUsage} />
-      </div>
+      {storageUsage && (
+        <div className="mt-auto px-3 pb-3">
+          <StorageIndicator usage={storageUsage} />
+        </div>
+      )}
     </>
   )
 }

--- a/src/hooks/use-files.tsx
+++ b/src/hooks/use-files.tsx
@@ -733,6 +733,10 @@ export function useFiles() {
   return ctx
 }
 
+export function useFilesOptional() {
+  return useContext(FilesContext)
+}
+
 function sortFiles(
   files: FileItem[],
   sortBy: SortField,


### PR DESCRIPTION
## Summary

- Right-click context menu now triggers across the entire dashboard viewport (sidebar, header, main content) instead of only within MainContent
- Fixed pre-existing crash where `NavFiles` called `useFiles()` outside `FilesProvider` when sidebar was expanded on the files route

## Changes

- **layout.tsx**: Hoisted `FeedbackWidget` and `DashboardContextMenu` to wrap `SidebarProvider`, covering sidebar + header + content
- **main-content.tsx**: Forward refs and spread props via `React.ComponentPropsWithRef<"div">` for Radix `asChild` compatibility
- **use-files.tsx**: Added `useFilesOptional()` hook that returns `null` instead of throwing outside provider
- **nav-files.tsx**: Uses `useFilesOptional()` and conditionally renders `StorageIndicator`

## Test plan

- [ ] Right-click anywhere in dashboard viewport shows custom context menu
- [ ] Right-click in sidebar shows context menu
- [ ] Right-click on header shows context menu
- [ ] Context menu items work (copy URL, toggle theme, navigate)
- [ ] File browser items retain their own context menu
- [ ] Expanding sidebar on `/dashboard/files` does not crash
- [ ] Storage indicator still shows in files sidebar nav