### PR TITLE
fix(feedback): improve navigation and daily log layout

### DIFF
--- a/src/app/dashboard/schedule/page.tsx
+++ b/src/app/dashboard/schedule/page.tsx
@@ -1,10 +1,36 @@
 export const dynamic = "force-dynamic"
 
 import { getWorkCalendar } from "@/app/actions/work-calendar"
-import { WorkCalendar } from "@/components/schedule/work-calendar"
+import {
+  WorkCalendar,
+  type WorkCalendarKindFilter,
+} from "@/components/schedule/work-calendar"
 
-export default async function SchedulePage(): Promise<React.ReactElement> {
+function kindFilter(
+  value: string | readonly string[] | undefined
+): WorkCalendarKindFilter {
+  const selected = typeof value === "string" ? value : value?.[0]
+
+  switch (selected) {
+    case "schedule":
+    case "task":
+    case "rfi":
+    case "purchase_order":
+      return selected
+    default:
+      return "all"
+  }
+}
+
+export default async function SchedulePage({
+  searchParams,
+}: {
+  readonly searchParams: Promise<{
+    readonly kind?: string | readonly string[]
+  }>
+}): Promise<React.ReactElement> {
+  const query = await searchParams
   const data = await getWorkCalendar()
 
-  return <WorkCalendar data={data} />
+  return <WorkCalendar data={data} initialKind={kindFilter(query.kind)} />
 }

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import {
   IconAddressBook,
   IconCalendarStats,
+  IconClipboardCheck,
   IconClipboardText,
   IconFiles,
   IconFileDollar,
@@ -47,12 +48,20 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar"
 
-const NAV_MAIN = [
+const PERSISTENT_NAV = [
   {
     title: "Dashboard",
     url: "/dashboard",
     icon: IconHome2,
   },
+  {
+    title: "To-Dos",
+    url: "/dashboard/schedule?kind=task",
+    icon: IconClipboardCheck,
+  },
+]
+
+const NAV_MAIN = [
   {
     title: "Projects",
     url: "/dashboard/projects",
@@ -189,6 +198,7 @@ function SidebarNav({
 
   return (
     <div key={mode} className="animate-in fade-in slide-in-from-left-1 flex flex-1 flex-col duration-150">
+      <NavMain items={PERSISTENT_NAV} />
       {mode === "files" && (
         <React.Suspense>
           <NavFiles />

--- a/src/components/projects/project-daily-log-workspace.tsx
+++ b/src/components/projects/project-daily-log-workspace.tsx
@@ -373,8 +373,8 @@ function DailyLogFields({
         </div>
       </div>
 
-      <div className="grid gap-3 lg:grid-cols-4">
-        <div className="grid gap-1.5">
+      <div className="grid gap-3 lg:grid-cols-12">
+        <div className="grid gap-1.5 lg:col-span-4">
           <Label htmlFor={`${idPrefix}-issues`}>Issues</Label>
           <Textarea
             id={`${idPrefix}-issues`}
@@ -385,7 +385,7 @@ function DailyLogFields({
             placeholder="Delays, conflicts, blockers..."
           />
         </div>
-        <div className="grid gap-1.5">
+        <div className="grid gap-1.5 lg:col-span-4">
           <Label htmlFor={`${idPrefix}-safety`}>Safety</Label>
           <Textarea
             id={`${idPrefix}-safety`}
@@ -396,7 +396,7 @@ function DailyLogFields({
             placeholder="Incidents or no incidents."
           />
         </div>
-        <div className="grid gap-1.5">
+        <div className="grid gap-1.5 lg:col-span-4">
           <Label htmlFor={`${idPrefix}-visitors`}>Visitors</Label>
           <Textarea
             id={`${idPrefix}-visitors`}
@@ -407,7 +407,7 @@ function DailyLogFields({
             placeholder="Owners, inspectors, suppliers..."
           />
         </div>
-        <div className="grid gap-1.5">
+        <div className="grid gap-1.5 lg:col-span-12">
           <Label htmlFor={`${idPrefix}-notes`}>Notes / Next</Label>
           <Textarea
             id={`${idPrefix}-notes`}
@@ -1259,7 +1259,7 @@ export function ProjectDailyLogWorkspace({
                     log.safetyIncidents ||
                     log.visitorLog ||
                     log.notes) && (
-                    <dl className="mt-3 grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-5">
+                    <dl className="mt-3 grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-4">
                       {log.issues && (
                         <div className="rounded-md border bg-muted/20 p-3">
                           <dt className="text-xs font-medium uppercase text-muted-foreground">
@@ -1293,7 +1293,7 @@ export function ProjectDailyLogWorkspace({
                         </div>
                       )}
                       {log.notes && (
-                        <div className="rounded-md border bg-muted/20 p-3">
+                        <div className="rounded-md border bg-muted/20 p-3 md:col-span-2 xl:col-span-4">
                           <dt className="text-xs font-medium uppercase text-muted-foreground">
                             Notes / Next
                           </dt>

--- a/src/components/schedule/work-calendar.tsx
+++ b/src/components/schedule/work-calendar.tsx
@@ -20,10 +20,10 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
 
-type KindFilter = WorkCalendarEntryKind | "all"
+export type WorkCalendarKindFilter = WorkCalendarEntryKind | "all"
 
 type KindConfig = {
-  readonly id: KindFilter
+  readonly id: WorkCalendarKindFilter
   readonly label: string
   readonly icon: React.ReactNode
 }
@@ -197,11 +197,17 @@ function WorkItem({
 
 export function WorkCalendar({
   data,
+  initialKind = "all",
 }: {
   readonly data: WorkCalendarData
+  readonly initialKind?: WorkCalendarKindFilter
 }): React.ReactElement {
   const [query, setQuery] = React.useState("")
-  const [activeKind, setActiveKind] = React.useState<KindFilter>("all")
+  const [activeKind, setActiveKind] =
+    React.useState<WorkCalendarKindFilter>(initialKind)
+  React.useEffect(() => {
+    setActiveKind(initialKind)
+  }, [initialKind])
   const today = React.useMemo(() => parseDateKey(data.today), [data.today])
   const days = React.useMemo(
     () => Array.from({ length: 14 }, (_, index) => toDateKey(addDays(today, index))),


### PR DESCRIPTION
## What changed

- keeps Dashboard and To-Dos links visible in every sidebar context
- opens the shared Work Calendar prefiltered to to-dos from the new link
- gives Daily Log Notes / Next the full available width in display and edit modes

## Why

These changes address three urgent requests submitted through Ask Jarvis in Compass. Project, file, and conversation context menus replaced the main navigation entirely, and Notes / Next occupied only a narrow grid cell despite being long-form content.

## Validation

- `bun run test` — 189 passed, 3 skipped
- `bunx tsc --noEmit`
- affected-file ESLint — no errors
- `bun run build`
