### PR TITLE
fix(projects): stabilize uploads and daily log links

### DIFF
--- a/src/app/api/projects/[id]/photos/upload/route.ts
+++ b/src/app/api/projects/[id]/photos/upload/route.ts
@@ -119,6 +119,20 @@ function isImageMimeType(value: string | null): boolean {
   return value !== null && value.startsWith("image/")
 }
 
+function uploadErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === "string" && error.trim().length > 0) return error
+
+  try {
+    const serialized = JSON.stringify(error)
+    return serialized === undefined || serialized === "{}"
+      ? "Unable to upload files."
+      : serialized
+  } catch {
+    return "Unable to upload files."
+  }
+}
+
 function driveFolderIdFromUrl(value: string | null): string | null {
   if (!value) return null
 
@@ -411,11 +425,11 @@ export async function POST(
       uploadedCount: files.length,
     })
   } catch (error) {
+    console.error("Daily-log file upload failed", error)
     return NextResponse.json(
       {
         success: false,
-        error:
-          error instanceof Error ? error.message : "Unable to upload files.",
+        error: uploadErrorMessage(error),
       },
       { status: 500 }
     )

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -64,6 +64,7 @@ export function NavUser({
 }): React.ReactElement | null {
   const { isMobile } = useSidebar()
   const [accountOpen, setAccountOpen] = React.useState(false)
+  const [isLoggingOut, startLogoutTransition] = React.useTransition()
   const {
     isMuted,
     isDeafened,
@@ -83,8 +84,10 @@ export function NavUser({
 
   const initials = getInitials(user.name)
 
-  async function handleLogout(): Promise<void> {
-    await logout()
+  function handleLogout(): void {
+    startLogoutTransition(async () => {
+      await logout()
+    })
   }
 
   return (
@@ -204,7 +207,7 @@ export function NavUser({
               </DropdownMenuItem>
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={handleLogout}>
+            <DropdownMenuItem disabled={isLoggingOut} onSelect={handleLogout}>
               <IconLogout />
               Log out
             </DropdownMenuItem>

--- a/src/components/projects/active-project-section-redirect.tsx
+++ b/src/components/projects/active-project-section-redirect.tsx
@@ -19,10 +19,9 @@ export function ActiveProjectSectionRedirect({
   readonly label: string
 }): React.ReactElement | null {
   const router = useRouter()
-  const { activeProjectId, activeProject, activeProjectReady } =
-    useActiveProject()
-  const href = activeProjectId
-    ? sectionHref(activeProjectId, targetSection)
+  const { activeProject, activeProjectReady } = useActiveProject()
+  const href = activeProject
+    ? sectionHref(activeProject.id, targetSection)
     : null
 
   React.useEffect(() => {

--- a/src/components/projects/project-daily-log-workspace.tsx
+++ b/src/components/projects/project-daily-log-workspace.tsx
@@ -627,7 +627,13 @@ export function ProjectDailyLogWorkspace({
           body: formData,
         }
       )
-      const result: unknown = await response.json()
+      const responseText = await response.text()
+      let result: unknown = null
+      try {
+        result = JSON.parse(responseText)
+      } catch {
+        // A platform-level upload rejection can return a non-JSON response.
+      }
 
       if (
         typeof result === "object" &&
@@ -657,7 +663,9 @@ export function ProjectDailyLogWorkspace({
         "error" in result &&
         typeof result.error === "string"
           ? result.error
-          : "Unable to upload files."
+          : responseText.trim().length > 0
+            ? `Upload failed (${response.status}): ${responseText.trim()}`
+            : `Upload failed (${response.status}).`
       setUploadMessage(error)
     } catch {
       setUploadMessage("Unable to upload files.")

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -43,12 +43,15 @@ export function SiteHeader({
   const searchInputRef = React.useRef<HTMLInputElement>(null)
   const agentContext = useAgentOptional()
   const [accountOpen, setAccountOpen] = React.useState(false)
+  const [isLoggingOut, startLogoutTransition] = React.useTransition()
   const { toggleSidebar } = useSidebar()
 
   const initials = user ? getInitials(user.name) : "?"
 
-  async function handleLogout() {
-    await logout()
+  function handleLogout(): void {
+    startLogoutTransition(async () => {
+      await logout()
+    })
   }
 
   return (
@@ -116,7 +119,7 @@ export function SiteHeader({
                 <span>Toggle theme</span>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onSelect={handleLogout}>
+              <DropdownMenuItem disabled={isLoggingOut} onSelect={handleLogout}>
                 <IconLogout />
                 Log out
               </DropdownMenuItem>
@@ -202,7 +205,7 @@ export function SiteHeader({
                 Account
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onSelect={handleLogout}>
+              <DropdownMenuItem disabled={isLoggingOut} onSelect={handleLogout}>
                 <IconLogout />
                 Log out
               </DropdownMenuItem>

--- a/src/lib/google/client/drive-client.ts
+++ b/src/lib/google/client/drive-client.ts
@@ -284,7 +284,6 @@ export class DriveClient {
       method: "PUT",
       headers: {
         "Content-Type": options.mimeType,
-        "Content-Length": String(options.data.size),
       },
       body: options.data,
     })


### PR DESCRIPTION
## Summary

- remove the multipart `Content-Length` header that Cloudflare can reject during Drive uploads
- preserve platform-level upload errors so the UI reports the real failure
- route active daily-log views using the current project id, preventing stale-id 404s
- run logout through a React transition and disable the action while it is pending

## Verification

- focused ESLint passed
- `bunx tsc --noEmit` passed
- `bun run build` passed through the repository pre-push gate
