### PR TITLE
fix(schedule): align progress dependencies and workdays

### DIFF
--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -14,6 +14,10 @@ import { calculateEndDate } from "@/lib/schedule/business-days"
 import { findCriticalPath } from "@/lib/schedule/critical-path"
 import { wouldCreateCycle } from "@/lib/schedule/dependency-validation"
 import { propagateDates } from "@/lib/schedule/propagate-dates"
+import {
+  effectivePercentComplete,
+  normalizeScheduleProgress,
+} from "@/lib/schedule/progress"
 import { requireAuth } from "@/lib/auth"
 import { requireOrg } from "@/lib/org-scope"
 import { isDemoUser } from "@/lib/demo"
@@ -25,6 +29,7 @@ import type {
   ExceptionRecurrence,
   ScheduleData,
   WorkdayExceptionData,
+  WorkdayExceptionType,
 } from "@/lib/schedule/types"
 
 async function fetchExceptions(
@@ -38,6 +43,7 @@ async function fetchExceptions(
 
   return rows.map((r) => ({
     ...r,
+    type: r.type as WorkdayExceptionType,
     category: r.category as ExceptionCategory,
     recurrence: r.recurrence as ExceptionRecurrence,
   }))
@@ -78,11 +84,15 @@ export async function getSchedule(
   )
 
   return {
-    tasks: tasks.map((t) => ({
-      ...t,
-      status: t.status as TaskStatus,
-      phase: t.phase,
-    })),
+    tasks: tasks.map((t) => {
+      const status = t.status as TaskStatus
+      return {
+        ...t,
+        status,
+        phase: t.phase,
+        percentComplete: effectivePercentComplete(status, t.percentComplete),
+      }
+    }),
     dependencies: projectDeps.map((d) => ({
       ...d,
       type: d.type as DependencyType,
@@ -104,7 +114,10 @@ export async function createTask(
     percentComplete?: number
     assignedTo?: string
   }
-): Promise<{ success: boolean; error?: string }> {
+): Promise<
+  | { readonly success: true; readonly taskId: string }
+  | { readonly success: false; readonly error: string }
+> {
   try {
     const user = await requireAuth()
     if (isDemoUser(user.id)) {
@@ -143,6 +156,10 @@ export async function createTask(
       : 0
 
     const id = crypto.randomUUID()
+    const progress = normalizeScheduleProgress(
+      data.status ?? "PENDING",
+      data.percentComplete ?? 0
+    )
     await db.insert(scheduleTasks).values({
       id,
       projectId,
@@ -152,10 +169,10 @@ export async function createTask(
       endDateCalculated: endDate,
       phase: data.phase,
       displayColor: data.displayColor ?? "blue",
-      status: data.status ?? "PENDING",
+      status: progress.status,
       isCriticalPath: false,
       isMilestone: data.isMilestone ?? false,
-      percentComplete: data.percentComplete ?? 0,
+      percentComplete: progress.percentComplete,
       assignedTo: data.assignedTo ?? null,
       sortOrder: nextOrder,
       createdAt: now,
@@ -181,7 +198,7 @@ export async function createTask(
 
     await recalcCriticalPath(db, projectId)
     revalidatePath(`/dashboard/projects/${projectId}/schedule`)
-    return { success: true }
+    return { success: true, taskId: id }
   } catch (error) {
     console.error("Failed to create task:", error)
     return { success: false, error: "Failed to create schedule item" }
@@ -235,6 +252,10 @@ export async function updateTask(
     const startDate = data.startDate ?? task.startDate
     const workdays = data.workdays ?? task.workdays
     const endDate = calculateEndDate(startDate, workdays, exceptions)
+    const progress = normalizeScheduleProgress(
+      (data.status ?? task.status) as TaskStatus,
+      data.percentComplete ?? task.percentComplete
+    )
 
     await db
       .update(scheduleTasks)
@@ -245,13 +266,11 @@ export async function updateTask(
         endDateCalculated: endDate,
         ...(data.phase && { phase: data.phase }),
         ...(data.displayColor && { displayColor: data.displayColor }),
-        ...(data.status && { status: data.status }),
+        status: progress.status,
         ...(data.isMilestone !== undefined && {
           isMilestone: data.isMilestone,
         }),
-        ...(data.percentComplete !== undefined && {
-          percentComplete: data.percentComplete,
-        }),
+        percentComplete: progress.percentComplete,
         ...(data.assignedTo !== undefined && {
           assignedTo: data.assignedTo,
         }),
@@ -286,7 +305,8 @@ export async function updateTask(
     const schedule = await getSchedule(task.projectId)
     const updatedTask = {
       ...task,
-      status: task.status as TaskStatus,
+      status: progress.status,
+      percentComplete: progress.percentComplete,
       startDate,
       workdays,
       endDateCalculated: endDate,
@@ -406,7 +426,10 @@ export async function createDependency(data: {
   type: DependencyType
   lagDays: number
   projectId: string
-}): Promise<{ success: boolean; error?: string }> {
+}): Promise<
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string }
+> {
   try {
     const user = await requireAuth()
     if (isDemoUser(user.id)) {
@@ -426,6 +449,54 @@ export async function createDependency(data: {
 
     if (!project) {
       return { success: false, error: "Project not found or access denied" }
+    }
+
+    if (data.predecessorId === data.successorId) {
+      return {
+        success: false,
+        error: "A schedule item cannot depend on itself",
+      }
+    }
+
+    const [predecessor] = await db
+      .select({ projectId: scheduleTasks.projectId })
+      .from(scheduleTasks)
+      .where(eq(scheduleTasks.id, data.predecessorId))
+      .limit(1)
+    const [successor] = await db
+      .select({ projectId: scheduleTasks.projectId })
+      .from(scheduleTasks)
+      .where(eq(scheduleTasks.id, data.successorId))
+      .limit(1)
+
+    if (
+      !predecessor ||
+      !successor ||
+      predecessor.projectId !== data.projectId ||
+      successor.projectId !== data.projectId
+    ) {
+      return {
+        success: false,
+        error: "Both schedule items must belong to this project",
+      }
+    }
+
+    const [duplicate] = await db
+      .select({ id: taskDependencies.id })
+      .from(taskDependencies)
+      .where(
+        and(
+          eq(taskDependencies.predecessorId, data.predecessorId),
+          eq(taskDependencies.successorId, data.successorId)
+        )
+      )
+      .limit(1)
+
+    if (duplicate) {
+      return {
+        success: false,
+        error: "That dependency already exists",
+      }
     }
 
     // get existing deps for cycle check
@@ -497,6 +568,34 @@ export async function deleteDependency(
       return { success: false, error: "Project not found or access denied" }
     }
 
+    const [dependency] = await db
+      .select()
+      .from(taskDependencies)
+      .where(eq(taskDependencies.id, depId))
+      .limit(1)
+
+    if (!dependency) {
+      return { success: false, error: "Dependency not found" }
+    }
+
+    const taskIds = new Set(
+      (
+        await db
+          .select({ id: scheduleTasks.id })
+          .from(scheduleTasks)
+          .where(eq(scheduleTasks.projectId, projectId))
+      ).map((task) => task.id)
+    )
+    if (
+      !taskIds.has(dependency.predecessorId) ||
+      !taskIds.has(dependency.successorId)
+    ) {
+      return {
+        success: false,
+        error: "Dependency does not belong to this project",
+      }
+    }
+
     await db.delete(taskDependencies).where(eq(taskDependencies.id, depId))
     await recalcCriticalPath(db, projectId)
     revalidatePath(`/dashboard/projects/${projectId}/schedule`)
@@ -542,7 +641,11 @@ export async function updateTaskStatus(
 
     await db
       .update(scheduleTasks)
-      .set({ status, updatedAt: new Date().toISOString() })
+      .set({
+        status,
+        percentComplete: effectivePercentComplete(status, task.percentComplete),
+        updatedAt: new Date().toISOString(),
+      })
       .where(eq(scheduleTasks.id, taskId))
 
     revalidatePath(`/dashboard/projects/${task.projectId}/schedule`)

--- a/src/app/actions/workday-exceptions.ts
+++ b/src/app/actions/workday-exceptions.ts
@@ -2,17 +2,71 @@
 
 import { getCloudflareContext } from "@/lib/db"
 import { getDb } from "@/db"
-import { workdayExceptions, projects } from "@/db/schema"
+import {
+  workdayExceptions,
+  projects,
+  scheduleTasks,
+  taskDependencies,
+} from "@/db/schema"
 import { eq, and } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { requireAuth } from "@/lib/auth"
 import { requireOrg } from "@/lib/org-scope"
 import { isDemoUser } from "@/lib/demo"
+import { recalculateScheduleDates } from "@/lib/schedule/propagate-dates"
 import type {
+  DependencyType,
+  TaskStatus,
   WorkdayExceptionData,
   ExceptionCategory,
   ExceptionRecurrence,
+  WorkdayExceptionType,
 } from "@/lib/schedule/types"
+
+async function recalculateProjectDates(
+  db: ReturnType<typeof getDb>,
+  projectId: string
+): Promise<void> {
+  const tasks = await db
+    .select()
+    .from(scheduleTasks)
+    .where(eq(scheduleTasks.projectId, projectId))
+  const taskIds = new Set(tasks.map((task) => task.id))
+  const dependencies = (await db.select().from(taskDependencies)).filter(
+    (dependency) =>
+      taskIds.has(dependency.predecessorId) &&
+      taskIds.has(dependency.successorId)
+  )
+  const exceptions = await db
+    .select()
+    .from(workdayExceptions)
+    .where(eq(workdayExceptions.projectId, projectId))
+
+  const { updatedTasks } = recalculateScheduleDates(
+    tasks.map((task) => ({
+      ...task,
+      status: task.status as TaskStatus,
+    })),
+    dependencies.map((dependency) => ({
+      ...dependency,
+      type: dependency.type as DependencyType,
+    })),
+    exceptions.map((exception) => ({
+      ...exception,
+      type: exception.type as WorkdayExceptionType,
+      category: exception.category as ExceptionCategory,
+      recurrence: exception.recurrence as ExceptionRecurrence,
+    }))
+  )
+
+  const updatedAt = new Date().toISOString()
+  for (const [taskId, dates] of updatedTasks) {
+    await db
+      .update(scheduleTasks)
+      .set({ ...dates, updatedAt })
+      .where(eq(scheduleTasks.id, taskId))
+  }
+}
 
 export async function getWorkdayExceptions(
   projectId: string
@@ -41,6 +95,7 @@ export async function getWorkdayExceptions(
 
   return rows.map((r) => ({
     ...r,
+    type: r.type as WorkdayExceptionType,
     category: r.category as ExceptionCategory,
     recurrence: r.recurrence as ExceptionRecurrence,
   }))
@@ -52,7 +107,7 @@ export async function createWorkdayException(
     title: string
     startDate: string
     endDate: string
-    type: string
+    type: WorkdayExceptionType
     category: ExceptionCategory
     recurrence: ExceptionRecurrence
     notes?: string
@@ -95,6 +150,7 @@ export async function createWorkdayException(
       updatedAt: now,
     })
 
+    await recalculateProjectDates(db, projectId)
     revalidatePath(`/dashboard/projects/${projectId}/schedule`)
     return { success: true }
   } catch (error) {
@@ -109,7 +165,7 @@ export async function updateWorkdayException(
     title?: string
     startDate?: string
     endDate?: string
-    type?: string
+    type?: WorkdayExceptionType
     category?: ExceptionCategory
     recurrence?: ExceptionRecurrence
     notes?: string | null
@@ -158,6 +214,7 @@ export async function updateWorkdayException(
       })
       .where(eq(workdayExceptions.id, exceptionId))
 
+    await recalculateProjectDates(db, existing.projectId)
     revalidatePath(
       `/dashboard/projects/${existing.projectId}/schedule`
     )
@@ -204,6 +261,7 @@ export async function deleteWorkdayException(
       .delete(workdayExceptions)
       .where(eq(workdayExceptions.id, exceptionId))
 
+    await recalculateProjectDates(db, existing.projectId)
     revalidatePath(
       `/dashboard/projects/${existing.projectId}/schedule`
     )

--- a/src/app/api/compass/schedule/route.ts
+++ b/src/app/api/compass/schedule/route.ts
@@ -7,12 +7,17 @@ import { calculateEndDate } from "@/lib/schedule/business-days"
 import { findCriticalPath } from "@/lib/schedule/critical-path"
 import { wouldCreateCycle } from "@/lib/schedule/dependency-validation"
 import { propagateDates } from "@/lib/schedule/propagate-dates"
+import {
+  effectivePercentComplete,
+  normalizeScheduleProgress,
+} from "@/lib/schedule/progress"
 import { revalidatePath } from "next/cache"
 import type {
   TaskStatus,
   DependencyType,
   ExceptionCategory,
   ExceptionRecurrence,
+  WorkdayExceptionType,
   WorkdayExceptionData,
 } from "@/lib/schedule/types"
 
@@ -26,6 +31,19 @@ type ScheduleAction =
   | "addException"
   | "removeException"
 
+function isTaskStatus(value: unknown): value is TaskStatus {
+  return (
+    value === "PENDING" ||
+    value === "IN_PROGRESS" ||
+    value === "COMPLETE" ||
+    value === "BLOCKED"
+  )
+}
+
+function isDependencyType(value: unknown): value is DependencyType {
+  return value === "FS" || value === "SS" || value === "FF" || value === "SF"
+}
+
 async function fetchProjectExceptions(
   db: ReturnType<typeof getDb>,
   projectId: string,
@@ -36,6 +54,7 @@ async function fetchProjectExceptions(
     .where(eq(workdayExceptions.projectId, projectId))
   return rows.map((r) => ({
     ...r,
+    type: r.type as WorkdayExceptionType,
     category: r.category as ExceptionCategory,
     recurrence: r.recurrence as ExceptionRecurrence,
   }))
@@ -56,10 +75,14 @@ async function fetchProjectDeps(
       taskIdSet.has(d.predecessorId) && taskIdSet.has(d.successorId),
   )
   return {
-    tasks: tasks.map((t) => ({
-      ...t,
-      status: t.status as TaskStatus,
-    })),
+    tasks: tasks.map((t) => {
+      const status = t.status as TaskStatus
+      return {
+        ...t,
+        status,
+        percentComplete: effectivePercentComplete(status, t.percentComplete),
+      }
+    }),
     deps: deps.map((d) => ({
       ...d,
       type: d.type as DependencyType,
@@ -234,6 +257,9 @@ export async function POST(req: Request): Promise<Response> {
         const startDate = body.startDate as string
         const workdays = body.workdays as number
         const phase = body.phase as string
+        const requestedStatus = isTaskStatus(body.status)
+          ? body.status
+          : "PENDING"
         const isMilestone = (body.isMilestone as boolean) ?? false
         const percentComplete = (body.percentComplete as number) ?? 0
         const assignedTo = (body.assignedTo as string | undefined) ?? null
@@ -285,6 +311,10 @@ export async function POST(req: Request): Promise<Response> {
             : 0
 
         const id = crypto.randomUUID()
+        const progress = normalizeScheduleProgress(
+          requestedStatus,
+          percentComplete
+        )
         await db.insert(scheduleTasks).values({
           id,
           projectId,
@@ -293,10 +323,10 @@ export async function POST(req: Request): Promise<Response> {
           workdays,
           endDateCalculated: endDate,
           phase,
-          status: "PENDING",
+          status: progress.status,
           isCriticalPath: false,
           isMilestone,
-          percentComplete,
+          percentComplete: progress.percentComplete,
           assignedTo,
           sortOrder: nextOrder,
           createdAt: now,
@@ -355,8 +385,48 @@ export async function POST(req: Request): Promise<Response> {
           )
         }
 
-        const { action: _action, taskId: _taskId, status, ...fields } = body
+        const [project] = await db
+          .select({ id: projects.id })
+          .from(projects)
+          .where(
+            and(
+              eq(projects.id, task.projectId),
+              eq(projects.organizationId, auth.orgId)
+            )
+          )
+          .limit(1)
+        if (!project) {
+          return new Response(JSON.stringify({ error: "Task not found" }), {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          })
+        }
+
+        const status = body.status
+        const fields: Record<string, unknown> = {}
+        for (const [key, value] of Object.entries(body)) {
+          if (key !== "action" && key !== "taskId" && key !== "status") {
+            fields[key] = value
+          }
+        }
         const hasFields = Object.keys(fields).length > 0
+        if (status !== undefined && !isTaskStatus(status)) {
+          return new Response(JSON.stringify({ error: "Invalid status" }), {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          })
+        }
+        const requestedStatus = isTaskStatus(status)
+          ? status
+          : (task.status as TaskStatus)
+        const requestedPercent =
+          fields.percentComplete !== undefined
+            ? (fields.percentComplete as number)
+            : task.percentComplete
+        const progress = normalizeScheduleProgress(
+          requestedStatus,
+          requestedPercent
+        )
 
         if (hasFields) {
           const exceptions = await fetchProjectExceptions(db, task.projectId)
@@ -373,12 +443,11 @@ export async function POST(req: Request): Promise<Response> {
               workdays,
               endDateCalculated: endDate,
               ...(fields.phase ? { phase: fields.phase as string } : {}),
+              status: progress.status,
               ...(fields.isMilestone !== undefined
                 ? { isMilestone: fields.isMilestone as boolean }
                 : {}),
-              ...(fields.percentComplete !== undefined
-                ? { percentComplete: fields.percentComplete as number }
-                : {}),
+              percentComplete: progress.percentComplete,
               ...(fields.assignedTo !== undefined
                 ? { assignedTo: fields.assignedTo as string | null }
                 : {}),
@@ -406,7 +475,8 @@ export async function POST(req: Request): Promise<Response> {
 
           const updatedTask = {
             ...task,
-            status: task.status as TaskStatus,
+            status: progress.status,
+            percentComplete: progress.percentComplete,
             startDate,
             workdays,
             endDateCalculated: endDate,
@@ -439,7 +509,8 @@ export async function POST(req: Request): Promise<Response> {
           await db
             .update(scheduleTasks)
             .set({
-              status: status as TaskStatus,
+              status: progress.status,
+              percentComplete: progress.percentComplete,
               updatedAt: new Date().toISOString(),
             })
             .where(eq(scheduleTasks.id, taskId))
@@ -507,6 +578,23 @@ export async function POST(req: Request): Promise<Response> {
           )
         }
 
+        const [project] = await db
+          .select({ id: projects.id })
+          .from(projects)
+          .where(
+            and(
+              eq(projects.id, task.projectId),
+              eq(projects.organizationId, auth.orgId)
+            )
+          )
+          .limit(1)
+        if (!project) {
+          return new Response(JSON.stringify({ error: "Task not found" }), {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          })
+        }
+
         await db
           .delete(scheduleTasks)
           .where(eq(scheduleTasks.id, taskId))
@@ -538,10 +626,15 @@ export async function POST(req: Request): Promise<Response> {
         const projectId = body.projectId as string
         const predecessorId = body.predecessorId as string
         const successorId = body.successorId as string
-        const type = body.type as DependencyType
+        const type = body.type
         const lagDays = (body.lagDays as number) ?? 0
 
-        if (!projectId || !predecessorId || !successorId || !type) {
+        if (
+          !projectId ||
+          !predecessorId ||
+          !successorId ||
+          !isDependencyType(type)
+        ) {
           return new Response(
             JSON.stringify({ error: "Missing required fields" }),
             {
@@ -551,7 +644,63 @@ export async function POST(req: Request): Promise<Response> {
           )
         }
 
-        const { deps: existingDeps } = await fetchProjectDeps(db, projectId)
+        const [project] = await db
+          .select({ id: projects.id })
+          .from(projects)
+          .where(
+            and(
+              eq(projects.id, projectId),
+              eq(projects.organizationId, auth.orgId)
+            )
+          )
+          .limit(1)
+        if (!project) {
+          return new Response(JSON.stringify({ error: "Project not found" }), {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          })
+        }
+
+        const {
+          tasks: projectTasks,
+          deps: existingDeps,
+        } = await fetchProjectDeps(db, projectId)
+        const projectTaskIds = new Set(projectTasks.map((task) => task.id))
+
+        if (
+          predecessorId === successorId ||
+          !projectTaskIds.has(predecessorId) ||
+          !projectTaskIds.has(successorId)
+        ) {
+          return new Response(
+            JSON.stringify({
+              error:
+                predecessorId === successorId
+                  ? "A schedule item cannot depend on itself"
+                  : "Both schedule items must belong to this project",
+            }),
+            {
+              status: 400,
+              headers: { "Content-Type": "application/json" },
+            }
+          )
+        }
+
+        if (
+          existingDeps.some(
+            (dependency) =>
+              dependency.predecessorId === predecessorId &&
+              dependency.successorId === successorId
+          )
+        ) {
+          return new Response(
+            JSON.stringify({ error: "That dependency already exists" }),
+            {
+              status: 400,
+              headers: { "Content-Type": "application/json" },
+            }
+          )
+        }
 
         if (
           wouldCreateCycle(existingDeps, predecessorId, successorId)
@@ -640,6 +789,41 @@ export async function POST(req: Request): Promise<Response> {
             JSON.stringify({ error: "dependencyId and projectId required" }),
             {
               status: 400,
+              headers: { "Content-Type": "application/json" },
+            }
+          )
+        }
+
+        const [project] = await db
+          .select({ id: projects.id })
+          .from(projects)
+          .where(
+            and(
+              eq(projects.id, projectId),
+              eq(projects.organizationId, auth.orgId)
+            )
+          )
+          .limit(1)
+        if (!project) {
+          return new Response(JSON.stringify({ error: "Project not found" }), {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          })
+        }
+
+        const { deps: projectDependencies } = await fetchProjectDeps(
+          db,
+          projectId
+        )
+        if (
+          !projectDependencies.some(
+            (dependency) => dependency.id === dependencyId
+          )
+        ) {
+          return new Response(
+            JSON.stringify({ error: "Dependency not found for this project" }),
+            {
+              status: 404,
               headers: { "Content-Type": "application/json" },
             }
           )

--- a/src/components/schedule/dependency-dialog.tsx
+++ b/src/components/schedule/dependency-dialog.tsx
@@ -159,10 +159,9 @@ export function DependencyDialog({
             </div>
 
             <div>
-              <Label>Lag (days)</Label>
+              <Label>Lag / lead (days)</Label>
               <Input
                 type="number"
-                min={0}
                 value={lagDays}
                 onChange={(e) => setLagDays(Number(e.target.value))}
                 className="mt-1"

--- a/src/components/schedule/schedule-calendar-view.tsx
+++ b/src/components/schedule/schedule-calendar-view.tsx
@@ -12,9 +12,7 @@ import {
   subMonths,
   isToday,
   isSameMonth,
-  isWeekend,
   parseISO,
-  isWithinInterval,
   differenceInCalendarDays,
 } from "date-fns"
 import { cn } from "@/lib/utils"
@@ -29,6 +27,8 @@ import type {
 } from "@/lib/schedule/types"
 import { useScheduleDisplayPalette } from "@/hooks/use-schedule-display-palette"
 import { getScheduleItemDisplayColor } from "@/lib/schedule/appearance"
+import { isNonWorkday } from "@/lib/schedule/business-days"
+import { effectivePercentComplete } from "@/lib/schedule/progress"
 
 interface ScheduleCalendarViewProps {
   readonly projectId: string
@@ -40,17 +40,6 @@ interface ScheduleCalendarViewProps {
 const MAX_LANES = 3
 const LANE_HEIGHT = 22
 const DAY_HEADER_HEIGHT = 24
-
-function isExceptionDay(
-  date: Date,
-  exceptions: readonly WorkdayExceptionData[]
-): boolean {
-  return exceptions.some((ex) => {
-    const start = parseISO(ex.startDate)
-    const end = parseISO(ex.endDate)
-    return isWithinInterval(date, { start, end })
-  })
-}
 
 interface WeekTask {
   readonly task: ScheduleTaskData
@@ -261,8 +250,7 @@ export function ScheduleCalendarView({
                 <div className="grid grid-cols-7 absolute inset-0">
                   {week.days.map((day) => {
                     const inMonth = isSameMonth(day, currentDate)
-                    const isNonWork =
-                      isWeekend(day) || isExceptionDay(day, exceptions)
+                    const nonWorkday = isNonWorkday(day, exceptions)
 
                     return (
                       <div
@@ -270,7 +258,7 @@ export function ScheduleCalendarView({
                         className={cn(
                           "border-r last:border-r-0 p-1",
                           !inMonth && "bg-muted/20",
-                          isNonWork && inMonth && "bg-muted/40",
+                          nonWorkday && inMonth && "bg-muted/40",
                         )}
                       >
                         <span
@@ -314,9 +302,17 @@ export function ScheduleCalendarView({
                         height: `${LANE_HEIGHT - 2}px`,
                         paddingLeft: wt.isStart ? "6px" : "2px",
                       }}
-                      title={`${wt.task.title} (${wt.task.startDate} - ${wt.task.endDateCalculated})`}
+                      title={`${wt.task.title} — ${effectivePercentComplete(
+                        wt.task.status,
+                        wt.task.percentComplete
+                      )}% complete (${wt.task.startDate} - ${wt.task.endDateCalculated})`}
                     >
-                      {wt.isStart ? wt.task.title : ""}
+                      {wt.isStart
+                        ? `${effectivePercentComplete(
+                            wt.task.status,
+                            wt.task.percentComplete
+                          )}% · ${wt.task.title}`
+                        : ""}
                     </div>
                   ))}
 

--- a/src/components/schedule/schedule-gantt-view.tsx
+++ b/src/components/schedule/schedule-gantt-view.tsx
@@ -53,6 +53,7 @@ import {
 import type { DisplayItem, FrappeTask } from "@/lib/schedule/gantt-transform"
 import { updateTask } from "@/app/actions/schedule"
 import { countBusinessDays } from "@/lib/schedule/business-days"
+import { effectivePercentComplete } from "@/lib/schedule/progress"
 import {
   DEFAULT_DISPLAY_COLOR_LABELS,
   DEFAULT_DISPLAY_COLOR_PALETTE,
@@ -66,6 +67,7 @@ import {
 import type {
   ScheduleTaskData,
   TaskDependencyData,
+  WorkdayExceptionData,
 } from "@/lib/schedule/types"
 import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
 import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
@@ -84,6 +86,7 @@ interface ScheduleGanttViewProps {
   readonly projectId: string
   readonly tasks: readonly ScheduleTaskData[]
   readonly dependencies: readonly TaskDependencyData[]
+  readonly exceptions: readonly WorkdayExceptionData[]
   readonly assigneeOptions: readonly ProjectTaskAssigneeOption[]
 }
 
@@ -91,6 +94,7 @@ export function ScheduleGanttView({
   projectId,
   tasks,
   dependencies,
+  exceptions,
   assigneeOptions,
 }: ScheduleGanttViewProps) {
   const router = useRouter()
@@ -223,7 +227,7 @@ export function ScheduleGanttView({
       if (task.id.startsWith("phase-")) return
       const startDate = format(start, "yyyy-MM-dd")
       const endDate = format(end, "yyyy-MM-dd")
-      const workdays = countBusinessDays(startDate, endDate)
+      const workdays = countBusinessDays(startDate, endDate, exceptions)
 
       const result = await updateTask(task.id, {
         startDate,
@@ -236,7 +240,7 @@ export function ScheduleGanttView({
         toast.error(result.error)
       }
     },
-    [router]
+    [exceptions, router]
   )
 
   const scrollToToday = () => {
@@ -255,6 +259,7 @@ export function ScheduleGanttView({
           <TableHead className="text-xs">Title</TableHead>
           <TableHead className="text-xs w-[80px]">Start</TableHead>
           <TableHead className="text-xs w-[52px]">Days</TableHead>
+          <TableHead className="text-xs w-[52px]">Done</TableHead>
           <TableHead className="w-[40px]" />
         </TableRow>
       </TableHeader>
@@ -269,7 +274,7 @@ export function ScheduleGanttView({
                 onClick={() => togglePhase(phase)}
               >
                 <TableCell
-                  colSpan={collapsed ? 4 : 1}
+                  colSpan={collapsed ? 5 : 1}
                   className="text-xs py-1.5 font-medium"
                 >
                   <span className="flex items-center gap-1">
@@ -293,6 +298,7 @@ export function ScheduleGanttView({
                       {group.startDate.slice(5)}
                     </TableCell>
                     <TableCell className="text-xs py-1.5" />
+                    <TableCell className="text-xs py-1.5" />
                     <TableCell className="py-1.5" />
                   </>
                 )}
@@ -313,6 +319,9 @@ export function ScheduleGanttView({
               </TableCell>
               <TableCell className="text-xs py-1.5">
                 {task.workdays}
+              </TableCell>
+              <TableCell className="text-xs py-1.5 tabular-nums">
+                {effectivePercentComplete(task.status, task.percentComplete)}%
               </TableCell>
               <TableCell className="py-1.5">
                 <div className="flex items-center">
@@ -349,7 +358,7 @@ export function ScheduleGanttView({
           )
         })}
         <TableRow>
-          <TableCell colSpan={4} className="py-1">
+          <TableCell colSpan={5} className="py-1">
             <Button
               variant="ghost"
               size="sm"
@@ -657,6 +666,7 @@ export function ScheduleGanttView({
         editingTask={editingTask}
         allTasks={tasks}
         dependencies={dependencies}
+        exceptions={exceptions}
         assigneeOptions={assigneeOptions}
       />
     </div>

--- a/src/components/schedule/schedule-item-form-dialog.tsx
+++ b/src/components/schedule/schedule-item-form-dialog.tsx
@@ -61,6 +61,7 @@ import type {
   ScheduleTaskData,
   TaskDependencyData,
   DependencyType,
+  WorkdayExceptionData,
 } from "@/lib/schedule/types"
 import { PHASE_ORDER, PHASE_LABELS, getPhaseColor } from "@/lib/schedule/phase-colors"
 import {
@@ -108,6 +109,7 @@ interface ScheduleItemFormDialogProps {
   editingTask: ScheduleTaskData | null
   allTasks?: readonly ScheduleTaskData[]
   dependencies?: readonly TaskDependencyData[]
+  exceptions?: readonly WorkdayExceptionData[]
   assigneeOptions?: readonly ProjectTaskAssigneeOption[]
 }
 
@@ -124,6 +126,7 @@ export function ScheduleItemFormDialog({
   editingTask,
   allTasks = [],
   dependencies = [],
+  exceptions = [],
   assigneeOptions = [],
 }: ScheduleItemFormDialogProps) {
   const router = useRouter()
@@ -196,45 +199,64 @@ export function ScheduleItemFormDialog({
   const watchedWorkdays = form.watch("workdays")
   const watchedPhase = form.watch("phase")
   const watchedDisplayColor = form.watch("displayColor")
+  const watchedStatus = form.watch("status")
   const watchedPercent = form.watch("percentComplete")
 
   const calculatedEnd = useMemo(() => {
     if (!watchedStart || !watchedWorkdays || watchedWorkdays < 1) return ""
-    return calculateEndDate(watchedStart, watchedWorkdays)
-  }, [watchedStart, watchedWorkdays])
+    return calculateEndDate(watchedStart, watchedWorkdays, exceptions)
+  }, [exceptions, watchedStart, watchedWorkdays])
 
   async function onSubmit(values: ScheduleItemFormValues) {
     const { notes, ...taskValues } = values
     void notes
-    let result
+    let savedTaskId: string
     if (isEditing) {
-      result = await updateTask(editingTask.id, {
+      const result = await updateTask(editingTask.id, {
         ...taskValues,
         assignedTo: taskValues.assignedTo || null,
       })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      savedTaskId = editingTask.id
     } else {
-      result = await createTask(projectId, {
+      const result = await createTask(projectId, {
         ...taskValues,
         assignedTo: taskValues.assignedTo || undefined,
       })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      savedTaskId = result.taskId
     }
 
-    if (result.success) {
-      for (const pred of pendingPredecessors) {
-        if (pred.taskId) {
-          await createDependency({
-            predecessorId: pred.taskId,
-            successorId: editingTask?.id ?? "",
-            type: pred.type,
-            lagDays: pred.lagDays,
-            projectId,
-          })
+    const dependencyErrors: string[] = []
+    for (const predecessor of pendingPredecessors) {
+      if (predecessor.taskId) {
+        const dependencyResult = await createDependency({
+          predecessorId: predecessor.taskId,
+          successorId: savedTaskId,
+          type: predecessor.type,
+          lagDays: predecessor.lagDays,
+          projectId,
+        })
+        if (!dependencyResult.success) {
+          dependencyErrors.push(dependencyResult.error)
         }
       }
-      onOpenChange(false)
-      router.refresh()
-    } else {
-      toast.error(result.error)
+    }
+
+    onOpenChange(false)
+    router.refresh()
+    if (dependencyErrors.length > 0) {
+      toast.warning(
+        `Schedule item saved, but ${dependencyErrors.length} dependency link${
+          dependencyErrors.length === 1 ? "" : "s"
+        } could not be added: ${dependencyErrors.join("; ")}`
+      )
     }
   }
 
@@ -468,7 +490,7 @@ export function ScheduleItemFormDialog({
 
                 <CollapsibleContent className="space-y-4 pt-3">
                   {/* Status + Assignee + Milestone row */}
-                  <div className="grid grid-cols-[140px_1fr_auto] gap-3 items-end">
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-[140px_1fr_auto] sm:items-end">
                     <FormField
                       control={form.control}
                       name="status"
@@ -478,7 +500,20 @@ export function ScheduleItemFormDialog({
                             Status
                           </FormLabel>
                           <Select
-                            onValueChange={field.onChange}
+                            onValueChange={(status) => {
+                              field.onChange(status)
+                              if (status === "COMPLETE") {
+                                form.setValue("percentComplete", 100, {
+                                  shouldDirty: true,
+                                })
+                              } else if (watchedPercent >= 100) {
+                                form.setValue(
+                                  "percentComplete",
+                                  status === "IN_PROGRESS" ? 50 : 0,
+                                  { shouldDirty: true }
+                                )
+                              }
+                            }}
                             value={field.value}
                           >
                             <FormControl>
@@ -551,7 +586,23 @@ export function ScheduleItemFormDialog({
                               max={100}
                               step={5}
                               value={[field.value]}
-                              onValueChange={([val]) => field.onChange(val)}
+                              onValueChange={([value]) => {
+                                field.onChange(value)
+                                if (value === 100 && watchedStatus !== "COMPLETE") {
+                                  form.setValue("status", "COMPLETE", {
+                                    shouldDirty: true,
+                                  })
+                                } else if (
+                                  value < 100 &&
+                                  watchedStatus === "COMPLETE"
+                                ) {
+                                  form.setValue(
+                                    "status",
+                                    value > 0 ? "IN_PROGRESS" : "PENDING",
+                                    { shouldDirty: true }
+                                  )
+                                }
+                              }}
                               className="flex-1"
                             />
                           </FormControl>
@@ -584,9 +635,10 @@ export function ScheduleItemFormDialog({
                           <span className="text-[10px] text-muted-foreground shrink-0 w-8 text-center">
                             {dep.type}
                           </span>
-                          {dep.lagDays > 0 && (
+                          {dep.lagDays !== 0 && (
                             <span className="text-[10px] text-muted-foreground shrink-0">
-                              +{dep.lagDays}d
+                              {dep.lagDays > 0 ? "+" : ""}
+                              {dep.lagDays}d
                             </span>
                           )}
                           <Button
@@ -605,7 +657,7 @@ export function ScheduleItemFormDialog({
                     {pendingPredecessors.map((pred, idx) => (
                       <div
                         key={idx}
-                        className="grid grid-cols-[1fr_90px_60px_28px] gap-1.5 items-center"
+                        className="grid grid-cols-[minmax(0,1fr)_72px_72px_28px] items-center gap-1.5 sm:grid-cols-[minmax(0,1fr)_90px_72px_28px]"
                       >
                         <Select
                           value={pred.taskId}
@@ -643,8 +695,7 @@ export function ScheduleItemFormDialog({
                         </Select>
                         <Input
                           type="number"
-                          min={0}
-                          placeholder="Lag"
+                          placeholder="Lag/lead"
                           className="h-8 text-xs text-center"
                           value={pred.lagDays || ""}
                           onChange={(e) =>

--- a/src/components/schedule/schedule-list-view.tsx
+++ b/src/components/schedule/schedule-list-view.tsx
@@ -32,10 +32,12 @@ import {
 } from "@/components/ui/select"
 import { ScheduleItemFormDialog } from "./schedule-item-form-dialog"
 import { DependencyDialog } from "./dependency-dialog"
+import { effectivePercentComplete } from "@/lib/schedule/progress"
 import { deleteTask } from "@/app/actions/schedule"
 import type {
   ScheduleTaskData,
   TaskDependencyData,
+  WorkdayExceptionData,
 } from "@/lib/schedule/types"
 import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
 import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
@@ -52,6 +54,7 @@ interface ScheduleListViewProps {
   readonly projectId: string
   readonly tasks: ScheduleTaskData[]
   readonly dependencies: TaskDependencyData[]
+  readonly exceptions: readonly WorkdayExceptionData[]
   readonly assigneeOptions: readonly ProjectTaskAssigneeOption[]
 }
 
@@ -70,46 +73,16 @@ function StatusDot({
   )
 }
 
-function ProgressRing({
-  percent,
-  size = 28,
-}: {
-  percent: number
-  size?: number
-}) {
-  const stroke = 3
-  const radius = (size - stroke) / 2
-  const circumference = 2 * Math.PI * radius
-  const offset = circumference - (percent / 100) * circumference
-
+function ProgressValue({ percent }: { readonly percent: number }) {
   return (
-    <div className="relative inline-flex items-center justify-center">
-      <svg width={size} height={size} className="-rotate-90">
-        <circle
-          cx={size / 2}
-          cy={size / 2}
-          r={radius}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={stroke}
-          className="text-muted-foreground/20"
+    <div className="w-12">
+      <span className="block text-xs font-medium tabular-nums">{percent}%</span>
+      <div className="mt-1 h-1 overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full bg-primary"
+          style={{ width: `${percent}%` }}
         />
-        <circle
-          cx={size / 2}
-          cy={size / 2}
-          r={radius}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={stroke}
-          strokeDasharray={circumference}
-          strokeDashoffset={offset}
-          strokeLinecap="round"
-          className="text-primary"
-        />
-      </svg>
-      <span className="absolute text-[9px] font-medium">
-        {percent}%
-      </span>
+      </div>
     </div>
   )
 }
@@ -146,6 +119,7 @@ export function ScheduleListView({
   projectId,
   tasks,
   dependencies,
+  exceptions,
   assigneeOptions,
 }: ScheduleListViewProps) {
   const router = useRouter()
@@ -221,7 +195,12 @@ export function ScheduleListView({
         id: "complete",
         header: "Complete",
         cell: ({ row }) => (
-          <ProgressRing percent={row.original.percentComplete} />
+          <ProgressValue
+            percent={effectivePercentComplete(
+              row.original.status,
+              row.original.percentComplete
+            )}
+          />
         ),
         size: 70,
         meta: { className: "hidden sm:table-cell" },
@@ -459,6 +438,7 @@ export function ScheduleListView({
         editingTask={editingTask}
         allTasks={localTasks}
         dependencies={dependencies}
+        exceptions={exceptions}
         assigneeOptions={assigneeOptions}
       />
 

--- a/src/components/schedule/schedule-mobile-view.tsx
+++ b/src/components/schedule/schedule-mobile-view.tsx
@@ -17,6 +17,7 @@ import {
 } from "date-fns"
 import { cn } from "@/lib/utils"
 import type { ScheduleTaskData } from "@/lib/schedule/types"
+import { effectivePercentComplete } from "@/lib/schedule/progress"
 import { useScheduleDisplayPalette } from "@/hooks/use-schedule-display-palette"
 import { getScheduleItemDisplayColor } from "@/lib/schedule/appearance"
 
@@ -210,7 +211,12 @@ export function ScheduleMobileView({
                   <div className="flex items-center gap-2 text-xs text-muted-foreground">
                     <span>{task.phase}</span>
                     <span>·</span>
-                    <span>{task.percentComplete}% complete</span>
+                    <span>
+                      {effectivePercentComplete(
+                        task.status,
+                        task.percentComplete
+                      )}% complete
+                    </span>
                   </div>
                 </div>
               </button>

--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -544,6 +544,7 @@ export function ScheduleView({
             projectId={projectId}
             tasks={filteredTasks}
             dependencies={initialData.dependencies}
+            exceptions={initialData.exceptions}
             assigneeOptions={assigneeOptions}
           />
         )}
@@ -552,6 +553,7 @@ export function ScheduleView({
             projectId={projectId}
             tasks={filteredTasks}
             dependencies={initialData.dependencies}
+            exceptions={initialData.exceptions}
             assigneeOptions={assigneeOptions}
           />
         )}
@@ -565,6 +567,7 @@ export function ScheduleView({
         editingTask={null}
         allTasks={initialData.tasks}
         dependencies={initialData.dependencies}
+        exceptions={initialData.exceptions}
         assigneeOptions={assigneeOptions}
       />
 
@@ -635,7 +638,7 @@ export function ScheduleView({
           <SheetHeader>
             <SheetTitle>Workday Exceptions</SheetTitle>
             <SheetDescription>
-              Holidays, vacation days, and other non-working days.
+              Holidays, shutdowns, and weekend working overrides.
             </SheetDescription>
           </SheetHeader>
           <div className="mt-4">

--- a/src/components/schedule/workday-exception-form-dialog.tsx
+++ b/src/components/schedule/workday-exception-form-dialog.tsx
@@ -35,6 +35,7 @@ import type {
   WorkdayExceptionData,
   ExceptionCategory,
   ExceptionRecurrence,
+  WorkdayExceptionType,
 } from "@/lib/schedule/types"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
@@ -45,6 +46,7 @@ const categories: { value: ExceptionCategory; label: string }[] = [
   { value: "vacation_day", label: "Vacation Day" },
   { value: "company_holiday", label: "Company Holiday" },
   { value: "weather_day", label: "Weather Day" },
+  { value: "extra_workday", label: "Extra Workday" },
 ]
 
 const recurrences: { value: ExceptionRecurrence; label: string }[] = [
@@ -52,15 +54,35 @@ const recurrences: { value: ExceptionRecurrence; label: string }[] = [
   { value: "yearly", label: "Yearly" },
 ]
 
-const exceptionSchema = z.object({
-  title: z.string().min(1, "Title is required"),
-  startDate: z.string().min(1, "Start date is required"),
-  endDate: z.string().min(1, "End date is required"),
-  type: z.string().min(1),
-  category: z.string().min(1),
-  recurrence: z.string().min(1),
-  notes: z.string(),
-})
+const exceptionTypes: {
+  readonly value: WorkdayExceptionType
+  readonly label: string
+}[] = [
+  { value: "non_working", label: "Non-working time" },
+  { value: "working", label: "Working override" },
+]
+
+const exceptionSchema = z
+  .object({
+    title: z.string().min(1, "Title is required"),
+    startDate: z.string().min(1, "Start date is required"),
+    endDate: z.string().min(1, "End date is required"),
+    type: z.enum(["non_working", "working"]),
+    category: z.enum([
+      "national_holiday",
+      "state_holiday",
+      "vacation_day",
+      "company_holiday",
+      "weather_day",
+      "extra_workday",
+    ]),
+    recurrence: z.enum(["one_time", "yearly"]),
+    notes: z.string(),
+  })
+  .refine((values) => values.endDate >= values.startDate, {
+    message: "End date must be on or after the start date",
+    path: ["endDate"],
+  })
 
 type ExceptionFormValues = z.infer<typeof exceptionSchema>
 
@@ -122,15 +144,11 @@ export function WorkdayExceptionFormDialog({
     if (isEditing) {
       result = await updateWorkdayException(editingException.id, {
         ...values,
-        category: values.category as ExceptionCategory,
-        recurrence: values.recurrence as ExceptionRecurrence,
         notes: values.notes || null,
       })
     } else {
       result = await createWorkdayException(projectId, {
         ...values,
-        category: values.category as ExceptionCategory,
-        recurrence: values.recurrence as ExceptionRecurrence,
         notes: values.notes || undefined,
       })
     }
@@ -198,6 +216,38 @@ export function WorkdayExceptionFormDialog({
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
               <FormField
                 control={form.control}
+                name="type"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">Calendar Effect</FormLabel>
+                    <Select
+                      onValueChange={(value) => {
+                        field.onChange(value)
+                        if (value === "working") {
+                          form.setValue("category", "extra_workday")
+                        }
+                      }}
+                      value={field.value}
+                    >
+                      <FormControl>
+                        <SelectTrigger className="h-9">
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {exceptionTypes.map((type) => (
+                          <SelectItem key={type.value} value={type.value}>
+                            {type.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
                 name="category"
                 render={({ field }) => (
                   <FormItem>
@@ -223,34 +273,32 @@ export function WorkdayExceptionFormDialog({
                   </FormItem>
                 )}
               />
-              <FormField
-                control={form.control}
-                name="recurrence"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-xs">Recurrence</FormLabel>
-                    <Select
-                      onValueChange={field.onChange}
-                      value={field.value}
-                    >
-                      <FormControl>
-                        <SelectTrigger className="h-9">
-                          <SelectValue />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {recurrences.map((r) => (
-                          <SelectItem key={r.value} value={r.value}>
-                            {r.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
             </div>
+
+            <FormField
+              control={form.control}
+              name="recurrence"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-xs">Recurrence</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger className="h-9">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {recurrences.map((r) => (
+                        <SelectItem key={r.value} value={r.value}>
+                          {r.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
             <FormField
               control={form.control}

--- a/src/components/schedule/workday-exceptions-view.tsx
+++ b/src/components/schedule/workday-exceptions-view.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useCallback } from "react"
+import { useState, useCallback, useMemo } from "react"
 import {
   Table,
   TableBody,
@@ -10,13 +10,22 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { Button } from "@/components/ui/button"
-import { IconPlus, IconPencil, IconTrash } from "@tabler/icons-react"
+import { Input } from "@/components/ui/input"
+import {
+  IconCalendarPlus,
+  IconPlus,
+  IconPencil,
+  IconTrash,
+} from "@tabler/icons-react"
 import { WorkdayExceptionFormDialog } from "./workday-exception-form-dialog"
-import { deleteWorkdayException } from "@/app/actions/workday-exceptions"
+import {
+  createWorkdayException,
+  deleteWorkdayException,
+} from "@/app/actions/workday-exceptions"
 import type { WorkdayExceptionData } from "@/lib/schedule/types"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
-import { format, parseISO } from "date-fns"
+import { addDays, format, isWeekend, parseISO } from "date-fns"
 
 interface WorkdayExceptionsViewProps {
   projectId: string
@@ -46,6 +55,13 @@ const categoryLabels: Record<string, string> = {
   vacation_day: "Vacation Day",
   company_holiday: "Company Holiday",
   weather_day: "Weather Day",
+  extra_workday: "Extra Workday",
+}
+
+function nextWeekendDate(): string {
+  const today = new Date()
+  const daysUntilSaturday = (6 - today.getDay() + 7) % 7
+  return format(addDays(today, daysUntilSaturday), "yyyy-MM-dd")
 }
 
 export function WorkdayExceptionsView({
@@ -56,6 +72,20 @@ export function WorkdayExceptionsView({
   const [formOpen, setFormOpen] = useState(false)
   const [editingException, setEditingException] =
     useState<WorkdayExceptionData | null>(null)
+  const [weekendDate, setWeekendDate] = useState(nextWeekendDate)
+  const [weekendSaving, setWeekendSaving] = useState(false)
+
+  const weekendOverride = useMemo(
+    () =>
+      exceptions.find(
+        (exception) =>
+          exception.type === "working" &&
+          exception.recurrence === "one_time" &&
+          exception.startDate === weekendDate &&
+          exception.endDate === weekendDate
+      ),
+    [exceptions, weekendDate]
+  )
 
   const handleDelete = useCallback(
     async (id: string) => {
@@ -69,8 +99,73 @@ export function WorkdayExceptionsView({
     [router]
   )
 
+  const handleWeekendToggle = useCallback(async () => {
+    if (!isWeekend(parseISO(weekendDate))) {
+      toast.error("Choose a Saturday or Sunday for a weekend override")
+      return
+    }
+
+    setWeekendSaving(true)
+    const result = weekendOverride
+      ? await deleteWorkdayException(weekendOverride.id)
+      : await createWorkdayException(projectId, {
+          title: `Weekend workday — ${format(
+            parseISO(weekendDate),
+            "MMM d, yyyy"
+          )}`,
+          startDate: weekendDate,
+          endDate: weekendDate,
+          type: "working",
+          category: "extra_workday",
+          recurrence: "one_time",
+        })
+    setWeekendSaving(false)
+
+    if (result.success) {
+      toast.success(
+        weekendOverride
+          ? "Weekend restored as non-working"
+          : "Weekend marked as a workday"
+      )
+      router.refresh()
+    } else {
+      toast.error(result.error)
+    }
+  }, [projectId, router, weekendDate, weekendOverride])
+
   return (
     <div>
+      <div className="mb-4 rounded-md border bg-muted/20 p-3">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium">Quick weekend override</p>
+            <p className="text-xs text-muted-foreground">
+              Pick a Saturday or Sunday, then toggle whether crews can work.
+            </p>
+          </div>
+          <Input
+            type="date"
+            value={weekendDate}
+            onChange={(event) => setWeekendDate(event.target.value)}
+            className="h-9 sm:w-[165px]"
+          />
+          <Button
+            type="button"
+            size="sm"
+            variant={weekendOverride ? "outline" : "default"}
+            disabled={weekendSaving}
+            onClick={handleWeekendToggle}
+          >
+            <IconCalendarPlus className="mr-1 size-4" />
+            {weekendSaving
+              ? "Saving..."
+              : weekendOverride
+                ? "Make non-working"
+                : "Make workday"}
+          </Button>
+        </div>
+      </div>
+
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-4">
         <h2 className="text-lg font-medium min-w-0 break-words">Workday Exceptions</h2>
         <Button
@@ -96,6 +191,7 @@ export function WorkdayExceptionsView({
                 <TableHead className="hidden sm:table-cell">Start</TableHead>
                 <TableHead className="hidden sm:table-cell">End</TableHead>
                 <TableHead className="hidden md:table-cell">Duration</TableHead>
+                <TableHead className="hidden md:table-cell">Effect</TableHead>
                 <TableHead className="hidden lg:table-cell">Category</TableHead>
                 <TableHead className="hidden lg:table-cell">Recurrence</TableHead>
                 <TableHead className="hidden lg:table-cell">Notes</TableHead>
@@ -106,7 +202,7 @@ export function WorkdayExceptionsView({
               {exceptions.length === 0 ? (
                 <TableRow>
                   <TableCell
-                    colSpan={8}
+                    colSpan={9}
                     className="text-center py-8 text-muted-foreground min-w-0"
                   >
                     <span className="block">No workday exceptions</span>
@@ -126,6 +222,9 @@ export function WorkdayExceptionsView({
                   </TableCell>
                   <TableCell className="hidden md:table-cell text-xs">
                     {calcDuration(ex.startDate, ex.endDate)} days
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell text-xs">
+                    {ex.type === "working" ? "Working" : "Non-working"}
                   </TableCell>
                   <TableCell className="hidden lg:table-cell text-xs">
                     {categoryLabels[ex.category] ?? ex.category}

--- a/src/lib/schedule/__tests__/business-days.test.ts
+++ b/src/lib/schedule/__tests__/business-days.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import {
+  addBusinessDays,
+  calculateEndDate,
+  countBusinessDays,
+  isNonWorkday,
+} from "../business-days"
+import type { WorkdayExceptionData } from "../types"
+
+function exception(
+  overrides: Partial<WorkdayExceptionData>
+): WorkdayExceptionData {
+  return {
+    id: "exception-1",
+    projectId: "project-1",
+    title: "Exception",
+    startDate: "2026-07-25",
+    endDate: "2026-07-25",
+    type: "non_working",
+    category: "company_holiday",
+    recurrence: "one_time",
+    notes: null,
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+describe("business-day calendar", () => {
+  it("skips weekends by default", () => {
+    expect(addBusinessDays("2026-07-24", 1)).toBe("2026-07-27")
+    expect(countBusinessDays("2026-07-24", "2026-07-27")).toBe(2)
+  })
+
+  it("allows a weekend to be made into a working day", () => {
+    const exceptions = [exception({ type: "working" })]
+
+    expect(isNonWorkday(new Date("2026-07-25T12:00:00"), exceptions)).toBe(false)
+    expect(calculateEndDate("2026-07-24", 2, exceptions)).toBe("2026-07-25")
+    expect(addBusinessDays("2026-07-24", 1, exceptions)).toBe("2026-07-25")
+  })
+
+  it("lets a working override take precedence over a shutdown", () => {
+    const exceptions = [
+      exception({
+        id: "shutdown",
+        startDate: "2026-07-24",
+        endDate: "2026-07-26",
+      }),
+      exception({ id: "override", type: "working" }),
+    ]
+
+    expect(isNonWorkday(new Date("2026-07-25T12:00:00"), exceptions)).toBe(false)
+  })
+
+  it("applies yearly exceptions in future years", () => {
+    const christmas = exception({
+      startDate: "2026-12-25",
+      endDate: "2026-12-25",
+      recurrence: "yearly",
+    })
+
+    expect(isNonWorkday(new Date("2027-12-25T12:00:00"), [christmas])).toBe(true)
+  })
+
+  it("supports negative leads when counting business days", () => {
+    expect(addBusinessDays("2026-07-27", -1)).toBe("2026-07-24")
+  })
+})

--- a/src/lib/schedule/__tests__/progress.test.ts
+++ b/src/lib/schedule/__tests__/progress.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import {
+  effectivePercentComplete,
+  normalizeScheduleProgress,
+} from "../progress"
+
+describe("schedule progress", () => {
+  it("always presents a completed schedule item as 100 percent", () => {
+    expect(effectivePercentComplete("COMPLETE", 0)).toBe(100)
+    expect(normalizeScheduleProgress("COMPLETE", 35)).toEqual({
+      status: "COMPLETE",
+      percentComplete: 100,
+    })
+  })
+
+  it("does not leave a non-complete item at 100 percent", () => {
+    expect(effectivePercentComplete("IN_PROGRESS", 100)).toBe(99)
+  })
+
+  it("clamps invalid progress values", () => {
+    expect(effectivePercentComplete("PENDING", -10)).toBe(0)
+    expect(effectivePercentComplete("BLOCKED", Number.NaN)).toBe(0)
+  })
+})

--- a/src/lib/schedule/__tests__/propagate-dates.test.ts
+++ b/src/lib/schedule/__tests__/propagate-dates.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest"
+import {
+  propagateDates,
+  recalculateScheduleDates,
+} from "../propagate-dates"
+import type {
+  DependencyType,
+  ScheduleTaskData,
+  TaskDependencyData,
+} from "../types"
+
+function task(
+  id: string,
+  startDate: string,
+  workdays: number,
+  endDateCalculated: string
+): ScheduleTaskData {
+  return {
+    id,
+    projectId: "project-1",
+    title: id,
+    startDate,
+    workdays,
+    endDateCalculated,
+    phase: "framing",
+    displayColor: "blue",
+    status: "PENDING",
+    isCriticalPath: false,
+    isMilestone: false,
+    percentComplete: 0,
+    assignedTo: null,
+    sortOrder: 0,
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+  }
+}
+
+function dependency(
+  type: DependencyType,
+  lagDays = 0,
+  predecessorId = "a",
+  successorId = "b"
+): TaskDependencyData {
+  return {
+    id: `${predecessorId}-${successorId}-${type}`,
+    predecessorId,
+    successorId,
+    type,
+    lagDays,
+  }
+}
+
+describe("schedule dependency propagation", () => {
+  it("propagates finish-to-start relationships through a chain", () => {
+    const tasks = [
+      task("a", "2026-07-20", 5, "2026-07-24"),
+      task("b", "2026-07-20", 2, "2026-07-21"),
+      task("c", "2026-07-20", 1, "2026-07-20"),
+    ]
+    const dependencies = [
+      dependency("FS"),
+      dependency("FS", 0, "b", "c"),
+    ]
+
+    expect(
+      Object.fromEntries(
+        propagateDates("a", tasks, dependencies).updatedTasks
+      )
+    ).toEqual({
+      b: {
+        startDate: "2026-07-27",
+        endDateCalculated: "2026-07-28",
+      },
+      c: {
+        startDate: "2026-07-29",
+        endDateCalculated: "2026-07-29",
+      },
+    })
+  })
+
+  it("supports start-to-start lags and negative leads", () => {
+    const tasks = [
+      task("a", "2026-07-27", 5, "2026-07-31"),
+      task("b", "2026-07-20", 1, "2026-07-20"),
+    ]
+
+    expect(
+      propagateDates("a", tasks, [dependency("SS", -1)]).updatedTasks.get("b")
+    ).toEqual({
+      startDate: "2026-07-24",
+      endDateCalculated: "2026-07-24",
+    })
+  })
+
+  it("supports finish-to-finish and start-to-finish relationships", () => {
+    const tasks = [
+      task("a", "2026-07-20", 5, "2026-07-24"),
+      task("b", "2026-07-20", 2, "2026-07-21"),
+    ]
+
+    expect(
+      propagateDates("a", tasks, [dependency("FF")]).updatedTasks.get("b")
+    ).toEqual({
+      startDate: "2026-07-23",
+      endDateCalculated: "2026-07-24",
+    })
+    expect(
+      propagateDates("a", tasks, [dependency("SF")]).updatedTasks.get("b")
+    ).toEqual({
+      startDate: "2026-07-17",
+      endDateCalculated: "2026-07-20",
+    })
+  })
+
+  it("uses the latest constraint when a task has multiple predecessors", () => {
+    const tasks = [
+      task("a", "2026-07-20", 2, "2026-07-21"),
+      task("x", "2026-07-20", 5, "2026-07-24"),
+      task("b", "2026-07-20", 1, "2026-07-20"),
+    ]
+    const dependencies = [
+      dependency("FS"),
+      dependency("FS", 0, "x", "b"),
+    ]
+
+    expect(
+      propagateDates("a", tasks, dependencies).updatedTasks.get("b")
+    ).toEqual({
+      startDate: "2026-07-27",
+      endDateCalculated: "2026-07-27",
+    })
+  })
+
+  it("recalculates task dates after the project work calendar changes", () => {
+    const tasks = [
+      task("a", "2026-07-24", 2, "2026-07-27"),
+      task("b", "2026-07-28", 1, "2026-07-28"),
+    ]
+    const workingSaturday = {
+      id: "weekend",
+      projectId: "project-1",
+      title: "Weekend workday",
+      startDate: "2026-07-25",
+      endDate: "2026-07-25",
+      type: "working" as const,
+      category: "company_holiday" as const,
+      recurrence: "one_time" as const,
+      notes: null,
+      createdAt: "2026-07-01T00:00:00.000Z",
+      updatedAt: "2026-07-01T00:00:00.000Z",
+    }
+
+    expect(
+      Object.fromEntries(
+        recalculateScheduleDates(
+          tasks,
+          [dependency("FS")],
+          [workingSaturday]
+        ).updatedTasks
+      )
+    ).toEqual({
+      a: {
+        startDate: "2026-07-24",
+        endDateCalculated: "2026-07-25",
+      },
+      b: {
+        startDate: "2026-07-27",
+        endDateCalculated: "2026-07-27",
+      },
+    })
+  })
+})

--- a/src/lib/schedule/business-days.ts
+++ b/src/lib/schedule/business-days.ts
@@ -1,28 +1,57 @@
-import { addDays, isWeekend, parseISO, format, isWithinInterval } from "date-fns"
+import {
+  addDays,
+  isWeekend,
+  parseISO,
+  format,
+} from "date-fns"
 import type { WorkdayExceptionData } from "./types"
 
-function isExceptionDay(
+function isExceptionActive(
   date: Date,
-  exceptions: WorkdayExceptionData[]
+  exception: WorkdayExceptionData
 ): boolean {
-  return exceptions.some((ex) => {
-    const start = parseISO(ex.startDate)
-    const end = parseISO(ex.endDate)
-    return isWithinInterval(date, { start, end })
-  })
+  if (exception.recurrence === "yearly") {
+    const dateKey = format(date, "MM-dd")
+    const startKey = exception.startDate.slice(5)
+    const endKey = exception.endDate.slice(5)
+
+    if (startKey <= endKey) {
+      return dateKey >= startKey && dateKey <= endKey
+    }
+
+    // A yearly range such as Dec 24–Jan 2 crosses the year boundary.
+    return dateKey >= startKey || dateKey <= endKey
+  }
+
+  const dateKey = format(date, "yyyy-MM-dd")
+  return dateKey >= exception.startDate && dateKey <= exception.endDate
 }
 
-function isNonWorkday(
+export function isNonWorkday(
   date: Date,
-  exceptions: WorkdayExceptionData[] = []
+  exceptions: readonly WorkdayExceptionData[] = []
 ): boolean {
-  return isWeekend(date) || isExceptionDay(date, exceptions)
+  const activeExceptions = exceptions.filter((exception) =>
+    isExceptionActive(date, exception)
+  )
+
+  // An explicit working override wins so a weekend or a broader shutdown
+  // range can be opened for work without changing the base calendar.
+  if (activeExceptions.some((exception) => exception.type === "working")) {
+    return false
+  }
+
+  if (activeExceptions.some((exception) => exception.type === "non_working")) {
+    return true
+  }
+
+  return isWeekend(date)
 }
 
 export function calculateEndDate(
   startDate: string,
   workdays: number,
-  exceptions: WorkdayExceptionData[] = []
+  exceptions: readonly WorkdayExceptionData[] = []
 ): string {
   if (workdays <= 0) return startDate
 
@@ -46,7 +75,7 @@ export function calculateEndDate(
 export function countBusinessDays(
   startDate: string,
   endDate: string,
-  exceptions: WorkdayExceptionData[] = []
+  exceptions: readonly WorkdayExceptionData[] = []
 ): number {
   let current = parseISO(startDate)
   const end = parseISO(endDate)
@@ -65,7 +94,7 @@ export function countBusinessDays(
 export function addBusinessDays(
   date: string,
   days: number,
-  exceptions: WorkdayExceptionData[] = []
+  exceptions: readonly WorkdayExceptionData[] = []
 ): string {
   let current = parseISO(date)
   let remaining = Math.abs(days)
@@ -79,4 +108,13 @@ export function addBusinessDays(
   }
 
   return format(current, "yyyy-MM-dd")
+}
+
+export function calculateStartDate(
+  endDate: string,
+  workdays: number,
+  exceptions: readonly WorkdayExceptionData[] = []
+): string {
+  if (workdays <= 1) return endDate
+  return addBusinessDays(endDate, -(workdays - 1), exceptions)
 }

--- a/src/lib/schedule/gantt-transform.ts
+++ b/src/lib/schedule/gantt-transform.ts
@@ -5,6 +5,7 @@ import type {
 } from "./types"
 import { PHASE_ORDER, PHASE_LABELS } from "./phase-colors"
 import { normalizeDisplayColor } from "./appearance"
+import { effectivePercentComplete } from "./progress"
 
 export interface FrappeTask {
   id: string
@@ -40,10 +41,10 @@ export function transformToFrappeTasks(
   tasks: ScheduleTaskData[],
   dependencies: TaskDependencyData[]
 ): FrappeTask[] {
-  // build dep lookup: successorId -> predecessorIds (FS only for visual lines)
+  // Build a lookup for visual dependency lines. Frappe Gantt does not expose
+  // dependency types, but every stored relationship should still be visible.
   const predMap = new Map<string, string[]>()
   for (const dep of dependencies) {
-    if (dep.type !== "FS") continue
     if (!predMap.has(dep.successorId)) {
       predMap.set(dep.successorId, [])
     }
@@ -54,9 +55,10 @@ export function transformToFrappeTasks(
     const preds = predMap.get(task.id) || []
     const depString = preds.join(", ")
 
-    let progress = 0
-    if (task.status === "COMPLETE") progress = 100
-    else if (task.status === "IN_PROGRESS") progress = 50
+    const progress = effectivePercentComplete(
+      task.status,
+      task.percentComplete
+    )
 
     // frappe-gantt uses classList.add() which throws on spaces,
     // so we can only pass a single class name
@@ -116,7 +118,11 @@ export function groupTasksByPhase(
     const ends = phaseTasks.map((t) => t.endDateCalculated).sort()
 
     const avgProgress = Math.round(
-      phaseTasks.reduce((sum, t) => sum + t.percentComplete, 0) /
+      phaseTasks.reduce(
+        (sum, task) =>
+          sum + effectivePercentComplete(task.status, task.percentComplete),
+        0
+      ) /
         phaseTasks.length
     )
 
@@ -147,7 +153,6 @@ function derivePhaseDeps(
   const predecessorPhases = new Set<string>()
 
   for (const dep of dependencies) {
-    if (dep.type !== "FS") continue
     if (!taskIds.has(dep.successorId)) continue
     if (taskIds.has(dep.predecessorId)) continue
 
@@ -178,7 +183,6 @@ export function transformWithPhaseGroups(
 
   const predMap = new Map<string, string[]>()
   for (const dep of dependencies) {
-    if (dep.type !== "FS") continue
     if (!predMap.has(dep.successorId)) predMap.set(dep.successorId, [])
     predMap.get(dep.successorId)!.push(dep.predecessorId)
   }
@@ -224,9 +228,10 @@ export function transformWithPhaseGroups(
         })
         const depString = [...new Set(resolvedPreds)].join(", ")
 
-        let progress = 0
-        if (task.status === "COMPLETE") progress = 100
-        else if (task.status === "IN_PROGRESS") progress = 50
+        const progress = effectivePercentComplete(
+          task.status,
+          task.percentComplete
+        )
 
         const customClass = `display-color-${normalizeDisplayColor(task.displayColor)}`
 

--- a/src/lib/schedule/progress.ts
+++ b/src/lib/schedule/progress.ts
@@ -1,0 +1,27 @@
+import type { TaskStatus } from "./types"
+
+function clampPercent(percentComplete: number): number {
+  if (!Number.isFinite(percentComplete)) return 0
+  return Math.min(100, Math.max(0, Math.round(percentComplete)))
+}
+
+export function effectivePercentComplete(
+  status: TaskStatus,
+  percentComplete: number
+): number {
+  if (status === "COMPLETE") return 100
+  return Math.min(99, clampPercent(percentComplete))
+}
+
+export function normalizeScheduleProgress(
+  status: TaskStatus,
+  percentComplete: number
+): {
+  readonly status: TaskStatus
+  readonly percentComplete: number
+} {
+  return {
+    status,
+    percentComplete: effectivePercentComplete(status, percentComplete),
+  }
+}

--- a/src/lib/schedule/propagate-dates.ts
+++ b/src/lib/schedule/propagate-dates.ts
@@ -3,65 +3,237 @@ import type {
   TaskDependencyData,
   WorkdayExceptionData,
 } from "./types"
-import { calculateEndDate, addBusinessDays } from "./business-days"
+import {
+  addBusinessDays,
+  calculateEndDate,
+  calculateStartDate,
+} from "./business-days"
+
+interface TaskDates {
+  readonly startDate: string
+  readonly endDateCalculated: string
+}
 
 interface PropagationResult {
-  updatedTasks: Map<string, { startDate: string; endDateCalculated: string }>
+  readonly updatedTasks: Map<string, TaskDates>
+}
+
+function constrainedDates(
+  successor: ScheduleTaskData,
+  incomingDependencies: readonly TaskDependencyData[],
+  taskMap: ReadonlyMap<string, ScheduleTaskData>,
+  exceptions: readonly WorkdayExceptionData[]
+): TaskDates | null {
+  const candidateStarts: string[] = []
+
+  for (const dependency of incomingDependencies) {
+    const predecessor = taskMap.get(dependency.predecessorId)
+    if (!predecessor) continue
+
+    if (dependency.type === "FS") {
+      candidateStarts.push(
+        addBusinessDays(
+          predecessor.endDateCalculated,
+          1 + dependency.lagDays,
+          exceptions
+        )
+      )
+      continue
+    }
+
+    if (dependency.type === "SS") {
+      candidateStarts.push(
+        addBusinessDays(
+          predecessor.startDate,
+          dependency.lagDays,
+          exceptions
+        )
+      )
+      continue
+    }
+
+    const constrainedEnd =
+      dependency.type === "FF"
+        ? addBusinessDays(
+            predecessor.endDateCalculated,
+            dependency.lagDays,
+            exceptions
+          )
+        : addBusinessDays(
+            predecessor.startDate,
+            dependency.lagDays,
+            exceptions
+          )
+
+    candidateStarts.push(
+      calculateStartDate(constrainedEnd, successor.workdays, exceptions)
+    )
+  }
+
+  if (candidateStarts.length === 0) return null
+
+  // A successor with multiple predecessors must satisfy the latest constraint.
+  const startDate = candidateStarts.sort().at(-1)
+  if (!startDate) return null
+
+  return {
+    startDate,
+    endDateCalculated: calculateEndDate(
+      startDate,
+      successor.workdays,
+      exceptions
+    ),
+  }
+}
+
+function incomingDependencyMap(
+  dependencies: readonly TaskDependencyData[]
+): Map<string, TaskDependencyData[]> {
+  const incoming = new Map<string, TaskDependencyData[]>()
+  for (const dependency of dependencies) {
+    const current = incoming.get(dependency.successorId) ?? []
+    current.push(dependency)
+    incoming.set(dependency.successorId, current)
+  }
+  return incoming
+}
+
+function successorDependencyMap(
+  dependencies: readonly TaskDependencyData[]
+): Map<string, TaskDependencyData[]> {
+  const successors = new Map<string, TaskDependencyData[]>()
+  for (const dependency of dependencies) {
+    const current = successors.get(dependency.predecessorId) ?? []
+    current.push(dependency)
+    successors.set(dependency.predecessorId, current)
+  }
+  return successors
 }
 
 export function propagateDates(
   changedTaskId: string,
-  tasks: ScheduleTaskData[],
-  dependencies: TaskDependencyData[],
-  exceptions: WorkdayExceptionData[] = []
+  tasks: readonly ScheduleTaskData[],
+  dependencies: readonly TaskDependencyData[],
+  exceptions: readonly WorkdayExceptionData[] = []
 ): PropagationResult {
-  const taskMap = new Map(tasks.map((t) => [t.id, { ...t }]))
-  const updates = new Map<string, { startDate: string; endDateCalculated: string }>()
-
-  // build successor map (only FS deps propagate dates)
-  const successorDeps = new Map<string, TaskDependencyData[]>()
-  for (const dep of dependencies) {
-    if (dep.type !== "FS") continue
-    if (!successorDeps.has(dep.predecessorId)) {
-      successorDeps.set(dep.predecessorId, [])
-    }
-    successorDeps.get(dep.predecessorId)!.push(dep)
-  }
-
-  // BFS from changed task through successors
+  const taskMap = new Map(tasks.map((task) => [task.id, { ...task }]))
+  const updates = new Map<string, TaskDates>()
+  const incoming = incomingDependencyMap(dependencies)
+  const successors = successorDependencyMap(dependencies)
   const queue = [changedTaskId]
-  const visited = new Set<string>()
+  const queued = new Set(queue)
 
   while (queue.length > 0) {
-    const currentId = queue.shift()!
-    if (visited.has(currentId)) continue
-    visited.add(currentId)
+    const currentId = queue.shift()
+    if (!currentId) continue
+    queued.delete(currentId)
 
-    const current = taskMap.get(currentId)
-    if (!current) continue
-
-    const deps = successorDeps.get(currentId) || []
-    for (const dep of deps) {
-      const successor = taskMap.get(dep.successorId)
+    const outgoing = successors.get(currentId) ?? []
+    for (const dependency of outgoing) {
+      const successor = taskMap.get(dependency.successorId)
       if (!successor) continue
 
-      // successor starts after predecessor ends + lag
-      const newStart = addBusinessDays(
-        current.endDateCalculated,
-        1 + dep.lagDays,
+      const dates = constrainedDates(
+        successor,
+        incoming.get(successor.id) ?? [],
+        taskMap,
         exceptions
       )
-      const newEnd = calculateEndDate(newStart, successor.workdays, exceptions)
+      if (!dates) continue
 
-      if (newStart !== successor.startDate || newEnd !== successor.endDateCalculated) {
-        successor.startDate = newStart
-        successor.endDateCalculated = newEnd
-        updates.set(successor.id, {
-          startDate: newStart,
-          endDateCalculated: newEnd,
-        })
-        queue.push(successor.id)
+      if (
+        dates.startDate !== successor.startDate ||
+        dates.endDateCalculated !== successor.endDateCalculated
+      ) {
+        const updatedSuccessor = { ...successor, ...dates }
+        taskMap.set(successor.id, updatedSuccessor)
+        updates.set(successor.id, dates)
+        if (!queued.has(successor.id)) {
+          queue.push(successor.id)
+          queued.add(successor.id)
+        }
       }
+    }
+  }
+
+  return { updatedTasks: updates }
+}
+
+export function recalculateScheduleDates(
+  tasks: readonly ScheduleTaskData[],
+  dependencies: readonly TaskDependencyData[],
+  exceptions: readonly WorkdayExceptionData[] = []
+): PropagationResult {
+  const originalById = new Map(tasks.map((task) => [task.id, task]))
+  const taskMap = new Map(
+    tasks.map((task) => [
+      task.id,
+      {
+        ...task,
+        endDateCalculated: calculateEndDate(
+          task.startDate,
+          task.workdays,
+          exceptions
+        ),
+      },
+    ])
+  )
+  const incoming = incomingDependencyMap(dependencies)
+  const successors = successorDependencyMap(dependencies)
+  const inDegree = new Map(tasks.map((task) => [task.id, 0]))
+
+  for (const dependency of dependencies) {
+    if (
+      taskMap.has(dependency.predecessorId) &&
+      taskMap.has(dependency.successorId)
+    ) {
+      inDegree.set(
+        dependency.successorId,
+        (inDegree.get(dependency.successorId) ?? 0) + 1
+      )
+    }
+  }
+
+  const queue = tasks
+    .filter((task) => (inDegree.get(task.id) ?? 0) === 0)
+    .map((task) => task.id)
+
+  while (queue.length > 0) {
+    const currentId = queue.shift()
+    if (!currentId) continue
+
+    for (const dependency of successors.get(currentId) ?? []) {
+      const nextDegree = (inDegree.get(dependency.successorId) ?? 1) - 1
+      inDegree.set(dependency.successorId, nextDegree)
+      if (nextDegree !== 0) continue
+
+      const successor = taskMap.get(dependency.successorId)
+      if (!successor) continue
+      const dates = constrainedDates(
+        successor,
+        incoming.get(successor.id) ?? [],
+        taskMap,
+        exceptions
+      )
+      if (dates) {
+        taskMap.set(successor.id, { ...successor, ...dates })
+      }
+      queue.push(successor.id)
+    }
+  }
+
+  const updates = new Map<string, TaskDates>()
+  for (const [taskId, task] of taskMap) {
+    const original = originalById.get(taskId)
+    if (
+      original &&
+      (original.startDate !== task.startDate ||
+        original.endDateCalculated !== task.endDateCalculated)
+    ) {
+      updates.set(taskId, {
+        startDate: task.startDate,
+        endDateCalculated: task.endDateCalculated,
+      })
     }
   }
 

--- a/src/lib/schedule/types.ts
+++ b/src/lib/schedule/types.ts
@@ -23,8 +23,11 @@ export type ExceptionCategory =
   | "vacation_day"
   | "company_holiday"
   | "weather_day"
+  | "extra_workday"
 
 export type ExceptionRecurrence = "one_time" | "yearly"
+
+export type WorkdayExceptionType = "non_working" | "working"
 
 export interface ScheduleTaskData {
   id: string
@@ -59,7 +62,7 @@ export interface WorkdayExceptionData {
   title: string
   startDate: string
   endDate: string
-  type: string
+  type: WorkdayExceptionType
   category: ExceptionCategory
   recurrence: ExceptionRecurrence
   notes: string | null


### PR DESCRIPTION
## Summary

- keep completed schedule items at 100% across list, Gantt, calendar, mobile, and agent responses
- repair predecessor creation and propagate FS, SS, FF, and SF dependencies, including negative leads
- honor working/non-working and yearly calendar exceptions, with a quick weekend workday toggle
- recalculate affected dates when the work calendar changes and validate schedule API project boundaries

## Verification

- `bun run test` — 202 passed, 3 skipped
- `bunx tsc --noEmit`
- `bun lint` — no errors
- `bun run build`
- focused business-day, progress, dependency propagation, and Gantt tests
