### PR TITLE
test(e2e): stabilize project workspace sweep

### DIFF
--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -99,6 +99,11 @@ test.describe("usable Compass areas", () => {
   test("project workspaces render without application errors", async ({
     page,
   }) => {
+    // This test intentionally compiles and opens every project workspace in a
+    // single cold dev-server session. Keep the 30-second navigation limit for
+    // each route, but give the complete cross-browser sweep a realistic budget.
+    test.slow()
+
     const projectsResponse = await page.goto("/dashboard/projects")
     await expectHealthyNavigation(
       page,

--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -88,8 +88,13 @@ test.describe("usable Compass areas", () => {
   })
 
   test("core areas render without application errors", async ({ page }) => {
+    test.slow()
+
     for (const area of coreAreas) {
       await test.step(area.name, async () => {
+        // Isolate each route from background client navigation started by the
+        // previous workspace while keeping the authenticated demo context.
+        await page.goto("about:blank")
         const response = await page.goto(area.path)
         await expectHealthyNavigation(page, response, area.path)
       })
@@ -118,6 +123,7 @@ test.describe("usable Compass areas", () => {
 
     for (const area of projectAreas) {
       await test.step(area.name, async () => {
+        await page.goto("about:blank")
         const path = `/dashboard/projects/${projectId}${area.suffix}`
         const response = await page.goto(path)
         await expectHealthyNavigation(page, response, path)

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+    allowedDevOrigins: ["127.0.0.1"],
     transpilePackages: ["agent-core"],
     experimental: {
         proxyClientMaxBodySize: "100mb",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,7 @@ const isElectron = () => {
 }
 
 const externalBaseUrl = process.env.PLAYWRIGHT_BASE_URL
-const baseURL = externalBaseUrl ?? "http://localhost:3000"
+const baseURL = externalBaseUrl ?? "http://127.0.0.1:3000"
 
 // Web-specific projects
 const webProjects = [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,7 @@ const isElectron = () => {
 }
 
 const externalBaseUrl = process.env.PLAYWRIGHT_BASE_URL
-const baseURL = externalBaseUrl ?? "http://127.0.0.1:3000"
+const baseURL = externalBaseUrl ?? "http://localhost:3000"
 
 // Web-specific projects
 const webProjects = [


### PR DESCRIPTION
## Summary

- gives both intentional multi-route usable-area sweeps a realistic total budget while preserving Playwright's 30-second per-navigation timeout
- loads each route in a clean document while retaining the authenticated demo context, so background navigation from the previous workspace cannot interrupt the next route check
- explicitly allows the established `127.0.0.1` Playwright dev origin in Next.js

## Diagnosis

Firefox repeatedly exhausted the single 60-second total budget on different final project routes even though individual routes remained within their navigation limit. Once corrected, WebKit exposed a separate cross-page race: an RSC fallback from the previous route interrupted the next `page.goto`.

## Verification

- seeded database via `LOCAL_DB_PATH=.e2e/compass.db bun run test:e2e:prepare`
- focused Firefox usable-area sweep: 3 passed
- focused WebKit usable-area sweep: 3 passed
- TypeScript and focused ESLint passed
- production build passed in the pre-push hook
- `git diff --check`

Closes #167
