### PR TITLE
fix(photos): normalize project image sources

### DIFF
--- a/src/app/actions/dashboard-overview.ts
+++ b/src/app/actions/dashboard-overview.ts
@@ -16,6 +16,7 @@ import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { requireOrg } from "@/lib/org-scope"
 import { canManageProjectRegistry } from "@/lib/permissions"
+import { resolvePhotoImageSource } from "@/lib/photo-sources"
 import {
   allowedWorkflowRoleIds,
   defaultWorkflowRoleId,
@@ -285,6 +286,7 @@ export async function getDashboardOverview(): Promise<DashboardOverview> {
         .select({
           id: dailyLogPhotos.id,
           fileName: dailyLogPhotos.fileName,
+          driveFileId: dailyLogPhotos.driveFileId,
           driveUrl: dailyLogPhotos.driveUrl,
           thumbnailUrl: dailyLogPhotos.thumbnailUrl,
           caption: dailyLogPhotos.caption,
@@ -308,9 +310,7 @@ export async function getDashboardOverview(): Promise<DashboardOverview> {
       photosToReview += projectPhotosToReview
 
       const progressPhotoRows = photoRows.filter((photo) => {
-        const hasImage =
-          photo.thumbnailUrl !== null ||
-          (photo.driveUrl !== null && photo.mimeType?.startsWith("image/") === true)
+        const hasImage = resolvePhotoImageSource(photo).src !== null
         return (
           hasImage &&
           photo.reviewStatus === "approved" &&
@@ -319,7 +319,7 @@ export async function getDashboardOverview(): Promise<DashboardOverview> {
       })
 
       for (const photo of progressPhotoRows.slice(0, 5)) {
-        const imageUrl = photo.thumbnailUrl ?? photo.driveUrl
+        const imageUrl = resolvePhotoImageSource(photo).src
         if (imageUrl === null) continue
 
         fieldPhotos.push({

--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -24,6 +24,7 @@ export type ProjectAudience = "owner" | "sub_vendor"
 export type AudiencePhoto = {
   readonly id: string
   readonly fileName: string
+  readonly driveFileId: string | null
   readonly thumbnailUrl: string | null
   readonly caption: string | null
   readonly capturedAt: string | null
@@ -385,6 +386,7 @@ export async function getProjectAudiencePreview(
     .select({
       id: dailyLogPhotos.id,
       fileName: dailyLogPhotos.fileName,
+      driveFileId: dailyLogPhotos.driveFileId,
       thumbnailUrl: dailyLogPhotos.thumbnailUrl,
       mimeType: dailyLogPhotos.mimeType,
       caption: dailyLogPhotos.caption,
@@ -608,6 +610,7 @@ export async function getProjectAudiencePreview(
       return {
         id: photo.id,
         fileName: photo.fileName,
+        driveFileId: photo.driveFileId,
         thumbnailUrl: photo.thumbnailUrl,
         caption: photo.caption,
         capturedAt: photo.capturedAt,

--- a/src/app/actions/project-field.ts
+++ b/src/app/actions/project-field.ts
@@ -34,6 +34,7 @@ type LatestPhoto = {
   readonly id: string
   readonly sourceSystem: string
   readonly fileName: string
+  readonly driveFileId: string | null
   readonly driveUrl: string | null
   readonly thumbnailUrl: string | null
   readonly caption: string | null
@@ -75,6 +76,7 @@ type OwnerUpdateDailyLog = {
 type OwnerUpdatePhoto = {
   readonly id: string
   readonly fileName: string
+  readonly driveFileId: string | null
   readonly driveUrl: string | null
   readonly thumbnailUrl: string | null
   readonly caption: string | null
@@ -102,6 +104,7 @@ export type ProjectDailyLogPhoto = {
   readonly id: string
   readonly fileName: string
   readonly mimeType: string | null
+  readonly driveFileId: string | null
   readonly driveUrl: string | null
   readonly thumbnailUrl: string | null
   readonly caption: string | null
@@ -843,6 +846,7 @@ export async function getProjectFieldSummary(
       sourceSystem: dailyLogPhotos.sourceSystem,
       fileName: dailyLogPhotos.fileName,
       mimeType: dailyLogPhotos.mimeType,
+      driveFileId: dailyLogPhotos.driveFileId,
       driveUrl: dailyLogPhotos.driveUrl,
       thumbnailUrl: dailyLogPhotos.thumbnailUrl,
       caption: dailyLogPhotos.caption,
@@ -955,6 +959,7 @@ export async function getProjectFieldSummary(
       id: photo.id,
       sourceSystem: photo.sourceSystem,
       fileName: photo.fileName,
+      driveFileId: photo.driveFileId,
       driveUrl: photo.driveUrl,
       thumbnailUrl: photo.thumbnailUrl,
       caption: photo.caption,
@@ -1044,6 +1049,7 @@ export async function getProjectDailyLogWorkspace(
       dailyLogId: dailyLogPhotos.dailyLogId,
       fileName: dailyLogPhotos.fileName,
       mimeType: dailyLogPhotos.mimeType,
+      driveFileId: dailyLogPhotos.driveFileId,
       driveUrl: dailyLogPhotos.driveUrl,
       thumbnailUrl: dailyLogPhotos.thumbnailUrl,
       caption: dailyLogPhotos.caption,
@@ -1088,6 +1094,7 @@ export async function getProjectDailyLogWorkspace(
       id: row.id,
       fileName: row.fileName,
       mimeType: row.mimeType,
+      driveFileId: row.driveFileId,
       driveUrl: row.driveUrl,
       thumbnailUrl: row.thumbnailUrl,
       caption: row.caption,
@@ -1573,6 +1580,7 @@ export async function getOwnerProjectUpdateDocument(
     .select({
       id: dailyLogPhotos.id,
       fileName: dailyLogPhotos.fileName,
+      driveFileId: dailyLogPhotos.driveFileId,
       driveUrl: dailyLogPhotos.driveUrl,
       thumbnailUrl: dailyLogPhotos.thumbnailUrl,
       mimeType: dailyLogPhotos.mimeType,
@@ -1654,6 +1662,7 @@ export async function getOwnerProjectUpdateDocument(
       id: row.id,
       fileName: row.fileName,
       driveUrl: row.driveUrl,
+      driveFileId: row.driveFileId,
       thumbnailUrl: row.thumbnailUrl,
       caption: row.caption,
       capturedAt: row.capturedAt,
@@ -1670,6 +1679,7 @@ export async function getOwnerProjectUpdateDocument(
       id: row.id,
       fileName: row.fileName,
       driveUrl: row.driveUrl,
+      driveFileId: row.driveFileId,
       thumbnailUrl: row.thumbnailUrl,
       caption: row.caption,
       capturedAt: row.capturedAt,

--- a/src/app/actions/project-photos.ts
+++ b/src/app/actions/project-photos.ts
@@ -18,6 +18,7 @@ export type ProjectPhotoLibraryItem = {
   readonly sourceSystem: string
   readonly fileName: string
   readonly mimeType: string | null
+  readonly driveFileId: string | null
   readonly driveUrl: string | null
   readonly thumbnailUrl: string | null
   readonly caption: string | null
@@ -325,6 +326,7 @@ export async function getProjectPhotoLibrary(
       sourceSystem: dailyLogPhotos.sourceSystem,
       fileName: dailyLogPhotos.fileName,
       mimeType: dailyLogPhotos.mimeType,
+      driveFileId: dailyLogPhotos.driveFileId,
       driveUrl: dailyLogPhotos.driveUrl,
       thumbnailUrl: dailyLogPhotos.thumbnailUrl,
       caption: dailyLogPhotos.caption,
@@ -393,6 +395,7 @@ export async function getProjectPhotoLibrary(
       sourceSystem: row.sourceSystem,
       fileName: row.fileName,
       mimeType: row.mimeType,
+      driveFileId: row.driveFileId,
       driveUrl: row.driveUrl,
       thumbnailUrl: row.thumbnailUrl,
       caption: row.caption,

--- a/src/components/projects/owner-cover-photo-control.tsx
+++ b/src/components/projects/owner-cover-photo-control.tsx
@@ -22,10 +22,12 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
+import { resolvePhotoImageSource } from "@/lib/photo-sources"
 
 type OwnerCoverPhotoOption = {
   readonly id: string
   readonly fileName: string
+  readonly driveFileId: string | null
   readonly thumbnailUrl: string | null
   readonly caption: string | null
 }
@@ -184,11 +186,17 @@ function approvedCoverPhotoUrl(
     const selectedPhoto = approvedPhotos.find(
       (photo) => photo.id === selection.photoId
     )
+    if (selectedPhoto) {
+      return resolvePhotoImageSource(selectedPhoto).src ?? selection.url
+    }
 
-    return selectedPhoto?.thumbnailUrl ?? selection.url
+    return selection.url
   }
 
-  return approvedPhotos[0]?.thumbnailUrl ?? null
+  const firstPhoto = approvedPhotos.find(
+    (photo) => resolvePhotoImageSource(photo).src !== null
+  )
+  return firstPhoto ? resolvePhotoImageSource(firstPhoto).src : null
 }
 
 export function OwnerCoverPhotoControl({
@@ -213,12 +221,13 @@ export function OwnerCoverPhotoControl({
   const coverUrl = approvedCoverPhotoUrl(selection, approvedPhotos)
 
   function handleSelectApproved(photo: OwnerCoverPhotoOption): void {
-    if (!photo.thumbnailUrl) return
+    const photoUrl = resolvePhotoImageSource(photo).src
+    if (photoUrl === null) return
 
     const nextSelection: OwnerCoverPhotoSelection = {
       kind: "approved",
       photoId: photo.id,
-      url: photo.thumbnailUrl,
+      url: photoUrl,
     }
     setSelection(nextSelection)
     saveCoverSelection(projectId, nextSelection)
@@ -337,7 +346,7 @@ export function OwnerCoverPhotoControl({
                       <Badge variant="outline">
                         {
                           approvedPhotos.filter(
-                            (photo) => photo.thumbnailUrl !== null
+                            (photo) => resolvePhotoImageSource(photo).src !== null
                           ).length
                         }{" "}
                         available
@@ -345,36 +354,38 @@ export function OwnerCoverPhotoControl({
                     </div>
                     <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-3">
                       {approvedPhotos
-                        .filter((photo) => photo.thumbnailUrl !== null)
-                        .map((photo) => (
+                        .map((photo) => {
+                          const photoUrl = resolvePhotoImageSource(photo).src
+                          if (photoUrl === null) return null
+
+                          return (
                           <button
                             key={photo.id}
                             type="button"
                             className="group overflow-hidden rounded-md border bg-background text-left transition hover:-translate-y-0.5 hover:border-primary hover:shadow-md"
                             onClick={() => handleSelectApproved(photo)}
                           >
-                            {photo.thumbnailUrl && (
-                              <div className="relative aspect-[4/3]">
-                                <Image
-                                  src={photo.thumbnailUrl}
-                                  alt={photo.caption ?? photo.fileName}
-                                  fill
-                                  sizes="240px"
-                                  unoptimized
-                                  className="object-cover"
-                                />
-                              </div>
-                            )}
+                            <div className="relative aspect-[4/3]">
+                              <Image
+                                src={photoUrl}
+                                alt={photo.caption ?? photo.fileName}
+                                fill
+                                sizes="240px"
+                                unoptimized
+                                className="object-cover"
+                              />
+                            </div>
                             <div className="p-2">
                               <p className="line-clamp-2 text-xs font-medium">
                                 {photo.caption ?? photo.fileName}
                               </p>
                             </div>
                           </button>
-                        ))}
+                          )
+                        })}
                     </div>
                     {approvedPhotos.every(
-                      (photo) => photo.thumbnailUrl === null
+                      (photo) => resolvePhotoImageSource(photo).src === null
                     ) && (
                       <p className="mt-3 rounded-md border p-3 text-sm text-muted-foreground">
                         No approved project photos ready yet.

--- a/src/components/projects/owner-update-document.tsx
+++ b/src/components/projects/owner-update-document.tsx
@@ -259,6 +259,7 @@ export function OwnerUpdateDocument({
                   <OwnerUpdatePhotoTile
                     key={photo.id}
                     fileName={photo.fileName}
+                    driveFileId={photo.driveFileId}
                     driveUrl={photo.driveUrl}
                     thumbnailUrl={photo.thumbnailUrl}
                     caption={photo.caption}

--- a/src/components/projects/owner-update-draft-editor.tsx
+++ b/src/components/projects/owner-update-draft-editor.tsx
@@ -13,18 +13,13 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import { resolvePhotoImageSource } from "@/lib/photo-sources"
 
 type DraftStatus =
   | { readonly kind: "idle" }
   | { readonly kind: "saving" }
   | { readonly kind: "saved"; readonly message: string }
   | { readonly kind: "error"; readonly message: string }
-
-function photoSrc(
-  photo: OwnerProjectUpdateDocument["availablePhotos"][number]
-): string | null {
-  return photo.thumbnailUrl ?? photo.driveUrl
-}
 
 export function OwnerUpdateDraftEditor({
   document,
@@ -39,7 +34,11 @@ export function OwnerUpdateDraftEditor({
     document.update.selectedPhotoIds
   )
   const [status, setStatus] = React.useState<DraftStatus>({ kind: "idle" })
+  const [failedImageIds, setFailedImageIds] = React.useState<readonly string[]>(
+    []
+  )
   const selectedPhotoIdSet = new Set(selectedPhotoIds)
+  const failedImageSet = new Set(failedImageIds)
 
   function togglePhoto(photoId: string, checked: boolean): void {
     setSelectedPhotoIds((current) => {
@@ -54,6 +53,13 @@ export function OwnerUpdateDraftEditor({
 
   function clearPhotos(): void {
     setSelectedPhotoIds([])
+  }
+
+  function markImageFailed(photoId: string): void {
+    setFailedImageIds((current) => {
+      if (current.includes(photoId)) return current
+      return [...current, photoId]
+    })
   }
 
   async function saveDraft(
@@ -175,7 +181,10 @@ export function OwnerUpdateDraftEditor({
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
               {document.availablePhotos.map((photo) => {
                 const checked = selectedPhotoIdSet.has(photo.id)
-                const src = photoSrc(photo)
+                const resolvedImage = resolvePhotoImageSource(photo)
+                const src = failedImageSet.has(photo.id)
+                  ? null
+                  : resolvedImage.src
 
                 return (
                   <label
@@ -196,10 +205,12 @@ export function OwnerUpdateDraftEditor({
                         src={src}
                         alt={photo.caption ?? photo.fileName}
                         className="aspect-[4/3] w-full object-cover"
+                        onError={() => markImageFailed(photo.id)}
                       />
                     ) : (
-                      <div className="flex aspect-[4/3] w-full items-center justify-center text-xs text-muted-foreground">
-                        No preview
+                      <div className="flex aspect-[4/3] w-full flex-col items-center justify-center gap-2 p-3 text-center text-xs text-muted-foreground">
+                        <IconPhoto className="size-6" />
+                        {resolvedImage.label}
                       </div>
                     )}
                     <div className="border-t bg-background px-2 py-1.5">

--- a/src/components/projects/owner-update-photo-tile.tsx
+++ b/src/components/projects/owner-update-photo-tile.tsx
@@ -4,18 +4,10 @@ import { useState } from "react"
 import Image from "next/image"
 import { IconExternalLink, IconPhoto } from "@tabler/icons-react"
 
-function browserHref(
-  value: string | null,
-  allowExternalSource: boolean
-): string | null {
-  if (value === null) return null
-  if (value.startsWith("https://") || value.startsWith("http://")) {
-    return allowExternalSource ? value : null
-  }
-  if (value.startsWith("/owner-update-photos/")) return value
-  if (value.startsWith("/project-photo-previews/")) return value
-  return null
-}
+import {
+  photoLinkHref,
+  resolvePhotoImageSource,
+} from "@/lib/photo-sources"
 
 function externalHref(value: string): boolean {
   return value.startsWith("https://") || value.startsWith("http://")
@@ -23,12 +15,14 @@ function externalHref(value: string): boolean {
 
 export function OwnerUpdatePhotoTile({
   fileName,
+  driveFileId,
   driveUrl,
   thumbnailUrl,
   caption,
   allowExternalSource = false,
 }: {
   readonly fileName: string
+  readonly driveFileId: string | null
   readonly driveUrl: string | null
   readonly thumbnailUrl: string | null
   readonly caption: string | null
@@ -36,16 +30,23 @@ export function OwnerUpdatePhotoTile({
 }): React.ReactElement {
   const [imageFailed, setImageFailed] = useState(false)
   const title = caption ?? fileName
-  const showImage = thumbnailUrl !== null && !imageFailed
-  const href = browserHref(driveUrl, allowExternalSource)
+  const resolvedImage = resolvePhotoImageSource({
+    driveFileId,
+    driveUrl,
+    thumbnailUrl,
+  })
+  const imageSrc = imageFailed ? null : resolvedImage.src
+  const href = photoLinkHref(driveUrl, {
+    allowExternalSource,
+  })
   const opensExternally = href !== null && externalHref(href)
 
   return (
     <div className="owner-update-photo-tile overflow-hidden rounded-md border bg-background print:break-inside-avoid print:rounded-none">
       <div className="owner-update-photo-frame flex aspect-[4/3] items-center justify-center bg-muted/50">
-        {showImage ? (
+        {imageSrc ? (
           <Image
-            src={thumbnailUrl}
+            src={imageSrc}
             alt={title}
             width={320}
             height={240}
@@ -57,7 +58,7 @@ export function OwnerUpdatePhotoTile({
           <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-3 text-center">
             <IconPhoto className="size-8 text-muted-foreground" />
             <span className="line-clamp-2 text-xs text-muted-foreground">
-              Photo preview
+              {resolvedImage.label}
             </span>
           </div>
         )}

--- a/src/components/projects/project-audience-photo-gallery.tsx
+++ b/src/components/projects/project-audience-photo-gallery.tsx
@@ -21,6 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { resolvePhotoImageSource } from "@/lib/photo-sources"
 
 type AudiencePhotoSort = "newest" | "oldest" | "phase_newest" | "phase_oldest"
 
@@ -108,8 +109,15 @@ export function ProjectAudiencePhotoGallery({
   const [previewPhoto, setPreviewPhoto] = React.useState<AudiencePhoto | null>(
     null
   )
+  const [failedImageIds, setFailedImageIds] = React.useState<readonly string[]>(
+    []
+  )
 
   const phases = React.useMemo(() => phaseOptions(photos), [photos])
+  const failedImageSet = React.useMemo(
+    () => new Set(failedImageIds),
+    [failedImageIds]
+  )
   const filteredPhotos = React.useMemo(() => {
     const filtered = photos.filter(
       (photo) =>
@@ -130,6 +138,13 @@ export function ProjectAudiencePhotoGallery({
       }
     })
   }, [dateFilter, phaseFilter, photoSort, photos])
+
+  function markImageFailed(photoId: string): void {
+    setFailedImageIds((current) => {
+      if (current.includes(photoId)) return current
+      return [...current, photoId]
+    })
+  }
 
   return (
     <section
@@ -226,51 +241,59 @@ export function ProjectAudiencePhotoGallery({
 
           {filteredPhotos.length > 0 ? (
             <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-              {filteredPhotos.map((photo) => (
-                <button
-                  key={photo.id}
-                  type="button"
-                  onClick={() => setPreviewPhoto(photo)}
-                  className="overflow-hidden rounded-md border bg-background text-left transition hover:-translate-y-1 hover:border-primary/50 hover:bg-muted/30 hover:shadow-md"
-                  aria-label={`Open larger preview for ${photo.caption ?? photo.fileName}`}
-                >
-                  <div className="relative flex aspect-[4/3] items-center justify-center bg-muted/50">
-                    {photo.thumbnailUrl ? (
-                      <Image
-                        src={photo.thumbnailUrl}
-                        alt={photo.caption ?? photo.fileName}
-                        fill
-                        sizes="(min-width: 1024px) 25vw, (min-width: 640px) 33vw, 50vw"
-                        unoptimized
-                        className="object-cover"
-                      />
-                    ) : (
-                      <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-3 text-center">
-                        <IconPhoto className="size-8 text-muted-foreground" />
-                        <span className="line-clamp-2 text-xs text-muted-foreground">
-                          Photo preview
-                        </span>
-                      </div>
-                    )}
-                    <span className="absolute left-2 top-2 rounded bg-background/90 px-2 py-0.5 text-xs font-medium">
-                      {photo.photoDate}
-                    </span>
-                    <span className="absolute bottom-2 left-2 max-w-[calc(100%-1rem)] rounded bg-background/90 px-2 py-0.5 text-xs font-medium">
-                      {photo.schedulePhase}
-                    </span>
-                  </div>
-                  <div className="space-y-2 p-2">
-                    <p className="line-clamp-2 min-h-10 text-xs font-medium">
-                      {photo.caption ?? photo.fileName}
-                    </p>
-                    <div className="flex flex-wrap items-center gap-1">
-                      <Badge variant="outline">
-                        {photo.schedulePhaseConfidence}% match
-                      </Badge>
+              {filteredPhotos.map((photo) => {
+                const resolvedImage = resolvePhotoImageSource(photo)
+                const imageSrc = failedImageSet.has(photo.id)
+                  ? null
+                  : resolvedImage.src
+
+                return (
+                  <button
+                    key={photo.id}
+                    type="button"
+                    onClick={() => setPreviewPhoto(photo)}
+                    className="overflow-hidden rounded-md border bg-background text-left transition hover:-translate-y-1 hover:border-primary/50 hover:bg-muted/30 hover:shadow-md"
+                    aria-label={`Open larger preview for ${photo.caption ?? photo.fileName}`}
+                  >
+                    <div className="relative flex aspect-[4/3] items-center justify-center bg-muted/50">
+                      {imageSrc ? (
+                        <Image
+                          src={imageSrc}
+                          alt={photo.caption ?? photo.fileName}
+                          fill
+                          sizes="(min-width: 1024px) 25vw, (min-width: 640px) 33vw, 50vw"
+                          unoptimized
+                          className="object-cover"
+                          onError={() => markImageFailed(photo.id)}
+                        />
+                      ) : (
+                        <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-3 text-center">
+                          <IconPhoto className="size-8 text-muted-foreground" />
+                          <span className="line-clamp-2 text-xs text-muted-foreground">
+                            {resolvedImage.label}
+                          </span>
+                        </div>
+                      )}
+                      <span className="absolute left-2 top-2 rounded bg-background/90 px-2 py-0.5 text-xs font-medium">
+                        {photo.photoDate}
+                      </span>
+                      <span className="absolute bottom-2 left-2 max-w-[calc(100%-1rem)] rounded bg-background/90 px-2 py-0.5 text-xs font-medium">
+                        {photo.schedulePhase}
+                      </span>
                     </div>
-                  </div>
-                </button>
-              ))}
+                    <div className="space-y-2 p-2">
+                      <p className="line-clamp-2 min-h-10 text-xs font-medium">
+                        {photo.caption ?? photo.fileName}
+                      </p>
+                      <div className="flex flex-wrap items-center gap-1">
+                        <Badge variant="outline">
+                          {photo.schedulePhaseConfidence}% match
+                        </Badge>
+                      </div>
+                    </div>
+                  </button>
+                )
+              })}
             </div>
           ) : (
             <div className="mt-4 rounded-md border bg-muted/20 p-6 text-sm text-muted-foreground">
@@ -295,6 +318,13 @@ export function ProjectAudiencePhotoGallery({
       >
         <DialogContent className="max-h-[92vh] overflow-hidden p-0 sm:max-w-5xl">
           {previewPhoto && (
+            (() => {
+              const resolvedImage = resolvePhotoImageSource(previewPhoto)
+              const imageSrc = failedImageSet.has(previewPhoto.id)
+                ? null
+                : resolvedImage.src
+
+              return (
             <div className="grid max-h-[92vh] grid-rows-[auto_minmax(0,1fr)]">
               <DialogHeader className="border-b px-4 py-3">
                 <DialogTitle className="line-clamp-1 text-base">
@@ -308,18 +338,22 @@ export function ProjectAudiencePhotoGallery({
               </DialogHeader>
               <div className="flex min-h-0 flex-col bg-muted/40">
                 <div className="relative min-h-[55vh] flex-1">
-                  {previewPhoto.thumbnailUrl ? (
+                  {imageSrc ? (
                     <Image
-                      src={previewPhoto.thumbnailUrl}
+                      src={imageSrc}
                       alt={previewPhoto.caption ?? previewPhoto.fileName}
                       fill
                       sizes="90vw"
                       unoptimized
                       className="object-contain"
+                      onError={() => markImageFailed(previewPhoto.id)}
                     />
                   ) : (
-                    <div className="flex h-full items-center justify-center">
+                    <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
                       <IconPhoto className="size-12 text-muted-foreground" />
+                      <p className="text-sm font-medium text-muted-foreground">
+                        {resolvedImage.label}
+                      </p>
                     </div>
                   )}
                 </div>
@@ -347,6 +381,8 @@ export function ProjectAudiencePhotoGallery({
                 </div>
               </div>
             </div>
+              )
+            })()
           )}
         </DialogContent>
       </Dialog>

--- a/src/components/projects/project-audience-preview.tsx
+++ b/src/components/projects/project-audience-preview.tsx
@@ -493,6 +493,7 @@ function OwnerProjectPreview({
           approvedPhotos={data.photos.map((photo) => ({
             id: photo.id,
             fileName: photo.fileName,
+            driveFileId: photo.driveFileId,
             thumbnailUrl: photo.thumbnailUrl,
             caption: photo.caption,
           }))}

--- a/src/components/projects/project-daily-log-workspace.tsx
+++ b/src/components/projects/project-daily-log-workspace.tsx
@@ -27,6 +27,7 @@ import {
   updateDailyLogReview,
   updateProjectDailyLog,
   type ProjectDailyLogItem,
+  type ProjectDailyLogPhoto,
   type ProjectDailyLogWorkspace as ProjectDailyLogWorkspaceData,
 } from "@/app/actions/project-field"
 import { Badge } from "@/components/ui/badge"
@@ -35,6 +36,10 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { ProjectContextSwitcher } from "@/components/projects/project-context-switcher"
+import {
+  photoLinkHref,
+  resolvePhotoImageSource,
+} from "@/lib/photo-sources"
 import { cn } from "@/lib/utils"
 
 type LogFilter = "all" | "needs_review" | "approved" | "owner_visible"
@@ -108,10 +113,6 @@ function formatBytes(value: number): string {
   return `${(value / (1024 * 1024)).toFixed(1)} MB`
 }
 
-function isImageFile(mimeType: string | null): boolean {
-  return mimeType !== null && mimeType.startsWith("image/")
-}
-
 function formatDate(value: string): string {
   return new Date(`${value}T00:00:00`).toLocaleDateString("en-US", {
     month: "short",
@@ -142,14 +143,6 @@ function sourceLabel(value: string): string {
     default:
       return "Compass"
   }
-}
-
-function browserHref(value: string | null): string | null {
-  if (value === null) return null
-  if (value.startsWith("https://") || value.startsWith("http://")) return value
-  if (value.startsWith("/owner-update-photos/")) return value
-  if (value.startsWith("/project-photo-previews/")) return value
-  return null
 }
 
 function readableJsonItem(value: unknown): string | null {
@@ -402,6 +395,41 @@ function DailyLogFields({
   )
 }
 
+function DailyLogPhotoThumb({
+  photo,
+}: {
+  readonly photo: ProjectDailyLogPhoto
+}): React.ReactElement {
+  const [imageFailed, setImageFailed] = React.useState(false)
+  const resolvedImage = resolvePhotoImageSource(photo)
+  const imageSrc = imageFailed ? null : resolvedImage.src
+
+  if (imageSrc !== null) {
+    return (
+      <Image
+        src={imageSrc}
+        alt={photo.caption ?? photo.fileName}
+        fill
+        sizes="160px"
+        unoptimized
+        className="object-cover transition-transform group-hover:scale-[1.03]"
+        onError={() => setImageFailed(true)}
+      />
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 p-3 text-center text-xs text-muted-foreground">
+      <IconFileText className="size-6" />
+      <span className="line-clamp-3 break-words">
+        {resolvedImage.reason === "missing"
+          ? photo.caption ?? photo.fileName
+          : resolvedImage.label}
+      </span>
+    </div>
+  )
+}
+
 function PhotoStrip({
   log,
 }: {
@@ -424,11 +452,9 @@ function PhotoStrip({
       </div>
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 lg:grid-cols-6">
         {log.photos.slice(0, 6).map((photo) => {
-          const href = browserHref(photo.driveUrl)
-          const imageSrc =
-            photo.thumbnailUrl !== null && isImageFile(photo.mimeType)
-              ? photo.thumbnailUrl
-              : null
+          const href = photoLinkHref(photo.driveUrl, {
+            allowExternalSource: true,
+          })
           return (
             <a
               key={photo.id}
@@ -440,23 +466,7 @@ function PhotoStrip({
                 href ? "cursor-pointer" : "cursor-default"
               )}
             >
-              {imageSrc !== null ? (
-                <Image
-                  src={imageSrc}
-                  alt={photo.caption ?? photo.fileName}
-                  fill
-                  sizes="160px"
-                  unoptimized
-                  className="object-cover transition-transform group-hover:scale-[1.03]"
-                />
-              ) : (
-                <div className="flex h-full flex-col items-center justify-center gap-2 p-3 text-center text-xs text-muted-foreground">
-                  <IconFileText className="size-6" />
-                  <span className="line-clamp-3 break-words">
-                    {photo.caption ?? photo.fileName}
-                  </span>
-                </div>
-              )}
+              <DailyLogPhotoThumb photo={photo} />
               <div className="absolute inset-x-0 bottom-0 bg-background/85 px-2 py-1 text-[11px]">
                 {photo.ownerVisible ? "Owner visible" : statusLabel(photo.reviewStatus)}
               </div>
@@ -1323,20 +1333,7 @@ export function ProjectDailyLogWorkspace({
                   key={photo.id}
                   className="relative aspect-[4/3] overflow-hidden rounded-md border bg-muted"
                 >
-                  {photo.thumbnailUrl ? (
-                    <Image
-                      src={photo.thumbnailUrl}
-                      alt={photo.caption ?? photo.fileName}
-                      fill
-                      sizes="140px"
-                      unoptimized
-                      className="object-cover"
-                    />
-                  ) : (
-                    <div className="flex h-full items-center justify-center p-2 text-center text-xs text-muted-foreground">
-                      {photo.caption ?? photo.fileName}
-                    </div>
-                  )}
+                  <DailyLogPhotoThumb photo={photo} />
                 </div>
               ))}
             </div>

--- a/src/components/projects/project-field-panel.tsx
+++ b/src/components/projects/project-field-panel.tsx
@@ -1,4 +1,4 @@
-import type * as React from "react"
+import * as React from "react"
 import Image from "next/image"
 import Link from "next/link"
 import {
@@ -12,6 +12,10 @@ import {
 
 import type { ProjectFieldSummary } from "@/app/actions/project-field"
 import { Badge } from "@/components/ui/badge"
+import {
+  photoLinkHref,
+  resolvePhotoImageSource,
+} from "@/lib/photo-sources"
 
 function formatDate(value: string): string {
   return new Date(`${value}T00:00:00`).toLocaleDateString("en-US", {
@@ -45,13 +49,6 @@ function sourceLabel(value: string): string {
   }
 }
 
-function browserHref(value: string | null): string | null {
-  if (value === null) return null
-  if (value.startsWith("https://") || value.startsWith("http://")) return value
-  if (value.startsWith("/owner-update-photos/")) return value
-  return null
-}
-
 function SummaryMetric({
   icon,
   label,
@@ -68,6 +65,32 @@ function SummaryMetric({
         <span className="text-muted-foreground">{icon}</span>
       </div>
       <p className="mt-2 text-2xl font-semibold leading-none">{value}</p>
+    </div>
+  )
+}
+
+function LatestPhotoThumb({
+  photo,
+}: {
+  readonly photo: ProjectFieldSummary["latestPhotos"][number]
+}): React.ReactElement | null {
+  const [imageFailed, setImageFailed] = React.useState(false)
+  const resolvedImage = resolvePhotoImageSource(photo)
+  const imageSrc = imageFailed ? null : resolvedImage.src
+
+  if (imageSrc === null) return null
+
+  return (
+    <div className="relative h-16 w-20 shrink-0 overflow-hidden rounded-md bg-muted">
+      <Image
+        src={imageSrc}
+        alt={photo.caption ?? photo.fileName}
+        fill
+        sizes="80px"
+        unoptimized
+        className="object-cover"
+        onError={() => setImageFailed(true)}
+      />
     </div>
   )
 }
@@ -292,7 +315,9 @@ export function ProjectFieldPanel({
           </div>
           <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-2">
             {summary.latestPhotos.map((photo) => {
-              const href = browserHref(photo.driveUrl)
+              const href = photoLinkHref(photo.driveUrl, {
+                allowExternalSource: true,
+              })
 
               return (
                 <div
@@ -300,18 +325,7 @@ export function ProjectFieldPanel({
                   className="flex min-w-0 items-start justify-between gap-3 rounded-md border p-2"
                 >
                   <div className="flex min-w-0 gap-3">
-                    {photo.thumbnailUrl && (
-                      <div className="relative h-16 w-20 shrink-0 overflow-hidden rounded-md bg-muted">
-                        <Image
-                          src={photo.thumbnailUrl}
-                          alt={photo.caption ?? photo.fileName}
-                          fill
-                          sizes="80px"
-                          unoptimized
-                          className="object-cover"
-                        />
-                      </div>
-                    )}
+                    <LatestPhotoThumb photo={photo} />
                     <div className="min-w-0 space-y-1">
                       <p className="truncate text-sm font-medium">
                         {photo.caption ?? photo.fileName}

--- a/src/components/projects/project-photo-review.tsx
+++ b/src/components/projects/project-photo-review.tsx
@@ -48,6 +48,10 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { ProjectContextSwitcher } from "@/components/projects/project-context-switcher"
+import {
+  photoLinkHref,
+  resolvePhotoImageSource,
+} from "@/lib/photo-sources"
 
 type VisibilityFilter =
   | "all"
@@ -116,14 +120,6 @@ function reviewStatusIcon(value: string): React.ReactElement {
 
 function projectLabel(library: ProjectPhotoLibrary): string {
   return library.project.projectNumber ?? library.project.name
-}
-
-function browserHref(value: string | null): string | null {
-  if (value === null) return null
-  if (value.startsWith("https://") || value.startsWith("http://")) return value
-  if (value.startsWith("/owner-update-photos/")) return value
-  if (value.startsWith("/project-photo-previews/")) return value
-  return null
 }
 
 function formatBytes(value: number): string {
@@ -275,6 +271,9 @@ export function ProjectPhotoReview({
   const [message, setMessage] = React.useState<string | null>(null)
   const [previewPhoto, setPreviewPhoto] =
     React.useState<ProjectPhotoLibraryItem | null>(null)
+  const [failedImageIds, setFailedImageIds] = React.useState<readonly string[]>(
+    []
+  )
   const [uploadOpen, setUploadOpen] = React.useState(false)
   const [uploadFiles, setUploadFiles] = React.useState<readonly File[]>([])
   const [uploadCaption, setUploadCaption] = React.useState("")
@@ -286,6 +285,10 @@ export function ProjectPhotoReview({
   const [isPending, startTransition] = React.useTransition()
 
   const selectedSet = React.useMemo(() => new Set(selectedIds), [selectedIds])
+  const failedImageSet = React.useMemo(
+    () => new Set(failedImageIds),
+    [failedImageIds]
+  )
   const filteredPhotos = React.useMemo(() => {
     const filtered = photos.filter(
       (photo) =>
@@ -340,6 +343,13 @@ export function ProjectPhotoReview({
 
   function openPreview(photo: ProjectPhotoLibraryItem): void {
     setPreviewPhoto(photo)
+  }
+
+  function markImageFailed(photoId: string): void {
+    setFailedImageIds((current) => {
+      if (current.includes(photoId)) return current
+      return [...current, photoId]
+    })
   }
 
   function resetUploadForm(): void {
@@ -826,8 +836,13 @@ export function ProjectPhotoReview({
           )}
           {filteredPhotos.map((photo) => {
             const selected = selectedSet.has(photo.id)
-            const href = browserHref(photo.driveUrl)
-            const imageSrc = photo.thumbnailUrl ?? photo.driveUrl
+            const href = photoLinkHref(photo.driveUrl, {
+              allowExternalSource: true,
+            })
+            const resolvedImage = resolvePhotoImageSource(photo)
+            const imageSrc = failedImageSet.has(photo.id)
+              ? null
+              : resolvedImage.src
             const sourceName = sourceLabel(photo.sourceSystem)
 
             return (
@@ -852,10 +867,14 @@ export function ProjectPhotoReview({
                         sizes="(min-width: 1280px) 20vw, (min-width: 768px) 33vw, 50vw"
                         unoptimized
                         className="object-cover"
+                        onError={() => markImageFailed(photo.id)}
                       />
                     ) : (
-                      <div className="flex h-full items-center justify-center">
+                      <div className="flex h-full flex-col items-center justify-center gap-2 p-3 text-center">
                         <IconPhoto className="size-8 text-muted-foreground" />
+                        <span className="text-xs font-medium text-muted-foreground">
+                          {resolvedImage.label}
+                        </span>
                       </div>
                     )}
                     <span className="absolute left-2 top-2 rounded bg-background/90 px-2 py-0.5 text-xs font-medium">
@@ -972,75 +991,87 @@ export function ProjectPhotoReview({
           }}
         >
           <DialogContent className="max-h-[92vh] overflow-hidden p-0 sm:max-w-5xl">
-            {previewPhoto && (
-              <div className="grid max-h-[92vh] grid-rows-[auto_minmax(0,1fr)]">
-                <DialogHeader className="border-b px-4 py-3">
-                <DialogTitle className="line-clamp-1 text-base">
-                  {previewPhoto.caption ?? previewPhoto.fileName}
-                </DialogTitle>
-                <DialogDescription>
-                  {previewPhoto.photoDate} · {previewPhoto.schedulePhase} ·{" "}
-                    {previewPhoto.schedulePhaseConfidence}% match ·{" "}
-                    {statusLabel(previewPhoto.reviewStatus)}
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="flex min-h-0 flex-col bg-muted/40">
-                  <div className="relative min-h-[55vh] flex-1">
-                    {previewPhoto.thumbnailUrl ?? previewPhoto.driveUrl ? (
-                      <Image
-                        src={previewPhoto.thumbnailUrl ?? previewPhoto.driveUrl ?? ""}
-                        alt={previewPhoto.caption ?? previewPhoto.fileName}
-                        fill
-                        sizes="90vw"
-                        unoptimized
-                        className="object-contain"
-                      />
-                    ) : (
-                      <div className="flex h-full items-center justify-center">
-                        <IconPhoto className="size-12 text-muted-foreground" />
-                      </div>
-                    )}
-                  </div>
-                  <div className="flex flex-wrap items-center justify-between gap-2 border-t bg-background px-4 py-3">
-                    <div>
-                      <div className="flex flex-wrap gap-1">
-                        <Badge variant="outline">
-                          {sourceLabel(previewPhoto.sourceSystem)}
-                        </Badge>
-                        <Badge variant="outline">
-                          {kindLabel(previewPhoto.photoKind)}
-                        </Badge>
-                        <Badge variant="secondary">
-                          Phase suggestion: {previewPhoto.schedulePhase}
-                        </Badge>
-                        {isInternalOnly(previewPhoto) && (
-                          <Badge variant="secondary">Internal</Badge>
-                        )}
-                        {previewPhoto.ownerVisible && (
-                          <Badge variant="secondary">Owner</Badge>
-                        )}
-                        {previewPhoto.subVendorVisible && (
-                          <Badge variant="secondary">Subs/vendors</Badge>
-                        )}
-                        {previewPhoto.publicShareable && (
-                          <Badge variant="secondary">Public</Badge>
+            {previewPhoto &&
+              (() => {
+                const resolvedImage = resolvePhotoImageSource(previewPhoto)
+                const imageSrc = failedImageSet.has(previewPhoto.id)
+                  ? null
+                  : resolvedImage.src
+
+                return (
+                  <div className="grid max-h-[92vh] grid-rows-[auto_minmax(0,1fr)]">
+                    <DialogHeader className="border-b px-4 py-3">
+                      <DialogTitle className="line-clamp-1 text-base">
+                        {previewPhoto.caption ?? previewPhoto.fileName}
+                      </DialogTitle>
+                      <DialogDescription>
+                        {previewPhoto.photoDate} · {previewPhoto.schedulePhase} ·{" "}
+                        {previewPhoto.schedulePhaseConfidence}% match ·{" "}
+                        {statusLabel(previewPhoto.reviewStatus)}
+                      </DialogDescription>
+                    </DialogHeader>
+                    <div className="flex min-h-0 flex-col bg-muted/40">
+                      <div className="relative min-h-[55vh] flex-1">
+                        {imageSrc ? (
+                          <Image
+                            src={imageSrc}
+                            alt={previewPhoto.caption ?? previewPhoto.fileName}
+                            fill
+                            sizes="90vw"
+                            unoptimized
+                            className="object-contain"
+                            onError={() => markImageFailed(previewPhoto.id)}
+                          />
+                        ) : (
+                          <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+                            <IconPhoto className="size-12 text-muted-foreground" />
+                            <p className="text-sm font-medium text-muted-foreground">
+                              {resolvedImage.label}
+                            </p>
+                          </div>
                         )}
                       </div>
-                      <p className="mt-2 max-w-2xl text-xs text-muted-foreground">
-                        {previewPhoto.schedulePhaseReason}
-                      </p>
+                      <div className="flex flex-wrap items-center justify-between gap-2 border-t bg-background px-4 py-3">
+                        <div>
+                          <div className="flex flex-wrap gap-1">
+                            <Badge variant="outline">
+                              {sourceLabel(previewPhoto.sourceSystem)}
+                            </Badge>
+                            <Badge variant="outline">
+                              {kindLabel(previewPhoto.photoKind)}
+                            </Badge>
+                            <Badge variant="secondary">
+                              Phase suggestion: {previewPhoto.schedulePhase}
+                            </Badge>
+                            {isInternalOnly(previewPhoto) && (
+                              <Badge variant="secondary">Internal</Badge>
+                            )}
+                            {previewPhoto.ownerVisible && (
+                              <Badge variant="secondary">Owner</Badge>
+                            )}
+                            {previewPhoto.subVendorVisible && (
+                              <Badge variant="secondary">Subs/vendors</Badge>
+                            )}
+                            {previewPhoto.publicShareable && (
+                              <Badge variant="secondary">Public</Badge>
+                            )}
+                          </div>
+                          <p className="mt-2 max-w-2xl text-xs text-muted-foreground">
+                            {previewPhoto.schedulePhaseReason}
+                          </p>
+                        </div>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={() => setPreviewPhoto(null)}
+                        >
+                          Close
+                        </Button>
+                      </div>
                     </div>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={() => setPreviewPhoto(null)}
-                    >
-                      Close
-                    </Button>
                   </div>
-                </div>
-              </div>
-            )}
+                )
+              })()}
           </DialogContent>
         </Dialog>
 

--- a/src/lib/photo-sources.ts
+++ b/src/lib/photo-sources.ts
@@ -1,0 +1,107 @@
+export type PhotoSourceInput = {
+  readonly thumbnailUrl: string | null
+  readonly driveUrl?: string | null
+  readonly driveFileId?: string | null
+}
+
+export type PhotoImageSource = {
+  readonly src: string | null
+  readonly reason: "ready" | "legacy_external" | "missing"
+  readonly label: string
+}
+
+type PhotoLinkOptions = {
+  readonly allowExternalSource?: boolean
+}
+
+function cleanUrl(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function isHttpUrl(value: string): boolean {
+  return value.startsWith("https://") || value.startsWith("http://")
+}
+
+function isLocalRenderablePhotoUrl(value: string): boolean {
+  return (
+    value.startsWith("/api/google/download/") ||
+    value.startsWith("/owner-update-photos/") ||
+    value.startsWith("/project-photo-previews/")
+  )
+}
+
+export function googleDriveDownloadUrl(fileId: string): string {
+  return `/api/google/download/${encodeURIComponent(fileId)}`
+}
+
+export function isLegacyExternalPhotoUrl(value: string): boolean {
+  if (!isHttpUrl(value)) return false
+
+  try {
+    const host = new URL(value).hostname.toLowerCase()
+    return (
+      host === "buildertrend.net" ||
+      host.endsWith(".buildertrend.net") ||
+      host === "buildertrend.com" ||
+      host.endsWith(".buildertrend.com")
+    )
+  } catch {
+    return false
+  }
+}
+
+export function resolvePhotoImageSource(
+  input: PhotoSourceInput
+): PhotoImageSource {
+  const thumbnailUrl = cleanUrl(input.thumbnailUrl)
+  const driveUrl = cleanUrl(input.driveUrl)
+  const driveFileId = cleanUrl(input.driveFileId)
+
+  if (thumbnailUrl !== null) {
+    if (isLocalRenderablePhotoUrl(thumbnailUrl)) {
+      return { src: thumbnailUrl, reason: "ready", label: "Photo preview" }
+    }
+
+    if (isHttpUrl(thumbnailUrl) && !isLegacyExternalPhotoUrl(thumbnailUrl)) {
+      return { src: thumbnailUrl, reason: "ready", label: "Photo preview" }
+    }
+  }
+
+  if (driveFileId !== null) {
+    return {
+      src: googleDriveDownloadUrl(driveFileId),
+      reason: "ready",
+      label: "Photo preview",
+    }
+  }
+
+  if (driveUrl !== null && isLocalRenderablePhotoUrl(driveUrl)) {
+    return { src: driveUrl, reason: "ready", label: "Photo preview" }
+  }
+
+  if (
+    (thumbnailUrl !== null && isLegacyExternalPhotoUrl(thumbnailUrl)) ||
+    (driveUrl !== null && isLegacyExternalPhotoUrl(driveUrl))
+  ) {
+    return {
+      src: null,
+      reason: "legacy_external",
+      label: "Needs Drive import",
+    }
+  }
+
+  return { src: null, reason: "missing", label: "No preview" }
+}
+
+export function photoLinkHref(
+  value: string | null | undefined,
+  options: PhotoLinkOptions = {}
+): string | null {
+  const url = cleanUrl(value)
+  if (url === null) return null
+  if (isLocalRenderablePhotoUrl(url)) return url
+  if (isHttpUrl(url)) return options.allowExternalSource === true ? url : null
+  return null
+}


### PR DESCRIPTION
## Summary
- Add a shared photo source resolver so Compass prefers Drive file IDs via `/api/google/download/:fileId` and avoids rendering legacy Buildertrend preview URLs as images.
- Carry `driveFileId` through photo library, audience preview, owner update, daily log, and dashboard photo DTOs.
- Update photo review, owner/sub galleries, owner update drafting, daily logs, field summary, dashboard field photos, and owner cover picker to show clear placeholders such as “Needs Drive import” instead of blank/broken image tiles.

## Verification
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
- Pre-push `next build` completed successfully.
- `bun run deploy` succeeded; active Cloudflare Worker version `9336eee6-fa77-4bec-9d6f-a9d3fce7d2ea` is deployed at 100%.
- Live smoke check on Loeffler photo review page showed no console errors and Buildertrend-only rows now show “Needs Drive import” while preserving the original Open link.

## Notes
- Images are not duplicated into D1. D1 stores pointers/provenance; Drive remains the source of truth. Legacy Buildertrend-only records are now explicitly flagged as needing Drive import.
