### PR TITLE
feat(daily-logs): add photo visibility and print controls

### DIFF
--- a/src/app/api/projects/[id]/photos/upload/route.ts
+++ b/src/app/api/projects/[id]/photos/upload/route.ts
@@ -26,6 +26,7 @@ import {
   MAX_PHOTO_UPLOAD_FILE_BYTES,
   PHOTO_UPLOAD_LIMIT_LABEL,
 } from "@/lib/photos/upload-limits"
+import { photoUploadVisibility } from "@/lib/photos/upload-visibility"
 
 const GOOGLE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
 const DEFAULT_PHOTO_FOLDER_NAME = "Pictures"
@@ -56,6 +57,10 @@ function isFile(value: FormDataEntryValue): value is File {
 function formText(formData: FormData, name: string): string {
   const value = formData.get(name)
   return typeof value === "string" ? value.trim() : ""
+}
+
+function formBoolean(formData: FormData, name: string): boolean {
+  return formText(formData, name) === "true"
 }
 
 function envString(env: Record<string, string>, key: string): string | null {
@@ -352,6 +357,10 @@ export async function POST(
     const photoKind = normalizedPhotoKind(formText(formData, "photoKind"))
     const schedulePhase = formText(formData, "schedulePhase")
     const dailyLogId = formText(formData, "dailyLogId")
+    const visibility = photoUploadVisibility(
+      formBoolean(formData, "ownerVisible"),
+      formBoolean(formData, "subVendorVisible")
+    )
     const validatedDailyLogId =
       dailyLogId.length > 0
         ? await db
@@ -420,9 +429,9 @@ export async function POST(
         caption: caption.length > 0 ? caption : null,
         capturedAt,
         uploadStatus: "uploaded",
-        reviewStatus: "needs_review",
-        ownerVisible: false,
-        subVendorVisible: false,
+        reviewStatus: visibility.reviewStatus,
+        ownerVisible: visibility.ownerVisible,
+        subVendorVisible: visibility.subVendorVisible,
         publicShareable: false,
         photoKind,
         schedulePhaseOverride: normalizedSchedulePhase(schedulePhase),

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -469,6 +469,33 @@ em-emoji-picker {
     overflow: visible !important;
   }
 
+  body.daily-log-printing * {
+    visibility: hidden !important;
+  }
+
+  body.daily-log-printing [data-daily-log-print-root="true"],
+  body.daily-log-printing [data-daily-log-print-root="true"] * {
+    visibility: visible !important;
+  }
+
+  body.daily-log-printing [data-daily-log-print-root="true"] {
+    display: block !important;
+    position: absolute !important;
+    inset: 0 auto auto 0;
+    width: 100%;
+    max-width: none !important;
+    height: auto !important;
+    overflow: visible !important;
+  }
+
+  body.daily-log-printing,
+  body.daily-log-printing .daily-log-print-root {
+    background: #ffffff !important;
+    height: auto !important;
+    min-height: 0 !important;
+    overflow: visible !important;
+  }
+
   .owner-update-printable {
     box-shadow: none !important;
   }

--- a/src/components/projects/daily-log-print-document.tsx
+++ b/src/components/projects/daily-log-print-document.tsx
@@ -1,0 +1,186 @@
+import type * as React from "react"
+
+import type { ProjectDailyLogItem } from "@/app/actions/project-field"
+
+function formatPrintDate(value: string): string {
+  const parsed = new Date(`${value}T12:00:00`)
+  if (Number.isNaN(parsed.getTime())) return value
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(parsed)
+}
+
+function sourceLabel(value: string): string {
+  if (value === "compass") return "Compass"
+  if (value === "buildertrend") return "Buildertrend"
+  return value.replace(/[_-]+/g, " ")
+}
+
+function readableField(value: string | null): string | null {
+  const trimmed = value?.trim() ?? ""
+  if (trimmed.length === 0 || trimmed === "[]") return null
+
+  try {
+    const parsed: unknown = JSON.parse(trimmed)
+    if (Array.isArray(parsed)) {
+      const values = parsed.filter(
+        (item): item is string =>
+          typeof item === "string" && item.trim().length > 0
+      )
+      return values.length > 0 ? values.join(", ") : null
+    }
+  } catch {
+    // Plain text is already suitable for print.
+  }
+
+  return trimmed
+}
+
+function PrintDetail({
+  label,
+  value,
+}: {
+  readonly label: string
+  readonly value: string | null
+}): React.ReactElement | null {
+  if (!value) return null
+
+  return (
+    <div className="min-w-0">
+      <dt className="text-[9px] font-bold uppercase tracking-wide">{label}</dt>
+      <dd className="mt-1 whitespace-pre-wrap break-words text-[11px] leading-5">
+        {value}
+      </dd>
+    </div>
+  )
+}
+
+export function DailyLogPrintDocument({
+  clientName,
+  logs,
+  projectLabel,
+  projectName,
+}: {
+  readonly clientName: string | null
+  readonly logs: readonly ProjectDailyLogItem[]
+  readonly projectLabel: string
+  readonly projectName: string
+}): React.ReactElement | null {
+  if (logs.length === 0) return null
+
+  return (
+    <article
+      data-daily-log-print-root="true"
+      className="daily-log-print-root hidden bg-white text-black"
+    >
+      <header className="border-b-2 border-black pb-4">
+        <div className="flex items-start justify-between gap-6">
+          <div>
+            <p className="text-sm font-bold uppercase">
+              High Performance Structures, Inc.
+            </p>
+            <h1 className="mt-1 text-2xl font-semibold">Daily Logs</h1>
+            <p className="mt-1 text-sm">{projectName}</p>
+            {clientName && <p className="text-xs">Client: {clientName}</p>}
+          </div>
+          <div className="text-right text-xs">
+            <p className="font-semibold">{projectLabel}</p>
+            <p>{logs.length} log{logs.length === 1 ? "" : "s"}</p>
+            <p>Printed {new Date().toLocaleDateString()}</p>
+          </div>
+        </div>
+      </header>
+
+      <div className="divide-y divide-black/30">
+        {logs.map((log) => {
+          const materials = readableField(log.materialsUsed)
+          const crew = readableField(log.crewPresent)
+
+          return (
+            <section
+              key={log.id}
+              className="break-inside-avoid py-5 first:pt-4"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h2 className="text-base font-semibold">
+                    {formatPrintDate(log.logDate)}
+                  </h2>
+                  <p className="mt-1 text-[10px] uppercase tracking-wide">
+                    {sourceLabel(log.sourceSystem)}
+                    {log.authorName ? ` · ${log.authorName}` : ""}
+                  </p>
+                </div>
+                <div className="text-right text-[10px]">
+                  {log.weather && <p>{log.weather}</p>}
+                  {(crew || log.hoursWorked !== null) && (
+                    <p>
+                      {[crew, log.hoursWorked === null
+                        ? null
+                        : `${log.hoursWorked} hours`]
+                        .filter((value) => value !== null)
+                        .join(" · ")}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              <div className="mt-4">
+                <h3 className="text-[9px] font-bold uppercase tracking-wide">
+                  Work Completed
+                </h3>
+                <p className="mt-1 whitespace-pre-wrap break-words text-[12px] leading-5">
+                  {log.workCompleted}
+                </p>
+              </div>
+
+              {(log.issues ||
+                materials ||
+                log.safetyIncidents ||
+                log.visitorLog ||
+                log.notes) && (
+                <dl className="mt-4 grid grid-cols-2 gap-x-6 gap-y-3 border-t border-black/30 pt-3">
+                  <PrintDetail label="Issues" value={log.issues} />
+                  <PrintDetail label="Materials" value={materials} />
+                  <PrintDetail
+                    label="Safety"
+                    value={log.safetyIncidents}
+                  />
+                  <PrintDetail label="Visitors" value={log.visitorLog} />
+                  {log.notes && (
+                    <div className="col-span-2 min-w-0">
+                      <PrintDetail label="Notes / Next" value={log.notes} />
+                    </div>
+                  )}
+                </dl>
+              )}
+
+              {log.photos.length > 0 && (
+                <div className="mt-4 border-t border-black/30 pt-3">
+                  <h3 className="text-[9px] font-bold uppercase tracking-wide">
+                    Attachments ({log.photos.length})
+                  </h3>
+                  <ul className="mt-1 columns-2 gap-6 text-[10px] leading-4">
+                    {log.photos.map((photo) => (
+                      <li key={photo.id} className="break-inside-avoid">
+                        {photo.driveUrl ? (
+                          <a href={photo.driveUrl} className="underline">
+                            {photo.caption ?? photo.fileName}
+                          </a>
+                        ) : (
+                          photo.caption ?? photo.fileName
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </section>
+          )
+        })}
+      </div>
+    </article>
+  )
+}

--- a/src/components/projects/project-daily-log-workspace.tsx
+++ b/src/components/projects/project-daily-log-workspace.tsx
@@ -15,6 +15,7 @@ import {
   IconPencil,
   IconPhoto,
   IconPlus,
+  IconPrinter,
   IconShieldCheck,
   IconUpload,
   IconUsers,
@@ -43,8 +44,14 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
+import { DailyLogPrintDocument } from "@/components/projects/daily-log-print-document"
 import { ProjectContextSwitcher } from "@/components/projects/project-context-switcher"
 import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
+import {
+  ALL_DAILY_LOG_AUTHORS,
+  matchesDailyLogPrintFilters,
+  UNKNOWN_DAILY_LOG_AUTHOR,
+} from "@/lib/daily-logs/print-selection"
 import {
   photoLinkHref,
   resolvePhotoImageSource,
@@ -230,9 +237,7 @@ function selectedLogIds(
   logs: readonly ProjectDailyLogItem[],
   selectedIds: readonly string[]
 ): readonly string[] {
-  const availableIds = new Set(
-    logs.filter(isOwnerUpdateEligibleLog).map((log) => log.id)
-  )
+  const availableIds = new Set(logs.map((log) => log.id))
   return selectedIds.filter((id) => availableIds.has(id))
 }
 
@@ -527,8 +532,17 @@ export function ProjectDailyLogWorkspace({
   const [uploadFiles, setUploadFiles] = React.useState<readonly File[]>([])
   const [uploadCaption, setUploadCaption] = React.useState("")
   const [uploadPhase, setUploadPhase] = React.useState(NO_PHASE_VALUE)
+  const [uploadOwnerVisible, setUploadOwnerVisible] = React.useState(false)
+  const [uploadSubVendorVisible, setUploadSubVendorVisible] =
+    React.useState(false)
   const [uploadMessage, setUploadMessage] = React.useState<string | null>(null)
   const [isUploading, setUploading] = React.useState(false)
+  const [showPrintOptions, setShowPrintOptions] = React.useState(false)
+  const [printStartDate, setPrintStartDate] = React.useState("")
+  const [printEndDate, setPrintEndDate] = React.useState("")
+  const [printAuthor, setPrintAuthor] = React.useState(ALL_DAILY_LOG_AUTHORS)
+  const [printLogs, setPrintLogs] =
+    React.useState<readonly ProjectDailyLogItem[]>([])
   const [message, setMessage] = React.useState<string | null>(null)
   const [isPending, startTransition] = React.useTransition()
   const [isWeatherPending, startWeatherTransition] = React.useTransition()
@@ -540,11 +554,51 @@ export function ProjectDailyLogWorkspace({
     setUploadingLogId(null)
   }, [workspace.logs])
 
+  React.useEffect(() => {
+    function finishPrinting(): void {
+      document.body.classList.remove("daily-log-printing")
+      setPrintLogs([])
+    }
+
+    window.addEventListener("afterprint", finishPrinting)
+    return () => {
+      window.removeEventListener("afterprint", finishPrinting)
+      document.body.classList.remove("daily-log-printing")
+    }
+  }, [])
+
   const filteredLogs = React.useMemo(
     () => logs.filter((log) => matchesFilter(log, filter)),
     [filter, logs]
   )
   const selectedIdsInView = selectedLogIds(filteredLogs, selectedIds)
+  const selectedLogs = React.useMemo(
+    () => logs.filter((log) => selectedIds.includes(log.id)),
+    [logs, selectedIds]
+  )
+  const ownerUpdateSelectedIds = selectedLogs
+    .filter(isOwnerUpdateEligibleLog)
+    .map((log) => log.id)
+  const printAuthorOptions = React.useMemo(
+    () =>
+      [...new Set(logs.map((log) => log.authorName).filter(
+        (author): author is string => author !== null
+      ))].sort((left, right) => left.localeCompare(right)),
+    [logs]
+  )
+  const hasUnknownPrintAuthor = logs.some((log) => log.authorName === null)
+  const dateAuthorPrintLogs = React.useMemo(
+    () =>
+      logs.filter((log) =>
+        matchesDailyLogPrintFilters(
+          log,
+          printStartDate,
+          printEndDate,
+          printAuthor
+        )
+      ),
+    [logs, printAuthor, printEndDate, printStartDate]
+  )
   const projectLabel = workspace.project.projectNumber ?? workspace.project.name
 
   function toggleLog(logId: string): void {
@@ -556,9 +610,7 @@ export function ProjectDailyLogWorkspace({
   }
 
   function selectVisibleLogs(): void {
-    setSelectedIds(
-      filteredLogs.filter(isOwnerUpdateEligibleLog).map((log) => log.id)
-    )
+    setSelectedIds(filteredLogs.map((log) => log.id))
   }
 
   function clearSelection(): void {
@@ -598,6 +650,8 @@ export function ProjectDailyLogWorkspace({
     setUploadFiles([])
     setUploadCaption("")
     setUploadPhase(NO_PHASE_VALUE)
+    setUploadOwnerVisible(false)
+    setUploadSubVendorVisible(false)
   }
 
   function cancelUploadingFiles(): void {
@@ -605,7 +659,21 @@ export function ProjectDailyLogWorkspace({
     setUploadFiles([])
     setUploadCaption("")
     setUploadPhase(NO_PHASE_VALUE)
+    setUploadOwnerVisible(false)
+    setUploadSubVendorVisible(false)
     setUploadMessage(null)
+  }
+
+  function printDailyLogs(targetLogs: readonly ProjectDailyLogItem[]): void {
+    if (targetLogs.length === 0) {
+      setMessage("Choose at least one daily log to print.")
+      return
+    }
+
+    setMessage(null)
+    setPrintLogs(targetLogs)
+    document.body.classList.add("daily-log-printing")
+    window.setTimeout(() => window.print(), 50)
   }
 
   function chooseUploadFiles(fileList: FileList | null): void {
@@ -677,6 +745,8 @@ export function ProjectDailyLogWorkspace({
       formData.set("capturedDate", log.logDate)
       formData.set("photoKind", "progress")
       formData.set("schedulePhase", uploadPhase)
+      formData.set("ownerVisible", String(uploadOwnerVisible))
+      formData.set("subVendorVisible", String(uploadSubVendorVisible))
 
       const response = await fetch(
         `/api/projects/${workspace.project.id}/photos/upload`,
@@ -711,6 +781,8 @@ export function ProjectDailyLogWorkspace({
         setUploadFiles([])
         setUploadCaption("")
         setUploadPhase(NO_PHASE_VALUE)
+        setUploadOwnerVisible(false)
+        setUploadSubVendorVisible(false)
         router.refresh()
         return
       }
@@ -869,11 +941,6 @@ export function ProjectDailyLogWorkspace({
               : item
           )
         )
-        if (reviewStatus !== "approved" || !isClientVisible) {
-          setSelectedIds((current) =>
-            current.filter((id) => id !== log.id)
-          )
-        }
         setMessage("Daily log review updated.")
       } else {
         setMessage(result.error)
@@ -882,7 +949,7 @@ export function ProjectDailyLogWorkspace({
   }
 
   function draftOwnerUpdate(): void {
-    const dailyLogIds = selectedIdsInView
+    const dailyLogIds = ownerUpdateSelectedIds
     setMessage(null)
     startTransition(async () => {
       const result = await draftOwnerUpdateFromDailyLogs(workspace.project.id, {
@@ -900,6 +967,7 @@ export function ProjectDailyLogWorkspace({
   }
 
   return (
+    <>
     <main className="min-h-screen bg-background">
       <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-4 sm:px-6 lg:px-8">
         <div className="flex flex-wrap items-center justify-between gap-3">
@@ -945,9 +1013,18 @@ export function ProjectDailyLogWorkspace({
                 </Link>
               </Button>
               <Button
+                type="button"
+                variant={showPrintOptions ? "secondary" : "outline"}
+                size="sm"
+                onClick={() => setShowPrintOptions((current) => !current)}
+              >
+                <IconPrinter className="size-4" />
+                Print
+              </Button>
+              <Button
                 size="sm"
                 onClick={draftOwnerUpdate}
-                disabled={isPending || selectedIdsInView.length === 0}
+                disabled={isPending || ownerUpdateSelectedIds.length === 0}
               >
                 <IconMailForward className="size-4" />
                 Draft owner update
@@ -1045,6 +1122,87 @@ export function ProjectDailyLogWorkspace({
           </section>
         )}
 
+        {showPrintOptions && (
+          <section className="border-y py-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h2 className="text-base font-semibold">Print Daily Logs</h2>
+                <p className="text-sm text-muted-foreground">
+                  Print checked logs, or choose a date range and author.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={selectedLogs.length === 0}
+                onClick={() => printDailyLogs(selectedLogs)}
+              >
+                <IconPrinter className="size-4" />
+                Print selected ({selectedLogs.length})
+              </Button>
+            </div>
+
+            <div className="mt-4 grid min-w-0 gap-3 sm:grid-cols-2 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,0.8fr)_minmax(0,1.2fr)_auto]">
+              <div className="grid min-w-0 gap-1.5">
+                <Label htmlFor="daily-log-print-start">From date</Label>
+                <Input
+                  id="daily-log-print-start"
+                  type="date"
+                  value={printStartDate}
+                  onChange={(event) =>
+                    setPrintStartDate(event.currentTarget.value)
+                  }
+                />
+              </div>
+              <div className="grid min-w-0 gap-1.5">
+                <Label htmlFor="daily-log-print-end">Through date</Label>
+                <Input
+                  id="daily-log-print-end"
+                  type="date"
+                  value={printEndDate}
+                  onChange={(event) =>
+                    setPrintEndDate(event.currentTarget.value)
+                  }
+                />
+              </div>
+              <div className="grid min-w-0 gap-1.5">
+                <Label htmlFor="daily-log-print-author">Author</Label>
+                <select
+                  id="daily-log-print-author"
+                  value={printAuthor}
+                  onChange={(event) =>
+                    setPrintAuthor(event.currentTarget.value)
+                  }
+                  className="h-9 min-w-0 rounded-md border bg-background px-3 text-sm"
+                >
+                  <option value={ALL_DAILY_LOG_AUTHORS}>All authors</option>
+                  {printAuthorOptions.map((author) => (
+                    <option key={author} value={author}>
+                      {author}
+                    </option>
+                  ))}
+                  {hasUnknownPrintAuthor && (
+                    <option value={UNKNOWN_DAILY_LOG_AUTHOR}>
+                      Imported / no author
+                    </option>
+                  )}
+                </select>
+              </div>
+              <div className="flex items-end">
+                <Button
+                  type="button"
+                  disabled={dateAuthorPrintLogs.length === 0}
+                  onClick={() => printDailyLogs(dateAuthorPrintLogs)}
+                >
+                  <IconPrinter className="size-4" />
+                  Print matches ({dateAuthorPrintLogs.length})
+                </Button>
+              </div>
+            </div>
+          </section>
+        )}
+
         <section className="rounded-lg border p-3 sm:p-4">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="flex flex-wrap items-center gap-2">
@@ -1059,19 +1217,24 @@ export function ProjectDailyLogWorkspace({
                 <option value="owner_visible">Owner visible</option>
               </select>
               <Button variant="outline" size="sm" onClick={selectVisibleLogs}>
-                Select visible
+                Select shown
               </Button>
               <Button variant="ghost" size="sm" onClick={clearSelection}>
                 Clear
               </Button>
             </div>
             <div className="text-sm text-muted-foreground">
-              {selectedIdsInView.length} selected · {filteredLogs.length} shown
+              {selectedLogs.length} selected
+              {selectedLogs.length !== selectedIdsInView.length
+                ? ` · ${selectedIdsInView.length} in view`
+                : ""}{" "}
+              · {filteredLogs.length} shown · {ownerUpdateSelectedIds.length}{" "}
+              owner-update ready
             </div>
           </div>
           <p className="mt-2 text-xs text-muted-foreground">
-            Owner updates can include only logs that are both approved and
-            marked Owner visible.
+            Any checked log can be printed. Owner updates include only checked
+            logs that are approved and marked Owner visible.
           </p>
           {message && (
             <p className="mt-3 rounded-md border bg-muted/30 px-3 py-2 text-sm">
@@ -1105,13 +1268,8 @@ export function ProjectDailyLogWorkspace({
                     type="checkbox"
                     checked={selectedIds.includes(log.id)}
                     onChange={() => toggleLog(log.id)}
-                    disabled={!isOwnerUpdateEligibleLog(log)}
                     className="mt-1 size-4 rounded border"
-                    aria-label={
-                      isOwnerUpdateEligibleLog(log)
-                        ? `Select daily log for ${formatDate(log.logDate)}`
-                        : `Approve and mark the ${formatDate(log.logDate)} log owner visible before selecting it`
-                    }
+                    aria-label={`Select daily log for ${formatDate(log.logDate)}`}
                   />
                   <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-2">
@@ -1350,7 +1508,7 @@ export function ProjectDailyLogWorkspace({
                     </Button>
                   </div>
 
-                  <div className="mt-3 grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)_minmax(0,0.7fr)_auto]">
+                  <div className="mt-3 grid min-w-0 gap-3 md:grid-cols-2 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)_minmax(0,0.7fr)_minmax(0,1fr)_auto]">
                     <div className="grid gap-1.5">
                       <Label htmlFor={`daily-log-files-${log.id}`}>
                         Photos / documents
@@ -1411,6 +1569,43 @@ export function ProjectDailyLogWorkspace({
                         </SelectContent>
                       </Select>
                     </div>
+                    <fieldset className="min-w-0">
+                      <legend className="text-sm font-medium">
+                        Visibility for this batch
+                      </legend>
+                      <div className="mt-2 flex flex-wrap gap-x-4 gap-y-2">
+                        <label className="flex items-center gap-2 text-sm">
+                          <input
+                            type="checkbox"
+                            checked={uploadOwnerVisible}
+                            onChange={(event) =>
+                              setUploadOwnerVisible(
+                                event.currentTarget.checked
+                              )
+                            }
+                            className="size-4 rounded border"
+                          />
+                          Owners
+                        </label>
+                        <label className="flex items-center gap-2 text-sm">
+                          <input
+                            type="checkbox"
+                            checked={uploadSubVendorVisible}
+                            onChange={(event) =>
+                              setUploadSubVendorVisible(
+                                event.currentTarget.checked
+                              )
+                            }
+                            className="size-4 rounded border"
+                          />
+                          Subcontractors
+                        </label>
+                      </div>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Shared uploads are approved immediately. Leave both
+                        unchecked to keep them in staff review.
+                      </p>
+                    </fieldset>
                     <div className="flex items-end">
                       <Button
                         type="button"
@@ -1529,5 +1724,12 @@ export function ProjectDailyLogWorkspace({
         )}
       </div>
     </main>
+    <DailyLogPrintDocument
+      clientName={workspace.project.clientName}
+      logs={printLogs}
+      projectLabel={projectLabel}
+      projectName={workspace.project.name}
+    />
+    </>
   )
 }

--- a/src/lib/daily-logs/__tests__/print-selection.test.ts
+++ b/src/lib/daily-logs/__tests__/print-selection.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ALL_DAILY_LOG_AUTHORS,
+  matchesDailyLogPrintFilters,
+  UNKNOWN_DAILY_LOG_AUTHOR,
+} from "@/lib/daily-logs/print-selection"
+
+const logs = [
+  { logDate: "2026-07-21", authorName: "Rebekah" },
+  { logDate: "2026-07-22", authorName: null },
+  { logDate: "2026-07-23", authorName: "Sylvi" },
+] as const
+
+describe("matchesDailyLogPrintFilters", () => {
+  it("includes both boundaries of a date range", () => {
+    expect(
+      logs.filter((log) =>
+        matchesDailyLogPrintFilters(
+          log,
+          "2026-07-21",
+          "2026-07-22",
+          ALL_DAILY_LOG_AUTHORS
+        )
+      )
+    ).toEqual([logs[0], logs[1]])
+  })
+
+  it("filters by author", () => {
+    expect(
+      logs.filter((log) =>
+        matchesDailyLogPrintFilters(
+          log,
+          "",
+          "",
+          "Sylvi"
+        )
+      )
+    ).toEqual([logs[2]])
+  })
+
+  it("supports imported logs without an author", () => {
+    expect(
+      logs.filter((log) =>
+        matchesDailyLogPrintFilters(
+          log,
+          "",
+          "",
+          UNKNOWN_DAILY_LOG_AUTHOR
+        )
+      )
+    ).toEqual([logs[1]])
+  })
+})

--- a/src/lib/daily-logs/print-selection.ts
+++ b/src/lib/daily-logs/print-selection.ts
@@ -1,0 +1,24 @@
+export const ALL_DAILY_LOG_AUTHORS = "all"
+export const UNKNOWN_DAILY_LOG_AUTHOR = "unknown"
+
+type PrintableDailyLog = {
+  readonly logDate: string
+  readonly authorName: string | null
+}
+
+export function dailyLogAuthorValue(log: PrintableDailyLog): string {
+  return log.authorName ?? UNKNOWN_DAILY_LOG_AUTHOR
+}
+
+export function matchesDailyLogPrintFilters(
+  log: PrintableDailyLog,
+  startDate: string,
+  endDate: string,
+  author: string
+): boolean {
+  if (startDate.length > 0 && log.logDate < startDate) return false
+  if (endDate.length > 0 && log.logDate > endDate) return false
+  return (
+    author === ALL_DAILY_LOG_AUTHORS || dailyLogAuthorValue(log) === author
+  )
+}

--- a/src/lib/photos/__tests__/upload-visibility.test.ts
+++ b/src/lib/photos/__tests__/upload-visibility.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import { photoUploadVisibility } from "@/lib/photos/upload-visibility"
+
+describe("photoUploadVisibility", () => {
+  it("keeps staff-only uploads in review", () => {
+    expect(photoUploadVisibility(false, false)).toEqual({
+      reviewStatus: "needs_review",
+      ownerVisible: false,
+      subVendorVisible: false,
+    })
+  })
+
+  it("approves owner-visible uploads", () => {
+    expect(photoUploadVisibility(true, false)).toEqual({
+      reviewStatus: "approved",
+      ownerVisible: true,
+      subVendorVisible: false,
+    })
+  })
+
+  it("approves subcontractor-visible uploads", () => {
+    expect(photoUploadVisibility(false, true)).toEqual({
+      reviewStatus: "approved",
+      ownerVisible: false,
+      subVendorVisible: true,
+    })
+  })
+
+  it("supports visibility for both audiences", () => {
+    expect(photoUploadVisibility(true, true)).toEqual({
+      reviewStatus: "approved",
+      ownerVisible: true,
+      subVendorVisible: true,
+    })
+  })
+})

--- a/src/lib/photos/upload-visibility.ts
+++ b/src/lib/photos/upload-visibility.ts
@@ -1,0 +1,17 @@
+export type PhotoUploadVisibility = {
+  readonly reviewStatus: "needs_review" | "approved"
+  readonly ownerVisible: boolean
+  readonly subVendorVisible: boolean
+}
+
+export function photoUploadVisibility(
+  ownerVisible: boolean,
+  subVendorVisible: boolean
+): PhotoUploadVisibility {
+  return {
+    reviewStatus:
+      ownerVisible || subVendorVisible ? "approved" : "needs_review",
+    ownerVisible,
+    subVendorVisible,
+  }
+}


### PR DESCRIPTION
## Summary
- let staff choose owner and subcontractor visibility while uploading a Daily Log photo batch
- approve intentionally shared uploads immediately while preserving staff review for internal uploads
- print checked Daily Logs or filter printable logs by inclusive date range and author
- add a clean, responsive print document without excess card styling

## Validation
- `bun run test` (213 passed, 3 skipped)
- `bun lint` (0 errors; existing warnings only)
- `bunx tsc --noEmit`
- `bun run build`
- focused upload visibility and print-filter regression tests
