### PR TITLE
fix(feedback): allow signed bridge requests

### DIFF
--- a/skills/compass-feedback-desk/scripts/compass_feedback_bridge.py
+++ b/skills/compass-feedback-desk/scripts/compass_feedback_bridge.py
@@ -137,6 +137,7 @@ def request_json(
     timestamp = str(int(time.time()))
     headers = {
         "Accept": "application/json",
+        "User-Agent": "Compass-Jarvis-Bridge/1.0",
         "X-Compass-Timestamp": timestamp,
         "X-Compass-Signature": signature(
             secret,
@@ -157,13 +158,22 @@ def request_json(
     )
     try:
         with urllib.request.urlopen(request, timeout=30) as response:
+            response_status = response.status
+            response_type = response.headers.get("Content-Type", "unknown")
             response_body = response.read(MAX_BODY_BYTES)
     except urllib.error.HTTPError as error:
         error_body = error.read(2048).decode("utf-8", errors="replace")
         raise RuntimeError(
             f"Compass returned HTTP {error.code}: {error_body}"
         ) from error
-    return json.loads(response_body)
+    try:
+        return json.loads(response_body)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(
+            "Compass returned non-JSON "
+            f"HTTP {response_status} ({response_type}, "
+            f"{len(response_body)} bytes)"
+        ) from error
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/lib/__tests__/middleware-routes.test.ts
+++ b/src/lib/__tests__/middleware-routes.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+import { isPublicPath } from "@/lib/public-paths"
+
+describe("middleware public routes", () => {
+  it("allows the HMAC-authenticated Jarvis bridge through WorkOS middleware", () => {
+    expect(isPublicPath("/api/integrations/jarvis/events")).toBe(true)
+    expect(
+      isPublicPath(
+        "/api/integrations/jarvis/events/event-123/ack",
+      ),
+    ).toBe(true)
+    expect(isPublicPath("/api/integrations/jarvis/replies")).toBe(true)
+  })
+
+  it("does not make unrelated integration routes public", () => {
+    expect(isPublicPath("/api/integrations/other/events")).toBe(false)
+  })
+})

--- a/src/lib/public-paths.ts
+++ b/src/lib/public-paths.ts
@@ -1,0 +1,28 @@
+const publicPaths = [
+  "/",
+  "/login",
+  "/signup",
+  "/reset-password",
+  "/verify-email",
+  "/invite",
+  "/callback",
+  "/demo",
+  "/manifest.json",
+]
+
+const bridgePaths = [
+  "/api/bridge/register",
+  "/api/bridge/tools",
+  "/api/bridge/context",
+]
+
+export function isPublicPath(pathname: string): boolean {
+  return (
+    publicPaths.includes(pathname) ||
+    bridgePaths.includes(pathname) ||
+    pathname.startsWith("/api/auth/") ||
+    pathname.startsWith("/api/integrations/jarvis/") ||
+    pathname.startsWith("/api/netsuite/") ||
+    pathname.startsWith("/api/google/")
+  )
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,34 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { authkit, handleAuthkitHeaders } from "@workos-inc/authkit-nextjs"
 import { isLocalDevelopment, isWorkOSConfigured } from "@/lib/auth-config"
-
-const publicPaths = [
-  "/",
-  "/login",
-  "/signup",
-  "/reset-password",
-  "/verify-email",
-  "/invite",
-  "/callback",
-  "/demo",
-  "/manifest.json",
-]
-
-const bridgePaths = [
-  "/api/bridge/register",
-  "/api/bridge/tools",
-  "/api/bridge/context",
-]
-
-function isPublicPath(pathname: string): boolean {
-  return (
-    publicPaths.includes(pathname) ||
-    bridgePaths.includes(pathname) ||
-    pathname.startsWith("/api/auth/") ||
-    pathname.startsWith("/api/netsuite/") ||
-    pathname.startsWith("/api/google/")
-  )
-}
+import { isPublicPath } from "@/lib/public-paths"
 
 export default async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl


### PR DESCRIPTION
## What

- let the HMAC-authenticated Jarvis bridge routes pass through WorkOS middleware
- keep all unrelated integration routes protected
- give the private adapter a stable named User-Agent accepted by Cloudflare
- report non-JSON upstream responses without printing their body

## Why

Live production validation found two edge-layer blockers: WorkOS redirected the signed machine route to login, and Cloudflare rejected Python's default urllib signature. The route handler already performs HMAC authentication and replay checks, so this narrowly exempts only `/api/integrations/jarvis/*` from WorkOS.

## Validation

- middleware route tests
- guest Ask Compass endpoint tests
- Python bridge tests
- TypeScript check
- repository pre-commit lint: 0 errors
- repository pre-push production build
- live diagnosis verified the former 307 login redirect and Cloudflare 1010 behavior
