### PR TITLE
fix(rfis): prioritize open work and add status filters

### DIFF
--- a/src/app/actions/project-rfis.ts
+++ b/src/app/actions/project-rfis.ts
@@ -14,6 +14,11 @@ import type { AuthUser } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { requireOrg } from "@/lib/org-scope"
 import { requirePermission } from "@/lib/permissions"
+import {
+  validRfiAudience,
+  validRfiPriority,
+  validRfiStatus,
+} from "@/lib/rfis/status"
 
 export type ProjectRfiAttachmentItem = {
   readonly id: string
@@ -314,6 +319,14 @@ export async function createProjectRfi(
 
     const now = new Date().toISOString()
     const id = crypto.randomUUID()
+    const priority = validRfiPriority(input.priority)
+    const audience = validRfiAudience(input.audience)
+    if (!priority) {
+      return { success: false, error: "Please choose a valid RFI priority." }
+    }
+    if (!audience) {
+      return { success: false, error: "Please choose a valid RFI audience." }
+    }
     const inserted: typeof projectRfis.$inferInsert = {
       id,
       projectId,
@@ -321,8 +334,8 @@ export async function createProjectRfi(
       subject: requireText(input.subject, "Subject"),
       question: requireText(input.question, "Question"),
       status: "new",
-      priority: input.priority,
-      audience: input.audience,
+      priority,
+      audience,
       requesterName: cleanText(input.requesterName),
       assignedToName: cleanText(input.assignedToName),
       companyName: cleanText(input.companyName),
@@ -416,13 +429,22 @@ export async function updateProjectRfi(
 
     const now = new Date().toISOString()
     const answer = cleanText(input.answer)
-    const status = answer && input.status === "new" ? "in_progress" : input.status
+    const requestedStatus = validRfiStatus(input.status)
+    const audience = validRfiAudience(input.audience)
+    if (!requestedStatus) {
+      return { success: false, error: "Please choose a valid RFI status." }
+    }
+    if (!audience) {
+      return { success: false, error: "Please choose a valid RFI audience." }
+    }
+    const status =
+      answer && requestedStatus === "new" ? "in_progress" : requestedStatus
     await db
       .update(projectRfis)
       .set({
         answer,
         status,
-        audience: input.audience,
+        audience,
         answeredAt: status === "complete" ? now : null,
         updatedAt: now,
       })

--- a/src/app/dashboard/projects/[id]/rfis/page.tsx
+++ b/src/app/dashboard/projects/[id]/rfis/page.tsx
@@ -20,6 +20,14 @@ import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switch
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
+import {
+  canonicalRfiStatus,
+  compareRfisForQueue,
+  isClosedRfiStatus,
+  parseRfiStatusFilter,
+  rfiMatchesStatusFilter,
+  type RfiStatusFilter,
+} from "@/lib/rfis/status"
 import { cn } from "@/lib/utils"
 
 function readFormText(formData: FormData, name: string): string {
@@ -48,12 +56,6 @@ function label(value: string): string {
     .join(" ")
 }
 
-function isActiveRfiStatus(status: string): boolean {
-  return !["complete", "closed", "void", "cancelled"].includes(
-    status.toLowerCase()
-  )
-}
-
 function unique(values: readonly (string | null | undefined)[]): readonly string[] {
   return Array.from(
     new Set(
@@ -68,6 +70,19 @@ function rfiTaskTitle(subject: string): string {
   return `Follow up RFI: ${subject}`
 }
 
+const RFI_FILTERS: readonly {
+  readonly value: RfiStatusFilter
+  readonly label: string
+}[] = [
+  { value: "open", label: "Open" },
+  { value: "new", label: "New" },
+  { value: "in_progress", label: "In progress" },
+  { value: "info_needed", label: "Info needed" },
+  { value: "complete", label: "Complete" },
+  { value: "void", label: "Void" },
+  { value: "all", label: "All" },
+]
+
 export default async function ProjectRfisPage({
   params,
   searchParams,
@@ -75,6 +90,7 @@ export default async function ProjectRfisPage({
   readonly params: Promise<{ readonly id: string }>
   readonly searchParams: Promise<{
     readonly created?: string | readonly string[]
+    readonly status?: string | readonly string[]
   }>
 }) {
   const { id } = await params
@@ -82,6 +98,7 @@ export default async function ProjectRfisPage({
   const createdRfiId = Array.isArray(query.created)
     ? query.created[0] ?? null
     : query.created ?? null
+  const statusFilter = parseRfiStatusFilter(query.status)
   const [projects, rfis, contactsSummary, taskAssigneeOptions] =
     await Promise.all([
       getProjects(),
@@ -94,7 +111,12 @@ export default async function ProjectRfisPage({
     ...taskAssigneeOptions.projectContacts,
     ...taskAssigneeOptions.directoryContacts,
   ]
-  const openCount = rfis.filter((rfi) => isActiveRfiStatus(rfi.status)).length
+  const openCount = rfis.filter(
+    (rfi) => !isClosedRfiStatus(rfi.status)
+  ).length
+  const visibleRfis = [...rfis]
+    .filter((rfi) => rfiMatchesStatusFilter(rfi.status, statusFilter))
+    .sort(compareRfisForQueue)
   const contacts = contactsSummary.allContacts
   const companyOrTradeOptions = unique(
     contacts.flatMap((contact) => [
@@ -181,9 +203,35 @@ export default async function ProjectRfisPage({
           />
         </div>
 
-        {rfis.length > 0 ? (
-          rfis.map((rfi) => {
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <nav
+            aria-label="Filter RFIs by status"
+            className="flex flex-wrap gap-1"
+          >
+            {RFI_FILTERS.map((option) => (
+              <Button
+                key={option.value}
+                asChild
+                size="sm"
+                variant={statusFilter === option.value ? "secondary" : "ghost"}
+              >
+                <Link
+                  href={`/dashboard/projects/${id}/rfis?status=${option.value}`}
+                >
+                  {option.label}
+                </Link>
+              </Button>
+            ))}
+          </nav>
+          <p className="text-xs text-muted-foreground">
+            {visibleRfis.length} of {rfis.length} shown
+          </p>
+        </div>
+
+        {visibleRfis.length > 0 ? (
+          visibleRfis.map((rfi) => {
             const isCreated = rfi.id === createdRfiId
+            const canonicalStatus = canonicalRfiStatus(rfi.status)
             return (
               <article
                 key={rfi.id}
@@ -209,10 +257,10 @@ export default async function ProjectRfisPage({
                     )}
                     <Badge
                       variant={
-                        isActiveRfiStatus(rfi.status) ? "secondary" : "outline"
+                        !isClosedRfiStatus(rfi.status) ? "secondary" : "outline"
                       }
                     >
-                      {label(rfi.status)}
+                      {label(canonicalStatus)}
                     </Badge>
                     <Badge variant="outline">{label(rfi.audience)}</Badge>
                     {rfi.priority === "high" && (
@@ -295,7 +343,7 @@ export default async function ProjectRfisPage({
                   <div className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_1fr_auto]">
                     <select
                       name="status"
-                      defaultValue={rfi.status}
+                      defaultValue={canonicalStatus}
                       className="h-9 rounded-md border bg-background px-3 text-sm"
                     >
                       <option value="new">New</option>
@@ -324,11 +372,15 @@ export default async function ProjectRfisPage({
             )
           })
         ) : (
-          <div className="rounded-lg border bg-background p-8 text-center">
+          <div className="border-y bg-background p-8 text-center">
             <IconClock className="mx-auto size-6 text-muted-foreground" />
-            <h2 className="mt-3 text-sm font-semibold">No RFIs yet</h2>
+            <h2 className="mt-3 text-sm font-semibold">
+              {rfis.length === 0 ? "No RFIs yet" : "No RFIs match this filter"}
+            </h2>
             <p className="mt-1 text-sm text-muted-foreground">
-              Create the first clarification for this project.
+              {rfis.length === 0
+                ? "Create the first clarification for this project."
+                : "Choose another status to see the rest of the RFI queue."}
             </p>
           </div>
         )}

--- a/src/lib/rfis/__tests__/status.test.ts
+++ b/src/lib/rfis/__tests__/status.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  canonicalRfiStatus,
+  compareRfisForQueue,
+  isClosedRfiStatus,
+  parseRfiStatusFilter,
+  rfiMatchesStatusFilter,
+  validRfiAudience,
+  validRfiPriority,
+  validRfiStatus,
+} from "@/lib/rfis/status"
+
+describe("RFI status handling", () => {
+  it("normalizes legacy production statuses", () => {
+    expect(canonicalRfiStatus("open")).toBe("new")
+    expect(canonicalRfiStatus("answered")).toBe("in_progress")
+    expect(canonicalRfiStatus("closed")).toBe("complete")
+    expect(canonicalRfiStatus("cancelled")).toBe("void")
+  })
+
+  it("defaults invalid filters to the open queue", () => {
+    expect(parseRfiStatusFilter(undefined)).toBe("open")
+    expect(parseRfiStatusFilter("not-a-status")).toBe("open")
+    expect(parseRfiStatusFilter(["complete", "open"])).toBe("complete")
+  })
+
+  it("includes active legacy statuses in the open filter", () => {
+    expect(rfiMatchesStatusFilter("open", "open")).toBe(true)
+    expect(rfiMatchesStatusFilter("answered", "open")).toBe(true)
+    expect(rfiMatchesStatusFilter("complete", "open")).toBe(false)
+    expect(isClosedRfiStatus("closed")).toBe(true)
+  })
+
+  it("sorts active RFIs before completed RFIs", () => {
+    const items = [
+      {
+        status: "complete",
+        dueDate: "2026-07-20",
+        submittedAt: "2026-07-20T12:00:00.000Z",
+        rfiNumber: "RFI-001",
+      },
+      {
+        status: "new",
+        dueDate: "2026-07-27",
+        submittedAt: "2026-07-26T12:00:00.000Z",
+        rfiNumber: "RFI-003",
+      },
+      {
+        status: "in_progress",
+        dueDate: "2026-07-26",
+        submittedAt: "2026-07-25T12:00:00.000Z",
+        rfiNumber: "RFI-002",
+      },
+    ]
+
+    expect(items.sort(compareRfisForQueue).map((item) => item.rfiNumber)).toEqual(
+      ["RFI-002", "RFI-003", "RFI-001"]
+    )
+  })
+
+  it("rejects unsupported mutation values", () => {
+    expect(validRfiStatus("complete")).toBe("complete")
+    expect(validRfiStatus("surprise")).toBeNull()
+    expect(validRfiPriority("high")).toBe("high")
+    expect(validRfiPriority("urgent")).toBeNull()
+    expect(validRfiAudience("owner")).toBe("owner")
+    expect(validRfiAudience("everyone")).toBeNull()
+  })
+})

--- a/src/lib/rfis/status.ts
+++ b/src/lib/rfis/status.ts
@@ -1,0 +1,133 @@
+export type RfiStatus =
+  | "new"
+  | "in_progress"
+  | "info_needed"
+  | "complete"
+  | "void"
+
+export type RfiStatusFilter = RfiStatus | "open" | "all"
+
+export type RfiPriority = "low" | "normal" | "high"
+
+export type RfiAudience = "internal" | "sub_vendor" | "owner" | "public"
+
+const RFI_STATUS_FILTER_VALUES: readonly RfiStatusFilter[] = [
+  "open",
+  "new",
+  "in_progress",
+  "info_needed",
+  "complete",
+  "void",
+  "all",
+]
+
+const RFI_PRIORITIES: readonly RfiPriority[] = ["low", "normal", "high"]
+
+const RFI_AUDIENCES: readonly RfiAudience[] = [
+  "internal",
+  "sub_vendor",
+  "owner",
+  "public",
+]
+
+type RfiQueueItem = {
+  readonly status: string
+  readonly dueDate: string | null
+  readonly submittedAt: string
+  readonly rfiNumber: string
+}
+
+function normalizedStatus(value: string): string {
+  return value.trim().toLowerCase().replaceAll("-", "_").replaceAll(" ", "_")
+}
+
+export function canonicalRfiStatus(value: string): RfiStatus {
+  switch (normalizedStatus(value)) {
+    case "open":
+    case "new":
+      return "new"
+    case "answered":
+    case "in_progress":
+      return "in_progress"
+    case "additional_information_needed":
+    case "info_needed":
+      return "info_needed"
+    case "closed":
+    case "complete":
+    case "completed":
+      return "complete"
+    case "cancelled":
+    case "canceled":
+    case "void":
+      return "void"
+    default:
+      return "new"
+  }
+}
+
+export function isClosedRfiStatus(value: string): boolean {
+  const status = canonicalRfiStatus(value)
+  return status === "complete" || status === "void"
+}
+
+export function parseRfiStatusFilter(
+  value: string | readonly string[] | undefined
+): RfiStatusFilter {
+  const candidate = Array.isArray(value) ? value[0] : value
+  if (!candidate) return "open"
+
+  return RFI_STATUS_FILTER_VALUES.find((item) => item === candidate) ?? "open"
+}
+
+export function rfiMatchesStatusFilter(
+  status: string,
+  filter: RfiStatusFilter
+): boolean {
+  if (filter === "all") return true
+  if (filter === "open") return !isClosedRfiStatus(status)
+  return canonicalRfiStatus(status) === filter
+}
+
+export function compareRfisForQueue(
+  left: RfiQueueItem,
+  right: RfiQueueItem
+): number {
+  const leftClosed = isClosedRfiStatus(left.status)
+  const rightClosed = isClosedRfiStatus(right.status)
+  if (leftClosed !== rightClosed) return leftClosed ? 1 : -1
+
+  if (!leftClosed) {
+    if (left.dueDate && right.dueDate && left.dueDate !== right.dueDate) {
+      return left.dueDate.localeCompare(right.dueDate)
+    }
+    if (left.dueDate && !right.dueDate) return -1
+    if (!left.dueDate && right.dueDate) return 1
+  }
+
+  if (left.submittedAt !== right.submittedAt) {
+    return right.submittedAt.localeCompare(left.submittedAt)
+  }
+  return right.rfiNumber.localeCompare(left.rfiNumber)
+}
+
+export function validRfiStatus(value: string): RfiStatus | null {
+  const normalized = normalizedStatus(value)
+  const allowed: readonly RfiStatus[] = [
+    "new",
+    "in_progress",
+    "info_needed",
+    "complete",
+    "void",
+  ]
+  return allowed.find((item) => item === normalized) ?? null
+}
+
+export function validRfiPriority(value: string): RfiPriority | null {
+  const normalized = value.trim().toLowerCase()
+  return RFI_PRIORITIES.find((item) => item === normalized) ?? null
+}
+
+export function validRfiAudience(value: string): RfiAudience | null {
+  const normalized = normalizedStatus(value)
+  return RFI_AUDIENCES.find((item) => item === normalized) ?? null
+}


### PR DESCRIPTION
## Summary
- default each project RFI queue to active work instead of completed history
- add explicit Open, New, In progress, Info needed, Complete, Void, and All filters
- order active RFIs by due date, then newest submission, with completed items last
- normalize legacy production statuses such as `open`, `answered`, and `closed`
- validate RFI status, audience, and priority values on mutations

## Validation
- `bun run test` (218 passed, 3 skipped)
- `bun lint` (0 errors; existing warnings only)
- `bunx tsc --noEmit`
- `bun run build`
- production status audit covering every existing RFI status value
