### PR TITLE
test(regression): add daily browser and native checks

### DIFF
--- a/.github/workflows/daily-regression.yml
+++ b/.github/workflows/daily-regression.yml
@@ -1,0 +1,222 @@
+name: Daily Regression
+
+on:
+  schedule:
+    # 13:15 UTC is early morning in the Mountain time zone.
+    - cron: "15 13 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: daily-regression
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  production-smoke:
+    name: Production Smoke (${{ matrix.project }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - project: chromium
+            browser: chromium
+          - project: mobile-chrome
+            browser: chromium
+          - project: mobile-safari
+            browser: webkit
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: bunx playwright install --with-deps ${{ matrix.browser }}
+
+      - name: Run read-only production journeys
+        run: bunx playwright test e2e/web --project=${{ matrix.project }}
+        env:
+          PLAYWRIGHT_BASE_URL: https://compass.openrangeconstruction.ltd
+          PLAYWRIGHT_REQUIRE_PROJECT: "false"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: daily-playwright-${{ matrix.project }}
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  android-build:
+    name: Android Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Synchronize Capacitor project
+        run: bunx cap sync android
+
+      - name: Run Android tests, lint, and debug build
+        working-directory: android
+        run: ./gradlew testDebugUnitTest lintDebug assembleDebug
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: daily-android-diagnostics
+          path: |
+            android/app/build/reports/
+            android/app/build/outputs/logs/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  ios-build:
+    name: iOS Simulator Build
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Synchronize Capacitor project
+        run: bunx cap sync ios
+
+      - name: Build for the iOS simulator
+        run: >-
+          xcodebuild
+          -project ios/App/App.xcodeproj
+          -scheme App
+          -sdk iphonesimulator
+          -configuration Debug
+          CODE_SIGNING_ALLOWED=NO
+          build
+
+  report:
+    name: Report Regression Status
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - production-smoke
+      - android-build
+      - ios-build
+
+    steps:
+      - name: Create, update, or close the rolling regression issue
+        uses: actions/github-script@v7
+        env:
+          PRODUCTION_SMOKE_RESULT: ${{ needs.production-smoke.result }}
+          ANDROID_BUILD_RESULT: ${{ needs.android-build.result }}
+          IOS_BUILD_RESULT: ${{ needs.ios-build.result }}
+        with:
+          script: |
+            const title = "Daily regression checks are failing"
+            const results = {
+              "Production smoke": process.env.PRODUCTION_SMOKE_RESULT,
+              "Android build": process.env.ANDROID_BUILD_RESULT,
+              "iOS simulator build": process.env.IOS_BUILD_RESULT,
+            }
+            const failed = Object.entries(results)
+              .filter(([, result]) => result !== "success")
+              .map(([name, result]) => `${name}: ${result}`)
+            const failureBullets = failed
+              .map((failure) => `- ${failure}`)
+              .join(String.fromCharCode(10))
+            const runUrl =
+              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
+              `/actions/runs/${context.runId}`
+
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: "regression",
+                color: "B60205",
+                description: "Automated regression check failure",
+              })
+            } catch (error) {
+              if (error.status !== 422) throw error
+            }
+
+            const openIssues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: "regression",
+              per_page: 100,
+            })
+            const existing = openIssues.data.find(
+              (issue) => issue.title === title && !issue.pull_request
+            )
+
+            if (failed.length > 0) {
+              const body = `The automated daily regression run found a problem.
+
+            Failing checks:
+            ${failureBullets}
+
+            [Open the workflow run](${runUrl}) for logs, screenshots, traces, and native build diagnostics.
+
+            This is a rolling issue. New failures are added as comments until all checks recover.`
+
+              if (existing) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existing.number,
+                  body,
+                })
+              } else {
+                await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title,
+                  body,
+                  labels: ["regression"],
+                })
+              }
+              return
+            }
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `All daily regression checks recovered in [this workflow run](${runUrl}). Closing the rolling issue.`,
+              })
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                state: "closed",
+                state_reason: "completed",
+              })
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,15 @@ jobs:
       - name: Build application
         run: bun run build
 
+      - name: Prepare deterministic E2E database
+        run: bun run test:e2e:prepare
+        env:
+          LOCAL_DB_PATH: .e2e/compass.db
+
       - name: Run E2E tests
         run: bunx playwright test --project=${{ matrix.browser }}
+        env:
+          LOCAL_DB_PATH: .e2e/compass.db
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ release/
 # dev tools
 .playwright-mcp
 .codex-snapshots/
+playwright-report/
+test-results/
 outputs/
 mobile-ui-references/
 .fuse_*
@@ -56,3 +58,4 @@ scripts/init-local-db.ts
 local.db
 local.db-wal
 local.db-shm
+.e2e/

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ How to work on Compass.
 
 - [getting started](development/getting-started.md) -- local setup, environment variables, dev server, database, deployment
 - [conventions](development/conventions.md) -- TypeScript discipline, component patterns, file organization
+- [regression testing](development/regression-testing.md) -- pull-request, daily, native, and release regression strategy
 - [sidebar](development/sidebar.md) -- sidebar component architecture, desktop vs mobile, collapsed state, animations
 - [theming](development/theming.md) -- oklch color system, preset themes, custom theme generation, how applyTheme works
 - [plugins](development/plugins.md) -- skills system, plugin manifests, registry, building new plugins

--- a/docs/development/regression-testing.md
+++ b/docs/development/regression-testing.md
@@ -1,0 +1,165 @@
+# Regression testing
+
+Compass is used while it is being actively developed, so regression protection
+must cover more than whether the application compiles. The testing program uses
+several layers because no single suite can be fast, realistic, and exhaustive
+at the same time.
+
+## The operating model
+
+| Layer | When | Purpose | Environment |
+| --- | --- | --- | --- |
+| Pull request | Every change | Prevent known workflows from breaking before merge | Seeded local database |
+| Daily regression | Every morning and on demand | Confirm the deployed app and native projects remain healthy | Production demo plus native builds |
+| Weekly deep checks | Planned | Exercise native devices, uploads, offline recovery, accessibility, and visual changes | Test tenant and simulators |
+| Release gate | Before a production or app-store release | Verify reversible write workflows and the packaged apps | Staging/test tenant |
+
+Pull requests should remain deterministic and reasonably fast. Daily checks can
+spend more time on browser and native coverage. Tests that create, edit, upload,
+or delete data belong in an isolated test tenant, never in the production
+workspace.
+
+## What is automated today
+
+### Pull requests and `main`
+
+The `Tests` workflow runs:
+
+- unit and integration tests;
+- seeded, read-only browser journeys in Chromium, Firefox, and WebKit;
+- the Electron runtime suite on `main`;
+- test coverage reporting.
+
+The browser suite enters through `/demo`, then checks the usable core areas,
+project workspaces, and schedule view switching. Its local database is recreated
+from migrations in CI and populated by `scripts/seed-e2e-local.mjs`, so it does not
+depend on a developer's database or external credentials.
+
+### Daily regression
+
+`.github/workflows/daily-regression.yml` runs every day and can also be started
+manually. It performs:
+
+- read-only production core-area journeys in desktop Chromium;
+- the same core journeys at Android and iPhone browser sizes;
+- Capacitor synchronization plus Android unit tests, lint, and a debug build;
+- Capacitor synchronization plus an unsigned iOS simulator build.
+
+If any job fails, the workflow creates or updates one rolling GitHub issue named
+`Daily regression checks are failing`. It links to the run containing browser
+screenshots/traces or native diagnostics. When all checks recover, the workflow
+comments on and closes that issue.
+
+The production browser journeys use the demo workspace and must remain
+read-only. The deployed demo currently has no project fixture, so the
+project-workspace journeys run against deterministic data on every pull request
+and skip during the production synthetic check. Once a production-safe demo
+project is provisioned, remove `PLAYWRIGHT_REQUIRE_PROJECT: "false"` from the
+daily workflow to enable them there as well. Browser emulation catches layout
+and navigation regressions, but it does not prove that the camera, biometric
+prompt, file picker, push notifications, background execution, or offline
+storage work on a real device.
+
+## Coverage map
+
+The smoke suite is organized by product area so failures are actionable and new
+areas have an obvious home.
+
+| Area | Current daily signal | Next deeper coverage |
+| --- | --- | --- |
+| Dashboard | Page journey | cards, links, role-specific data |
+| Projects | Hub and workspace journeys | create/edit in test tenant |
+| Schedule | Global page, project page, calendar/list/Gantt switching | create, assign, color, dependency, baseline |
+| Daily logs | Project page journey | create log, link to-do, upload multiple photos |
+| Photos | Project page journey | camera/library selection, size errors, retry queue |
+| Contacts and people | Page journeys | search, manual entry, permissions |
+| RFIs and RFQs | Global/project journeys | create, share, status transitions |
+| Purchase orders | Global/project journeys | draft, validation, approval boundary |
+| Financials and budget | Global/project journeys | totals and Sage read-model fixtures |
+| Files | Page journey | folder navigation, upload limits, Drive errors |
+| Conversations | Page journey | channel/message/thread flows |
+| Owner updates and selections | Project journeys | draft, preview, publish in test tenant |
+| Desktop | Electron launch/runtime | update, offline, deep-link, packaging |
+| Android and iOS | Sync, lint/tests, build | simulator/device field journeys |
+
+Whenever a usable product area or critical workflow is added, update this table
+and add its route or journey in the same pull request. A feature is not complete
+until its regression signal is identified.
+
+## Running checks locally
+
+Install the browser used by the test once:
+
+```bash
+bunx playwright install chromium
+```
+
+Run the seeded web journeys:
+
+```bash
+LOCAL_DB_PATH=.e2e/compass.db bun run test:e2e:web --project=chromium
+```
+
+Run a mobile-sized browser project:
+
+```bash
+LOCAL_DB_PATH=.e2e/compass.db bun run test:e2e:prepare
+LOCAL_DB_PATH=.e2e/compass.db bunx playwright test e2e/web --project=mobile-chrome
+```
+
+Run against the deployed demo without starting a local server:
+
+```bash
+PLAYWRIGHT_BASE_URL=https://compass.openrangeconstruction.ltd \
+  PLAYWRIGHT_REQUIRE_PROJECT=false \
+  bunx playwright test e2e/web --project=chromium
+```
+
+Run the native build checks:
+
+```bash
+bunx cap sync android
+(cd android && ./gradlew testDebugUnitTest lintDebug assembleDebug)
+
+bunx cap sync ios
+xcodebuild -project ios/App/App.xcodeproj -scheme App \
+  -sdk iphonesimulator -configuration Debug CODE_SIGNING_ALLOWED=NO build
+```
+
+Playwright retains screenshots, video, and traces for failures. CI uploads those
+artifacts for diagnosis.
+
+## Test design rules
+
+- Prefer a short user journey over checking implementation details.
+- Give each test a product-area name and use steps for individual screens.
+- Keep production checks read-only and safe to repeat.
+- Use deterministic IDs and data in local/test environments.
+- Test mutations through public UI or server-action boundaries, not direct
+  database changes; direct SQL is reserved for fixture setup.
+- Assert the outcome the user sees, including useful validation and file-size
+  messages, not only that a button was clickable.
+- Add a regression test with every bug fix when the failure can be reproduced
+  reliably.
+- Keep camera, offline, biometric, push, and background behavior in native
+  simulator/device suites rather than treating responsive browser tests as
+  substitutes.
+- Quarantine a flaky test only with an issue, owner, and removal date. Do not
+  silently make a regression check optional.
+
+## Planned next stage
+
+The next investment should be a dedicated test organization with reversible
+write data, followed by one critical native field journey:
+
+1. authenticate in an Android emulator and iOS simulator;
+2. open a project;
+3. create a daily log;
+4. attach several photos, including an over-limit selection;
+5. create and assign a linked to-do;
+6. go offline, queue a change, reconnect, and confirm synchronization.
+
+After that is stable, add accessibility scans and focused visual snapshots for
+the dashboard, schedule views, daily log, and mobile field shell. These should
+run weekly at first; promote stable, high-value checks into the pull-request
+gate.

--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test, type Page, type Response } from "@playwright/test"
+
+const applicationErrorText =
+  /Application error|Internal Server Error|This page could not be found/i
+
+const coreAreas = [
+  { name: "dashboard", path: "/dashboard" },
+  { name: "projects", path: "/dashboard/projects" },
+  { name: "work calendar", path: "/dashboard/schedule" },
+  { name: "RFIs", path: "/dashboard/rfis" },
+  { name: "purchase orders", path: "/dashboard/purchase-orders" },
+  { name: "files", path: "/dashboard/files" },
+  { name: "contacts", path: "/dashboard/contacts" },
+  { name: "financials", path: "/dashboard/financials" },
+  { name: "people", path: "/dashboard/people" },
+  { name: "conversations", path: "/dashboard/conversations" },
+  { name: "settings", path: "/dashboard/settings" },
+]
+
+const projectAreas = [
+  { name: "overview", suffix: "" },
+  { name: "schedule", suffix: "/schedule" },
+  { name: "daily logs", suffix: "/daily-logs" },
+  { name: "photos", suffix: "/photos" },
+  { name: "contacts", suffix: "/contacts" },
+  { name: "financials", suffix: "/financials" },
+  { name: "budget", suffix: "/budget" },
+  { name: "purchase orders", suffix: "/purchase-orders" },
+  { name: "RFIs", suffix: "/rfis" },
+  { name: "RFQs", suffix: "/rfqs" },
+  { name: "selections", suffix: "/selections" },
+  { name: "owner updates", suffix: "/owner-updates" },
+]
+
+async function enterDemo(page: Page): Promise<void> {
+  await page.goto("/demo")
+  await page.waitForURL(/\/dashboard/)
+  await expect(page.locator("body")).not.toContainText(applicationErrorText)
+}
+
+async function expectHealthyNavigation(
+  page: Page,
+  response: Response | null,
+  path: string
+): Promise<void> {
+  expect(response, `${path} did not return a document response`).not.toBeNull()
+  if (!response) return
+
+  expect(
+    response.status(),
+    `${path} returned HTTP ${response.status()}`
+  ).toBeLessThan(400)
+  await expect(page).toHaveURL(new RegExp(path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")))
+  await expect(page.locator("body")).not.toContainText(applicationErrorText)
+  await expect(page.locator("body")).not.toBeEmpty()
+}
+
+async function findProjectId(page: Page): Promise<string | null> {
+  const projectLink = page
+    .locator(
+      'a[href^="/dashboard/projects/"]' +
+        ':not([href^="/dashboard/projects/select"])'
+    )
+    .first()
+
+  if ((await projectLink.count()) === 0) {
+    const response = await page.goto("/dashboard")
+    await expectHealthyNavigation(page, response, "/dashboard")
+  }
+
+  if ((await projectLink.count()) === 0) {
+    if (process.env.PLAYWRIGHT_REQUIRE_PROJECT !== "false") {
+      throw new Error("The demo workspace does not expose a project to test")
+    }
+    return null
+  }
+
+  const href = await projectLink.getAttribute("href")
+  const match = href?.match(/^\/dashboard\/projects\/([^/?#]+)/)
+  if (match?.[1]) return match[1]
+
+  return null
+}
+
+test.describe("usable Compass areas", () => {
+  test.beforeEach(async ({ page }) => {
+    await enterDemo(page)
+  })
+
+  test("core areas render without application errors", async ({ page }) => {
+    for (const area of coreAreas) {
+      await test.step(area.name, async () => {
+        const response = await page.goto(area.path)
+        await expectHealthyNavigation(page, response, area.path)
+      })
+    }
+  })
+
+  test("project workspaces render without application errors", async ({
+    page,
+  }) => {
+    const projectsResponse = await page.goto("/dashboard/projects")
+    await expectHealthyNavigation(
+      page,
+      projectsResponse,
+      "/dashboard/projects"
+    )
+    const projectId = await findProjectId(page)
+    if (!projectId) {
+      test.skip(true, "The deployed demo has no read-only project fixture")
+      return
+    }
+
+    for (const area of projectAreas) {
+      await test.step(area.name, async () => {
+        const path = `/dashboard/projects/${projectId}${area.suffix}`
+        const response = await page.goto(path)
+        await expectHealthyNavigation(page, response, path)
+      })
+    }
+  })
+
+  test("schedule switches between calendar, list, and Gantt", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard/projects")
+    const projectId = await findProjectId(page)
+    if (!projectId) {
+      test.skip(true, "The deployed demo has no read-only project fixture")
+      return
+    }
+    const schedulePath = `/dashboard/projects/${projectId}/schedule`
+    const response = await page.goto(schedulePath)
+    await expectHealthyNavigation(page, response, schedulePath)
+
+    for (const view of ["Calendar", "List", "Gantt"]) {
+      await test.step(view, async () => {
+        const switcher = page.locator("button").filter({ hasText: view }).first()
+        await expect(switcher).toBeVisible()
+        await switcher.click()
+        await expect(page.locator("body")).not.toContainText(applicationErrorText)
+      })
+    }
+  })
+})

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"name": "compass",
 	"version": "0.1.0",
 	"private": true,
+	"trustedDependencies": [
+		"better-sqlite3"
+	],
 	"scripts": {
 		"dev": "next dev --turbopack",
 		"build": "next build",
@@ -30,6 +33,8 @@
 		"test:coverage": "vitest run --coverage",
 		"test:integration": "vitest run __tests__/integration",
 		"test:e2e": "playwright test",
+		"test:e2e:prepare": "bun run db:init-local && node scripts/seed-e2e-local.mjs",
+		"test:e2e:web": "bun run test:e2e:prepare && playwright test e2e/web",
 		"test:e2e:ui": "playwright test --ui",
 		"test:e2e:desktop": "bun run desktop:compile && bun scripts/run-desktop-e2e.mjs",
 		"db:init-local": "node scripts/init-local-db.mjs"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,9 @@ const isElectron = () => {
   return process.env.ELECTRON === "true" || process.env.ELECTRON_TEST === "true"
 }
 
+const externalBaseUrl = process.env.PLAYWRIGHT_BASE_URL
+const baseURL = externalBaseUrl ?? "http://127.0.0.1:3000"
+
 // Web-specific projects
 const webProjects = [
   {
@@ -18,6 +21,14 @@ const webProjects = [
   {
     name: "webkit",
     use: { ...devices["Desktop Safari"] },
+  },
+  {
+    name: "mobile-chrome",
+    use: { ...devices["Pixel 7"] },
+  },
+  {
+    name: "mobile-safari",
+    use: { ...devices["iPhone 13"] },
   },
 ]
 
@@ -44,6 +55,7 @@ export default defineConfig({
   reporter: [["html"], ["list"]],
   testDir: "./e2e",
   use: {
+    baseURL,
     actionTimeout: 30000,
     navigationTimeout: 30000,
     trace: "on-first-retry",
@@ -53,10 +65,12 @@ export default defineConfig({
   outputDir: "test-results",
   preserveOutput: "always",
   projects: isElectron() ? desktopProjects : webProjects,
-  webServer: {
-    command: "bun dev",
-    port: 3000,
-    timeout: 120000,
-    reuseExistingServer: !process.env.CI,
-  },
+  webServer: externalBaseUrl
+    ? undefined
+    : {
+        command: "bun dev",
+        url: baseURL,
+        timeout: 120000,
+        reuseExistingServer: !process.env.CI,
+      },
 })

--- a/scripts/init-local-db.mjs
+++ b/scripts/init-local-db.mjs
@@ -1,8 +1,8 @@
 import Database from "better-sqlite3"
-import { readFileSync, readdirSync } from "fs"
-import { join } from "path"
+import { mkdirSync, readFileSync, readdirSync } from "fs"
+import { dirname, join, resolve } from "path"
 
-const DB_PATH = process.env.LOCAL_DB_PATH || "local.db"
+const DB_PATH = resolve(process.env.LOCAL_DB_PATH || "local.db")
 const MIGRATIONS_DIR = join(process.cwd(), "drizzle")
 const MIGRATIONS_TABLE = "__compass_local_migrations"
 
@@ -78,6 +78,7 @@ function markMigrationsApplied(db, migrations) {
 }
 
 function main() {
+    mkdirSync(dirname(DB_PATH), { recursive: true })
     const db = new Database(DB_PATH)
     const migrations = readdirSync(MIGRATIONS_DIR)
         .filter((f) => f.endsWith(".sql") && !f.includes("seed"))

--- a/scripts/run-desktop-e2e.mjs
+++ b/scripts/run-desktop-e2e.mjs
@@ -1,7 +1,15 @@
 import { spawnSync } from "node:child_process"
 
-const command = process.platform === "win32" ? "bunx.cmd" : "bunx"
-const args = ["playwright", "test", "--project=desktop-chromium", ...process.argv.slice(2)]
+// Reuse the Bun executable that launched this script. Spawning `bunx.cmd`
+// directly is unreliable on Windows GitHub runners because it is a shell shim.
+const command = process.execPath
+const args = [
+	"x",
+	"playwright",
+	"test",
+	"--project=desktop-chromium",
+	...process.argv.slice(2),
+]
 
 const result = spawnSync(command, args, {
 	env: {

--- a/scripts/seed-e2e-local.mjs
+++ b/scripts/seed-e2e-local.mjs
@@ -1,0 +1,127 @@
+import Database from "better-sqlite3"
+import { mkdirSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+
+const databasePath = resolve(process.env.LOCAL_DB_PATH || ".e2e/compass.db")
+const now = new Date().toISOString()
+const today = now.slice(0, 10)
+
+mkdirSync(dirname(databasePath), { recursive: true })
+
+const db = new Database(databasePath)
+
+const upsert = db.transaction(() => {
+  db.prepare(`
+    INSERT INTO organizations (
+      id, name, slug, type, is_active, created_at, updated_at
+    ) VALUES (
+      'demo-org-meridian', 'Meridian Group', 'meridian-demo', 'demo', 1, ?, ?
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      name = excluded.name,
+      is_active = excluded.is_active,
+      updated_at = excluded.updated_at
+  `).run(now, now)
+
+  db.prepare(`
+    INSERT INTO users (
+      id, email, first_name, last_name, display_name, role, is_active,
+      created_at, updated_at
+    ) VALUES (
+      'demo-user-001', 'demo@compass.build', 'Demo', 'User', 'Demo User',
+      'admin', 1, ?, ?
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      display_name = excluded.display_name,
+      role = excluded.role,
+      is_active = excluded.is_active,
+      updated_at = excluded.updated_at
+  `).run(now, now)
+
+  db.prepare(`
+    INSERT INTO organization_members (
+      id, organization_id, user_id, role, joined_at
+    ) VALUES (
+      'e2e-membership-001', 'demo-org-meridian', 'demo-user-001', 'admin', ?
+    )
+    ON CONFLICT(id) DO UPDATE SET role = excluded.role
+  `).run(now)
+
+  db.prepare(`
+    INSERT INTO projects (
+      id, project_number, name, status, address, client_name, project_manager,
+      organization_id, owner_updates_enabled, owner_update_channel,
+      owner_update_cadence, created_at, updated_at
+    ) VALUES (
+      'e2e-project-001', 'H-E2E-001', 'Regression Test Project', 'OPEN',
+      '100 Test Lane', 'Compass Demo Client', 'Demo User',
+      'demo-org-meridian', 1, 'compass', 'weekly', ?, ?
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      project_number = excluded.project_number,
+      name = excluded.name,
+      status = excluded.status,
+      organization_id = excluded.organization_id,
+      updated_at = excluded.updated_at
+  `).run(now, now)
+
+  db.prepare(`
+    INSERT INTO schedule_tasks (
+      id, project_id, title, start_date, workdays, end_date_calculated, phase,
+      display_color, status, is_critical_path, is_milestone, percent_complete,
+      assigned_to, sort_order, created_at, updated_at
+    ) VALUES (
+      'e2e-schedule-001', 'e2e-project-001', 'Regression Schedule Item',
+      ?, 3, ?, 'Preconstruction', 'blue', 'IN_PROGRESS', 1, 0, 25,
+      'Demo User', 1, ?, ?
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      title = excluded.title,
+      start_date = excluded.start_date,
+      end_date_calculated = excluded.end_date_calculated,
+      status = excluded.status,
+      updated_at = excluded.updated_at
+  `).run(today, today, now, now)
+
+  db.prepare(`
+    INSERT INTO daily_logs (
+      id, project_id, author_id, source_system, log_date, weather_source,
+      work_completed, issues, is_client_visible, review_status, sync_status,
+      created_at, updated_at
+    ) VALUES (
+      'e2e-daily-log-001', 'e2e-project-001', 'demo-user-001', 'compass',
+      ?, 'manual', 'Verified the regression test workspace.', 'None', 0,
+      'draft', 'synced', ?, ?
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      log_date = excluded.log_date,
+      work_completed = excluded.work_completed,
+      updated_at = excluded.updated_at
+  `).run(today, now, now)
+
+  db.prepare(`
+    INSERT INTO project_operations (
+      id, project_id, source_system, source_record_type, source_record_number,
+      title, description, status, priority, assignee_type, assignee_name,
+      company_name, due_date, sage_write_status, sync_direction, sync_status,
+      created_at, updated_at
+    ) VALUES (
+      'e2e-todo-001', 'e2e-project-001', 'compass', 'todo', 'E2E-TODO-001',
+      'Regression follow-up', 'Seeded task for read-only workflow checks.',
+      'open', 'normal', 'user', 'Demo User', 'Compass Demo Client', ?,
+      'not_ready', 'read', 'synced', ?, ?
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      title = excluded.title,
+      status = excluded.status,
+      due_date = excluded.due_date,
+      updated_at = excluded.updated_at
+  `).run(today, now, now)
+})
+
+try {
+  upsert()
+  console.log(`Seeded deterministic E2E data in ${databasePath}`)
+} finally {
+  db.close()
+}


### PR DESCRIPTION
## What changed

- add real Playwright journeys for Compass core areas, project workspaces, and schedule view switching
- seed a deterministic local E2E database from the repository migrations
- run the browser journeys in the existing Chromium, Firefox, and WebKit pull-request jobs
- add daily read-only production smoke checks for desktop, Android-sized, and iPhone-sized browsers
- add daily Android test/lint/debug builds and iOS simulator builds
- automatically create/update one rolling regression issue on failures and close it on recovery
- correct the Windows desktop Playwright launcher to reuse the Bun executable
- document the layered pull-request, daily, weekly, and release regression strategy

## Why

The existing web E2E matrix had no committed web journey tests, so green browser jobs only proved that Compass could build and start. There was also no scheduled regression workflow and no automated native project build check. This foundation makes regressions visible while keeping production checks read-only.

The deployed demo currently has no project fixture. Production synthetics therefore cover all core areas and explicitly skip project-only journeys; seeded pull-request jobs exercise those project workspaces on every change.

## Validation

- `bun run lint`
- `bunx tsc --noEmit`
- `bun run test` — 142 passed, 3 skipped
- `bun run build`
- seeded Chromium usable-area journeys — 3 passed
- seeded mobile-Chrome usable-area journeys — 3 passed
- deployed Chromium core smoke — 1 passed, 2 project-only journeys skipped as designed
- `bun scripts/run-desktop-e2e.mjs --list`
- GitHub workflow YAML parsing and `git diff --check`

The structured external autoreview was not run because the environment blocked sending the repository diff to an external model; the staged diff was reviewed locally instead.
