### PR TITLE
fix(agent): restore Jarvis inference routing

### DIFF
--- a/packages/agent-core/src/system-prompt.ts
+++ b/packages/agent-core/src/system-prompt.ts
@@ -32,8 +32,10 @@ export function buildSystemPrompt(
     opts.externalMcpTools
   )
 
-  return `You are Compass AI, an intelligent assistant for project \
-management and collaboration.
+  return `You are Jarvis, the trusted project operations assistant inside \
+Compass. Staff should experience one consistent assistant identity regardless \
+of which internal model or provider handles a request. Never present yourself \
+as the underlying model or provider.
 
 Current context:
 - User ID: ${ctx.userId}

--- a/src/app/actions/ai-config.ts
+++ b/src/app/actions/ai-config.ts
@@ -57,6 +57,7 @@ const CACHE_TTL_MS = 5 * 60 * 1000
 
 export async function getActiveModel(): Promise<{
   success: true
+  isAdmin: boolean
   data: {
     modelId: string
     modelName: string
@@ -66,7 +67,6 @@ export async function getActiveModel(): Promise<{
     contextLength: number
     maxCostPerMillion: string | null
     allowUserSelection: boolean
-    isAdmin: boolean
   } | null
 } | {
   success: false
@@ -77,7 +77,6 @@ export async function getActiveModel(): Promise<{
     if (!user) {
       return { success: false, error: "Unauthorized" }
     }
-
     const isAdmin = can(user, "agent", "update")
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
@@ -90,6 +89,7 @@ export async function getActiveModel(): Promise<{
 
     return {
       success: true,
+      isAdmin,
       data: config
         ? {
             modelId: config.modelId,
@@ -102,7 +102,6 @@ export async function getActiveModel(): Promise<{
               config.maxCostPerMillion ?? null,
             allowUserSelection:
               config.allowUserSelection === 1,
-            isAdmin,
           }
         : null,
     }
@@ -203,6 +202,12 @@ export async function getModelList(): Promise<{
     const user = await getCurrentUser()
     if (!user) {
       return { success: false, error: "Unauthorized" }
+    }
+    if (!can(user, "agent", "update")) {
+      return {
+        success: false,
+        error: "Permission denied",
+      }
     }
 
     if (

--- a/src/app/actions/provider-config.ts
+++ b/src/app/actions/provider-config.ts
@@ -4,10 +4,7 @@ import { getCloudflareContext } from "@/lib/db"
 import { eq } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { getDb } from "@/db"
-import {
-  userProviderConfig,
-  agentConfig,
-} from "@/db/schema-ai-config"
+import { userProviderConfig } from "@/db/schema-ai-config"
 import { getCurrentUser } from "@/lib/auth"
 import { can } from "@/lib/permissions"
 import { encrypt, decrypt } from "@/lib/crypto"
@@ -44,6 +41,9 @@ export async function getUserProviderConfig(): Promise<
     const user = await getCurrentUser()
     if (!user) {
       return { success: false, error: "Unauthorized" }
+    }
+    if (!can(user, "agent", "update")) {
+      return { success: false, error: "Permission denied" }
     }
 
     const { env } = await getCloudflareContext()
@@ -104,7 +104,7 @@ export async function getProviderConfigForJwt(
       .where(eq(userProviderConfig.userId, userId))
       .get()
 
-    if (!config) {
+    if (!config || config.isActive !== 1) {
       return null
     }
 
@@ -165,6 +165,9 @@ export async function setUserProviderConfig(
     if (!user) {
       return { success: false, error: "Unauthorized" }
     }
+    if (!can(user, "agent", "update")) {
+      return { success: false, error: "Permission denied" }
+    }
 
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
@@ -172,25 +175,6 @@ export async function setUserProviderConfig(
 
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
-
-    const config = await db
-      .select()
-      .from(agentConfig)
-      .where(eq(agentConfig.id, "global"))
-      .get()
-
-    const isAdmin = can(user, "agent", "update")
-
-    if (
-      !isAdmin &&
-      config &&
-      config.allowUserSelection !== 1
-    ) {
-      return {
-        success: false,
-        error: "User provider selection is disabled",
-      }
-    }
 
     let encryptedApiKey: string | null = null
     if (apiKey) {
@@ -262,6 +246,9 @@ export async function updateUserModelOverrides(
     if (!user) {
       return { success: false, error: "Unauthorized" }
     }
+    if (!can(user, "agent", "update")) {
+      return { success: false, error: "Permission denied" }
+    }
 
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
@@ -315,6 +302,9 @@ export async function clearUserProviderConfig(): Promise<{
     const user = await getCurrentUser()
     if (!user) {
       return { success: false, error: "Unauthorized" }
+    }
+    if (!can(user, "agent", "update")) {
+      return { success: false, error: "Permission denied" }
     }
 
     if (isDemoUser(user.id)) {

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -11,8 +11,14 @@ import { generateAgentToken } from "@/lib/agent/api-auth"
 import { getCloudflareContext } from "@/lib/db"
 import { getDb } from "@/db"
 import { mcpServers } from "@/db/schema-mcp"
+import { agentConfig } from "@/db/schema-ai-config"
 import { eq } from "drizzle-orm"
-import { canUseAskCompass } from "@/lib/permissions"
+import { can, canUseAskCompass } from "@/lib/permissions"
+import {
+  resolveRuntimeModelId,
+  resolveRuntimeProvider,
+  selectRuntimeModel,
+} from "@/lib/agent/runtime-config"
 import {
   runAgent,
   buildSystemPrompt,
@@ -31,64 +37,6 @@ interface ChatRequest {
     readonly role: "user" | "assistant"
     readonly content: string
   }>
-}
-
-function mapProviderType(
-  type: string
-): ProviderConfig["type"] {
-  switch (type) {
-    case "anthropic-key":
-    case "anthropic-oauth":
-      return "anthropic"
-    case "openrouter":
-      return "openrouter"
-    case "ollama":
-      return "ollama"
-    default:
-      return "custom"
-  }
-}
-
-/**
- * Resolves short model names (sonnet, opus, haiku) to full model IDs
- * based on the provider type. Passes through full model IDs unchanged.
- */
-function resolveModelId(
-  model: string,
-  providerType: string
-): string {
-  // If already a full model ID, use as-is
-  if (model.includes("/") || model.startsWith("claude-")) {
-    return model
-  }
-
-  // Map short names to full IDs
-  const anthropicModels: Record<string, string> = {
-    sonnet: "claude-sonnet-4-20250514",
-    opus: "claude-opus-4-20250514",
-    haiku: "claude-3-5-haiku-20241022",
-  }
-
-  const openrouterModels: Record<string, string> = {
-    sonnet: "anthropic/claude-sonnet-4",
-    opus: "anthropic/claude-opus-4",
-    haiku: "anthropic/claude-3.5-haiku",
-  }
-
-  if (
-    providerType === "anthropic" ||
-    providerType === "anthropic-oauth" ||
-    providerType === "anthropic-key"
-  ) {
-    return anthropicModels[model] ?? model
-  }
-
-  if (providerType === "openrouter") {
-    return openrouterModels[model] ?? model
-  }
-
-  // Ollama and custom use the model as-is
-  return model
 }
 
 export async function POST(
@@ -140,8 +88,6 @@ export async function POST(
     )
   }
 
-  const model =
-    request.headers.get("x-model") ?? "sonnet"
   const currentPage =
     request.headers.get("x-current-page") ?? "/dashboard"
   const timezone =
@@ -154,40 +100,29 @@ export async function POST(
     string
   >
 
-  // Resolve provider config from DB
-  let providerConfig = await getProviderConfigForJwt(
-    user.id
-  )
+  const db = getDb(env.DB)
+  const activeAgentConfig = await db
+    .select({ modelId: agentConfig.modelId })
+    .from(agentConfig)
+    .where(eq(agentConfig.id, "global"))
+    .get()
+
+  // Staff use the shared organizational provider. Administrators may keep a
+  // personal provider for controlled testing from the settings screen.
+  let providerConfig = can(user, "agent", "update")
+    ? await getProviderConfigForJwt(user.id)
+    : null
   if (!providerConfig) {
     providerConfig = await getProviderConfigForJwt(
       "org_default"
     )
   }
 
-  let provider: ProviderConfig = providerConfig
-    ? {
-        type: mapProviderType(providerConfig.type),
-        apiKey: providerConfig.apiKey ?? undefined,
-        baseUrl: providerConfig.baseUrl ?? undefined,
-        modelOverrides:
-          providerConfig.modelOverrides ?? undefined,
-      }
-    : {
-        type: "anthropic",
-        apiKey: envRecord.ANTHROPIC_API_KEY,
-      }
+  let provider: ProviderConfig
+  let runtimeProviderType: string
 
-  // Log warning if no API key available (unless using OAuth which handles its own auth)
-  if (
-    !provider.apiKey &&
-    providerConfig?.type !== "anthropic-oauth"
-  ) {
-    console.warn(
-      "No API key configured for agent - requests may fail"
-    )
-  }
-
-  // Resolve OAuth access token if needed
+  // OAuth supplies its own token, so it must be resolved before checking
+  // deployment API-key fallbacks.
   if (providerConfig?.type === "anthropic-oauth") {
     const accessToken = await getOAuthAccessToken(user.id)
     if (!accessToken) {
@@ -205,6 +140,20 @@ export async function POST(
       type: "anthropic",
       apiKey: accessToken,
     }
+    runtimeProviderType = "anthropic-oauth"
+  } else {
+    const runtimeProvider = resolveRuntimeProvider(
+      providerConfig,
+      envRecord
+    )
+    if (!runtimeProvider.success) {
+      return Response.json(
+        { error: runtimeProvider.error },
+        { status: 503 }
+      )
+    }
+    provider = runtimeProvider.provider
+    runtimeProviderType = runtimeProvider.providerType
   }
 
   // Generate JWT for bridge route auth
@@ -277,7 +226,6 @@ export async function POST(
 
   if (user.organizationId) {
     try {
-      const db = getDb(env.DB)
       const rows = await db
         .select()
         .from(mcpServers)
@@ -349,10 +297,15 @@ export async function POST(
   const isOAuth =
     provider.apiKey?.startsWith("sk-ant-oat") ?? false
 
-  // Resolve short model names to full model IDs based on provider
-  const resolvedModel = resolveModelId(
-    model,
-    providerConfig?.type ?? "anthropic"
+  // The server-side active model is authoritative. The request header remains
+  // only as a compatibility fallback for deployments without agent_config.
+  const configuredModel = selectRuntimeModel(
+    activeAgentConfig?.modelId,
+    request.headers.get("x-model")
+  )
+  const resolvedModel = resolveRuntimeModelId(
+    configuredModel,
+    runtimeProviderType
   )
 
   const stream = runAgent({

--- a/src/components/agent/chat-panel-shell.tsx
+++ b/src/components/agent/chat-panel-shell.tsx
@@ -142,8 +142,8 @@ export function ChatPanelShell() {
           size="icon-sm"
           className="absolute right-3 top-3 z-20 size-8 rounded-full bg-background/80 text-muted-foreground shadow-sm backdrop-blur hover:bg-accent hover:text-foreground"
           onClick={close}
-          aria-label="Collapse assistant"
-          title="Collapse assistant"
+          aria-label="Collapse Jarvis"
+          title="Collapse Jarvis"
         >
           <PanelRightClose className="size-4" />
         </Button>
@@ -164,7 +164,7 @@ export function ChatPanelShell() {
           size="icon"
           className="fixed bottom-4 right-4 z-50 h-12 w-12 rounded-full shadow-lg md:hidden"
           onClick={toggle}
-          aria-label="Open chat"
+            aria-label="Open Jarvis"
         >
           <MessageSquare className="h-5 w-5" />
         </Button>

--- a/src/components/agent/chat-view.tsx
+++ b/src/components/agent/chat-view.tsx
@@ -62,7 +62,6 @@ import { useAudioRecorder } from "@/hooks/use-audio-recorder"
 import type { AudioRecorder } from "@/hooks/use-audio-recorder"
 import { AudioWaveform } from "@/components/ai/audio-waveform"
 import { useChatState } from "./chat-provider"
-import { ModelDropdown } from "./model-dropdown"
 import { getRepoStats } from "@/app/actions/github"
 
 type RepoStats = {
@@ -461,7 +460,6 @@ function ChatInput({
                 <SquarePenIcon className="size-4" />
               </PromptInputButton>
             )}
-            <ModelDropdown />
           </PromptInputTools>
           <div className="flex items-center gap-1">
             <PromptInputButton
@@ -667,7 +665,7 @@ export function ChatView({
             style={LOGO_MASK}
           />
           <h1 className="text-base sm:text-lg font-bold tracking-tight">
-            Compass
+            Jarvis
           </h1>
         </div>
 
@@ -690,17 +688,16 @@ export function ChatView({
                   style={LOGO_MASK}
                 />
                 <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">
-                  Compass
+                  Jarvis
                 </h1>
                 <p className="text-muted-foreground/60 mt-1.5 text-xs px-2">
-                  Development preview — features may be
-                  incomplete or change without notice.
+                  Your Compass project assistant
                 </p>
               </div>
               <ChatInput
                 textareaRef={textareaRef}
                 placeholder={
-                  animatedPlaceholder || "Ask anything..."
+                  animatedPlaceholder || "Ask Jarvis..."
                 }
                 recorder={recorder}
                 status={chat.status}
@@ -831,7 +828,7 @@ export function ChatView({
           <div className="mx-auto max-w-3xl">
             <ChatInput
               textareaRef={textareaRef}
-              placeholder="Ask follow-up..."
+              placeholder="Ask Jarvis a follow-up..."
               recorder={recorder}
               status={chat.status}
               isGenerating={chat.isGenerating}
@@ -934,7 +931,7 @@ export function ChatView({
       <div className="p-3">
             <ChatInput
               textareaRef={textareaRef}
-              placeholder={inputPlaceholder ?? "Ask anything..."}
+              placeholder={inputPlaceholder ?? "Ask Jarvis..."}
               recorder={recorder}
               status={chat.status}
               isGenerating={chat.isGenerating}

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -137,17 +137,17 @@ export function CommandMenu({
         <CommandGroup heading="Actions">
           {canUseAskCompass && query.trim() && agent && chat && (
             <CommandItem
-              value={`ask compass ${query}`}
+              value={`ask jarvis ${query}`}
               onSelect={() => runCommand(askAgent)}
             >
               <IconSparkles />
-              Ask Compass: {query}
+              Ask Jarvis: {query}
             </CommandItem>
           )}
           {canUseAskCompass && agent && (
             <CommandItem onSelect={() => runCommand(() => agent.open())}>
               <IconMessageCircle />
-              Ask Assistant
+              Open Jarvis
             </CommandItem>
           )}
           <CommandItem onSelect={() => runCommand(() => setTheme(theme === "dark" ? "light" : "dark"))}>

--- a/src/components/mobile-search.tsx
+++ b/src/components/mobile-search.tsx
@@ -276,8 +276,8 @@ export function MobileSearch({
       ? [
           {
             icon: IconSparkles,
-            label: `Ask Compass: ${query.trim()}`,
-            sublabel: "Use the project agent to navigate or build a view",
+            label: `Ask Jarvis: ${query.trim()}`,
+            sublabel: "Use Jarvis to navigate or build a view",
             category: "action",
             action: "ask-agent",
           },

--- a/src/components/settings/ai-model-tab.tsx
+++ b/src/components/settings/ai-model-tab.tsx
@@ -60,7 +60,6 @@ import {
 } from "@/lib/anthropic-oauth-client"
 import { openExternalUrl } from "@/lib/native/platform"
 import { Slider } from "@/components/ui/slider"
-import { Switch } from "@/components/ui/switch"
 import { cn } from "@/lib/utils"
 import {
   ProviderIcon,
@@ -97,7 +96,6 @@ interface ActiveConfig {
   readonly contextLength: number
   readonly maxCostPerMillion: string | null
   readonly allowUserSelection: boolean
-  readonly isAdmin: boolean
 }
 
 interface UsageMetrics {
@@ -1118,31 +1116,19 @@ export function AIModelTab() {
   const [isAdmin, setIsAdmin] = React.useState(false)
   const [modelsError, setModelsError] =
     React.useState<string | null>(null)
-  const [allowUserSelection, setAllowUserSelection] =
-    React.useState(true)
   const [costCeiling, setCostCeiling] =
     React.useState<number | null>(null)
   const [policySaving, setPolicySaving] =
     React.useState(false)
-  const [userProviderType, setUserProviderType] =
-    React.useState<string | null>(null)
-
   const loadData = React.useCallback(async () => {
     setLoading(true)
 
-    const [configResult, providerResult] =
-      await Promise.all([
-        getActiveModel(),
-        getUserProviderConfig(),
-      ])
+    const configResult = await getActiveModel()
 
     if (configResult.success) {
+      setIsAdmin(configResult.isAdmin)
       setActiveConfig(configResult.data)
       if (configResult.data) {
-        setIsAdmin(configResult.data.isAdmin)
-        setAllowUserSelection(
-          configResult.data.allowUserSelection
-        )
         setCostCeiling(
           configResult.data.maxCostPerMillion
             ? parseFloat(
@@ -1154,15 +1140,11 @@ export function AIModelTab() {
     }
 
     if (
-      "success" in providerResult &&
-      providerResult.success &&
-      providerResult.data
+      !configResult.success ||
+      !configResult.isAdmin
     ) {
-      setUserProviderType(
-        providerResult.data.providerType
-      )
-    } else {
-      setUserProviderType(null)
+      setLoading(false)
+      return
     }
 
     const [modelsResult, metricsResult] =
@@ -1221,9 +1203,29 @@ export function AIModelTab() {
     )
   }
 
+  if (!isAdmin) {
+    return (
+      <div className="space-y-3">
+        <div className="space-y-1.5">
+          <Label className="text-xs">Jarvis</Label>
+          <p className="text-sm">
+            AI provider and model selection are managed by a
+            Compass administrator.
+          </p>
+          {activeConfig && (
+            <p className="text-xs text-muted-foreground">
+              Jarvis is online and using the organization&apos;s
+              managed AI configuration.
+            </p>
+          )}
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-3">
-      {/* Provider configuration — always visible */}
+      {/* Provider configuration is restricted to administrators. */}
       <ProviderConfigSection
         onProviderChanged={loadData}
       />
@@ -1251,37 +1253,6 @@ export function AIModelTab() {
         )}
       </div>
 
-      {/* Model picker for non-admin users with a custom provider */}
-      {!isAdmin &&
-        userProviderType !== null &&
-        userProviderType !== "anthropic-oauth" &&
-        userProviderType !== "anthropic-key" && (
-          <>
-            <Separator />
-            <div className="space-y-1.5">
-              <Label className="text-xs">
-                Choose Model
-              </Label>
-              <p className="text-muted-foreground text-xs">
-                Pick a model for your provider.
-              </p>
-              {modelsError ? (
-                <p className="text-destructive text-xs">
-                  {modelsError}
-                </p>
-              ) : (
-                <ModelPicker
-                  groups={groups}
-                  activeConfig={activeConfig}
-                  onSaved={loadData}
-                  maxCostPerMillion={costCeiling}
-                  saveAsOverride
-                />
-              )}
-            </div>
-          </>
-        )}
-
       {isAdmin && (
         <>
           <Separator />
@@ -1289,20 +1260,15 @@ export function AIModelTab() {
             <Label className="text-xs">
               Model Policy
             </Label>
-            <div className="flex items-center justify-between">
-              <div className="space-y-0.5">
-                <p className="text-sm font-medium">
-                  Allow user model selection
-                </p>
-                <p className="text-muted-foreground text-xs">
-                  When off, all users use the model
-                  set above.
-                </p>
-              </div>
-              <Switch
-                checked={allowUserSelection}
-                onCheckedChange={setAllowUserSelection}
-              />
+            <div className="space-y-0.5">
+              <p className="text-sm font-medium">
+                Organization-managed model
+              </p>
+              <p className="text-muted-foreground text-xs">
+                Staff interact with Jarvis. The underlying model
+                is selected here by administrators and is not
+                exposed in chat.
+              </p>
             </div>
             <div className="space-y-2">
               <div className="flex items-center justify-between">
@@ -1348,7 +1314,7 @@ export function AIModelTab() {
                     costCeiling !== null
                       ? costCeiling.toFixed(2)
                       : null,
-                    allowUserSelection
+                    false
                   )
                 setPolicySaving(false)
                 if (result.success) {
@@ -1375,11 +1341,7 @@ export function AIModelTab() {
               Change Model
             </Label>
             <p className="text-muted-foreground text-xs">
-              {userProviderType &&
-              userProviderType !== "anthropic-oauth" &&
-              userProviderType !== "anthropic-key"
-                ? "Pick a model for your provider."
-                : "Select a model from OpenRouter. Applies to all users."}
+              Select the internal model Jarvis uses for all staff.
             </p>
             {modelsError ? (
               <p className="text-destructive text-xs">
@@ -1391,11 +1353,7 @@ export function AIModelTab() {
                 activeConfig={activeConfig}
                 onSaved={loadData}
                 maxCostPerMillion={costCeiling}
-                saveAsOverride={
-                  userProviderType !== null &&
-                  userProviderType !== "anthropic-oauth" &&
-                  userProviderType !== "anthropic-key"
-                }
+                saveAsOverride={false}
               />
             )}
           </div>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -174,7 +174,7 @@ export function SiteHeader({
               size="icon"
               className="size-7 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
               onClick={() => agentContext?.toggle()}
-              aria-label="Toggle assistant"
+              aria-label="Toggle Jarvis"
             >
               <IconSparkles className="size-4" />
             </Button>

--- a/src/hooks/use-agent.ts
+++ b/src/hooks/use-agent.ts
@@ -89,12 +89,12 @@ export function useAgent(options: UseAgentOptions = {}): UseAgentReturn {
           "x-session-id": sessionId,
           "x-current-page": currentPage,
           "x-timezone": timezone,
-          "x-model": getAgentModelId(),
         }
 
         // Standalone mode: JWT auth via server action
         // Cloud mode: WorkOS session cookie (same-origin, automatic)
         if (isStandalone) {
+          headers["x-model"] = getAgentModelId()
           const { getAgentToken } = await import("@/app/actions/agent-auth")
           const tokenResult = await getAgentToken()
           if ("error" in tokenResult) {
@@ -121,7 +121,17 @@ export function useAgent(options: UseAgentOptions = {}): UseAgentReturn {
         })
 
         if (!response.ok) {
-          throw new Error(`Agent server error: ${response.status}`)
+          const payload = await response
+            .json()
+            .catch(() => null)
+          const message =
+            payload &&
+            typeof payload === "object" &&
+            "error" in payload &&
+            typeof payload.error === "string"
+              ? payload.error
+              : `Agent server error: ${response.status}`
+          throw new Error(message)
         }
 
         if (!response.body) {

--- a/src/lib/agent/__tests__/runtime-config.test.ts
+++ b/src/lib/agent/__tests__/runtime-config.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest"
+import {
+  resolveRuntimeModelId,
+  resolveRuntimeProvider,
+  selectRuntimeModel,
+} from "@/lib/agent/runtime-config"
+
+describe("resolveRuntimeProvider", () => {
+  it("uses the shared OpenRouter secret when a stored provider has no key", () => {
+    const result = resolveRuntimeProvider(
+      {
+        type: "openrouter",
+        apiKey: null,
+        baseUrl: "https://openrouter.ai/api",
+        modelOverrides: null,
+      },
+      { OPENROUTER_API_KEY: "shared-openrouter-key" }
+    )
+
+    expect(result).toEqual({
+      success: true,
+      providerType: "openrouter",
+      provider: {
+        type: "openrouter",
+        apiKey: "shared-openrouter-key",
+        baseUrl: "https://openrouter.ai/api",
+        modelOverrides: undefined,
+      },
+    })
+  })
+
+  it("prefers a stored key over the shared deployment secret", () => {
+    const result = resolveRuntimeProvider(
+      {
+        type: "openrouter",
+        apiKey: "stored-key",
+        baseUrl: null,
+        modelOverrides: null,
+      },
+      { OPENROUTER_API_KEY: "shared-key" }
+    )
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.provider.apiKey).toBe("stored-key")
+    }
+  })
+
+  it("defaults to the shared OpenRouter provider when no row exists", () => {
+    const result = resolveRuntimeProvider(null, {
+      OPENROUTER_API_KEY: "shared-openrouter-key",
+    })
+
+    expect(result).toEqual({
+      success: true,
+      providerType: "openrouter",
+      provider: {
+        type: "openrouter",
+        apiKey: "shared-openrouter-key",
+      },
+    })
+  })
+
+  it("returns a useful configuration error instead of an unauthenticated client", () => {
+    const result = resolveRuntimeProvider(
+      {
+        type: "openrouter",
+        apiKey: null,
+        baseUrl: null,
+        modelOverrides: null,
+      },
+      {}
+    )
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        "The openrouter provider is selected but OPENROUTER_API_KEY is not configured.",
+    })
+  })
+})
+
+describe("resolveRuntimeModelId", () => {
+  it("preserves the globally configured OpenRouter model ID", () => {
+    expect(
+      resolveRuntimeModelId(
+        "deepseek/deepseek-chat-v3.1",
+        "openrouter"
+      )
+    ).toBe("deepseek/deepseek-chat-v3.1")
+  })
+
+  it("keeps compatibility with legacy short model names", () => {
+    expect(
+      resolveRuntimeModelId("sonnet", "openrouter")
+    ).toBe("anthropic/claude-sonnet-4")
+  })
+})
+
+describe("selectRuntimeModel", () => {
+  it("makes the server-side active model authoritative", () => {
+    expect(
+      selectRuntimeModel(
+        "deepseek/deepseek-chat-v3.1",
+        "anthropic/claude-opus-4"
+      )
+    ).toBe("deepseek/deepseek-chat-v3.1")
+  })
+
+  it("uses a request model only for legacy deployments without agent config", () => {
+    expect(
+      selectRuntimeModel(null, "anthropic/claude-sonnet-4")
+    ).toBe("anthropic/claude-sonnet-4")
+  })
+})

--- a/src/lib/agent/runtime-config.ts
+++ b/src/lib/agent/runtime-config.ts
@@ -1,0 +1,173 @@
+import type { ProviderConfig } from "agent-core"
+
+export interface StoredProviderConfig {
+  readonly type: string
+  readonly apiKey: string | null
+  readonly baseUrl: string | null
+  readonly modelOverrides: Readonly<Record<string, string>> | null
+}
+
+export interface AgentRuntimeSecrets {
+  readonly ANTHROPIC_API_KEY?: string
+  readonly OPENROUTER_API_KEY?: string
+}
+
+export type RuntimeProviderResult =
+  | {
+      readonly success: true
+      readonly provider: ProviderConfig
+      readonly providerType: string
+    }
+  | {
+      readonly success: false
+      readonly error: string
+    }
+
+function requiresApiKey(type: ProviderConfig["type"]): boolean {
+  return type !== "ollama"
+}
+
+export function mapRuntimeProviderType(
+  type: string
+): ProviderConfig["type"] {
+  switch (type) {
+    case "anthropic-key":
+    case "anthropic-oauth":
+    case "anthropic":
+      return "anthropic"
+    case "openrouter":
+      return "openrouter"
+    case "ollama":
+      return "ollama"
+    default:
+      return "custom"
+  }
+}
+
+function sharedApiKey(
+  type: ProviderConfig["type"],
+  secrets: AgentRuntimeSecrets
+): string | undefined {
+  if (type === "openrouter") {
+    return secrets.OPENROUTER_API_KEY
+  }
+  if (type === "anthropic") {
+    return secrets.ANTHROPIC_API_KEY
+  }
+  return undefined
+}
+
+/**
+ * Builds the runtime provider without exposing deployment secrets to the
+ * browser. A stored provider may intentionally omit its own key and use the
+ * organization's shared Worker secret.
+ */
+export function resolveRuntimeProvider(
+  stored: StoredProviderConfig | null,
+  secrets: AgentRuntimeSecrets
+): RuntimeProviderResult {
+  if (!stored) {
+    if (secrets.OPENROUTER_API_KEY) {
+      return {
+        success: true,
+        providerType: "openrouter",
+        provider: {
+          type: "openrouter",
+          apiKey: secrets.OPENROUTER_API_KEY,
+        },
+      }
+    }
+
+    if (secrets.ANTHROPIC_API_KEY) {
+      return {
+        success: true,
+        providerType: "anthropic",
+        provider: {
+          type: "anthropic",
+          apiKey: secrets.ANTHROPIC_API_KEY,
+        },
+      }
+    }
+
+    return {
+      success: false,
+      error:
+        "No shared AI provider is configured. An administrator must configure OPENROUTER_API_KEY or ANTHROPIC_API_KEY.",
+    }
+  }
+
+  const type = mapRuntimeProviderType(stored.type)
+  const apiKey =
+    stored.apiKey ?? sharedApiKey(type, secrets)
+
+  if (requiresApiKey(type) && !apiKey) {
+    const secretName =
+      type === "openrouter"
+        ? "OPENROUTER_API_KEY"
+        : type === "anthropic"
+          ? "ANTHROPIC_API_KEY"
+          : "an API key"
+    return {
+      success: false,
+      error: `The ${stored.type} provider is selected but ${secretName} is not configured.`,
+    }
+  }
+
+  return {
+    success: true,
+    providerType: stored.type,
+    provider: {
+      type,
+      apiKey,
+      baseUrl: stored.baseUrl ?? undefined,
+      modelOverrides:
+        stored.modelOverrides ?? undefined,
+    },
+  }
+}
+
+/**
+ * Resolves legacy short model names for providers that still use them.
+ * Full OpenRouter and Anthropic model IDs pass through unchanged.
+ */
+export function resolveRuntimeModelId(
+  model: string,
+  providerType: string
+): string {
+  if (model.includes("/") || model.startsWith("claude-")) {
+    return model
+  }
+
+  const anthropicModels: Readonly<Record<string, string>> = {
+    sonnet: "claude-sonnet-4-20250514",
+    opus: "claude-opus-4-20250514",
+    haiku: "claude-3-5-haiku-20241022",
+  }
+
+  const openrouterModels: Readonly<Record<string, string>> = {
+    sonnet: "anthropic/claude-sonnet-4",
+    opus: "anthropic/claude-opus-4",
+    haiku: "anthropic/claude-3.5-haiku",
+  }
+
+  if (
+    providerType === "anthropic" ||
+    providerType === "anthropic-oauth" ||
+    providerType === "anthropic-key"
+  ) {
+    return anthropicModels[model] ?? model
+  }
+
+  if (providerType === "openrouter") {
+    return openrouterModels[model] ?? model
+  }
+
+  return model
+}
+
+export function selectRuntimeModel(
+  configuredModel: string | null | undefined,
+  requestedModel: string | null | undefined
+): string {
+  return configuredModel ?? requestedModel ?? "sonnet"
+}


### PR DESCRIPTION
## What changed

- restore the shared OpenRouter secret fallback when a stored provider row does not contain its own key
- make the server-side active model authoritative instead of accepting stale browser model choices
- present Jarvis as the single staff-facing assistant identity in Ask Compass
- remove the model picker from chat and restrict provider/model controls to administrators
- preserve the explicit guest-user denial across every Ask Compass API endpoint
- show useful provider configuration errors instead of an opaque HTTP status

## Root cause

Production had an active OpenRouter provider record without a per-user API key and a valid shared `OPENROUTER_API_KEY` Worker secret. The agent route never applied that shared secret to the stored provider, so it constructed an unauthenticated OpenRouter client. The route also ignored the global active model and trusted a legacy browser model header.

## User impact

Staff interact with Jarvis through Ask Compass without choosing or seeing internal models. Administrators manage the internal provider and model in settings. Guest accounts remain unable to access Ask Compass.

## Validation

- `bunx tsc --noEmit`
- targeted Vitest suite: 14 tests passed
- `bun lint` (0 errors; existing repository warnings only)
- `bun run build`
- verified the configured DeepSeek model remains in OpenRouter's live model catalog with tool support
