### PR TITLE
feat(schedule): add managed Work Calendar events

### DIFF
--- a/drizzle/0067_work_calendar_events.sql
+++ b/drizzle/0067_work_calendar_events.sql
@@ -1,0 +1,162 @@
+CREATE TABLE `organization_calendar_settings` (
+  `organization_id` text PRIMARY KEY NOT NULL,
+  `default_project_id` text,
+  `time_zone` text NOT NULL DEFAULT 'America/Denver',
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`default_project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+INSERT OR IGNORE INTO `organization_calendar_settings` (
+  `organization_id`,
+  `default_project_id`,
+  `time_zone`,
+  `created_at`,
+  `updated_at`
+)
+SELECT
+  organization.`id`,
+  NULL,
+  'America/Denver',
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+FROM `organizations` AS organization;
+--> statement-breakpoint
+CREATE TABLE `work_calendar_events` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `project_id` text,
+  `title` text NOT NULL,
+  `description` text,
+  `start_date` text,
+  `end_date_exclusive` text,
+  `starts_at` text,
+  `ends_at` text,
+  `all_day` integer NOT NULL DEFAULT 0,
+  `time_zone` text NOT NULL DEFAULT 'UTC',
+  `location` text,
+  `status` text NOT NULL DEFAULT 'open',
+  `version` integer NOT NULL DEFAULT 1,
+  `created_by` text,
+  `updated_by` text,
+  `cancelled_by` text,
+  `cancelled_at` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`updated_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`cancelled_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  CHECK (`status` IN ('open', 'cancelled')),
+  CHECK (
+    (
+      `all_day` = 1
+      AND `start_date` IS NOT NULL
+      AND `end_date_exclusive` IS NOT NULL
+      AND `starts_at` IS NULL
+      AND `ends_at` IS NULL
+      AND `start_date` < `end_date_exclusive`
+    )
+    OR
+    (
+      `all_day` = 0
+      AND `start_date` IS NULL
+      AND `end_date_exclusive` IS NULL
+      AND `starts_at` IS NOT NULL
+      AND `ends_at` IS NOT NULL
+      AND `starts_at` < `ends_at`
+    )
+  )
+);
+--> statement-breakpoint
+CREATE INDEX `idx_work_calendar_events_org_start`
+  ON `work_calendar_events` (
+    `organization_id`,
+    `status`,
+    `start_date`,
+    `starts_at`
+  );
+--> statement-breakpoint
+CREATE INDEX `idx_work_calendar_events_project_start`
+  ON `work_calendar_events` (
+    `project_id`,
+    `status`,
+    `start_date`,
+    `starts_at`
+  );
+--> statement-breakpoint
+CREATE TABLE `work_calendar_event_attendees` (
+  `id` text PRIMARY KEY NOT NULL,
+  `event_id` text NOT NULL,
+  `user_id` text NOT NULL,
+  `response_status` text NOT NULL DEFAULT 'needs_action',
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`event_id`) REFERENCES `work_calendar_events`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+  CHECK (`response_status` IN ('needs_action', 'accepted', 'tentative', 'declined'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `work_calendar_event_attendee_unique`
+  ON `work_calendar_event_attendees` (`event_id`, `user_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_work_calendar_event_attendees_user`
+  ON `work_calendar_event_attendees` (`user_id`);
+--> statement-breakpoint
+INSERT OR IGNORE INTO `work_calendar_events` (
+  `id`,
+  `organization_id`,
+  `project_id`,
+  `title`,
+  `description`,
+  `start_date`,
+  `end_date_exclusive`,
+  `starts_at`,
+  `ends_at`,
+  `all_day`,
+  `time_zone`,
+  `location`,
+  `status`,
+  `version`,
+  `created_by`,
+  `updated_by`,
+  `cancelled_by`,
+  `cancelled_at`,
+  `created_at`,
+  `updated_at`
+)
+SELECT
+  operation.`id`,
+  project.`organization_id`,
+  operation.`project_id`,
+  operation.`title`,
+  operation.`description`,
+  COALESCE(operation.`start_date`, operation.`due_date`),
+  date(COALESCE(operation.`due_date`, operation.`start_date`), '+1 day'),
+  NULL,
+  NULL,
+  1,
+  'UTC',
+  NULL,
+  CASE
+    WHEN lower(operation.`status`) = 'cancelled' THEN 'cancelled'
+    ELSE 'open'
+  END,
+  1,
+  NULL,
+  NULL,
+  NULL,
+  CASE
+    WHEN lower(operation.`status`) = 'cancelled' THEN operation.`updated_at`
+    ELSE NULL
+  END,
+  operation.`created_at`,
+  operation.`updated_at`
+FROM `project_operations` AS operation
+INNER JOIN `projects` AS project
+  ON project.`id` = operation.`project_id`
+WHERE operation.`source_record_type` = 'calendar_event'
+  AND COALESCE(operation.`start_date`, operation.`due_date`) IS NOT NULL
+  AND COALESCE(operation.`due_date`, operation.`start_date`) IS NOT NULL;

--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -153,4 +153,25 @@ test.describe("usable Compass areas", () => {
       })
     }
   })
+
+  test("work calendar compact cards show the actual item title", async ({
+    page,
+  }) => {
+    const response = await page.goto("/dashboard/schedule")
+    await expectHealthyNavigation(page, response, "/dashboard/schedule")
+
+    const nextFourteenDays = page.locator("section").filter({
+      has: page.getByRole("heading", { name: "Next 14 days" }),
+    })
+    await expect(
+      nextFourteenDays.getByText("Regression Schedule Item", {
+        exact: true,
+      }).first()
+    ).toBeVisible()
+    await expect(
+      nextFourteenDays.getByText("Regression follow-up", {
+        exact: true,
+      }).first()
+    ).toBeVisible()
+  })
 })

--- a/src/app/actions/work-calendar.ts
+++ b/src/app/actions/work-calendar.ts
@@ -1,20 +1,34 @@
 "use server"
 
-import { asc, eq } from "drizzle-orm"
+import { and, asc, eq, inArray } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
 import {
+  organizationCalendarSettings,
+  organizationMembers,
   projectOperations,
   projectRfis,
   projects,
   scheduleTasks,
+  users,
+  workCalendarEventAttendees,
+  workCalendarEvents,
 } from "@/db/schema"
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import { createNotificationEvent } from "@/lib/notifications/events"
 import { requireOrg } from "@/lib/org-scope"
-import { can, requirePermission } from "@/lib/permissions"
 import {
+  can,
+  canManageWorkCalendarEvents,
+  requirePermission,
+} from "@/lib/permissions"
+import {
+  dateKeyInTimeZone,
+  inclusiveEndDateFromExclusive,
+  normalizeWorkCalendarEventTiming,
   projectTodoHref,
   resolveHOfficeProjectId,
   scheduleItemHref,
@@ -27,10 +41,9 @@ export type WorkCalendarEntryKind =
   | "purchase_order"
   | "task"
 
-export type WorkCalendarEntry = {
+type WorkCalendarEntryBase = {
   readonly id: string
-  readonly kind: WorkCalendarEntryKind
-  readonly projectId: string
+  readonly projectId: string | null
   readonly projectLabel: string
   readonly projectName: string
   readonly title: string
@@ -44,12 +57,49 @@ export type WorkCalendarEntry = {
   readonly href: string
 }
 
+export type WorkCalendarEventAttendee = {
+  readonly userId: string
+  readonly name: string
+  readonly email: string
+}
+
+export type WorkCalendarEventDetails = {
+  readonly description: string | null
+  readonly startDate: string
+  readonly endDate: string
+  readonly startTime: string
+  readonly endTime: string
+  readonly startsAt: string | null
+  readonly endsAt: string | null
+  readonly allDay: boolean
+  readonly timeZone: string
+  readonly location: string | null
+  readonly attendees: readonly WorkCalendarEventAttendee[]
+  readonly version: number
+  readonly managed: boolean
+}
+
+type NonEventKind = Exclude<WorkCalendarEntryKind, "event">
+
+export type WorkCalendarEntry =
+  | (WorkCalendarEntryBase & {
+      readonly kind: NonEventKind
+      readonly eventDetails: null
+    })
+  | (WorkCalendarEntryBase & {
+      readonly kind: "event"
+      readonly eventDetails: WorkCalendarEventDetails
+    })
+
 export type WorkCalendarData = {
   readonly today: string
   readonly entries: readonly WorkCalendarEntry[]
   readonly projects: readonly ProjectRow[]
+  readonly attendeeOptions: readonly WorkCalendarEventAttendee[]
   readonly defaultProjectId: string | null
+  readonly defaultTimeZone: string
   readonly canCreateEvents: boolean
+  readonly canManageEvents: boolean
 }
 
 export type ProjectRow = {
@@ -72,6 +122,44 @@ function projectLabel(project: ProjectRow): string {
   return project.projectNumber ?? project.name
 }
 
+function userDisplayName(input: {
+  readonly displayName: string | null
+  readonly firstName: string | null
+  readonly lastName: string | null
+  readonly email: string
+}): string {
+  const fullName = [input.firstName, input.lastName]
+    .filter((part): part is string => Boolean(part?.trim()))
+    .join(" ")
+    .trim()
+  return input.displayName?.trim() || fullName || input.email
+}
+
+function localTimeInZone(
+  instant: string | null,
+  timeZone: string
+): string {
+  if (!instant) return ""
+  const parsed = new Date(instant)
+  if (Number.isNaN(parsed.getTime())) return ""
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(parsed)
+    const values = new Map(
+      parts.map((part) => [part.type, part.value])
+    )
+    const hour = values.get("hour")
+    const minute = values.get("minute")
+    return hour && minute ? `${hour}:${minute}` : ""
+  } catch {
+    return ""
+  }
+}
+
 function isClosedStatus(status: string): boolean {
   return [
     "closed",
@@ -85,9 +173,8 @@ function isClosedStatus(status: string): boolean {
   ].includes(status.trim().toLowerCase())
 }
 
-function operationKind(recordType: string): WorkCalendarEntryKind {
+function operationKind(recordType: string): NonEventKind {
   if (recordType === "purchase_order") return "purchase_order"
-  if (recordType === "calendar_event") return "event"
   return "task"
 }
 
@@ -110,15 +197,30 @@ function operationSourceLabel(recordType: string, recordNumber: string | null): 
 
 export async function getWorkCalendar(): Promise<WorkCalendarData> {
   const user = await requireAuth()
+  requirePermission(user, "schedule", "read")
   const orgId = requireOrg(user)
+  const canManageEvents =
+    !isDemoUser(user.id) && canManageWorkCalendarEvents(user)
+  const canCreateEvents =
+    canManageEvents && can(user, "schedule", "create")
 
   const { env } = await getCloudflareContext()
   const db = getDb(env.DB)
-
-  const todayDate = new Date()
-  const today = toDateKey(todayDate)
-  const rangeStart = toDateKey(addDays(todayDate, -14))
-  const rangeEnd = toDateKey(addDays(todayDate, 30))
+  const calendarSettings = await db
+    .select({
+      defaultProjectId: organizationCalendarSettings.defaultProjectId,
+      timeZone: organizationCalendarSettings.timeZone,
+    })
+    .from(organizationCalendarSettings)
+    .where(eq(organizationCalendarSettings.organizationId, orgId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  const defaultTimeZone =
+    calendarSettings?.timeZone ?? "America/Denver"
+  const today = dateKeyInTimeZone(new Date(), defaultTimeZone)
+  const todayAnchor = new Date(`${today}T12:00:00Z`)
+  const rangeStart = toDateKey(addDays(todayAnchor, -14))
+  const rangeEnd = toDateKey(addDays(todayAnchor, 30))
   const projectRows = await db
     .select({
       id: projects.id,
@@ -128,6 +230,48 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
     .from(projects)
     .where(eq(projects.organizationId, orgId))
     .orderBy(asc(projects.projectNumber), asc(projects.name))
+  const projectById = new Map(
+    projectRows.map((project) => [project.id, project])
+  )
+  const configuredDefaultProjectId =
+    calendarSettings?.defaultProjectId &&
+    projectById.has(calendarSettings.defaultProjectId)
+      ? calendarSettings.defaultProjectId
+      : null
+  const defaultProjectId =
+    configuredDefaultProjectId ?? resolveHOfficeProjectId(projectRows)
+  const organizationUsers = canManageEvents
+    ? await db
+        .select({
+          id: users.id,
+          email: users.email,
+          displayName: users.displayName,
+          firstName: users.firstName,
+          lastName: users.lastName,
+        })
+        .from(organizationMembers)
+        .innerJoin(users, eq(users.id, organizationMembers.userId))
+        .where(
+          and(
+            eq(organizationMembers.organizationId, orgId),
+            eq(users.isActive, true)
+          )
+        )
+        .orderBy(asc(users.displayName), asc(users.email))
+    : []
+  const attendeeOptions = organizationUsers.map((member) => ({
+    userId: member.id,
+    name: userDisplayName(member),
+    email: member.email,
+  }))
+  const dedicatedEventIds = new Set(
+    (
+      await db
+        .select({ id: workCalendarEvents.id })
+        .from(workCalendarEvents)
+        .where(eq(workCalendarEvents.organizationId, orgId))
+    ).map((event) => event.id)
+  )
 
   const entries: WorkCalendarEntry[] = []
 
@@ -167,6 +311,7 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
         companyName: null,
         sourceLabel: "Project schedule",
         href: scheduleItemHref(project.id, task.id),
+        eventDetails: null,
       })
     }
 
@@ -206,6 +351,7 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
         companyName: rfi.companyName,
         sourceLabel: `RFI ${rfi.rfiNumber}`,
         href: `/dashboard/projects/${project.id}/rfis`,
+        eventDetails: null,
       })
     }
 
@@ -227,6 +373,50 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
       .orderBy(asc(projectOperations.dueDate), asc(projectOperations.title))
 
     for (const operation of operationRows) {
+      if (operation.sourceRecordType === "calendar_event") {
+        if (dedicatedEventIds.has(operation.id)) continue
+        const startDate = operation.startDate ?? operation.dueDate
+        const endDate = operation.dueDate ?? operation.startDate
+        if (!startDate || !endDate) continue
+        if (endDate < rangeStart || startDate > rangeEnd) continue
+
+        // Preserve visibility for a legacy row created in the brief window
+        // between the additive schema migration and the new application
+        // deployment. A reconciliation pass can promote it without changing
+        // the user-visible ID.
+        entries.push({
+          id: operation.id,
+          kind: "event",
+          projectId: project.id,
+          projectLabel: label,
+          projectName: project.name,
+          title: operation.title,
+          status: operation.status,
+          priority: operation.priority,
+          startDate,
+          endDate,
+          assignedTo: operation.assigneeName,
+          companyName: operation.companyName,
+          sourceLabel: "Legacy calendar event",
+          href: eventHref(operation.id),
+          eventDetails: {
+            description: null,
+            startDate,
+            endDate,
+            startTime: "",
+            endTime: "",
+            startsAt: null,
+            endsAt: null,
+            allDay: true,
+            timeZone: "UTC",
+            location: null,
+            attendees: [],
+            version: 0,
+            managed: false,
+          },
+        })
+        continue
+      }
       if (isClosedStatus(operation.status)) continue
       const startDate = operation.startDate ?? operation.dueDate
       const endDate = operation.dueDate ?? operation.startDate
@@ -253,9 +443,7 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
         href:
           operation.sourceRecordType === "purchase_order"
             ? `/dashboard/projects/${project.id}/purchase-orders`
-            : operation.sourceRecordType === "calendar_event"
-              ? `/dashboard/schedule?kind=event&item=${encodeURIComponent(operation.id)}#work-calendar-${encodeURIComponent(operation.id)}`
-              : [
+            : [
                     "staff_task",
                     "subcontractor_task",
                     "supplier_task",
@@ -263,8 +451,118 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
                   ].includes(operation.sourceRecordType)
                 ? projectTodoHref(project.id, operation.id)
                 : `/dashboard/projects/${project.id}`,
+        eventDetails: null,
       })
     }
+  }
+
+  const eventRows = await db
+    .select()
+    .from(workCalendarEvents)
+    .where(eq(workCalendarEvents.organizationId, orgId))
+    .orderBy(
+      asc(workCalendarEvents.startDate),
+      asc(workCalendarEvents.startsAt),
+      asc(workCalendarEvents.title)
+    )
+  const eventIds = eventRows.map((event) => event.id)
+  const attendeeRows =
+    eventIds.length === 0
+      ? []
+      : await db
+          .select({
+            eventId: workCalendarEventAttendees.eventId,
+            userId: users.id,
+            email: users.email,
+            displayName: users.displayName,
+            firstName: users.firstName,
+            lastName: users.lastName,
+          })
+          .from(workCalendarEventAttendees)
+          .innerJoin(users, eq(users.id, workCalendarEventAttendees.userId))
+          .where(inArray(workCalendarEventAttendees.eventId, eventIds))
+          .orderBy(asc(users.displayName), asc(users.email))
+  const attendeesByEventId = new Map<
+    string,
+    WorkCalendarEventAttendee[]
+  >()
+  for (const attendee of attendeeRows) {
+    const eventAttendees = attendeesByEventId.get(attendee.eventId) ?? []
+    eventAttendees.push({
+      userId: attendee.userId,
+      name: userDisplayName(attendee),
+      email: canManageEvents ? attendee.email : "",
+    })
+    attendeesByEventId.set(attendee.eventId, eventAttendees)
+  }
+
+  for (const event of eventRows) {
+    if (isClosedStatus(event.status)) continue
+    const project = event.projectId
+      ? projectById.get(event.projectId) ?? null
+      : null
+    const timedStart =
+      event.startsAt !== null ? new Date(event.startsAt) : null
+    const timedEnd =
+      event.endsAt !== null ? new Date(event.endsAt) : null
+    const timedEndDisplay =
+      timedEnd && !Number.isNaN(timedEnd.getTime())
+        ? new Date(timedEnd.getTime() - 1)
+        : null
+    const startDate = event.allDay
+      ? event.startDate
+      : timedStart && !Number.isNaN(timedStart.getTime())
+        ? dateKeyInTimeZone(timedStart, event.timeZone)
+        : null
+    const endDate = event.allDay
+      ? event.endDateExclusive
+        ? inclusiveEndDateFromExclusive(event.endDateExclusive)
+        : null
+      : timedEndDisplay
+        ? dateKeyInTimeZone(timedEndDisplay, event.timeZone)
+        : null
+    if (!startDate || !endDate) continue
+    if (endDate < rangeStart || startDate > rangeEnd) continue
+    const attendees = attendeesByEventId.get(event.id) ?? []
+
+    entries.push({
+      id: event.id,
+      kind: "event",
+      projectId: project?.id ?? null,
+      projectLabel: project ? projectLabel(project) : "No project",
+      projectName: project?.name ?? "Archived project",
+      title: event.title,
+      status: event.status,
+      priority: "normal",
+      startDate,
+      endDate,
+      assignedTo:
+        attendees.length > 0
+          ? attendees.map((attendee) => attendee.name).join(", ")
+          : null,
+      companyName: null,
+      sourceLabel: "Calendar event",
+      href: `/dashboard/schedule?kind=event&item=${encodeURIComponent(event.id)}#work-calendar-${encodeURIComponent(event.id)}`,
+      eventDetails: {
+        description: event.description,
+        startDate,
+        endDate,
+        startTime: event.allDay
+          ? ""
+          : localTimeInZone(event.startsAt, event.timeZone),
+        endTime: event.allDay
+          ? ""
+          : localTimeInZone(event.endsAt, event.timeZone),
+        startsAt: event.startsAt,
+        endsAt: event.endsAt,
+        allDay: event.allDay,
+        timeZone: event.timeZone,
+        location: event.location,
+        attendees,
+        version: event.version,
+        managed: true,
+      },
+    })
   }
 
   entries.sort((left, right) => {
@@ -281,108 +579,691 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
     today,
     entries,
     projects: projectRows,
-    defaultProjectId: resolveHOfficeProjectId(projectRows),
-    canCreateEvents: can(user, "schedule", "create"),
+    attendeeOptions,
+    defaultProjectId,
+    defaultTimeZone,
+    canCreateEvents,
+    canManageEvents,
   }
 }
 
-export type CreateWorkCalendarEventInput = {
+export type WorkCalendarEventMutationInput = {
   readonly title: string
   readonly description: string | null
   readonly projectId: string | null
+  readonly allDay: boolean
   readonly startDate: string
   readonly endDate: string
+  readonly startTime: string
+  readonly endTime: string
+  readonly startsAt: string | null
+  readonly endsAt: string | null
+  readonly timeZone: string
+  readonly location: string | null
+  readonly attendeeUserIds: readonly string[]
 }
 
-type CreateWorkCalendarEventResult =
+type WorkCalendarEventMutationResult =
   | { readonly success: true; readonly id: string }
   | { readonly success: false; readonly error: string }
 
-function cleanRequiredText(value: string, label: string): string {
+type ValidatedEventInput = {
+  readonly project: ProjectRow
+  readonly title: string
+  readonly description: string | null
+  readonly startDate: string | null
+  readonly endDateExclusive: string | null
+  readonly startsAt: string | null
+  readonly endsAt: string | null
+  readonly allDay: boolean
+  readonly timeZone: string
+  readonly location: string | null
+  readonly attendees: readonly WorkCalendarEventAttendee[]
+}
+
+function cleanRequiredText(
+  value: string,
+  label: string,
+  maxLength: number
+): string {
   const cleaned = value.trim()
   if (cleaned.length === 0) throw new Error(`${label} is required`)
+  if (cleaned.length > maxLength) {
+    throw new Error(`${label} must be ${maxLength} characters or fewer`)
+  }
   return cleaned
 }
 
-function isDateKey(value: string): boolean {
-  return /^\d{4}-\d{2}-\d{2}$/.test(value)
+function cleanOptionalText(
+  value: string | null,
+  label: string,
+  maxLength: number
+): string | null {
+  const cleaned = value?.trim() ?? ""
+  if (cleaned.length > maxLength) {
+    throw new Error(`${label} must be ${maxLength} characters or fewer`)
+  }
+  return cleaned || null
+}
+
+async function organizationProjects(
+  db: ReturnType<typeof getDb>,
+  organizationId: string
+): Promise<readonly ProjectRow[]> {
+  return db
+    .select({
+      id: projects.id,
+      name: projects.name,
+      projectNumber: projects.projectNumber,
+    })
+    .from(projects)
+    .where(eq(projects.organizationId, organizationId))
+}
+
+async function validateAttendees(
+  db: ReturnType<typeof getDb>,
+  organizationId: string,
+  attendeeUserIds: readonly string[]
+): Promise<readonly WorkCalendarEventAttendee[]> {
+  const normalizedIds = Array.from(
+    new Set(
+      attendeeUserIds
+        .map((userId) => userId.trim())
+        .filter((userId) => userId.length > 0)
+    )
+  )
+  if (normalizedIds.length > 100) {
+    throw new Error("An event can include up to 100 attendees")
+  }
+  if (normalizedIds.length === 0) return []
+
+  const rows = await db
+    .select({
+      userId: users.id,
+      email: users.email,
+      displayName: users.displayName,
+      firstName: users.firstName,
+      lastName: users.lastName,
+    })
+    .from(organizationMembers)
+    .innerJoin(users, eq(users.id, organizationMembers.userId))
+    .where(
+      and(
+        eq(organizationMembers.organizationId, organizationId),
+        eq(users.isActive, true),
+        inArray(organizationMembers.userId, normalizedIds)
+      )
+    )
+
+  if (rows.length !== normalizedIds.length) {
+    throw new Error(
+      "One or more attendees are not active members of this organization"
+    )
+  }
+
+  return rows.map((row) => ({
+    userId: row.userId,
+    name: userDisplayName(row),
+    email: row.email,
+  }))
+}
+
+async function validateEventInput(
+  db: ReturnType<typeof getDb>,
+  organizationId: string,
+  input: WorkCalendarEventMutationInput
+): Promise<ValidatedEventInput> {
+  const projectRows = await organizationProjects(db, organizationId)
+  const settings = await db
+    .select({
+      defaultProjectId: organizationCalendarSettings.defaultProjectId,
+    })
+    .from(organizationCalendarSettings)
+    .where(eq(organizationCalendarSettings.organizationId, organizationId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  const configuredDefaultProjectId =
+    settings?.defaultProjectId &&
+    projectRows.some(
+      (project) => project.id === settings.defaultProjectId
+    )
+      ? settings.defaultProjectId
+      : null
+  const inferredDefaultProjectId =
+    resolveHOfficeProjectId(projectRows)
+  const projectId =
+    input.projectId?.trim() ||
+    configuredDefaultProjectId ||
+    inferredDefaultProjectId
+  if (!projectId) {
+    throw new Error(
+      "Select a project. Compass could not resolve one unique H-Office project for this organization."
+    )
+  }
+
+  const project = projectRows.find((candidate) => candidate.id === projectId)
+  if (!project) throw new Error("Project not found")
+  if (
+    !input.projectId?.trim() &&
+    !configuredDefaultProjectId &&
+    inferredDefaultProjectId === project.id
+  ) {
+    const now = new Date().toISOString()
+    await db
+      .insert(organizationCalendarSettings)
+      .values({
+        organizationId,
+        defaultProjectId: project.id,
+        timeZone: "America/Denver",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: organizationCalendarSettings.organizationId,
+        set: {
+          defaultProjectId: project.id,
+          updatedAt: now,
+        },
+      })
+  }
+
+  const timing = normalizeWorkCalendarEventTiming(input)
+  if (!timing.success) throw new Error(timing.error)
+
+  return {
+    project,
+    title: cleanRequiredText(input.title, "Event title", 200),
+    description: cleanOptionalText(input.description, "Description", 5_000),
+    startDate: timing.startDate,
+    endDateExclusive: timing.endDateExclusive,
+    startsAt: timing.startsAt,
+    endsAt: timing.endsAt,
+    allDay: input.allDay,
+    timeZone: timing.timeZone,
+    location: cleanOptionalText(input.location, "Location", 500),
+    attendees: await validateAttendees(
+      db,
+      organizationId,
+      input.attendeeUserIds
+    ),
+  }
+}
+
+async function syncEventAttendees(
+  db: ReturnType<typeof getDb>,
+  eventId: string,
+  previousAttendees: readonly WorkCalendarEventAttendee[],
+  nextAttendees: readonly WorkCalendarEventAttendee[],
+  now: string
+): Promise<void> {
+  const previousIds = new Set(
+    previousAttendees.map((attendee) => attendee.userId)
+  )
+  const nextIds = new Set(
+    nextAttendees.map((attendee) => attendee.userId)
+  )
+
+  // Preserve response state for retained attendees. Adding before removing
+  // also avoids clearing the entire attendee list if D1 is interrupted.
+  for (const attendee of nextAttendees) {
+    if (previousIds.has(attendee.userId)) continue
+    await db
+      .insert(workCalendarEventAttendees)
+      .values({
+        id: crypto.randomUUID(),
+        eventId,
+        userId: attendee.userId,
+        responseStatus: "needs_action",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoNothing()
+  }
+
+  const removedIds = previousAttendees
+    .map((attendee) => attendee.userId)
+    .filter((userId) => !nextIds.has(userId))
+  if (removedIds.length > 0) {
+    await db
+      .delete(workCalendarEventAttendees)
+      .where(
+        and(
+          eq(workCalendarEventAttendees.eventId, eventId),
+          inArray(workCalendarEventAttendees.userId, removedIds)
+        )
+      )
+  }
+}
+
+async function eventAttendees(
+  db: ReturnType<typeof getDb>,
+  eventId: string
+): Promise<readonly WorkCalendarEventAttendee[]> {
+  const rows = await db
+    .select({
+      userId: users.id,
+      email: users.email,
+      displayName: users.displayName,
+      firstName: users.firstName,
+      lastName: users.lastName,
+    })
+    .from(workCalendarEventAttendees)
+    .innerJoin(users, eq(users.id, workCalendarEventAttendees.userId))
+    .where(eq(workCalendarEventAttendees.eventId, eventId))
+
+  return rows.map((row) => ({
+    userId: row.userId,
+    name: userDisplayName(row),
+    email: row.email,
+  }))
+}
+
+function eventHref(eventId: string): string {
+  return `/dashboard/schedule?kind=event&item=${encodeURIComponent(eventId)}#work-calendar-${encodeURIComponent(eventId)}`
+}
+
+function eventStartLabel(input: {
+  readonly startDate: string | null
+  readonly startsAt: string | null
+  readonly timeZone: string
+}): string {
+  if (input.startDate) {
+    return new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      timeZone: "UTC",
+    }).format(new Date(`${input.startDate}T12:00:00Z`))
+  }
+  if (!input.startsAt) return "its scheduled time"
+
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone: input.timeZone,
+      timeZoneName: "short",
+    }).format(new Date(input.startsAt))
+  } catch {
+    return input.startsAt
+  }
+}
+
+async function notifyEventParticipants(input: {
+  readonly organizationId: string
+  readonly projectId: string | null
+  readonly project: ProjectRow | null
+  readonly eventId: string
+  readonly eventTitle: string
+  readonly startLabel: string
+  readonly change: "created" | "updated" | "cancelled"
+  readonly actorId: string
+  readonly actorName: string
+  readonly attendees: readonly WorkCalendarEventAttendee[]
+}): Promise<void> {
+  const recipients = input.attendees.filter(
+    (attendee) => attendee.userId !== input.actorId
+  )
+  if (recipients.length === 0) return
+
+  const projectName = input.project
+    ? input.project.projectNumber
+      ? `${input.project.projectNumber} — ${input.project.name}`
+      : input.project.name
+    : "an archived project"
+
+  try {
+    await createNotificationEvent({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      eventType: `schedule.event_${input.change}`,
+      sourceType: "calendar_event",
+      sourceId: input.eventId,
+      title: `${input.eventTitle} ${input.change}`,
+      body: `${input.actorName} ${input.change} this event for ${projectName} on ${input.startLabel}.`,
+      href: eventHref(input.eventId),
+      priority: "normal",
+      audience: "attendees",
+      createdBy: input.actorId,
+      recipients,
+      delivery: {
+        inApp: true,
+        email: false,
+        push: true,
+      },
+    })
+  } catch (error) {
+    // The event mutation is durable even if a downstream notification
+    // provider is temporarily unavailable.
+    console.error("Failed to notify calendar event attendees:", error)
+  }
+}
+
+function revalidateEventPaths(
+  projectIds: readonly (string | null)[]
+): void {
+  revalidatePath("/dashboard/schedule")
+  revalidatePath("/dashboard")
+  const concreteProjectIds = projectIds.filter(
+    (projectId): projectId is string => projectId !== null
+  )
+  for (const projectId of new Set(concreteProjectIds)) {
+    revalidatePath(`/dashboard/projects/${projectId}`)
+  }
 }
 
 export async function createWorkCalendarEvent(
-  input: CreateWorkCalendarEventInput
-): Promise<CreateWorkCalendarEventResult> {
+  input: WorkCalendarEventMutationInput
+): Promise<WorkCalendarEventMutationResult> {
   try {
     const user = await requireAuth()
+    if (!canManageWorkCalendarEvents(user)) {
+      return { success: false, error: "Permission denied" }
+    }
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
     requirePermission(user, "schedule", "create")
     const orgId = requireOrg(user)
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
-
-    const projectRows = await db
-      .select({
-        id: projects.id,
-        name: projects.name,
-        projectNumber: projects.projectNumber,
-      })
-      .from(projects)
-      .where(eq(projects.organizationId, orgId))
-
-    const projectId =
-      input.projectId?.trim() || resolveHOfficeProjectId(projectRows)
-    if (!projectId) {
-      return {
-        success: false,
-        error:
-          "Select a project. Compass could not resolve one unique H-Office project for this organization.",
-      }
-    }
-
-    const project = projectRows.find((candidate) => candidate.id === projectId)
-    if (!project) {
-      return { success: false, error: "Project not found" }
-    }
-
-    const title = cleanRequiredText(input.title, "Event title")
-    const startDate = cleanRequiredText(input.startDate, "Start date")
-    const endDate = cleanRequiredText(input.endDate, "End date")
-    if (!isDateKey(startDate) || !isDateKey(endDate)) {
-      return { success: false, error: "Enter valid event dates." }
-    }
-    if (endDate < startDate) {
-      return {
-        success: false,
-        error: "End date must be on or after the start date.",
-      }
-    }
-
+    const validated = await validateEventInput(db, orgId, input)
     const id = crypto.randomUUID()
     const now = new Date().toISOString()
-    await db.insert(projectOperations).values({
+    await db.insert(workCalendarEvents).values({
       id,
-      projectId,
-      sourceSystem: "compass",
-      sourceRecordType: "calendar_event",
-      title,
-      description: input.description?.trim() || null,
+      organizationId: orgId,
+      projectId: validated.project.id,
+      title: validated.title,
+      description: validated.description,
+      startDate: validated.startDate,
+      endDateExclusive: validated.endDateExclusive,
+      startsAt: validated.startsAt,
+      endsAt: validated.endsAt,
+      allDay: validated.allDay,
+      timeZone: validated.timeZone,
+      location: validated.location,
       status: "open",
-      priority: "normal",
-      startDate,
-      dueDate: endDate,
-      syncDirection: "read",
-      syncStatus: "compass_only",
+      version: 1,
+      createdBy: user.id,
+      updatedBy: user.id,
+      cancelledBy: null,
+      cancelledAt: null,
       createdAt: now,
       updatedAt: now,
     })
+    await syncEventAttendees(db, id, [], validated.attendees, now)
+    await notifyEventParticipants({
+      organizationId: orgId,
+      projectId: validated.project.id,
+      project: validated.project,
+      eventId: id,
+      eventTitle: validated.title,
+      startLabel: eventStartLabel(validated),
+      change: "created",
+      actorId: user.id,
+      actorName: user.displayName ?? user.email,
+      attendees: validated.attendees,
+    })
 
-    revalidatePath("/dashboard/schedule")
-    revalidatePath(`/dashboard/projects/${projectId}`)
-    revalidatePath("/dashboard")
+    revalidateEventPaths([validated.project.id])
     return { success: true, id }
   } catch (error) {
     return {
       success: false,
       error:
         error instanceof Error ? error.message : "Failed to create calendar event",
+    }
+  }
+}
+
+export async function updateWorkCalendarEvent(
+  eventId: string,
+  expectedVersion: number,
+  input: WorkCalendarEventMutationInput
+): Promise<WorkCalendarEventMutationResult> {
+  try {
+    const user = await requireAuth()
+    if (!canManageWorkCalendarEvents(user)) {
+      return { success: false, error: "Permission denied" }
+    }
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    requirePermission(user, "schedule", "update")
+    const orgId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+
+    const existing = await db
+      .select({
+        id: workCalendarEvents.id,
+        projectId: workCalendarEvents.projectId,
+        status: workCalendarEvents.status,
+        version: workCalendarEvents.version,
+      })
+      .from(workCalendarEvents)
+      .where(
+        and(
+          eq(workCalendarEvents.id, eventId),
+          eq(workCalendarEvents.organizationId, orgId)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!existing) {
+      return { success: false, error: "Calendar event not found" }
+    }
+    if (isClosedStatus(existing.status)) {
+      return {
+        success: false,
+        error: "Cancelled events cannot be edited.",
+      }
+    }
+    if (
+      !Number.isInteger(expectedVersion) ||
+      expectedVersion < 1 ||
+      existing.version !== expectedVersion
+    ) {
+      return {
+        success: false,
+        error:
+          "This event changed after you opened it. Refresh and try again.",
+      }
+    }
+
+    const previousAttendees = await eventAttendees(db, eventId)
+    const validated = await validateEventInput(db, orgId, input)
+    const now = new Date().toISOString()
+    const updated = await db
+      .update(workCalendarEvents)
+      .set({
+        projectId: validated.project.id,
+        title: validated.title,
+        description: validated.description,
+        startDate: validated.startDate,
+        endDateExclusive: validated.endDateExclusive,
+        startsAt: validated.startsAt,
+        endsAt: validated.endsAt,
+        allDay: validated.allDay,
+        timeZone: validated.timeZone,
+        location: validated.location,
+        version: expectedVersion + 1,
+        updatedBy: user.id,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(workCalendarEvents.id, eventId),
+          eq(workCalendarEvents.organizationId, orgId),
+          eq(workCalendarEvents.status, "open"),
+          eq(workCalendarEvents.version, expectedVersion)
+        )
+      )
+      .returning({ id: workCalendarEvents.id })
+      .then((rows) => rows[0] ?? null)
+    if (!updated) {
+      return {
+        success: false,
+        error:
+          "This event changed after you opened it. Refresh and try again.",
+      }
+    }
+    await syncEventAttendees(
+      db,
+      eventId,
+      previousAttendees,
+      validated.attendees,
+      now
+    )
+
+    const notificationAttendees = new Map<
+      string,
+      WorkCalendarEventAttendee
+    >()
+    for (const attendee of [
+      ...previousAttendees,
+      ...validated.attendees,
+    ]) {
+      notificationAttendees.set(attendee.userId, attendee)
+    }
+    await notifyEventParticipants({
+      organizationId: orgId,
+      projectId: validated.project.id,
+      project: validated.project,
+      eventId,
+      eventTitle: validated.title,
+      startLabel: eventStartLabel(validated),
+      change: "updated",
+      actorId: user.id,
+      actorName: user.displayName ?? user.email,
+      attendees: Array.from(notificationAttendees.values()),
+    })
+
+    revalidateEventPaths([existing.projectId, validated.project.id])
+    return { success: true, id: eventId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to update calendar event",
+    }
+  }
+}
+
+export async function cancelWorkCalendarEvent(
+  eventId: string,
+  expectedVersion: number
+): Promise<WorkCalendarEventMutationResult> {
+  try {
+    const user = await requireAuth()
+    if (!canManageWorkCalendarEvents(user)) {
+      return { success: false, error: "Permission denied" }
+    }
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    requirePermission(user, "schedule", "update")
+    const orgId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+
+    const existing = await db
+      .select({
+        id: workCalendarEvents.id,
+        projectId: workCalendarEvents.projectId,
+        title: workCalendarEvents.title,
+        startDate: workCalendarEvents.startDate,
+        startsAt: workCalendarEvents.startsAt,
+        timeZone: workCalendarEvents.timeZone,
+        allDay: workCalendarEvents.allDay,
+        status: workCalendarEvents.status,
+        version: workCalendarEvents.version,
+      })
+      .from(workCalendarEvents)
+      .where(
+        and(
+          eq(workCalendarEvents.id, eventId),
+          eq(workCalendarEvents.organizationId, orgId)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!existing) {
+      return { success: false, error: "Calendar event not found" }
+    }
+    if (isClosedStatus(existing.status)) {
+      return { success: true, id: eventId }
+    }
+    if (
+      !Number.isInteger(expectedVersion) ||
+      expectedVersion < 1 ||
+      existing.version !== expectedVersion
+    ) {
+      return {
+        success: false,
+        error:
+          "This event changed after you opened it. Refresh and try again.",
+      }
+    }
+
+    const attendees = await eventAttendees(db, eventId)
+    const project = existing.projectId
+      ? (await organizationProjects(db, orgId)).find(
+          (candidate) => candidate.id === existing.projectId
+        ) ?? null
+      : null
+    const now = new Date().toISOString()
+    const cancelled = await db
+      .update(workCalendarEvents)
+      .set({
+        status: "cancelled",
+        version: expectedVersion + 1,
+        updatedBy: user.id,
+        cancelledBy: user.id,
+        cancelledAt: now,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(workCalendarEvents.id, eventId),
+          eq(workCalendarEvents.organizationId, orgId),
+          eq(workCalendarEvents.status, "open"),
+          eq(workCalendarEvents.version, expectedVersion)
+        )
+      )
+      .returning({ id: workCalendarEvents.id })
+      .then((rows) => rows[0] ?? null)
+    if (!cancelled) {
+      return {
+        success: false,
+        error:
+          "This event changed after you opened it. Refresh and try again.",
+      }
+    }
+    await notifyEventParticipants({
+      organizationId: orgId,
+      projectId: existing.projectId,
+      project,
+      eventId,
+      eventTitle: existing.title,
+      startLabel: eventStartLabel(existing),
+      change: "cancelled",
+      actorId: user.id,
+      actorName: user.displayName ?? user.email,
+      attendees,
+    })
+
+    revalidateEventPaths([existing.projectId])
+    return { success: true, id: eventId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to cancel calendar event",
     }
   }
 }

--- a/src/components/schedule/work-calendar-event-dialog.tsx
+++ b/src/components/schedule/work-calendar-event-dialog.tsx
@@ -2,14 +2,34 @@
 
 import * as React from "react"
 import { useRouter } from "next/navigation"
-import { IconCalendarPlus } from "@tabler/icons-react"
+import {
+  IconCalendarPlus,
+  IconPencil,
+  IconTrash,
+} from "@tabler/icons-react"
 import { toast } from "sonner"
 
 import {
+  cancelWorkCalendarEvent,
   createWorkCalendarEvent,
+  updateWorkCalendarEvent,
   type ProjectRow,
+  type WorkCalendarEntry,
+  type WorkCalendarEventAttendee,
 } from "@/app/actions/work-calendar"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   Dialog,
   DialogContent,
@@ -29,8 +49,46 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
+import { instantForLocalDateTime } from "@/lib/work-calendar"
 
 const DEFAULT_PROJECT_VALUE = "__h_office_default__"
+
+type CalendarEventEntry = Extract<WorkCalendarEntry, { kind: "event" }>
+
+type CommonProps = {
+  readonly projects: readonly ProjectRow[]
+  readonly attendeeOptions: readonly WorkCalendarEventAttendee[]
+  readonly defaultProjectId: string | null
+  readonly defaultTimeZone: string
+  readonly today: string
+}
+
+type WorkCalendarEventDialogProps = CommonProps &
+  (
+    | {
+        readonly variant: "create"
+      }
+    | {
+        readonly variant: "edit"
+        readonly event: CalendarEventEntry
+        readonly open: boolean
+        readonly onOpenChange: (open: boolean) => void
+      }
+  )
+
+type EventFormSeed = {
+  readonly title: string
+  readonly description: string
+  readonly projectValue: string
+  readonly allDay: boolean
+  readonly startDate: string
+  readonly endDate: string
+  readonly startTime: string
+  readonly endTime: string
+  readonly timeZone: string
+  readonly location: string
+  readonly attendeeUserIds: readonly string[]
+}
 
 function projectLabel(project: ProjectRow): string {
   return project.projectNumber
@@ -38,116 +96,246 @@ function projectLabel(project: ProjectRow): string {
     : project.name
 }
 
-export function WorkCalendarEventDialog({
-  projects,
-  defaultProjectId,
-  today,
-}: {
-  readonly projects: readonly ProjectRow[]
-  readonly defaultProjectId: string | null
-  readonly today: string
-}): React.ReactElement {
+function formSeed(
+  props: WorkCalendarEventDialogProps
+): EventFormSeed {
+  if (props.variant === "edit") {
+    const details = props.event.eventDetails
+    return {
+      title: props.event.title,
+      description: details.description ?? "",
+      projectValue:
+        props.event.projectId ??
+        (props.defaultProjectId ? DEFAULT_PROJECT_VALUE : ""),
+      allDay: details.allDay,
+      startDate: details.startDate,
+      endDate: details.endDate,
+      startTime: details.startTime || "09:00",
+      endTime: details.endTime || "10:00",
+      timeZone: details.timeZone,
+      location: details.location ?? "",
+      attendeeUserIds: details.attendees.map(
+        (attendee) => attendee.userId
+      ),
+    }
+  }
+
+  return {
+    title: "",
+    description: "",
+    projectValue: props.defaultProjectId
+      ? DEFAULT_PROJECT_VALUE
+      : "",
+    allDay: false,
+    startDate: props.today,
+    endDate: props.today,
+    startTime: "09:00",
+    endTime: "10:00",
+    timeZone: props.defaultTimeZone,
+    location: "",
+    attendeeUserIds: [],
+  }
+}
+
+export function WorkCalendarEventDialog(
+  props: WorkCalendarEventDialogProps
+): React.ReactElement {
   const router = useRouter()
-  const [open, setOpen] = React.useState(false)
+  const seed = formSeed(props)
+  const [createOpen, setCreateOpen] = React.useState(false)
   const [pending, startTransition] = React.useTransition()
-  const [title, setTitle] = React.useState("")
-  const [description, setDescription] = React.useState("")
-  const [projectValue, setProjectValue] = React.useState(
-    defaultProjectId ? DEFAULT_PROJECT_VALUE : ""
-  )
-  const [startDate, setStartDate] = React.useState(today)
-  const [endDate, setEndDate] = React.useState(today)
+  const [title, setTitle] = React.useState(seed.title)
+  const [description, setDescription] = React.useState(seed.description)
+  const [projectValue, setProjectValue] = React.useState(seed.projectValue)
+  const [allDay, setAllDay] = React.useState(seed.allDay)
+  const [startDate, setStartDate] = React.useState(seed.startDate)
+  const [endDate, setEndDate] = React.useState(seed.endDate)
+  const [startTime, setStartTime] = React.useState(seed.startTime)
+  const [endTime, setEndTime] = React.useState(seed.endTime)
+  const [timeZone, setTimeZone] = React.useState(seed.timeZone)
+  const [location, setLocation] = React.useState(seed.location)
+  const [attendeeUserIds, setAttendeeUserIds] = React.useState<
+    readonly string[]
+  >(seed.attendeeUserIds)
+
+  const open = props.variant === "create" ? createOpen : props.open
 
   function reset(): void {
-    setTitle("")
-    setDescription("")
-    setProjectValue(defaultProjectId ? DEFAULT_PROJECT_VALUE : "")
-    setStartDate(today)
-    setEndDate(today)
+    const next = formSeed(props)
+    setTitle(next.title)
+    setDescription(next.description)
+    setProjectValue(next.projectValue)
+    setAllDay(next.allDay)
+    setStartDate(next.startDate)
+    setEndDate(next.endDate)
+    setStartTime(next.startTime)
+    setEndTime(next.endTime)
+    setTimeZone(next.timeZone)
+    setLocation(next.location)
+    setAttendeeUserIds(next.attendeeUserIds)
+  }
+
+  function changeOpen(nextOpen: boolean): void {
+    if (props.variant === "create") {
+      setCreateOpen(nextOpen)
+    } else {
+      props.onOpenChange(nextOpen)
+    }
+    if (!nextOpen) reset()
+  }
+
+  function toggleAttendee(userId: string, checked: boolean): void {
+    setAttendeeUserIds((current) =>
+      checked
+        ? Array.from(new Set([...current, userId]))
+        : current.filter((candidate) => candidate !== userId)
+    )
   }
 
   function submit(event: React.FormEvent<HTMLFormElement>): void {
     event.preventDefault()
     const projectId =
       projectValue === DEFAULT_PROJECT_VALUE ? null : projectValue || null
+    const startResolution = allDay
+      ? null
+      : instantForLocalDateTime(startDate, startTime, timeZone)
+    const endResolution = allDay
+      ? null
+      : instantForLocalDateTime(endDate, endTime, timeZone)
+    if (startResolution && !startResolution.success) {
+      toast.error(`Start time: ${startResolution.error}`)
+      return
+    }
+    if (endResolution && !endResolution.success) {
+      toast.error(`End time: ${endResolution.error}`)
+      return
+    }
+    if (startResolution?.ambiguous || endResolution?.ambiguous) {
+      toast.info(
+        "This time occurs twice at daylight-saving time; Compass will use the first occurrence."
+      )
+    }
+    const input = {
+      title,
+      description: description || null,
+      projectId,
+      allDay,
+      startDate,
+      endDate,
+      startTime,
+      endTime,
+      startsAt: startResolution?.instant ?? null,
+      endsAt: endResolution?.instant ?? null,
+      timeZone,
+      location: location || null,
+      attendeeUserIds,
+    }
 
     startTransition(async () => {
-      const result = await createWorkCalendarEvent({
-        title,
-        description: description || null,
-        projectId,
-        startDate,
-        endDate,
-      })
+      const result =
+        props.variant === "create"
+          ? await createWorkCalendarEvent(input)
+          : await updateWorkCalendarEvent(
+              props.event.id,
+              props.event.eventDetails.version,
+              input
+            )
 
       if (!result.success) {
         toast.error(result.error)
         return
       }
 
-      toast.success("Event added to the work calendar.")
-      setOpen(false)
-      reset()
+      toast.success(
+        props.variant === "create"
+          ? "Event added to the work calendar."
+          : "Event updated."
+      )
+      changeOpen(false)
+      router.refresh()
+    })
+  }
+
+  function cancelEvent(): void {
+    if (props.variant !== "edit") return
+    startTransition(async () => {
+      const result = await cancelWorkCalendarEvent(
+        props.event.id,
+        props.event.eventDetails.version
+      )
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success("Event cancelled.")
+      changeOpen(false)
       router.refresh()
     })
   }
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(nextOpen) => {
-        setOpen(nextOpen)
-        if (!nextOpen) reset()
-      }}
-    >
-      <DialogTrigger asChild>
-        <Button type="button" size="sm">
-          <IconCalendarPlus className="size-4" />
-          Add event
-        </Button>
-      </DialogTrigger>
-      <DialogContent>
+    <Dialog open={open} onOpenChange={changeOpen}>
+      {props.variant === "create" && (
+        <DialogTrigger asChild>
+          <Button type="button" size="sm">
+            <IconCalendarPlus className="size-4" />
+            Add event
+          </Button>
+        </DialogTrigger>
+      )}
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
         <form onSubmit={submit}>
           <DialogHeader>
-            <DialogTitle>Add work calendar event</DialogTitle>
+            <DialogTitle>
+              {props.variant === "create"
+                ? "Add work calendar event"
+                : "Edit work calendar event"}
+            </DialogTitle>
             <DialogDescription>
-              Add a meeting or other dated event. Leave the project at its
-              default to file it under H-Office.
+              Add a meeting or ordinary event. A blank project files it under
+              the one configured H-Office project.
             </DialogDescription>
           </DialogHeader>
 
           <div className="grid gap-4 py-5">
             <div className="grid gap-2">
-              <Label htmlFor="work-calendar-event-title">Title</Label>
+              <Label htmlFor={`work-calendar-event-title-${props.variant}`}>
+                Title
+              </Label>
               <Input
-                id="work-calendar-event-title"
+                id={`work-calendar-event-title-${props.variant}`}
                 value={title}
                 onChange={(event) => setTitle(event.target.value)}
                 placeholder="Weekly operations meeting"
+                maxLength={200}
                 required
               />
             </div>
 
             <div className="grid gap-2">
-              <Label htmlFor="work-calendar-event-project">Project</Label>
+              <Label htmlFor={`work-calendar-event-project-${props.variant}`}>
+                Project
+              </Label>
               <Select value={projectValue} onValueChange={setProjectValue}>
-                <SelectTrigger id="work-calendar-event-project">
+                <SelectTrigger
+                  id={`work-calendar-event-project-${props.variant}`}
+                >
                   <SelectValue placeholder="Select a project" />
                 </SelectTrigger>
                 <SelectContent>
-                  {defaultProjectId && (
+                  {props.defaultProjectId && (
                     <SelectItem value={DEFAULT_PROJECT_VALUE}>
                       H-Office (default)
                     </SelectItem>
                   )}
-                  {projects.map((project) => (
+                  {props.projects.map((project) => (
                     <SelectItem key={project.id} value={project.id}>
                       {projectLabel(project)}
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
-              {!defaultProjectId && (
+              {!props.defaultProjectId && (
                 <p className="text-xs text-muted-foreground">
                   Compass could not identify one unique H-Office project, so a
                   project is required.
@@ -155,62 +343,205 @@ export function WorkCalendarEventDialog({
               )}
             </div>
 
+            <label className="flex items-center gap-3 border-y py-3 text-sm font-medium">
+              <Checkbox
+                checked={allDay}
+                onCheckedChange={(checked) => setAllDay(checked === true)}
+              />
+              All-day event
+            </label>
+
             <div className="grid gap-4 sm:grid-cols-2">
               <div className="grid gap-2">
-                <Label htmlFor="work-calendar-event-start">Starts</Label>
+                <Label htmlFor={`work-calendar-event-start-${props.variant}`}>
+                  Starts
+                </Label>
                 <Input
-                  id="work-calendar-event-start"
+                  id={`work-calendar-event-start-${props.variant}`}
                   type="date"
                   value={startDate}
-                  onChange={(event) => setStartDate(event.target.value)}
+                  onChange={(event) => {
+                    setStartDate(event.target.value)
+                    if (endDate < event.target.value) {
+                      setEndDate(event.target.value)
+                    }
+                  }}
                   required
                 />
+                {!allDay && (
+                  <Input
+                    aria-label="Start time"
+                    type="time"
+                    value={startTime}
+                    onChange={(event) => setStartTime(event.target.value)}
+                    required
+                  />
+                )}
               </div>
               <div className="grid gap-2">
-                <Label htmlFor="work-calendar-event-end">Ends</Label>
+                <Label htmlFor={`work-calendar-event-end-${props.variant}`}>
+                  Ends
+                </Label>
                 <Input
-                  id="work-calendar-event-end"
+                  id={`work-calendar-event-end-${props.variant}`}
                   type="date"
                   value={endDate}
                   min={startDate}
                   onChange={(event) => setEndDate(event.target.value)}
                   required
                 />
+                {!allDay && (
+                  <Input
+                    aria-label="End time"
+                    type="time"
+                    value={endTime}
+                    onChange={(event) => setEndTime(event.target.value)}
+                    required
+                  />
+                )}
               </div>
             </div>
+            {!allDay && (
+              <p className="text-xs text-muted-foreground">
+                Time zone: {timeZone}
+              </p>
+            )}
 
             <div className="grid gap-2">
-              <Label htmlFor="work-calendar-event-notes">Notes</Label>
+              <Label htmlFor={`work-calendar-event-location-${props.variant}`}>
+                Location
+              </Label>
+              <Input
+                id={`work-calendar-event-location-${props.variant}`}
+                value={location}
+                onChange={(event) => setLocation(event.target.value)}
+                placeholder="Office, job site, or video link"
+                maxLength={500}
+              />
+            </div>
+
+            <fieldset className="grid gap-2">
+              <legend className="text-sm font-medium">Attendees</legend>
+              {props.attendeeOptions.length > 0 ? (
+                <div className="max-h-40 overflow-y-auto border-y py-1">
+                  {props.attendeeOptions.map((attendee) => (
+                    <label
+                      key={attendee.userId}
+                      className="flex items-start gap-3 px-1 py-2 text-sm"
+                    >
+                      <Checkbox
+                        checked={attendeeUserIds.includes(attendee.userId)}
+                        onCheckedChange={(checked) =>
+                          toggleAttendee(
+                            attendee.userId,
+                            checked === true
+                          )
+                        }
+                      />
+                      <span>
+                        <span className="block font-medium">
+                          {attendee.name}
+                        </span>
+                        <span className="block text-xs text-muted-foreground">
+                          {attendee.email}
+                        </span>
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  No active organization members are available.
+                </p>
+              )}
+              <p className="text-xs text-muted-foreground">
+                Attendees receive a Compass notification when the event is
+                created, changed, or cancelled.
+              </p>
+            </fieldset>
+
+            <div className="grid gap-2">
+              <Label htmlFor={`work-calendar-event-notes-${props.variant}`}>
+                Description
+              </Label>
               <Textarea
-                id="work-calendar-event-notes"
+                id={`work-calendar-event-notes-${props.variant}`}
                 value={description}
                 onChange={(event) => setDescription(event.target.value)}
-                placeholder="Optional details"
+                placeholder="Optional agenda or details"
+                maxLength={5_000}
               />
             </div>
           </div>
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setOpen(false)}
-              disabled={pending}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              disabled={
-                pending ||
-                title.trim().length === 0 ||
-                startDate.length === 0 ||
-                endDate.length === 0 ||
-                (!defaultProjectId && projectValue.length === 0)
-              }
-            >
-              {pending ? "Adding…" : "Add event"}
-            </Button>
+          <DialogFooter className="gap-2 sm:justify-between">
+            <div>
+              {props.variant === "edit" && (
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="destructive"
+                      disabled={pending}
+                    >
+                      <IconTrash className="size-4" />
+                      Cancel event
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Cancel this event?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        The event will leave the active calendar and its
+                        attendees will be notified.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel type="button">
+                        Keep event
+                      </AlertDialogCancel>
+                      <AlertDialogAction
+                        type="button"
+                        onClick={cancelEvent}
+                      >
+                        Cancel event
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => changeOpen(false)}
+                disabled={pending}
+              >
+                Close
+              </Button>
+              <Button
+                type="submit"
+                disabled={
+                  pending ||
+                  title.trim().length === 0 ||
+                  startDate.length === 0 ||
+                  endDate.length === 0 ||
+                  (!allDay &&
+                    (startTime.length === 0 || endTime.length === 0)) ||
+                  (!props.defaultProjectId && projectValue.length === 0)
+                }
+              >
+                {props.variant === "edit" && (
+                  <IconPencil className="size-4" />
+                )}
+                {pending
+                  ? "Saving…"
+                  : props.variant === "create"
+                    ? "Add event"
+                    : "Save changes"}
+              </Button>
+            </div>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/src/components/schedule/work-calendar.tsx
+++ b/src/components/schedule/work-calendar.tsx
@@ -24,6 +24,7 @@ import { workCalendarEntryMatches } from "@/lib/work-calendar"
 import { WorkCalendarEventDialog } from "./work-calendar-event-dialog"
 
 export type WorkCalendarKindFilter = WorkCalendarEntryKind | "all"
+type CalendarEventEntry = Extract<WorkCalendarEntry, { kind: "event" }>
 
 type KindConfig = {
   readonly id: WorkCalendarKindFilter
@@ -75,7 +76,10 @@ function addDays(date: Date, days: number): Date {
 }
 
 function toDateKey(date: Date): string {
-  return date.toISOString().slice(0, 10)
+  const year = date.getFullYear()
+  const month = `${date.getMonth() + 1}`.padStart(2, "0")
+  const day = `${date.getDate()}`.padStart(2, "0")
+  return `${year}-${month}-${day}`
 }
 
 function formatShortDate(date: string): string {
@@ -121,6 +125,21 @@ function kindTone(kind: WorkCalendarEntryKind): string {
   }
 }
 
+function compactKindTone(kind: WorkCalendarEntryKind): string {
+  switch (kind) {
+    case "schedule":
+      return "border-l-[#2f5963]"
+    case "event":
+      return "border-l-[#5f4b8b]"
+    case "task":
+      return "border-l-[#3f7d4d]"
+    case "rfi":
+      return "border-l-[#9d832c]"
+    case "purchase_order":
+      return "border-l-[#6f471f]"
+  }
+}
+
 function entryOnDay(entry: WorkCalendarEntry, date: string): boolean {
   return entry.startDate <= date && entry.endDate >= date
 }
@@ -129,21 +148,23 @@ function WorkItem({
   entry,
   compact = false,
   focused = false,
+  onEditEvent,
+  canManageEvents,
 }: {
   readonly entry: WorkCalendarEntry
   readonly compact?: boolean
   readonly focused?: boolean
+  readonly onEditEvent: (event: CalendarEventEntry) => void
+  readonly canManageEvents: boolean
 }): React.ReactElement {
-  return (
-    <Link
-      id={compact ? undefined : `work-calendar-${entry.id}`}
-      href={entry.href}
-      className={cn(
-        "block rounded-lg border bg-background p-3 transition-all duration-200 hover:-translate-y-0.5 hover:bg-muted/60 hover:shadow-md",
-        compact && "p-2",
-        focused && "border-primary bg-primary/5 ring-2 ring-primary/30"
-      )}
-    >
+  const className = cn(
+    "block w-full rounded-lg border bg-background p-3 text-left transition-all duration-200 hover:-translate-y-0.5 hover:bg-muted/60 hover:shadow-md",
+    compact && "border-l-4 p-2",
+    compact && compactKindTone(entry.kind),
+    focused && "border-primary bg-primary/5 ring-2 ring-primary/30"
+  )
+  const contents = (
+    <>
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <p className={cn("line-clamp-2 font-medium", compact ? "text-xs" : "text-sm")}>
@@ -153,12 +174,14 @@ function WorkItem({
             {entry.projectLabel} · {entry.sourceLabel}
           </p>
         </div>
-        <Badge
-          variant="outline"
-          className={cn("shrink-0 border", kindTone(entry.kind))}
-        >
-          {kindLabel(entry.kind)}
-        </Badge>
+        {!compact && (
+          <Badge
+            variant="outline"
+            className={cn("shrink-0 border", kindTone(entry.kind))}
+          >
+            {kindLabel(entry.kind)}
+          </Badge>
+        )}
       </div>
       {!compact && (
         <div className="mt-3 flex flex-wrap gap-1.5 text-xs text-muted-foreground">
@@ -170,6 +193,22 @@ function WorkItem({
           </span>
           <span>·</span>
           <span>{entry.status}</span>
+          {entry.kind === "event" && (
+            <>
+              <span>·</span>
+              <span>
+                {entry.eventDetails.allDay
+                  ? "All day"
+                  : `${entry.eventDetails.startTime}–${entry.eventDetails.endTime}`}
+              </span>
+            </>
+          )}
+          {entry.kind === "event" && entry.eventDetails.location && (
+            <>
+              <span>·</span>
+              <span className="truncate">{entry.eventDetails.location}</span>
+            </>
+          )}
           {(entry.assignedTo || entry.companyName) && (
             <>
               <span>·</span>
@@ -178,6 +217,34 @@ function WorkItem({
           )}
         </div>
       )}
+    </>
+  )
+
+  if (
+    entry.kind === "event" &&
+    entry.eventDetails.managed &&
+    canManageEvents
+  ) {
+    return (
+      <button
+        id={compact ? undefined : `work-calendar-${entry.id}`}
+        type="button"
+        className={className}
+        onClick={() => onEditEvent(entry)}
+        aria-label={`Edit calendar event ${entry.title}`}
+      >
+        {contents}
+      </button>
+    )
+  }
+
+  return (
+    <Link
+      id={compact ? undefined : `work-calendar-${entry.id}`}
+      href={entry.href}
+      className={className}
+    >
+      {contents}
     </Link>
   )
 }
@@ -192,6 +259,8 @@ export function WorkCalendar({
   readonly initialItemId?: string | null
 }): React.ReactElement {
   const [query, setQuery] = React.useState("")
+  const [editingEvent, setEditingEvent] =
+    React.useState<CalendarEventEntry | null>(null)
   const [activeKind, setActiveKind] =
     React.useState<WorkCalendarKindFilter>(initialKind)
   React.useEffect(() => {
@@ -282,8 +351,11 @@ export function WorkCalendar({
           <div className="flex flex-wrap gap-2">
             {data.canCreateEvents && (
               <WorkCalendarEventDialog
+                variant="create"
                 projects={data.projects}
+                attendeeOptions={data.attendeeOptions}
                 defaultProjectId={data.defaultProjectId}
+                defaultTimeZone={data.defaultTimeZone}
                 today={data.today}
               />
             )}
@@ -333,7 +405,13 @@ export function WorkCalendar({
                   </div>
                   <div className="mt-2 space-y-2">
                     {dayEntries.slice(0, 3).map((entry) => (
-                      <WorkItem key={`${day}-${entry.kind}-${entry.id}`} entry={entry} compact />
+                      <WorkItem
+                        key={`${day}-${entry.kind}-${entry.id}`}
+                        entry={entry}
+                        compact
+                        onEditEvent={setEditingEvent}
+                        canManageEvents={data.canManageEvents}
+                      />
                     ))}
                     {dayEntries.length > 3 && (
                       <p className="px-1 text-xs text-muted-foreground">
@@ -360,6 +438,8 @@ export function WorkCalendar({
                     key={`${entry.kind}-${entry.id}`}
                     entry={entry}
                     focused={entry.id === initialItemId}
+                    onEditEvent={setEditingEvent}
+                    canManageEvents={data.canManageEvents}
                   />
                 ))
               ) : (
@@ -401,6 +481,22 @@ export function WorkCalendar({
           </aside>
         </section>
       </div>
+      {editingEvent && data.canManageEvents && (
+        <WorkCalendarEventDialog
+          key={`${editingEvent.id}-${editingEvent.eventDetails.version}`}
+          variant="edit"
+          event={editingEvent}
+          open
+          onOpenChange={(open) => {
+            if (!open) setEditingEvent(null)
+          }}
+          projects={data.projects}
+          attendeeOptions={data.attendeeOptions}
+          defaultProjectId={data.defaultProjectId}
+          defaultTimeZone={data.defaultTimeZone}
+          today={data.today}
+        />
+      )}
     </div>
   )
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,8 +1,10 @@
 import {
+  index,
   sqliteTable,
   text,
   integer,
   real,
+  uniqueIndex,
 } from "drizzle-orm/sqlite-core"
 
 // Auth and user management tables
@@ -395,6 +397,97 @@ export const projectOperations = sqliteTable("project_operations", {
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
 })
+
+export const organizationCalendarSettings = sqliteTable(
+  "organization_calendar_settings",
+  {
+    organizationId: text("organization_id")
+      .primaryKey()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    defaultProjectId: text("default_project_id").references(
+      () => projects.id,
+      { onDelete: "set null" },
+    ),
+    timeZone: text("time_zone").notNull().default("America/Denver"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+)
+
+export const workCalendarEvents = sqliteTable(
+  "work_calendar_events",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id").references(() => projects.id, {
+      onDelete: "set null",
+    }),
+    title: text("title").notNull(),
+    description: text("description"),
+    startDate: text("start_date"),
+    endDateExclusive: text("end_date_exclusive"),
+    startsAt: text("starts_at"),
+    endsAt: text("ends_at"),
+    allDay: integer("all_day", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    timeZone: text("time_zone").notNull().default("UTC"),
+    location: text("location"),
+    status: text("status").notNull().default("open"),
+    version: integer("version").notNull().default(1),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    updatedBy: text("updated_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    cancelledBy: text("cancelled_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    cancelledAt: text("cancelled_at"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    index("idx_work_calendar_events_org_start").on(
+      table.organizationId,
+      table.status,
+      table.startDate,
+      table.startsAt,
+    ),
+    index("idx_work_calendar_events_project_start").on(
+      table.projectId,
+      table.status,
+      table.startDate,
+      table.startsAt,
+    ),
+  ],
+)
+
+export const workCalendarEventAttendees = sqliteTable(
+  "work_calendar_event_attendees",
+  {
+    id: text("id").primaryKey(),
+    eventId: text("event_id")
+      .notNull()
+      .references(() => workCalendarEvents.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    responseStatus: text("response_status").notNull().default("needs_action"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("work_calendar_event_attendee_unique").on(
+      table.eventId,
+      table.userId,
+    ),
+    index("idx_work_calendar_event_attendees_user").on(table.userId),
+  ],
+)
 
 export const projectPurchaseOrderLines = sqliteTable("project_purchase_order_lines", {
   id: text("id").primaryKey(),
@@ -816,6 +909,16 @@ export type OwnerProjectUpdate = typeof ownerProjectUpdates.$inferSelect
 export type NewOwnerProjectUpdate = typeof ownerProjectUpdates.$inferInsert
 export type ProjectOperation = typeof projectOperations.$inferSelect
 export type NewProjectOperation = typeof projectOperations.$inferInsert
+export type WorkCalendarEvent = typeof workCalendarEvents.$inferSelect
+export type NewWorkCalendarEvent = typeof workCalendarEvents.$inferInsert
+export type OrganizationCalendarSettings =
+  typeof organizationCalendarSettings.$inferSelect
+export type NewOrganizationCalendarSettings =
+  typeof organizationCalendarSettings.$inferInsert
+export type WorkCalendarEventAttendee =
+  typeof workCalendarEventAttendees.$inferSelect
+export type NewWorkCalendarEventAttendee =
+  typeof workCalendarEventAttendees.$inferInsert
 export type ProjectPurchaseOrderLine =
   typeof projectPurchaseOrderLines.$inferSelect
 export type NewProjectPurchaseOrderLine =

--- a/src/lib/__tests__/permissions.test.ts
+++ b/src/lib/__tests__/permissions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import type { AuthUser } from "@/lib/auth"
 import {
+  canManageWorkCalendarEvents,
   canUseAskCompass,
   canUseFieldDesk,
 } from "@/lib/permissions"
@@ -71,5 +72,31 @@ describe("canUseFieldDesk", () => {
       }),
     ).toBe(false)
     expect(canUseFieldDesk(null)).toBe(false)
+  })
+})
+
+describe("canManageWorkCalendarEvents", () => {
+  it.each(["admin", "office"])(
+    "allows calendar management for %s",
+    (role) => {
+      expect(canManageWorkCalendarEvents(userWithRole(role))).toBe(true)
+    },
+  )
+
+  it.each(["field", "client", "guest", "unknown"])(
+    "does not inherit calendar management from broad schedule access for %s",
+    (role) => {
+      expect(canManageWorkCalendarEvents(userWithRole(role))).toBe(false)
+    },
+  )
+
+  it("denies inactive and unauthenticated users", () => {
+    expect(
+      canManageWorkCalendarEvents({
+        ...userWithRole("admin"),
+        isActive: false,
+      }),
+    ).toBe(false)
+    expect(canManageWorkCalendarEvents(null)).toBe(false)
   })
 })

--- a/src/lib/__tests__/work-calendar.test.ts
+++ b/src/lib/__tests__/work-calendar.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  instantForLocalDateTime,
+  normalizeWorkCalendarEventTiming,
   projectTodoHref,
   resolveHOfficeProjectId,
   scheduleItemHref,
@@ -58,5 +60,155 @@ describe("H-Office default project resolution", () => {
         { id: "office-2", name: "H Office Project", projectNumber: null },
       ])
     ).toBeNull()
+  })
+})
+
+describe("work calendar event timing", () => {
+  it("resolves wall-clock times in the organization time zone", () => {
+    expect(
+      instantForLocalDateTime(
+        "2026-07-27",
+        "09:30",
+        "America/Denver"
+      )
+    ).toEqual({
+      success: true,
+      instant: "2026-07-27T15:30:00.000Z",
+      ambiguous: false,
+    })
+  })
+
+  it("rejects the spring-forward gap and marks the fall-back fold", () => {
+    expect(
+      instantForLocalDateTime(
+        "2026-03-08",
+        "02:30",
+        "America/Denver"
+      )
+    ).toEqual({
+      success: false,
+      error: "That local time does not exist in the selected time zone.",
+    })
+
+    expect(
+      instantForLocalDateTime(
+        "2026-11-01",
+        "01:30",
+        "America/Denver"
+      )
+    ).toEqual({
+      success: true,
+      instant: "2026-11-01T07:30:00.000Z",
+      ambiguous: true,
+    })
+  })
+
+  it("normalizes all-day date ranges without inventing a time", () => {
+    expect(
+      normalizeWorkCalendarEventTiming({
+        allDay: true,
+        startDate: "2026-07-27",
+        endDate: "2026-07-29",
+        startTime: "",
+        endTime: "",
+        startsAt: null,
+        endsAt: null,
+        timeZone: "America/Denver",
+      })
+    ).toEqual({
+      success: true,
+      startDate: "2026-07-27",
+      endDateExclusive: "2026-07-30",
+      startsAt: null,
+      endsAt: null,
+      timeZone: "America/Denver",
+    })
+  })
+
+  it("normalizes timed events and rejects zero or negative durations", () => {
+    expect(
+      normalizeWorkCalendarEventTiming({
+        allDay: false,
+        startDate: "2026-07-27",
+        endDate: "2026-07-27",
+        startTime: "09:30",
+        endTime: "10:15",
+        startsAt: "2026-07-27T15:30:00.000Z",
+        endsAt: "2026-07-27T16:15:00.000Z",
+        timeZone: "America/Denver",
+      })
+    ).toMatchObject({
+      success: true,
+      startDate: null,
+      endDateExclusive: null,
+      startsAt: "2026-07-27T15:30:00.000Z",
+      endsAt: "2026-07-27T16:15:00.000Z",
+    })
+
+    expect(
+      normalizeWorkCalendarEventTiming({
+        allDay: false,
+        startDate: "2026-07-27",
+        endDate: "2026-07-27",
+        startTime: "10:15",
+        endTime: "10:15",
+        startsAt: "2026-07-27T16:15:00.000Z",
+        endsAt: "2026-07-27T16:15:00.000Z",
+        timeZone: "America/Denver",
+      })
+    ).toEqual({
+      success: false,
+      error: "A timed event must end after it starts.",
+    })
+  })
+
+  it("rejects impossible dates and backwards all-day ranges", () => {
+    expect(
+      normalizeWorkCalendarEventTiming({
+        allDay: true,
+        startDate: "2026-02-30",
+        endDate: "2026-03-01",
+        startTime: "",
+        endTime: "",
+        startsAt: null,
+        endsAt: null,
+        timeZone: "UTC",
+      })
+    ).toEqual({
+      success: false,
+      error: "Enter valid event dates.",
+    })
+
+    expect(
+      normalizeWorkCalendarEventTiming({
+        allDay: true,
+        startDate: "2026-07-29",
+        endDate: "2026-07-27",
+        startTime: "",
+        endTime: "",
+        startsAt: null,
+        endsAt: null,
+        timeZone: "UTC",
+      })
+    ).toEqual({
+      success: false,
+      error: "End date must be on or after the start date.",
+    })
+
+    expect(
+      normalizeWorkCalendarEventTiming({
+        allDay: true,
+        startDate: "2026-07-27",
+        endDate: "2026-07-27",
+        startTime: "",
+        endTime: "",
+        startsAt: null,
+        endsAt: null,
+        timeZone: "Not/A_Time_Zone",
+      })
+    ).toEqual({
+      success: false,
+      error: "The event time zone is invalid.",
+    })
   })
 })

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -129,6 +129,21 @@ export function canUseFieldDesk(user: AuthUser | null): boolean {
   )
 }
 
+/**
+ * Meetings are organization-wide coordination records. Keep their mutation
+ * surface narrower than schedule.update, which field staff use for progress
+ * updates on assigned schedule work.
+ */
+export function canManageWorkCalendarEvents(
+  user: AuthUser | null
+): boolean {
+  if (!user || !user.isActive) return false
+  return (
+    (user.role === "admin" || user.role === "office") &&
+    can(user, "schedule", "update")
+  )
+}
+
 export function requirePermission(
   user: AuthUser | null,
   resource: Resource,

--- a/src/lib/work-calendar.ts
+++ b/src/lib/work-calendar.ts
@@ -15,6 +15,269 @@ export type WorkCalendarSearchableEntry = {
   readonly sourceLabel: string
 }
 
+export type WorkCalendarEventTimingInput = {
+  readonly allDay: boolean
+  readonly startDate: string
+  readonly endDate: string
+  readonly startTime: string
+  readonly endTime: string
+  readonly startsAt: string | null
+  readonly endsAt: string | null
+  readonly timeZone: string
+}
+
+export type WorkCalendarEventTiming =
+  | {
+      readonly success: true
+      readonly startDate: string | null
+      readonly endDateExclusive: string | null
+      readonly startsAt: string | null
+      readonly endsAt: string | null
+      readonly timeZone: string
+    }
+  | {
+      readonly success: false
+      readonly error: string
+    }
+
+const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+const TIME_KEY_PATTERN = /^(?:[01]\d|2[0-3]):[0-5]\d$/
+
+function isRealDateKey(value: string): boolean {
+  if (!DATE_KEY_PATTERN.test(value)) return false
+  const parsed = new Date(`${value}T00:00:00Z`)
+  return (
+    !Number.isNaN(parsed.getTime()) &&
+    parsed.toISOString().slice(0, 10) === value
+  )
+}
+
+function addDateKeyDays(value: string, days: number): string {
+  const parsed = new Date(`${value}T12:00:00Z`)
+  parsed.setUTCDate(parsed.getUTCDate() + days)
+  return parsed.toISOString().slice(0, 10)
+}
+
+function isCanonicalInstant(value: string): boolean {
+  const parsed = new Date(value)
+  return (
+    !Number.isNaN(parsed.getTime()) &&
+    parsed.toISOString() === value
+  )
+}
+
+function isValidTimeZone(value: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: value }).format(new Date(0))
+    return true
+  } catch {
+    return false
+  }
+}
+
+function localDateTimeInZone(
+  instant: string,
+  timeZone: string
+): string | null {
+  try {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(new Date(instant))
+    const values = new Map(
+      parts.map((part) => [part.type, part.value])
+    )
+    const year = values.get("year")
+    const month = values.get("month")
+    const day = values.get("day")
+    const hour = values.get("hour")
+    const minute = values.get("minute")
+    if (!year || !month || !day || !hour || !minute) return null
+    return `${year}-${month}-${day}T${hour}:${minute}`
+  } catch {
+    return null
+  }
+}
+
+export type LocalDateTimeResolution =
+  | {
+      readonly success: true
+      readonly instant: string
+      readonly ambiguous: boolean
+    }
+  | {
+      readonly success: false
+      readonly error: string
+    }
+
+export function instantForLocalDateTime(
+  date: string,
+  time: string,
+  timeZone: string
+): LocalDateTimeResolution {
+  if (!isRealDateKey(date) || !TIME_KEY_PATTERN.test(time)) {
+    return { success: false, error: "Enter a valid date and time." }
+  }
+
+  const zone = timeZone.trim()
+  const target = `${date}T${time}`
+  const [year, month, day] = date.split("-").map(Number)
+  const [hour, minute] = time.split(":").map(Number)
+  if (
+    year === undefined ||
+    month === undefined ||
+    day === undefined ||
+    hour === undefined ||
+    minute === undefined
+  ) {
+    return { success: false, error: "Enter a valid date and time." }
+  }
+
+  // Searching possible UTC offsets avoids relying on the device's own time
+  // zone. Fifteen-minute increments cover every currently used IANA offset,
+  // including half-hour and 45-minute regions.
+  const localAsUtc = Date.UTC(year, month - 1, day, hour, minute)
+  const matches: string[] = []
+  for (
+    let offsetMinutes = -14 * 60;
+    offsetMinutes <= 14 * 60;
+    offsetMinutes += 15
+  ) {
+    const instant = new Date(
+      localAsUtc - offsetMinutes * 60_000
+    ).toISOString()
+    if (localDateTimeInZone(instant, zone) === target) matches.push(instant)
+  }
+
+  if (matches.length === 0) {
+    return {
+      success: false,
+      error: "That local time does not exist in the selected time zone.",
+    }
+  }
+
+  matches.sort()
+  const firstMatch = matches[0]
+  if (!firstMatch) {
+    return {
+      success: false,
+      error: "That local time could not be resolved.",
+    }
+  }
+
+  return {
+    success: true,
+    instant: firstMatch,
+    ambiguous: matches.length > 1,
+  }
+}
+
+export function dateKeyInTimeZone(
+  instant: Date,
+  timeZone: string
+): string {
+  const iso = instant.toISOString()
+  const local = localDateTimeInZone(iso, timeZone)
+  return local?.slice(0, 10) ?? iso.slice(0, 10)
+}
+
+export function inclusiveEndDateFromExclusive(
+  endDateExclusive: string
+): string {
+  return addDateKeyDays(endDateExclusive, -1)
+}
+
+export function normalizeWorkCalendarEventTiming(
+  input: WorkCalendarEventTimingInput
+): WorkCalendarEventTiming {
+  if (!isRealDateKey(input.startDate) || !isRealDateKey(input.endDate)) {
+    return { success: false, error: "Enter valid event dates." }
+  }
+
+  if (input.endDate < input.startDate) {
+    return {
+      success: false,
+      error: "End date must be on or after the start date.",
+    }
+  }
+
+  const timeZone = input.timeZone.trim()
+  if (
+    timeZone.length === 0 ||
+    timeZone.length > 100 ||
+    !isValidTimeZone(timeZone)
+  ) {
+    return {
+      success: false,
+      error: "The event time zone is invalid.",
+    }
+  }
+
+  if (input.allDay) {
+    return {
+      success: true,
+      startDate: input.startDate,
+      endDateExclusive: addDateKeyDays(input.endDate, 1),
+      startsAt: null,
+      endsAt: null,
+      timeZone,
+    }
+  }
+
+  if (
+    !TIME_KEY_PATTERN.test(input.startTime) ||
+    !TIME_KEY_PATTERN.test(input.endTime)
+  ) {
+    return { success: false, error: "Enter valid start and end times." }
+  }
+
+  if (
+    !input.startsAt ||
+    !input.endsAt ||
+    !isCanonicalInstant(input.startsAt) ||
+    !isCanonicalInstant(input.endsAt)
+  ) {
+    return {
+      success: false,
+      error: "The timed event could not be resolved in its time zone.",
+    }
+  }
+
+  if (
+    localDateTimeInZone(input.startsAt, timeZone) !==
+      `${input.startDate}T${input.startTime}` ||
+    localDateTimeInZone(input.endsAt, timeZone) !==
+      `${input.endDate}T${input.endTime}`
+  ) {
+    return {
+      success: false,
+      error:
+        "One of these local times does not exist in the selected time zone.",
+    }
+  }
+
+  if (input.endsAt <= input.startsAt) {
+    return {
+      success: false,
+      error: "A timed event must end after it starts.",
+    }
+  }
+
+  return {
+    success: true,
+    startDate: null,
+    endDateExclusive: null,
+    startsAt: input.startsAt,
+    endsAt: input.endsAt,
+    timeZone,
+  }
+}
+
 export function normalizeWorkCalendarSearch(value: string): string {
   return value
     .trim()


### PR DESCRIPTION
## Outcome

Adds a dedicated, permission-gated Work Calendar event workflow for meetings and ordinary events, and repairs the compact full-calendar cards so their actual schedule/to-do titles remain visible.

## Included

- create, edit, and softly cancel timed or all-day events
- location, description, active organization attendees, and optional project
- deterministic configured H-Office fallback with a clear setup error when unavailable
- organization tenant boundary and admin/office mutation policy
- demo-user write protection
- attendee in-app/push lifecycle notifications without exposing private event details
- optimistic version checks for concurrent edits
- IANA time-zone and daylight-saving validation
- additive dedicated event/attendee/settings schema
- migration of legacy `project_operations` calendar events without deleting source rows
- preservation of attendee response state on edits
- compact calendar cards show actual titles with a slim type-color edge instead of a width-consuming generic badge

## Verification

- `vitest run`: 33 files passed; 261 tests passed, 3 skipped
- TypeScript: clean
- targeted ESLint: clean
- `next build --webpack`: passed
- fresh local database: all 51 migrations applied
- `PRAGMA foreign_key_check`: clean
- legacy migration fixture preserved ID, organization/project, title, inclusive dates, and status
- Chromium regression: actual schedule-item and to-do titles visible in compact calendar cards
- manual production comparison confirmed the prior generic-badge title collapse and the repaired local layout

## Deployment note

Migration `0067_work_calendar_events.sql` is additive. Apply it before the application deployment; the migration keeps legacy source rows and the application temporarily renders any late unmatched legacy rows read-only.

Closes #140
Refs #142
