### PR TITLE
fix(owner-updates): restore draft and history access

### DIFF
--- a/src/app/actions/project-field.ts
+++ b/src/app/actions/project-field.ts
@@ -27,7 +27,8 @@ import {
   serializeOwnerUpdateScheduleSnapshot,
   type OwnerUpdateScheduleItem,
 } from "@/lib/owner-updates/snapshot"
-import { requirePermission } from "@/lib/permissions"
+import { isOwnerUpdateVisibleToRole } from "@/lib/owner-updates/history"
+import { can, requirePermission } from "@/lib/permissions"
 import { revalidatePath } from "next/cache"
 
 type LatestDailyLog = {
@@ -60,6 +61,19 @@ type LatestOwnerUpdate = {
   readonly status: string
   readonly channel: string
   readonly summary: string
+}
+
+export type ProjectOwnerUpdateListItem = {
+  readonly id: string
+  readonly title: string
+  readonly updateDate: string
+  readonly status: string
+  readonly channel: string
+  readonly summary: string
+  readonly publishedAt: string | null
+  readonly sentAt: string | null
+  readonly createdAt: string
+  readonly updatedAt: string
 }
 
 type OwnerUpdateProject = {
@@ -254,6 +268,7 @@ type OwnerUpdateDraftResult =
   | { readonly success: false; readonly error: string }
 
 export type OwnerProjectUpdateDocument = {
+  readonly canManage: boolean
   readonly project: OwnerUpdateProject
   readonly update: {
     readonly id: string
@@ -899,6 +914,7 @@ function weatherLabel(row: {
 export async function getProjectFieldSummary(
   projectId: string
 ): Promise<ProjectFieldSummary> {
+  const viewer = await requireAuth()
   const db = await verifyProjectAccess(projectId)
   const today = new Date().toISOString().slice(0, 10)
 
@@ -987,7 +1003,10 @@ export async function getProjectFieldSummary(
     .limit(1)
 
   const latestLog = logRows[0]
-  const latestUpdate = updateRows[0]
+  const visibleUpdateRows = updateRows.filter((update) =>
+    isOwnerUpdateVisibleToRole(update.status, viewer.role)
+  )
+  const latestUpdate = visibleUpdateRows[0]
   const thumbnailPhotoRows = photoRows.filter(
     (photo) => photo.thumbnailUrl !== null
   )
@@ -1055,8 +1074,8 @@ export async function getProjectFieldSummary(
             photoCount: photoReviewPhotoCount(photoReviewFolder.metadata),
           }
         : null,
-    ownerUpdateCount: updateRows.length,
-    draftOwnerUpdateCount: updateRows.filter(
+    ownerUpdateCount: visibleUpdateRows.length,
+    draftOwnerUpdateCount: visibleUpdateRows.filter(
       (update) => update.status === "draft"
     ).length,
     latestOwnerUpdate: latestUpdate
@@ -1071,6 +1090,37 @@ export async function getProjectFieldSummary(
       : null,
     nextScheduleItem: nextTask ?? null,
   }
+}
+
+export async function getProjectOwnerUpdates(
+  projectId: string
+): Promise<readonly ProjectOwnerUpdateListItem[]> {
+  const viewer = await requireAuth()
+  const db = await verifyProjectAccess(projectId)
+
+  const updateRows = await db
+    .select({
+      id: ownerProjectUpdates.id,
+      title: ownerProjectUpdates.title,
+      updateDate: ownerProjectUpdates.updateDate,
+      status: ownerProjectUpdates.status,
+      channel: ownerProjectUpdates.channel,
+      summary: ownerProjectUpdates.summary,
+      publishedAt: ownerProjectUpdates.publishedAt,
+      sentAt: ownerProjectUpdates.sentAt,
+      createdAt: ownerProjectUpdates.createdAt,
+      updatedAt: ownerProjectUpdates.updatedAt,
+    })
+    .from(ownerProjectUpdates)
+    .where(eq(ownerProjectUpdates.projectId, projectId))
+    .orderBy(
+      desc(ownerProjectUpdates.updateDate),
+      desc(ownerProjectUpdates.createdAt)
+    )
+
+  return updateRows.filter((update) =>
+    isOwnerUpdateVisibleToRole(update.status, viewer.role)
+  )
 }
 
 export async function getProjectDailyLogWorkspace(
@@ -1673,6 +1723,7 @@ export async function getOwnerProjectUpdateDocument(
   projectId: string,
   updateId: string
 ): Promise<OwnerProjectUpdateDocument> {
+  const viewer = await requireAuth()
   const db = await verifyProjectAccess(projectId)
 
   const [project] = await db
@@ -1715,6 +1766,9 @@ export async function getOwnerProjectUpdateDocument(
     .limit(1)
 
   if (!project || !update) {
+    throw new Error("Owner update not found")
+  }
+  if (!isOwnerUpdateVisibleToRole(update.status, viewer.role)) {
     throw new Error("Owner update not found")
   }
 
@@ -1869,6 +1923,7 @@ export async function getOwnerProjectUpdateDocument(
     }))
 
   return {
+    canManage: can(viewer, "project", "update"),
     project,
     update: {
       id: update.id,

--- a/src/app/dashboard/projects/[id]/owner-updates/page.tsx
+++ b/src/app/dashboard/projects/[id]/owner-updates/page.tsx
@@ -13,6 +13,8 @@ import {
 import {
   getProjectDailyLogWorkspace,
   getProjectFieldSummary,
+  getProjectOwnerUpdates,
+  type ProjectOwnerUpdateListItem,
 } from "@/app/actions/project-field"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -38,6 +40,40 @@ function formatDate(value: string | null): string {
   })
 }
 
+function OwnerUpdateLink({
+  baseHref,
+  update,
+}: {
+  readonly baseHref: string
+  readonly update: ProjectOwnerUpdateListItem
+}): React.ReactElement {
+  return (
+    <Link
+      href={`${baseHref}/${update.id}`}
+      className="group block rounded-lg border p-4 transition-colors hover:bg-accent/40"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant={update.status === "draft" ? "secondary" : "outline"}>
+              {update.status}
+            </Badge>
+            <span className="text-sm text-muted-foreground">
+              {formatDate(update.updateDate)}
+            </span>
+            <Badge variant="outline">{update.channel}</Badge>
+          </div>
+          <h3 className="mt-2 text-base font-semibold">{update.title}</h3>
+          <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+            {update.summary}
+          </p>
+        </div>
+        <IconArrowRight className="size-5 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+      </div>
+    </Link>
+  )
+}
+
 export default async function ProjectOwnerUpdatesPage({
   params,
 }: {
@@ -46,11 +82,13 @@ export default async function ProjectOwnerUpdatesPage({
   const { id } = await params
   let workspace: Awaited<ReturnType<typeof getProjectDailyLogWorkspace>>
   let summary: Awaited<ReturnType<typeof getProjectFieldSummary>>
+  let ownerUpdates: Awaited<ReturnType<typeof getProjectOwnerUpdates>>
 
   try {
-    ;[workspace, summary] = await Promise.all([
+    ;[workspace, summary, ownerUpdates] = await Promise.all([
       getProjectDailyLogWorkspace(id),
       getProjectFieldSummary(id),
+      getProjectOwnerUpdates(id),
     ])
   } catch (error) {
     if (hasDigest(error) && error.digest === "NEXT_NOT_FOUND") throw error
@@ -59,7 +97,13 @@ export default async function ProjectOwnerUpdatesPage({
 
   const projectLabel =
     workspace.project.projectNumber ?? workspace.project.name
-  const latestUpdate = summary.latestOwnerUpdate
+  const baseHref = `/dashboard/projects/${workspace.project.id}/owner-updates`
+  const draftUpdates = ownerUpdates.filter(
+    (update) => update.status === "draft"
+  )
+  const historicalUpdates = ownerUpdates.filter(
+    (update) => update.status !== "draft"
+  )
 
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-4 p-3 sm:p-4 lg:p-6">
@@ -133,49 +177,52 @@ export default async function ProjectOwnerUpdatesPage({
         </div>
       </section>
 
+      {draftUpdates.length > 0 && (
+        <Card className="rounded-lg">
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <IconClipboardText className="size-5 text-muted-foreground" />
+              <CardTitle>Draft Updates</CardTitle>
+            </div>
+            <CardDescription>
+              Staff-only updates that can be opened, reviewed, and published.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {draftUpdates.map((update) => (
+              <OwnerUpdateLink
+                key={update.id}
+                baseHref={baseHref}
+                update={update}
+              />
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
       <Card className="rounded-lg">
         <CardHeader>
           <div className="flex items-center gap-2">
             <IconMailForward className="size-5 text-muted-foreground" />
-            <CardTitle>Latest Owner Update</CardTitle>
+            <CardTitle>Update History</CardTitle>
           </div>
           <CardDescription>
-            Latest published or drafted update.
+            Published and sent updates remain available to staff and project
+            owners for historical progress reference.
           </CardDescription>
         </CardHeader>
-        <CardContent>
-          {latestUpdate ? (
-            <Link
-              href={
-                `/dashboard/projects/${workspace.project.id}` +
-                `/owner-updates/${latestUpdate.id}`
-              }
-              className="group block rounded-lg border p-4 transition-colors hover:bg-accent/40"
-            >
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Badge variant="secondary">
-                      {latestUpdate.status}
-                    </Badge>
-                    <span className="text-sm text-muted-foreground">
-                      {formatDate(latestUpdate.updateDate)}
-                    </span>
-                  </div>
-                  <h2 className="mt-2 text-lg font-semibold">
-                    {latestUpdate.title}
-                  </h2>
-                  <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
-                    {latestUpdate.summary}
-                  </p>
-                </div>
-                <IconArrowRight className="size-5 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
-              </div>
-            </Link>
+        <CardContent className="space-y-3">
+          {historicalUpdates.length > 0 ? (
+            historicalUpdates.map((update) => (
+              <OwnerUpdateLink
+                key={update.id}
+                baseHref={baseHref}
+                update={update}
+              />
+            ))
           ) : (
             <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
-              No owner updates have been drafted yet. Start from Daily Logs
-              when field notes are ready.
+              No published owner updates are available yet.
             </div>
           )}
         </CardContent>

--- a/src/components/projects/owner-update-actions.tsx
+++ b/src/components/projects/owner-update-actions.tsx
@@ -14,6 +14,7 @@ import { publishOwnerProjectUpdate } from "@/app/actions/project-field"
 import { Button } from "@/components/ui/button"
 
 export function OwnerUpdateActions({
+  canManage,
   projectId,
   updateId,
   status,
@@ -23,6 +24,7 @@ export function OwnerUpdateActions({
   projectLabel,
   updateTitle,
 }: {
+  readonly canManage: boolean
   readonly projectId: string
   readonly updateId: string
   readonly status: string
@@ -149,7 +151,7 @@ export function OwnerUpdateActions({
 
   return (
     <div className="flex flex-wrap items-center gap-2 print:hidden">
-      {status !== "published" && (
+      {canManage && status !== "published" && (
         <Button size="sm" onClick={publish} disabled={isPublishing}>
           <IconSend className="size-4" />
           {isPublishing ? "Publishing..." : "Publish"}

--- a/src/components/projects/owner-update-document.tsx
+++ b/src/components/projects/owner-update-document.tsx
@@ -74,6 +74,7 @@ export function OwnerUpdateDocument({
             </Link>
           </Button>
           <OwnerUpdateActions
+            canManage={document.canManage}
             projectId={document.project.id}
             updateId={document.update.id}
             status={document.update.status}
@@ -85,7 +86,7 @@ export function OwnerUpdateDocument({
           />
         </div>
 
-        {document.update.status !== "published" && (
+        {document.canManage && document.update.status !== "published" && (
           <OwnerUpdateDraftEditor document={document} />
         )}
 

--- a/src/lib/owner-updates/__tests__/history.test.ts
+++ b/src/lib/owner-updates/__tests__/history.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  canViewOwnerUpdateDrafts,
+  isOwnerUpdateVisibleToRole,
+} from "@/lib/owner-updates/history"
+
+describe("owner update history access", () => {
+  it.each(["admin", "secondary_admin", "office", "field"])(
+    "allows %s staff to see drafts",
+    (role) => {
+      expect(canViewOwnerUpdateDrafts(role)).toBe(true)
+      expect(isOwnerUpdateVisibleToRole("draft", role)).toBe(true)
+    }
+  )
+
+  it.each(["client", "guest", "unknown"])(
+    "hides drafts from %s viewers",
+    (role) => {
+      expect(canViewOwnerUpdateDrafts(role)).toBe(false)
+      expect(isOwnerUpdateVisibleToRole("draft", role)).toBe(false)
+    }
+  )
+
+  it.each(["published", "sent"])(
+    "shows %s updates to owners",
+    (status) => {
+      expect(isOwnerUpdateVisibleToRole(status, "client")).toBe(true)
+    }
+  )
+})

--- a/src/lib/owner-updates/history.ts
+++ b/src/lib/owner-updates/history.ts
@@ -1,0 +1,20 @@
+export function canViewOwnerUpdateDrafts(role: string): boolean {
+  switch (role) {
+    case "admin":
+    case "secondary_admin":
+    case "office":
+    case "field":
+      return true
+    default:
+      return false
+  }
+}
+
+export function isOwnerUpdateVisibleToRole(
+  status: string,
+  role: string
+): boolean {
+  if (canViewOwnerUpdateDrafts(role)) return true
+
+  return status === "published" || status === "sent"
+}


### PR DESCRIPTION
## What changed

- replaces the single latest-update card with a complete owner-update history
- gives staff a separate, linked Draft Updates section
- keeps published and sent updates available to both staff and project owners
- filters owner-update counts and latest-update summaries by viewer role
- blocks owner accounts from opening drafts directly by URL
- only shows draft editing and publishing controls to users with project-update permission

## Root cause

Production queried and counted every owner update, but the page rendered only one latest-update card. The historical and draft records were intact in D1 but had no list or navigation path.

## Production evidence

- Loomis: 12 published updates and 2 drafts are present
- Loeffler: 11 published updates and 1 draft are present

## Validation

- `bun run test` — 189 passed, 3 skipped
- focused owner-update access and snapshot tests — 15 passed
- `bunx tsc --noEmit`
- affected-file ESLint — no errors
- `bun run build`
