### PR TITLE
feat(field): add offline Jarvis and CHERISH desk

### DIFF
--- a/docs/architecture/jarvis-feedback-bridge.md
+++ b/docs/architecture/jarvis-feedback-bridge.md
@@ -21,6 +21,25 @@ The bridge has three separate responsibilities:
    the originating authenticated Compass request using the existing agent SSE
    protocol.
 
+Field access and offline replay
+---
+
+Active field-role users have `agent:read` permission and may open Ask Jarvis
+from the Field Desk on mobile or desktop. Guest and client accounts remain
+denied in both the UI and every agent API route.
+
+When a field user submits a text prompt while `navigator.onLine` is false,
+Compass stores it in the scoped field outbox rather than attempting the
+bridge request. On reconnection, the normal authenticated `/api/agent`
+request is made with the current organization/user session and the existing
+Signet isolation headers. A queued prompt is deleted locally only after the
+SSE response completes successfully. CHERISH submissions use the same
+outbox lifecycle but replay through the existing authenticated server action.
+
+The outbox is not a media transport. Photo, video, and document handoff needs
+a separately reviewed attachment contract so an offline file cannot be
+replayed under the wrong user, organization, project, or conversion target.
+
 Data flow
 ---
 

--- a/docs/modules/mobile.md
+++ b/docs/modules/mobile.md
@@ -118,6 +118,46 @@ The queue lifecycle:
 4. **Cleanup**: Successfully uploaded photos are deleted from the filesystem and removed from the queue
 5. **Retry**: Failed uploads get retried up to 3 times. After that, they stay in `failed` status until manually retried
 
+
+field desk and offline text outbox
+---
+
+`/dashboard/field` is the staff field surface. It gives active admin, office,
+and field roles a direct Ask Jarvis entry point plus the CHERISH response
+form. Client, guest, inactive, and unknown roles do not receive the route or
+navigation entry. The existing `agent:read` permission remains the final
+server-side gate for Ask Jarvis.
+
+Text-only Jarvis prompts and CHERISH responses can be saved while the browser
+or Capacitor webview is offline. `src/lib/field/offline-outbox.ts` stores a
+bounded, seven-day outbox under an organization-and-user-specific key. The
+global chat provider replays eligible entries sequentially after the browser
+reports that connectivity has returned:
+
+1. validate and trim the item before it reaches device storage;
+2. retain at most 50 recent entries;
+3. process only entries belonging to the currently authenticated
+   organization/user scope;
+4. re-run the normal authenticated server action or Ask Jarvis request;
+5. remove an entry only after the server reports success.
+
+This first slice works when the authenticated Compass shell is already
+loaded. Cold-launching the hosted webview without any network still requires
+the planned service-worker/app-shell cache; the outbox does not claim to make
+uncached routes available offline.
+
+The outbox does not bypass Compass permissions, and it does not place an
+organization ID, user ID, role, or authorization claim in the replay payload.
+The live authenticated session supplies identity when the request is sent.
+
+Media and document capture for Jarvis is deliberately separate from this
+text outbox. The existing native photo queue is project-photo-specific and
+cannot safely represent ownership plus an intended conversion target. A
+follow-up must define an attachment record with organization, user, project,
+upload state, content metadata, retention policy, and an explicit target
+(`daily_log`, `todo`, `rfi`, or `delivery_notification`) before automatic
+conversion is enabled.
+
 ```typescript
 await Uploader.startUpload({
   filePath: photo.localPath,

--- a/src/app/actions/cherish-pulse.ts
+++ b/src/app/actions/cherish-pulse.ts
@@ -51,6 +51,7 @@ export type SubmitCherishPulseInput = {
   readonly responseType: CherishPulseResponseType
   readonly message: string
   readonly source?: CherishPulseSource
+  readonly clientSubmissionId?: string
 }
 
 export type ReviewCherishPulseInput = {
@@ -126,10 +127,56 @@ export async function submitCherishPulseResponse(
       }
     }
 
+    const clientSubmissionId = input.clientSubmissionId?.trim()
+    if (
+      clientSubmissionId !== undefined &&
+      !isValidClientSubmissionId(clientSubmissionId)
+    ) {
+      return {
+        success: false,
+        error: "The offline submission identifier is invalid.",
+      }
+    }
+
+    const db = getDb(env.DB)
+    if (clientSubmissionId) {
+      const existing = await db
+        .select({
+          id: cherishPulseResponses.id,
+          cherishValue: cherishPulseResponses.cherishValue,
+          responseType: cherishPulseResponses.responseType,
+          message: cherishPulseResponses.message,
+          source: cherishPulseResponses.source,
+          visibility: cherishPulseResponses.visibility,
+          reviewStatus: cherishPulseResponses.reviewStatus,
+          submittedByName: cherishPulseResponses.submittedByName,
+          submittedByEmail: cherishPulseResponses.submittedByEmail,
+          weekStart: cherishPulseResponses.weekStart,
+          createdAt: cherishPulseResponses.createdAt,
+        })
+        .from(cherishPulseResponses)
+        .where(
+          and(
+            eq(cherishPulseResponses.id, clientSubmissionId),
+            eq(cherishPulseResponses.organizationId, organizationId),
+            eq(cherishPulseResponses.submittedBy, user.id)
+          )
+        )
+        .limit(1)
+
+      const existingItem = existing[0]
+      if (existingItem) {
+        return {
+          success: true,
+          data: rowToReviewItem(existingItem),
+        }
+      }
+    }
+
     const now = new Date().toISOString()
     const visibility = visibilityForType(input.responseType)
     const item: CherishPulseReviewItem = {
-      id: crypto.randomUUID(),
+      id: clientSubmissionId ?? crypto.randomUUID(),
       cherishValue: input.cherishValue,
       responseType: input.responseType,
       message,
@@ -142,7 +189,6 @@ export async function submitCherishPulseResponse(
       createdAt: now,
     }
 
-    const db = getDb(env.DB)
     await db
       .insert(cherishPulseResponses)
       .values({
@@ -336,6 +382,12 @@ function canSubmitCherishPulse(user: AuthUser): boolean {
       user.role === "secondary_admin" ||
       user.role === "office" ||
       user.role === "field")
+  )
+}
+
+function isValidClientSubmissionId(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value
   )
 }
 

--- a/src/app/dashboard/field/page.tsx
+++ b/src/app/dashboard/field/page.tsx
@@ -1,0 +1,23 @@
+import { notFound } from "next/navigation"
+
+import { getCurrentUser } from "@/lib/auth"
+import { canUseAskCompass, canUseFieldDesk } from "@/lib/permissions"
+import { FieldDesk } from "@/components/field/field-desk"
+
+export default async function FieldDeskPage(): Promise<React.ReactElement> {
+  const user = await getCurrentUser()
+  if (
+    !user?.organizationId ||
+    !canUseFieldDesk(user) ||
+    !canUseAskCompass(user)
+  ) {
+    notFound()
+  }
+
+  return (
+    <FieldDesk
+      offlineScopeKey={`${user.organizationId}:${user.id}`}
+      displayName={user.displayName ?? user.firstName ?? "Team member"}
+    />
+  )
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -29,7 +29,10 @@ import { DesktopOfflineBanner } from "@/components/desktop/offline-banner"
 import { VoiceProvider } from "@/components/voice/voice-provider"
 import { DemoBanner } from "@/components/demo/demo-banner"
 import { isDemoUser } from "@/lib/demo"
-import { canUseAskCompass } from "@/lib/permissions"
+import {
+  canUseAskCompass,
+  canUseFieldDesk,
+} from "@/lib/permissions"
 
 export default async function DashboardLayout({
   children,
@@ -48,9 +51,18 @@ export default async function DashboardLayout({
   const activeOrgName = authUser?.organizationName ?? null
   const isDemo = authUser ? isDemoUser(authUser.id) : false
   const canUseCompassAgent = canUseAskCompass(authUser)
+  const canUseCompassFieldDesk = canUseFieldDesk(authUser)
+  const offlineScopeKey =
+    authUser?.organizationId && authUser.id
+      ? `${authUser.organizationId}:${authUser.id}`
+      : null
 
   return (
-    <ChatProvider enabled={canUseCompassAgent}>
+    <ChatProvider
+      enabled={canUseCompassAgent}
+      offlineScopeKey={offlineScopeKey}
+      canSubmitCherish={canUseCompassFieldDesk}
+    >
     <VoiceProvider>
     <SettingsProvider>
     <ProjectListProvider projects={projectList}>
@@ -75,6 +87,7 @@ export default async function DashboardLayout({
           user={user}
           activeOrgId={activeOrgId}
           activeOrgName={activeOrgName}
+          canUseFieldDesk={canUseCompassFieldDesk}
         />
         <SidebarInset className="overflow-hidden">
           <DesktopOfflineBanner />
@@ -91,7 +104,7 @@ export default async function DashboardLayout({
             {canUseCompassAgent && <ChatPanelShell />}
           </div>
         </SidebarInset>
-        <MobileBottomNav />
+        <MobileBottomNav canUseFieldDesk={canUseCompassFieldDesk} />
         <NativeShell />
         <PushNotificationRegistrar />
         <p className="pointer-events-none fixed bottom-3 left-0 right-0 hidden text-center text-xs text-muted-foreground/60 md:block">

--- a/src/components/agent/chat-provider.tsx
+++ b/src/components/agent/chat-provider.tsx
@@ -20,6 +20,7 @@ import {
   setBridgeConnected as storeBridgeConnected,
   setBridgeEnabled as storeBridgeEnabled,
 } from "@/lib/agent/bridge-store"
+import { useFieldOutboxSync } from "@/hooks/use-field-outbox-sync"
 
 // --- Panel context (open/close sidebar) ---
 
@@ -52,7 +53,7 @@ interface ChatStateValue {
       | AgentMessage[]
       | ((prev: AgentMessage[]) => AgentMessage[])
   ) => void
-  sendMessage: (params: { text: string }) => void
+  sendMessage: (params: { text: string }) => Promise<boolean>
   regenerate: () => void
   stop: () => void
   readonly status: string
@@ -185,19 +186,34 @@ function findGenerateUIOutput(
 export function ChatProvider({
   children,
   enabled = true,
+  offlineScopeKey = null,
+  canSubmitCherish = false,
 }: {
   readonly children: React.ReactNode
   readonly enabled?: boolean
+  readonly offlineScopeKey?: string | null
+  readonly canSubmitCherish?: boolean
 }) {
   if (!enabled) return <>{children}</>
 
-  return <EnabledChatProvider>{children}</EnabledChatProvider>
+  return (
+    <EnabledChatProvider
+      offlineScopeKey={offlineScopeKey}
+      canSubmitCherish={canSubmitCherish}
+    >
+      {children}
+    </EnabledChatProvider>
+  )
 }
 
 function EnabledChatProvider({
   children,
+  offlineScopeKey,
+  canSubmitCherish,
 }: {
   readonly children: React.ReactNode
+  readonly offlineScopeKey: string | null
+  readonly canSubmitCherish: boolean
 }) {
   const [isOpen, setIsOpen] = React.useState(false)
   const [conversationId, setConversationId] =
@@ -265,6 +281,13 @@ function EnabledChatProvider({
 
       await saveConversation(conversationId, serialized)
     },
+  })
+  const fieldOutbox = useFieldOutboxSync({
+    scopeKey: offlineScopeKey,
+    canUseAskJarvis: true,
+    canSubmitCherish,
+    chatStatus: chat.status,
+    sendOnlineMessage: chat.sendMessage,
   })
 
   // UI stream for json-render — stabilize callbacks
@@ -499,61 +522,66 @@ function EnabledChatProvider({
     if (!isOpen || resumeLoaded) return
 
     const resume = async () => {
-      const result = await loadConversations()
-      if (
-        !result.success ||
-        !result.data ||
-        result.data.length === 0
-      ) {
-        setResumeLoaded(true)
-        return
-      }
+      try {
+        const result = await loadConversations()
+        if (
+          !result.success ||
+          !result.data ||
+          result.data.length === 0
+        ) {
+          setResumeLoaded(true)
+          return
+        }
 
-      const lastConv = result.data[0]
-      const msgResult = await loadConversation(lastConv.id)
-      if (
-        !msgResult.success ||
-        !msgResult.data ||
-        msgResult.data.length === 0
-      ) {
-        setResumeLoaded(true)
-        return
-      }
+        const lastConv = result.data[0]
+        const msgResult = await loadConversation(lastConv.id)
+        if (
+          !msgResult.success ||
+          !msgResult.data ||
+          msgResult.data.length === 0
+        ) {
+          setResumeLoaded(true)
+          return
+        }
 
-      setConversationId(lastConv.id)
+        setConversationId(lastConv.id)
 
-      const restored: AgentMessage[] = msgResult.data.map(
-        (m) => ({
-          id: m.id,
-          role: m.role as "user" | "assistant",
-          parts:
-            (m.parts as AgentMessage["parts"]) ?? [
-              { type: "text" as const, text: m.content },
-            ],
-          createdAt: m.createdAt ? new Date(m.createdAt) : new Date(),
-        })
-      )
-
-      // mark all generateUI tool calls from restored messages
-      // as already-dispatched so the watcher doesn't re-trigger
-      // renders or navigate to /dashboard on resume
-      for (const m of restored) {
-        if (m.role !== "assistant") continue
-        let result = findGenerateUIOutput(
-          m.parts,
-          renderDispatchedRef.current
+        const restored: AgentMessage[] = msgResult.data.map(
+          (m) => ({
+            id: m.id,
+            role: m.role as "user" | "assistant",
+            parts:
+              (m.parts as AgentMessage["parts"]) ?? [
+                { type: "text" as const, text: m.content },
+              ],
+            createdAt: m.createdAt ? new Date(m.createdAt) : new Date(),
+          })
         )
-        while (result) {
-          renderDispatchedRef.current.add(result.callId)
-          result = findGenerateUIOutput(
+
+        // mark all generateUI tool calls from restored messages
+        // as already-dispatched so the watcher doesn't re-trigger
+        // renders or navigate to /dashboard on resume
+        for (const m of restored) {
+          if (m.role !== "assistant") continue
+          let result = findGenerateUIOutput(
             m.parts,
             renderDispatchedRef.current
           )
+          while (result) {
+            renderDispatchedRef.current.add(result.callId)
+            result = findGenerateUIOutput(
+              m.parts,
+              renderDispatchedRef.current
+            )
+          }
         }
-      }
 
-      chat.setMessages(restored)
-      setResumeLoaded(true)
+        chat.setMessages(restored)
+        setResumeLoaded(true)
+      } catch {
+        // Offline field users can still open Jarvis and queue a message.
+        setResumeLoaded(true)
+      }
     }
 
     resume()
@@ -582,7 +610,7 @@ function EnabledChatProvider({
     () => ({
       messages: chat.messages,
       setMessages: chat.setMessages,
-      sendMessage: chat.sendMessage,
+      sendMessage: fieldOutbox.sendMessage,
       regenerate: chat.regenerate,
       stop: chat.stop,
       status: chat.status,
@@ -595,7 +623,7 @@ function EnabledChatProvider({
     [
       chat.messages,
       chat.setMessages,
-      chat.sendMessage,
+      fieldOutbox.sendMessage,
       chat.regenerate,
       chat.stop,
       chat.status,

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -8,6 +8,7 @@ import {
   IconClipboardText,
   IconFiles,
   IconFileDollar,
+  IconHeartHandshake,
   IconFolder,
   IconHome2,
   IconMailForward,
@@ -152,8 +153,10 @@ const NAV_MAIN = [
 
 function SidebarNav({
   projects,
+  canUseFieldDesk,
 }: {
   projects: ReadonlyArray<ProjectListItem>
+  readonly canUseFieldDesk: boolean
 }) {
   const pathname = usePathname()
   const { state } = useSidebar()
@@ -177,7 +180,7 @@ function SidebarNav({
         ? "projects"
         : "main"
 
-  const persistentNav = PERSISTENT_NAV.map((item) =>
+  const projectScopedPersistentNav = PERSISTENT_NAV.map((item) =>
     item.title === "To-Dos" && activeProjectId
       ? {
           ...item,
@@ -197,6 +200,17 @@ function SidebarNav({
         }
       : item
   )
+
+  const persistentNav = canUseFieldDesk
+    ? [
+        ...projectScopedPersistentNav,
+        {
+          title: "Field Desk",
+          url: "/dashboard/field",
+          icon: IconHeartHandshake,
+        },
+      ]
+    : projectScopedPersistentNav
 
   return (
     <div key={mode} className="animate-in fade-in slide-in-from-left-1 flex flex-1 flex-col duration-150">
@@ -224,12 +238,14 @@ export function AppSidebar({
   user,
   activeOrgId = null,
   activeOrgName = null,
+  canUseFieldDesk = false,
   ...props
 }: React.ComponentProps<typeof Sidebar> & {
   readonly projects?: ReadonlyArray<ProjectListItem>
   readonly user: SidebarUser | null
   readonly activeOrgId?: string | null
   readonly activeOrgName?: string | null
+  readonly canUseFieldDesk?: boolean
 }) {
   const { isMobile } = useSidebar()
   const { channelId } = useVoiceState()
@@ -240,7 +256,10 @@ export function AppSidebar({
         <OrgSwitcher activeOrgId={activeOrgId} activeOrgName={activeOrgName} />
       </SidebarHeader>
       <SidebarContent className="compass-sidebar-scroll">
-        <SidebarNav projects={projects} />
+        <SidebarNav
+          projects={projects}
+          canUseFieldDesk={canUseFieldDesk}
+        />
       </SidebarContent>
       <SidebarFooter className="border-t border-sidebar-border/60">
         {isMobile && (

--- a/src/components/field/field-desk.tsx
+++ b/src/components/field/field-desk.tsx
@@ -98,10 +98,14 @@ export function FieldDesk({
     }
   }, [offlineScopeKey])
 
-  function queueCherishResponse(trimmedMessage: string): boolean {
+  function queueCherishResponse(
+    trimmedMessage: string,
+    submissionId: string,
+  ): boolean {
     return enqueueFieldOutboxItem(
       offlineScopeKey,
       createCherishPulseOutboxItem({
+        id: submissionId,
         cherishValue,
         responseType,
         message: trimmedMessage,
@@ -126,8 +130,9 @@ export function FieldDesk({
       return
     }
 
+    const submissionId = crypto.randomUUID()
     if (!navigator.onLine) {
-      if (queueCherishResponse(trimmedMessage)) {
+      if (queueCherishResponse(trimmedMessage, submissionId)) {
         resetForm()
         setFeedback(
           "Saved on this device. The response will sync when service returns.",
@@ -146,6 +151,7 @@ export function FieldDesk({
           responseType,
           message: trimmedMessage,
           source: "compass_mobile",
+          clientSubmissionId: submissionId,
         })
         if (!result.success) {
           setFeedback(result.error)
@@ -159,7 +165,7 @@ export function FieldDesk({
             : "Saved to the CHERISH review queue.",
         )
       } catch {
-        if (queueCherishResponse(trimmedMessage)) {
+        if (queueCherishResponse(trimmedMessage, submissionId)) {
           resetForm()
           setFeedback(
             "Connection was interrupted. The response is saved for automatic sync.",

--- a/src/components/field/field-desk.tsx
+++ b/src/components/field/field-desk.tsx
@@ -1,0 +1,339 @@
+"use client"
+
+import { useEffect, useState, useTransition } from "react"
+import {
+  IconCloudCheck,
+  IconCloudOff,
+  IconHeartHandshake,
+  IconMessageCircle,
+} from "@tabler/icons-react"
+
+import {
+  submitCherishPulseResponse,
+  type CherishPulseResponseType,
+  type CherishValue,
+} from "@/app/actions/cherish-pulse"
+import { useChatPanel } from "@/components/agent/chat-provider"
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  createCherishPulseOutboxItem,
+  enqueueFieldOutboxItem,
+  FIELD_OUTBOX_CHANGED_EVENT,
+  listFieldOutboxItems,
+} from "@/lib/field/offline-outbox"
+import { cn } from "@/lib/utils"
+
+const CHERISH_VALUES: readonly CherishValue[] = [
+  "Camaraderie",
+  "Honor",
+  "Excellence",
+  "Reliability",
+  "Integrity",
+  "Servitude",
+  "Humility",
+]
+
+const RESPONSE_TYPES: readonly {
+  readonly value: CherishPulseResponseType
+  readonly label: string
+}[] = [
+  { value: "shoutout", label: "Shoutout" },
+  { value: "win", label: "Project win" },
+  { value: "concern", label: "Private concern" },
+]
+
+export function FieldDesk({
+  offlineScopeKey,
+  displayName,
+}: {
+  readonly offlineScopeKey: string
+  readonly displayName: string
+}): React.ReactElement {
+  const chatPanel = useChatPanel()
+  const [online, setOnline] = useState(true)
+  const [pendingCount, setPendingCount] = useState(0)
+  const [cherishValue, setCherishValue] =
+    useState<CherishValue>("Reliability")
+  const [responseType, setResponseType] =
+    useState<CherishPulseResponseType>("shoutout")
+  const [message, setMessage] = useState("")
+  const [feedback, setFeedback] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  useEffect(() => {
+    function refresh(): void {
+      setOnline(navigator.onLine)
+      setPendingCount(listFieldOutboxItems(offlineScopeKey).length)
+    }
+
+    function handleOutboxChanged(event: Event): void {
+      if (!(event instanceof CustomEvent)) return
+      const detail: unknown = event.detail
+      if (
+        typeof detail === "object" &&
+        detail !== null &&
+        "scopeKey" in detail &&
+        detail.scopeKey === offlineScopeKey
+      ) {
+        refresh()
+      }
+    }
+
+    refresh()
+    window.addEventListener("online", refresh)
+    window.addEventListener("offline", refresh)
+    window.addEventListener(FIELD_OUTBOX_CHANGED_EVENT, handleOutboxChanged)
+    return () => {
+      window.removeEventListener("online", refresh)
+      window.removeEventListener("offline", refresh)
+      window.removeEventListener(FIELD_OUTBOX_CHANGED_EVENT, handleOutboxChanged)
+    }
+  }, [offlineScopeKey])
+
+  function queueCherishResponse(trimmedMessage: string): boolean {
+    return enqueueFieldOutboxItem(
+      offlineScopeKey,
+      createCherishPulseOutboxItem({
+        cherishValue,
+        responseType,
+        message: trimmedMessage,
+      }),
+    )
+  }
+
+  function resetForm(): void {
+    setMessage("")
+    setFeedback(null)
+  }
+
+  function submitResponse(): void {
+    const trimmedMessage = message.trim()
+    if (trimmedMessage.length < 3) {
+      setFeedback("Add a little more detail before submitting.")
+      return
+    }
+
+    if (trimmedMessage.length > 1_200) {
+      setFeedback("Keep CHERISH responses under 1,200 characters.")
+      return
+    }
+
+    if (!navigator.onLine) {
+      if (queueCherishResponse(trimmedMessage)) {
+        resetForm()
+        setFeedback(
+          "Saved on this device. The response will sync when service returns.",
+        )
+      } else {
+        setFeedback("Unable to save this response for later.")
+      }
+      return
+    }
+
+    startTransition(async () => {
+      setFeedback(null)
+      try {
+        const result = await submitCherishPulseResponse({
+          cherishValue,
+          responseType,
+          message: trimmedMessage,
+          source: "compass_mobile",
+        })
+        if (!result.success) {
+          setFeedback(result.error)
+          return
+        }
+
+        resetForm()
+        setFeedback(
+          responseType === "concern"
+            ? "Saved privately for leadership review."
+            : "Saved to the CHERISH review queue.",
+        )
+      } catch {
+        if (queueCherishResponse(trimmedMessage)) {
+          resetForm()
+          setFeedback(
+            "Connection was interrupted. The response is saved for automatic sync.",
+          )
+        } else {
+          setFeedback("Unable to save this response.")
+        }
+      }
+    })
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-4xl px-4 py-5 sm:px-6">
+      <header className="border-b pb-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-sm text-muted-foreground">Field Desk</p>
+            <h1 className="text-2xl font-semibold tracking-tight">
+              Welcome, {displayName}
+            </h1>
+          </div>
+          <div
+            className={cn(
+              "flex items-center gap-2 text-sm",
+              online ? "text-emerald-700" : "text-amber-700",
+            )}
+          >
+            {online ? (
+              <IconCloudCheck className="size-5" />
+            ) : (
+              <IconCloudOff className="size-5" />
+            )}
+            <span>{online ? "Online" : "Offline — changes will sync later"}</span>
+          </div>
+        </div>
+        {pendingCount > 0 && (
+          <p className="mt-2 text-sm text-amber-700">
+            {pendingCount} field {pendingCount === 1 ? "item" : "items"} pending
+            sync on this device.
+          </p>
+        )}
+      </header>
+
+      <section className="grid gap-3 border-b py-5 sm:grid-cols-[1fr_auto] sm:items-center">
+        <div>
+          <div className="flex items-center gap-2">
+            <IconMessageCircle className="size-5 text-primary" />
+            <h2 className="text-lg font-semibold">Ask Jarvis</h2>
+          </div>
+          <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">
+            Ask a project question or describe something that needs follow-up.
+            Text messages written without service stay on this device and send
+            automatically after reconnection.
+          </p>
+        </div>
+        <Button type="button" onClick={chatPanel.open}>
+          Open Jarvis
+        </Button>
+      </section>
+
+      <section className="py-5">
+        <div className="flex items-center gap-2">
+          <IconHeartHandshake className="size-5 text-emerald-700" />
+          <h2 className="text-lg font-semibold">CHERISH feedback</h2>
+        </div>
+        <p className="mt-1 text-sm leading-6 text-muted-foreground">
+          Share a team shoutout, a project win, or a private concern. Offline
+          responses remain scoped to your Compass account on this device.
+        </p>
+
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">
+              CHERISH value
+            </label>
+            <Select
+              value={cherishValue}
+              onValueChange={(value) => {
+                const nextValue = CHERISH_VALUES.find(
+                  (candidate) => candidate === value,
+                )
+                if (nextValue) setCherishValue(nextValue)
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CHERISH_VALUES.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {value}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium">
+              Response type
+            </label>
+            <Select
+              value={responseType}
+              onValueChange={(value) => {
+                if (
+                  value === "shoutout" ||
+                  value === "win" ||
+                  value === "concern"
+                ) {
+                  setResponseType(value)
+                }
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RESPONSE_TYPES.map((type) => (
+                  <SelectItem key={type.value} value={type.value}>
+                    {type.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <label className="mb-1.5 mt-3 block text-sm font-medium">
+          Message
+        </label>
+        <Textarea
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          placeholder={
+            responseType === "concern"
+              ? "What should leadership know?"
+              : "What happened, and who helped?"
+          }
+          className="min-h-28 resize-y"
+          maxLength={1_200}
+        />
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+          <p
+            className={cn(
+              "text-sm",
+              feedback?.startsWith("Unable") ||
+                feedback?.startsWith("Add") ||
+                feedback?.startsWith("Keep")
+                ? "text-destructive"
+                : "text-muted-foreground",
+            )}
+          >
+            {feedback ??
+              (responseType === "concern"
+                ? "Private concerns are visible only to leadership reviewers."
+                : "Team responses are visible after review.")}
+          </p>
+          <Button
+            type="button"
+            onClick={submitResponse}
+            disabled={isPending || message.trim().length < 3}
+          >
+            {isPending ? "Saving..." : online ? "Submit" : "Save for sync"}
+          </Button>
+        </div>
+      </section>
+
+      <footer className="border-t pt-4 text-sm leading-6 text-muted-foreground">
+        Secure photo, video, and document handoff to Jarvis is planned as the
+        next field phase. The existing project-photo queue is intentionally not
+        reused until Compass can preserve attachment ownership, project scope,
+        and an explicit conversion target such as a daily log, to-do, RFI, or
+        delivery notification.
+      </footer>
+    </div>
+  )
+}

--- a/src/components/mobile-bottom-nav.tsx
+++ b/src/components/mobile-bottom-nav.tsx
@@ -11,6 +11,7 @@ import {
   IconSettingsFilled,
   IconFile,
   IconFileFilled,
+  IconHeartHandshake,
 } from "@tabler/icons-react"
 import { cn } from "@/lib/utils"
 
@@ -65,7 +66,11 @@ function NavItem({
   )
 }
 
-export function MobileBottomNav() {
+export function MobileBottomNav({
+  canUseFieldDesk = false,
+}: {
+  readonly canUseFieldDesk?: boolean
+}) {
   const pathname = usePathname()
 
   const isActive = (path: string) => {
@@ -80,7 +85,12 @@ export function MobileBottomNav() {
         "border-t bg-background"
       )}
     >
-      <div className="grid h-14 grid-cols-4 items-center pb-[env(safe-area-inset-bottom)]">
+      <div
+        className={cn(
+          "grid h-14 items-center pb-[env(safe-area-inset-bottom)]",
+          canUseFieldDesk ? "grid-cols-5" : "grid-cols-4",
+        )}
+      >
         <NavItem
           href="/dashboard"
           icon={<IconHome className="size-[22px]" />}
@@ -97,6 +107,15 @@ export function MobileBottomNav() {
           label="Projects"
           isActive={isActive("/dashboard/projects")}
         />
+        {canUseFieldDesk && (
+          <NavItem
+            href="/dashboard/field"
+            icon={<IconHeartHandshake className="size-[22px]" />}
+            activeIcon={<IconHeartHandshake className="size-[22px]" />}
+            label="Field"
+            isActive={isActive("/dashboard/field")}
+          />
+        )}
         <NavItem
           href="/dashboard/settings"
           icon={<IconSettings className="size-[22px]" />}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -75,11 +75,15 @@ export function SiteHeader({
             type="button"
             className="flex h-9 flex-1 items-center gap-2 rounded-full px-2 hover:bg-background/60"
             onClick={openCommand}
-            aria-label="Ask Jarvis or search Compass"
+            aria-label={
+              canUseAskCompass
+                ? "Ask Jarvis or search Compass"
+                : "Search Compass"
+            }
           >
             <IconSearch className="size-4 text-muted-foreground shrink-0" />
             <span className="text-muted-foreground text-sm">
-              Ask Jarvis or search...
+              {canUseAskCompass ? "Ask Jarvis or search..." : "Search Compass..."}
             </span>
           </button>
           <button
@@ -156,7 +160,11 @@ export function SiteHeader({
                 searchInputRef.current?.blur()
               }
             }}
-            placeholder="Ask Jarvis or search Compass..."
+            placeholder={
+              canUseAskCompass
+                ? "Ask Jarvis or search Compass..."
+                : "Search Compass..."
+            }
             className="flex h-8 w-full items-center rounded-full border border-border/50 bg-muted/30 pl-9 pr-16 text-sm outline-none transition-colors placeholder:text-muted-foreground/60 hover:bg-muted/50 focus:bg-muted/50 focus:border-border"
           />
           <kbd

--- a/src/hooks/use-agent.ts
+++ b/src/hooks/use-agent.ts
@@ -18,7 +18,7 @@ export interface UseAgentReturn {
   setMessages: (
     msgs: AgentMessage[] | ((prev: AgentMessage[]) => AgentMessage[])
   ) => void
-  sendMessage: (params: { text: string }) => void
+  sendMessage: (params: { text: string }) => Promise<boolean>
   stop: () => void
   regenerate: () => void
   readonly status: "ready" | "streaming" | "error"
@@ -46,9 +46,9 @@ export function useAgent(options: UseAgentOptions = {}): UseAgentReturn {
   const dispatchedRef = useRef(new Set<string>())
 
   const sendMessage = useCallback(
-    async (params: { text: string }) => {
-      if (status === "streaming") return
-      if (!params.text.trim()) return
+    async (params: { text: string }): Promise<boolean> => {
+      if (status === "streaming") return false
+      if (!params.text.trim()) return false
 
       // add user message
       const userMessage: AgentMessage = {
@@ -180,9 +180,16 @@ export function useAgent(options: UseAgentOptions = {}): UseAgentReturn {
               setMessages(finalMessages)
 
               if (onFinish) {
-                await onFinish(finalMessages)
+                try {
+                  await onFinish(finalMessages)
+                } catch (finishError) {
+                  console.error(
+                    "Agent response completed but conversation persistence failed:",
+                    finishError,
+                  )
+                }
               }
-              return
+              return true
             }
 
             try {
@@ -293,7 +300,7 @@ export function useAgent(options: UseAgentOptions = {}): UseAgentReturn {
                 case "error": {
                   setError(event.error)
                   setStatus("error")
-                  return
+                  return false
                 }
               }
 
@@ -328,8 +335,16 @@ export function useAgent(options: UseAgentOptions = {}): UseAgentReturn {
         setMessages(finalMessages)
 
         if (onFinish) {
-          await onFinish(finalMessages)
+          try {
+            await onFinish(finalMessages)
+          } catch (finishError) {
+            console.error(
+              "Agent response completed but conversation persistence failed:",
+              finishError,
+            )
+          }
         }
+        return true
       } catch (err) {
         if (err instanceof Error && err.name === "AbortError") {
           setStatus("ready")
@@ -339,6 +354,7 @@ export function useAgent(options: UseAgentOptions = {}): UseAgentReturn {
           setError(errMsg)
           setStatus("error")
         }
+        return false
       } finally {
         abortControllerRef.current = null
       }

--- a/src/hooks/use-field-outbox-sync.ts
+++ b/src/hooks/use-field-outbox-sync.ts
@@ -1,0 +1,180 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { toast } from "sonner"
+
+import { submitCherishPulseResponse } from "@/app/actions/cherish-pulse"
+import {
+  createJarvisPromptOutboxItem,
+  enqueueFieldOutboxItem,
+  FIELD_OUTBOX_CHANGED_EVENT,
+  listFieldOutboxItems,
+  removeFieldOutboxItem,
+  type FieldOutboxItem,
+} from "@/lib/field/offline-outbox"
+
+type SendOnlineMessage = (params: {
+  readonly text: string
+}) => Promise<boolean>
+
+export function useFieldOutboxSync(input: {
+  readonly scopeKey: string | null
+  readonly canUseAskJarvis: boolean
+  readonly canSubmitCherish: boolean
+  readonly chatStatus: string
+  readonly sendOnlineMessage: SendOnlineMessage
+}): {
+  readonly sendMessage: SendOnlineMessage
+  readonly pendingCount: number
+} {
+  const {
+    scopeKey,
+    canUseAskJarvis,
+    canSubmitCherish,
+    chatStatus,
+    sendOnlineMessage,
+  } = input
+  const [revision, setRevision] = useState(0)
+  const processingRef = useRef(false)
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const refresh = useCallback(() => {
+    setRevision((current) => current + 1)
+  }, [])
+
+  useEffect(() => {
+    function handleChanged(event: Event): void {
+      if (!(event instanceof CustomEvent)) return
+      const detail: unknown = event.detail
+      if (
+        typeof detail === "object" &&
+        detail !== null &&
+        "scopeKey" in detail &&
+        detail.scopeKey === scopeKey
+      ) {
+        refresh()
+      }
+    }
+
+    window.addEventListener("online", refresh)
+    window.addEventListener(FIELD_OUTBOX_CHANGED_EVENT, handleChanged)
+    return () => {
+      window.removeEventListener("online", refresh)
+      window.removeEventListener(FIELD_OUTBOX_CHANGED_EVENT, handleChanged)
+    }
+  }, [refresh, scopeKey])
+
+  useEffect(
+    () => () => {
+      if (retryTimerRef.current !== null) {
+        clearTimeout(retryTimerRef.current)
+      }
+    },
+    [],
+  )
+
+  useEffect(() => {
+    if (
+      !scopeKey ||
+      !navigator.onLine ||
+      processingRef.current ||
+      chatStatus === "streaming"
+    ) {
+      return
+    }
+
+    const item = listFieldOutboxItems(scopeKey).find((candidate) => {
+      if (candidate.kind === "jarvis_prompt") return canUseAskJarvis
+      return canSubmitCherish
+    })
+    if (!item) return
+
+    processingRef.current = true
+    let completed = false
+
+    async function processItem(
+      pendingItem: FieldOutboxItem,
+    ): Promise<void> {
+      if (pendingItem.kind === "jarvis_prompt") {
+        completed = await sendOnlineMessage({ text: pendingItem.text })
+        return
+      }
+
+      const result = await submitCherishPulseResponse({
+        cherishValue: pendingItem.cherishValue,
+        responseType: pendingItem.responseType,
+        message: pendingItem.message,
+        source: "compass_mobile",
+      })
+      completed = result.success
+    }
+
+    void processItem(item)
+      .catch(() => {
+        completed = false
+      })
+      .finally(() => {
+        processingRef.current = false
+        if (!completed) {
+          if (retryTimerRef.current !== null) {
+            clearTimeout(retryTimerRef.current)
+          }
+          retryTimerRef.current = setTimeout(refresh, 30_000)
+          return
+        }
+
+        if (retryTimerRef.current !== null) {
+          clearTimeout(retryTimerRef.current)
+          retryTimerRef.current = null
+        }
+        removeFieldOutboxItem(scopeKey, item.id)
+        refresh()
+        toast.success(
+          item.kind === "jarvis_prompt"
+            ? "Pending message sent to Jarvis."
+            : "Pending CHERISH response synced.",
+        )
+      })
+  }, [
+    canSubmitCherish,
+    canUseAskJarvis,
+    chatStatus,
+    refresh,
+    revision,
+    scopeKey,
+    sendOnlineMessage,
+  ])
+
+  const sendMessage = useCallback<SendOnlineMessage>(
+    async ({ text }) => {
+      const trimmed = text.trim()
+      if (!trimmed || !canUseAskJarvis) return false
+
+      if (!scopeKey || navigator.onLine) {
+        return sendOnlineMessage({ text: trimmed })
+      }
+
+      const queued = enqueueFieldOutboxItem(
+        scopeKey,
+        createJarvisPromptOutboxItem(trimmed),
+      )
+      if (!queued) {
+        toast.error("Unable to save this message for later.")
+        return false
+      }
+
+      refresh()
+      toast.success(
+        "Message saved on this device. Jarvis will receive it when you reconnect.",
+      )
+      return true
+    },
+    [canUseAskJarvis, refresh, scopeKey, sendOnlineMessage],
+  )
+
+  const pendingCount = scopeKey
+    ? listFieldOutboxItems(scopeKey).length
+    : 0
+
+  return { sendMessage, pendingCount }
+}

--- a/src/hooks/use-field-outbox-sync.ts
+++ b/src/hooks/use-field-outbox-sync.ts
@@ -105,6 +105,7 @@ export function useFieldOutboxSync(input: {
         responseType: pendingItem.responseType,
         message: pendingItem.message,
         source: "compass_mobile",
+        clientSubmissionId: pendingItem.id,
       })
       completed = result.success
     }

--- a/src/lib/__tests__/permissions.test.ts
+++ b/src/lib/__tests__/permissions.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 import type { AuthUser } from "@/lib/auth"
-import { canUseAskCompass } from "@/lib/permissions"
+import {
+  canUseAskCompass,
+  canUseFieldDesk,
+} from "@/lib/permissions"
 
 function userWithRole(role: string): AuthUser {
   return {
@@ -42,5 +45,31 @@ describe("canUseAskCompass", () => {
     expect(canUseAskCompass(inactiveAdmin)).toBe(false)
     expect(canUseAskCompass(userWithRole("client"))).toBe(false)
     expect(canUseAskCompass(null)).toBe(false)
+  })
+})
+
+describe("canUseFieldDesk", () => {
+  it.each(["admin", "office", "field"])(
+    "allows active internal role %s",
+    (role) => {
+      expect(canUseFieldDesk(userWithRole(role))).toBe(true)
+    },
+  )
+
+  it.each(["secondary_admin", "client", "guest", "unknown"])(
+    "denies external or unknown role %s",
+    (role) => {
+      expect(canUseFieldDesk(userWithRole(role))).toBe(false)
+    },
+  )
+
+  it("denies inactive and unauthenticated users", () => {
+    expect(
+      canUseFieldDesk({
+        ...userWithRole("field"),
+        isActive: false,
+      }),
+    ).toBe(false)
+    expect(canUseFieldDesk(null)).toBe(false)
   })
 })

--- a/src/lib/field/__tests__/offline-outbox.test.ts
+++ b/src/lib/field/__tests__/offline-outbox.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  enqueueFieldOutboxItem,
+  listFieldOutboxItems,
+  removeFieldOutboxItem,
+  type FieldOutboxCherishPulse,
+  type FieldOutboxStorage,
+} from "@/lib/field/offline-outbox"
+
+class MemoryStorage implements FieldOutboxStorage {
+  private readonly values = new Map<string, string>()
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value)
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key)
+  }
+
+  firstValue(): string | null {
+    return this.values.values().next().value ?? null
+  }
+}
+
+function jarvisItem(id: string): {
+  readonly id: string
+  readonly kind: "jarvis_prompt"
+  readonly text: string
+  readonly createdAt: string
+} {
+  return {
+    id,
+    kind: "jarvis_prompt",
+    text: `Prompt ${id}`,
+    createdAt: new Date().toISOString(),
+  }
+}
+
+describe("field offline outbox", () => {
+  it("keeps pending work isolated by organization and user scope", () => {
+    const storage = new MemoryStorage()
+    const firstItem = jarvisItem("one")
+    const secondItem = jarvisItem("two")
+
+    expect(
+      enqueueFieldOutboxItem("org-a:user-a", firstItem, storage),
+    ).toBe(true)
+    expect(
+      enqueueFieldOutboxItem("org-a:user-b", secondItem, storage),
+    ).toBe(true)
+
+    expect(listFieldOutboxItems("org-a:user-a", storage)).toEqual([firstItem])
+    expect(listFieldOutboxItems("org-a:user-b", storage)).toEqual([secondItem])
+    expect(listFieldOutboxItems("org-b:user-a", storage)).toEqual([])
+  })
+
+  it("stores CHERISH inputs needed for an authenticated replay", () => {
+    const storage = new MemoryStorage()
+    const item: FieldOutboxCherishPulse = {
+      id: "pulse-1",
+      kind: "cherish_pulse",
+      cherishValue: "Integrity",
+      responseType: "concern",
+      message: "Please review this privately.",
+      createdAt: new Date().toISOString(),
+    }
+
+    expect(enqueueFieldOutboxItem("org:user", item, storage)).toBe(true)
+    expect(listFieldOutboxItems("org:user", storage)).toEqual([item])
+
+    removeFieldOutboxItem("org:user", item.id, storage)
+    expect(listFieldOutboxItems("org:user", storage)).toEqual([])
+  })
+
+  it("rejects malformed items and recovers from corrupt storage", () => {
+    const storage = new MemoryStorage()
+    storage.setItem(
+      "compass_field_outbox_v1:org%3Auser",
+      "{not-valid-json",
+    )
+
+    expect(listFieldOutboxItems("org:user", storage)).toEqual([])
+    expect(
+      enqueueFieldOutboxItem(
+        "org:user",
+        {
+          ...jarvisItem("empty"),
+          text: "",
+        },
+        storage,
+      ),
+    ).toBe(false)
+  })
+
+  it("caps device storage to the newest fifty items", () => {
+    const storage = new MemoryStorage()
+    for (let index = 0; index < 55; index += 1) {
+      enqueueFieldOutboxItem(
+        "org:user",
+        jarvisItem(String(index).padStart(2, "0")),
+        storage,
+      )
+    }
+
+    const items = listFieldOutboxItems("org:user", storage)
+    expect(items).toHaveLength(50)
+    expect(items[0]?.id).toBe("05")
+    expect(items[49]?.id).toBe("54")
+    expect(storage.firstValue()).not.toBeNull()
+  })
+})

--- a/src/lib/field/__tests__/offline-outbox.test.ts
+++ b/src/lib/field/__tests__/offline-outbox.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  createCherishPulseOutboxItem,
   enqueueFieldOutboxItem,
   listFieldOutboxItems,
   removeFieldOutboxItem,
@@ -76,6 +77,18 @@ describe("field offline outbox", () => {
 
     removeFieldOutboxItem("org:user", item.id, storage)
     expect(listFieldOutboxItems("org:user", storage)).toEqual([])
+  })
+
+  it("preserves a client submission id across an online retry", () => {
+    const id = "51da9e0f-a85e-4ad3-81ef-3881062413bc"
+    const item = createCherishPulseOutboxItem({
+      id,
+      cherishValue: "Integrity",
+      responseType: "concern",
+      message: "Please review this privately.",
+    })
+
+    expect(item.id).toBe(id)
   })
 
   it("rejects malformed items and recovers from corrupt storage", () => {

--- a/src/lib/field/offline-outbox.ts
+++ b/src/lib/field/offline-outbox.ts
@@ -224,12 +224,13 @@ export function createJarvisPromptOutboxItem(
 }
 
 export function createCherishPulseOutboxItem(input: {
+  readonly id?: string
   readonly cherishValue: CherishValue
   readonly responseType: CherishPulseResponseType
   readonly message: string
 }): FieldOutboxCherishPulse {
   return {
-    id: crypto.randomUUID(),
+    id: input.id ?? crypto.randomUUID(),
     kind: "cherish_pulse",
     cherishValue: input.cherishValue,
     responseType: input.responseType,

--- a/src/lib/field/offline-outbox.ts
+++ b/src/lib/field/offline-outbox.ts
@@ -1,0 +1,239 @@
+import type {
+  CherishPulseResponseType,
+  CherishValue,
+} from "@/app/actions/cherish-pulse"
+
+export type FieldOutboxJarvisPrompt = {
+  readonly id: string
+  readonly kind: "jarvis_prompt"
+  readonly text: string
+  readonly createdAt: string
+}
+
+export type FieldOutboxCherishPulse = {
+  readonly id: string
+  readonly kind: "cherish_pulse"
+  readonly cherishValue: CherishValue
+  readonly responseType: CherishPulseResponseType
+  readonly message: string
+  readonly createdAt: string
+}
+
+export type FieldOutboxItem =
+  | FieldOutboxJarvisPrompt
+  | FieldOutboxCherishPulse
+
+export type FieldOutboxStorage = {
+  readonly getItem: (key: string) => string | null
+  readonly setItem: (key: string, value: string) => void
+  readonly removeItem: (key: string) => void
+}
+
+type StoredOutbox = {
+  readonly version: 1
+  readonly items: readonly FieldOutboxItem[]
+}
+
+const STORAGE_PREFIX = "compass_field_outbox_v1"
+const MAX_ITEMS = 50
+const MAX_ITEM_AGE_MS = 7 * 24 * 60 * 60 * 1000
+export const FIELD_OUTBOX_CHANGED_EVENT = "compass-field-outbox-changed"
+
+const CHERISH_VALUES: readonly CherishValue[] = [
+  "Camaraderie",
+  "Honor",
+  "Excellence",
+  "Reliability",
+  "Integrity",
+  "Servitude",
+  "Humility",
+]
+
+function defaultStorage(): FieldOutboxStorage | null {
+  if (typeof window === "undefined") return null
+  return window.localStorage
+}
+
+function storageKey(scopeKey: string): string {
+  return `${STORAGE_PREFIX}:${encodeURIComponent(scopeKey)}`
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isCherishValue(value: unknown): value is CherishValue {
+  return (
+    typeof value === "string" &&
+    CHERISH_VALUES.some((candidate) => candidate === value)
+  )
+}
+
+function isResponseType(
+  value: unknown,
+): value is CherishPulseResponseType {
+  return value === "shoutout" || value === "concern" || value === "win"
+}
+
+function parseItem(value: unknown): FieldOutboxItem | null {
+  if (!isRecord(value)) return null
+  if (
+    typeof value.id !== "string" ||
+    typeof value.createdAt !== "string"
+  ) {
+    return null
+  }
+
+  if (
+    value.kind === "jarvis_prompt" &&
+    typeof value.text === "string" &&
+    value.text.trim().length > 0 &&
+    value.text.length <= 20_000
+  ) {
+    return {
+      id: value.id,
+      kind: "jarvis_prompt",
+      text: value.text,
+      createdAt: value.createdAt,
+    }
+  }
+
+  if (
+    value.kind === "cherish_pulse" &&
+    isCherishValue(value.cherishValue) &&
+    isResponseType(value.responseType) &&
+    typeof value.message === "string" &&
+    value.message.trim().length >= 3 &&
+    value.message.length <= 1_200
+  ) {
+    return {
+      id: value.id,
+      kind: "cherish_pulse",
+      cherishValue: value.cherishValue,
+      responseType: value.responseType,
+      message: value.message,
+      createdAt: value.createdAt,
+    }
+  }
+
+  return null
+}
+
+function parseStoredOutbox(raw: string | null): StoredOutbox {
+  if (!raw) return { version: 1, items: [] }
+
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (
+      !isRecord(parsed) ||
+      parsed.version !== 1 ||
+      !Array.isArray(parsed.items)
+    ) {
+      return { version: 1, items: [] }
+    }
+
+    const now = Date.now()
+    const items = parsed.items
+      .map(parseItem)
+      .filter((item): item is FieldOutboxItem => item !== null)
+      .filter((item) => {
+        const createdAt = new Date(item.createdAt).getTime()
+        return (
+          Number.isFinite(createdAt) &&
+          now - createdAt <= MAX_ITEM_AGE_MS
+        )
+      })
+      .slice(-MAX_ITEMS)
+
+    return { version: 1, items }
+  } catch {
+    return { version: 1, items: [] }
+  }
+}
+
+function notifyOutboxChanged(scopeKey: string): void {
+  if (typeof window === "undefined") return
+  window.dispatchEvent(
+    new CustomEvent(FIELD_OUTBOX_CHANGED_EVENT, {
+      detail: { scopeKey },
+    }),
+  )
+}
+
+function writeItems(
+  scopeKey: string,
+  items: readonly FieldOutboxItem[],
+  storage: FieldOutboxStorage,
+): void {
+  if (items.length === 0) {
+    storage.removeItem(storageKey(scopeKey))
+  } else {
+    storage.setItem(
+      storageKey(scopeKey),
+      JSON.stringify({
+        version: 1,
+        items: items.slice(-MAX_ITEMS),
+      }),
+    )
+  }
+  notifyOutboxChanged(scopeKey)
+}
+
+export function listFieldOutboxItems(
+  scopeKey: string,
+  storage: FieldOutboxStorage | null = defaultStorage(),
+): readonly FieldOutboxItem[] {
+  if (!storage || !scopeKey) return []
+  return parseStoredOutbox(storage.getItem(storageKey(scopeKey))).items
+}
+
+export function enqueueFieldOutboxItem(
+  scopeKey: string,
+  item: FieldOutboxItem,
+  storage: FieldOutboxStorage | null = defaultStorage(),
+): boolean {
+  if (!storage || !scopeKey || parseItem(item) === null) return false
+  const items = listFieldOutboxItems(scopeKey, storage)
+  writeItems(scopeKey, [...items, item], storage)
+  return true
+}
+
+export function removeFieldOutboxItem(
+  scopeKey: string,
+  itemId: string,
+  storage: FieldOutboxStorage | null = defaultStorage(),
+): void {
+  if (!storage || !scopeKey) return
+  const items = listFieldOutboxItems(scopeKey, storage)
+  writeItems(
+    scopeKey,
+    items.filter((item) => item.id !== itemId),
+    storage,
+  )
+}
+
+export function createJarvisPromptOutboxItem(
+  text: string,
+): FieldOutboxJarvisPrompt {
+  return {
+    id: crypto.randomUUID(),
+    kind: "jarvis_prompt",
+    text: text.trim(),
+    createdAt: new Date().toISOString(),
+  }
+}
+
+export function createCherishPulseOutboxItem(input: {
+  readonly cherishValue: CherishValue
+  readonly responseType: CherishPulseResponseType
+  readonly message: string
+}): FieldOutboxCherishPulse {
+  return {
+    id: crypto.randomUUID(),
+    kind: "cherish_pulse",
+    cherishValue: input.cherishValue,
+    responseType: input.responseType,
+    message: input.message.trim(),
+    createdAt: new Date().toISOString(),
+  }
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -115,6 +115,20 @@ export function canUseAskCompass(user: AuthUser | null): boolean {
   return user?.role !== "guest" && can(user, "agent", "read")
 }
 
+/**
+ * The field desk is an internal staff surface. Client and guest accounts must
+ * never receive its Jarvis or CHERISH submission controls.
+ */
+export function canUseFieldDesk(user: AuthUser | null): boolean {
+  if (!canUseAskCompass(user)) return false
+  if (!user) return false
+  return (
+    user.role === "admin" ||
+    user.role === "office" ||
+    user.role === "field"
+  )
+}
+
 export function requirePermission(
   user: AuthUser | null,
   resource: Resource,


### PR DESCRIPTION
## Summary

- add a permission-gated Field Desk for field, office, and admin staff while keeping guests, clients, and inactive users out
- expose Ask Jarvis and CHERISH from desktop and mobile navigation
- queue Jarvis text and CHERISH submissions when the device is offline and replay them after connectivity returns
- scope queued content to the active organization and user, cap device retention, and document the offline behavior
- make CHERISH replay idempotent with a device-generated submission ID so retries do not create duplicate responses
- preserve project-scoped To-Dos navigation introduced on main

## Security and scope

- server-side permission checks remain authoritative for the route and actions
- no authentication claims or credentials are stored in the device outbox
- this first phase queues text/CHERISH content only; secure photo, video, and document conversion remains tracked
- true cold-launch service-worker support and native airplane-mode QA remain tracked

## Verification

- `bunx tsc --noEmit`
- `bun run test` (249 passed, 3 skipped)
- `bun lint` (0 errors; existing warnings only)
- `git diff --check origin/main...HEAD`

Advances #137 and #138.
