### PR TITLE
Add notification lifecycle and audience alerts

### DIFF
--- a/docs/architecture/jarvis-feedback-bridge.md
+++ b/docs/architecture/jarvis-feedback-bridge.md
@@ -235,6 +235,29 @@ POST /api/integrations/jarvis/events
 The adapter must not send a Telegram token or message-provider credential in
 the payload or metadata.
 
+### Update a Feedback Desk request
+
+```text
+POST /api/integrations/jarvis/feedback/<feedback-desk-item-id>/status
+```
+
+The signed lifecycle endpoint accepts an idempotency key, one of the visible
+request states (`new`, `triaged`, `needs_info`, `planned`, `in_progress`,
+`testing`, `deployed`, or `closed`), an optional staff-facing message,
+priority, and GitHub issue URL. Compass updates the durable Feedback Desk
+record and creates:
+
+- an in-app notification for the matching authenticated requester;
+- preference-aware email/push delivery for information-needed, testing, and
+  deployment milestones; and
+- a `feedback.status_changed` outbound bridge event so Telegram, email, and
+  originating Compass-thread adapters can reply through the source channel.
+
+The notification links to `/dashboard/requests`, where authenticated users
+see only requests matching their organization and account email. GitHub
+remains the developer record and is not required for staff to follow a
+request.
+
 ### Reply to a Compass assistance request
 
 ```text
@@ -274,6 +297,24 @@ Substantive answers should be drafts until the response policy has been
 validated with staff. Never automatically send commitments, personnel
 decisions, security or privacy disclosures, legal or financial guidance, or
 customer-sensitive statements.
+
+Compass notification behavior
+---
+
+The notification bell is the default awareness surface:
+
+- every ordinary conversation message creates a bell notification for other
+  channel members whose channel notification level allows it;
+- ordinary channel messages are bell-only so routine traffic does not create
+  an email flood;
+- direct mentions keep their existing push behavior;
+- RFI participants and mapped to-do or schedule assignees receive
+  preference-aware notifications; and
+- Feedback Desk milestones create requester notifications.
+
+The bell refreshes when opened, when the browser regains focus, and every 15
+seconds while Compass is open. Conversation unread counts are incremented for
+other channel members when a message is stored.
 
 Rollout checklist
 ---

--- a/src/app/actions/chat-messages.ts
+++ b/src/app/actions/chat-messages.ts
@@ -1,7 +1,16 @@
 "use server"
 
 import { getCloudflareContext } from "@/lib/db"
-import { eq, and, desc, lt, sql, like, or } from "drizzle-orm"
+import {
+  eq,
+  and,
+  desc,
+  lt,
+  sql,
+  like,
+  ne,
+  or,
+} from "drizzle-orm"
 import { marked } from "marked"
 import { getDb } from "@/db"
 import {
@@ -25,6 +34,7 @@ import { isDemoUser } from "@/lib/demo"
 import { requireOrg } from "@/lib/org-scope"
 import { revalidatePath } from "next/cache"
 import { enqueueFeedbackDeskItem } from "@/lib/jarvis/feedback-desk"
+import { notifyChannelMessage } from "@/lib/notifications/events"
 
 const MAX_MESSAGE_LENGTH = 4000
 const EMOJI_REGEX = /^[\p{Emoji}\u200d]+$/u
@@ -266,6 +276,7 @@ export async function sendMessage(data: {
       .select({
         name: channels.name,
         organizationId: channels.organizationId,
+        projectId: channels.projectId,
       })
       .from(channels)
       .where(eq(channels.id, data.channelId))
@@ -301,6 +312,43 @@ export async function sendMessage(data: {
         })
       } catch (error) {
         console.error("conversation_feedback_enqueue_failed", {
+          messageId,
+          channelId: data.channelId,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Unknown error",
+        })
+      }
+    }
+
+    await db
+      .update(channelReadState)
+      .set({
+        unreadCount: sql`${channelReadState.unreadCount} + 1`,
+      })
+      .where(
+        and(
+          eq(channelReadState.channelId, data.channelId),
+          ne(channelReadState.userId, user.id)
+        )
+      )
+
+    if (channel) {
+      try {
+        await notifyChannelMessage({
+          organizationId: channel.organizationId,
+          projectId: channel.projectId,
+          channelId: data.channelId,
+          channelName: channel.name,
+          messageId,
+          threadId: data.threadId ?? null,
+          content: data.content,
+          sender: user,
+          mentions: data.mentions ?? [],
+        })
+      } catch (error) {
+        console.error("channel_message_notification_failed", {
           messageId,
           channelId: data.channelId,
           error:

--- a/src/app/actions/feedback-requests.ts
+++ b/src/app/actions/feedback-requests.ts
@@ -1,0 +1,76 @@
+"use server"
+
+import { and, desc, eq, or, sql } from "drizzle-orm"
+
+import { getDb } from "@/db"
+import { feedbackDeskItems } from "@/db/schema-jarvis"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { requireOrg } from "@/lib/org-scope"
+
+export type MyFeedbackRequest = {
+  readonly id: string
+  readonly kind: string
+  readonly status: string
+  readonly priority: string
+  readonly title: string
+  readonly description: string
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+type MyFeedbackRequestsResult =
+  | {
+      readonly success: true
+      readonly data: readonly MyFeedbackRequest[]
+    }
+  | { readonly success: false; readonly error: string }
+
+export async function getMyFeedbackRequests(): Promise<MyFeedbackRequestsResult> {
+  try {
+    const user = await requireAuth()
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const email = user.email.trim().toLowerCase()
+    const googleEmail = user.googleEmail?.trim().toLowerCase()
+    const reporterMatches =
+      googleEmail && googleEmail !== email
+        ? or(
+            sql`lower(${feedbackDeskItems.reporterEmail}) = ${email}`,
+            sql`lower(${feedbackDeskItems.reporterEmail}) = ${googleEmail}`
+          )
+        : sql`lower(${feedbackDeskItems.reporterEmail}) = ${email}`
+
+    const rows = await db
+      .select({
+        id: feedbackDeskItems.id,
+        kind: feedbackDeskItems.kind,
+        status: feedbackDeskItems.status,
+        priority: feedbackDeskItems.priority,
+        title: feedbackDeskItems.title,
+        description: feedbackDeskItems.description,
+        createdAt: feedbackDeskItems.createdAt,
+        updatedAt: feedbackDeskItems.updatedAt,
+      })
+      .from(feedbackDeskItems)
+      .where(
+        and(
+          eq(feedbackDeskItems.organizationId, organizationId),
+          reporterMatches
+        )
+      )
+      .orderBy(desc(feedbackDeskItems.updatedAt))
+      .limit(100)
+
+    return { success: true, data: rows }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to load your requests",
+    }
+  }
+}

--- a/src/app/actions/notifications.ts
+++ b/src/app/actions/notifications.ts
@@ -198,7 +198,7 @@ export async function getNotificationCenter(): Promise<NotificationCenterResult>
         )
       )
       .orderBy(desc(notificationRecipients.createdAt))
-      .limit(20)
+      .limit(100)
 
     return {
       success: true,

--- a/src/app/actions/project-messages.ts
+++ b/src/app/actions/project-messages.ts
@@ -11,10 +11,14 @@ import {
   projects,
   users,
 } from "@/db/schema"
-import { channels } from "@/db/schema-conversations"
+import {
+  channelMembers,
+  channels,
+} from "@/db/schema-conversations"
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { requireOrg } from "@/lib/org-scope"
+import { channelNotificationRecipients } from "@/lib/notifications/audience"
 
 export type ProjectMessageRecipient =
   | { readonly kind: "channel" }
@@ -222,6 +226,25 @@ export async function sendProjectMessage(input: {
       organizationId,
       selectedContacts
     )
+    const memberRows = await db
+      .select({
+        userId: channelMembers.userId,
+        notifyLevel: channelMembers.notifyLevel,
+        email: users.email,
+      })
+      .from(channelMembers)
+      .innerJoin(users, eq(users.id, channelMembers.userId))
+      .where(eq(channelMembers.channelId, input.channelId))
+    const channelBellUserIds = new Set(
+      channelNotificationRecipients(
+        memberRows,
+        user.id,
+        input.mentions ?? []
+      ).map((recipient) => recipient.userId)
+    )
+    const additionalBellRecipients = matchedUsers.filter(
+      (recipient) => !channelBellUserIds.has(recipient.userId)
+    )
 
     const project = await db
       .select({
@@ -257,6 +280,30 @@ export async function sendProjectMessage(input: {
       audience: input.recipient.kind,
       createdBy: user.id,
       recipients: matchedUsers,
+      delivery: {
+        inApp: false,
+        email: true,
+        push: true,
+      },
+    })
+    await createNotificationEvent({
+      organizationId,
+      projectId: channel.projectId,
+      eventType: "message.project_audience",
+      sourceType: "message",
+      sourceId: sent.data.id,
+      title: `${importantPrefix}New Compass message for ${projectLabel}`,
+      body: `${importantPrefix}${user.displayName ?? user.email} sent a project message to ${label}.`,
+      href: `/dashboard/conversations/${input.channelId}`,
+      priority,
+      audience: input.recipient.kind,
+      createdBy: user.id,
+      recipients: additionalBellRecipients,
+      delivery: {
+        inApp: true,
+        email: false,
+        push: false,
+      },
     })
 
     return {

--- a/src/app/actions/project-operations.ts
+++ b/src/app/actions/project-operations.ts
@@ -18,6 +18,7 @@ import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { requireOrg } from "@/lib/org-scope"
 import { requirePermission } from "@/lib/permissions"
+import { notifyProjectAssignment } from "@/lib/notifications/events"
 
 export type ProjectOperationItem = {
   readonly id: string
@@ -1935,6 +1936,8 @@ export async function createProjectTask(
   input: CreateProjectTaskInput
 ): Promise<ProjectOperationActionResult> {
   try {
+    const user = await requireAuth()
+    const organizationId = requireOrg(user)
     const db = await verifyProjectUpdateAccess(projectId)
     const [project] = await db
       .select({
@@ -2010,6 +2013,23 @@ export async function createProjectTask(
       createdAt: now,
       updatedAt: now,
     })
+
+    try {
+      await notifyProjectAssignment({
+        organizationId,
+        projectId,
+        itemId: id,
+        title,
+        assignedToName: cleanText(input.assigneeName),
+        createdBy: user,
+        kind: "task",
+      })
+    } catch (notificationError) {
+      console.error(
+        "Project task assignment notification failed:",
+        notificationError
+      )
+    }
 
     revalidatePath(`/dashboard/projects/${projectId}`)
     revalidatePath(`/dashboard/projects/${projectId}/rfis`)

--- a/src/app/actions/project-rfis.ts
+++ b/src/app/actions/project-rfis.ts
@@ -5,7 +5,10 @@ import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
 import { projectRfiAttachments, projectRfis, projects } from "@/db/schema"
-import { notifyRfiCreated } from "@/lib/notifications/events"
+import {
+  notifyRfiCreated,
+  notifyRfiUpdated,
+} from "@/lib/notifications/events"
 import { requireAuth } from "@/lib/auth"
 import type { AuthUser } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
@@ -389,7 +392,28 @@ export async function updateProjectRfi(
   input: UpdateProjectRfiInput
 ): Promise<ProjectRfiActionResult> {
   try {
-    const db = await verifyProjectUpdateAccess(projectId)
+    const { db, user, orgId } =
+      await getProjectUpdateContext(projectId)
+    const existing = await db
+      .select({
+        rfiNumber: projectRfis.rfiNumber,
+        subject: projectRfis.subject,
+        requesterName: projectRfis.requesterName,
+        assignedToName: projectRfis.assignedToName,
+      })
+      .from(projectRfis)
+      .where(
+        and(
+          eq(projectRfis.id, rfiId),
+          eq(projectRfis.projectId, projectId)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!existing) {
+      return { success: false, error: "RFI not found" }
+    }
+
     const now = new Date().toISOString()
     const answer = cleanText(input.answer)
     const status = answer && input.status === "new" ? "in_progress" : input.status
@@ -408,6 +432,22 @@ export async function updateProjectRfi(
     revalidatePath(`/dashboard/projects/${projectId}/rfis`)
     revalidatePath(`/dashboard/projects/${projectId}/preview/owner`)
     revalidatePath(`/dashboard/projects/${projectId}/preview/sub-vendor`)
+
+    try {
+      await notifyRfiUpdated({
+        organizationId: orgId,
+        projectId,
+        rfiId,
+        rfiNumber: existing.rfiNumber,
+        subject: existing.subject,
+        status,
+        requesterName: existing.requesterName,
+        assignedToName: existing.assignedToName,
+        updatedBy: user,
+      })
+    } catch (notificationError) {
+      console.error("[project-rfis] update notification error", notificationError)
+    }
 
     return { success: true, id: rfiId }
   } catch (error) {

--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -17,6 +17,7 @@ import { propagateDates } from "@/lib/schedule/propagate-dates"
 import { requireAuth } from "@/lib/auth"
 import { requireOrg } from "@/lib/org-scope"
 import { isDemoUser } from "@/lib/demo"
+import { notifyProjectAssignment } from "@/lib/notifications/events"
 import type {
   TaskStatus,
   DependencyType,
@@ -161,6 +162,23 @@ export async function createTask(
       updatedAt: now,
     })
 
+    try {
+      await notifyProjectAssignment({
+        organizationId: orgId,
+        projectId,
+        itemId: id,
+        title: data.title,
+        assignedToName: data.assignedTo ?? null,
+        createdBy: user,
+        kind: "schedule",
+      })
+    } catch (notificationError) {
+      console.error(
+        "Schedule assignment notification failed:",
+        notificationError
+      )
+    }
+
     await recalcCriticalPath(db, projectId)
     revalidatePath(`/dashboard/projects/${projectId}/schedule`)
     return { success: true }
@@ -240,6 +258,29 @@ export async function updateTask(
         updatedAt: new Date().toISOString(),
       })
       .where(eq(scheduleTasks.id, taskId))
+
+    if (
+      data.assignedTo !== undefined &&
+      data.assignedTo !== null &&
+      data.assignedTo !== task.assignedTo
+    ) {
+      try {
+        await notifyProjectAssignment({
+          organizationId: orgId,
+          projectId: task.projectId,
+          itemId: taskId,
+          title: data.title ?? task.title,
+          assignedToName: data.assignedTo,
+          createdBy: user,
+          kind: "schedule",
+        })
+      } catch (notificationError) {
+        console.error(
+          "Schedule reassignment notification failed:",
+          notificationError
+        )
+      }
+    }
 
     // propagate date changes to downstream tasks
     const schedule = await getSchedule(task.projectId)

--- a/src/app/api/integrations/jarvis/feedback/[id]/status/route.ts
+++ b/src/app/api/integrations/jarvis/feedback/[id]/status/route.ts
@@ -1,0 +1,290 @@
+import { and, eq, or, sql } from "drizzle-orm"
+import { z } from "zod/v4"
+
+import { getDb } from "@/db"
+import { organizationMembers, users } from "@/db/schema"
+import {
+  feedbackDeskItems,
+  jarvisBridgeEvents,
+} from "@/db/schema-jarvis"
+import { getCloudflareContext } from "@/lib/db"
+import {
+  getJarvisEnvValue,
+  readBoundedBody,
+  verifyJarvisRequest,
+} from "@/lib/jarvis/auth"
+import {
+  FEEDBACK_DESK_STATUSES,
+  feedbackStatusLabel,
+  feedbackStatusMessage,
+  feedbackStatusUsesEmail,
+} from "@/lib/jarvis/feedback-lifecycle"
+import { createSystemNotificationEvent } from "@/lib/notifications/events"
+
+const statusUpdateSchema = z.object({
+  idempotencyKey: z.string().min(1).max(256),
+  status: z.enum(FEEDBACK_DESK_STATUSES),
+  message: z.string().min(1).max(2_000).optional(),
+  priority: z.enum(["low", "normal", "high", "urgent"]).optional(),
+  githubIssueUrl: z.union([z.url().max(2_048), z.null()]).optional(),
+})
+
+function metadataActorId(metadata: string | null): string | null {
+  if (!metadata) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(metadata)
+  } catch {
+    return null
+  }
+  if (typeof parsed !== "object" || parsed === null) return null
+  const actorId = Reflect.get(parsed, "externalActorId")
+  return typeof actorId === "string" && actorId.length > 0
+    ? actorId
+    : null
+}
+
+export async function POST(
+  request: Request,
+  { params }: {
+    readonly params: Promise<{ readonly id: string }>
+  }
+): Promise<Response> {
+  const bodyResult = await readBoundedBody(request)
+  if (!bodyResult.success) {
+    return Response.json(
+      { error: bodyResult.error },
+      { status: 413 }
+    )
+  }
+
+  const { env } = await getCloudflareContext()
+  const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
+  const organizationId = getJarvisEnvValue(
+    env,
+    "JARVIS_BRIDGE_ORGANIZATION_ID"
+  )
+  if (!secret || !organizationId) {
+    return Response.json(
+      { error: "Jarvis lifecycle bridge is not configured" },
+      { status: 503 }
+    )
+  }
+
+  const verification = await verifyJarvisRequest(
+    request,
+    secret,
+    bodyResult.rawBody
+  )
+  if (!verification.success) {
+    return Response.json(
+      { error: verification.error },
+      { status: 401 }
+    )
+  }
+
+  let body: unknown
+  try {
+    body = JSON.parse(bodyResult.rawBody)
+  } catch {
+    return Response.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+  const parsed = statusUpdateSchema.safeParse(body)
+  if (!parsed.success) {
+    return Response.json(
+      {
+        error: "Invalid feedback status update",
+        details: parsed.error.issues,
+      },
+      { status: 400 }
+    )
+  }
+
+  const { id } = await params
+  const db = getDb(env.DB)
+  const eventKey =
+    `feedback-status:${id}:${parsed.data.idempotencyKey}`
+  const duplicate = await db
+    .select({ id: jarvisBridgeEvents.id })
+    .from(jarvisBridgeEvents)
+    .where(eq(jarvisBridgeEvents.idempotencyKey, eventKey))
+    .get()
+  if (duplicate) {
+    return Response.json({ success: true, duplicate: true })
+  }
+
+  const item = await db
+    .select()
+    .from(feedbackDeskItems)
+    .where(
+      and(
+        eq(feedbackDeskItems.id, id),
+        eq(feedbackDeskItems.organizationId, organizationId)
+      )
+    )
+    .get()
+  if (!item) {
+    return Response.json(
+      { error: "Feedback request not found" },
+      { status: 404 }
+    )
+  }
+
+  // Only Ask Jarvis carries an authenticated Compass user ID. External
+  // adapter actor IDs (Telegram/email) must never be treated as user IDs.
+  const actorId =
+    item.source === "ask-jarvis"
+      ? metadataActorId(item.metadata)
+      : null
+  const reporterEmail = item.reporterEmail?.trim().toLowerCase()
+  const recipientFilter =
+    actorId && reporterEmail
+      ? or(
+          eq(users.id, actorId),
+          sql`lower(${users.email}) = ${reporterEmail}`,
+          sql`lower(${users.googleEmail}) = ${reporterEmail}`
+        )
+      : actorId
+        ? eq(users.id, actorId)
+        : reporterEmail
+          ? or(
+              sql`lower(${users.email}) = ${reporterEmail}`,
+              sql`lower(${users.googleEmail}) = ${reporterEmail}`
+            )
+          : null
+  const recipients = recipientFilter
+    ? await db
+        .select({
+          userId: users.id,
+          email: users.email,
+        })
+        .from(organizationMembers)
+        .innerJoin(users, eq(users.id, organizationMembers.userId))
+        .where(
+          and(
+            eq(
+              organizationMembers.organizationId,
+              organizationId
+            ),
+            eq(users.isActive, true),
+            recipientFilter
+          )
+        )
+    : []
+
+  const now = new Date().toISOString()
+  const message =
+    parsed.data.message ??
+    feedbackStatusMessage(parsed.data.status, item.title)
+  await db
+    .update(feedbackDeskItems)
+    .set({
+      status: parsed.data.status,
+      priority: parsed.data.priority ?? item.priority,
+      githubIssueUrl:
+        parsed.data.githubIssueUrl === undefined
+          ? item.githubIssueUrl
+          : parsed.data.githubIssueUrl,
+      updatedAt: now,
+    })
+    .where(eq(feedbackDeskItems.id, id))
+
+  if (recipients.length > 0) {
+    try {
+      await createSystemNotificationEvent({
+        organizationId,
+        projectId: null,
+        eventType: `feedback.status.${parsed.data.status}`,
+        sourceType: "feedback",
+        sourceId: id,
+        title: `Request update: ${feedbackStatusLabel(parsed.data.status)}`,
+        body: message,
+        href: `/dashboard/requests#request-${id}`,
+        priority:
+          parsed.data.status === "needs_info" ? "high" : "normal",
+        audience: "requester",
+        recipients,
+        delivery: {
+          inApp: true,
+          email: feedbackStatusUsesEmail(parsed.data.status),
+          push: feedbackStatusUsesEmail(parsed.data.status),
+        },
+      })
+    } catch (error) {
+      console.error("feedback_lifecycle_notification_failed", {
+        feedbackDeskItemId: id,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unknown error",
+      })
+    }
+  }
+
+  const statusPayload = JSON.stringify({
+    schemaVersion: 1,
+    feedbackDeskItemId: id,
+    source: item.source,
+    sourceId: item.sourceId,
+    status: parsed.data.status,
+    title: item.title,
+    message,
+    reporter: {
+      name: item.reporterName,
+      email: item.reporterEmail,
+      externalActorId: actorId,
+    },
+    compass: {
+      organizationId,
+      channelId: item.channelId,
+      messageId: item.messageId,
+      threadId: item.threadId,
+    },
+    metadata: item.metadata,
+    githubIssueUrl:
+      parsed.data.githubIssueUrl === undefined
+        ? item.githubIssueUrl
+        : parsed.data.githubIssueUrl,
+    updatedAt: now,
+  })
+
+  await db.insert(jarvisBridgeEvents).values({
+    id: crypto.randomUUID(),
+    organizationId,
+    direction: "inbound",
+    source: "signet",
+    eventType: "feedback.status_updated",
+    status: "completed",
+    idempotencyKey: eventKey,
+    feedbackDeskItemId: id,
+    payload: bodyResult.rawBody,
+    result: statusPayload,
+    availableAt: now,
+    completedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  })
+  await db
+    .insert(jarvisBridgeEvents)
+    .values({
+      id: crypto.randomUUID(),
+      organizationId,
+      direction: "outbound",
+      source: "feedback-lifecycle",
+      eventType: "feedback.status_changed",
+      idempotencyKey: `notify:${eventKey}`,
+      feedbackDeskItemId: id,
+      payload: statusPayload,
+      availableAt: now,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing()
+
+  return Response.json({
+    success: true,
+    feedbackDeskItemId: id,
+    status: parsed.data.status,
+    notifiedUserCount: recipients.length,
+  })
+}

--- a/src/app/dashboard/requests/page.tsx
+++ b/src/app/dashboard/requests/page.tsx
@@ -1,0 +1,100 @@
+import {
+  IconMessageCircleQuestion,
+} from "@tabler/icons-react"
+
+import { getMyFeedbackRequests } from "@/app/actions/feedback-requests"
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { feedbackStatusLabel } from "@/lib/jarvis/feedback-lifecycle"
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value))
+}
+
+export default async function RequestsPage() {
+  const result = await getMyFeedbackRequests()
+  const requests = result.success ? result.data : []
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-4 md:p-6">
+      <div>
+        <p className="text-sm font-medium text-primary">
+          Compass Feedback Desk
+        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          My requests
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Follow feature requests and problem reports from receipt
+          through deployment.
+        </p>
+      </div>
+
+      {!result.success && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Requests are temporarily unavailable</CardTitle>
+            <CardDescription>{result.error}</CardDescription>
+          </CardHeader>
+        </Card>
+      )}
+
+      {result.success && requests.length === 0 && (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+            <IconMessageCircleQuestion className="size-8 text-muted-foreground" />
+            <div>
+              <p className="font-medium">No requests yet</p>
+              <p className="text-sm text-muted-foreground">
+                Requests submitted through Ask Jarvis or Compass
+                Feedback will appear here.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="grid gap-4">
+        {requests.map((request) => (
+          <Card key={request.id} id={`request-${request.id}`}>
+            <CardHeader className="gap-3">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <CardTitle className="text-base">
+                    {request.title}
+                  </CardTitle>
+                  <CardDescription className="mt-1">
+                    Submitted {formatDate(request.createdAt)}
+                  </CardDescription>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant="secondary">
+                    {feedbackStatusLabel(request.status)}
+                  </Badge>
+                  <Badge variant="outline">{request.kind}</Badge>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <p className="whitespace-pre-wrap text-sm text-muted-foreground">
+                {request.description}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Last updated {formatDate(request.updatedAt)}
+              </p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -12,6 +12,7 @@ import {
   IconMailForward,
   IconMessageCircle,
   IconMessageCircleQuestion,
+  IconMessageReport,
   IconPalette,
   IconPhoto,
   IconReceipt,
@@ -113,6 +114,11 @@ const NAV_MAIN = [
     title: "Conversations",
     url: "/dashboard/conversations",
     icon: IconMessageCircle,
+  },
+  {
+    title: "My Requests",
+    url: "/dashboard/requests",
+    icon: IconMessageReport,
   },
   {
     title: "Files",

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -90,7 +90,7 @@ export function CommandMenu({
   return (
     <CommandDialog open={open} onOpenChange={setOpen}>
       <CommandInput
-        placeholder="Type a command or search..."
+        placeholder="Ask Jarvis or search Compass..."
         value={query}
         onValueChange={setQuery}
       />

--- a/src/components/mobile-search.tsx
+++ b/src/components/mobile-search.tsx
@@ -407,7 +407,7 @@ export function MobileSearch({
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search..."
+          placeholder="Ask Jarvis or search Compass..."
           className={cn(
             "flex-1 h-10 bg-transparent text-base",
             "text-foreground placeholder:text-muted-foreground",

--- a/src/components/notifications-popover.tsx
+++ b/src/components/notifications-popover.tsx
@@ -1,6 +1,12 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import Link from "next/link"
 import {
   IconAlertCircle,
@@ -132,30 +138,64 @@ export function NotificationsPopover() {
   const [loading, setLoading] = useState(true)
   const [notifications, setNotifications] =
     useState<readonly NotificationCenterItem[]>([])
+  const mountedRef = useRef(true)
   const unreadCount = useMemo(
     () => notifications.filter((item) => item.readAt === null).length,
     [notifications]
   )
   const hasUnread = unreadCount > 0
 
-  useEffect(() => {
-    let cancelled = false
-    async function load(): Promise<void> {
-      setLoading(true)
-      const result = await getNotificationCenter()
-      if (!cancelled && result.success) {
-        setNotifications(result.data.items)
+  const loadNotifications = useCallback(
+    async (showLoading: boolean): Promise<void> => {
+      if (showLoading) setLoading(true)
+      try {
+        const result = await getNotificationCenter()
+        if (!mountedRef.current) return
+        if (result.success) {
+          setNotifications(result.data.items)
+        }
+      } catch {
+        // Keep the last known notifications during a transient refresh error.
+      } finally {
+        if (mountedRef.current) setLoading(false)
       }
-      if (!cancelled) {
-        setLoading(false)
-      }
-    }
+    },
+    []
+  )
 
-    load()
-    return () => {
-      cancelled = true
+  useEffect(() => {
+    mountedRef.current = true
+    void loadNotifications(true)
+    const intervalId = window.setInterval(() => {
+      void loadNotifications(false)
+    }, 15_000)
+    function refreshWhenVisible(): void {
+      if (document.visibilityState === "visible") {
+        void loadNotifications(false)
+      }
     }
-  }, [])
+    window.addEventListener("focus", refreshWhenVisible)
+    document.addEventListener(
+      "visibilitychange",
+      refreshWhenVisible
+    )
+    return () => {
+      mountedRef.current = false
+      window.clearInterval(intervalId)
+      window.removeEventListener("focus", refreshWhenVisible)
+      document.removeEventListener(
+        "visibilitychange",
+        refreshWhenVisible
+      )
+    }
+  }, [loadNotifications])
+
+  function changeOpen(nextOpen: boolean): void {
+    setOpen(nextOpen)
+    if (nextOpen) {
+      void loadNotifications(false)
+    }
+  }
 
   async function clearAll(): Promise<void> {
     const result = await markAllNotificationsRead()
@@ -197,7 +237,7 @@ export function NotificationsPopover() {
 
   if (isMobile) {
     return (
-      <Sheet open={open} onOpenChange={setOpen}>
+      <Sheet open={open} onOpenChange={changeOpen}>
         <SheetTrigger asChild>{trigger}</SheetTrigger>
         <SheetContent side="bottom" className="p-0" showClose={false}>
           <SheetHeader className="border-b px-4 py-3 text-left">
@@ -217,7 +257,7 @@ export function NotificationsPopover() {
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={changeOpen}>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent align="end" className="w-80 p-0">
         <div className="border-b px-4 py-3">

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -75,11 +75,11 @@ export function SiteHeader({
             type="button"
             className="flex h-9 flex-1 items-center gap-2 rounded-full px-2 hover:bg-background/60"
             onClick={openCommand}
-            aria-label="Search"
+            aria-label="Ask Jarvis or search Compass"
           >
             <IconSearch className="size-4 text-muted-foreground shrink-0" />
             <span className="text-muted-foreground text-sm">
-              Search...
+              Ask Jarvis or search...
             </span>
           </button>
           <button
@@ -156,7 +156,7 @@ export function SiteHeader({
                 searchInputRef.current?.blur()
               }
             }}
-            placeholder="Search..."
+            placeholder="Ask Jarvis or search Compass..."
             className="flex h-8 w-full items-center rounded-full border border-border/50 bg-muted/30 pl-9 pr-16 text-sm outline-none transition-colors placeholder:text-muted-foreground/60 hover:bg-muted/50 focus:bg-muted/50 focus:border-border"
           />
           <kbd

--- a/src/lib/__tests__/middleware-routes.test.ts
+++ b/src/lib/__tests__/middleware-routes.test.ts
@@ -10,6 +10,11 @@ describe("middleware public routes", () => {
       ),
     ).toBe(true)
     expect(isPublicPath("/api/integrations/jarvis/replies")).toBe(true)
+    expect(
+      isPublicPath(
+        "/api/integrations/jarvis/feedback/request-123/status"
+      )
+    ).toBe(true)
   })
 
   it("does not make unrelated integration routes public", () => {

--- a/src/lib/jarvis/__tests__/feedback-lifecycle.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-lifecycle.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  feedbackStatusLabel,
+  feedbackStatusMessage,
+  feedbackStatusUsesEmail,
+} from "@/lib/jarvis/feedback-lifecycle"
+
+describe("Feedback Desk lifecycle", () => {
+  it("uses staff-facing labels for every visible lifecycle state", () => {
+    expect(feedbackStatusLabel("new")).toBe("New")
+    expect(feedbackStatusLabel("needs_info")).toBe(
+      "Information needed"
+    )
+    expect(feedbackStatusLabel("in_progress")).toBe("In progress")
+    expect(feedbackStatusLabel("testing")).toBe(
+      "Ready for testing"
+    )
+    expect(feedbackStatusLabel("deployed")).toBe("Deployed")
+  })
+
+  it("creates an understandable default update message", () => {
+    expect(
+      feedbackStatusMessage("in_progress", "Daily Log printing")
+    ).toContain("Development has started")
+    expect(
+      feedbackStatusMessage("deployed", "Daily Log printing")
+    ).toContain("deployed to Compass")
+  })
+
+  it("reserves email for updates that need attention or close the loop", () => {
+    expect(feedbackStatusUsesEmail("triaged")).toBe(false)
+    expect(feedbackStatusUsesEmail("in_progress")).toBe(false)
+    expect(feedbackStatusUsesEmail("needs_info")).toBe(true)
+    expect(feedbackStatusUsesEmail("testing")).toBe(true)
+    expect(feedbackStatusUsesEmail("deployed")).toBe(true)
+  })
+})

--- a/src/lib/jarvis/feedback-lifecycle.ts
+++ b/src/lib/jarvis/feedback-lifecycle.ts
@@ -1,0 +1,72 @@
+export const FEEDBACK_DESK_STATUSES = [
+  "new",
+  "triaged",
+  "needs_info",
+  "planned",
+  "in_progress",
+  "testing",
+  "deployed",
+  "closed",
+] as const
+
+export type FeedbackDeskStatus =
+  (typeof FEEDBACK_DESK_STATUSES)[number]
+
+export function feedbackStatusLabel(status: string): string {
+  switch (status) {
+    case "new":
+      return "New"
+    case "triaged":
+      return "Triaged"
+    case "needs_info":
+      return "Information needed"
+    case "planned":
+      return "Planned"
+    case "in_progress":
+      return "In progress"
+    case "testing":
+      return "Ready for testing"
+    case "deployed":
+      return "Deployed"
+    case "closed":
+      return "Closed"
+    default:
+      return status
+        .replace(/[_-]+/g, " ")
+        .replace(/\b\w/g, (letter) => letter.toUpperCase())
+  }
+}
+
+export function feedbackStatusMessage(
+  status: FeedbackDeskStatus,
+  title: string
+): string {
+  switch (status) {
+    case "new":
+      return `Your request “${title}” has been received.`
+    case "triaged":
+      return `Your request “${title}” has been reviewed and triaged.`
+    case "needs_info":
+      return `Jarvis needs more information about “${title}” before work can continue.`
+    case "planned":
+      return `Your request “${title}” has been accepted and planned.`
+    case "in_progress":
+      return `Development has started on “${title}”.`
+    case "testing":
+      return `“${title}” is ready for testing.`
+    case "deployed":
+      return `“${title}” has been deployed to Compass.`
+    case "closed":
+      return `Your request “${title}” has been completed and closed.`
+  }
+}
+
+export function feedbackStatusUsesEmail(
+  status: FeedbackDeskStatus
+): boolean {
+  return (
+    status === "needs_info" ||
+    status === "testing" ||
+    status === "deployed"
+  )
+}

--- a/src/lib/notifications/__tests__/audience.test.ts
+++ b/src/lib/notifications/__tests__/audience.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+
+import { channelNotificationRecipients } from "@/lib/notifications/audience"
+
+const MEMBERS = [
+  {
+    userId: "sender",
+    email: "sender@example.com",
+    notifyLevel: "all",
+  },
+  {
+    userId: "channel-member",
+    email: "member@example.com",
+    notifyLevel: "all",
+  },
+  {
+    userId: "mentions-only",
+    email: "mentions@example.com",
+    notifyLevel: "mentions",
+  },
+  {
+    userId: "muted",
+    email: "muted@example.com",
+    notifyLevel: "none",
+  },
+] as const
+
+describe("channel notification audience", () => {
+  it("notifies ordinary channel members without requiring a mention", () => {
+    expect(
+      channelNotificationRecipients(MEMBERS, "sender", [])
+    ).toEqual([
+      {
+        userId: "channel-member",
+        email: "member@example.com",
+      },
+    ])
+  })
+
+  it("respects mentions-only and muted channel preferences", () => {
+    expect(
+      channelNotificationRecipients(MEMBERS, "sender", [
+        {
+          mentionType: "user",
+          targetId: "mentions-only",
+        },
+      ])
+    ).toEqual([
+      {
+        userId: "channel-member",
+        email: "member@example.com",
+      },
+      {
+        userId: "mentions-only",
+        email: "mentions@example.com",
+      },
+    ])
+  })
+})

--- a/src/lib/notifications/__tests__/create-event.test.ts
+++ b/src/lib/notifications/__tests__/create-event.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { resolveNotificationDelivery } from "@/lib/notifications/create-event"
+import { resolveNotificationDelivery } from "@/lib/notifications/delivery"
 
 describe("notification delivery", () => {
   it("keeps ordinary channel messages in the notification bell", () => {

--- a/src/lib/notifications/__tests__/create-event.test.ts
+++ b/src/lib/notifications/__tests__/create-event.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveNotificationDelivery } from "@/lib/notifications/create-event"
+
+describe("notification delivery", () => {
+  it("keeps ordinary channel messages in the notification bell", () => {
+    expect(
+      resolveNotificationDelivery(
+        {
+          inAppEnabled: true,
+          emailEnabled: true,
+          pushEnabled: true,
+        },
+        {
+          inApp: true,
+          email: false,
+          push: false,
+        }
+      )
+    ).toEqual({
+      inApp: true,
+      email: false,
+      push: false,
+    })
+  })
+
+  it("honors a recipient's disabled delivery preferences", () => {
+    expect(
+      resolveNotificationDelivery(
+        {
+          inAppEnabled: true,
+          emailEnabled: false,
+          pushEnabled: false,
+        },
+        {
+          inApp: true,
+          email: true,
+          push: true,
+        }
+      )
+    ).toEqual({
+      inApp: true,
+      email: false,
+      push: false,
+    })
+  })
+})

--- a/src/lib/notifications/audience.ts
+++ b/src/lib/notifications/audience.ts
@@ -1,0 +1,47 @@
+import type { NotificationRecipientInput } from "@/lib/notifications/create-event"
+
+export type ChannelMessageMention = {
+  readonly mentionType: "user" | "channel" | "here" | "agent"
+  readonly targetId: string | null
+}
+
+type ChannelNotificationMember = {
+  readonly userId: string
+  readonly email: string
+  readonly notifyLevel: string
+}
+
+export function channelNotificationRecipients(
+  members: readonly ChannelNotificationMember[],
+  senderId: string,
+  mentions: readonly ChannelMessageMention[]
+): readonly NotificationRecipientInput[] {
+  const directlyMentioned = new Set(
+    mentions
+      .filter(
+        (mention) =>
+          mention.mentionType === "user" &&
+          mention.targetId !== null
+      )
+      .map((mention) => mention.targetId)
+  )
+  const mentionsChannel = mentions.some(
+    (mention) =>
+      mention.mentionType === "channel" ||
+      mention.mentionType === "here"
+  )
+
+  return members
+    .filter((member) => {
+      if (member.userId === senderId) return false
+      if (member.notifyLevel === "none") return false
+      if (member.notifyLevel === "all") return true
+      return (
+        directlyMentioned.has(member.userId) || mentionsChannel
+      )
+    })
+    .map((member) => ({
+      userId: member.userId,
+      email: member.email,
+    }))
+}

--- a/src/lib/notifications/create-event.ts
+++ b/src/lib/notifications/create-event.ts
@@ -12,6 +12,10 @@ import {
 } from "@/db/schema"
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
+import {
+  resolveNotificationDelivery,
+  type NotificationDelivery,
+} from "@/lib/notifications/delivery"
 import { requireOrg } from "@/lib/org-scope"
 import { sendPushNotification } from "@/lib/push/send"
 
@@ -29,12 +33,6 @@ type NotificationPreferenceState = {
 export type NotificationRecipientInput = {
   readonly userId: string
   readonly email: string
-}
-
-export type NotificationDelivery = {
-  readonly inApp: boolean
-  readonly email: boolean
-  readonly push: boolean
 }
 
 export type CreateNotificationInput = {
@@ -119,20 +117,6 @@ function notificationCategoryEnabled(
   return true
 }
 
-export function resolveNotificationDelivery(
-  preferences: Pick<
-    NotificationPreferenceState,
-    "inAppEnabled" | "emailEnabled" | "pushEnabled"
-  >,
-  requested: NotificationDelivery
-): NotificationDelivery {
-  return {
-    inApp: requested.inApp && preferences.inAppEnabled,
-    email: requested.email && preferences.emailEnabled,
-    push: requested.push && preferences.pushEnabled,
-  }
-}
-
 function notificationEmailBody(
   input: Pick<CreateNotificationInput, "title" | "body" | "href">
 ): string {
@@ -144,6 +128,11 @@ function notificationEmailBody(
     `Open in Compass: ${input.href}`,
   ].join("\n")
 }
+
+export {
+  resolveNotificationDelivery,
+  type NotificationDelivery,
+} from "@/lib/notifications/delivery"
 
 async function sendResendEmail(
   env: unknown,

--- a/src/lib/notifications/create-event.ts
+++ b/src/lib/notifications/create-event.ts
@@ -1,0 +1,410 @@
+import { and, eq, inArray } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import {
+  notificationDeliveries,
+  notificationEvents,
+  notificationPreferences,
+  notificationRecipients,
+  organizationMembers,
+  users,
+} from "@/db/schema"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { requireOrg } from "@/lib/org-scope"
+import { sendPushNotification } from "@/lib/push/send"
+
+type NotificationPreferenceState = {
+  readonly inAppEnabled: boolean
+  readonly emailEnabled: boolean
+  readonly pushEnabled: boolean
+  readonly weeklyDigestEnabled: boolean
+  readonly rfiEnabled: boolean
+  readonly ownerUpdateEnabled: boolean
+  readonly scheduleEnabled: boolean
+  readonly poEnabled: boolean
+}
+
+export type NotificationRecipientInput = {
+  readonly userId: string
+  readonly email: string
+}
+
+export type NotificationDelivery = {
+  readonly inApp: boolean
+  readonly email: boolean
+  readonly push: boolean
+}
+
+export type CreateNotificationInput = {
+  readonly organizationId: string
+  readonly projectId: string | null
+  readonly eventType: string
+  readonly sourceType: string
+  readonly sourceId: string | null
+  readonly title: string
+  readonly body: string
+  readonly href: string
+  readonly priority: string
+  readonly audience: string
+  readonly createdBy: string | null
+  readonly recipients: readonly NotificationRecipientInput[]
+  readonly delivery: NotificationDelivery
+}
+
+const DEFAULT_PREFERENCES: NotificationPreferenceState = {
+  inAppEnabled: true,
+  emailEnabled: true,
+  pushEnabled: true,
+  weeklyDigestEnabled: false,
+  rfiEnabled: true,
+  ownerUpdateEnabled: true,
+  scheduleEnabled: true,
+  poEnabled: true,
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function envString(env: unknown, key: string): string | null {
+  if (!isRecord(env)) return process.env[key] ?? null
+  const value = env[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : process.env[key] ?? null
+}
+
+export function isMissingNotificationTableError(
+  error: unknown
+): boolean {
+  if (!(error instanceof Error)) return false
+  const message = error.message.toLowerCase()
+  return (
+    message.includes("notification_") &&
+    (message.includes("no such table") ||
+      message.includes("failed query"))
+  )
+}
+
+function preferenceFromRow(
+  row: typeof notificationPreferences.$inferSelect | null
+): NotificationPreferenceState {
+  if (!row) return DEFAULT_PREFERENCES
+  return {
+    inAppEnabled: row.inAppEnabled,
+    emailEnabled: row.emailEnabled,
+    pushEnabled: row.pushEnabled,
+    weeklyDigestEnabled: row.weeklyDigestEnabled,
+    rfiEnabled: row.rfiEnabled,
+    ownerUpdateEnabled: row.ownerUpdateEnabled,
+    scheduleEnabled: row.scheduleEnabled,
+    poEnabled: row.poEnabled,
+  }
+}
+
+function notificationCategoryEnabled(
+  preferences: NotificationPreferenceState,
+  eventType: string
+): boolean {
+  if (eventType.startsWith("rfi.")) return preferences.rfiEnabled
+  if (eventType.startsWith("owner_update.")) {
+    return preferences.ownerUpdateEnabled
+  }
+  if (eventType.startsWith("schedule.")) {
+    return preferences.scheduleEnabled
+  }
+  if (eventType.startsWith("po.")) return preferences.poEnabled
+  return true
+}
+
+export function resolveNotificationDelivery(
+  preferences: Pick<
+    NotificationPreferenceState,
+    "inAppEnabled" | "emailEnabled" | "pushEnabled"
+  >,
+  requested: NotificationDelivery
+): NotificationDelivery {
+  return {
+    inApp: requested.inApp && preferences.inAppEnabled,
+    email: requested.email && preferences.emailEnabled,
+    push: requested.push && preferences.pushEnabled,
+  }
+}
+
+function notificationEmailBody(
+  input: Pick<CreateNotificationInput, "title" | "body" | "href">
+): string {
+  return [
+    input.title,
+    "",
+    input.body,
+    "",
+    `Open in Compass: ${input.href}`,
+  ].join("\n")
+}
+
+async function sendResendEmail(
+  env: unknown,
+  toAddress: string,
+  subject: string,
+  body: string
+): Promise<{
+  readonly status: string
+  readonly providerMessageId: string | null
+  readonly error: string | null
+}> {
+  const apiKey = envString(env, "RESEND_API_KEY")
+  if (!apiKey) {
+    return {
+      status: "pending_provider",
+      providerMessageId: null,
+      error: "RESEND_API_KEY is not configured",
+    }
+  }
+
+  const fromAddress =
+    envString(env, "COMPASS_EMAIL_FROM") ??
+    "Compass <notifications@compass.build>"
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: fromAddress,
+      to: [toAddress],
+      subject,
+      text: body,
+    }),
+  })
+
+  const responseText = await response.text()
+  let providerMessageId: string | null = null
+  try {
+    const parsed: unknown = JSON.parse(responseText)
+    if (isRecord(parsed) && typeof parsed.id === "string") {
+      providerMessageId = parsed.id
+    }
+  } catch {
+    providerMessageId = null
+  }
+
+  return {
+    status: response.ok ? "sent" : "failed",
+    providerMessageId,
+    error: response.ok ? null : responseText.slice(0, 500),
+  }
+}
+
+async function getPreferenceForUser(
+  db: ReturnType<typeof getDb>,
+  userId: string
+): Promise<NotificationPreferenceState> {
+  const row = await db
+    .select()
+    .from(notificationPreferences)
+    .where(eq(notificationPreferences.userId, userId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+
+  return preferenceFromRow(row)
+}
+
+async function persistNotificationEvent(
+  input: CreateNotificationInput
+): Promise<void> {
+  const requestedRecipientIds = Array.from(
+    new Set(input.recipients.map((recipient) => recipient.userId))
+  )
+  if (requestedRecipientIds.length === 0) return
+
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const recipients = await db
+    .select({
+      userId: users.id,
+      email: users.email,
+      googleEmail: users.googleEmail,
+    })
+    .from(organizationMembers)
+    .innerJoin(users, eq(users.id, organizationMembers.userId))
+    .where(
+      and(
+        eq(
+          organizationMembers.organizationId,
+          input.organizationId
+        ),
+        eq(users.isActive, true),
+        inArray(organizationMembers.userId, requestedRecipientIds)
+      )
+    )
+  if (recipients.length === 0) return
+
+  const now = new Date().toISOString()
+  const eventId = crypto.randomUUID()
+  try {
+    await db.insert(notificationEvents).values({
+      id: eventId,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      eventType: input.eventType,
+      sourceType: input.sourceType,
+      sourceId: input.sourceId,
+      title: input.title,
+      body: input.body,
+      href: input.href,
+      priority: input.priority,
+      audience: input.audience,
+      createdBy: input.createdBy,
+      createdAt: now,
+    })
+
+    for (const recipient of recipients) {
+      const preferences = await getPreferenceForUser(
+        db,
+        recipient.userId
+      )
+      if (
+        !notificationCategoryEnabled(preferences, input.eventType)
+      ) {
+        continue
+      }
+
+      const delivery = resolveNotificationDelivery(
+        preferences,
+        input.delivery
+      )
+      if (!delivery.email && !delivery.inApp && !delivery.push) {
+        continue
+      }
+
+      const recipientId = crypto.randomUUID()
+      await db.insert(notificationRecipients).values({
+        id: recipientId,
+        eventId,
+        userId: recipient.userId,
+        inApp: delivery.inApp,
+        email: delivery.email,
+        push: delivery.push,
+        readAt: null,
+        dismissedAt: null,
+        createdAt: now,
+      })
+
+      if (delivery.email) {
+        const emailDelivery = await sendResendEmail(
+          env,
+          recipient.googleEmail ?? recipient.email,
+          input.title,
+          notificationEmailBody(input)
+        )
+        await db.insert(notificationDeliveries).values({
+          id: crypto.randomUUID(),
+          eventId,
+          recipientId,
+          userId: recipient.userId,
+          channel: "email",
+          status: emailDelivery.status,
+          toAddress: recipient.email,
+          provider: "resend",
+          providerMessageId: emailDelivery.providerMessageId,
+          error: emailDelivery.error,
+          attemptedAt: new Date().toISOString(),
+          createdAt: now,
+        })
+      }
+
+      if (delivery.push) {
+        const fcmServerKey = envString(env, "FCM_SERVER_KEY")
+        let status = "pending_provider"
+        let error: string | null =
+          "FCM_SERVER_KEY is not configured"
+        if (fcmServerKey) {
+          try {
+            const result = await sendPushNotification(
+              env.DB,
+              fcmServerKey,
+              {
+                userId: recipient.userId,
+                title: input.title,
+                body: input.body,
+                data: {
+                  href: input.href,
+                  eventType: input.eventType,
+                },
+              }
+            )
+            status =
+              result.failed > 0
+                ? "failed"
+                : result.sent > 0
+                  ? "sent"
+                  : "skipped_no_token"
+            error =
+              result.failed > 0
+                ? `${result.failed} push delivery attempt(s) failed`
+                : null
+          } catch (pushError) {
+            status = "failed"
+            error =
+              pushError instanceof Error
+                ? pushError.message
+                : "Push delivery failed"
+          }
+        }
+
+        await db.insert(notificationDeliveries).values({
+          id: crypto.randomUUID(),
+          eventId,
+          recipientId,
+          userId: recipient.userId,
+          channel: "push",
+          status,
+          toAddress: null,
+          provider: "fcm",
+          providerMessageId: null,
+          error,
+          attemptedAt: new Date().toISOString(),
+          createdAt: now,
+        })
+      }
+    }
+
+    revalidatePath("/", "layout")
+  } catch (error) {
+    if (!isMissingNotificationTableError(error)) {
+      throw error
+    }
+  }
+}
+
+export async function createNotificationEvent(
+  input: CreateNotificationInput
+): Promise<void> {
+  const user = await requireAuth()
+  const organizationId = requireOrg(user)
+  if (organizationId !== input.organizationId) {
+    throw new Error(
+      "Cannot create notifications outside the active organization"
+    )
+  }
+  if (input.createdBy !== user.id) {
+    throw new Error(
+      "Cannot create notifications on behalf of another user"
+    )
+  }
+
+  await persistNotificationEvent(input)
+}
+
+export async function createSystemNotificationEvent(
+  input: Omit<CreateNotificationInput, "createdBy">
+): Promise<void> {
+  await persistNotificationEvent({
+    ...input,
+    createdBy: null,
+  })
+}

--- a/src/lib/notifications/delivery.ts
+++ b/src/lib/notifications/delivery.ts
@@ -1,0 +1,22 @@
+export type NotificationDelivery = {
+  readonly inApp: boolean
+  readonly email: boolean
+  readonly push: boolean
+}
+
+type NotificationDeliveryPreferences = {
+  readonly inAppEnabled: boolean
+  readonly emailEnabled: boolean
+  readonly pushEnabled: boolean
+}
+
+export function resolveNotificationDelivery(
+  preferences: NotificationDeliveryPreferences,
+  requested: NotificationDelivery
+): NotificationDelivery {
+  return {
+    inApp: requested.inApp && preferences.inAppEnabled,
+    email: requested.email && preferences.emailEnabled,
+    push: requested.push && preferences.pushEnabled,
+  }
+}

--- a/src/lib/notifications/events.ts
+++ b/src/lib/notifications/events.ts
@@ -1,52 +1,29 @@
-import { and, eq, inArray, or } from "drizzle-orm"
-import { revalidatePath } from "next/cache"
+import { and, eq } from "drizzle-orm"
 
 import { getDb } from "@/db"
 import {
-  notificationDeliveries,
-  notificationEvents,
-  notificationPreferences,
-  notificationRecipients,
   organizationMembers,
   projectContacts,
   projects,
   users,
 } from "@/db/schema"
+import { channelMembers } from "@/db/schema-conversations"
 import type { AuthUser } from "@/lib/auth"
-import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
-import { requireOrg } from "@/lib/org-scope"
+import {
+  createNotificationEvent,
+  type NotificationRecipientInput,
+} from "@/lib/notifications/create-event"
+import {
+  channelNotificationRecipients,
+  type ChannelMessageMention,
+} from "@/lib/notifications/audience"
 
-type NotificationPreferenceState = {
-  readonly inAppEnabled: boolean
-  readonly emailEnabled: boolean
-  readonly pushEnabled: boolean
-  readonly weeklyDigestEnabled: boolean
-  readonly rfiEnabled: boolean
-  readonly ownerUpdateEnabled: boolean
-  readonly scheduleEnabled: boolean
-  readonly poEnabled: boolean
-}
-
-type NotificationRecipientInput = {
-  readonly userId: string
-  readonly email: string
-}
-
-type CreateNotificationInput = {
-  readonly organizationId: string
-  readonly projectId: string | null
-  readonly eventType: string
-  readonly sourceType: string
-  readonly sourceId: string | null
-  readonly title: string
-  readonly body: string
-  readonly href: string
-  readonly priority: string
-  readonly audience: string
-  readonly createdBy: string | null
-  readonly recipients: readonly NotificationRecipientInput[]
-}
+export {
+  createNotificationEvent,
+  createSystemNotificationEvent,
+  isMissingNotificationTableError,
+} from "@/lib/notifications/create-event"
 
 type RfiNotificationInput = {
   readonly organizationId: string
@@ -58,63 +35,38 @@ type RfiNotificationInput = {
   readonly createdBy: AuthUser
 }
 
-const DEFAULT_PREFERENCES: NotificationPreferenceState = {
-  inAppEnabled: true,
-  emailEnabled: true,
-  pushEnabled: true,
-  weeklyDigestEnabled: false,
-  rfiEnabled: true,
-  ownerUpdateEnabled: true,
-  scheduleEnabled: true,
-  poEnabled: true,
+type RfiUpdatedNotificationInput = {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly rfiId: string
+  readonly rfiNumber: string
+  readonly subject: string
+  readonly status: string
+  readonly requesterName: string | null
+  readonly assignedToName: string | null
+  readonly updatedBy: AuthUser
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null
+type ProjectAssignmentNotificationInput = {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly itemId: string
+  readonly title: string
+  readonly assignedToName: string | null
+  readonly createdBy: AuthUser
+  readonly kind: "task" | "schedule"
 }
 
-function envString(env: unknown, key: string): string | null {
-  if (!isRecord(env)) return process.env[key] ?? null
-  const value = env[key]
-  return typeof value === "string" && value.trim().length > 0
-    ? value
-    : process.env[key] ?? null
-}
-
-export function isMissingNotificationTableError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false
-  const message = error.message.toLowerCase()
-  return (
-    message.includes("notification_") &&
-    (message.includes("no such table") || message.includes("failed query"))
-  )
-}
-
-function preferenceFromRow(
-  row: typeof notificationPreferences.$inferSelect | null
-): NotificationPreferenceState {
-  if (!row) return DEFAULT_PREFERENCES
-  return {
-    inAppEnabled: row.inAppEnabled,
-    emailEnabled: row.emailEnabled,
-    pushEnabled: row.pushEnabled,
-    weeklyDigestEnabled: row.weeklyDigestEnabled,
-    rfiEnabled: row.rfiEnabled,
-    ownerUpdateEnabled: row.ownerUpdateEnabled,
-    scheduleEnabled: row.scheduleEnabled,
-    poEnabled: row.poEnabled,
-  }
-}
-
-function notificationCategoryEnabled(
-  preferences: NotificationPreferenceState,
-  eventType: string
-): boolean {
-  if (eventType.startsWith("rfi.")) return preferences.rfiEnabled
-  if (eventType.startsWith("owner_update.")) return preferences.ownerUpdateEnabled
-  if (eventType.startsWith("schedule.")) return preferences.scheduleEnabled
-  if (eventType.startsWith("po.")) return preferences.poEnabled
-  return true
+type ChannelMessageNotificationInput = {
+  readonly organizationId: string
+  readonly projectId: string | null
+  readonly channelId: string
+  readonly channelName: string
+  readonly messageId: string
+  readonly threadId: string | null
+  readonly content: string
+  readonly sender: AuthUser
+  readonly mentions: readonly ChannelMessageMention[]
 }
 
 function normalizeName(value: string | null): string {
@@ -124,194 +76,147 @@ function normalizeName(value: string | null): string {
     .trim()
 }
 
-function notificationEmailBody(input: CreateNotificationInput): string {
-  return [
-    input.title,
-    "",
-    input.body,
-    "",
-    `Open in Compass: ${input.href}`,
-  ].join("\n")
-}
-
-async function sendResendEmail(
-  env: unknown,
-  toAddress: string,
-  subject: string,
-  body: string
-): Promise<{
-  readonly status: string
-  readonly providerMessageId: string | null
-  readonly error: string | null
-}> {
-  const apiKey = envString(env, "RESEND_API_KEY")
-  if (!apiKey) {
-    return {
-      status: "pending_provider",
-      providerMessageId: null,
-      error: "RESEND_API_KEY is not configured",
-    }
-  }
-
-  const fromAddress =
-    envString(env, "COMPASS_EMAIL_FROM") ??
-    "Compass <notifications@compass.build>"
-
-  const response = await fetch("https://api.resend.com/emails", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      from: fromAddress,
-      to: [toAddress],
-      subject,
-      text: body,
-    }),
-  })
-
-  const responseText = await response.text()
-  let providerMessageId: string | null = null
-  try {
-    const parsed = JSON.parse(responseText)
-    if (isRecord(parsed) && typeof parsed.id === "string") {
-      providerMessageId = parsed.id
-    }
-  } catch {
-    providerMessageId = null
-  }
-
-  return {
-    status: response.ok ? "sent" : "failed",
-    providerMessageId,
-    error: response.ok ? null : responseText.slice(0, 500),
-  }
-}
-
-async function getPreferenceForUser(
+async function projectAssignmentRecipients(
   db: ReturnType<typeof getDb>,
-  userId: string
-): Promise<NotificationPreferenceState> {
-  const row = await db
-    .select()
-    .from(notificationPreferences)
-    .where(eq(notificationPreferences.userId, userId))
-    .limit(1)
-    .then((rows) => rows[0] ?? null)
-
-  return preferenceFromRow(row)
-}
-
-export async function createNotificationEvent(
-  input: CreateNotificationInput
-): Promise<void> {
-  const user = await requireAuth()
-  const orgId = requireOrg(user)
-
-  if (orgId !== input.organizationId) {
-    throw new Error("Cannot create notifications outside the active organization")
-  }
-
-  if (input.createdBy !== user.id) {
-    throw new Error("Cannot create notifications on behalf of another user")
-  }
-
-  const requestedRecipientIds = Array.from(
-    new Set(input.recipients.map((recipient) => recipient.userId))
+  organizationId: string,
+  projectId: string,
+  names: readonly (string | null)[]
+): Promise<readonly NotificationRecipientInput[]> {
+  const normalizedNames = new Set(
+    names.map(normalizeName).filter((name) => name.length > 0)
   )
-  if (requestedRecipientIds.length === 0) return
+  if (normalizedNames.size === 0) return []
 
-  const { env } = await getCloudflareContext()
-  const db = getDb(env.DB)
-  const now = new Date().toISOString()
-  const eventId = crypto.randomUUID()
-
-  const recipients = await db
+  const contacts = await db
     .select({
-      userId: users.id,
+      displayName: projectContacts.displayName,
+      companyName: projectContacts.companyName,
+      email: projectContacts.email,
+    })
+    .from(projectContacts)
+    .where(eq(projectContacts.projectId, projectId))
+  const matchingEmails = new Set(
+    contacts
+      .filter((contact) => {
+        const candidates = [
+          contact.displayName,
+          contact.companyName,
+          contact.companyName
+            ? `${contact.displayName} - ${contact.companyName}`
+            : null,
+        ].map(normalizeName)
+        return candidates.some((candidate) =>
+          normalizedNames.has(candidate)
+        )
+      })
+      .map((contact) => contact.email?.trim().toLowerCase() ?? "")
+      .filter((email) => email.length > 0)
+  )
+
+  const orgUsers = await db
+    .select({
+      id: users.id,
       email: users.email,
       googleEmail: users.googleEmail,
+      displayName: users.displayName,
+      firstName: users.firstName,
+      lastName: users.lastName,
     })
-    .from(organizationMembers)
-    .innerJoin(users, eq(users.id, organizationMembers.userId))
+    .from(users)
+    .innerJoin(
+      organizationMembers,
+      eq(organizationMembers.userId, users.id)
+    )
     .where(
       and(
-        eq(organizationMembers.organizationId, orgId),
-        eq(users.isActive, true),
-        inArray(organizationMembers.userId, requestedRecipientIds)
+        eq(organizationMembers.organizationId, organizationId),
+        eq(users.isActive, true)
       )
     )
 
-  if (recipients.length === 0) return
-
-  try {
-    await db.insert(notificationEvents).values({
-      id: eventId,
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      eventType: input.eventType,
-      sourceType: input.sourceType,
-      sourceId: input.sourceId,
-      title: input.title,
-      body: input.body,
-      href: input.href,
-      priority: input.priority,
-      audience: input.audience,
-      createdBy: input.createdBy,
-      createdAt: now,
-    })
-
-    for (const recipient of recipients) {
-      const preferences = await getPreferenceForUser(db, recipient.userId)
-      if (!notificationCategoryEnabled(preferences, input.eventType)) continue
-
-      const recipientId = crypto.randomUUID()
-      const emailEnabled = preferences.emailEnabled
-      const inAppEnabled = preferences.inAppEnabled
-
-      await db.insert(notificationRecipients).values({
-        id: recipientId,
-        eventId,
-        userId: recipient.userId,
-        inApp: inAppEnabled,
-        email: emailEnabled,
-        push: preferences.pushEnabled,
-        readAt: null,
-        dismissedAt: null,
-        createdAt: now,
+  const recipients = new Map<string, NotificationRecipientInput>()
+  for (const orgUser of orgUsers) {
+    const primaryEmail = orgUser.email.trim().toLowerCase()
+    const googleEmail =
+      orgUser.googleEmail?.trim().toLowerCase() ?? null
+    const candidates = [
+      orgUser.displayName,
+      [orgUser.firstName, orgUser.lastName]
+        .filter((part) => part !== null)
+        .join(" "),
+      primaryEmail.split("@")[0] ?? "",
+    ].map(normalizeName)
+    const matchesName = candidates.some((candidate) =>
+      normalizedNames.has(candidate)
+    )
+    const matchesEmail =
+      matchingEmails.has(primaryEmail) ||
+      (googleEmail !== null && matchingEmails.has(googleEmail))
+    if (matchesName || matchesEmail) {
+      recipients.set(orgUser.id, {
+        userId: orgUser.id,
+        email: googleEmail ?? primaryEmail,
       })
-
-      if (emailEnabled) {
-        const delivery = await sendResendEmail(
-          env,
-          recipient.googleEmail ?? recipient.email,
-          input.title,
-          notificationEmailBody(input)
-        )
-        await db.insert(notificationDeliveries).values({
-          id: crypto.randomUUID(),
-          eventId,
-          recipientId,
-          userId: recipient.userId,
-          channel: "email",
-          status: delivery.status,
-          toAddress: recipient.email,
-          provider: "resend",
-          providerMessageId: delivery.providerMessageId,
-          error: delivery.error,
-          attemptedAt: new Date().toISOString(),
-          createdAt: now,
-        })
-      }
-    }
-
-    revalidatePath("/", "layout")
-  } catch (error) {
-    if (!isMissingNotificationTableError(error)) {
-      throw error
     }
   }
+
+  return Array.from(recipients.values())
+}
+
+function notificationPreview(content: string): string {
+  const compact = content.replace(/\s+/g, " ").trim()
+  if (compact.length <= 240) return compact
+  return `${compact.slice(0, 237)}...`
+}
+
+export async function notifyChannelMessage(
+  input: ChannelMessageNotificationInput
+): Promise<void> {
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const members = await db
+    .select({
+      userId: channelMembers.userId,
+      notifyLevel: channelMembers.notifyLevel,
+      email: users.email,
+    })
+    .from(channelMembers)
+    .innerJoin(users, eq(users.id, channelMembers.userId))
+    .where(eq(channelMembers.channelId, input.channelId))
+
+  const recipients = channelNotificationRecipients(
+    members,
+    input.sender.id,
+    input.mentions
+  )
+
+  if (recipients.length === 0) return
+
+  const senderName =
+    input.sender.displayName ?? input.sender.email
+  await createNotificationEvent({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    eventType: input.threadId
+      ? "message.thread_reply"
+      : "message.channel",
+    sourceType: "message",
+    sourceId: input.messageId,
+    title: input.threadId
+      ? `${senderName} replied in #${input.channelName}`
+      : `${senderName} in #${input.channelName}`,
+    body: notificationPreview(input.content),
+    href: `/dashboard/conversations/${input.channelId}`,
+    priority: "normal",
+    audience: "channel",
+    createdBy: input.sender.id,
+    recipients,
+    delivery: {
+      inApp: true,
+      email: false,
+      push: false,
+    },
+  })
 }
 
 export async function notifyRfiCreated(
@@ -337,60 +242,14 @@ export async function notifyRfiCreated(
     email: input.createdBy.email,
   })
 
-  const assigned = normalizeName(input.assignedToName)
-  if (assigned.length > 0) {
-    const contacts = await db
-      .select({
-        displayName: projectContacts.displayName,
-        companyName: projectContacts.companyName,
-        email: projectContacts.email,
-      })
-      .from(projectContacts)
-      .where(eq(projectContacts.projectId, input.projectId))
-
-    const emails = contacts
-      .filter((contact) => {
-        const candidates = [
-          contact.displayName,
-          contact.companyName,
-          contact.companyName
-            ? `${contact.displayName} - ${contact.companyName}`
-            : null,
-        ].map(normalizeName)
-        return candidates.includes(assigned)
-      })
-      .map((contact) => contact.email?.trim().toLowerCase() ?? "")
-      .filter((email) => email.length > 0)
-
-    if (emails.length > 0) {
-      const matchedUsers = await db
-        .select({
-          id: users.id,
-          email: users.email,
-          googleEmail: users.googleEmail,
-        })
-        .from(users)
-        .innerJoin(
-          organizationMembers,
-          eq(organizationMembers.userId, users.id)
-        )
-        .where(
-          and(
-            eq(organizationMembers.organizationId, input.organizationId),
-            or(
-              inArray(users.email, emails),
-              inArray(users.googleEmail, emails)
-            )
-          )
-        )
-
-      for (const matchedUser of matchedUsers) {
-        recipients.set(matchedUser.id, {
-          userId: matchedUser.id,
-          email: matchedUser.googleEmail ?? matchedUser.email,
-        })
-      }
-    }
+  const assignedRecipients = await projectAssignmentRecipients(
+    db,
+    input.organizationId,
+    input.projectId,
+    [input.assignedToName]
+  )
+  for (const recipient of assignedRecipients) {
+    recipients.set(recipient.userId, recipient)
   }
 
   const projectLabel = project?.projectNumber
@@ -412,5 +271,87 @@ export async function notifyRfiCreated(
     audience: "internal",
     createdBy: input.createdBy.id,
     recipients: Array.from(recipients.values()),
+    delivery: {
+      inApp: true,
+      email: true,
+      push: true,
+    },
+  })
+}
+
+export async function notifyRfiUpdated(
+  input: RfiUpdatedNotificationInput
+): Promise<void> {
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const recipients = (
+    await projectAssignmentRecipients(
+      db,
+      input.organizationId,
+      input.projectId,
+      [input.requesterName, input.assignedToName]
+    )
+  ).filter((recipient) => recipient.userId !== input.updatedBy.id)
+  if (recipients.length === 0) return
+
+  await createNotificationEvent({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    eventType: "rfi.updated",
+    sourceType: "rfi",
+    sourceId: input.rfiId,
+    title: `${input.rfiNumber}: ${input.subject}`,
+    body: `${input.updatedBy.displayName ?? input.updatedBy.email} updated this RFI to ${input.status.replace(/_/g, " ")}.`,
+    href: `/dashboard/projects/${input.projectId}/rfis`,
+    priority: "normal",
+    audience: "participants",
+    createdBy: input.updatedBy.id,
+    recipients,
+    delivery: {
+      inApp: true,
+      email: true,
+      push: true,
+    },
+  })
+}
+
+export async function notifyProjectAssignment(
+  input: ProjectAssignmentNotificationInput
+): Promise<void> {
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const recipients = (
+    await projectAssignmentRecipients(
+      db,
+      input.organizationId,
+      input.projectId,
+      [input.assignedToName]
+    )
+  ).filter((recipient) => recipient.userId !== input.createdBy.id)
+  if (recipients.length === 0) return
+
+  const isSchedule = input.kind === "schedule"
+  await createNotificationEvent({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    eventType: isSchedule ? "schedule.assigned" : "task.assigned",
+    sourceType: isSchedule ? "schedule_item" : "task",
+    sourceId: input.itemId,
+    title: isSchedule
+      ? `Schedule item assigned: ${input.title}`
+      : `To-do assigned: ${input.title}`,
+    body: `${input.createdBy.displayName ?? input.createdBy.email} assigned this to you.`,
+    href: isSchedule
+      ? `/dashboard/projects/${input.projectId}/schedule`
+      : `/dashboard/projects/${input.projectId}`,
+    priority: "normal",
+    audience: "assignee",
+    createdBy: input.createdBy.id,
+    recipients,
+    delivery: {
+      inApp: true,
+      email: true,
+      push: true,
+    },
   })
 }


### PR DESCRIPTION
## What changed

- notify channel members through the Compass notification bell for ordinary messages without requiring an `@mention`, while respecting each member's channel notification level
- notify assignees and participants for project to-dos, schedule items, and RFI changes
- add preference-aware in-app, email, and push delivery with durable delivery records
- add a signed Jarvis feedback lifecycle endpoint and a staff-facing **My Requests** page
- refresh the notification bell automatically and retain the last known state through transient refresh failures
- rename the hybrid search prompts to **Ask Jarvis or search Compass**

## Why

Messages and staff feedback could be missed unless recipients were explicitly tagged. Staff also had no visible lifecycle showing that feature requests were triaged, planned, tested, or deployed.

## Impact

Channel participants now receive bell notifications according to their channel settings. Requesters can follow their own Compass feedback requests, and Jarvis can send lifecycle updates back into Compass. Important lifecycle milestones can also use email and push delivery.

## Validation

- `bunx tsc --noEmit`
- focused notification, lifecycle, audience, and middleware tests: 9 passed
- `bun lint`: 0 errors; 94 existing repository warnings
- `bun run build`
- push-time production build

The full `bun test` command still encounters existing runner incompatibilities in unrelated Playwright, better-sqlite3, and Vitest-helper suites; the focused suites added or affected by this change pass.
