### PR TITLE
feat(calendar): focus project work items

### DIFF
--- a/src/app/actions/conversations.ts
+++ b/src/app/actions/conversations.ts
@@ -11,7 +11,7 @@ import {
   type NewChannelMember,
   type NewChannelReadState,
 } from "@/db/schema-conversations"
-import { users, organizationMembers } from "@/db/schema"
+import { projects } from "@/db/schema"
 import { getCurrentUser } from "@/lib/auth"
 import { requirePermission } from "@/lib/permissions"
 import { revalidatePath } from "next/cache"
@@ -177,6 +177,22 @@ export async function createChannel(data: {
 
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
+
+    if (data.projectId) {
+      const [project] = await db
+        .select({ id: projects.id })
+        .from(projects)
+        .where(
+          and(
+            eq(projects.id, data.projectId),
+            eq(projects.organizationId, orgId)
+          )
+        )
+        .limit(1)
+      if (!project) {
+        return { success: false, error: "Project not found" }
+      }
+    }
 
     const now = new Date().toISOString()
     const channelId = crypto.randomUUID()

--- a/src/app/actions/work-calendar.ts
+++ b/src/app/actions/work-calendar.ts
@@ -1,6 +1,7 @@
 "use server"
 
 import { asc, eq } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
 import {
@@ -12,9 +13,16 @@ import {
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { requireOrg } from "@/lib/org-scope"
+import { can, requirePermission } from "@/lib/permissions"
+import {
+  projectTodoHref,
+  resolveHOfficeProjectId,
+  scheduleItemHref,
+} from "@/lib/work-calendar"
 
 export type WorkCalendarEntryKind =
   | "schedule"
+  | "event"
   | "rfi"
   | "purchase_order"
   | "task"
@@ -24,6 +32,7 @@ export type WorkCalendarEntry = {
   readonly kind: WorkCalendarEntryKind
   readonly projectId: string
   readonly projectLabel: string
+  readonly projectName: string
   readonly title: string
   readonly status: string
   readonly priority: string
@@ -38,9 +47,12 @@ export type WorkCalendarEntry = {
 export type WorkCalendarData = {
   readonly today: string
   readonly entries: readonly WorkCalendarEntry[]
+  readonly projects: readonly ProjectRow[]
+  readonly defaultProjectId: string | null
+  readonly canCreateEvents: boolean
 }
 
-type ProjectRow = {
+export type ProjectRow = {
   readonly id: string
   readonly name: string
   readonly projectNumber: string | null
@@ -75,10 +87,12 @@ function isClosedStatus(status: string): boolean {
 
 function operationKind(recordType: string): WorkCalendarEntryKind {
   if (recordType === "purchase_order") return "purchase_order"
+  if (recordType === "calendar_event") return "event"
   return "task"
 }
 
 function operationSourceLabel(recordType: string, recordNumber: string | null): string {
+  if (recordType === "calendar_event") return "Calendar event"
   if (recordType === "schedule_task") {
     return recordNumber
       ? `Schedule item follow-up ${recordNumber}`
@@ -143,6 +157,7 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
         kind: "schedule",
         projectId: project.id,
         projectLabel: label,
+        projectName: project.name,
         title: task.title,
         status: task.status,
         priority: task.isCriticalPath ? "critical" : "normal",
@@ -151,7 +166,7 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
         assignedTo: task.assignedTo,
         companyName: null,
         sourceLabel: "Project schedule",
-        href: `/dashboard/projects/${project.id}/schedule`,
+        href: scheduleItemHref(project.id, task.id),
       })
     }
 
@@ -181,6 +196,7 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
         kind: "rfi",
         projectId: project.id,
         projectLabel: label,
+        projectName: project.name,
         title: rfi.subject,
         status: rfi.status,
         priority: rfi.priority,
@@ -222,6 +238,7 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
         kind: operationKind(operation.sourceRecordType),
         projectId: project.id,
         projectLabel: label,
+        projectName: project.name,
         title: operation.title,
         status: operation.status,
         priority: operation.priority,
@@ -236,7 +253,16 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
         href:
           operation.sourceRecordType === "purchase_order"
             ? `/dashboard/projects/${project.id}/purchase-orders`
-            : `/dashboard/projects/${project.id}`,
+            : operation.sourceRecordType === "calendar_event"
+              ? `/dashboard/schedule?kind=event&item=${encodeURIComponent(operation.id)}#work-calendar-${encodeURIComponent(operation.id)}`
+              : [
+                    "staff_task",
+                    "subcontractor_task",
+                    "supplier_task",
+                    "schedule_task",
+                  ].includes(operation.sourceRecordType)
+                ? projectTodoHref(project.id, operation.id)
+                : `/dashboard/projects/${project.id}`,
       })
     }
   }
@@ -251,5 +277,112 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
     return left.title.localeCompare(right.title)
   })
 
-  return { today, entries }
+  return {
+    today,
+    entries,
+    projects: projectRows,
+    defaultProjectId: resolveHOfficeProjectId(projectRows),
+    canCreateEvents: can(user, "schedule", "create"),
+  }
+}
+
+export type CreateWorkCalendarEventInput = {
+  readonly title: string
+  readonly description: string | null
+  readonly projectId: string | null
+  readonly startDate: string
+  readonly endDate: string
+}
+
+type CreateWorkCalendarEventResult =
+  | { readonly success: true; readonly id: string }
+  | { readonly success: false; readonly error: string }
+
+function cleanRequiredText(value: string, label: string): string {
+  const cleaned = value.trim()
+  if (cleaned.length === 0) throw new Error(`${label} is required`)
+  return cleaned
+}
+
+function isDateKey(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value)
+}
+
+export async function createWorkCalendarEvent(
+  input: CreateWorkCalendarEventInput
+): Promise<CreateWorkCalendarEventResult> {
+  try {
+    const user = await requireAuth()
+    requirePermission(user, "schedule", "create")
+    const orgId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+
+    const projectRows = await db
+      .select({
+        id: projects.id,
+        name: projects.name,
+        projectNumber: projects.projectNumber,
+      })
+      .from(projects)
+      .where(eq(projects.organizationId, orgId))
+
+    const projectId =
+      input.projectId?.trim() || resolveHOfficeProjectId(projectRows)
+    if (!projectId) {
+      return {
+        success: false,
+        error:
+          "Select a project. Compass could not resolve one unique H-Office project for this organization.",
+      }
+    }
+
+    const project = projectRows.find((candidate) => candidate.id === projectId)
+    if (!project) {
+      return { success: false, error: "Project not found" }
+    }
+
+    const title = cleanRequiredText(input.title, "Event title")
+    const startDate = cleanRequiredText(input.startDate, "Start date")
+    const endDate = cleanRequiredText(input.endDate, "End date")
+    if (!isDateKey(startDate) || !isDateKey(endDate)) {
+      return { success: false, error: "Enter valid event dates." }
+    }
+    if (endDate < startDate) {
+      return {
+        success: false,
+        error: "End date must be on or after the start date.",
+      }
+    }
+
+    const id = crypto.randomUUID()
+    const now = new Date().toISOString()
+    await db.insert(projectOperations).values({
+      id,
+      projectId,
+      sourceSystem: "compass",
+      sourceRecordType: "calendar_event",
+      title,
+      description: input.description?.trim() || null,
+      status: "open",
+      priority: "normal",
+      startDate,
+      dueDate: endDate,
+      syncDirection: "read",
+      syncStatus: "compass_only",
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    revalidatePath("/dashboard/schedule")
+    revalidatePath(`/dashboard/projects/${projectId}`)
+    revalidatePath("/dashboard")
+    return { success: true, id }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to create calendar event",
+    }
+  }
 }

--- a/src/app/dashboard/conversations/page.tsx
+++ b/src/app/dashboard/conversations/page.tsx
@@ -3,23 +3,39 @@ import { MessageSquare } from "lucide-react"
 import { listChannels } from "@/app/actions/conversations"
 import { CreateChannelButton } from "@/components/conversations/create-channel-button"
 
-export default async function ConversationsPage() {
+export default async function ConversationsPage({
+  searchParams,
+}: {
+  readonly searchParams: Promise<{
+    readonly projectId?: string | readonly string[]
+  }>
+}) {
+  const query = await searchParams
+  const projectId =
+    typeof query.projectId === "string"
+      ? query.projectId
+      : query.projectId?.[0] ?? null
   const result = await listChannels()
 
   if (result.success && result.data && result.data.length > 0) {
-    redirect(`/dashboard/conversations/${result.data[0].id}`)
+    const channel = projectId
+      ? result.data.find((candidate) => candidate.projectId === projectId)
+      : result.data[0]
+    if (channel) redirect(`/dashboard/conversations/${channel.id}`)
   }
 
   return (
     <div className="flex h-full flex-1 flex-col items-center justify-center gap-4 p-8">
       <MessageSquare className="h-16 w-16 text-muted-foreground/40" />
       <div className="text-center">
-        <h2 className="text-2xl font-semibold">No channels yet</h2>
+        <h2 className="text-2xl font-semibold">
+          {projectId ? "No conversations for this project yet" : "No channels yet"}
+        </h2>
         <p className="mt-2 text-muted-foreground">
           Create your first channel to start conversations with your team
         </p>
       </div>
-      <CreateChannelButton />
+      <CreateChannelButton projectId={projectId ?? undefined} />
     </div>
   )
 }

--- a/src/app/dashboard/projects/[id]/conversations/page.tsx
+++ b/src/app/dashboard/projects/[id]/conversations/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from "next/navigation"
+
+export default async function ProjectConversationsPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<never> {
+  const { id } = await params
+  redirect(`/dashboard/conversations?projectId=${encodeURIComponent(id)}`)
+}

--- a/src/app/dashboard/projects/[id]/schedule/page.tsx
+++ b/src/app/dashboard/projects/[id]/schedule/page.tsx
@@ -23,10 +23,25 @@ const emptySchedule: ScheduleData = {
 
 export default async function SchedulePage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>
+  searchParams: Promise<{
+    readonly view?: string | readonly string[]
+    readonly item?: string | readonly string[]
+  }>
 }) {
-  const { id } = await params
+  const [{ id }, query] = await Promise.all([params, searchParams])
+  const requestedView =
+    typeof query.view === "string" ? query.view : query.view?.[0]
+  const initialView =
+    requestedView === "calendar" ||
+    requestedView === "list" ||
+    requestedView === "gantt"
+      ? requestedView
+      : undefined
+  const focusTaskId =
+    typeof query.item === "string" ? query.item : query.item?.[0] ?? null
 
   let projectName = "Project"
   let schedule: ScheduleData = emptySchedule
@@ -77,6 +92,8 @@ export default async function SchedulePage({
         baselines={baselines}
         allProjects={allProjects}
         assigneeOptions={assigneeOptions}
+        initialView={focusTaskId ? "list" : initialView}
+        focusTaskId={focusTaskId}
       />
     </div>
   )

--- a/src/app/dashboard/projects/[id]/todos/page.tsx
+++ b/src/app/dashboard/projects/[id]/todos/page.tsx
@@ -1,0 +1,39 @@
+export const dynamic = "force-dynamic"
+
+import { notFound } from "next/navigation"
+
+import { getProjectOperationsSummary } from "@/app/actions/project-operations"
+import { getProjects } from "@/app/actions/projects"
+import { ProjectTodosView } from "@/components/projects/project-todos-view"
+
+export default async function ProjectTodosPage({
+  params,
+  searchParams,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+  readonly searchParams: Promise<{
+    readonly item?: string | readonly string[]
+  }>
+}): Promise<React.ReactElement> {
+  const [{ id }, query] = await Promise.all([params, searchParams])
+  const [projects, summary] = await Promise.all([
+    getProjects(),
+    getProjectOperationsSummary(id),
+  ])
+  const project = projects.find((candidate) => candidate.id === id)
+  if (!project) notFound()
+
+  const projectLabel = project.projectNumber
+    ? `${project.projectNumber} — ${project.name}`
+    : project.name
+  const initialItemId =
+    typeof query.item === "string" ? query.item : query.item?.[0] ?? null
+
+  return (
+    <ProjectTodosView
+      projectLabel={projectLabel}
+      items={summary.commitments}
+      initialItemId={initialItemId}
+    />
+  )
+}

--- a/src/app/dashboard/schedule/page.tsx
+++ b/src/app/dashboard/schedule/page.tsx
@@ -13,6 +13,7 @@ function kindFilter(
 
   switch (selected) {
     case "schedule":
+    case "event":
     case "task":
     case "rfi":
     case "purchase_order":
@@ -27,10 +28,20 @@ export default async function SchedulePage({
 }: {
   readonly searchParams: Promise<{
     readonly kind?: string | readonly string[]
+    readonly item?: string | readonly string[]
   }>
 }): Promise<React.ReactElement> {
   const query = await searchParams
   const data = await getWorkCalendar()
 
-  return <WorkCalendar data={data} initialKind={kindFilter(query.kind)} />
+  const initialItemId =
+    typeof query.item === "string" ? query.item : query.item?.[0] ?? null
+
+  return (
+    <WorkCalendar
+      data={data}
+      initialKind={kindFilter(query.kind)}
+      initialItemId={initialItemId}
+    />
+  )
 }

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -177,6 +177,14 @@ function SidebarNav({
         ? "projects"
         : "main"
 
+  const persistentNav = PERSISTENT_NAV.map((item) =>
+    item.title === "To-Dos" && activeProjectId
+      ? {
+          ...item,
+          url: `/dashboard/projects/${activeProjectId}/todos`,
+        }
+      : item
+  )
   const navMain = NAV_MAIN.map((item) =>
     typeof item.projectPath === "string"
       ? {
@@ -192,7 +200,7 @@ function SidebarNav({
 
   return (
     <div key={mode} className="animate-in fade-in slide-in-from-left-1 flex flex-1 flex-col duration-150">
-      <NavMain items={PERSISTENT_NAV} />
+      <NavMain items={persistentNav} />
       {mode === "files" && (
         <React.Suspense>
           <NavFiles />

--- a/src/components/conversations/create-channel-button.tsx
+++ b/src/components/conversations/create-channel-button.tsx
@@ -5,7 +5,11 @@ import { Plus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { CreateChannelDialog } from "./create-channel-dialog"
 
-export function CreateChannelButton() {
+export function CreateChannelButton({
+  projectId,
+}: {
+  readonly projectId?: string
+}) {
   const [open, setOpen] = React.useState(false)
 
   return (
@@ -14,7 +18,11 @@ export function CreateChannelButton() {
         <Plus className="mr-2 h-4 w-4" />
         Create Channel
       </Button>
-      <CreateChannelDialog open={open} onOpenChange={setOpen} />
+      <CreateChannelDialog
+        open={open}
+        onOpenChange={setOpen}
+        projectId={projectId}
+      />
     </>
   )
 }

--- a/src/components/conversations/create-channel-dialog.tsx
+++ b/src/components/conversations/create-channel-dialog.tsx
@@ -86,11 +86,13 @@ type CategoryData = {
 type CreateChannelDialogProps = {
   readonly open: boolean
   readonly onOpenChange: (open: boolean) => void
+  readonly projectId?: string
 }
 
 export function CreateChannelDialog({
   open,
   onOpenChange,
+  projectId,
 }: CreateChannelDialogProps) {
   const router = useRouter()
   const [isSubmitting, setIsSubmitting] = React.useState(false)
@@ -135,6 +137,7 @@ export function CreateChannelDialog({
       type: data.type,
       categoryId: data.categoryId,
       isPrivate: data.isPrivate,
+      projectId,
     })
 
     if (result.success && result.data) {

--- a/src/components/nav-projects.tsx
+++ b/src/components/nav-projects.tsx
@@ -5,6 +5,7 @@ import {
   IconAddressBook,
   IconArrowLeft,
   IconCalendarStats,
+  IconClipboardCheck,
   IconClipboardText,
   IconEye,
   IconFileDollar,
@@ -12,6 +13,7 @@ import {
   IconHome2,
   IconMailForward,
   IconMessageCircleQuestion,
+  IconMessages,
   IconPalette,
   IconPhoto,
   IconShoppingCart,
@@ -34,6 +36,8 @@ import type { ProjectListItem } from "@/app/actions/projects"
 type ProjectSectionKey =
   | "overview"
   | "schedule"
+  | "todos"
+  | "conversations"
   | "owner-updates"
   | "daily-logs"
   | "photos"
@@ -66,6 +70,18 @@ const PROJECT_SECTION_ITEMS: readonly ProjectSectionItem[] = [
     hrefSuffix: "schedule",
     icon: IconCalendarStats,
     section: "schedule",
+  },
+  {
+    title: "To-Dos",
+    hrefSuffix: "todos",
+    icon: IconClipboardCheck,
+    section: "todos",
+  },
+  {
+    title: "Conversations",
+    hrefSuffix: "conversations",
+    icon: IconMessages,
+    section: "conversations",
   },
   {
     title: "Owner Updates",
@@ -172,6 +188,8 @@ function activeProjectSection(pathname: string | null): ProjectSectionKey {
     case "rfqs":
     case "rfis":
     case "schedule":
+    case "todos":
+    case "conversations":
       return section
     default:
       return "overview"

--- a/src/components/projects/project-todos-view.tsx
+++ b/src/components/projects/project-todos-view.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import * as React from "react"
+import { IconSearch } from "@tabler/icons-react"
+
+import type { ProjectOperationItem } from "@/app/actions/project-operations"
+import { Badge } from "@/components/ui/badge"
+import { Input } from "@/components/ui/input"
+import { cn } from "@/lib/utils"
+import { normalizeWorkCalendarSearch } from "@/lib/work-calendar"
+
+function formatDate(value: string | null): string {
+  if (!value) return "No due date"
+  return new Date(`${value}T00:00:00`).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+function typeLabel(value: string): string {
+  if (value === "subcontractor_task") return "Subcontractor"
+  if (value === "supplier_task") return "Supplier"
+  if (value === "schedule_task") return "Schedule follow-up"
+  return "Staff"
+}
+
+function todoMatches(item: ProjectOperationItem, query: string): boolean {
+  const normalizedQuery = normalizeWorkCalendarSearch(query)
+  if (!normalizedQuery) return true
+
+  return normalizeWorkCalendarSearch(
+    [
+      item.title,
+      item.description,
+      item.sourceRecordNumber,
+      item.assigneeName,
+      item.companyName,
+      item.status,
+      item.priority,
+      typeLabel(item.sourceRecordType),
+    ]
+      .filter((value): value is string => Boolean(value))
+      .join(" ")
+  ).includes(normalizedQuery)
+}
+
+export function ProjectTodosView({
+  projectLabel,
+  items,
+  initialItemId,
+}: {
+  readonly projectLabel: string
+  readonly items: readonly ProjectOperationItem[]
+  readonly initialItemId: string | null
+}): React.ReactElement {
+  const [query, setQuery] = React.useState("")
+  const visibleItems = items.filter((item) => todoMatches(item, query))
+
+  React.useEffect(() => {
+    if (!initialItemId) return
+    document
+      .getElementById(`todo-${initialItemId}`)
+      ?.scrollIntoView({ behavior: "smooth", block: "center" })
+  }, [initialItemId])
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 p-4 md:p-6">
+      <header>
+        <p className="text-sm text-muted-foreground">{projectLabel}</p>
+        <h1 className="text-2xl font-semibold tracking-tight">To-dos</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Staff, subcontractor, supplier, and schedule follow-up work for this
+          project.
+        </p>
+      </header>
+
+      <div className="relative max-w-xl">
+        <IconSearch className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search title, assignee, company, status…"
+          className="pl-9"
+        />
+      </div>
+
+      <section className="divide-y border-y">
+        {visibleItems.length > 0 ? (
+          visibleItems.map((item) => {
+            const focused = item.id === initialItemId
+            return (
+              <article
+                id={`todo-${item.id}`}
+                key={item.id}
+                tabIndex={focused ? -1 : undefined}
+                className={cn(
+                  "grid gap-3 px-1 py-4 transition-colors sm:grid-cols-[minmax(0,1fr)_auto]",
+                  focused && "bg-primary/5 outline outline-2 outline-primary/30"
+                )}
+              >
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h2 className="font-medium">{item.title}</h2>
+                    <Badge variant="outline">
+                      {typeLabel(item.sourceRecordType)}
+                    </Badge>
+                    <Badge variant="secondary">{item.status}</Badge>
+                  </div>
+                  {item.description && (
+                    <p className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
+                      {item.description}
+                    </p>
+                  )}
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {item.sourceRecordNumber ?? "Compass to-do"}
+                    {item.assigneeName ? ` · ${item.assigneeName}` : ""}
+                    {item.companyName ? ` · ${item.companyName}` : ""}
+                  </p>
+                </div>
+                <div className="text-sm text-muted-foreground sm:text-right">
+                  <p>{formatDate(item.dueDate ?? item.startDate)}</p>
+                  <p className="mt-1 capitalize">{item.priority} priority</p>
+                </div>
+              </article>
+            )
+          })
+        ) : (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            No to-dos match this search.
+          </p>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/components/schedule/schedule-list-view.tsx
+++ b/src/components/schedule/schedule-list-view.tsx
@@ -45,6 +45,7 @@ import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { format, parseISO } from "date-fns"
 import { useScheduleDisplayPalette } from "@/hooks/use-schedule-display-palette"
+import { cn } from "@/lib/utils"
 import {
   getScheduleItemDisplayColor,
   type DisplayColorPalette,
@@ -56,6 +57,7 @@ interface ScheduleListViewProps {
   readonly dependencies: TaskDependencyData[]
   readonly exceptions: readonly WorkdayExceptionData[]
   readonly assigneeOptions: readonly ProjectTaskAssigneeOption[]
+  readonly focusTaskId?: string | null
 }
 
 function StatusDot({
@@ -121,6 +123,7 @@ export function ScheduleListView({
   dependencies,
   exceptions,
   assigneeOptions,
+  focusTaskId = null,
 }: ScheduleListViewProps) {
   const router = useRouter()
   const displayColorPalette = useScheduleDisplayPalette(projectId)
@@ -314,6 +317,19 @@ export function ScheduleListView({
     initialState: { pagination: { pageSize: 25 } },
   })
 
+  useEffect(() => {
+    if (!focusTaskId) return
+    const index = localTasks.findIndex((task) => task.id === focusTaskId)
+    if (index < 0) return
+
+    table.setPageIndex(Math.floor(index / table.getState().pagination.pageSize))
+    window.requestAnimationFrame(() => {
+      document
+        .getElementById(`schedule-item-${focusTaskId}`)
+        ?.scrollIntoView({ behavior: "smooth", block: "center" })
+    })
+  }, [focusTaskId, localTasks, table])
+
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <div className="flex gap-2 mb-2">
@@ -363,7 +379,14 @@ export function ScheduleListView({
                 </TableRow>
               ) : (
                 table.getRowModel().rows.map((row) => (
-                  <TableRow key={row.id}>
+                  <TableRow
+                    id={`schedule-item-${row.original.id}`}
+                    key={row.id}
+                    className={cn(
+                      row.original.id === focusTaskId &&
+                        "bg-primary/5 outline outline-2 outline-primary/30"
+                    )}
+                  >
                     {row.getVisibleCells().map((cell) => {
                       const meta = cell.column.columnDef.meta as { className?: string } | undefined
                       return (

--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -89,6 +89,8 @@ interface ScheduleViewProps {
   readonly baselines: ScheduleBaselineData[]
   readonly allProjects?: readonly ProjectListItem[]
   readonly assigneeOptions?: readonly ProjectTaskAssigneeOption[]
+  readonly initialView?: View
+  readonly focusTaskId?: string | null
 }
 
 export function ScheduleView({
@@ -98,9 +100,11 @@ export function ScheduleView({
   baselines,
   allProjects = [],
   assigneeOptions = [],
+  initialView = "gantt",
+  focusTaskId = null,
 }: ScheduleViewProps) {
   const isMobile = useIsMobile()
-  const [view, setView] = useState<View>("gantt")
+  const [view, setView] = useState<View>(initialView)
   const [taskFormOpen, setTaskFormOpen] = useState(false)
   const [filters, setFilters] = useState<TaskFilters>(EMPTY_FILTERS)
   const [baselinesOpen, setBaselinesOpen] = useState(false)
@@ -546,6 +550,7 @@ export function ScheduleView({
             dependencies={initialData.dependencies}
             exceptions={initialData.exceptions}
             assigneeOptions={assigneeOptions}
+            focusTaskId={focusTaskId}
           />
         )}
         {view === "gantt" && (

--- a/src/components/schedule/work-calendar-event-dialog.tsx
+++ b/src/components/schedule/work-calendar-event-dialog.tsx
@@ -1,0 +1,219 @@
+"use client"
+
+import * as React from "react"
+import { useRouter } from "next/navigation"
+import { IconCalendarPlus } from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import {
+  createWorkCalendarEvent,
+  type ProjectRow,
+} from "@/app/actions/work-calendar"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+
+const DEFAULT_PROJECT_VALUE = "__h_office_default__"
+
+function projectLabel(project: ProjectRow): string {
+  return project.projectNumber
+    ? `${project.projectNumber} — ${project.name}`
+    : project.name
+}
+
+export function WorkCalendarEventDialog({
+  projects,
+  defaultProjectId,
+  today,
+}: {
+  readonly projects: readonly ProjectRow[]
+  readonly defaultProjectId: string | null
+  readonly today: string
+}): React.ReactElement {
+  const router = useRouter()
+  const [open, setOpen] = React.useState(false)
+  const [pending, startTransition] = React.useTransition()
+  const [title, setTitle] = React.useState("")
+  const [description, setDescription] = React.useState("")
+  const [projectValue, setProjectValue] = React.useState(
+    defaultProjectId ? DEFAULT_PROJECT_VALUE : ""
+  )
+  const [startDate, setStartDate] = React.useState(today)
+  const [endDate, setEndDate] = React.useState(today)
+
+  function reset(): void {
+    setTitle("")
+    setDescription("")
+    setProjectValue(defaultProjectId ? DEFAULT_PROJECT_VALUE : "")
+    setStartDate(today)
+    setEndDate(today)
+  }
+
+  function submit(event: React.FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    const projectId =
+      projectValue === DEFAULT_PROJECT_VALUE ? null : projectValue || null
+
+    startTransition(async () => {
+      const result = await createWorkCalendarEvent({
+        title,
+        description: description || null,
+        projectId,
+        startDate,
+        endDate,
+      })
+
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+
+      toast.success("Event added to the work calendar.")
+      setOpen(false)
+      reset()
+      router.refresh()
+    })
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen)
+        if (!nextOpen) reset()
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button type="button" size="sm">
+          <IconCalendarPlus className="size-4" />
+          Add event
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <form onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>Add work calendar event</DialogTitle>
+            <DialogDescription>
+              Add a meeting or other dated event. Leave the project at its
+              default to file it under H-Office.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-4 py-5">
+            <div className="grid gap-2">
+              <Label htmlFor="work-calendar-event-title">Title</Label>
+              <Input
+                id="work-calendar-event-title"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="Weekly operations meeting"
+                required
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="work-calendar-event-project">Project</Label>
+              <Select value={projectValue} onValueChange={setProjectValue}>
+                <SelectTrigger id="work-calendar-event-project">
+                  <SelectValue placeholder="Select a project" />
+                </SelectTrigger>
+                <SelectContent>
+                  {defaultProjectId && (
+                    <SelectItem value={DEFAULT_PROJECT_VALUE}>
+                      H-Office (default)
+                    </SelectItem>
+                  )}
+                  {projects.map((project) => (
+                    <SelectItem key={project.id} value={project.id}>
+                      {projectLabel(project)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {!defaultProjectId && (
+                <p className="text-xs text-muted-foreground">
+                  Compass could not identify one unique H-Office project, so a
+                  project is required.
+                </p>
+              )}
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="grid gap-2">
+                <Label htmlFor="work-calendar-event-start">Starts</Label>
+                <Input
+                  id="work-calendar-event-start"
+                  type="date"
+                  value={startDate}
+                  onChange={(event) => setStartDate(event.target.value)}
+                  required
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="work-calendar-event-end">Ends</Label>
+                <Input
+                  id="work-calendar-event-end"
+                  type="date"
+                  value={endDate}
+                  min={startDate}
+                  onChange={(event) => setEndDate(event.target.value)}
+                  required
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="work-calendar-event-notes">Notes</Label>
+              <Textarea
+                id="work-calendar-event-notes"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                placeholder="Optional details"
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={pending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={
+                pending ||
+                title.trim().length === 0 ||
+                startDate.length === 0 ||
+                endDate.length === 0 ||
+                (!defaultProjectId && projectValue.length === 0)
+              }
+            >
+              {pending ? "Adding…" : "Add event"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/schedule/work-calendar.tsx
+++ b/src/components/schedule/work-calendar.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import Link from "next/link"
 import {
   IconCalendarEvent,
+  IconCalendarPlus,
   IconClipboardCheck,
   IconMessageQuestion,
   IconReceipt,
@@ -19,6 +20,8 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
+import { workCalendarEntryMatches } from "@/lib/work-calendar"
+import { WorkCalendarEventDialog } from "./work-calendar-event-dialog"
 
 export type WorkCalendarKindFilter = WorkCalendarEntryKind | "all"
 
@@ -38,6 +41,11 @@ const KIND_FILTERS: readonly KindConfig[] = [
     id: "schedule",
     label: "Schedule items",
     icon: <IconCalendarEvent className="size-4" />,
+  },
+  {
+    id: "event",
+    label: "Events",
+    icon: <IconCalendarPlus className="size-4" />,
   },
   {
     id: "task",
@@ -83,19 +91,12 @@ function formatWeekday(date: string): string {
   }).format(parseDateKey(date))
 }
 
-function normalize(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-}
-
 function kindLabel(kind: WorkCalendarEntryKind): string {
   switch (kind) {
     case "schedule":
       return "Schedule item"
+    case "event":
+      return "Event"
     case "task":
       return "To-do"
     case "rfi":
@@ -109,6 +110,8 @@ function kindTone(kind: WorkCalendarEntryKind): string {
   switch (kind) {
     case "schedule":
       return "border-[#2f5963] bg-card text-[#2f5963]"
+    case "event":
+      return "border-[#5f4b8b] bg-card text-[#5f4b8b]"
     case "task":
       return "border-[#3f7d4d] bg-card text-[#3f7d4d]"
     case "rfi":
@@ -118,26 +121,6 @@ function kindTone(kind: WorkCalendarEntryKind): string {
   }
 }
 
-function entryMatches(entry: WorkCalendarEntry, query: string): boolean {
-  if (!query) return true
-
-  const haystack = normalize(
-    [
-      entry.projectLabel,
-      entry.title,
-      entry.status,
-      entry.priority,
-      entry.assignedTo,
-      entry.companyName,
-      entry.sourceLabel,
-    ]
-      .filter((value): value is string => Boolean(value))
-      .join(" ")
-  )
-
-  return haystack.includes(query)
-}
-
 function entryOnDay(entry: WorkCalendarEntry, date: string): boolean {
   return entry.startDate <= date && entry.endDate >= date
 }
@@ -145,16 +128,20 @@ function entryOnDay(entry: WorkCalendarEntry, date: string): boolean {
 function WorkItem({
   entry,
   compact = false,
+  focused = false,
 }: {
   readonly entry: WorkCalendarEntry
   readonly compact?: boolean
+  readonly focused?: boolean
 }): React.ReactElement {
   return (
     <Link
+      id={compact ? undefined : `work-calendar-${entry.id}`}
       href={entry.href}
       className={cn(
         "block rounded-lg border bg-background p-3 transition-all duration-200 hover:-translate-y-0.5 hover:bg-muted/60 hover:shadow-md",
-        compact && "p-2"
+        compact && "p-2",
+        focused && "border-primary bg-primary/5 ring-2 ring-primary/30"
       )}
     >
       <div className="flex items-start justify-between gap-2">
@@ -198,9 +185,11 @@ function WorkItem({
 export function WorkCalendar({
   data,
   initialKind = "all",
+  initialItemId = null,
 }: {
   readonly data: WorkCalendarData
   readonly initialKind?: WorkCalendarKindFilter
+  readonly initialItemId?: string | null
 }): React.ReactElement {
   const [query, setQuery] = React.useState("")
   const [activeKind, setActiveKind] =
@@ -213,11 +202,10 @@ export function WorkCalendar({
     () => Array.from({ length: 14 }, (_, index) => toDateKey(addDays(today, index))),
     [today]
   )
-  const normalizedQuery = normalize(query)
   const filteredEntries = data.entries.filter(
     (entry) =>
       (activeKind === "all" || entry.kind === activeKind) &&
-      entryMatches(entry, normalizedQuery)
+      workCalendarEntryMatches(entry, query)
   )
   const overdueEntries = filteredEntries.filter(
     (entry) => entry.endDate < data.today
@@ -227,6 +215,13 @@ export function WorkCalendar({
   )
   const taskCount = filteredEntries.filter((entry) => entry.kind === "task").length
   const rfiCount = filteredEntries.filter((entry) => entry.kind === "rfi").length
+
+  React.useEffect(() => {
+    if (!initialItemId) return
+    document
+      .getElementById(`work-calendar-${initialItemId}`)
+      ?.scrollIntoView({ behavior: "smooth", block: "center" })
+  }, [initialItemId])
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">
@@ -285,6 +280,13 @@ export function WorkCalendar({
             />
           </div>
           <div className="flex flex-wrap gap-2">
+            {data.canCreateEvents && (
+              <WorkCalendarEventDialog
+                projects={data.projects}
+                defaultProjectId={data.defaultProjectId}
+                today={data.today}
+              />
+            )}
             {KIND_FILTERS.map((filter) => (
               <Button
                 key={filter.id}
@@ -354,7 +356,11 @@ export function WorkCalendar({
             <div className="mt-4 grid gap-3">
               {filteredEntries.length > 0 ? (
                 filteredEntries.slice(0, 50).map((entry) => (
-                  <WorkItem key={`${entry.kind}-${entry.id}`} entry={entry} />
+                  <WorkItem
+                    key={`${entry.kind}-${entry.id}`}
+                    entry={entry}
+                    focused={entry.id === initialItemId}
+                  />
                 ))
               ) : (
                 <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">

--- a/src/lib/__tests__/work-calendar.test.ts
+++ b/src/lib/__tests__/work-calendar.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  projectTodoHref,
+  resolveHOfficeProjectId,
+  scheduleItemHref,
+  workCalendarEntryMatches,
+} from "@/lib/work-calendar"
+
+const entry = {
+  projectLabel: "O-202",
+  projectName: "Loeffler Residence",
+  title: "Confirm cabinet delivery",
+  status: "open",
+  priority: "normal",
+  assignedTo: "Rebekah",
+  companyName: "HPS",
+  sourceLabel: "Staff Task TASK-014",
+}
+
+describe("work calendar navigation and search", () => {
+  it("matches a project name even when the display label is its project number", () => {
+    expect(workCalendarEntryMatches(entry, "Loeffler")).toBe(true)
+    expect(workCalendarEntryMatches(entry, "O-202")).toBe(true)
+    expect(workCalendarEntryMatches(entry, "cabinet delivery")).toBe(true)
+    expect(workCalendarEntryMatches(entry, "Loomis")).toBe(false)
+  })
+
+  it("builds focused links for to-dos and schedule items", () => {
+    expect(projectTodoHref("proj/o 202", "todo/14")).toBe(
+      "/dashboard/projects/proj%2Fo%20202/todos?item=todo%2F14#todo-todo%2F14"
+    )
+    expect(scheduleItemHref("proj/o 202", "task/8")).toBe(
+      "/dashboard/projects/proj%2Fo%20202/schedule?view=list&item=task%2F8#schedule-item-task%2F8"
+    )
+  })
+})
+
+describe("H-Office default project resolution", () => {
+  it("resolves one exact H-Office identity", () => {
+    expect(
+      resolveHOfficeProjectId([
+        { id: "loeffler", name: "Loeffler", projectNumber: "O-202" },
+        { id: "office", name: "H-Office", projectNumber: "H-OFFICE" },
+      ])
+    ).toBe("office")
+  })
+
+  it("fails closed when the default is missing or ambiguous", () => {
+    expect(
+      resolveHOfficeProjectId([
+        { id: "loeffler", name: "Loeffler", projectNumber: "O-202" },
+      ])
+    ).toBeNull()
+    expect(
+      resolveHOfficeProjectId([
+        { id: "office-1", name: "H-Office", projectNumber: null },
+        { id: "office-2", name: "H Office Project", projectNumber: null },
+      ])
+    ).toBeNull()
+  })
+})

--- a/src/lib/work-calendar.ts
+++ b/src/lib/work-calendar.ts
@@ -1,0 +1,74 @@
+export type WorkCalendarProjectIdentity = {
+  readonly id: string
+  readonly name: string
+  readonly projectNumber: string | null
+}
+
+export type WorkCalendarSearchableEntry = {
+  readonly projectLabel: string
+  readonly projectName: string
+  readonly title: string
+  readonly status: string
+  readonly priority: string
+  readonly assignedTo: string | null
+  readonly companyName: string | null
+  readonly sourceLabel: string
+}
+
+export function normalizeWorkCalendarSearch(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+export function workCalendarEntryMatches(
+  entry: WorkCalendarSearchableEntry,
+  query: string
+): boolean {
+  const normalizedQuery = normalizeWorkCalendarSearch(query)
+  if (!normalizedQuery) return true
+
+  const haystack = normalizeWorkCalendarSearch(
+    [
+      entry.projectLabel,
+      entry.projectName,
+      entry.title,
+      entry.status,
+      entry.priority,
+      entry.assignedTo,
+      entry.companyName,
+      entry.sourceLabel,
+    ]
+      .filter((value): value is string => Boolean(value))
+      .join(" ")
+  )
+
+  return haystack.includes(normalizedQuery)
+}
+
+export function resolveHOfficeProjectId(
+  projects: readonly WorkCalendarProjectIdentity[]
+): string | null {
+  const matches = projects.filter((project) => {
+    const names = [project.name, project.projectNumber]
+      .filter((value): value is string => Boolean(value))
+      .map(normalizeWorkCalendarSearch)
+
+    return names.some(
+      (value) => value === "h office" || value === "h office project"
+    )
+  })
+
+  return matches.length === 1 ? matches[0]?.id ?? null : null
+}
+
+export function scheduleItemHref(projectId: string, itemId: string): string {
+  return `/dashboard/projects/${encodeURIComponent(projectId)}/schedule?view=list&item=${encodeURIComponent(itemId)}#schedule-item-${encodeURIComponent(itemId)}`
+}
+
+export function projectTodoHref(projectId: string, itemId: string): string {
+  return `/dashboard/projects/${encodeURIComponent(projectId)}/todos?item=${encodeURIComponent(itemId)}#todo-${encodeURIComponent(itemId)}`
+}


### PR DESCRIPTION
## Summary

- makes Work Calendar to-do and schedule entries open the exact record, with list focus and highlighting
- adds a project-scoped To-Dos view plus project-preserving To-Dos and Conversations navigation
- makes cross-project to-do search match full project names such as Loeffler, Loomis, and Litten
- adds ordinary date-range Work Calendar events with a deterministic, fail-closed H-Office default
- keeps real work-item titles as the primary calendar text and validates project/channel organization ownership

## Safety

- unknown work-calendar operation types fall back to the project instead of producing false deep links
- project-bound channels are validated against the authenticated organization
- blank-project events use H-Office only when one exact normalized match exists; otherwise explicit selection is required
- event dates are validated server-side

## Verification

- `bunx tsc --noEmit`
- `bun run test`: 236 passed, 3 skipped after rebase
- production build passed in the pre-push hook
- focused ESLint: no errors
- `git diff --check`

Closes #133
Advances #140 and #141
