### PR TITLE
feat(schedule): separate schedule items from to-dos

### DIFF
--- a/src/app/actions/project-field.ts
+++ b/src/app/actions/project-field.ts
@@ -9,6 +9,7 @@ import {
   dailyLogTaskLinks,
   ownerProjectUpdates,
   projectExternalLinks,
+  projectOperations,
   scheduleTasks,
   projects,
   users,
@@ -115,13 +116,23 @@ export type ProjectDailyLogPhoto = {
   readonly publicShareable: boolean
 }
 
-export type ProjectDailyLogTask = {
+export type ProjectDailyLogScheduleItem = {
   readonly id: string
   readonly title: string
   readonly startDate: string
   readonly endDate: string
   readonly status: string
   readonly notes: string | null
+}
+
+export type ProjectDailyLogTodo = {
+  readonly id: string
+  readonly title: string
+  readonly status: string
+  readonly priority: string
+  readonly assigneeName: string | null
+  readonly companyName: string | null
+  readonly dueDate: string | null
 }
 
 export type ProjectDailyLogItem = {
@@ -146,7 +157,8 @@ export type ProjectDailyLogItem = {
   readonly syncStatus: string
   readonly authorName: string | null
   readonly photos: readonly ProjectDailyLogPhoto[]
-  readonly tasks: readonly ProjectDailyLogTask[]
+  readonly scheduleItems: readonly ProjectDailyLogScheduleItem[]
+  readonly todos: readonly ProjectDailyLogTodo[]
 }
 
 export type ProjectDailyLogWorkspace = {
@@ -1101,6 +1113,35 @@ export async function getProjectDailyLogWorkspace(
           .where(inArray(dailyLogTaskLinks.dailyLogId, logIds))
           .orderBy(asc(scheduleTasks.startDate), asc(scheduleTasks.sortOrder))
 
+  const todoRows =
+    logIds.length === 0
+      ? []
+      : await db
+          .select({
+            sourceRecordId: projectOperations.sourceRecordId,
+            id: projectOperations.id,
+            title: projectOperations.title,
+            status: projectOperations.status,
+            priority: projectOperations.priority,
+            assigneeName: projectOperations.assigneeName,
+            companyName: projectOperations.companyName,
+            dueDate: projectOperations.dueDate,
+          })
+          .from(projectOperations)
+          .where(
+            and(
+              eq(projectOperations.projectId, projectId),
+              inArray(projectOperations.sourceRecordId, logIds),
+              inArray(projectOperations.sourceRecordType, [
+                "staff_task",
+                "subcontractor_task",
+                "supplier_task",
+                "schedule_task",
+              ])
+            )
+          )
+          .orderBy(asc(projectOperations.dueDate), asc(projectOperations.title))
+
   const photosByLogId = new Map<string, ProjectDailyLogPhoto[]>()
   const unattachedPhotos: ProjectDailyLogPhoto[] = []
 
@@ -1130,10 +1171,13 @@ export async function getProjectDailyLogWorkspace(
     }
   }
 
-  const tasksByLogId = new Map<string, ProjectDailyLogTask[]>()
+  const scheduleItemsByLogId = new Map<
+    string,
+    ProjectDailyLogScheduleItem[]
+  >()
   for (const row of taskRows) {
-    tasksByLogId.set(row.dailyLogId, [
-      ...(tasksByLogId.get(row.dailyLogId) ?? []),
+    scheduleItemsByLogId.set(row.dailyLogId, [
+      ...(scheduleItemsByLogId.get(row.dailyLogId) ?? []),
       {
         id: row.id,
         title: row.title,
@@ -1141,6 +1185,24 @@ export async function getProjectDailyLogWorkspace(
         endDate: row.endDate,
         status: row.status,
         notes: row.notes,
+      },
+    ])
+  }
+
+  const todosByLogId = new Map<string, ProjectDailyLogTodo[]>()
+  for (const row of todoRows) {
+    if (!row.sourceRecordId) continue
+
+    todosByLogId.set(row.sourceRecordId, [
+      ...(todosByLogId.get(row.sourceRecordId) ?? []),
+      {
+        id: row.id,
+        title: row.title,
+        status: row.status,
+        priority: row.priority,
+        assigneeName: row.assigneeName,
+        companyName: row.companyName,
+        dueDate: row.dueDate,
       },
     ])
   }
@@ -1178,7 +1240,8 @@ export async function getProjectDailyLogWorkspace(
         email: row.authorEmail,
       }),
       photos: photosByLogId.get(row.id) ?? [],
-      tasks: tasksByLogId.get(row.id) ?? [],
+      scheduleItems: scheduleItemsByLogId.get(row.id) ?? [],
+      todos: todosByLogId.get(row.id) ?? [],
     })),
     unattachedPhotos,
     schedulePhases,

--- a/src/app/actions/project-operations.ts
+++ b/src/app/actions/project-operations.ts
@@ -1274,6 +1274,8 @@ export async function queueProjectOperationForSageSync(
 
     revalidatePath(`/dashboard/projects/${projectId}`)
     revalidatePath(`/dashboard/projects/${projectId}/purchase-orders`)
+    revalidatePath(`/dashboard/projects/${projectId}/daily-logs`)
+    revalidatePath(`/dashboard/projects/${projectId}/schedule`)
     revalidatePath("/dashboard")
     return { success: true, updatedCount: 1 }
   } catch (error) {

--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -166,7 +166,7 @@ export async function createTask(
     return { success: true }
   } catch (error) {
     console.error("Failed to create task:", error)
-    return { success: false, error: "Failed to create task" }
+    return { success: false, error: "Failed to create schedule item" }
   }
 }
 
@@ -200,7 +200,7 @@ export async function updateTask(
       .where(eq(scheduleTasks.id, taskId))
       .limit(1)
 
-    if (!task) return { success: false, error: "Task not found" }
+    if (!task) return { success: false, error: "Schedule item not found" }
 
     // verify project belongs to user's org
     const [project] = await db
@@ -273,7 +273,7 @@ export async function updateTask(
     return { success: true }
   } catch (error) {
     console.error("Failed to update task:", error)
-    return { success: false, error: "Failed to update task" }
+    return { success: false, error: "Failed to update schedule item" }
   }
 }
 
@@ -296,7 +296,7 @@ export async function deleteTask(
       .where(eq(scheduleTasks.id, taskId))
       .limit(1)
 
-    if (!task) return { success: false, error: "Task not found" }
+    if (!task) return { success: false, error: "Schedule item not found" }
 
     // verify project belongs to user's org
     const [project] = await db
@@ -315,7 +315,7 @@ export async function deleteTask(
     return { success: true }
   } catch (error) {
     console.error("Failed to delete task:", error)
-    return { success: false, error: "Failed to delete task" }
+    return { success: false, error: "Failed to delete schedule item" }
   }
 }
 
@@ -355,7 +355,7 @@ export async function reorderTasks(
     return { success: true }
   } catch (error) {
     console.error("Failed to reorder tasks:", error)
-    return { success: false, error: "Failed to reorder tasks" }
+    return { success: false, error: "Failed to reorder schedule items" }
   }
 }
 
@@ -486,7 +486,7 @@ export async function updateTaskStatus(
       .where(eq(scheduleTasks.id, taskId))
       .limit(1)
 
-    if (!task) return { success: false, error: "Task not found" }
+    if (!task) return { success: false, error: "Schedule item not found" }
 
     // verify project belongs to user's org
     const [project] = await db

--- a/src/app/actions/work-calendar.ts
+++ b/src/app/actions/work-calendar.ts
@@ -79,6 +79,12 @@ function operationKind(recordType: string): WorkCalendarEntryKind {
 }
 
 function operationSourceLabel(recordType: string, recordNumber: string | null): string {
+  if (recordType === "schedule_task") {
+    return recordNumber
+      ? `Schedule item follow-up ${recordNumber}`
+      : "Schedule item follow-up"
+  }
+
   const label = recordType
     .split("_")
     .filter(Boolean)

--- a/src/app/dashboard/projects/[id]/daily-logs/page.tsx
+++ b/src/app/dashboard/projects/[id]/daily-logs/page.tsx
@@ -4,6 +4,10 @@ import type * as React from "react"
 import { notFound } from "next/navigation"
 
 import { getProjectDailyLogWorkspace } from "@/app/actions/project-field"
+import {
+  getProjectTaskAssigneeOptions,
+  type ProjectTaskAssigneeOption,
+} from "@/app/actions/project-contacts"
 import { ProjectDailyLogWorkspace } from "@/components/projects/project-daily-log-workspace"
 
 function hasDigest(error: unknown): error is { readonly digest: string } {
@@ -17,6 +21,7 @@ export default async function ProjectDailyLogsPage({
 }): Promise<React.ReactElement> {
   const { id } = await params
   let workspace: Awaited<ReturnType<typeof getProjectDailyLogWorkspace>>
+  let assigneeOptions: ProjectTaskAssigneeOption[] = []
 
   try {
     workspace = await getProjectDailyLogWorkspace(id)
@@ -25,5 +30,20 @@ export default async function ProjectDailyLogsPage({
     notFound()
   }
 
-  return <ProjectDailyLogWorkspace workspace={workspace} />
+  try {
+    const assigneeData = await getProjectTaskAssigneeOptions(id)
+    assigneeOptions = [
+      ...assigneeData.projectContacts,
+      ...assigneeData.directoryContacts,
+    ]
+  } catch (error) {
+    console.warn("Unable to load daily-log assignee options", error)
+  }
+
+  return (
+    <ProjectDailyLogWorkspace
+      workspace={workspace}
+      assigneeOptions={assigneeOptions}
+    />
+  )
 }

--- a/src/app/dashboard/projects/[id]/schedule/page.tsx
+++ b/src/app/dashboard/projects/[id]/schedule/page.tsx
@@ -8,6 +8,10 @@ import { notFound } from "next/navigation"
 import { getSchedule } from "@/app/actions/schedule"
 import { getBaselines } from "@/app/actions/baselines"
 import { getProjects, type ProjectListItem } from "@/app/actions/projects"
+import {
+  getProjectTaskAssigneeOptions,
+  type ProjectTaskAssigneeOption,
+} from "@/app/actions/project-contacts"
 import { ScheduleView } from "@/components/schedule/schedule-view"
 import type { ScheduleData, ScheduleBaselineData } from "@/lib/schedule/types"
 
@@ -28,6 +32,7 @@ export default async function SchedulePage({
   let schedule: ScheduleData = emptySchedule
   let baselines: ScheduleBaselineData[] = []
   let allProjects: ProjectListItem[] = []
+  let assigneeOptions: ProjectTaskAssigneeOption[] = []
 
   try {
     const { env } = await getCloudflareContext()
@@ -53,6 +58,16 @@ export default async function SchedulePage({
     console.warn("D1 unavailable in dev mode, using empty data")
   }
 
+  try {
+    const assigneeData = await getProjectTaskAssigneeOptions(id)
+    assigneeOptions = [
+      ...assigneeData.projectContacts,
+      ...assigneeData.directoryContacts,
+    ]
+  } catch (error) {
+    console.warn("Unable to load schedule assignee options", error)
+  }
+
   return (
     <div className="px-4 py-2 flex flex-col flex-1 min-h-0">
       <ScheduleView
@@ -61,6 +76,7 @@ export default async function SchedulePage({
         initialData={schedule}
         baselines={baselines}
         allProjects={allProjects}
+        assigneeOptions={assigneeOptions}
       />
     </div>
   )

--- a/src/components/projects/project-assignee-picker.tsx
+++ b/src/components/projects/project-assignee-picker.tsx
@@ -1,0 +1,221 @@
+"use client"
+
+import * as React from "react"
+import {
+  IconCheck,
+  IconChevronDown,
+  IconUserPlus,
+} from "@tabler/icons-react"
+
+import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+
+type ProjectAssigneePickerProps = {
+  readonly value: string
+  readonly options: readonly ProjectTaskAssigneeOption[]
+  readonly onValueChange: (
+    value: string,
+    option: ProjectTaskAssigneeOption | null
+  ) => void
+  readonly placeholder?: string
+  readonly className?: string
+}
+
+function normalizeChoice(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+}
+
+function optionMatches(
+  option: ProjectTaskAssigneeOption,
+  normalizedQuery: string
+): boolean {
+  if (!normalizedQuery) return true
+
+  return normalizeChoice(
+    [
+      option.name,
+      option.label,
+      option.companyName,
+      option.email,
+      option.contactType,
+    ]
+      .filter((value): value is string => Boolean(value))
+      .join(" ")
+  ).includes(normalizedQuery)
+}
+
+function AssigneeOption({
+  option,
+  selected,
+  onSelect,
+}: {
+  readonly option: ProjectTaskAssigneeOption
+  readonly selected: boolean
+  readonly onSelect: () => void
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="flex w-full items-start justify-between gap-3 rounded-md px-2 py-2 text-left text-sm hover:bg-accent"
+    >
+      <span className="min-w-0">
+        <span className="block truncate font-medium">{option.name}</span>
+        <span className="block truncate text-xs text-muted-foreground">
+          {option.source === "directory"
+            ? `${option.companyName ?? option.contactType} · Directory`
+            : option.companyName ?? option.contactType}
+        </span>
+      </span>
+      {selected && <IconCheck className="mt-0.5 size-4 shrink-0" />}
+    </button>
+  )
+}
+
+export function ProjectAssigneePicker({
+  value,
+  options,
+  onValueChange,
+  placeholder = "Choose contact or type a name...",
+  className,
+}: ProjectAssigneePickerProps): React.ReactElement {
+  const [open, setOpen] = React.useState(false)
+  const [query, setQuery] = React.useState("")
+  const normalizedQuery = normalizeChoice(query)
+  const normalizedValue = normalizeChoice(value)
+  const selectedOption =
+    options.find(
+      (option) =>
+        normalizeChoice(option.name) === normalizedValue ||
+        normalizeChoice(option.label) === normalizedValue
+    ) ?? null
+  const projectOptions = options.filter(
+    (option) =>
+      option.source === "project" && optionMatches(option, normalizedQuery)
+  )
+  const directoryOptions = options.filter(
+    (option) =>
+      option.source === "directory" && optionMatches(option, normalizedQuery)
+  )
+
+  function selectOption(option: ProjectTaskAssigneeOption): void {
+    onValueChange(option.name, option)
+    setQuery("")
+    setOpen(false)
+  }
+
+  function useTypedName(): void {
+    const typedName = query.trim()
+    if (!typedName) return
+
+    onValueChange(typedName, null)
+    setQuery("")
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          className={cn(
+            "h-9 w-full justify-between bg-background px-3 text-left font-normal",
+            !value && "text-muted-foreground",
+            className
+          )}
+        >
+          <span className="min-w-0 truncate">{value || placeholder}</span>
+          <IconChevronDown className="size-4 shrink-0 opacity-60" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[min(28rem,calc(100vw-3rem))] p-0"
+      >
+        <div className="border-b p-3">
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search contacts or type a name..."
+            autoFocus
+          />
+        </div>
+        <div className="max-h-72 overflow-y-auto p-2">
+          {projectOptions.length > 0 && (
+            <div className="space-y-1">
+              <p className="px-2 py-1 text-xs font-medium text-muted-foreground">
+                Project contacts
+              </p>
+              {projectOptions.map((option) => (
+                <AssigneeOption
+                  key={option.id}
+                  option={option}
+                  selected={selectedOption?.id === option.id}
+                  onSelect={() => selectOption(option)}
+                />
+              ))}
+            </div>
+          )}
+
+          {directoryOptions.length > 0 && (
+            <div className="mt-2 space-y-1 border-t pt-2">
+              <p className="px-2 py-1 text-xs font-medium text-muted-foreground">
+                Directory contacts
+              </p>
+              {directoryOptions.map((option) => (
+                <AssigneeOption
+                  key={option.id}
+                  option={option}
+                  selected={selectedOption?.id === option.id}
+                  onSelect={() => selectOption(option)}
+                />
+              ))}
+            </div>
+          )}
+
+          {projectOptions.length === 0 && directoryOptions.length === 0 && (
+            <p className="px-2 py-3 text-sm text-muted-foreground">
+              No matching contacts.
+            </p>
+          )}
+        </div>
+        <div className="flex items-center justify-between gap-2 border-t p-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              onValueChange("", null)
+              setQuery("")
+              setOpen(false)
+            }}
+          >
+            Clear
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={!query.trim()}
+            onClick={useTypedName}
+          >
+            <IconUserPlus className="size-4" />
+            Use typed name
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/projects/project-daily-log-workspace.tsx
+++ b/src/components/projects/project-daily-log-workspace.tsx
@@ -30,6 +30,7 @@ import {
   type ProjectDailyLogPhoto,
   type ProjectDailyLogWorkspace as ProjectDailyLogWorkspaceData,
 } from "@/app/actions/project-field"
+import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -43,6 +44,7 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import { ProjectContextSwitcher } from "@/components/projects/project-context-switcher"
+import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
 import {
   photoLinkHref,
   resolvePhotoImageSource,
@@ -190,6 +192,14 @@ function readableField(value: string | null): string | null {
   } catch {
     return value
   }
+}
+
+function dailyLogTodoDescription(log: ProjectDailyLogItem): string {
+  return (
+    [log.issues, log.safetyIncidents, log.notes]
+      .filter((value): value is string => Boolean(value?.trim()))
+      .join("\n\n") || log.workCompleted
+  )
 }
 
 function filterValue(value: string): LogFilter {
@@ -492,8 +502,10 @@ function PhotoStrip({
 
 export function ProjectDailyLogWorkspace({
   workspace,
+  assigneeOptions,
 }: {
   readonly workspace: ProjectDailyLogWorkspaceData
+  readonly assigneeOptions: readonly ProjectTaskAssigneeOption[]
 }): React.ReactElement {
   const router = useRouter()
   const [logs, setLogs] =
@@ -1053,7 +1065,11 @@ export function ProjectDailyLogWorkspace({
 
         <div className="grid grid-cols-1 gap-3">
           {filteredLogs.map((log) => (
-            <section key={log.id} className="rounded-lg border p-3 sm:p-4">
+            <section
+              key={log.id}
+              id={`daily-log-${log.id}`}
+              className="rounded-lg border p-3 sm:p-4"
+            >
               {(() => {
                 const crewPresent = readableField(log.crewPresent)
                 const materialsUsed = readableField(log.materialsUsed)
@@ -1115,6 +1131,24 @@ export function ProjectDailyLogWorkspace({
                 </div>
 
                 <div className="flex flex-wrap gap-2">
+                  <ProjectTaskCreateButton
+                    projectId={workspace.project.id}
+                    sourceLabel="Daily log"
+                    sourceRecordId={log.id}
+                    sourceRecordNumber={
+                      log.sourceExternalId ?? formatDate(log.logDate)
+                    }
+                    sourceHref={`/dashboard/projects/${workspace.project.id}/daily-logs#daily-log-${log.id}`}
+                    defaultTitle={`Follow up from ${formatDate(log.logDate)}`}
+                    defaultDescription={dailyLogTodoDescription(log)}
+                    defaultAssigneeName={null}
+                    defaultCompanyName={null}
+                    defaultDueDate={null}
+                    defaultPriority={
+                      log.issues || log.safetyIncidents ? "high" : "normal"
+                    }
+                    assigneeOptions={assigneeOptions}
+                  />
                   <Button
                     variant={editingLogId === log.id ? "secondary" : "outline"}
                     size="sm"
@@ -1354,24 +1388,49 @@ export function ProjectDailyLogWorkspace({
                 </div>
               )}
 
-              {log.tasks.length > 0 && (
+              {log.todos.length > 0 && (
+                <div className="mt-3 rounded-md border bg-muted/20 p-3">
+                  <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase text-muted-foreground">
+                    <IconClipboardText className="size-3.5" />
+                    To-dos
+                  </div>
+                  <div className="grid gap-2 md:grid-cols-2">
+                    {log.todos.map((todo) => (
+                      <div key={todo.id} className="rounded-md bg-background p-2">
+                        <p className="text-sm font-medium">{todo.title}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {statusLabel(todo.status)}
+                          {todo.dueDate
+                            ? ` · Due ${formatDate(todo.dueDate)}`
+                            : ""}
+                          {todo.assigneeName || todo.companyName
+                            ? ` · ${todo.assigneeName ?? todo.companyName}`
+                            : ""}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {log.scheduleItems.length > 0 && (
                 <div className="mt-3 rounded-md border bg-muted/20 p-3">
                   <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase text-muted-foreground">
                     <IconCalendarStats className="size-3.5" />
                     Schedule links
                   </div>
                   <div className="grid gap-2 md:grid-cols-2">
-                    {log.tasks.map((task) => (
-                      <div key={task.id} className="rounded-md bg-background p-2">
-                        <p className="text-sm font-medium">{task.title}</p>
+                    {log.scheduleItems.map((item) => (
+                      <div key={item.id} className="rounded-md bg-background p-2">
+                        <p className="text-sm font-medium">{item.title}</p>
                         <p className="mt-1 text-xs text-muted-foreground">
-                          {formatDate(task.startDate)} - {formatDate(task.endDate)}
+                          {formatDate(item.startDate)} - {formatDate(item.endDate)}
                           {" · "}
-                          {statusLabel(task.status)}
+                          {statusLabel(item.status)}
                         </p>
-                        {task.notes && (
+                        {item.notes && (
                           <p className="mt-1 text-xs text-muted-foreground">
-                            {task.notes}
+                            {item.notes}
                           </p>
                         )}
                       </div>

--- a/src/components/projects/project-task-create-button.tsx
+++ b/src/components/projects/project-task-create-button.tsx
@@ -57,6 +57,7 @@ type ProjectTaskCreateButtonProps = {
   readonly defaultPriority: string
   readonly defaultTaskType?: ProjectTaskRecordType
   readonly assigneeOptions?: readonly ProjectTaskAssigneeOption[]
+  readonly compact?: boolean
 }
 
 function cleanValue(value: string): string | null {
@@ -122,6 +123,7 @@ export function ProjectTaskCreateButton({
   defaultPriority,
   defaultTaskType = "staff_task",
   assigneeOptions = [],
+  compact = false,
 }: ProjectTaskCreateButtonProps): React.ReactElement {
   const router = useRouter()
   const [open, setOpen] = React.useState(false)
@@ -232,7 +234,7 @@ export function ProjectTaskCreateButton({
 
     setStatus({
       kind: "saved",
-      message: "Task created and added to the project work queue.",
+      message: "To-do created and added to the project work queue.",
     })
     router.refresh()
   }
@@ -267,23 +269,33 @@ export function ProjectTaskCreateButton({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button type="button" variant="outline" size="sm">
+        <Button
+          type="button"
+          variant={compact ? "ghost" : "outline"}
+          size={compact ? "icon" : "sm"}
+          className={compact ? "size-7" : undefined}
+          title={compact ? "Create linked to-do" : undefined}
+        >
           <IconListCheck className="size-4" />
-          Task
+          {compact ? (
+            <span className="sr-only">Create linked to-do</span>
+          ) : (
+            "To-do"
+          )}
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-2xl">
         <form onSubmit={submitTask} className="space-y-5">
           <DialogHeader>
-            <DialogTitle>Create task</DialogTitle>
+            <DialogTitle>Create to-do</DialogTitle>
             <DialogDescription>
-              Add a to-do from this {sourceLabel.toLowerCase()}.
+              Add an assignable to-do from this {sourceLabel.toLowerCase()}.
             </DialogDescription>
           </DialogHeader>
 
           <div className="space-y-2">
             <Label htmlFor={`task-title-${sourceRecordId ?? sourceLabel}`}>
-              Task
+              To-do
             </Label>
             <Input
               id={`task-title-${sourceRecordId ?? sourceLabel}`}
@@ -314,9 +326,9 @@ export function ProjectTaskCreateButton({
                 }}
                 className="h-10 w-full rounded-md border bg-background px-3 text-sm"
               >
-                <option value="staff_task">Internal staff task</option>
-                <option value="subcontractor_task">Subcontractor task</option>
-                <option value="supplier_task">Supplier task</option>
+                <option value="staff_task">Internal staff to-do</option>
+                <option value="subcontractor_task">Subcontractor to-do</option>
+                <option value="supplier_task">Supplier to-do</option>
                 <option value="schedule_task">Schedule follow-up</option>
               </select>
             </div>
@@ -505,7 +517,7 @@ export function ProjectTaskCreateButton({
                 project yet.
               </p>
               <p className="mt-1 text-amber-900">
-                You can create the task without changing project contacts, or
+                You can create the to-do without changing project contacts, or
                 add this contact to the project first. Portal visibility still
                 needs a separate review.
               </p>
@@ -515,7 +527,7 @@ export function ProjectTaskCreateButton({
             <div className="border-l-2 border-muted-foreground/40 bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
               <p>
                 This assignee is not matched to a contact yet. Compass can save
-                the task label, but notifications need a matched contact.
+                the to-do label, but notifications need a matched contact.
               </p>
             </div>
           )}
@@ -556,8 +568,8 @@ export function ProjectTaskCreateButton({
                 : status.kind === "saved"
                   ? "Created"
                   : directoryAssignee
-                    ? "Assign task only"
-                    : "Create task"}
+                    ? "Assign to-do only"
+                    : "Create to-do"}
             </Button>
           </DialogFooter>
         </form>

--- a/src/components/schedule/dependency-dialog.tsx
+++ b/src/components/schedule/dependency-dialog.tsx
@@ -58,11 +58,11 @@ export function DependencyDialog({
 
   function validate() {
     if (!predecessorId || !successorId) {
-      setError("Select both tasks")
+      setError("Select both schedule items")
       return false
     }
     if (predecessorId === successorId) {
-      setError("A task cannot depend on itself")
+      setError("A schedule item cannot depend on itself")
       return false
     }
     if (wouldCreateCycle(dependencies, predecessorId, successorId)) {
@@ -108,7 +108,7 @@ export function DependencyDialog({
             <Label>Predecessor (must finish first)</Label>
             <Select value={predecessorId} onValueChange={setPredecessorId}>
               <SelectTrigger className="mt-1">
-                <SelectValue placeholder="Select task" />
+                <SelectValue placeholder="Select schedule item" />
               </SelectTrigger>
               <SelectContent>
                 {tasks.map((t) => (
@@ -124,7 +124,7 @@ export function DependencyDialog({
             <Label>Successor (depends on predecessor)</Label>
             <Select value={successorId} onValueChange={setSuccessorId}>
               <SelectTrigger className="mt-1">
-                <SelectValue placeholder="Select task" />
+                <SelectValue placeholder="Select schedule item" />
               </SelectTrigger>
               <SelectContent>
                 {tasks

--- a/src/components/schedule/schedule-baseline-view.tsx
+++ b/src/components/schedule/schedule-baseline-view.tsx
@@ -218,7 +218,7 @@ export function ScheduleBaselineView({
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Task</TableHead>
+                  <TableHead>Schedule Item</TableHead>
                   <TableHead>Baseline Start</TableHead>
                   <TableHead>Baseline End</TableHead>
                   <TableHead>Current Start</TableHead>

--- a/src/components/schedule/schedule-calendar-view.tsx
+++ b/src/components/schedule/schedule-calendar-view.tsx
@@ -27,6 +27,8 @@ import type {
   ScheduleTaskData,
   WorkdayExceptionData,
 } from "@/lib/schedule/types"
+import { useScheduleDisplayPalette } from "@/hooks/use-schedule-display-palette"
+import { getScheduleItemDisplayColor } from "@/lib/schedule/appearance"
 
 interface ScheduleCalendarViewProps {
   readonly projectId: string
@@ -48,14 +50,6 @@ function isExceptionDay(
     const end = parseISO(ex.endDate)
     return isWithinInterval(date, { start, end })
   })
-}
-
-function getTaskColor(task: ScheduleTaskData): string {
-  if (task.status === "COMPLETE") return "bg-green-600/90 dark:bg-green-600/80"
-  if (task.status === "IN_PROGRESS") return "bg-blue-600/90 dark:bg-blue-500/80"
-  if (task.status === "BLOCKED") return "bg-red-600/90 dark:bg-red-500/80"
-  if (task.isCriticalPath) return "bg-orange-600/90 dark:bg-orange-500/80"
-  return "bg-muted-foreground/70"
 }
 
 interface WeekTask {
@@ -179,20 +173,21 @@ function buildWeekRows(
 }
 
 export function ScheduleCalendarView({
+  projectId,
   tasks,
   exceptions,
 }: ScheduleCalendarViewProps) {
   const [currentDate, setCurrentDate] = useState(new Date())
+  const displayColorPalette = useScheduleDisplayPalette(projectId)
 
-  const monthStart = startOfMonth(currentDate)
-  const monthEnd = endOfMonth(currentDate)
-  const calendarStart = startOfWeek(monthStart)
-  const calendarEnd = endOfWeek(monthEnd)
-
-  const calendarDays = useMemo(
-    () => eachDayOfInterval({ start: calendarStart, end: calendarEnd }),
-    [calendarStart.getTime(), calendarEnd.getTime()]
-  )
+  const calendarDays = useMemo(() => {
+    const monthStart = startOfMonth(currentDate)
+    const monthEnd = endOfMonth(currentDate)
+    return eachDayOfInterval({
+      start: startOfWeek(monthStart),
+      end: endOfWeek(monthEnd),
+    })
+  }, [currentDate])
 
   const weekRows = useMemo(
     () => buildWeekRows(calendarDays, tasks),
@@ -303,13 +298,16 @@ export function ScheduleCalendarView({
                       key={`${wt.task.id}-${weekIdx}`}
                       className={cn(
                         "absolute text-[10px] text-white font-medium truncate px-1.5 leading-[20px] cursor-default",
-                        getTaskColor(wt.task),
                         wt.isStart && wt.isEnd && "rounded",
                         wt.isStart && !wt.isEnd && "rounded-l",
                         !wt.isStart && wt.isEnd && "rounded-r",
                         !wt.isStart && !wt.isEnd && "rounded-none",
                       )}
                       style={{
+                        backgroundColor: getScheduleItemDisplayColor(
+                          wt.task,
+                          displayColorPalette
+                        ),
                         top: `${DAY_HEADER_HEIGHT + wt.lane * LANE_HEIGHT}px`,
                         left: `${(wt.startCol / 7) * 100}%`,
                         width: `${(wt.span / 7) * 100}%`,

--- a/src/components/schedule/schedule-gantt-view.tsx
+++ b/src/components/schedule/schedule-gantt-view.tsx
@@ -45,7 +45,7 @@ import {
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { GanttChart } from "./gantt-chart"
-import { TaskFormDialog } from "./task-form-dialog"
+import { ScheduleItemFormDialog } from "./schedule-item-form-dialog"
 import {
   transformToFrappeTasks,
   transformWithPhaseGroups,
@@ -67,6 +67,8 @@ import type {
   ScheduleTaskData,
   TaskDependencyData,
 } from "@/lib/schedule/types"
+import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
+import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { format } from "date-fns"
@@ -82,12 +84,14 @@ interface ScheduleGanttViewProps {
   readonly projectId: string
   readonly tasks: readonly ScheduleTaskData[]
   readonly dependencies: readonly TaskDependencyData[]
+  readonly assigneeOptions: readonly ProjectTaskAssigneeOption[]
 }
 
 export function ScheduleGanttView({
   projectId,
   tasks,
   dependencies,
+  assigneeOptions,
 }: ScheduleGanttViewProps) {
   const router = useRouter()
   const isMobile = useIsMobile()
@@ -311,17 +315,35 @@ export function ScheduleGanttView({
                 {task.workdays}
               </TableCell>
               <TableCell className="py-1.5">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="size-6"
-                  onClick={() => {
-                    setEditingTask(task)
-                    setTaskFormOpen(true)
-                  }}
-                >
-                  <IconPencil className="size-3" />
-                </Button>
+                <div className="flex items-center">
+                  <ProjectTaskCreateButton
+                    compact
+                    projectId={projectId}
+                    sourceLabel="Schedule item"
+                    sourceRecordId={task.id}
+                    sourceRecordNumber={null}
+                    sourceHref={`/dashboard/projects/${projectId}/schedule`}
+                    defaultTitle={`Follow up: ${task.title}`}
+                    defaultDescription={`${task.phase} schedule item.`}
+                    defaultAssigneeName={task.assignedTo}
+                    defaultCompanyName={null}
+                    defaultDueDate={task.endDateCalculated}
+                    defaultPriority={task.isCriticalPath ? "high" : "normal"}
+                    defaultTaskType="schedule_task"
+                    assigneeOptions={assigneeOptions}
+                  />
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-6"
+                    onClick={() => {
+                      setEditingTask(task)
+                      setTaskFormOpen(true)
+                    }}
+                  >
+                    <IconPencil className="size-3" />
+                  </Button>
+                </div>
               </TableCell>
             </TableRow>
           )
@@ -338,7 +360,7 @@ export function ScheduleGanttView({
               }}
             >
               <IconPlus className="size-3 mr-1" />
-              Add Task
+              Add Schedule Item
             </Button>
           </TableCell>
         </TableRow>
@@ -441,7 +463,7 @@ export function ScheduleGanttView({
             Reset personal colors
           </Button>
           <div className="mt-3 border-t pt-2 text-[10px] leading-snug text-muted-foreground">
-            <p>Task bars use their chosen display color; phase is grouping only.</p>
+            <p>Schedule item bars use their chosen display color; phase is grouping only.</p>
             <p className="mt-1">Critical Path View: blue is critical work; gray has float.</p>
           </div>
         </div>
@@ -479,7 +501,7 @@ export function ScheduleGanttView({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="chart">Chart</SelectItem>
-                <SelectItem value="tasks">Tasks</SelectItem>
+                <SelectItem value="tasks">Schedule Items</SelectItem>
               </SelectContent>
             </Select>
           )}
@@ -628,13 +650,14 @@ export function ScheduleGanttView({
         </ResizablePanelGroup>
       )}
 
-      <TaskFormDialog
+      <ScheduleItemFormDialog
         open={taskFormOpen}
         onOpenChange={setTaskFormOpen}
         projectId={projectId}
         editingTask={editingTask}
         allTasks={tasks}
         dependencies={dependencies}
+        assigneeOptions={assigneeOptions}
       />
     </div>
   )

--- a/src/components/schedule/schedule-item-form-dialog.tsx
+++ b/src/components/schedule/schedule-item-form-dialog.tsx
@@ -71,6 +71,8 @@ import { STATUS_OPTIONS } from "@/lib/schedule/types"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { cn } from "@/lib/utils"
+import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
+import { ProjectAssigneePicker } from "@/components/projects/project-assignee-picker"
 
 const phases = PHASE_ORDER.map((value) => ({
   value,
@@ -84,7 +86,7 @@ const DEPENDENCY_TYPES: readonly { value: DependencyType; label: string }[] = [
   { value: "SF", label: "Start-to-Finish" },
 ]
 
-const taskSchema = z.object({
+const scheduleItemSchema = z.object({
   title: z.string().min(1, "Title is required"),
   startDate: z.string().min(1, "Start date is required"),
   workdays: z.number().min(1, "Must be at least 1 day"),
@@ -97,15 +99,16 @@ const taskSchema = z.object({
   notes: z.string(),
 })
 
-type TaskFormValues = z.infer<typeof taskSchema>
+type ScheduleItemFormValues = z.infer<typeof scheduleItemSchema>
 
-interface TaskFormDialogProps {
+interface ScheduleItemFormDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   projectId: string
   editingTask: ScheduleTaskData | null
   allTasks?: readonly ScheduleTaskData[]
   dependencies?: readonly TaskDependencyData[]
+  assigneeOptions?: readonly ProjectTaskAssigneeOption[]
 }
 
 interface PendingPredecessor {
@@ -114,14 +117,15 @@ interface PendingPredecessor {
   lagDays: number
 }
 
-export function TaskFormDialog({
+export function ScheduleItemFormDialog({
   open,
   onOpenChange,
   projectId,
   editingTask,
   allTasks = [],
   dependencies = [],
-}: TaskFormDialogProps) {
+  assigneeOptions = [],
+}: ScheduleItemFormDialogProps) {
   const router = useRouter()
   const isEditing = !!editingTask
   const [detailsOpen, setDetailsOpen] = useState(false)
@@ -138,8 +142,8 @@ export function TaskFormDialog({
     return allTasks.filter((t) => t.id !== editingTask?.id)
   }, [allTasks, editingTask])
 
-  const form = useForm<TaskFormValues>({
-    resolver: zodResolver(taskSchema),
+  const form = useForm<ScheduleItemFormValues>({
+    resolver: zodResolver(scheduleItemSchema),
     defaultValues: {
       title: "",
       startDate: new Date().toISOString().split("T")[0],
@@ -199,7 +203,7 @@ export function TaskFormDialog({
     return calculateEndDate(watchedStart, watchedWorkdays)
   }, [watchedStart, watchedWorkdays])
 
-  async function onSubmit(values: TaskFormValues) {
+  async function onSubmit(values: ScheduleItemFormValues) {
     const { notes, ...taskValues } = values
     void notes
     let result
@@ -272,7 +276,7 @@ export function TaskFormDialog({
       <DialogContent className="sm:max-w-xl max-h-[85vh] flex flex-col overflow-hidden p-0 gap-0">
         <DialogHeader className="px-5 pt-4 pb-3 shrink-0">
           <DialogTitle className="text-base font-semibold">
-            {isEditing ? "Edit Task" : "New Task"}
+            {isEditing ? "Edit Schedule Item" : "New Schedule Item"}
           </DialogTitle>
         </DialogHeader>
 
@@ -292,7 +296,7 @@ export function TaskFormDialog({
                   <FormItem>
                     <FormControl>
                       <Input
-                        placeholder="Task name"
+                        placeholder="Schedule item name"
                         className="h-10 text-sm font-medium border-0 border-b rounded-none px-0 focus-visible:ring-0 focus-visible:border-primary"
                         autoFocus
                         {...field}
@@ -500,15 +504,14 @@ export function TaskFormDialog({
                       render={({ field }) => (
                         <FormItem>
                           <FormLabel className="text-[11px] text-muted-foreground font-medium">
-                            Assignee
+                            Responsible contact
                           </FormLabel>
-                          <FormControl>
-                            <Input
-                              placeholder="Name or team"
-                              className="h-9"
-                              {...field}
-                            />
-                          </FormControl>
+                          <ProjectAssigneePicker
+                            value={field.value}
+                            options={assigneeOptions}
+                            onValueChange={(value) => field.onChange(value)}
+                            placeholder="Choose contact or type a name..."
+                          />
                         </FormItem>
                       )}
                     />
@@ -611,7 +614,7 @@ export function TaskFormDialog({
                           }
                         >
                           <SelectTrigger className="h-8 text-xs">
-                            <SelectValue placeholder="Select task" />
+                            <SelectValue placeholder="Select schedule item" />
                           </SelectTrigger>
                           <SelectContent>
                             {availableTasks.map((t) => (
@@ -680,7 +683,7 @@ export function TaskFormDialog({
                     {availableTasks.length === 0 &&
                       existingPredecessors.length === 0 && (
                         <p className="text-[11px] text-muted-foreground/60">
-                          No other tasks to link as predecessors.
+                          No other schedule items to link as predecessors.
                         </p>
                       )}
                   </div>

--- a/src/components/schedule/schedule-list-view.tsx
+++ b/src/components/schedule/schedule-list-view.tsx
@@ -30,30 +30,44 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { TaskFormDialog } from "./task-form-dialog"
+import { ScheduleItemFormDialog } from "./schedule-item-form-dialog"
 import { DependencyDialog } from "./dependency-dialog"
 import { deleteTask } from "@/app/actions/schedule"
 import type {
   ScheduleTaskData,
   TaskDependencyData,
 } from "@/lib/schedule/types"
+import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
+import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { format, parseISO } from "date-fns"
+import { useScheduleDisplayPalette } from "@/hooks/use-schedule-display-palette"
+import {
+  getScheduleItemDisplayColor,
+  type DisplayColorPalette,
+} from "@/lib/schedule/appearance"
 
 interface ScheduleListViewProps {
-  projectId: string
-  tasks: ScheduleTaskData[]
-  dependencies: TaskDependencyData[]
+  readonly projectId: string
+  readonly tasks: ScheduleTaskData[]
+  readonly dependencies: TaskDependencyData[]
+  readonly assigneeOptions: readonly ProjectTaskAssigneeOption[]
 }
 
-function StatusDot({ task }: { task: ScheduleTaskData }) {
-  let color = "bg-gray-400"
-  if (task.status === "COMPLETE") color = "bg-green-500"
-  else if (task.status === "IN_PROGRESS") color = "bg-blue-500"
-  else if (task.status === "BLOCKED") color = "bg-red-500"
-  else if (task.isCriticalPath) color = "bg-orange-500"
-  return <span className={`inline-block size-2.5 rounded-full ${color}`} />
+function StatusDot({
+  task,
+  palette,
+}: {
+  task: ScheduleTaskData
+  palette: DisplayColorPalette
+}) {
+  return (
+    <span
+      className="inline-block size-2.5 rounded-full"
+      style={{ backgroundColor: getScheduleItemDisplayColor(task, palette) }}
+    />
+  )
 }
 
 function ProgressRing({
@@ -132,8 +146,10 @@ export function ScheduleListView({
   projectId,
   tasks,
   dependencies,
+  assigneeOptions,
 }: ScheduleListViewProps) {
   const router = useRouter()
+  const displayColorPalette = useScheduleDisplayPalette(projectId)
   const [taskFormOpen, setTaskFormOpen] = useState(false)
   const [editingTask, setEditingTask] = useState<ScheduleTaskData | null>(null)
   const [depDialogOpen, setDepDialogOpen] = useState(false)
@@ -191,7 +207,10 @@ export function ScheduleListView({
         header: "Title",
         cell: ({ row }) => (
           <div className="flex items-center gap-2">
-            <StatusDot task={row.original} />
+            <StatusDot
+              task={row.original}
+              palette={displayColorPalette}
+            />
             <span className="font-medium text-sm truncate max-w-[150px] sm:max-w-[200px]">
               {row.original.title}
             </span>
@@ -248,7 +267,7 @@ export function ScheduleListView({
       },
       {
         id: "assignedTo",
-        header: "Assigned To",
+        header: "Responsible",
         cell: ({ row }) =>
           row.original.assignedTo ? (
             <InitialsAvatar name={row.original.assignedTo} />
@@ -260,6 +279,24 @@ export function ScheduleListView({
         id: "actions",
         cell: ({ row }) => (
           <div className="flex items-center gap-1">
+            <ProjectTaskCreateButton
+              compact
+              projectId={projectId}
+              sourceLabel="Schedule item"
+              sourceRecordId={row.original.id}
+              sourceRecordNumber={null}
+              sourceHref={`/dashboard/projects/${projectId}/schedule`}
+              defaultTitle={`Follow up: ${row.original.title}`}
+              defaultDescription={`${row.original.phase} schedule item.`}
+              defaultAssigneeName={row.original.assignedTo}
+              defaultCompanyName={null}
+              defaultDueDate={row.original.endDateCalculated}
+              defaultPriority={
+                row.original.isCriticalPath ? "high" : "normal"
+              }
+              defaultTaskType="schedule_task"
+              assigneeOptions={assigneeOptions}
+            />
             <Button
               variant="ghost"
               size="icon"
@@ -281,10 +318,10 @@ export function ScheduleListView({
             </Button>
           </div>
         ),
-        size: 80,
+        size: 110,
       },
     ],
-    [handleDelete]
+    [assigneeOptions, displayColorPalette, handleDelete, projectId]
   )
 
   const table = useReactTable({
@@ -341,7 +378,8 @@ export function ScheduleListView({
                     colSpan={columns.length}
                     className="text-center py-8 text-muted-foreground"
                   >
-                    No tasks yet. Click &quot;New Schedule Item&quot; to get started.
+                    No schedule items yet. Click &quot;New Schedule Item&quot; to
+                    get started.
                   </TableCell>
                 </TableRow>
               ) : (
@@ -414,13 +452,14 @@ export function ScheduleListView({
         </div>
       </div>
 
-      <TaskFormDialog
+      <ScheduleItemFormDialog
         open={taskFormOpen}
         onOpenChange={setTaskFormOpen}
         projectId={projectId}
         editingTask={editingTask}
         allTasks={localTasks}
         dependencies={dependencies}
+        assigneeOptions={assigneeOptions}
       />
 
       <DependencyDialog

--- a/src/components/schedule/schedule-mobile-view.tsx
+++ b/src/components/schedule/schedule-mobile-view.tsx
@@ -17,8 +17,11 @@ import {
 } from "date-fns"
 import { cn } from "@/lib/utils"
 import type { ScheduleTaskData } from "@/lib/schedule/types"
+import { useScheduleDisplayPalette } from "@/hooks/use-schedule-display-palette"
+import { getScheduleItemDisplayColor } from "@/lib/schedule/appearance"
 
 interface ScheduleMobileViewProps {
+  projectId: string
   tasks: ScheduleTaskData[]
   exceptions?: unknown[]
   onTaskClick?: (task: ScheduleTaskData) => void
@@ -31,42 +34,26 @@ const MONTHS = [
 
 const WEEKDAYS = ["S", "M", "T", "W", "T", "F", "S"]
 
-function getTaskColor(task: ScheduleTaskData): string {
-  if (task.status === "COMPLETE") return "bg-green-500"
-  if (task.status === "IN_PROGRESS") return "bg-blue-500"
-  if (task.status === "BLOCKED") return "bg-red-500"
-  if (task.isCriticalPath) return "bg-orange-500"
-  return "bg-muted-foreground"
-}
-
-function getTaskBorderColor(task: ScheduleTaskData): string {
-  if (task.status === "COMPLETE") return "border-green-500"
-  if (task.status === "IN_PROGRESS") return "border-blue-500"
-  if (task.status === "BLOCKED") return "border-red-500"
-  if (task.isCriticalPath) return "border-orange-500"
-  return "border-muted-foreground"
-}
-
 export function ScheduleMobileView({
+  projectId,
   tasks,
-  exceptions,
   onTaskClick,
 }: ScheduleMobileViewProps) {
+  const displayColorPalette = useScheduleDisplayPalette(projectId)
   const [currentDate, setCurrentDate] = useState(new Date())
   const [selectedDate, setSelectedDate] = useState(new Date())
 
   const currentMonth = currentDate.getMonth()
   const currentYear = currentDate.getFullYear()
 
-  const monthStart = startOfMonth(currentDate)
-  const monthEnd = endOfMonth(currentDate)
-  const calendarStart = startOfWeek(monthStart)
-  const calendarEnd = endOfWeek(monthEnd)
-
-  const days = useMemo(
-    () => eachDayOfInterval({ start: calendarStart, end: calendarEnd }),
-    [calendarStart.getTime(), calendarEnd.getTime()]
-  )
+  const days = useMemo(() => {
+    const monthStart = startOfMonth(currentDate)
+    const monthEnd = endOfMonth(currentDate)
+    return eachDayOfInterval({
+      start: startOfWeek(monthStart),
+      end: endOfWeek(monthEnd),
+    })
+  }, [currentDate])
 
   const tasksByDate = useMemo(() => {
     const map = new Map<string, ScheduleTaskData[]>()
@@ -177,7 +164,13 @@ export function ScheduleMobileView({
                   {dayTasks.slice(0, 3).map((task, i) => (
                     <span
                       key={`${task.id}-${i}`}
-                      className={cn("size-1 rounded-full", getTaskColor(task))}
+                      className="size-1 rounded-full"
+                      style={{
+                        backgroundColor: getScheduleItemDisplayColor(
+                          task,
+                          displayColorPalette
+                        ),
+                      }}
                     />
                   ))}
                 </div>
@@ -193,16 +186,23 @@ export function ScheduleMobileView({
           {format(selectedDate, "EEE, MMM d")}
         </h3>
         {selectedDayTasks.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No tasks scheduled</p>
+          <p className="text-sm text-muted-foreground">
+            No schedule items planned
+          </p>
         ) : (
           <div className="space-y-2">
             {selectedDayTasks.map((task) => (
               <button
                 key={task.id}
                 className={cn(
-                  "flex w-full gap-3 border-l-2 pl-3 py-2 text-left active:bg-muted/50 rounded-r-md",
-                  getTaskBorderColor(task)
+                  "flex w-full gap-3 border-l-2 pl-3 py-2 text-left active:bg-muted/50 rounded-r-md"
                 )}
+                style={{
+                  borderLeftColor: getScheduleItemDisplayColor(
+                    task,
+                    displayColorPalette
+                  ),
+                }}
                 onClick={() => onTaskClick?.(task)}
               >
                 <div className="flex-1 min-w-0">

--- a/src/components/schedule/schedule-toolbar.tsx
+++ b/src/components/schedule/schedule-toolbar.tsx
@@ -122,7 +122,7 @@ export function ScheduleToolbar({
   }
 
   const handleExportCSV = () => {
-    const headers = ["Title", "Phase", "Status", "Start Date", "End Date", "Duration (days)", "% Complete", "Assigned To", "Critical Path", "Milestone"]
+    const headers = ["Title", "Phase", "Status", "Start Date", "End Date", "Duration (days)", "% Complete", "Responsible Contact", "Critical Path", "Milestone"]
     const rows = tasks.map((task) => [
       task.title,
       task.phase,
@@ -202,12 +202,14 @@ export function ScheduleToolbar({
         const url = URL.createObjectURL(blob)
         const link = document.createElement("a")
         link.href = url
-        link.download = `imported-tasks-${Date.now()}.json`
+        link.download = `imported-schedule-items-${Date.now()}.json`
         link.click()
         URL.revokeObjectURL(url)
-        toast.success(`Parsed ${tasks.length} tasks from CSV for review.`)
+        toast.success(
+          `Parsed ${tasks.length} schedule items from CSV for review.`
+        )
       } else {
-        toast.error("No valid tasks found in the CSV file.")
+        toast.error("No valid schedule items found in the CSV file.")
       }
     } catch (error) {
       console.error("Import failed:", error)
@@ -235,7 +237,7 @@ export function ScheduleToolbar({
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
                 <IconFilter className="size-4 mr-2" />
-                Filter Tasks
+                Filter Schedule Items
                 {activeFiltersCount > 0 && (
                   <span className="ml-auto bg-primary text-primary-foreground text-xs px-1.5 py-0.5 rounded">
                     {activeFiltersCount}
@@ -307,11 +309,11 @@ export function ScheduleToolbar({
             </Button>
           )}
           <span className="text-xs text-muted-foreground hidden sm:inline">
-            {tasksCount} task{tasksCount !== 1 ? "s" : ""}
+            {tasksCount} schedule item{tasksCount !== 1 ? "s" : ""}
           </span>
           <Button size="sm" onClick={onNewItem} className="h-9">
             <IconPlus className="size-4 mr-2" />
-            New Task
+            New Schedule Item
           </Button>
         </div>
       </div>
@@ -319,9 +321,9 @@ export function ScheduleToolbar({
       <Dialog open={filterDialogOpen} onOpenChange={setFilterDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Filter Tasks</DialogTitle>
+            <DialogTitle>Filter Schedule Items</DialogTitle>
             <DialogDescription>
-              Narrow down tasks by status, phase, or assignee.
+              Narrow down schedule items by status, phase, or assignee.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
@@ -336,7 +338,7 @@ export function ScheduleToolbar({
               />
             </div>
             <div className="space-y-2">
-              <Label>Assigned To</Label>
+              <Label>Responsible Contact</Label>
               <Input
                 placeholder="Filter by assignee..."
                 value={filters.assignedTo}
@@ -355,7 +357,7 @@ export function ScheduleToolbar({
             <DialogTitle>Import Schedule</DialogTitle>
             <DialogDescription>
               Upload a CSV file with your schedule data. The file should have columns
-              for title, start date, duration, phase, and assigned to.
+              for title, start date, duration, phase, and responsible contact.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">

--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -59,9 +59,10 @@ import { ScheduleCalendarView } from "./schedule-calendar-view"
 import { ScheduleMobileView } from "./schedule-mobile-view"
 import { WorkdayExceptionsView } from "./workday-exceptions-view"
 import { ScheduleBaselineView } from "./schedule-baseline-view"
-import { TaskFormDialog } from "./task-form-dialog"
+import { ScheduleItemFormDialog } from "./schedule-item-form-dialog"
 import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
 import type { ProjectListItem } from "@/app/actions/projects"
+import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
 import type {
   ScheduleData,
   ScheduleBaselineData,
@@ -87,6 +88,7 @@ interface ScheduleViewProps {
   readonly initialData: ScheduleData
   readonly baselines: ScheduleBaselineData[]
   readonly allProjects?: readonly ProjectListItem[]
+  readonly assigneeOptions?: readonly ProjectTaskAssigneeOption[]
 }
 
 export function ScheduleView({
@@ -95,6 +97,7 @@ export function ScheduleView({
   initialData,
   baselines,
   allProjects = [],
+  assigneeOptions = [],
 }: ScheduleViewProps) {
   const isMobile = useIsMobile()
   const [view, setView] = useState<View>("gantt")
@@ -275,9 +278,11 @@ export function ScheduleView({
         link.download = `imported-tasks-${Date.now()}.json`
         link.click()
         URL.revokeObjectURL(url)
-        toast.success(`Parsed ${parsed.length} tasks from CSV for review.`)
+        toast.success(
+          `Parsed ${parsed.length} schedule items from CSV for review.`
+        )
       } else {
-        toast.error("No valid tasks found in the CSV file.")
+        toast.error("No valid schedule items found in the CSV file.")
       }
     } catch (error) {
       console.error("Import failed:", error)
@@ -339,7 +344,7 @@ export function ScheduleView({
 
           <Button size="sm" onClick={() => setTaskFormOpen(true)} className="h-8">
             <IconPlus className="size-3.5" />
-            <span className="hidden sm:inline ml-1.5">New Task</span>
+            <span className="hidden sm:inline ml-1.5">New Schedule Item</span>
           </Button>
         </div>
       </div>
@@ -350,7 +355,7 @@ export function ScheduleView({
         <div className="relative flex-1 sm:flex-none sm:w-52">
           <IconSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground pointer-events-none" />
           <Input
-            placeholder="Search tasks..."
+            placeholder="Search schedule items..."
             value={filters.search}
             onChange={(e) => setFilters({ ...filters, search: e.target.value })}
             className="h-8 pl-8 text-sm"
@@ -415,7 +420,7 @@ export function ScheduleView({
               </div>
               <div>
                 <Label className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                  Assigned To
+                  Responsible Contact
                 </Label>
                 <Input
                   placeholder="Filter by name..."
@@ -479,7 +484,8 @@ export function ScheduleView({
 
         <div className="ml-auto flex items-center gap-2 shrink-0">
           <span className="text-xs text-muted-foreground hidden sm:inline tabular-nums">
-            {filteredTasks.length} task{filteredTasks.length !== 1 ? "s" : ""}
+            {filteredTasks.length} schedule item
+            {filteredTasks.length !== 1 ? "s" : ""}
           </span>
 
           {/* Overflow menu */}
@@ -521,6 +527,7 @@ export function ScheduleView({
         {view === "calendar" && (
           isMobile ? (
             <ScheduleMobileView
+              projectId={projectId}
               tasks={filteredTasks}
               exceptions={initialData.exceptions}
             />
@@ -537,6 +544,7 @@ export function ScheduleView({
             projectId={projectId}
             tasks={filteredTasks}
             dependencies={initialData.dependencies}
+            assigneeOptions={assigneeOptions}
           />
         )}
         {view === "gantt" && (
@@ -544,18 +552,20 @@ export function ScheduleView({
             projectId={projectId}
             tasks={filteredTasks}
             dependencies={initialData.dependencies}
+            assigneeOptions={assigneeOptions}
           />
         )}
       </div>
 
-      {/* New task dialog */}
-      <TaskFormDialog
+      {/* New schedule item dialog */}
+      <ScheduleItemFormDialog
         open={taskFormOpen}
         onOpenChange={setTaskFormOpen}
         projectId={projectId}
         editingTask={null}
         allTasks={initialData.tasks}
         dependencies={initialData.dependencies}
+        assigneeOptions={assigneeOptions}
       />
 
       {/* Import dialog */}

--- a/src/components/schedule/work-calendar.tsx
+++ b/src/components/schedule/work-calendar.tsx
@@ -36,12 +36,12 @@ const KIND_FILTERS: readonly KindConfig[] = [
   },
   {
     id: "schedule",
-    label: "Schedule",
+    label: "Schedule items",
     icon: <IconCalendarEvent className="size-4" />,
   },
   {
     id: "task",
-    label: "Tasks",
+    label: "To-dos",
     icon: <IconClipboardCheck className="size-4" />,
   },
   {
@@ -95,9 +95,9 @@ function normalize(value: string): string {
 function kindLabel(kind: WorkCalendarEntryKind): string {
   switch (kind) {
     case "schedule":
-      return "Schedule"
+      return "Schedule item"
     case "task":
-      return "Task"
+      return "To-do"
     case "rfi":
       return "RFI"
     case "purchase_order":
@@ -236,7 +236,7 @@ export function WorkCalendar({
                   Work calendar
                 </p>
                 <h1 className="text-2xl font-semibold tracking-tight">
-                  Tasks, due dates, and field follow-ups.
+                  To-dos, schedule items, and field follow-ups.
                 </h1>
               </div>
             </div>
@@ -252,7 +252,7 @@ export function WorkCalendar({
               <p className="mt-1 text-2xl font-semibold">{todayEntries.length}</p>
             </div>
             <div>
-              <p className="text-xs text-muted-foreground">Tasks</p>
+              <p className="text-xs text-muted-foreground">To-dos</p>
               <p className="mt-1 text-2xl font-semibold">{taskCount}</p>
             </div>
             <div>
@@ -274,7 +274,7 @@ export function WorkCalendar({
             <Input
               value={query}
               onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search by task, project, assignee, RFI, PO..."
+              placeholder="Search by to-do, project, assignee, RFI, PO..."
               className="pl-9"
             />
           </div>
@@ -300,7 +300,7 @@ export function WorkCalendar({
               <h2 className="text-sm font-semibold">Next 14 days</h2>
               <p className="mt-1 text-xs text-muted-foreground">
                 {filteredEntries.length} visible work items across project
-                schedules, RFIs, Sage operations, and Compass tasks.
+                schedule items, RFIs, Sage operations, and Compass to-dos.
               </p>
             </div>
             <Badge variant="secondary">{formatShortDate(data.today)} onward</Badge>
@@ -359,7 +359,7 @@ export function WorkCalendar({
           </div>
 
           <aside className="rounded-lg border bg-card p-4">
-            <h2 className="text-sm font-semibold">Task Sources</h2>
+            <h2 className="text-sm font-semibold">To-do Sources</h2>
             <div className="mt-3 grid gap-2">
               <Link
                 href="/dashboard/projects/select?target=daily-logs"

--- a/src/hooks/use-schedule-display-palette.ts
+++ b/src/hooks/use-schedule-display-palette.ts
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+
+import {
+  DEFAULT_DISPLAY_COLOR_PALETTE,
+  normalizeDisplayColorPalette,
+  schedulePaletteStorageKey,
+  type DisplayColorPalette,
+} from "@/lib/schedule/appearance"
+
+export function useScheduleDisplayPalette(
+  projectId: string
+): DisplayColorPalette {
+  const [palette, setPalette] = React.useState<DisplayColorPalette>(
+    DEFAULT_DISPLAY_COLOR_PALETTE
+  )
+
+  React.useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(
+        schedulePaletteStorageKey(projectId)
+      )
+      if (stored) {
+        setPalette(normalizeDisplayColorPalette(JSON.parse(stored)))
+      }
+    } catch {
+      setPalette(DEFAULT_DISPLAY_COLOR_PALETTE)
+    }
+  }, [projectId])
+
+  return palette
+}

--- a/src/lib/schedule/__tests__/appearance.test.ts
+++ b/src/lib/schedule/__tests__/appearance.test.ts
@@ -3,9 +3,10 @@ import {
   DEFAULT_DISPLAY_COLOR,
   DEFAULT_DISPLAY_COLOR_PALETTE,
   DISPLAY_COLOR_OPTIONS,
-  normalizeDisplayColorPalette,
+  getScheduleItemDisplayColor,
   getScheduleItemClasses,
   normalizeDisplayColor,
+  normalizeDisplayColorPalette,
 } from "../appearance"
 import { transformToFrappeTasks } from "../gantt-transform"
 import type { ScheduleTaskData } from "../types"
@@ -31,6 +32,15 @@ describe("display-color palette", () => {
       red: DEFAULT_DISPLAY_COLOR_PALETTE.red,
       green: DEFAULT_DISPLAY_COLOR_PALETTE.green,
     })
+  })
+
+  it("resolves a schedule item's selected color from the active palette", () => {
+    expect(
+      getScheduleItemDisplayColor(
+        { displayColor: "purple" },
+        { ...DEFAULT_DISPLAY_COLOR_PALETTE, purple: "#123456" }
+      )
+    ).toBe("#123456")
   })
 })
 

--- a/src/lib/schedule/appearance.ts
+++ b/src/lib/schedule/appearance.ts
@@ -84,6 +84,13 @@ export function normalizeDisplayColor(
   return isDisplayColor(value) ? value : DEFAULT_DISPLAY_COLOR
 }
 
+export function getScheduleItemDisplayColor(
+  item: { readonly displayColor: string | null | undefined },
+  palette: DisplayColorPalette = DEFAULT_DISPLAY_COLOR_PALETTE
+): string {
+  return palette[normalizeDisplayColor(item.displayColor)]
+}
+
 export function getScheduleItemClasses(item: {
   readonly displayColor: string | null | undefined
   readonly isCriticalPath: boolean


### PR DESCRIPTION
## Summary

- rename user-facing schedule tasks to schedule items while preserving existing internal storage contracts
- carry each schedule item's selected color into calendar, list, and mobile schedule views
- add a searchable project/directory contact picker with manual-name fallback for responsible contacts
- create assignable, source-linked to-dos from schedule items and daily logs
- display daily-log to-dos alongside existing schedule links and clarify schedule-item versus to-do labels in the work calendar

## Why

Schedule planning records and actionable work were using the same “task” language even though they have different ownership and lifecycle needs. Schedule colors also only appeared in the Gantt view. This change makes schedule items the planning layer and reuses the existing project operations queue for assignable to-dos that can originate from schedule items or field daily logs.

No database migration is required; the existing `project_operations` source-link fields provide the reusable to-do model.

## Validation

- `bunx eslint` on all changed files
- `bunx tsc --noEmit`
- `bun test src/lib/schedule/__tests__/appearance.test.ts` (8 passed)
- `bun run build`
- repository pre-commit lint hook (0 errors)
- repository pre-push production build hook
