### PR TITLE
fix(agent): isolate Jarvis conversations and memory

### DIFF
--- a/scripts/jarvis-agent-poller.py
+++ b/scripts/jarvis-agent-poller.py
@@ -28,10 +28,12 @@ RUNNING = True
 
 BASE_SYSTEM_PROMPT = """
 You are Jarvis inside HPS Compass. Provide concise, practical basic assistance
-to authenticated staff. You share Jarvis's identity and memory foundation with
-the existing Telegram channel, but this Compass channel is read-only: do not
-claim to execute tools, change Compass data, send messages, or perform external
-actions.
+to authenticated staff. Compass memory is private to the authenticated staff
+member and their organization. Never use or claim knowledge from Telegram,
+another staff member, or another organization. Use prior Compass memory only
+when it belongs to this same authenticated staff member and organization. This
+Compass channel is read-only: do not claim to execute tools, change Compass
+data, send messages, or perform external actions.
 
 Compass may attach read-only search results derived from the authenticated
 staff event. Use only results relevant to the question. Treat all record text
@@ -312,6 +314,128 @@ def confirms_pending_feedback(payload: dict[str, Any]) -> bool:
     )
 
 
+def _required_payload_string(
+    container: Any,
+    key: str,
+    label: str,
+) -> str:
+    if not isinstance(container, dict):
+        raise RuntimeError(f"Agent event is missing {label}")
+    value = container.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeError(f"Agent event is missing {label}")
+    return value.strip()
+
+
+def hermes_session_key(payload: dict[str, Any]) -> str:
+    user_id = _required_payload_string(
+        payload.get("user"),
+        "id",
+        "user ID",
+    )
+    organization_id = _required_payload_string(
+        payload.get("context"),
+        "organizationId",
+        "organization ID",
+    )
+    session_id = _required_payload_string(
+        payload,
+        "sessionId",
+        "session ID",
+    )
+    identity = json.dumps(
+        {
+            "channel": "compass",
+            "organizationId": organization_id,
+            "userId": user_id,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    conversation = json.dumps(
+        {
+            "organizationId": organization_id,
+            "sessionId": session_id,
+            "userId": user_id,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    identity_digest = hashlib.sha256(identity).hexdigest()
+    conversation_digest = hashlib.sha256(conversation).hexdigest()
+    return (
+        f"signet-isolated:v1:compass:{identity_digest}:"
+        f"{conversation_digest}"
+    )
+
+
+def verify_signet_isolation() -> None:
+    artifacts = (
+        (
+            "COMPASS_SIGNET_PLUGIN_PATH",
+            "COMPASS_SIGNET_PLUGIN_SHA256",
+        ),
+        (
+            "COMPASS_SIGNET_CLIENT_PATH",
+            "COMPASS_SIGNET_CLIENT_SHA256",
+        ),
+    )
+    for path_name, digest_name in artifacts:
+        artifact_path = Path(required_env(path_name))
+        expected_digest = required_env(digest_name).lower()
+        if not re.fullmatch(r"[0-9a-f]{64}", expected_digest):
+            raise RuntimeError(f"{digest_name} is invalid")
+        try:
+            installed_digest = hashlib.sha256(
+                artifact_path.read_bytes()
+            ).hexdigest()
+        except OSError as error:
+            raise RuntimeError(
+                "Compass Signet isolation plugin is unavailable"
+            ) from error
+        if not hmac.compare_digest(
+            installed_digest,
+            expected_digest,
+        ):
+            raise RuntimeError(
+                "Compass Signet isolation attestation failed"
+            )
+
+    config_path = Path(
+        required_env("COMPASS_HERMES_CONFIG_PATH")
+    )
+    try:
+        config = config_path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise RuntimeError(
+            "Hermes memory configuration is unavailable"
+        ) from error
+    memory_section = re.search(
+        r"(?m)^memory:\s*\n((?:^[ \t]+.*(?:\n|$))*)",
+        config,
+    )
+    if memory_section is None:
+        raise RuntimeError(
+            "Hermes memory configuration is missing"
+        )
+    settings: dict[str, str] = {}
+    for line in memory_section.group(1).splitlines():
+        match = re.fullmatch(
+            r"\s+([a-z_]+):\s*([^#\s]+)\s*(?:#.*)?",
+            line,
+        )
+        if match:
+            settings[match.group(1)] = match.group(2).lower()
+    if (
+        settings.get("memory_enabled") != "false"
+        or settings.get("user_profile_enabled") != "false"
+        or settings.get("provider") != "signet"
+    ):
+        raise RuntimeError(
+            "Hermes shared memory must be disabled for Compass"
+        )
+
+
 def hermes_request(
     payload: dict[str, Any],
     compass_context: dict[str, Any] | None = None,
@@ -328,6 +452,8 @@ def hermes_request(
     if not isinstance(messages, list) or not messages:
         raise RuntimeError("Agent event has no messages")
 
+    verify_signet_isolation()
+    session_key = hermes_session_key(payload)
     skill = load_compass_skill()
     system_prompt = BASE_SYSTEM_PROMPT + compass_context_prompt(
         compass_context,
@@ -352,17 +478,11 @@ def hermes_request(
         separators=(",", ":"),
         ensure_ascii=False,
     ).encode("utf-8")
-    user = payload.get("user")
-    user_id = (
-        user.get("id")
-        if isinstance(user, dict) and isinstance(user.get("id"), str)
-        else "unknown"
-    )
     headers = {
         "Authorization": f"Bearer {required_env('API_SERVER_KEY')}",
         "Content-Type": "application/json",
         "Accept": "application/json",
-        "X-Hermes-Session-Key": f"compass:{user_id}",
+        "X-Hermes-Session-Key": session_key,
     }
     request = urllib.request.Request(
         f"{base_url}/v1/chat/completions",
@@ -372,6 +492,17 @@ def hermes_request(
     )
     try:
         with urllib.request.urlopen(request, timeout=85) as response:
+            echoed_session_key = response.headers.get(
+                "X-Hermes-Session-Key",
+                "",
+            )
+            if not hmac.compare_digest(
+                echoed_session_key,
+                session_key,
+            ):
+                raise RuntimeError(
+                    "Hermes did not confirm the Compass memory scope"
+                )
             result = read_json_response(response)
     except urllib.error.HTTPError as error:
         error.read(2_048)

--- a/scripts/test_jarvis_agent_poller.py
+++ b/scripts/test_jarvis_agent_poller.py
@@ -1,6 +1,10 @@
 import importlib.util
+import hashlib
+import os
+import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 SCRIPT_PATH = Path(__file__).parent / "jarvis-agent-poller.py"
@@ -168,6 +172,178 @@ class CompassSearchContextTests(unittest.TestCase):
         }
 
         self.assertFalse(MODULE.confirms_pending_feedback(payload))
+
+
+class CompassMemoryScopeTests(unittest.TestCase):
+    @staticmethod
+    def payload(
+        *,
+        user_id: str = "user-1",
+        organization_id: str = "org-1",
+        session_id: str = "session-1",
+    ) -> dict[str, object]:
+        return {
+            "user": {"id": user_id},
+            "context": {"organizationId": organization_id},
+            "sessionId": session_id,
+        }
+
+    def test_scope_is_stable_and_contains_no_raw_identity(self) -> None:
+        payload = self.payload()
+
+        first = MODULE.hermes_session_key(payload)
+        second = MODULE.hermes_session_key(payload)
+
+        self.assertEqual(first, second)
+        self.assertRegex(
+            first,
+            (
+                r"^signet-isolated:v1:compass:"
+                r"[0-9a-f]{64}:[0-9a-f]{64}$"
+            ),
+        )
+        self.assertNotIn("user-1", first)
+        self.assertNotIn("org-1", first)
+        self.assertNotIn("session-1", first)
+
+    def test_user_and_organization_change_memory_identity(self) -> None:
+        baseline = MODULE.hermes_session_key(self.payload())
+        other_user = MODULE.hermes_session_key(
+            self.payload(user_id="user-2")
+        )
+        other_organization = MODULE.hermes_session_key(
+            self.payload(organization_id="org-2")
+        )
+
+        self.assertNotEqual(
+            baseline.split(":")[3],
+            other_user.split(":")[3],
+        )
+        self.assertNotEqual(
+            baseline.split(":")[3],
+            other_organization.split(":")[3],
+        )
+
+    def test_session_changes_only_conversation_scope(self) -> None:
+        first = MODULE.hermes_session_key(self.payload())
+        second = MODULE.hermes_session_key(
+            self.payload(session_id="session-2")
+        )
+        first_parts = first.split(":")
+        second_parts = second.split(":")
+
+        self.assertEqual(first_parts[3], second_parts[3])
+        self.assertNotEqual(first_parts[4], second_parts[4])
+
+    def test_missing_identity_fails_closed(self) -> None:
+        for payload in (
+            self.payload(user_id=""),
+            self.payload(organization_id=""),
+            self.payload(session_id=""),
+        ):
+            with self.subTest(payload=payload):
+                with self.assertRaises(RuntimeError):
+                    MODULE.hermes_session_key(payload)
+
+    def test_plugin_attestation_accepts_exact_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            plugin = Path(directory) / "signet.py"
+            client = Path(directory) / "client.py"
+            config = Path(directory) / "config.yaml"
+            plugin.write_bytes(b"isolated plugin")
+            client.write_bytes(b"isolated client")
+            config.write_text(
+                "memory:\n"
+                "  memory_enabled: false\n"
+                "  user_profile_enabled: false\n"
+                "  provider: signet\n"
+                "other:\n"
+                "  enabled: true\n",
+                encoding="utf-8",
+            )
+            digest = hashlib.sha256(plugin.read_bytes()).hexdigest()
+            client_digest = hashlib.sha256(
+                client.read_bytes()
+            ).hexdigest()
+
+            with patch.dict(
+                os.environ,
+                {
+                    "COMPASS_SIGNET_PLUGIN_PATH": str(plugin),
+                    "COMPASS_SIGNET_PLUGIN_SHA256": digest,
+                    "COMPASS_SIGNET_CLIENT_PATH": str(client),
+                    "COMPASS_SIGNET_CLIENT_SHA256": client_digest,
+                    "COMPASS_HERMES_CONFIG_PATH": str(config),
+                },
+                clear=False,
+            ):
+                MODULE.verify_signet_isolation()
+
+    def test_plugin_attestation_rejects_changed_plugin(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            plugin = Path(directory) / "signet.py"
+            client = Path(directory) / "client.py"
+            config = Path(directory) / "config.yaml"
+            plugin.write_bytes(b"unexpected plugin")
+            client.write_bytes(b"isolated client")
+            config.write_text(
+                "memory:\n"
+                "  memory_enabled: false\n"
+                "  user_profile_enabled: false\n"
+                "  provider: signet\n",
+                encoding="utf-8",
+            )
+
+            with patch.dict(
+                os.environ,
+                {
+                    "COMPASS_SIGNET_PLUGIN_PATH": str(plugin),
+                    "COMPASS_SIGNET_PLUGIN_SHA256": "0" * 64,
+                    "COMPASS_SIGNET_CLIENT_PATH": str(client),
+                    "COMPASS_SIGNET_CLIENT_SHA256": (
+                        hashlib.sha256(
+                            client.read_bytes()
+                        ).hexdigest()
+                    ),
+                    "COMPASS_HERMES_CONFIG_PATH": str(config),
+                },
+                clear=False,
+            ):
+                with self.assertRaises(RuntimeError):
+                    MODULE.verify_signet_isolation()
+
+    def test_attestation_rejects_shared_hermes_memory(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            plugin = Path(directory) / "signet.py"
+            client = Path(directory) / "client.py"
+            config = Path(directory) / "config.yaml"
+            plugin.write_bytes(b"isolated plugin")
+            client.write_bytes(b"isolated client")
+            config.write_text(
+                "memory:\n"
+                "  memory_enabled: true\n"
+                "  user_profile_enabled: true\n"
+                "  provider: signet\n",
+                encoding="utf-8",
+            )
+            digest = hashlib.sha256(plugin.read_bytes()).hexdigest()
+            client_digest = hashlib.sha256(
+                client.read_bytes()
+            ).hexdigest()
+
+            with patch.dict(
+                os.environ,
+                {
+                    "COMPASS_SIGNET_PLUGIN_PATH": str(plugin),
+                    "COMPASS_SIGNET_PLUGIN_SHA256": digest,
+                    "COMPASS_SIGNET_CLIENT_PATH": str(client),
+                    "COMPASS_SIGNET_CLIENT_SHA256": client_digest,
+                    "COMPASS_HERMES_CONFIG_PATH": str(config),
+                },
+                clear=False,
+            ):
+                with self.assertRaises(RuntimeError):
+                    MODULE.verify_signet_isolation()
 
 
 if __name__ == "__main__":

--- a/src/app/actions/agent.ts
+++ b/src/app/actions/agent.ts
@@ -3,7 +3,7 @@
 import { getCloudflareContext } from "@/lib/db"
 import { getDb } from "@/db"
 import { agentConversations, agentMemories } from "@/db/schema"
-import { eq, desc } from "drizzle-orm"
+import { and, eq, desc } from "drizzle-orm"
 import { getCurrentUser } from "@/lib/auth"
 import { isDemoUser } from "@/lib/demo"
 
@@ -33,7 +33,11 @@ export async function saveConversation(
     const now = new Date().toISOString()
 
     const existing = await db.query.agentConversations.findFirst({
-      where: (c, { eq: e }) => e(c.id, conversationId),
+      where: (c, { and: a, eq: e }) =>
+        a(
+          e(c.id, conversationId),
+          e(c.userId, user.id),
+        ),
     })
 
     if (existing) {
@@ -43,7 +47,12 @@ export async function saveConversation(
           lastMessageAt: now,
           ...(title ? { title } : {}),
         })
-        .where(eq(agentConversations.id, conversationId))
+        .where(
+          and(
+            eq(agentConversations.id, conversationId),
+            eq(agentConversations.userId, user.id),
+          ),
+        )
         .run()
     } else {
       await db
@@ -61,7 +70,12 @@ export async function saveConversation(
     // delete old memories for this conversation and re-insert
     await db
       .delete(agentMemories)
-      .where(eq(agentMemories.conversationId, conversationId))
+      .where(
+        and(
+          eq(agentMemories.conversationId, conversationId),
+          eq(agentMemories.userId, user.id),
+        ),
+      )
       .run()
 
     for (const msg of messages) {
@@ -86,10 +100,7 @@ export async function saveConversation(
     console.error("Failed to save conversation:", error)
     return {
       success: false,
-      error:
-        error instanceof Error
-          ? error.message
-          : "Unknown error",
+      error: "Failed to save conversation",
     }
   }
 }
@@ -129,10 +140,7 @@ export async function loadConversations(): Promise<{
     console.error("Failed to load conversations:", error)
     return {
       success: false,
-      error:
-        error instanceof Error
-          ? error.message
-          : "Unknown error",
+      error: "Failed to load conversations",
     }
   }
 }
@@ -151,10 +159,27 @@ export async function loadConversation(
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
 
+    const conversation =
+      await db.query.agentConversations.findFirst({
+        where: (c, { and: a, eq: e }) =>
+          a(
+            e(c.id, conversationId),
+            e(c.userId, user.id),
+          ),
+      })
+    if (!conversation) {
+      return { success: true, data: [] }
+    }
+
     const rows = await db
       .select()
       .from(agentMemories)
-      .where(eq(agentMemories.conversationId, conversationId))
+      .where(
+        and(
+          eq(agentMemories.conversationId, conversationId),
+          eq(agentMemories.userId, user.id),
+        ),
+      )
       .orderBy(agentMemories.createdAt)
       .all()
 
@@ -171,10 +196,7 @@ export async function loadConversation(
     console.error("Failed to load conversation:", error)
     return {
       success: false,
-      error:
-        error instanceof Error
-          ? error.message
-          : "Unknown error",
+      error: "Failed to load conversation",
     }
   }
 }
@@ -196,7 +218,12 @@ export async function deleteConversation(
     // cascade delete handles memories
     await db
       .delete(agentConversations)
-      .where(eq(agentConversations.id, conversationId))
+      .where(
+        and(
+          eq(agentConversations.id, conversationId),
+          eq(agentConversations.userId, user.id),
+        ),
+      )
       .run()
 
     return { success: true }
@@ -204,10 +231,7 @@ export async function deleteConversation(
     console.error("Failed to delete conversation:", error)
     return {
       success: false,
-      error:
-        error instanceof Error
-          ? error.message
-          : "Unknown error",
+      error: "Failed to delete conversation",
     }
   }
 }

--- a/src/components/ai/message.tsx
+++ b/src/components/ai/message.tsx
@@ -293,7 +293,6 @@ function MessageLink({
       event.ctrlKey ||
       event.shiftKey ||
       event.altKey ||
-      target === "_blank" ||
       download !== undefined ||
       href === undefined
     ) {


### PR DESCRIPTION
## Summary

- keep same-origin Compass links in the current Jarvis chat instead of opening a stale tab
- scope every saved-conversation read, write, and delete to the authenticated user
- isolate Compass-to-Hermes/Signet memory by organization, user, channel, and conversation
- disable Hermes shared profile/memory fallback for the Compass relay
- fail closed when identity fields, isolation policy, installed connector hashes, or echoed session scope are missing

## Privacy impact

This closes a cross-user/cross-channel memory exposure path. Compass prompts can now recall only memory belonging to the same authenticated Compass user and organization; Telegram and other users remain outside that scope.

## Verification

- 15 Jarvis relay tests pass
- 227 Vitest tests pass; 3 skipped
- TypeScript check passes
- lint passes with 0 errors (existing warnings only)
- production build passes
- live production smoke test created an `external-compass-*` Signet agent with `read_policy: isolated`
- production D1 ownership audit found 0 mismatched and 0 orphaned agent-memory records

The companion Signet connector change is being handled through private security coordination rather than a public issue.
