### PR TITLE
feat(feedback): secure bridge secret setup

### DIFF
--- a/docs/architecture/jarvis-feedback-bridge.md
+++ b/docs/architecture/jarvis-feedback-bridge.md
@@ -221,3 +221,8 @@ Rollout checklist
 9. Confirm a guest sees no Ask Compass entry point and receives HTTP 403 from
    all three agent endpoints.
 10. Enable Telegram and email intake one source at a time.
+
+The bundled bridge helper includes a `configure` command for step 5. It
+generates the HMAC key on the private runtime and returns only RSA-encrypted
+ciphertext for one-time transfer into Cloudflare. The raw shared key must not
+be printed, logged, or committed.

--- a/skills/compass-feedback-desk/SKILL.md
+++ b/skills/compass-feedback-desk/SKILL.md
@@ -69,6 +69,15 @@ python scripts/compass_feedback_bridge.py pull --limit 20
 
 Do not invoke a model when the response contains no events.
 
+## Configure the private runtime
+
+For first-time setup, use the helper's `configure` command with an ephemeral
+RSA public key. It generates the bridge secret on the private runtime, writes
+only `COMPASS_BASE_URL` and `JARVIS_BRIDGE_SECRET` to the selected dotenv
+file with mode `0600`, and returns only encrypted ciphertext. Decrypt that
+ciphertext outside the runtime and pipe it directly into the Compass secret
+store. Never commit the transfer key or decrypted secret.
+
 ## Guardrails
 
 - Never expose `JARVIS_BRIDGE_SECRET`, Telegram credentials, email

--- a/skills/compass-feedback-desk/scripts/compass_feedback_bridge.py
+++ b/skills/compass-feedback-desk/scripts/compass_feedback_bridge.py
@@ -4,11 +4,15 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import hmac
 import json
 import os
+import secrets
+import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.parse
@@ -17,6 +21,71 @@ from pathlib import Path
 from typing import Any
 
 MAX_BODY_BYTES = 64 * 1024
+
+
+def update_env_file(path: Path, values: dict[str, str]) -> None:
+    """Update selected dotenv keys without disturbing unrelated settings."""
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    remaining = dict(values)
+    managed_keys = set(values)
+    updated: list[str] = []
+
+    for line in existing.splitlines():
+        key, separator, _value = line.partition("=")
+        if separator and key in managed_keys:
+            if key in remaining:
+                updated.append(f"{key}={remaining.pop(key)}")
+        else:
+            updated.append(line)
+
+    if updated and updated[-1]:
+        updated.append("")
+    updated.extend(f"{key}={value}" for key, value in remaining.items())
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(updated).rstrip() + "\n", encoding="utf-8")
+    path.chmod(0o600)
+
+
+def encrypt_for_transfer(secret: str, public_key_der: str) -> str:
+    """Encrypt a generated secret so the bridge key never enters tool output."""
+    try:
+        public_key = base64.b64decode(public_key_der, validate=True)
+    except ValueError as error:
+        raise ValueError("Public key must be valid base64-encoded DER") from error
+
+    with tempfile.TemporaryDirectory(prefix="compass-bridge-") as directory:
+        temporary = Path(directory)
+        public_key_path = temporary / "public.der"
+        secret_path = temporary / "secret"
+        encrypted_path = temporary / "secret.enc"
+        public_key_path.write_bytes(public_key)
+        secret_path.write_bytes(secret.encode("utf-8"))
+        result = subprocess.run(
+            [
+                "openssl",
+                "pkeyutl",
+                "-encrypt",
+                "-pubin",
+                "-inkey",
+                str(public_key_path),
+                "-keyform",
+                "DER",
+                "-pkeyopt",
+                "rsa_padding_mode:oaep",
+                "-pkeyopt",
+                "rsa_oaep_md:sha256",
+                "-in",
+                str(secret_path),
+                "-out",
+                str(encrypted_path),
+            ],
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError("OpenSSL could not encrypt the bridge secret")
+        return base64.b64encode(encrypted_path.read_bytes()).decode("ascii")
 
 
 def signature(
@@ -116,13 +185,38 @@ def build_parser() -> argparse.ArgumentParser:
     reply = commands.add_parser("reply")
     reply.add_argument("--payload-file", required=True)
 
+    configure = commands.add_parser("configure")
+    configure.add_argument("--base-url", required=True)
+    configure.add_argument("--env-file", required=True)
+    configure.add_argument("--public-key-der-base64", required=True)
+
     return parser
 
 
 def main() -> int:
     args = build_parser().parse_args()
 
-    if args.command == "pull":
+    if args.command == "configure":
+        parsed_base_url = urllib.parse.urlsplit(args.base_url)
+        if parsed_base_url.scheme != "https" or not parsed_base_url.netloc:
+            raise ValueError("Configure requires an HTTPS Compass base URL")
+        secret = secrets.token_urlsafe(48)
+        encrypted_secret = encrypt_for_transfer(
+            secret,
+            args.public_key_der_base64,
+        )
+        update_env_file(
+            Path(args.env_file),
+            {
+                "COMPASS_BASE_URL": args.base_url.rstrip("/"),
+                "JARVIS_BRIDGE_SECRET": secret,
+            },
+        )
+        result = {
+            "configured": True,
+            "encryptedSecret": encrypted_secret,
+        }
+    elif args.command == "pull":
         limit = min(50, max(1, args.limit))
         target = (
             "/api/integrations/jarvis/events?"

--- a/skills/compass-feedback-desk/scripts/test_compass_feedback_bridge.py
+++ b/skills/compass-feedback-desk/scripts/test_compass_feedback_bridge.py
@@ -1,4 +1,6 @@
 import importlib.util
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -30,6 +32,103 @@ class SignatureTests(unittest.TestCase):
             "sha256=bc5d2a69489415e9bbbb469ffcc36b3036ab8f"
             "442e866dc0a48fbae587d4ba92",
         )
+
+    def test_update_env_file_preserves_unrelated_values(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            env_path = Path(directory) / ".env"
+            env_path.write_text(
+                "TELEGRAM_BOT_TOKEN=unchanged\n"
+                "JARVIS_BRIDGE_SECRET=old\n"
+                "JARVIS_BRIDGE_SECRET=duplicate\n",
+                encoding="utf-8",
+            )
+
+            MODULE.update_env_file(
+                env_path,
+                {
+                    "COMPASS_BASE_URL": "https://compass.example.com",
+                    "JARVIS_BRIDGE_SECRET": "new",
+                },
+            )
+
+            self.assertEqual(
+                env_path.read_text(encoding="utf-8"),
+                "TELEGRAM_BOT_TOKEN=unchanged\n"
+                "JARVIS_BRIDGE_SECRET=new\n"
+                "\n"
+                "COMPASS_BASE_URL=https://compass.example.com\n",
+            )
+            self.assertEqual(env_path.stat().st_mode & 0o777, 0o600)
+
+    def test_encrypt_for_transfer_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temporary = Path(directory)
+            private_key = temporary / "private.pem"
+            public_der = temporary / "public.der"
+            encrypted = temporary / "encrypted.bin"
+            decrypted = temporary / "decrypted.txt"
+            subprocess.run(
+                [
+                    "openssl",
+                    "genpkey",
+                    "-quiet",
+                    "-algorithm",
+                    "RSA",
+                    "-pkeyopt",
+                    "rsa_keygen_bits:2048",
+                    "-out",
+                    str(private_key),
+                ],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "openssl",
+                    "pkey",
+                    "-in",
+                    str(private_key),
+                    "-pubout",
+                    "-outform",
+                    "DER",
+                    "-out",
+                    str(public_der),
+                ],
+                check=True,
+            )
+            encoded_public_key = MODULE.base64.b64encode(
+                public_der.read_bytes()
+            ).decode("ascii")
+            encrypted.write_bytes(
+                MODULE.base64.b64decode(
+                    MODULE.encrypt_for_transfer(
+                        "shared-bridge-secret",
+                        encoded_public_key,
+                    )
+                )
+            )
+            subprocess.run(
+                [
+                    "openssl",
+                    "pkeyutl",
+                    "-decrypt",
+                    "-inkey",
+                    str(private_key),
+                    "-pkeyopt",
+                    "rsa_padding_mode:oaep",
+                    "-pkeyopt",
+                    "rsa_oaep_md:sha256",
+                    "-in",
+                    str(encrypted),
+                    "-out",
+                    str(decrypted),
+                ],
+                check=True,
+            )
+
+            self.assertEqual(
+                decrypted.read_text(encoding="utf-8"),
+                "shared-bridge-secret",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

- add a one-time `configure` command to the Compass Feedback Desk bridge helper
- generate the shared HMAC key on the private Signet runtime
- preserve unrelated Hermes dotenv settings and enforce mode `0600`
- return only RSA-OAEP encrypted ciphertext for transfer into Cloudflare

## Why

Signet correctly prevents raw secret access and blocks inline shell scripting. This creates a narrow, auditable setup path without placing the shared key in chat, GitHub, command arguments, or tool output.

## Validation

- Python bridge unit tests, including RSA-OAEP round trip and dotenv preservation
- official skill validator
- `git diff --check`
- repository pre-commit lint: 0 errors
- repository pre-push production build and TypeScript check

The external autoreview helper remains unavailable under the workspace data-export policy. A local security review was completed, including duplicate dotenv-key handling and failure-before-write behavior.
