### PR TITLE
fix(daily-logs): remove duplicate notes and simplify layout

### DIFF
--- a/docs/development/conventions.md
+++ b/docs/development/conventions.md
@@ -210,6 +210,21 @@ Built on `@tanstack/react-table`. The pattern uses a `DataTable` component that 
 
 React Hook Form with Zod resolvers. The validation schemas from `src/lib/validations/` plug directly into form configuration.
 
+### Information density and responsive text
+
+Keep Compass clean, crisp, professional, and easy to scan. Rounded cards,
+badges, pills, and other bordered "bubbles" should normally account for no
+more than roughly 20% of an informational layout. Prefer typography,
+whitespace, and subtle rules or dividers for grouping. Reserve a bounded
+container for a meaningful section or interaction instead of wrapping every
+individual value.
+
+Text must remain readable when a window narrows. Content containers need
+`min-w-0`, and user-entered prose should use `break-words` with
+`whitespace-pre-wrap` when line breaks are meaningful. Do not place prose in
+fixed-size bubbles. Use truncation only when the complete value remains
+available through an intentional detail view or accessible affordance.
+
 
 File organization
 ---

--- a/src/app/actions/project-field.ts
+++ b/src/app/actions/project-field.ts
@@ -16,6 +16,7 @@ import {
 } from "@/db/schema"
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
+import { normalizeDailyLogNotes } from "@/lib/daily-logs/notes"
 import { isDemoUser } from "@/lib/demo"
 import { requireOrg } from "@/lib/org-scope"
 import {
@@ -1346,7 +1347,7 @@ export async function getProjectDailyLogWorkspace(
       hoursWorked: row.hoursWorked,
       safetyIncidents: row.safetyIncidents,
       visitorLog: row.visitorLog,
-      notes: row.notes,
+      notes: normalizeDailyLogNotes(row.workCompleted, row.notes),
       isClientVisible: row.isClientVisible,
       reviewStatus: row.reviewStatus,
       syncStatus: row.syncStatus,
@@ -1405,7 +1406,7 @@ export async function createProjectDailyLog(
       hoursWorked: input.hoursWorked,
       safetyIncidents: optionalText(input.safetyIncidents),
       visitorLog: optionalText(input.visitorLog),
-      notes: optionalText(input.notes),
+      notes: normalizeDailyLogNotes(workCompleted, input.notes),
       isClientVisible: false,
       reviewStatus: "needs_review",
       tags: null,
@@ -1468,7 +1469,7 @@ export async function updateProjectDailyLog(
         hoursWorked: input.hoursWorked,
         safetyIncidents: optionalText(input.safetyIncidents),
         visitorLog: optionalText(input.visitorLog),
-        notes: optionalText(input.notes),
+        notes: normalizeDailyLogNotes(workCompleted, input.notes),
         isClientVisible: false,
         reviewStatus: "needs_review",
         syncStatus: "pending",
@@ -1861,7 +1862,9 @@ export async function getOwnerProjectUpdateDocument(
       manpower: row.crewPresent,
       safetyNotes: row.safetyIncidents,
       issues: row.issues,
-      nextSteps: ownerFacingDailyLogNotes(row.notes),
+      nextSteps: ownerFacingDailyLogNotes(
+        normalizeDailyLogNotes(row.workCompleted, row.notes)
+      ),
       authorName: displayName({
         displayName: row.authorDisplayName,
         firstName: row.authorFirstName,

--- a/src/components/projects/project-daily-log-workspace.tsx
+++ b/src/components/projects/project-daily-log-workspace.tsx
@@ -1090,6 +1090,12 @@ export function ProjectDailyLogWorkspace({
               {(() => {
                 const crewPresent = readableField(log.crewPresent)
                 const materialsUsed = readableField(log.materialsUsed)
+                const hasSupplementalDetails = Boolean(
+                  log.issues ||
+                    materialsUsed ||
+                    log.safetyIncidents ||
+                    log.visitorLog
+                )
 
                 return (
                   <>
@@ -1252,52 +1258,69 @@ export function ProjectDailyLogWorkspace({
                 </form>
               ) : (
                 <>
-                  <p className="mt-3 text-sm leading-6">{log.workCompleted}</p>
+                  <p className="mt-3 whitespace-pre-wrap break-words text-sm leading-6">
+                    {log.workCompleted}
+                  </p>
 
                   {(log.issues ||
                     materialsUsed ||
                     log.safetyIncidents ||
                     log.visitorLog ||
                     log.notes) && (
-                    <dl className="mt-3 grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-4">
+                    <dl className="mt-4 grid min-w-0 gap-x-6 gap-y-4 border-t pt-4 text-sm md:grid-cols-2 xl:grid-cols-4">
                       {log.issues && (
-                        <div className="rounded-md border bg-muted/20 p-3">
+                        <div className="min-w-0">
                           <dt className="text-xs font-medium uppercase text-muted-foreground">
                             Issues
                           </dt>
-                          <dd className="mt-1">{log.issues}</dd>
+                          <dd className="mt-1 whitespace-pre-wrap break-words leading-6">
+                            {log.issues}
+                          </dd>
                         </div>
                       )}
                       {materialsUsed && (
-                        <div className="rounded-md border bg-muted/20 p-3">
+                        <div className="min-w-0">
                           <dt className="text-xs font-medium uppercase text-muted-foreground">
                             Materials
                           </dt>
-                          <dd className="mt-1">{materialsUsed}</dd>
+                          <dd className="mt-1 whitespace-pre-wrap break-words leading-6">
+                            {materialsUsed}
+                          </dd>
                         </div>
                       )}
                       {log.safetyIncidents && (
-                        <div className="rounded-md border bg-muted/20 p-3">
+                        <div className="min-w-0">
                           <dt className="text-xs font-medium uppercase text-muted-foreground">
                             Safety
                           </dt>
-                          <dd className="mt-1">{log.safetyIncidents}</dd>
+                          <dd className="mt-1 whitespace-pre-wrap break-words leading-6">
+                            {log.safetyIncidents}
+                          </dd>
                         </div>
                       )}
                       {log.visitorLog && (
-                        <div className="rounded-md border bg-muted/20 p-3">
+                        <div className="min-w-0">
                           <dt className="text-xs font-medium uppercase text-muted-foreground">
                             Visitors
                           </dt>
-                          <dd className="mt-1">{log.visitorLog}</dd>
+                          <dd className="mt-1 whitespace-pre-wrap break-words leading-6">
+                            {log.visitorLog}
+                          </dd>
                         </div>
                       )}
                       {log.notes && (
-                        <div className="rounded-md border bg-muted/20 p-3 md:col-span-2 xl:col-span-4">
+                        <div
+                          className={cn(
+                            "min-w-0 md:col-span-2 xl:col-span-4",
+                            hasSupplementalDetails && "border-t pt-4"
+                          )}
+                        >
                           <dt className="text-xs font-medium uppercase text-muted-foreground">
                             Notes / Next
                           </dt>
-                          <dd className="mt-1">{log.notes}</dd>
+                          <dd className="mt-1 whitespace-pre-wrap break-words leading-6">
+                            {log.notes}
+                          </dd>
                         </div>
                       )}
                     </dl>

--- a/src/lib/daily-logs/__tests__/notes.test.ts
+++ b/src/lib/daily-logs/__tests__/notes.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import { normalizeDailyLogNotes } from "@/lib/daily-logs/notes"
+
+describe("normalizeDailyLogNotes", () => {
+  it("removes an exact copy of work completed", () => {
+    expect(
+      normalizeDailyLogNotes(
+        "Framing continued on the second floor.",
+        "Framing continued on the second floor."
+      )
+    ).toBeNull()
+  })
+
+  it("removes copies that differ only by whitespace or case", () => {
+    expect(
+      normalizeDailyLogNotes(
+        "Framing continued on the second floor.",
+        "  FRAMING   continued on the second floor.  "
+      )
+    ).toBeNull()
+  })
+
+  it("preserves distinct next-step notes", () => {
+    expect(
+      normalizeDailyLogNotes(
+        "Framing continued on the second floor.",
+        "Complete the stair opening tomorrow."
+      )
+    ).toBe("Complete the stair opening tomorrow.")
+  })
+
+  it("normalizes blank notes to null", () => {
+    expect(normalizeDailyLogNotes("Work completed.", "   ")).toBeNull()
+    expect(normalizeDailyLogNotes("Work completed.", null)).toBeNull()
+  })
+})

--- a/src/lib/daily-logs/notes.ts
+++ b/src/lib/daily-logs/notes.ts
@@ -1,0 +1,24 @@
+function comparableDailyLogText(value: string): string {
+  return value.trim().replace(/\s+/g, " ").toLowerCase()
+}
+
+/**
+ * Notes / Next should add information beyond Work Completed. Imported systems
+ * sometimes copy the same text into both fields, so treat those copies as empty.
+ */
+export function normalizeDailyLogNotes(
+  workCompleted: string,
+  notes: string | null
+): string | null {
+  const trimmedNotes = notes?.trim() ?? ""
+  if (trimmedNotes.length === 0) return null
+
+  if (
+    comparableDailyLogText(trimmedNotes) ===
+    comparableDailyLogText(workCompleted)
+  ) {
+    return null
+  }
+
+  return trimmedNotes
+}


### PR DESCRIPTION
## Summary
- suppress Notes / Next when it only duplicates Work Completed
- normalize new and edited daily logs and owner-update next steps
- replace nested Daily Log detail bubbles with a clean responsive text grid
- document the 20% bubble and responsive prose conventions

## Production audit
- found 599 exact duplicate Notes / Next values
- all affected rows are Buildertrend imports
- no Compass-created logs are included in the cleanup scope

## Verification
- `bun run test` (206 passed, 3 skipped)
- `bun lint` (0 errors; existing warnings only)
- `bunx tsc --noEmit`
- `bun run build`
