### PR TITLE
fix(photos): make daily log uploads reliable

### DIFF
--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -188,151 +188,6 @@ function photoDate(value: {
   return value.createdAt.slice(0, 10)
 }
 
-function phaseKeywords(phase: string): readonly string[] {
-  const normalized = phase.toLowerCase()
-  const terms = new Set(
-    normalized
-      .split(/[^a-z0-9]+/)
-      .filter((part) => part.length > 2)
-  )
-
-  const keywordGroups: readonly {
-    readonly match: string
-    readonly keywords: readonly string[]
-  }[] = [
-    {
-      match: "foundation",
-      keywords: ["footing", "footer", "forms", "rebar", "pour", "concrete"],
-    },
-    {
-      match: "excavat",
-      keywords: ["dig", "soil", "grading", "trench", "utility", "backfill"],
-    },
-    {
-      match: "floor",
-      keywords: ["joist", "decking", "subfloor", "rim", "beam"],
-    },
-    {
-      match: "framing",
-      keywords: ["wall", "truss", "roof", "sheathing", "stud", "plate"],
-    },
-    {
-      match: "mechanical",
-      keywords: ["hvac", "duct", "furnace", "vent", "rough"],
-    },
-    {
-      match: "electrical",
-      keywords: ["wire", "panel", "outlet", "switch", "rough"],
-    },
-    {
-      match: "plumbing",
-      keywords: ["pipe", "drain", "water", "rough", "fixture"],
-    },
-    {
-      match: "insulation",
-      keywords: ["batts", "foam", "seal", "thermal"],
-    },
-    {
-      match: "drywall",
-      keywords: ["sheetrock", "tape", "mud", "texture"],
-    },
-    {
-      match: "finish",
-      keywords: ["cabinet", "trim", "paint", "flooring", "tile", "counter"],
-    },
-    {
-      match: "inspection",
-      keywords: ["inspect", "correction", "certificate", "co", "punch"],
-    },
-  ]
-
-  for (const group of keywordGroups) {
-    if (normalized.includes(group.match)) {
-      for (const keyword of group.keywords) terms.add(keyword)
-    }
-  }
-
-  return [...terms]
-}
-
-function keywordScore(phase: string, text: string): number {
-  const normalizedText = text.toLowerCase()
-  return phaseKeywords(phase).reduce(
-    (score, keyword) =>
-      normalizedText.includes(keyword.toLowerCase()) ? score + 1 : score,
-    0
-  )
-}
-
-function suggestPhaseForPhoto(
-  photoDateValue: string,
-  contextText: string,
-  tasks: readonly {
-    readonly phase: string
-    readonly startDate: string
-    readonly endDateCalculated: string
-  }[]
-): {
-  readonly phase: string
-  readonly confidence: number
-  readonly reason: string
-} {
-  const matchingTask = tasks.find(
-    (task) =>
-      task.phase.trim().length > 0 &&
-      task.startDate <= photoDateValue &&
-      task.endDateCalculated >= photoDateValue
-  )
-
-  const phaseNames = [...new Set(tasks.map((task) => task.phase))]
-  const scoredPhases = phaseNames
-    .map((phase) => ({
-      phase,
-      score: keywordScore(phase, contextText),
-    }))
-    .filter((item) => item.score > 0)
-    .sort((left, right) => right.score - left.score)
-  const keywordMatch = scoredPhases[0]
-
-  if (keywordMatch && matchingTask?.phase === keywordMatch.phase) {
-    return {
-      phase: keywordMatch.phase,
-      confidence: 92,
-      reason: "Schedule date and photo context both point to this phase.",
-    }
-  }
-
-  if (keywordMatch && keywordMatch.score >= 2) {
-    return {
-      phase: keywordMatch.phase,
-      confidence: 78,
-      reason: "Photo caption, filename, or daily log text matches this phase.",
-    }
-  }
-
-  if (matchingTask) {
-    return {
-      phase: matchingTask.phase,
-      confidence: 64,
-      reason: "Photo date falls inside this scheduled phase.",
-    }
-  }
-
-  if (keywordMatch) {
-    return {
-      phase: keywordMatch.phase,
-      confidence: 56,
-      reason: "Photo context lightly matches this phase.",
-    }
-  }
-
-  return {
-    phase: "Unassigned phase",
-    confidence: 0,
-    reason: "No schedule date or photo context match was found.",
-  }
-}
-
 function normalizeVisibleName(value: string | null): string {
   return value?.trim().toLowerCase() ?? ""
 }
@@ -409,17 +264,6 @@ export async function getProjectAudiencePreview(
       )
     )
     .orderBy(desc(dailyLogPhotos.capturedAt), desc(dailyLogPhotos.createdAt))
-
-  const phaseTaskRows = await db
-    .select({
-      phase: scheduleTasks.phase,
-      startDate: scheduleTasks.startDate,
-      endDateCalculated: scheduleTasks.endDateCalculated,
-      sortOrder: scheduleTasks.sortOrder,
-    })
-    .from(scheduleTasks)
-    .where(eq(scheduleTasks.projectId, projectId))
-    .orderBy(asc(scheduleTasks.sortOrder), asc(scheduleTasks.startDate))
 
   const scheduleRows = await db
     .select({
@@ -584,28 +428,7 @@ export async function getProjectAudiencePreview(
         logDate: photo.logDate,
         createdAt: photo.createdAt,
       })
-      const suggestion =
-        photo.schedulePhaseOverride &&
-        photo.schedulePhaseOverride.trim().length > 0
-          ? {
-              phase: photo.schedulePhaseOverride,
-              confidence: 100,
-              reason: "Phase was manually assigned during photo review.",
-            }
-          : suggestPhaseForPhoto(
-              resolvedPhotoDate,
-              [
-                photo.fileName,
-                photo.caption,
-                photo.photoKind,
-                photo.logWorkCompleted,
-                photo.logIssues,
-                photo.logNotes,
-              ]
-                .filter((part) => part !== null && part.trim().length > 0)
-                .join(" "),
-              phaseTaskRows
-            )
+      const schedulePhase = photo.schedulePhaseOverride?.trim() ?? ""
 
       return {
         id: photo.id,
@@ -615,9 +438,12 @@ export async function getProjectAudiencePreview(
         caption: photo.caption,
         capturedAt: photo.capturedAt,
         photoDate: resolvedPhotoDate,
-        schedulePhase: suggestion.phase,
-        schedulePhaseConfidence: suggestion.confidence,
-        schedulePhaseReason: suggestion.reason,
+        schedulePhase,
+        schedulePhaseConfidence: schedulePhase.length > 0 ? 100 : 0,
+        schedulePhaseReason:
+          schedulePhase.length > 0
+            ? "Phase was selected during upload or review."
+            : "No phase assigned.",
       }
     }),
     scheduleItems: scheduleRows,

--- a/src/app/actions/project-field.ts
+++ b/src/app/actions/project-field.ts
@@ -158,6 +158,7 @@ export type ProjectDailyLogWorkspace = {
   }
   readonly logs: readonly ProjectDailyLogItem[]
   readonly unattachedPhotos: readonly ProjectDailyLogPhoto[]
+  readonly schedulePhases: readonly string[]
   readonly counts: {
     readonly totalLogs: number
     readonly approvedLogs: number
@@ -1064,6 +1065,20 @@ export async function getProjectDailyLogWorkspace(
     .where(eq(dailyLogPhotos.projectId, projectId))
     .orderBy(asc(dailyLogPhotos.sortOrder), desc(dailyLogPhotos.createdAt))
 
+  const phaseRows = await db
+    .select({ phase: scheduleTasks.phase })
+    .from(scheduleTasks)
+    .where(eq(scheduleTasks.projectId, projectId))
+    .orderBy(asc(scheduleTasks.sortOrder), asc(scheduleTasks.startDate))
+
+  const schedulePhases = [
+    ...new Set(
+      phaseRows
+        .map((row) => row.phase.trim())
+        .filter((phase) => phase.length > 0)
+    ),
+  ]
+
   const logIds = logRows.map((row) => row.id)
   const taskRows =
     logIds.length === 0
@@ -1166,6 +1181,7 @@ export async function getProjectDailyLogWorkspace(
       tasks: tasksByLogId.get(row.id) ?? [],
     })),
     unattachedPhotos,
+    schedulePhases,
     counts: {
       totalLogs: logRows.length,
       approvedLogs: logRows.filter((row) => row.reviewStatus === "approved")

--- a/src/app/actions/project-photos.ts
+++ b/src/app/actions/project-photos.ts
@@ -68,12 +68,6 @@ type UpdatePhotoPhaseResult =
   | { readonly success: true; readonly phase: string }
   | { readonly success: false; readonly error: string }
 
-type PhaseSuggestion = {
-  readonly phase: string
-  readonly confidence: number
-  readonly reason: string
-}
-
 async function verifyProjectAccess(
   projectId: string,
   action: "read" | "update"
@@ -139,163 +133,20 @@ function isImage(value: {
   return value.thumbnailUrl !== null || value.mimeType?.startsWith("image/") === true
 }
 
-function phaseKeywords(phase: string): readonly string[] {
-  const normalized = phase.toLowerCase()
-  const terms = new Set(
-    normalized
-      .split(/[^a-z0-9]+/)
-      .filter((part) => part.length > 2)
-  )
-
-  const keywordGroups: readonly {
-    readonly match: string
-    readonly keywords: readonly string[]
-  }[] = [
-    {
-      match: "foundation",
-      keywords: ["footing", "footer", "forms", "rebar", "pour", "concrete"],
-    },
-    {
-      match: "excavat",
-      keywords: ["dig", "soil", "grading", "trench", "utility", "backfill"],
-    },
-    {
-      match: "floor",
-      keywords: ["joist", "decking", "subfloor", "rim", "beam"],
-    },
-    {
-      match: "framing",
-      keywords: ["wall", "truss", "roof", "sheathing", "stud", "plate"],
-    },
-    {
-      match: "mechanical",
-      keywords: ["hvac", "duct", "furnace", "vent", "rough"],
-    },
-    {
-      match: "electrical",
-      keywords: ["wire", "panel", "outlet", "switch", "rough"],
-    },
-    {
-      match: "plumbing",
-      keywords: ["pipe", "drain", "water", "rough", "fixture"],
-    },
-    {
-      match: "insulation",
-      keywords: ["batts", "foam", "seal", "thermal"],
-    },
-    {
-      match: "drywall",
-      keywords: ["sheetrock", "tape", "mud", "texture"],
-    },
-    {
-      match: "finish",
-      keywords: ["cabinet", "trim", "paint", "flooring", "tile", "counter"],
-    },
-    {
-      match: "inspection",
-      keywords: ["inspect", "correction", "certificate", "co", "punch"],
-    },
-  ]
-
-  for (const group of keywordGroups) {
-    if (normalized.includes(group.match)) {
-      for (const keyword of group.keywords) terms.add(keyword)
-    }
-  }
-
-  return [...terms]
-}
-
-function keywordScore(phase: string, text: string): number {
-  const normalizedText = text.toLowerCase()
-  return phaseKeywords(phase).reduce(
-    (score, keyword) =>
-      normalizedText.includes(keyword.toLowerCase()) ? score + 1 : score,
-    0
-  )
-}
-
-function suggestPhaseForPhoto(
-  photoDateValue: string,
-  contextText: string,
-  tasks: readonly {
-    readonly phase: string
-    readonly startDate: string
-    readonly endDateCalculated: string
-  }[]
-): PhaseSuggestion {
-  const matchingTask = tasks.find(
-    (task) =>
-      task.phase.trim().length > 0 &&
-      task.startDate <= photoDateValue &&
-      task.endDateCalculated >= photoDateValue
-  )
-
-  const phaseNames = [...new Set(tasks.map((task) => task.phase))]
-  const scoredPhases = phaseNames
-    .map((phase) => ({
-      phase,
-      score: keywordScore(phase, contextText),
-    }))
-    .filter((item) => item.score > 0)
-    .sort((left, right) => right.score - left.score)
-  const keywordMatch = scoredPhases[0]
-
-  if (keywordMatch && matchingTask?.phase === keywordMatch.phase) {
-    return {
-      phase: keywordMatch.phase,
-      confidence: 92,
-      reason: "Schedule date and photo context both point to this phase.",
-    }
-  }
-
-  if (keywordMatch && keywordMatch.score >= 2) {
-    return {
-      phase: keywordMatch.phase,
-      confidence: 78,
-      reason: "Photo caption, filename, or daily log text matches this phase.",
-    }
-  }
-
-  if (matchingTask) {
-    return {
-      phase: matchingTask.phase,
-      confidence: 64,
-      reason: "Photo date falls inside this scheduled phase.",
-    }
-  }
-
-  if (keywordMatch) {
-    return {
-      phase: keywordMatch.phase,
-      confidence: 56,
-      reason: "Photo context lightly matches this phase.",
-    }
-  }
-
-  return {
-    phase: "Unassigned phase",
-    confidence: 0,
-    reason: "No schedule date or photo context match was found.",
-  }
-}
-
 function phaseOptions(
   photos: readonly ProjectPhotoLibraryItem[],
   phases: readonly string[]
 ): readonly ProjectPhotoPhaseOption[] {
   const counts = new Map<string, number>()
   for (const photo of photos) {
-    counts.set(photo.schedulePhase, (counts.get(photo.schedulePhase) ?? 0) + 1)
+    if (photo.schedulePhase.length > 0) {
+      counts.set(photo.schedulePhase, (counts.get(photo.schedulePhase) ?? 0) + 1)
+    }
   }
 
-  return [...new Set([...phases, ...counts.keys(), "Unassigned phase"])]
+  return [...new Set([...phases, ...counts.keys()])]
     .filter((phase) => phase.trim().length > 0)
-    .sort((left, right) => {
-      if (left === "Unassigned phase") return 1
-      if (right === "Unassigned phase") return -1
-      return left.localeCompare(right)
-    })
+    .sort((left, right) => left.localeCompare(right))
     .map((value) => ({ value, label: value, count: counts.get(value) ?? 0 }))
 }
 
@@ -351,8 +202,6 @@ export async function getProjectPhotoLibrary(
   const tasks = await db
     .select({
       phase: scheduleTasks.phase,
-      startDate: scheduleTasks.startDate,
-      endDateCalculated: scheduleTasks.endDateCalculated,
       sortOrder: scheduleTasks.sortOrder,
     })
     .from(scheduleTasks)
@@ -366,27 +215,7 @@ export async function getProjectPhotoLibrary(
       logDate: row.logDate,
       createdAt: row.createdAt,
     })
-    const suggestion =
-      row.schedulePhaseOverride && row.schedulePhaseOverride.trim().length > 0
-        ? {
-            phase: row.schedulePhaseOverride,
-            confidence: 100,
-            reason: "Phase was manually assigned during photo review.",
-          }
-        : suggestPhaseForPhoto(
-            resolvedPhotoDate,
-            [
-              row.fileName,
-              row.caption,
-              row.photoKind,
-              row.logWorkCompleted,
-              row.logIssues,
-              row.logNotes,
-            ]
-              .filter((part) => part !== null && part.trim().length > 0)
-              .join(" "),
-            tasks
-          )
+    const schedulePhase = row.schedulePhaseOverride?.trim() ?? ""
 
     return {
       id: row.id,
@@ -407,9 +236,12 @@ export async function getProjectPhotoLibrary(
       subVendorVisible: row.subVendorVisible,
       publicShareable: row.publicShareable,
       photoKind: row.photoKind,
-      schedulePhase: suggestion.phase,
-      schedulePhaseConfidence: suggestion.confidence,
-      schedulePhaseReason: suggestion.reason,
+      schedulePhase,
+      schedulePhaseConfidence: schedulePhase.length > 0 ? 100 : 0,
+      schedulePhaseReason:
+        schedulePhase.length > 0
+          ? "Phase was selected during upload or review."
+          : "No phase assigned.",
     }
   })
 
@@ -448,15 +280,13 @@ export async function updateProjectPhotoPhase(
       return { success: false, error: "Project not found" }
     }
 
-    const normalizedPhase = phase.trim()
-    if (normalizedPhase.length === 0) {
-      return { success: false, error: "Select a phase." }
-    }
+    const normalizedPhase = phase.trim() === "unassigned" ? "" : phase.trim()
 
     await db
       .update(dailyLogPhotos)
       .set({
-        schedulePhaseOverride: normalizedPhase,
+        schedulePhaseOverride:
+          normalizedPhase.length > 0 ? normalizedPhase : null,
         updatedAt: new Date().toISOString(),
       })
       .where(

--- a/src/app/api/projects/[id]/photos/upload/route.ts
+++ b/src/app/api/projects/[id]/photos/upload/route.ts
@@ -25,6 +25,8 @@ import { isDemoUser } from "@/lib/demo"
 const GOOGLE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
 const DEFAULT_PHOTO_FOLDER_NAME = "Pictures"
 const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024
+const DEFAULT_COMPASS_GOOGLE_UPLOAD_USER = "compass@hps-colorado.com"
+const NO_PHASE_VALUE = "unassigned"
 
 type UploadPhotoResult =
   | {
@@ -50,6 +52,30 @@ function isFile(value: FormDataEntryValue): value is File {
 function formText(formData: FormData, name: string): string {
   const value = formData.get(name)
   return typeof value === "string" ? value.trim() : ""
+}
+
+function envString(env: Record<string, string>, key: string): string | null {
+  const value = env[key]?.trim()
+  return value && value.length > 0 ? value : null
+}
+
+function resolveGoogleUploadEmail(input: {
+  readonly userEmail: string
+  readonly googleEmail: string | null
+  readonly env: Record<string, string>
+}): string {
+  const configuredEmail = envString(input.env, "COMPASS_GOOGLE_UPLOAD_USER")
+  if (configuredEmail) return configuredEmail
+  if (input.googleEmail) return input.googleEmail
+  if (input.userEmail.endsWith("@hps-colorado.com")) return input.userEmail
+  return DEFAULT_COMPASS_GOOGLE_UPLOAD_USER
+}
+
+function normalizedSchedulePhase(value: string): string | null {
+  if (value.length === 0 || value === "all" || value === NO_PHASE_VALUE) {
+    return null
+  }
+  return value
 }
 
 function isInternalStaffRole(role: string): boolean {
@@ -223,11 +249,15 @@ export async function POST(
       )
     }
     const organizationId = requireOrg(user)
-    const googleEmail = user.googleEmail ?? user.email
     const { id: projectId } = await params
 
     const { env } = await getCloudflareContext()
     const envRecord = env as unknown as Record<string, string>
+    const googleEmail = resolveGoogleUploadEmail({
+      userEmail: user.email,
+      googleEmail: user.googleEmail,
+      env: envRecord,
+    })
     const config = getGoogleConfig(envRecord)
     const db = getDb(env.DB)
 
@@ -332,9 +362,10 @@ export async function POST(
     )
 
     for (const file of files) {
+      const mimeType = file.type || "application/octet-stream"
       const driveFile = await client.uploadFile(googleEmail, {
         name: safeFileName(file.name),
-        mimeType: file.type,
+        mimeType,
         parentId: targetFolderId,
         driveId: auth.sharedDriveId ?? undefined,
         data: file,
@@ -352,7 +383,7 @@ export async function POST(
         mimeType: driveFile.mimeType,
         driveFileId: driveFile.id,
         driveUrl: driveFile.webViewLink ?? null,
-        thumbnailUrl: isImageMimeType(driveFile.mimeType ?? file.type)
+        thumbnailUrl: isImageMimeType(driveFile.mimeType ?? mimeType)
           ? `/api/google/download/${driveFile.id}`
           : null,
         caption: caption.length > 0 ? caption : null,
@@ -363,10 +394,7 @@ export async function POST(
         subVendorVisible: false,
         publicShareable: false,
         photoKind,
-        schedulePhaseOverride:
-          schedulePhase.length > 0 && schedulePhase !== "all"
-            ? schedulePhase
-            : null,
+        schedulePhaseOverride: normalizedSchedulePhase(schedulePhase),
         sortOrder: 0,
         createdAt: now,
         updatedAt: now,

--- a/src/components/projects/project-audience-photo-gallery.tsx
+++ b/src/components/projects/project-audience-photo-gallery.tsx
@@ -24,6 +24,11 @@ import {
 import { resolvePhotoImageSource } from "@/lib/photo-sources"
 
 type AudiencePhotoSort = "newest" | "oldest" | "phase_newest" | "phase_oldest"
+const NO_PHASE_VALUE = "unassigned"
+
+function phaseLabel(value: string): string {
+  return value.length > 0 ? value : "No phase"
+}
 
 function formatDate(value: string | null): string {
   if (!value) return "Unscheduled"
@@ -74,15 +79,12 @@ function phaseOptions(
   const counts = new Map<string, number>()
 
   for (const photo of photos) {
-    counts.set(photo.schedulePhase, (counts.get(photo.schedulePhase) ?? 0) + 1)
+    const value = photo.schedulePhase.length > 0 ? photo.schedulePhase : NO_PHASE_VALUE
+    counts.set(value, (counts.get(value) ?? 0) + 1)
   }
 
   return [...counts.entries()]
-    .sort(([left], [right]) => {
-      if (left === "Unassigned phase") return 1
-      if (right === "Unassigned phase") return -1
-      return left.localeCompare(right)
-    })
+    .sort(([left], [right]) => left.localeCompare(right))
     .map(([value, count]) => ({ value, count }))
 }
 
@@ -122,7 +124,10 @@ export function ProjectAudiencePhotoGallery({
     const filtered = photos.filter(
       (photo) =>
         (dateFilter.length === 0 || photo.photoDate === dateFilter) &&
-        (phaseFilter === "all" || photo.schedulePhase === phaseFilter)
+        (phaseFilter === "all" ||
+          (phaseFilter === NO_PHASE_VALUE
+            ? photo.schedulePhase.length === 0
+            : photo.schedulePhase === phaseFilter))
     )
 
     return [...filtered].sort((left, right) => {
@@ -188,7 +193,9 @@ export function ProjectAudiencePhotoGallery({
                   <SelectItem value="all">All phases</SelectItem>
                   {phases.map((phase) => (
                     <SelectItem key={phase.value} value={phase.value}>
-                      {phase.value} ({phase.count})
+                      {phaseLabel(
+                        phase.value === NO_PHASE_VALUE ? "" : phase.value
+                      )} ({phase.count})
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -278,18 +285,13 @@ export function ProjectAudiencePhotoGallery({
                         {photo.photoDate}
                       </span>
                       <span className="absolute bottom-2 left-2 max-w-[calc(100%-1rem)] rounded bg-background/90 px-2 py-0.5 text-xs font-medium">
-                        {photo.schedulePhase}
+                        {phaseLabel(photo.schedulePhase)}
                       </span>
                     </div>
                     <div className="space-y-2 p-2">
                       <p className="line-clamp-2 min-h-10 text-xs font-medium">
                         {photo.caption ?? photo.fileName}
                       </p>
-                      <div className="flex flex-wrap items-center gap-1">
-                        <Badge variant="outline">
-                          {photo.schedulePhaseConfidence}% match
-                        </Badge>
-                      </div>
                     </div>
                   </button>
                 )
@@ -332,8 +334,7 @@ export function ProjectAudiencePhotoGallery({
                 </DialogTitle>
                 <DialogDescription>
                   {formatDate(previewPhoto.photoDate)} ·{" "}
-                  {previewPhoto.schedulePhase} ·{" "}
-                  {previewPhoto.schedulePhaseConfidence}% match
+                  {phaseLabel(previewPhoto.schedulePhase)}
                 </DialogDescription>
               </DialogHeader>
               <div className="flex min-h-0 flex-col bg-muted/40">
@@ -361,15 +362,14 @@ export function ProjectAudiencePhotoGallery({
                   <div>
                     <div className="flex flex-wrap gap-1">
                       <Badge variant="secondary">
-                        Phase: {previewPhoto.schedulePhase}
-                      </Badge>
-                      <Badge variant="outline">
-                        {previewPhoto.schedulePhaseConfidence}% match
+                        Phase: {phaseLabel(previewPhoto.schedulePhase)}
                       </Badge>
                     </div>
-                    <p className="mt-2 max-w-2xl text-xs text-muted-foreground">
-                      {previewPhoto.schedulePhaseReason}
-                    </p>
+                    {previewPhoto.schedulePhase.length > 0 && (
+                      <p className="mt-2 max-w-2xl text-xs text-muted-foreground">
+                        {previewPhoto.schedulePhaseReason}
+                      </p>
+                    )}
                   </div>
                   <Button
                     type="button"

--- a/src/components/projects/project-daily-log-workspace.tsx
+++ b/src/components/projects/project-daily-log-workspace.tsx
@@ -34,6 +34,13 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import { ProjectContextSwitcher } from "@/components/projects/project-context-switcher"
 import {
@@ -45,6 +52,7 @@ import { cn } from "@/lib/utils"
 type LogFilter = "all" | "needs_review" | "approved" | "owner_visible"
 
 const MAX_DAILY_LOG_UPLOAD_BYTES = 50 * 1024 * 1024
+const NO_PHASE_VALUE = "unassigned"
 
 type DailyLogDraft = {
   readonly logDate: string
@@ -496,6 +504,7 @@ export function ProjectDailyLogWorkspace({
   const [uploadingLogId, setUploadingLogId] = React.useState<string | null>(null)
   const [uploadFiles, setUploadFiles] = React.useState<readonly File[]>([])
   const [uploadCaption, setUploadCaption] = React.useState("")
+  const [uploadPhase, setUploadPhase] = React.useState(NO_PHASE_VALUE)
   const [uploadMessage, setUploadMessage] = React.useState<string | null>(null)
   const [isUploading, setUploading] = React.useState(false)
   const [message, setMessage] = React.useState<string | null>(null)
@@ -564,12 +573,14 @@ export function ProjectDailyLogWorkspace({
     setUploadingLogId(log.id)
     setUploadFiles([])
     setUploadCaption("")
+    setUploadPhase(NO_PHASE_VALUE)
   }
 
   function cancelUploadingFiles(): void {
     setUploadingLogId(null)
     setUploadFiles([])
     setUploadCaption("")
+    setUploadPhase(NO_PHASE_VALUE)
     setUploadMessage(null)
   }
 
@@ -607,6 +618,7 @@ export function ProjectDailyLogWorkspace({
       formData.set("caption", uploadCaption)
       formData.set("capturedDate", log.logDate)
       formData.set("photoKind", "progress")
+      formData.set("schedulePhase", uploadPhase)
 
       const response = await fetch(
         `/api/projects/${workspace.project.id}/photos/upload`,
@@ -634,6 +646,7 @@ export function ProjectDailyLogWorkspace({
         )
         setUploadFiles([])
         setUploadCaption("")
+        setUploadPhase(NO_PHASE_VALUE)
         router.refresh()
         return
       }
@@ -1208,7 +1221,7 @@ export function ProjectDailyLogWorkspace({
                     </Button>
                   </div>
 
-                  <div className="mt-3 grid gap-3 lg:grid-cols-[1fr_1fr_auto]">
+                  <div className="mt-3 grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)_minmax(0,0.7fr)_auto]">
                     <div className="grid gap-1.5">
                       <Label htmlFor={`daily-log-files-${log.id}`}>
                         Photos / documents
@@ -1247,6 +1260,24 @@ export function ProjectDailyLogWorkspace({
                         }
                         placeholder="Optional shared note for selected files"
                       />
+                    </div>
+                    <div className="grid gap-1.5">
+                      <Label htmlFor={`daily-log-file-phase-${log.id}`}>
+                        Phase for this batch
+                      </Label>
+                      <Select value={uploadPhase} onValueChange={setUploadPhase}>
+                        <SelectTrigger id={`daily-log-file-phase-${log.id}`}>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={NO_PHASE_VALUE}>No phase</SelectItem>
+                          {workspace.schedulePhases.map((phase) => (
+                            <SelectItem key={phase} value={phase}>
+                              {phase}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                     </div>
                     <div className="flex items-end">
                       <Button

--- a/src/components/projects/project-photo-review.tsx
+++ b/src/components/projects/project-photo-review.tsx
@@ -65,6 +65,11 @@ type VisibilityFilter =
 type PhotoSort = "newest" | "oldest" | "phase_newest" | "phase_oldest"
 
 const MAX_UPLOAD_FILE_BYTES = 50 * 1024 * 1024
+const NO_PHASE_VALUE = "unassigned"
+
+function phaseLabel(value: string): string {
+  return value.length > 0 ? value : "No phase"
+}
 
 function statusLabel(value: string): string {
   return value
@@ -279,7 +284,7 @@ export function ProjectPhotoReview({
   const [uploadCaption, setUploadCaption] = React.useState("")
   const [uploadCapturedDate, setUploadCapturedDate] = React.useState("")
   const [uploadPhotoKind, setUploadPhotoKind] = React.useState("progress")
-  const [uploadPhase, setUploadPhase] = React.useState("all")
+  const [uploadPhase, setUploadPhase] = React.useState(NO_PHASE_VALUE)
   const [uploadMessage, setUploadMessage] = React.useState<string | null>(null)
   const [uploading, setUploading] = React.useState(false)
   const [isPending, startTransition] = React.useTransition()
@@ -293,7 +298,10 @@ export function ProjectPhotoReview({
     const filtered = photos.filter(
       (photo) =>
         (dateFilter.length === 0 || photo.photoDate === dateFilter) &&
-        (phaseFilter === "all" || photo.schedulePhase === phaseFilter) &&
+        (phaseFilter === "all" ||
+          (phaseFilter === NO_PHASE_VALUE
+            ? photo.schedulePhase.length === 0
+            : photo.schedulePhase === phaseFilter)) &&
         matchesVisibility(photo, visibilityFilter)
     )
 
@@ -357,7 +365,7 @@ export function ProjectPhotoReview({
     setUploadCaption("")
     setUploadCapturedDate(currentDateInputValue())
     setUploadPhotoKind("progress")
-    setUploadPhase("all")
+    setUploadPhase(NO_PHASE_VALUE)
   }
 
   function openUploadSheet(): void {
@@ -465,14 +473,21 @@ export function ProjectPhotoReview({
               ? {
                   ...photo,
                   schedulePhase: result.phase,
-                  schedulePhaseConfidence: 100,
+                  schedulePhaseConfidence:
+                    result.phase.length > 0 ? 100 : 0,
                   schedulePhaseReason:
-                    "Phase was manually assigned during photo review.",
+                    result.phase.length > 0
+                      ? "Phase was selected during upload or review."
+                      : "No phase assigned.",
                 }
               : photo
           )
         )
-        setMessage(`Updated phase to ${result.phase}.`)
+        setMessage(
+          result.phase.length > 0
+            ? `Updated phase to ${result.phase}.`
+            : "Cleared the phase."
+        )
       } else {
         setMessage(result.error)
       }
@@ -671,17 +686,18 @@ export function ProjectPhotoReview({
               </label>
               <label className="w-full space-y-1 text-sm sm:w-60">
                 <span className="text-xs font-medium uppercase text-muted-foreground">
-                  Suggested phase
+                  Phase
                 </span>
                 <Select
                   value={phaseFilter}
                   onValueChange={setPhaseFilter}
                 >
-                  <SelectTrigger aria-label="Suggested phase" className="w-full">
+                  <SelectTrigger aria-label="Phase" className="w-full">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="all">All phases</SelectItem>
+                    <SelectItem value={NO_PHASE_VALUE}>No phase</SelectItem>
                     {library.phases.map((phase) => (
                       <SelectItem key={phase.value} value={phase.value}>
                         {phase.label} ({phase.count})
@@ -881,7 +897,7 @@ export function ProjectPhotoReview({
                       {photo.photoDate}
                     </span>
                     <span className="absolute bottom-2 left-2 max-w-[calc(100%-1rem)] rounded bg-background/90 px-2 py-0.5 text-xs font-medium">
-                      {photo.schedulePhase} · {photo.schedulePhaseConfidence}%
+                      {phaseLabel(photo.schedulePhase)}
                     </span>
                   </div>
                   <div className="space-y-2 p-2">
@@ -934,7 +950,7 @@ export function ProjectPhotoReview({
                   <label className="flex min-w-0 items-center justify-between gap-2 text-xs text-muted-foreground">
                     <span className="shrink-0">Phase</span>
                     <Select
-                      value={photo.schedulePhase}
+                      value={photo.schedulePhase || NO_PHASE_VALUE}
                       onValueChange={(value) => changePhotoPhase(photo.id, value)}
                       disabled={isPending}
                     >
@@ -946,6 +962,7 @@ export function ProjectPhotoReview({
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
+                        <SelectItem value={NO_PHASE_VALUE}>No phase</SelectItem>
                         {library.phases.map((phase) => (
                           <SelectItem key={phase.value} value={phase.value}>
                             {phase.label}
@@ -1005,8 +1022,7 @@ export function ProjectPhotoReview({
                         {previewPhoto.caption ?? previewPhoto.fileName}
                       </DialogTitle>
                       <DialogDescription>
-                        {previewPhoto.photoDate} · {previewPhoto.schedulePhase} ·{" "}
-                        {previewPhoto.schedulePhaseConfidence}% match ·{" "}
+                        {previewPhoto.photoDate} · {phaseLabel(previewPhoto.schedulePhase)} ·{" "}
                         {statusLabel(previewPhoto.reviewStatus)}
                       </DialogDescription>
                     </DialogHeader>
@@ -1041,7 +1057,7 @@ export function ProjectPhotoReview({
                               {kindLabel(previewPhoto.photoKind)}
                             </Badge>
                             <Badge variant="secondary">
-                              Phase suggestion: {previewPhoto.schedulePhase}
+                              Phase: {phaseLabel(previewPhoto.schedulePhase)}
                             </Badge>
                             {isInternalOnly(previewPhoto) && (
                               <Badge variant="secondary">Internal</Badge>
@@ -1056,9 +1072,11 @@ export function ProjectPhotoReview({
                               <Badge variant="secondary">Public</Badge>
                             )}
                           </div>
-                          <p className="mt-2 max-w-2xl text-xs text-muted-foreground">
-                            {previewPhoto.schedulePhaseReason}
-                          </p>
+                          {previewPhoto.schedulePhase.length > 0 && (
+                            <p className="mt-2 max-w-2xl text-xs text-muted-foreground">
+                              {previewPhoto.schedulePhaseReason}
+                            </p>
+                          )}
                         </div>
                         <Button
                           type="button"
@@ -1183,7 +1201,7 @@ export function ProjectPhotoReview({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">Suggest phase</SelectItem>
+                    <SelectItem value={NO_PHASE_VALUE}>No phase</SelectItem>
                     {library.phases.map((phase) => (
                       <SelectItem key={phase.value} value={phase.value}>
                         {phase.label}


### PR DESCRIPTION
## Summary
- route daily log file uploads through the configured Compass Drive identity when a staff member has no Workspace identity
- allow a batch phase to be selected before uploads begin
- retain unassigned photos as blank rather than inferring an incorrect phase

## Verification
- `bunx tsc --noEmit --pretty false`
- `bun run build`