### PR TITLE
fix(dashboard): improve photo and dashboard navigation

### DIFF
--- a/docs/wip/legacy-custom-dashboard-visibility.md
+++ b/docs/wip/legacy-custom-dashboard-visibility.md
@@ -1,0 +1,17 @@
+# Legacy custom dashboard visibility
+
+The legacy agent-generated dashboard interface is temporarily hidden from the
+primary navigation. Dashboard records remain in `custom_dashboards`; this
+change does not delete or rewrite user data.
+
+The direct `/dashboard/boards/{id}` route and existing server actions remain
+available for controlled recovery. Restoring dashboard creation or navigation
+should follow a product review of the supported generation, editing, and
+permission model. Until then:
+
+- the dashboard page does not offer a customization shortcut;
+- generated interfaces do not offer a save-as-dashboard action; and
+- saved dashboards are not listed in the sidebar.
+
+If permanent removal is approved later, add an explicit archive field and a
+reversible migration before removing records.

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -17,7 +17,6 @@ import {
   SidebarProvider,
 } from "@/components/ui/sidebar"
 import { getProjects } from "@/app/actions/projects"
-import { getCustomDashboards } from "@/app/actions/dashboards"
 import { ProjectListProvider } from "@/components/project-list-provider"
 import { getCurrentUser, toSidebarUser } from "@/lib/auth"
 import { cookies } from "next/headers"
@@ -37,20 +36,16 @@ export default async function DashboardLayout({
 }: {
   readonly children: React.ReactNode
 }) {
-  const [projectList, authUser, dashboardResult, cookieStore] =
+  const [projectList, authUser, cookieStore] =
     await Promise.all([
       getProjects(),
       getCurrentUser(),
-      getCustomDashboards(),
       cookies(),
     ])
   const sidebarOpen = cookieStore.get("sidebar_state")?.value !== "false"
   const user = authUser ? toSidebarUser(authUser) : null
   const activeOrgId = authUser?.organizationId ?? null
   const activeOrgName = authUser?.organizationName ?? null
-  const dashboardList = dashboardResult.success
-    ? dashboardResult.data
-    : []
   const isDemo = authUser ? isDemoUser(authUser.id) : false
   const canUseCompassAgent = canUseAskCompass(authUser)
 
@@ -77,7 +72,6 @@ export default async function DashboardLayout({
         <AppSidebar
           variant="inset"
           projects={projectList}
-          dashboards={dashboardList}
           user={user}
           activeOrgId={activeOrgId}
           activeOrgName={activeOrgName}

--- a/src/components/agent/rendered-view.tsx
+++ b/src/components/agent/rendered-view.tsx
@@ -1,24 +1,11 @@
 "use client"
-
-import * as React from "react"
 import {
   XIcon,
   Loader2Icon,
-  BookmarkIcon,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import { useRenderState } from "./chat-provider"
 import { CompassRenderer } from "@/lib/agent/render/compass-renderer"
-import { saveCustomDashboard } from "@/app/actions/dashboards"
 
 export function RenderedView() {
   const {
@@ -29,45 +16,7 @@ export function RenderedView() {
     clearRender,
   } = useRenderState()
 
-  const [saveOpen, setSaveOpen] = React.useState(false)
-  const [saveName, setSaveName] = React.useState("")
-  const [saving, setSaving] = React.useState(false)
-
   const hasRoot = !!spec?.root
-
-  const handleSave = async () => {
-    if (!saveName.trim() || !spec) return
-    setSaving(true)
-    const result = await saveCustomDashboard(
-      saveName.trim(),
-      "",
-      JSON.stringify(spec),
-      JSON.stringify([]),
-      saveName.trim(),
-    )
-    setSaving(false)
-    if (result.success) {
-      setSaveOpen(false)
-      setSaveName("")
-      window.dispatchEvent(
-        new CustomEvent("agent-toast", {
-          detail: {
-            message: `Dashboard "${saveName.trim()}" saved`,
-            type: "success",
-          },
-        })
-      )
-    } else {
-      window.dispatchEvent(
-        new CustomEvent("agent-toast", {
-          detail: {
-            message: result.error,
-            type: "error",
-          },
-        })
-      )
-    }
-  }
 
   return (
     <div className="flex flex-1 flex-col min-h-0 p-4">
@@ -85,17 +34,6 @@ export function RenderedView() {
           )}
         </div>
         <div className="flex items-center gap-1">
-          {hasRoot && !isRendering && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setSaveOpen(true)}
-              className="gap-1.5"
-            >
-              <BookmarkIcon className="size-4" />
-              Save as Dashboard
-            </Button>
-          )}
           <Button
             variant="ghost"
             size="sm"
@@ -107,44 +45,6 @@ export function RenderedView() {
           </Button>
         </div>
       </div>
-
-      <Dialog open={saveOpen} onOpenChange={setSaveOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Save as Dashboard</DialogTitle>
-          </DialogHeader>
-          <div className="grid gap-4 py-4">
-            <div className="grid gap-2">
-              <Label htmlFor="dashboard-name">Name</Label>
-              <Input
-                id="dashboard-name"
-                placeholder="Project Overview"
-                value={saveName}
-                onChange={(e) =>
-                  setSaveName(e.target.value)
-                }
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") handleSave()
-                }}
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setSaveOpen(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={handleSave}
-              disabled={!saveName.trim() || saving}
-            >
-              {saving ? "Saving..." : "Save"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
 
       {/* Rendered content */}
       <div className="flex-1 overflow-auto">

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -23,7 +23,6 @@ import {
 import { usePathname } from "next/navigation"
 
 import { NavMain } from "@/components/nav-main"
-import { NavDashboards } from "@/components/nav-dashboards"
 import { NavFiles } from "@/components/nav-files"
 import { NavProjects } from "@/components/nav-projects"
 import { NavConversations } from "@/components/nav-conversations"
@@ -153,13 +152,8 @@ const NAV_MAIN = [
 
 function SidebarNav({
   projects,
-  dashboards = [],
 }: {
   projects: ReadonlyArray<ProjectListItem>
-  dashboards?: ReadonlyArray<{
-    readonly id: string
-    readonly name: string
-  }>
 }) {
   const pathname = usePathname()
   const { state } = useSidebar()
@@ -211,10 +205,7 @@ function SidebarNav({
       )}
       {mode === "projects" && <NavProjects projects={projects} />}
       {mode === "main" && (
-        <>
-          <NavMain items={navMain} />
-          <NavDashboards dashboards={dashboards} />
-        </>
+        <NavMain items={navMain} />
       )}
     </div>
   )
@@ -222,14 +213,12 @@ function SidebarNav({
 
 export function AppSidebar({
   projects = [],
-  dashboards = [],
   user,
   activeOrgId = null,
   activeOrgName = null,
   ...props
 }: React.ComponentProps<typeof Sidebar> & {
   readonly projects?: ReadonlyArray<ProjectListItem>
-  readonly dashboards?: ReadonlyArray<{ readonly id: string; readonly name: string }>
   readonly user: SidebarUser | null
   readonly activeOrgId?: string | null
   readonly activeOrgName?: string | null
@@ -243,10 +232,7 @@ export function AppSidebar({
         <OrgSwitcher activeOrgId={activeOrgId} activeOrgName={activeOrgName} />
       </SidebarHeader>
       <SidebarContent className="compass-sidebar-scroll">
-        <SidebarNav
-          projects={projects}
-          dashboards={dashboards}
-        />
+        <SidebarNav projects={projects} />
       </SidebarContent>
       <SidebarFooter className="border-t border-sidebar-border/60">
         {isMobile && (

--- a/src/components/dashboard/operational-dashboard.tsx
+++ b/src/components/dashboard/operational-dashboard.tsx
@@ -21,7 +21,6 @@ import {
   IconMessageCircleQuestion,
   IconPhoto,
   IconRoute,
-  IconSparkles,
   IconTargetArrow,
   IconTools,
   IconTrendingUp,
@@ -38,10 +37,7 @@ import {
   type CherishPulseReviewItem,
   type CherishValue,
 } from "@/app/actions/cherish-pulse"
-import {
-  useChatPanel,
-  useRenderState,
-} from "@/components/agent/chat-provider"
+import { useRenderState } from "@/components/agent/chat-provider"
 import { RenderedView } from "@/components/agent/rendered-view"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -78,6 +74,7 @@ import {
   type ProjectWorkspaceMode,
 } from "@/lib/project-workflow-roles"
 import { cn } from "@/lib/utils"
+import { dashboardNavigation } from "@/lib/dashboard/navigation"
 
 type DashboardLayoutMode = "list" | "compass"
 type SignalTone = "green" | "amber" | "blue" | "red" | "neutral"
@@ -496,7 +493,7 @@ function DashboardCommandCenter({
         : "No open POs",
       progress: Math.min(100, overview.metrics.openPoAmount / 1000),
       tone: "green",
-      href: "/dashboard/financials",
+      href: dashboardNavigation.openPurchaseOrders,
       icon: <IconCurrencyDollar className="size-4" />,
     },
   ]
@@ -1508,7 +1505,6 @@ export function OperationalDashboard({
   readonly overview: DashboardOverview
 }) {
   const { spec, isRendering } = useRenderState()
-  const chatPanel = useChatPanel()
   const [layoutMode, setLayoutMode] =
     useState<DashboardLayoutMode>("list")
   const [activeRoleId, setActiveRoleId] = useState<ProjectWorkflowRoleId>(
@@ -1619,15 +1615,6 @@ export function OperationalDashboard({
               Compass
             </ToggleGroupItem>
           </ToggleGroup>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={chatPanel.open}
-          >
-            <IconSparkles className="size-4" />
-            Customize view
-          </Button>
           <Button asChild size="sm">
             <Link href="/dashboard/projects">
               <IconFolder className="size-4" />

--- a/src/components/projects/project-audience-photo-gallery.tsx
+++ b/src/components/projects/project-audience-photo-gallery.tsx
@@ -2,7 +2,12 @@
 
 import * as React from "react"
 import Image from "next/image"
-import { IconPhoto, IconSearch } from "@tabler/icons-react"
+import {
+  IconChevronLeft,
+  IconChevronRight,
+  IconPhoto,
+  IconSearch,
+} from "@tabler/icons-react"
 
 import type { AudiencePhoto } from "@/app/actions/project-audience-preview"
 import { Badge } from "@/components/ui/badge"
@@ -22,6 +27,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { resolvePhotoImageSource } from "@/lib/photo-sources"
+import { adjacentPhoto } from "@/lib/photos/carousel"
 
 type AudiencePhotoSort = "newest" | "oldest" | "phase_newest" | "phase_oldest"
 const NO_PHASE_VALUE = "unassigned"
@@ -143,6 +149,33 @@ export function ProjectAudiencePhotoGallery({
       }
     })
   }, [dateFilter, phaseFilter, photoSort, photos])
+
+  const showAdjacentPreview = React.useCallback(
+    (direction: "previous" | "next"): void => {
+      if (!previewPhoto) return
+      const adjacent = adjacentPhoto(filteredPhotos, previewPhoto.id, direction)
+      if (adjacent) setPreviewPhoto(adjacent)
+    },
+    [filteredPhotos, previewPhoto]
+  )
+
+  React.useEffect(() => {
+    if (!previewPhoto || filteredPhotos.length < 2) return
+
+    function handlePreviewKeyDown(event: KeyboardEvent): void {
+      if (event.altKey || event.ctrlKey || event.metaKey) return
+      if (event.key === "ArrowLeft") {
+        event.preventDefault()
+        showAdjacentPreview("previous")
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault()
+        showAdjacentPreview("next")
+      }
+    }
+
+    window.addEventListener("keydown", handlePreviewKeyDown)
+    return () => window.removeEventListener("keydown", handlePreviewKeyDown)
+  }, [filteredPhotos.length, previewPhoto, showAdjacentPreview])
 
   function markImageFailed(photoId: string): void {
     setFailedImageIds((current) => {
@@ -357,9 +390,39 @@ export function ProjectAudiencePhotoGallery({
                       </p>
                     </div>
                   )}
+                  {filteredPhotos.length > 1 && (
+                    <>
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="icon"
+                        onClick={() => showAdjacentPreview("previous")}
+                        aria-label="Show previous photo"
+                        className="absolute left-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-background/90 shadow-md"
+                      >
+                        <IconChevronLeft className="size-5" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="icon"
+                        onClick={() => showAdjacentPreview("next")}
+                        aria-label="Show next photo"
+                        className="absolute right-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-background/90 shadow-md"
+                      >
+                        <IconChevronRight className="size-5" />
+                      </Button>
+                    </>
+                  )}
                 </div>
                 <div className="flex flex-wrap items-center justify-between gap-2 border-t bg-background px-4 py-3">
                   <div>
+                    <p className="mb-2 text-xs text-muted-foreground">
+                      {filteredPhotos.findIndex(
+                        (photo) => photo.id === previewPhoto.id
+                      ) + 1}{" "}
+                      of {filteredPhotos.length}
+                    </p>
                     <div className="flex flex-wrap gap-1">
                       <Badge variant="secondary">
                         Phase: {phaseLabel(previewPhoto.schedulePhase)}

--- a/src/components/projects/project-photo-review.tsx
+++ b/src/components/projects/project-photo-review.tsx
@@ -8,6 +8,8 @@ import {
   IconArrowLeft,
   IconCompass,
   IconCompassFilled,
+  IconChevronLeft,
+  IconChevronRight,
   IconExternalLink,
   IconCheck,
   IconHourglass,
@@ -52,6 +54,7 @@ import {
   photoLinkHref,
   resolvePhotoImageSource,
 } from "@/lib/photo-sources"
+import { adjacentPhoto } from "@/lib/photos/carousel"
 
 type VisibilityFilter =
   | "all"
@@ -352,6 +355,33 @@ export function ProjectPhotoReview({
   function openPreview(photo: ProjectPhotoLibraryItem): void {
     setPreviewPhoto(photo)
   }
+
+  const showAdjacentPreview = React.useCallback(
+    (direction: "previous" | "next"): void => {
+      if (!previewPhoto) return
+      const adjacent = adjacentPhoto(filteredPhotos, previewPhoto.id, direction)
+      if (adjacent) setPreviewPhoto(adjacent)
+    },
+    [filteredPhotos, previewPhoto]
+  )
+
+  React.useEffect(() => {
+    if (!previewPhoto || filteredPhotos.length < 2) return
+
+    function handlePreviewKeyDown(event: KeyboardEvent): void {
+      if (event.altKey || event.ctrlKey || event.metaKey) return
+      if (event.key === "ArrowLeft") {
+        event.preventDefault()
+        showAdjacentPreview("previous")
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault()
+        showAdjacentPreview("next")
+      }
+    }
+
+    window.addEventListener("keydown", handlePreviewKeyDown)
+    return () => window.removeEventListener("keydown", handlePreviewKeyDown)
+  }, [filteredPhotos.length, previewPhoto, showAdjacentPreview])
 
   function markImageFailed(photoId: string): void {
     setFailedImageIds((current) => {
@@ -1046,9 +1076,39 @@ export function ProjectPhotoReview({
                             </p>
                           </div>
                         )}
+                        {filteredPhotos.length > 1 && (
+                          <>
+                            <Button
+                              type="button"
+                              variant="secondary"
+                              size="icon"
+                              onClick={() => showAdjacentPreview("previous")}
+                              aria-label="Show previous photo"
+                              className="absolute left-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-background/90 shadow-md"
+                            >
+                              <IconChevronLeft className="size-5" />
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="secondary"
+                              size="icon"
+                              onClick={() => showAdjacentPreview("next")}
+                              aria-label="Show next photo"
+                              className="absolute right-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-background/90 shadow-md"
+                            >
+                              <IconChevronRight className="size-5" />
+                            </Button>
+                          </>
+                        )}
                       </div>
                       <div className="flex flex-wrap items-center justify-between gap-2 border-t bg-background px-4 py-3">
                         <div>
+                          <p className="mb-2 text-xs text-muted-foreground">
+                            {filteredPhotos.findIndex(
+                              (photo) => photo.id === previewPhoto.id
+                            ) + 1}{" "}
+                            of {filteredPhotos.length}
+                          </p>
                           <div className="flex flex-wrap gap-1">
                             <Badge variant="outline">
                               {sourceLabel(previewPhoto.sourceSystem)}

--- a/src/lib/dashboard/__tests__/navigation.test.ts
+++ b/src/lib/dashboard/__tests__/navigation.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest"
+
+import { dashboardNavigation } from "@/lib/dashboard/navigation"
+
+describe("dashboardNavigation", () => {
+  it("routes Open POs to the purchase-order workflow", () => {
+    expect(dashboardNavigation.openPurchaseOrders).toBe(
+      "/dashboard/purchase-orders"
+    )
+    expect(dashboardNavigation.openPurchaseOrders).not.toContain("financials")
+  })
+})

--- a/src/lib/dashboard/navigation.ts
+++ b/src/lib/dashboard/navigation.ts
@@ -1,0 +1,3 @@
+export const dashboardNavigation = Object.freeze({
+  openPurchaseOrders: "/dashboard/purchase-orders",
+})

--- a/src/lib/photos/__tests__/carousel.test.ts
+++ b/src/lib/photos/__tests__/carousel.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+
+import { adjacentPhoto } from "@/lib/photos/carousel"
+
+const projectPhotos = [
+  { id: "project-photo-1", projectId: "project-a" },
+  { id: "project-photo-2", projectId: "project-a" },
+  { id: "project-photo-3", projectId: "project-a" },
+]
+
+describe("adjacentPhoto", () => {
+  it("moves forward and backward within the supplied photo scope", () => {
+    expect(adjacentPhoto(projectPhotos, "project-photo-2", "next")?.id).toBe(
+      "project-photo-3"
+    )
+    expect(
+      adjacentPhoto(projectPhotos, "project-photo-2", "previous")?.id
+    ).toBe("project-photo-1")
+  })
+
+  it("wraps at both ends of the carousel", () => {
+    expect(adjacentPhoto(projectPhotos, "project-photo-3", "next")?.id).toBe(
+      "project-photo-1"
+    )
+    expect(
+      adjacentPhoto(projectPhotos, "project-photo-1", "previous")?.id
+    ).toBe("project-photo-3")
+  })
+
+  it("does not escape the supplied project or visibility scope", () => {
+    const ownerVisiblePhotos = projectPhotos.slice(0, 2)
+
+    expect(
+      adjacentPhoto(ownerVisiblePhotos, "project-photo-2", "next")?.id
+    ).toBe("project-photo-1")
+    expect(adjacentPhoto(ownerVisiblePhotos, "project-photo-3", "next")).toBe(
+      null
+    )
+  })
+
+  it("returns null for an empty scope", () => {
+    expect(adjacentPhoto([], "project-photo-1", "next")).toBe(null)
+  })
+})

--- a/src/lib/photos/carousel.ts
+++ b/src/lib/photos/carousel.ts
@@ -1,0 +1,20 @@
+export interface PhotoCarouselItem {
+  readonly id: string
+}
+
+export type PhotoCarouselDirection = "previous" | "next"
+
+export function adjacentPhoto<T extends PhotoCarouselItem>(
+  photos: readonly T[],
+  activePhotoId: string,
+  direction: PhotoCarouselDirection
+): T | null {
+  if (photos.length === 0) return null
+
+  const activeIndex = photos.findIndex((photo) => photo.id === activePhotoId)
+  if (activeIndex < 0) return null
+
+  const offset = direction === "next" ? 1 : -1
+  const nextIndex = (activeIndex + offset + photos.length) % photos.length
+  return photos[nextIndex] ?? null
+}


### PR DESCRIPTION
## Summary

- add previous/next photo controls, keyboard navigation, wraparound, and position counters to staff and audience galleries
- keep carousel navigation inside each already-filtered project and visibility scope
- route Open POs to the purchase-order workspace
- remove the nonfunctional Customize View and Save as Dashboard controls
- hide legacy custom dashboards from navigation without deleting their stored data

## User impact

Staff can review a photo set without repeatedly closing the viewer. Dashboard links now lead to the intended workflow, and obsolete AI-dashboard controls no longer open Ask Jarvis or clutter navigation.

## Data safety

No custom-dashboard records are deleted. Direct recovery routes and existing actions remain available while the creation/navigation feature is intentionally hidden.

## Verification

- 232 Vitest tests passed; 3 skipped
- focused carousel and dashboard navigation tests passed
- TypeScript passed
- targeted ESLint passed
- production build passed
- `git diff --check` passed

Closes #134
Closes #139
