### PR TITLE
fix(ci): restore and gate Electron runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,41 @@ jobs:
           path: test-results/
           retention-days: 7
 
+  # Fast Electron smoke on pull requests so lifecycle/runtime issues are caught
+  # before merge. The full cross-platform matrix remains a main-branch check.
+  e2e-desktop-pr:
+    name: E2E Desktop (PR smoke)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Electron runtime dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+
+      - name: Run desktop E2E smoke
+        run: xvfb-run -a bun run test:e2e:desktop
+        env:
+          ELECTRON: "true"
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report-desktop-pr
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
   # Desktop E2E tests (Electron) - only on main branch
   e2e-desktop:
     name: E2E Desktop

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
 	"version": "0.1.0",
 	"private": true,
 	"trustedDependencies": [
-		"better-sqlite3"
+		"better-sqlite3",
+		"electron"
 	],
 	"scripts": {
 		"dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary

- restore Bun lifecycle trust for Electron alongside `better-sqlite3`
- add a pull-request Ubuntu Electron smoke test so runtime installation failures are caught before merge
- keep the full Ubuntu, macOS, and Windows desktop matrix on `main`

## Cause

Adding an explicit `trustedDependencies` list for the regression database replaced Bun's default trust set. Electron's install script therefore did not run, leaving its runtime binary missing on every desktop CI platform.

## Validation

- fresh `bun install --frozen-lockfile` installs the Electron runtime
- `bun run test:e2e:desktop` passes locally
- pull-request CI now exercises the Electron app under Xvfb

Follow-up to #112.
