### PR TITLE
fix(schedule): make imported to-dos manageable

### DIFF
--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -20,6 +20,7 @@ const coreAreas = [
 const projectAreas = [
   { name: "overview", suffix: "" },
   { name: "schedule", suffix: "/schedule" },
+  { name: "to-dos", suffix: "/todos" },
   { name: "daily logs", suffix: "/daily-logs" },
   { name: "photos", suffix: "/photos" },
   { name: "contacts", suffix: "/contacts" },
@@ -173,5 +174,30 @@ test.describe("usable Compass areas", () => {
         exact: true,
       }).first()
     ).toBeVisible()
+  })
+
+  test("work calendar to-dos open and focus the exact project record", async ({
+    page,
+  }) => {
+    const response = await page.goto("/dashboard/schedule")
+    await expectHealthyNavigation(page, response, "/dashboard/schedule")
+
+    const todoLink = page
+      .getByRole("link", { name: /Regression follow-up/ })
+      .first()
+    await expect(todoLink).toHaveAttribute(
+      "href",
+      /\/dashboard\/projects\/e2e-project-001\/todos\?item=e2e-todo-001/
+    )
+    await todoLink.click()
+
+    await expect(page).toHaveURL(
+      /\/dashboard\/projects\/e2e-project-001\/todos\?item=e2e-todo-001/
+    )
+    const focusedTodo = page.locator(
+      'article[data-focused="true"]#todo-e2e-todo-001'
+    )
+    await expect(focusedTodo).toContainText("Regression follow-up")
+    await expect(focusedTodo).toBeFocused()
   })
 })

--- a/src/app/actions/project-operations.ts
+++ b/src/app/actions/project-operations.ts
@@ -16,9 +16,18 @@ import {
 } from "@/db/schema"
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
 import { requireOrg } from "@/lib/org-scope"
 import { requirePermission } from "@/lib/permissions"
 import { notifyProjectAssignment } from "@/lib/notifications/events"
+import {
+  PROJECT_TODO_RECORD_TYPES,
+  type ProjectTodoStatus,
+  isArchivedProjectTodoStatus,
+  isCompletedProjectTodoStatus,
+  isProjectTodoRecordType,
+  isProjectTodoStatus,
+} from "@/lib/project-todos"
 
 export type ProjectOperationItem = {
   readonly id: string
@@ -49,6 +58,7 @@ export type ProjectOperationItem = {
   readonly sageRequiredDate: string | null
   readonly sageWriteStatus: string
   readonly sagePayloadJson: string | null
+  readonly updatedAt: string
 }
 
 export type ProjectPurchaseOrderLineItem = {
@@ -239,6 +249,27 @@ export type CreateProjectTaskInput = {
   readonly externalUrl: string | null
 }
 
+export type UpdateProjectTodoInput = {
+  readonly title: string
+  readonly description: string | null
+  readonly sourceRecordType: ProjectTaskRecordType
+  readonly status: ProjectTodoStatus
+  readonly priority: string
+  readonly assigneeName: string | null
+  readonly companyName: string | null
+  readonly startDate: string | null
+  readonly dueDate: string | null
+  readonly expectedUpdatedAt: string
+}
+
+export type ProjectTodoActionResult =
+  | {
+      readonly success: true
+      readonly id: string
+      readonly updatedAt: string
+    }
+  | { readonly success: false; readonly error: string }
+
 type SagePurchaseOrderPayload = {
   readonly source: "compass_po_request"
   readonly header: {
@@ -320,6 +351,9 @@ async function verifyProjectUpdateAccess(
   projectId: string
 ): Promise<ReturnType<typeof getDb>> {
   const user = await requireAuth()
+  if (isDemoUser(user.id)) {
+    throw new Error("DEMO_READ_ONLY")
+  }
   requirePermission(user, "project", "update")
   const orgId = requireOrg(user)
 
@@ -342,6 +376,23 @@ async function verifyProjectUpdateAccess(
 function cleanText(value: string | null): string | null {
   const trimmed = value?.trim() ?? ""
   return trimmed.length > 0 ? trimmed : null
+}
+
+function cleanDate(value: string | null, label: string): string | null {
+  const cleaned = cleanText(value)
+  if (cleaned === null) return null
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(cleaned)) {
+    throw new Error(`${label} must be a valid date`)
+  }
+
+  const parsed = new Date(`${cleaned}T12:00:00Z`)
+  if (
+    Number.isNaN(parsed.getTime()) ||
+    parsed.toISOString().slice(0, 10) !== cleaned
+  ) {
+    throw new Error(`${label} must be a valid date`)
+  }
+  return cleaned
 }
 
 function requireText(value: string, label: string): string {
@@ -449,6 +500,21 @@ function normalizeTaskRecordType(value: ProjectTaskRecordType): ProjectTaskRecor
   if (value === "supplier_task") return "supplier_task"
   if (value === "schedule_task") return "schedule_task"
   return "staff_task"
+}
+
+function assigneeTypeForTask(recordType: ProjectTaskRecordType): string {
+  if (recordType === "subcontractor_task") return "subcontractor"
+  if (recordType === "supplier_task") return "supplier"
+  return "internal"
+}
+
+function revalidateProjectTodoPaths(projectId: string): void {
+  revalidatePath(`/dashboard/projects/${projectId}`)
+  revalidatePath(`/dashboard/projects/${projectId}/todos`)
+  revalidatePath(`/dashboard/projects/${projectId}/daily-logs`)
+  revalidatePath(`/dashboard/projects/${projectId}/schedule`)
+  revalidatePath("/dashboard")
+  revalidatePath("/dashboard/schedule")
 }
 
 function operationSyncKind(recordType: string): ProjectSageSyncItemKind {
@@ -773,6 +839,7 @@ function toOperationItem(row: typeof projectOperations.$inferSelect): ProjectOpe
     sageRequiredDate: row.sageRequiredDate,
     sageWriteStatus: row.sageWriteStatus,
     sagePayloadJson: row.sagePayloadJson,
+    updatedAt: row.updatedAt,
   }
 }
 
@@ -1066,19 +1133,16 @@ export async function getProjectOperationsSummary(
     (operation) => operation.sourceRecordType === "purchase_order"
   )
   const commitments = operations.filter((operation) =>
-    [
-      "staff_task",
-      "subcontractor_task",
-      "supplier_task",
-      "schedule_task",
-    ].includes(operation.sourceRecordType)
+    isProjectTodoRecordType(operation.sourceRecordType)
   )
 
   const openPurchaseOrders = purchaseOrders.filter(
     (operation) => !["closed", "void", "complete"].includes(operation.status)
   )
   const activeCommitments = commitments.filter(
-    (operation) => !["complete", "cancelled"].includes(operation.status)
+    (operation) =>
+      !isCompletedProjectTodoStatus(operation.status) &&
+      !isArchivedProjectTodoStatus(operation.status)
   )
 
   const [nextCompassTask] = await db
@@ -1124,6 +1188,30 @@ export async function getProjectOperationsSummary(
     purchaseOrders: purchaseOrders.slice(0, 5).map(toOperationItem),
     commitments: commitments.slice(0, 6).map(toOperationItem),
   }
+}
+
+export async function getProjectTodos(
+  projectId: string
+): Promise<readonly ProjectOperationItem[]> {
+  const db = await verifyProjectAccess(projectId)
+  const operations = await db
+    .select()
+    .from(projectOperations)
+    .where(
+      and(
+        eq(projectOperations.projectId, projectId),
+        inArray(projectOperations.sourceRecordType, [
+          ...PROJECT_TODO_RECORD_TYPES,
+        ])
+      )
+    )
+    .orderBy(
+      asc(projectOperations.dueDate),
+      asc(projectOperations.createdAt),
+      asc(projectOperations.title)
+    )
+
+  return operations.map(toOperationItem)
 }
 
 export async function getProjectSageSyncQueue(
@@ -1955,10 +2043,7 @@ export async function createProjectTask(
         and(
           eq(projectOperations.projectId, projectId),
           inArray(projectOperations.sourceRecordType, [
-            "staff_task",
-            "subcontractor_task",
-            "supplier_task",
-            "schedule_task",
+            ...PROJECT_TODO_RECORD_TYPES,
           ])
         )
       )
@@ -1981,12 +2066,7 @@ export async function createProjectTask(
       description: cleanText(input.description),
       status: "open",
       priority: cleanText(input.priority) ?? "normal",
-      assigneeType:
-        sourceRecordType === "subcontractor_task"
-          ? "subcontractor"
-          : sourceRecordType === "supplier_task"
-            ? "supplier"
-            : "internal",
+      assigneeType: assigneeTypeForTask(sourceRecordType),
       assigneeName: cleanText(input.assigneeName),
       companyName: cleanText(input.companyName),
       startDate,
@@ -2035,8 +2115,7 @@ export async function createProjectTask(
     revalidatePath(`/dashboard/projects/${projectId}/rfis`)
     revalidatePath(`/dashboard/projects/${projectId}/rfqs`)
     revalidatePath(`/dashboard/projects/${projectId}/purchase-orders`)
-    revalidatePath("/dashboard")
-    revalidatePath("/dashboard/schedule")
+    revalidateProjectTodoPaths(projectId)
 
     return { success: true, id }
   } catch (error) {
@@ -2048,6 +2127,239 @@ export async function createProjectTask(
           : "Failed to create project task",
     }
   }
+}
+
+async function findEditableProjectTodo(
+  projectId: string,
+  todoId: string,
+  expectedUpdatedAt: string
+): Promise<{
+  readonly db: ReturnType<typeof getDb>
+  readonly operation: typeof projectOperations.$inferSelect
+}> {
+  const db = await verifyProjectUpdateAccess(projectId)
+  const [operation] = await db
+    .select()
+    .from(projectOperations)
+    .where(
+      and(
+        eq(projectOperations.id, todoId),
+        eq(projectOperations.projectId, projectId)
+      )
+    )
+    .limit(1)
+
+  if (!operation || !isProjectTodoRecordType(operation.sourceRecordType)) {
+    throw new Error("To-do not found")
+  }
+  if (operation.updatedAt !== expectedUpdatedAt) {
+    throw new Error(
+      "This to-do changed after you opened it. Refresh and review the latest version."
+    )
+  }
+
+  return { db, operation }
+}
+
+export async function updateProjectTodo(
+  projectId: string,
+  todoId: string,
+  input: UpdateProjectTodoInput
+): Promise<ProjectTodoActionResult> {
+  try {
+    const user = await requireAuth()
+    const organizationId = requireOrg(user)
+    const { db, operation } = await findEditableProjectTodo(
+      projectId,
+      todoId,
+      input.expectedUpdatedAt
+    )
+    if (!isProjectTodoStatus(input.status)) {
+      return { success: false, error: "Choose a valid to-do status." }
+    }
+    const sourceRecordType = normalizeTaskRecordType(input.sourceRecordType)
+    const title = requireText(input.title, "Title")
+    const assigneeName = cleanText(input.assigneeName)
+    const companyName = cleanText(input.companyName)
+    const startDate = cleanDate(input.startDate, "Start date")
+    const dueDate = cleanDate(input.dueDate, "Due date")
+    if (startDate && dueDate && dueDate < startDate) {
+      return {
+        success: false,
+        error: "Due date must be on or after the start date.",
+      }
+    }
+
+    const updatedAt = new Date().toISOString()
+    const updatedRows = await db
+      .update(projectOperations)
+      .set({
+        sourceRecordType,
+        title,
+        description: cleanText(input.description),
+        status: input.status,
+        priority: cleanText(input.priority) ?? "normal",
+        assigneeType: assigneeTypeForTask(sourceRecordType),
+        assigneeName,
+        companyName,
+        startDate,
+        dueDate,
+        updatedAt,
+      })
+      .where(
+        and(
+          eq(projectOperations.id, todoId),
+          eq(projectOperations.projectId, projectId),
+          eq(projectOperations.updatedAt, input.expectedUpdatedAt)
+        )
+      )
+      .returning({
+        id: projectOperations.id,
+        updatedAt: projectOperations.updatedAt,
+      })
+    const updated = updatedRows[0]
+    if (!updated) {
+      return {
+        success: false,
+        error:
+          "This to-do changed while you were saving. Refresh and review the latest version.",
+      }
+    }
+
+    if (assigneeName && assigneeName !== operation.assigneeName) {
+      try {
+        await notifyProjectAssignment({
+          organizationId,
+          projectId,
+          itemId: todoId,
+          title,
+          assignedToName: assigneeName,
+          createdBy: user,
+          kind: "task",
+        })
+      } catch (notificationError) {
+        console.error(
+          "Updated project task assignment notification failed:",
+          notificationError
+        )
+      }
+    }
+
+    revalidateProjectTodoPaths(projectId)
+    return { success: true, id: updated.id, updatedAt: updated.updatedAt }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to update to-do",
+    }
+  }
+}
+
+export async function setProjectTodoStatus(
+  projectId: string,
+  todoId: string,
+  status: ProjectTodoStatus,
+  expectedUpdatedAt: string
+): Promise<ProjectTodoActionResult> {
+  try {
+    if (!isProjectTodoStatus(status)) {
+      return { success: false, error: "Choose a valid to-do status." }
+    }
+    const { db } = await findEditableProjectTodo(
+      projectId,
+      todoId,
+      expectedUpdatedAt
+    )
+    const updatedAt = new Date().toISOString()
+    const updatedRows = await db
+      .update(projectOperations)
+      .set({ status, updatedAt })
+      .where(
+        and(
+          eq(projectOperations.id, todoId),
+          eq(projectOperations.projectId, projectId),
+          eq(projectOperations.updatedAt, expectedUpdatedAt)
+        )
+      )
+      .returning({
+        id: projectOperations.id,
+        updatedAt: projectOperations.updatedAt,
+      })
+    const updated = updatedRows[0]
+    if (!updated) {
+      return {
+        success: false,
+        error:
+          "This to-do changed while you were saving. Refresh and review the latest version.",
+      }
+    }
+
+    revalidateProjectTodoPaths(projectId)
+    return { success: true, id: updated.id, updatedAt: updated.updatedAt }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to change to-do status",
+    }
+  }
+}
+
+export async function archiveProjectTodo(
+  projectId: string,
+  todoId: string,
+  expectedUpdatedAt: string
+): Promise<ProjectTodoActionResult> {
+  try {
+    const { db } = await findEditableProjectTodo(
+      projectId,
+      todoId,
+      expectedUpdatedAt
+    )
+    const updatedAt = new Date().toISOString()
+    const updatedRows = await db
+      .update(projectOperations)
+      .set({ status: "archived", updatedAt })
+      .where(
+        and(
+          eq(projectOperations.id, todoId),
+          eq(projectOperations.projectId, projectId),
+          eq(projectOperations.updatedAt, expectedUpdatedAt)
+        )
+      )
+      .returning({
+        id: projectOperations.id,
+        updatedAt: projectOperations.updatedAt,
+      })
+    const updated = updatedRows[0]
+    if (!updated) {
+      return {
+        success: false,
+        error:
+          "This to-do changed while you were archiving it. Refresh and review the latest version.",
+      }
+    }
+
+    revalidateProjectTodoPaths(projectId)
+    return { success: true, id: updated.id, updatedAt: updated.updatedAt }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to archive to-do",
+    }
+  }
+}
+
+export async function restoreProjectTodo(
+  projectId: string,
+  todoId: string,
+  expectedUpdatedAt: string
+): Promise<ProjectTodoActionResult> {
+  return setProjectTodoStatus(projectId, todoId, "open", expectedUpdatedAt)
 }
 
 export async function sendPurchaseOrderEmail(

--- a/src/app/actions/work-calendar.ts
+++ b/src/app/actions/work-calendar.ts
@@ -33,6 +33,7 @@ import {
   resolveHOfficeProjectId,
   scheduleItemHref,
 } from "@/lib/work-calendar"
+import { isProjectTodoRecordType } from "@/lib/project-todos"
 
 export type WorkCalendarEntryKind =
   | "schedule"
@@ -443,12 +444,7 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
         href:
           operation.sourceRecordType === "purchase_order"
             ? `/dashboard/projects/${project.id}/purchase-orders`
-            : [
-                    "staff_task",
-                    "subcontractor_task",
-                    "supplier_task",
-                    "schedule_task",
-                  ].includes(operation.sourceRecordType)
+            : isProjectTodoRecordType(operation.sourceRecordType)
                 ? projectTodoHref(project.id, operation.id)
                 : `/dashboard/projects/${project.id}`,
         eventDetails: null,

--- a/src/app/dashboard/projects/[id]/todos/page.tsx
+++ b/src/app/dashboard/projects/[id]/todos/page.tsx
@@ -2,9 +2,16 @@ export const dynamic = "force-dynamic"
 
 import { notFound } from "next/navigation"
 
-import { getProjectOperationsSummary } from "@/app/actions/project-operations"
+import {
+  getProjectTaskAssigneeOptions,
+  type ProjectTaskAssigneeOption,
+} from "@/app/actions/project-contacts"
+import { getProjectTodos } from "@/app/actions/project-operations"
 import { getProjects } from "@/app/actions/projects"
 import { ProjectTodosView } from "@/components/projects/project-todos-view"
+import { requireAuth } from "@/lib/auth"
+import { isDemoUser } from "@/lib/demo"
+import { can } from "@/lib/permissions"
 
 export default async function ProjectTodosPage({
   params,
@@ -16,9 +23,10 @@ export default async function ProjectTodosPage({
   }>
 }): Promise<React.ReactElement> {
   const [{ id }, query] = await Promise.all([params, searchParams])
-  const [projects, summary] = await Promise.all([
+  const [projects, items, user] = await Promise.all([
     getProjects(),
-    getProjectOperationsSummary(id),
+    getProjectTodos(id),
+    requireAuth(),
   ])
   const project = projects.find((candidate) => candidate.id === id)
   if (!project) notFound()
@@ -28,12 +36,25 @@ export default async function ProjectTodosPage({
     : project.name
   const initialItemId =
     typeof query.item === "string" ? query.item : query.item?.[0] ?? null
+  const canManage =
+    !isDemoUser(user.id) && can(user, "project", "update")
+  let assigneeOptions: ProjectTaskAssigneeOption[] = []
+  if (canManage) {
+    const assigneeData = await getProjectTaskAssigneeOptions(id)
+    assigneeOptions = [
+      ...assigneeData.projectContacts,
+      ...assigneeData.directoryContacts,
+    ]
+  }
 
   return (
     <ProjectTodosView
+      projectId={id}
       projectLabel={projectLabel}
-      items={summary.commitments}
+      items={items}
       initialItemId={initialItemId}
+      assigneeOptions={assigneeOptions}
+      canManage={canManage}
     />
   )
 }

--- a/src/components/projects/project-assignee-picker.tsx
+++ b/src/components/projects/project-assignee-picker.tsx
@@ -26,6 +26,7 @@ type ProjectAssigneePickerProps = {
   ) => void
   readonly placeholder?: string
   readonly className?: string
+  readonly disabled?: boolean
 }
 
 function normalizeChoice(value: string): string {
@@ -89,6 +90,7 @@ export function ProjectAssigneePicker({
   onValueChange,
   placeholder = "Choose contact or type a name...",
   className,
+  disabled = false,
 }: ProjectAssigneePickerProps): React.ReactElement {
   const [open, setOpen] = React.useState(false)
   const [query, setQuery] = React.useState("")
@@ -130,6 +132,7 @@ export function ProjectAssigneePicker({
         <Button
           type="button"
           variant="outline"
+          disabled={disabled}
           className={cn(
             "h-9 w-full justify-between bg-background px-3 text-left font-normal",
             !value && "text-muted-foreground",

--- a/src/components/projects/project-todo-edit-dialog.tsx
+++ b/src/components/projects/project-todo-edit-dialog.tsx
@@ -1,0 +1,376 @@
+"use client"
+
+import * as React from "react"
+import { useRouter } from "next/navigation"
+import { IconArchive, IconDeviceFloppy, IconRestore } from "@tabler/icons-react"
+
+import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
+import {
+  archiveProjectTodo,
+  restoreProjectTodo,
+  updateProjectTodo,
+  type ProjectOperationItem,
+  type ProjectTaskRecordType,
+} from "@/app/actions/project-operations"
+import { ProjectAssigneePicker } from "@/components/projects/project-assignee-picker"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  canonicalProjectTodoRecordType,
+  isArchivedProjectTodoStatus,
+  normalizeProjectTodoStatus,
+  projectTodoStatusLabel,
+} from "@/lib/project-todos"
+
+type SaveState =
+  | { readonly kind: "idle" }
+  | { readonly kind: "saving" }
+  | { readonly kind: "error"; readonly message: string }
+
+function cleanValue(value: string): string | null {
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function sourceLabel(item: ProjectOperationItem): string {
+  if (item.sourceSystem === "buildertrend") return "Imported from Buildertrend"
+  if (item.sourceSystem === "compass") return "Created in Compass"
+  if (item.sourceSystem === "sage") return "Imported from Sage"
+  return `Imported from ${item.sourceSystem}`
+}
+
+export function ProjectTodoEditDialog({
+  projectId,
+  item,
+  assigneeOptions,
+  open,
+  onOpenChange,
+}: {
+  readonly projectId: string
+  readonly item: ProjectOperationItem
+  readonly assigneeOptions: readonly ProjectTaskAssigneeOption[]
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
+}): React.ReactElement {
+  const router = useRouter()
+  const [title, setTitle] = React.useState(item.title)
+  const [description, setDescription] = React.useState(item.description ?? "")
+  const [taskType, setTaskType] = React.useState<ProjectTaskRecordType>(
+    canonicalProjectTodoRecordType(item.sourceRecordType)
+  )
+  const [status, setStatus] = React.useState(
+    normalizeProjectTodoStatus(item.status)
+  )
+  const [priority, setPriority] = React.useState(item.priority)
+  const [assigneeName, setAssigneeName] = React.useState(
+    item.assigneeName ?? ""
+  )
+  const [companyName, setCompanyName] = React.useState(item.companyName ?? "")
+  const [startDate, setStartDate] = React.useState(item.startDate ?? "")
+  const [dueDate, setDueDate] = React.useState(item.dueDate ?? "")
+  const [saveState, setSaveState] = React.useState<SaveState>({ kind: "idle" })
+  const archived = isArchivedProjectTodoStatus(item.status)
+
+  async function save(event: React.FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault()
+    setSaveState({ kind: "saving" })
+    const result = await updateProjectTodo(projectId, item.id, {
+      title,
+      description: cleanValue(description),
+      sourceRecordType: taskType,
+      status,
+      priority,
+      assigneeName: cleanValue(assigneeName),
+      companyName: cleanValue(companyName),
+      startDate: cleanValue(startDate),
+      dueDate: cleanValue(dueDate),
+      expectedUpdatedAt: item.updatedAt,
+    })
+
+    if (!result.success) {
+      setSaveState({ kind: "error", message: result.error })
+      return
+    }
+
+    onOpenChange(false)
+    router.refresh()
+  }
+
+  async function archive(): Promise<void> {
+    setSaveState({ kind: "saving" })
+    const result = await archiveProjectTodo(
+      projectId,
+      item.id,
+      item.updatedAt
+    )
+    if (!result.success) {
+      setSaveState({ kind: "error", message: result.error })
+      return
+    }
+
+    onOpenChange(false)
+    router.refresh()
+  }
+
+  async function restore(): Promise<void> {
+    setSaveState({ kind: "saving" })
+    const result = await restoreProjectTodo(
+      projectId,
+      item.id,
+      item.updatedAt
+    )
+    if (!result.success) {
+      setSaveState({ kind: "error", message: result.error })
+      return
+    }
+
+    onOpenChange(false)
+    router.refresh()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+        <form onSubmit={save} className="space-y-5">
+          <DialogHeader>
+            <DialogTitle>Edit to-do</DialogTitle>
+            <DialogDescription>
+              {sourceLabel(item)}
+              {item.sourceRecordNumber
+                ? ` · ${item.sourceRecordNumber}`
+                : ""}
+              . Original source identifiers remain preserved when this record is
+              updated in Compass.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            <Label htmlFor={`todo-title-${item.id}`}>To-do</Label>
+            <Input
+              id={`todo-title-${item.id}`}
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              disabled={archived}
+              required
+              autoFocus
+            />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor={`todo-type-${item.id}`}>Type</Label>
+              <select
+                id={`todo-type-${item.id}`}
+                value={taskType}
+                onChange={(event) => {
+                  const value = event.target.value
+                  if (
+                    value === "staff_task" ||
+                    value === "subcontractor_task" ||
+                    value === "supplier_task" ||
+                    value === "schedule_task"
+                  ) {
+                    setTaskType(value)
+                  }
+                }}
+                disabled={archived}
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              >
+                <option value="staff_task">Internal staff</option>
+                <option value="subcontractor_task">Subcontractor</option>
+                <option value="supplier_task">Supplier</option>
+                <option value="schedule_task">Schedule follow-up</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={`todo-status-${item.id}`}>Status</Label>
+              <select
+                id={`todo-status-${item.id}`}
+                value={status}
+                onChange={(event) => {
+                  const value = event.target.value
+                  if (
+                    value === "open" ||
+                    value === "in_progress" ||
+                    value === "blocked" ||
+                    value === "complete"
+                  ) {
+                    setStatus(value)
+                  }
+                }}
+                disabled={archived}
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              >
+                <option value="open">Open</option>
+                <option value="in_progress">In progress</option>
+                <option value="blocked">Blocked</option>
+                <option value="complete">Complete</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={`todo-priority-${item.id}`}>Priority</Label>
+              <select
+                id={`todo-priority-${item.id}`}
+                value={priority}
+                onChange={(event) => setPriority(event.target.value)}
+                disabled={archived}
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              >
+                <option value="low">Low</option>
+                <option value="normal">Normal</option>
+                <option value="high">High</option>
+                <option value="critical">Critical</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Assigned to</Label>
+              <ProjectAssigneePicker
+                value={assigneeName}
+                options={assigneeOptions}
+                onValueChange={(value, option) => {
+                  setAssigneeName(value)
+                  if (option?.companyName) setCompanyName(option.companyName)
+                }}
+                className="h-10"
+                disabled={archived}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={`todo-company-${item.id}`}>Company</Label>
+              <Input
+                id={`todo-company-${item.id}`}
+                value={companyName}
+                onChange={(event) => setCompanyName(event.target.value)}
+                disabled={archived}
+                placeholder="Optional"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor={`todo-start-${item.id}`}>Start date</Label>
+              <Input
+                id={`todo-start-${item.id}`}
+                type="date"
+                value={startDate}
+                onChange={(event) => setStartDate(event.target.value)}
+                disabled={archived}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={`todo-due-${item.id}`}>Due date</Label>
+              <Input
+                id={`todo-due-${item.id}`}
+                type="date"
+                value={dueDate}
+                onChange={(event) => setDueDate(event.target.value)}
+                disabled={archived}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor={`todo-description-${item.id}`}>Notes</Label>
+            <Textarea
+              id={`todo-description-${item.id}`}
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              disabled={archived}
+              className="min-h-32"
+            />
+          </div>
+
+          {archived && (
+            <p className="border-l-2 border-muted-foreground/40 px-3 py-2 text-sm text-muted-foreground">
+              This to-do is archived. Restore it before making changes.
+            </p>
+          )}
+          {saveState.kind === "error" && (
+            <p className="border-l-2 border-destructive px-3 py-2 text-sm text-destructive">
+              {saveState.message}
+            </p>
+          )}
+
+          <div className="flex flex-col-reverse gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+            {archived ? (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={restore}
+                disabled={saveState.kind === "saving"}
+              >
+                <IconRestore className="size-4" />
+                Restore to-do
+              </Button>
+            ) : (
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={saveState.kind === "saving"}
+                  >
+                    <IconArchive className="size-4" />
+                    Archive
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Archive this to-do?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      It will leave active work views but remain available in
+                      the Archived filter with its source history intact.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Keep active</AlertDialogCancel>
+                    <AlertDialogAction onClick={archive}>
+                      Archive to-do
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            )}
+
+            {!archived && (
+              <Button type="submit" disabled={saveState.kind === "saving"}>
+                <IconDeviceFloppy className="size-4" />
+                {saveState.kind === "saving" ? "Saving..." : "Save changes"}
+              </Button>
+            )}
+          </div>
+
+          {archived && (
+            <p className="text-xs text-muted-foreground">
+              Current status: {projectTodoStatusLabel(item.status)}
+            </p>
+          )}
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/projects/project-todos-view.tsx
+++ b/src/components/projects/project-todos-view.tsx
@@ -1,13 +1,35 @@
 "use client"
 
 import * as React from "react"
-import { IconSearch } from "@tabler/icons-react"
+import { useRouter } from "next/navigation"
+import {
+  IconArchive,
+  IconEdit,
+  IconSearch,
+} from "@tabler/icons-react"
 
-import type { ProjectOperationItem } from "@/app/actions/project-operations"
+import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
+import {
+  setProjectTodoStatus,
+  type ProjectOperationItem,
+} from "@/app/actions/project-operations"
+import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
+import { ProjectTodoEditDialog } from "@/components/projects/project-todo-edit-dialog"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
+import {
+  isArchivedProjectTodoStatus,
+  isCompletedProjectTodoStatus,
+  normalizeProjectTodoStatus,
+  projectTodoStatusLabel,
+  projectTodoTypeLabel,
+  type ProjectTodoStatus,
+} from "@/lib/project-todos"
 import { normalizeWorkCalendarSearch } from "@/lib/work-calendar"
+
+type TodoFilter = "active" | "completed" | "archived" | "all"
 
 function formatDate(value: string | null): string {
   if (!value) return "No due date"
@@ -18,11 +40,11 @@ function formatDate(value: string | null): string {
   })
 }
 
-function typeLabel(value: string): string {
-  if (value === "subcontractor_task") return "Subcontractor"
-  if (value === "supplier_task") return "Supplier"
-  if (value === "schedule_task") return "Schedule follow-up"
-  return "Staff"
+function sourceLabel(item: ProjectOperationItem): string {
+  if (item.sourceSystem === "buildertrend") return "Buildertrend import"
+  if (item.sourceSystem === "compass") return "Compass"
+  if (item.sourceSystem === "sage") return "Sage"
+  return item.sourceSystem
 }
 
 function todoMatches(item: ProjectOperationItem, query: string): boolean {
@@ -38,77 +60,251 @@ function todoMatches(item: ProjectOperationItem, query: string): boolean {
       item.companyName,
       item.status,
       item.priority,
-      typeLabel(item.sourceRecordType),
+      projectTodoTypeLabel(item.sourceRecordType),
+      sourceLabel(item),
     ]
       .filter((value): value is string => Boolean(value))
       .join(" ")
   ).includes(normalizedQuery)
 }
 
+function itemMatchesFilter(
+  item: ProjectOperationItem,
+  filter: TodoFilter
+): boolean {
+  if (filter === "all") return true
+  if (filter === "archived") {
+    return isArchivedProjectTodoStatus(item.status)
+  }
+  if (filter === "completed") {
+    return (
+      !isArchivedProjectTodoStatus(item.status) &&
+      isCompletedProjectTodoStatus(item.status)
+    )
+  }
+  return (
+    !isArchivedProjectTodoStatus(item.status) &&
+    !isCompletedProjectTodoStatus(item.status)
+  )
+}
+
+function initialFilterForItem(
+  item: ProjectOperationItem | null
+): TodoFilter {
+  if (!item) return "active"
+  if (isArchivedProjectTodoStatus(item.status)) return "archived"
+  if (isCompletedProjectTodoStatus(item.status)) return "completed"
+  return "active"
+}
+
+function StatusControl({
+  projectId,
+  item,
+}: {
+  readonly projectId: string
+  readonly item: ProjectOperationItem
+}): React.ReactElement {
+  const router = useRouter()
+  const [pending, startTransition] = React.useTransition()
+  const [error, setError] = React.useState<string | null>(null)
+  const status = normalizeProjectTodoStatus(item.status)
+
+  function changeStatus(nextStatus: ProjectTodoStatus): void {
+    setError(null)
+    startTransition(async () => {
+      const result = await setProjectTodoStatus(
+        projectId,
+        item.id,
+        nextStatus,
+        item.updatedAt
+      )
+      if (!result.success) {
+        setError(result.error)
+        return
+      }
+      router.refresh()
+    })
+  }
+
+  return (
+    <div>
+      <label className="sr-only" htmlFor={`todo-status-control-${item.id}`}>
+        Status for {item.title}
+      </label>
+      <select
+        id={`todo-status-control-${item.id}`}
+        value={status}
+        disabled={pending}
+        onChange={(event) => {
+          const value = event.target.value
+          if (
+            value === "open" ||
+            value === "in_progress" ||
+            value === "blocked" ||
+            value === "complete"
+          ) {
+            changeStatus(value)
+          }
+        }}
+        className="h-8 rounded-md border bg-background px-2 text-xs"
+      >
+        <option value="open">Open</option>
+        <option value="in_progress">In progress</option>
+        <option value="blocked">Blocked</option>
+        <option value="complete">Complete</option>
+      </select>
+      {error && (
+        <p className="mt-1 max-w-56 text-xs text-destructive">{error}</p>
+      )}
+    </div>
+  )
+}
+
 export function ProjectTodosView({
+  projectId,
   projectLabel,
   items,
   initialItemId,
+  assigneeOptions,
+  canManage,
 }: {
+  readonly projectId: string
   readonly projectLabel: string
   readonly items: readonly ProjectOperationItem[]
   readonly initialItemId: string | null
+  readonly assigneeOptions: readonly ProjectTaskAssigneeOption[]
+  readonly canManage: boolean
 }): React.ReactElement {
+  const initialItem =
+    items.find((item) => item.id === initialItemId) ?? null
   const [query, setQuery] = React.useState("")
-  const visibleItems = items.filter((item) => todoMatches(item, query))
+  const [filter, setFilter] = React.useState<TodoFilter>(
+    initialFilterForItem(initialItem)
+  )
+  const [editingItem, setEditingItem] =
+    React.useState<ProjectOperationItem | null>(null)
+  const counts = React.useMemo(
+    () => ({
+      active: items.filter((item) => itemMatchesFilter(item, "active")).length,
+      completed: items.filter((item) => itemMatchesFilter(item, "completed"))
+        .length,
+      archived: items.filter((item) => itemMatchesFilter(item, "archived"))
+        .length,
+      all: items.length,
+    }),
+    [items]
+  )
+  const visibleItems = items.filter(
+    (item) => itemMatchesFilter(item, filter) && todoMatches(item, query)
+  )
 
   React.useEffect(() => {
     if (!initialItemId) return
-    document
-      .getElementById(`todo-${initialItemId}`)
-      ?.scrollIntoView({ behavior: "smooth", block: "center" })
-  }, [initialItemId])
+    const element = document.getElementById(`todo-${initialItemId}`)
+    if (!element) return
+    element.scrollIntoView({ behavior: "smooth", block: "center" })
+    element.focus({ preventScroll: true })
+  }, [initialItemId, filter])
 
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 p-4 md:p-6">
-      <header>
-        <p className="text-sm text-muted-foreground">{projectLabel}</p>
-        <h1 className="text-2xl font-semibold tracking-tight">To-dos</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Staff, subcontractor, supplier, and schedule follow-up work for this
-          project.
-        </p>
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-5 p-4 md:p-6">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-sm text-muted-foreground">{projectLabel}</p>
+          <h1 className="text-2xl font-semibold tracking-tight">To-dos</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Edit, assign, complete, or archive project work regardless of
+            whether it began in Compass, Buildertrend, or Sage.
+          </p>
+        </div>
+        {canManage && (
+          <ProjectTaskCreateButton
+            projectId={projectId}
+            sourceLabel="Project"
+            sourceRecordId={null}
+            sourceRecordNumber={null}
+            sourceHref={null}
+            defaultTitle=""
+            defaultDescription={null}
+            defaultAssigneeName={null}
+            defaultCompanyName={null}
+            defaultDueDate={null}
+            defaultPriority="normal"
+            assigneeOptions={assigneeOptions}
+          />
+        )}
       </header>
 
-      <div className="relative max-w-xl">
-        <IconSearch className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-        <Input
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder="Search title, assignee, company, status…"
-          className="pl-9"
-        />
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="relative w-full lg:max-w-xl">
+          <IconSearch className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search title, assignee, company, status, or source…"
+            className="pl-9"
+          />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {(
+            [
+              ["active", "Active"],
+              ["completed", "Completed"],
+              ["archived", "Archived"],
+              ["all", "All"],
+            ] as const
+          ).map(([value, label]) => (
+            <Button
+              key={value}
+              type="button"
+              size="sm"
+              variant={filter === value ? "default" : "outline"}
+              onClick={() => setFilter(value)}
+            >
+              {label} {counts[value]}
+            </Button>
+          ))}
+        </div>
       </div>
+
+      {initialItemId && !initialItem && (
+        <p className="border-l-2 border-destructive px-3 py-2 text-sm text-destructive">
+          The linked to-do was not found in this project.
+        </p>
+      )}
 
       <section className="divide-y border-y">
         {visibleItems.length > 0 ? (
           visibleItems.map((item) => {
             const focused = item.id === initialItemId
+            const archived = isArchivedProjectTodoStatus(item.status)
             return (
               <article
                 id={`todo-${item.id}`}
                 key={item.id}
-                tabIndex={focused ? -1 : undefined}
+                tabIndex={-1}
+                data-focused={focused ? "true" : "false"}
                 className={cn(
-                  "grid gap-3 px-1 py-4 transition-colors sm:grid-cols-[minmax(0,1fr)_auto]",
-                  focused && "bg-primary/5 outline outline-2 outline-primary/30"
+                  "grid gap-3 px-2 py-4 outline-none transition-colors sm:grid-cols-[minmax(0,1fr)_auto]",
+                  focused &&
+                    "border-l-4 border-l-primary bg-primary/5 ring-2 ring-inset ring-primary/20"
                 )}
               >
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-center gap-2">
                     <h2 className="font-medium">{item.title}</h2>
                     <Badge variant="outline">
-                      {typeLabel(item.sourceRecordType)}
+                      {projectTodoTypeLabel(item.sourceRecordType)}
                     </Badge>
-                    <Badge variant="secondary">{item.status}</Badge>
+                    <Badge variant="secondary">
+                      {projectTodoStatusLabel(item.status)}
+                    </Badge>
+                    <span className="text-xs text-muted-foreground">
+                      {sourceLabel(item)}
+                    </span>
                   </div>
                   {item.description && (
-                    <p className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
+                    <p className="mt-2 line-clamp-3 whitespace-pre-wrap text-sm text-muted-foreground">
                       {item.description}
                     </p>
                   )}
@@ -118,19 +314,52 @@ export function ProjectTodosView({
                     {item.companyName ? ` · ${item.companyName}` : ""}
                   </p>
                 </div>
-                <div className="text-sm text-muted-foreground sm:text-right">
-                  <p>{formatDate(item.dueDate ?? item.startDate)}</p>
-                  <p className="mt-1 capitalize">{item.priority} priority</p>
+                <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+                  <div className="mr-2 text-sm text-muted-foreground sm:text-right">
+                    <p>{formatDate(item.dueDate ?? item.startDate)}</p>
+                    <p className="mt-1 capitalize">{item.priority} priority</p>
+                  </div>
+                  {canManage && !archived && (
+                    <StatusControl projectId={projectId} item={item} />
+                  )}
+                  {canManage && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setEditingItem(item)}
+                    >
+                      {archived ? (
+                        <IconArchive className="size-4" />
+                      ) : (
+                        <IconEdit className="size-4" />
+                      )}
+                      {archived ? "Review" : "Edit"}
+                    </Button>
+                  )}
                 </div>
               </article>
             )
           })
         ) : (
-          <p className="py-8 text-center text-sm text-muted-foreground">
-            No to-dos match this search.
+          <p className="py-10 text-center text-sm text-muted-foreground">
+            No to-dos match this view.
           </p>
         )}
       </section>
+
+      {editingItem && canManage && (
+        <ProjectTodoEditDialog
+          key={`${editingItem.id}-${editingItem.updatedAt}`}
+          projectId={projectId}
+          item={editingItem}
+          assigneeOptions={assigneeOptions}
+          open
+          onOpenChange={(open) => {
+            if (!open) setEditingItem(null)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/src/lib/__tests__/project-todos.test.ts
+++ b/src/lib/__tests__/project-todos.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  canonicalProjectTodoRecordType,
+  isArchivedProjectTodoStatus,
+  isCompletedProjectTodoStatus,
+  isProjectTodoRecordType,
+  isProjectTodoStatus,
+  normalizeProjectTodoStatus,
+  projectTodoStatusLabel,
+  projectTodoTypeLabel,
+} from "@/lib/project-todos"
+
+describe("project to-do normalization", () => {
+  it("includes canonical and legacy to-do record types", () => {
+    expect(isProjectTodoRecordType("staff_task")).toBe(true)
+    expect(isProjectTodoRecordType("schedule_task")).toBe(true)
+    expect(isProjectTodoRecordType("todo")).toBe(true)
+    expect(isProjectTodoRecordType("purchase_order")).toBe(false)
+  })
+
+  it("maps legacy types to an editable Compass type", () => {
+    expect(canonicalProjectTodoRecordType("todo")).toBe("staff_task")
+    expect(canonicalProjectTodoRecordType("supplier_task")).toBe(
+      "supplier_task"
+    )
+  })
+
+  it("normalizes imported statuses without losing archive semantics", () => {
+    expect(normalizeProjectTodoStatus("In Progress")).toBe("in_progress")
+    expect(normalizeProjectTodoStatus("closed")).toBe("complete")
+    expect(isCompletedProjectTodoStatus("done")).toBe(true)
+    expect(isArchivedProjectTodoStatus("archived")).toBe(true)
+    expect(projectTodoStatusLabel("on-hold")).toBe("Blocked")
+    expect(isProjectTodoStatus("in_progress")).toBe(true)
+    expect(isProjectTodoStatus("archived")).toBe(false)
+  })
+
+  it("uses concise staff-facing type labels", () => {
+    expect(projectTodoTypeLabel("schedule_task")).toBe("Schedule follow-up")
+    expect(projectTodoTypeLabel("todo")).toBe("Staff")
+  })
+})

--- a/src/lib/project-todos.ts
+++ b/src/lib/project-todos.ts
@@ -1,0 +1,78 @@
+export const PROJECT_TODO_RECORD_TYPES = [
+  "staff_task",
+  "subcontractor_task",
+  "supplier_task",
+  "schedule_task",
+  "todo",
+  "task",
+] as const
+
+export type ProjectTodoRecordType =
+  (typeof PROJECT_TODO_RECORD_TYPES)[number]
+
+export const PROJECT_TODO_STATUSES = [
+  "open",
+  "in_progress",
+  "blocked",
+  "complete",
+] as const
+
+export type ProjectTodoStatus = (typeof PROJECT_TODO_STATUSES)[number]
+
+const ARCHIVED_STATUSES = new Set(["archive", "archived", "cancelled"])
+const COMPLETED_STATUSES = new Set(["complete", "completed", "closed", "done"])
+
+export function isProjectTodoRecordType(value: string): boolean {
+  return PROJECT_TODO_RECORD_TYPES.some((type) => type === value)
+}
+
+export function canonicalProjectTodoRecordType(
+  value: string
+): "staff_task" | "subcontractor_task" | "supplier_task" | "schedule_task" {
+  if (value === "subcontractor_task") return "subcontractor_task"
+  if (value === "supplier_task") return "supplier_task"
+  if (value === "schedule_task") return "schedule_task"
+  return "staff_task"
+}
+
+export function normalizeProjectTodoStatus(value: string): ProjectTodoStatus {
+  const normalized = value.trim().toLowerCase().replace(/[\s-]+/g, "_")
+  if (normalized === "in_progress") return "in_progress"
+  if (normalized === "blocked" || normalized === "on_hold") return "blocked"
+  if (COMPLETED_STATUSES.has(normalized)) return "complete"
+  return "open"
+}
+
+export function isProjectTodoStatus(value: string): value is ProjectTodoStatus {
+  return PROJECT_TODO_STATUSES.some((status) => status === value)
+}
+
+export function isArchivedProjectTodoStatus(value: string): boolean {
+  return ARCHIVED_STATUSES.has(value.trim().toLowerCase())
+}
+
+export function isCompletedProjectTodoStatus(value: string): boolean {
+  return COMPLETED_STATUSES.has(value.trim().toLowerCase())
+}
+
+export function projectTodoStatusLabel(value: string): string {
+  if (isArchivedProjectTodoStatus(value)) return "Archived"
+
+  switch (normalizeProjectTodoStatus(value)) {
+    case "open":
+      return "Open"
+    case "in_progress":
+      return "In progress"
+    case "blocked":
+      return "Blocked"
+    case "complete":
+      return "Complete"
+  }
+}
+
+export function projectTodoTypeLabel(value: string): string {
+  if (value === "subcontractor_task") return "Subcontractor"
+  if (value === "supplier_task") return "Supplier"
+  if (value === "schedule_task") return "Schedule follow-up"
+  return "Staff"
+}


### PR DESCRIPTION
## Summary

- deep-link Work Calendar to-do cards to the exact project record and visibly focus it
- replace the six-record read-only summary with the complete project to-do workspace
- add authorized editing for title, notes, type, status, priority, assignee, company, and dates
- add quick status changes plus active, completed, archived, and all filters
- add archive and restore without deleting Buildertrend or Sage provenance
- preserve imported source system, IDs, record numbers, external metadata, and payloads
- exclude completed and archived records from active work counts
- enforce tenant scoping, optimistic concurrency, role permissions, demo read-only behavior, and directory-data privacy

## Root cause

The project To-dos route reused `getProjectOperationsSummary()`, which intentionally truncates dashboard commitments to six rows. The resulting page had no mutation surface, so calendar links could route to the correct project while the referenced item was absent and imported records remained read-only.

## Validation

- `bunx tsc --noEmit`
- targeted ESLint: no errors
- `bun run test` — 35 files, 266 passed, 3 skipped
- focused Chromium regression for Work Calendar → exact to-do focus
- `bun run build`
- production D1 read-only audit confirmed 191 open Buildertrend-origin to-dos use the supported project-operation task types
- manual security/data-integrity review completed; external autoreview was intentionally not used because it would transmit the private diff to another AI service

Closes #174
