### PR TITLE
fix(owner-updates): allow clearing invalid photos

### DIFF
--- a/src/components/projects/owner-update-draft-editor.tsx
+++ b/src/components/projects/owner-update-draft-editor.tsx
@@ -198,25 +198,30 @@ export function OwnerUpdateDraftEditor({
                 {selectedPhotoIds.length} selected
               </span>
             </div>
-            {document.availablePhotos.length > 0 && (
+            {(document.availablePhotos.length > 0 ||
+              selectedPhotoIds.length > 0) && (
               <div className="flex flex-wrap gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={selectAllPhotos}
-                >
-                  Select all
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={clearPhotos}
-                >
-                  <IconX className="size-4" />
-                  Clear
-                </Button>
+                {document.availablePhotos.length > 0 && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={selectAllPhotos}
+                  >
+                    Select all
+                  </Button>
+                )}
+                {selectedPhotoIds.length > 0 && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={clearPhotos}
+                  >
+                    <IconX className="size-4" />
+                    Clear
+                  </Button>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
## What changed

Keep the **Clear** photo-selection control visible whenever a draft still has
saved photo IDs, even when none of those photos remain eligible for the editor
grid.

## Why

Live verification found a legacy Loeffler draft with one saved photo ID but no
eligible photo tiles. Publish-time validation correctly blocks that photo, but
the hidden Clear control left staff no way to repair the draft.

This also covers future drafts whose selected photos become hidden or lose
approval before publication.

## Validation

- `bun run test` — 180 passed, 3 skipped
- `bunx tsc --noEmit`
- affected-file ESLint — no errors
- pre-push production build
