### PR TITLE
fix(compass): complete messaging and work queues

### DIFF
--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -155,22 +155,61 @@ test.describe("usable Compass areas", () => {
     }
   })
 
-  test("work calendar compact cards show the actual item title", async ({
+  test("schedule list exposes edit and selection actions", async ({ page }) => {
+    const path =
+      "/dashboard/projects/e2e-project-001/schedule?view=list"
+    const response = await page.goto(path)
+    await expectHealthyNavigation(
+      page,
+      response,
+      "/dashboard/projects/e2e-project-001/schedule"
+    )
+
+    const scheduleRow = page.locator("#schedule-item-e2e-schedule-001")
+    await expect(
+      scheduleRow
+        .getByRole("button", { name: "Edit Regression Schedule Item" })
+        .first()
+    ).toBeVisible()
+
+    await scheduleRow
+      .getByRole("checkbox", { name: "Select Regression Schedule Item" })
+      .check()
+    await expect(page.getByText("1 selected", { exact: true })).toBeVisible()
+    await expect(
+      page.getByRole("button", { name: "Edit selected" })
+    ).toBeEnabled()
+    await expect(
+      page.getByRole("button", { name: "Mark complete" })
+    ).toBeVisible()
+    await expect(
+      page.getByRole("button", { name: "Delete selected" })
+    ).toBeVisible()
+
+    await page.getByRole("button", { name: "Clear" }).click()
+    await expect(page.getByText("1 selected", { exact: true })).toHaveCount(0)
+  })
+
+  test("work calendar list shows the actual item title", async ({
     page,
   }) => {
     const response = await page.goto("/dashboard/schedule")
     await expectHealthyNavigation(page, response, "/dashboard/schedule")
 
-    const nextFourteenDays = page.locator("section").filter({
-      has: page.getByRole("heading", { name: "Next 14 days" }),
+    await page
+      .getByRole("group", { name: "Work calendar view" })
+      .getByRole("button", { name: "List" })
+      .click()
+    const workQueue = page.locator("section").filter({
+      has: page.getByRole("heading", { name: "Work Queue" }),
     })
     await expect(
-      nextFourteenDays.getByText("Regression Schedule Item", {
+      workQueue.getByText("Regression Schedule Item", {
         exact: true,
       }).first()
     ).toBeVisible()
     await expect(
-      nextFourteenDays.getByText("Regression follow-up", {
+      workQueue.getByText("Regression follow-up", {
         exact: true,
       }).first()
     ).toBeVisible()
@@ -182,6 +221,10 @@ test.describe("usable Compass areas", () => {
     const response = await page.goto("/dashboard/schedule")
     await expectHealthyNavigation(page, response, "/dashboard/schedule")
 
+    await page
+      .getByRole("group", { name: "Work calendar view" })
+      .getByRole("button", { name: "List" })
+      .click()
     const todoLink = page
       .getByRole("link", { name: /Regression follow-up/ })
       .first()

--- a/src/app/actions/chat-messages.ts
+++ b/src/app/actions/chat-messages.ts
@@ -10,11 +10,13 @@ import {
   like,
   ne,
   or,
+  inArray,
 } from "drizzle-orm"
 import { marked } from "marked"
 import { getDb } from "@/db"
 import {
   messages,
+  messageAttachments,
   messageReactions,
   channelMembers,
   channelReadState,
@@ -37,7 +39,21 @@ import { enqueueFeedbackDeskItem } from "@/lib/jarvis/feedback-desk"
 import { notifyChannelMessage } from "@/lib/notifications/events"
 
 const MAX_MESSAGE_LENGTH = 4000
-const EMOJI_REGEX = /^[\p{Emoji}\u200d]+$/u
+const EMOJI_REGEX = /^[\p{Emoji}\u200d\uFE0F]+$/u
+
+type MessageAttachmentItem = {
+  readonly id: string
+  readonly fileName: string
+  readonly mimeType: string
+  readonly fileSize: number
+  readonly storageUrl: string
+}
+
+type MessageReactionItem = {
+  readonly emoji: string
+  readonly count: number
+  readonly reactedByCurrentUser: boolean
+}
 
 // Configure marked for safe rendering
 marked.setOptions({
@@ -103,6 +119,87 @@ function sanitizeHtml(html: string): string {
 async function renderMarkdown(content: string): Promise<string> {
   const html = await marked(content)
   return sanitizeHtml(html)
+}
+
+async function getAttachmentsByMessage(
+  db: ReturnType<typeof getDb>,
+  messageIds: readonly string[]
+): Promise<ReadonlyMap<string, readonly MessageAttachmentItem[]>> {
+  if (messageIds.length === 0) return new Map()
+
+  const rows = await db
+    .select({
+      id: messageAttachments.id,
+      messageId: messageAttachments.messageId,
+      fileName: messageAttachments.fileName,
+      mimeType: messageAttachments.mimeType,
+      fileSize: messageAttachments.fileSize,
+      storageUrl: messageAttachments.r2Path,
+    })
+    .from(messageAttachments)
+    .where(inArray(messageAttachments.messageId, messageIds))
+
+  const attachments = new Map<string, MessageAttachmentItem[]>()
+  for (const row of rows) {
+    const existing = attachments.get(row.messageId) ?? []
+    existing.push({
+      id: row.id,
+      fileName: row.fileName,
+      mimeType: row.mimeType,
+      fileSize: row.fileSize,
+      storageUrl: row.storageUrl,
+    })
+    attachments.set(row.messageId, existing)
+  }
+  return attachments
+}
+
+async function getReactionsByMessage(
+  db: ReturnType<typeof getDb>,
+  messageIds: readonly string[],
+  currentUserId: string
+): Promise<ReadonlyMap<string, readonly MessageReactionItem[]>> {
+  if (messageIds.length === 0) return new Map()
+
+  const rows = await db
+    .select({
+      messageId: messageReactions.messageId,
+      userId: messageReactions.userId,
+      emoji: messageReactions.emoji,
+    })
+    .from(messageReactions)
+    .where(inArray(messageReactions.messageId, messageIds))
+
+  const counts = new Map<
+    string,
+    Map<string, { count: number; reactedByCurrentUser: boolean }>
+  >()
+  for (const row of rows) {
+    const messageCounts = counts.get(row.messageId) ?? new Map()
+    const reaction = messageCounts.get(row.emoji) ?? {
+      count: 0,
+      reactedByCurrentUser: false,
+    }
+    messageCounts.set(row.emoji, {
+      count: reaction.count + 1,
+      reactedByCurrentUser:
+        reaction.reactedByCurrentUser || row.userId === currentUserId,
+    })
+    counts.set(row.messageId, messageCounts)
+  }
+
+  const reactions = new Map<string, MessageReactionItem[]>()
+  for (const [messageId, messageCounts] of counts) {
+    reactions.set(
+      messageId,
+      Array.from(messageCounts.entries()).map(([emoji, reaction]) => ({
+        emoji,
+        count: reaction.count,
+        reactedByCurrentUser: reaction.reactedByCurrentUser,
+      }))
+    )
+  }
+  return reactions
 }
 
 export async function searchMentionableUsers(
@@ -383,6 +480,7 @@ export async function sendMessage(data: {
         content: messages.content,
         contentHtml: messages.contentHtml,
         editedAt: messages.editedAt,
+        deletedAt: messages.deletedAt,
         isPinned: messages.isPinned,
         replyCount: messages.replyCount,
         lastReplyAt: messages.lastReplyAt,
@@ -401,99 +499,16 @@ export async function sendMessage(data: {
       .then((rows) => rows[0] ?? null)
 
     revalidatePath("/dashboard")
-    return { success: true, data: messageWithUser }
+    return {
+      success: true,
+      data: messageWithUser
+        ? { ...messageWithUser, attachments: [], reactions: [] }
+        : null,
+    }
   } catch (err) {
     return {
       success: false,
       error: err instanceof Error ? err.message : "Failed to send message",
-    }
-  }
-}
-
-export async function editMessage(
-  messageId: string,
-  newContent: string,
-  options?: {
-    mentions?: Array<MentionInput>
-    contentHtml?: string
-  }
-) {
-  try {
-    const user = await getCurrentUser()
-    if (!user) {
-      return { success: false, error: "Unauthorized" }
-    }
-    if (isDemoUser(user.id)) {
-      return { success: false, error: "DEMO_READ_ONLY" }
-    }
-
-    const { env } = await getCloudflareContext()
-    const db = getDb(env.DB)
-
-    // fetch the message
-    const message = await db
-      .select()
-      .from(messages)
-      .where(eq(messages.id, messageId))
-      .limit(1)
-      .then((rows) => rows[0] ?? null)
-
-    if (!message) {
-      return { success: false, error: "Message not found" }
-    }
-
-    // check permission: own message or admin
-    if (message.userId !== user.id) {
-      try {
-        requirePermission(user, "channels", "moderate")
-      } catch {
-        return { success: false, error: "Cannot edit other users' messages" }
-      }
-    }
-
-    const now = new Date().toISOString()
-
-    // Use provided HTML or re-render markdown to sanitized HTML
-    const contentHtml = options?.contentHtml
-      ? sanitizeHtml(options.contentHtml)
-      : await renderMarkdown(newContent)
-
-    await db
-      .update(messages)
-      .set({
-        content: newContent,
-        contentHtml,
-        editedAt: now,
-      })
-      .where(eq(messages.id, messageId))
-
-    // update mentions if provided
-    if (options?.mentions !== undefined) {
-      // delete existing mentions
-      await db
-        .delete(messageMentions)
-        .where(eq(messageMentions.messageId, messageId))
-
-      // insert new mentions
-      if (options.mentions.length > 0) {
-        const mentionRows: NewMessageMention[] = options.mentions.map((m) => ({
-          id: crypto.randomUUID(),
-          messageId,
-          mentionType: m.mentionType,
-          targetId: m.targetId,
-          createdAt: now,
-        }))
-        await db.insert(messageMentions).values(mentionRows)
-      }
-      // Note: we do NOT re-notify on edit (MVP requirement)
-    }
-
-    revalidatePath("/dashboard")
-    return { success: true }
-  } catch (err) {
-    return {
-      success: false,
-      error: err instanceof Error ? err.message : "Failed to edit message",
     }
   }
 }
@@ -619,10 +634,25 @@ export async function getMessages(
     const results = await query
 
     // replace deleted content with placeholder
+    const attachmentsByMessage = await getAttachmentsByMessage(
+      db,
+      results.map((message) => message.id)
+    )
+    const reactionsByMessage = await getReactionsByMessage(
+      db,
+      results.map((message) => message.id),
+      user.id
+    )
     const sanitized = results.map((msg) => ({
       ...msg,
       content: msg.deletedAt ? "[Message deleted]" : msg.content,
       contentHtml: msg.deletedAt ? null : msg.contentHtml,
+      attachments: msg.deletedAt
+        ? []
+        : attachmentsByMessage.get(msg.id) ?? [],
+      reactions: msg.deletedAt
+        ? []
+        : reactionsByMessage.get(msg.id) ?? [],
     }))
 
     return { success: true, data: sanitized }
@@ -713,10 +743,25 @@ export async function getThreadMessages(
     const results = await query
 
     // replace deleted content with placeholder
+    const attachmentsByMessage = await getAttachmentsByMessage(
+      db,
+      results.map((message) => message.id)
+    )
+    const reactionsByMessage = await getReactionsByMessage(
+      db,
+      results.map((message) => message.id),
+      user.id
+    )
     const sanitized = results.map((msg) => ({
       ...msg,
       content: msg.deletedAt ? "[Message deleted]" : msg.content,
       contentHtml: msg.deletedAt ? null : msg.contentHtml,
+      attachments: msg.deletedAt
+        ? []
+        : attachmentsByMessage.get(msg.id) ?? [],
+      reactions: msg.deletedAt
+        ? []
+        : reactionsByMessage.get(msg.id) ?? [],
     }))
 
     return { success: true, data: sanitized }

--- a/src/app/actions/project-operations.ts
+++ b/src/app/actions/project-operations.ts
@@ -28,6 +28,12 @@ import {
   isProjectTodoRecordType,
   isProjectTodoStatus,
 } from "@/lib/project-todos"
+import {
+  isPurchaseOrderStatus,
+  isRfqStatus,
+} from "@/lib/project-operations/status"
+
+export type ProjectOperationKind = "purchase_order" | "rfq"
 
 export type ProjectOperationItem = {
   readonly id: string
@@ -1549,6 +1555,83 @@ export async function getProjectRfqs(
   return rows.map((row) =>
     toRfqItem(row, purchaseOrderVendorEmail(row, contactRows, vendorRows))
   )
+}
+
+export async function updateProjectOperationStatus(
+  projectId: string,
+  operationId: string,
+  operationKind: ProjectOperationKind,
+  requestedStatus: string
+): Promise<ProjectOperationActionResult> {
+  try {
+    const db = await verifyProjectUpdateAccess(projectId)
+    const statusIsValid =
+      operationKind === "purchase_order"
+        ? isPurchaseOrderStatus(requestedStatus)
+        : isRfqStatus(requestedStatus)
+
+    if (!statusIsValid) {
+      return { success: false, error: "Please choose a valid status." }
+    }
+
+    const existing = await db
+      .select({ id: projectOperations.id })
+      .from(projectOperations)
+      .where(
+        and(
+          eq(projectOperations.id, operationId),
+          eq(projectOperations.projectId, projectId),
+          eq(projectOperations.sourceRecordType, operationKind)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+
+    if (!existing) {
+      return {
+        success: false,
+        error:
+          operationKind === "purchase_order"
+            ? "Purchase order not found."
+            : "RFQ not found.",
+      }
+    }
+
+    await db
+      .update(projectOperations)
+      .set({
+        status: requestedStatus,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(
+        and(
+          eq(projectOperations.id, operationId),
+          eq(projectOperations.projectId, projectId),
+          eq(projectOperations.sourceRecordType, operationKind)
+        )
+      )
+
+    revalidatePath(`/dashboard/projects/${projectId}`)
+    revalidatePath(
+      `/dashboard/projects/${projectId}/${
+        operationKind === "purchase_order" ? "purchase-orders" : "rfqs"
+      }`
+    )
+    revalidatePath("/dashboard/purchase-orders")
+    revalidatePath("/dashboard/financials")
+    revalidatePath("/dashboard/schedule")
+    revalidatePath("/dashboard")
+
+    return { success: true, id: operationId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to update status.",
+    }
+  }
 }
 
 export async function createPurchaseOrderRequest(

--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -8,7 +8,7 @@ import {
   workdayExceptions,
   projects,
 } from "@/db/schema"
-import { eq, asc, and } from "drizzle-orm"
+import { eq, asc, and, inArray } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { calculateEndDate } from "@/lib/schedule/business-days"
 import { findCriticalPath } from "@/lib/schedule/critical-path"
@@ -31,6 +31,11 @@ import type {
   WorkdayExceptionData,
   WorkdayExceptionType,
 } from "@/lib/schedule/types"
+
+function revalidateSchedulePaths(projectId: string): void {
+  revalidatePath(`/dashboard/projects/${projectId}/schedule`)
+  revalidatePath("/dashboard/schedule")
+}
 
 async function fetchExceptions(
   db: ReturnType<typeof getDb>,
@@ -197,7 +202,7 @@ export async function createTask(
     }
 
     await recalcCriticalPath(db, projectId)
-    revalidatePath(`/dashboard/projects/${projectId}/schedule`)
+    revalidateSchedulePaths(projectId)
     return { success: true, taskId: id }
   } catch (error) {
     console.error("Failed to create task:", error)
@@ -330,7 +335,7 @@ export async function updateTask(
     }
 
     await recalcCriticalPath(db, task.projectId)
-    revalidatePath(`/dashboard/projects/${task.projectId}/schedule`)
+    revalidateSchedulePaths(task.projectId)
     return { success: true }
   } catch (error) {
     console.error("Failed to update task:", error)
@@ -372,11 +377,154 @@ export async function deleteTask(
 
     await db.delete(scheduleTasks).where(eq(scheduleTasks.id, taskId))
     await recalcCriticalPath(db, task.projectId)
-    revalidatePath(`/dashboard/projects/${task.projectId}/schedule`)
+    revalidateSchedulePaths(task.projectId)
     return { success: true }
   } catch (error) {
     console.error("Failed to delete task:", error)
     return { success: false, error: "Failed to delete schedule item" }
+  }
+}
+
+export async function completeScheduleTasks(
+  projectId: string,
+  taskIds: readonly string[]
+): Promise<{ readonly success: true } | { readonly success: false; readonly error: string }> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    const orgId = requireOrg(user)
+    const ids = [...new Set(taskIds.map((id) => id.trim()).filter(Boolean))]
+
+    if (ids.length === 0) {
+      return { success: false, error: "Select at least one schedule item" }
+    }
+    if (ids.length > 200) {
+      return {
+        success: false,
+        error: "Update no more than 200 schedule items at a time",
+      }
+    }
+
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const [project] = await db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(and(eq(projects.id, projectId), eq(projects.organizationId, orgId)))
+      .limit(1)
+
+    if (!project) {
+      return { success: false, error: "Project not found or access denied" }
+    }
+
+    const matchingTasks = await db
+      .select({ id: scheduleTasks.id })
+      .from(scheduleTasks)
+      .where(
+        and(
+          eq(scheduleTasks.projectId, projectId),
+          inArray(scheduleTasks.id, ids)
+        )
+      )
+
+    if (matchingTasks.length !== ids.length) {
+      return {
+        success: false,
+        error: "One or more schedule items could not be found",
+      }
+    }
+
+    await db
+      .update(scheduleTasks)
+      .set({
+        status: "COMPLETE",
+        percentComplete: 100,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(
+        and(
+          eq(scheduleTasks.projectId, projectId),
+          inArray(scheduleTasks.id, ids)
+        )
+      )
+
+    await recalcCriticalPath(db, projectId)
+    revalidateSchedulePaths(projectId)
+    return { success: true }
+  } catch (error) {
+    console.error("Failed to complete schedule items:", error)
+    return { success: false, error: "Failed to complete schedule items" }
+  }
+}
+
+export async function deleteScheduleTasks(
+  projectId: string,
+  taskIds: readonly string[]
+): Promise<{ readonly success: true } | { readonly success: false; readonly error: string }> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    const orgId = requireOrg(user)
+    const ids = [...new Set(taskIds.map((id) => id.trim()).filter(Boolean))]
+
+    if (ids.length === 0) {
+      return { success: false, error: "Select at least one schedule item" }
+    }
+    if (ids.length > 200) {
+      return {
+        success: false,
+        error: "Delete no more than 200 schedule items at a time",
+      }
+    }
+
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const [project] = await db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(and(eq(projects.id, projectId), eq(projects.organizationId, orgId)))
+      .limit(1)
+
+    if (!project) {
+      return { success: false, error: "Project not found or access denied" }
+    }
+
+    const matchingTasks = await db
+      .select({ id: scheduleTasks.id })
+      .from(scheduleTasks)
+      .where(
+        and(
+          eq(scheduleTasks.projectId, projectId),
+          inArray(scheduleTasks.id, ids)
+        )
+      )
+
+    if (matchingTasks.length !== ids.length) {
+      return {
+        success: false,
+        error: "One or more schedule items could not be found",
+      }
+    }
+
+    await db
+      .delete(scheduleTasks)
+      .where(
+        and(
+          eq(scheduleTasks.projectId, projectId),
+          inArray(scheduleTasks.id, ids)
+        )
+      )
+
+    await recalcCriticalPath(db, projectId)
+    revalidateSchedulePaths(projectId)
+    return { success: true }
+  } catch (error) {
+    console.error("Failed to delete schedule items:", error)
+    return { success: false, error: "Failed to delete schedule items" }
   }
 }
 
@@ -412,7 +560,7 @@ export async function reorderTasks(
         .where(eq(scheduleTasks.id, item.id))
     }
 
-    revalidatePath(`/dashboard/projects/${projectId}/schedule`)
+    revalidateSchedulePaths(projectId)
     return { success: true }
   } catch (error) {
     console.error("Failed to reorder tasks:", error)
@@ -535,7 +683,7 @@ export async function createDependency(data: {
     }
 
     await recalcCriticalPath(db, data.projectId)
-    revalidatePath(`/dashboard/projects/${data.projectId}/schedule`)
+    revalidateSchedulePaths(data.projectId)
     return { success: true }
   } catch (error) {
     console.error("Failed to create dependency:", error)
@@ -598,7 +746,7 @@ export async function deleteDependency(
 
     await db.delete(taskDependencies).where(eq(taskDependencies.id, depId))
     await recalcCriticalPath(db, projectId)
-    revalidatePath(`/dashboard/projects/${projectId}/schedule`)
+    revalidateSchedulePaths(projectId)
     return { success: true }
   } catch (error) {
     console.error("Failed to delete dependency:", error)
@@ -648,7 +796,7 @@ export async function updateTaskStatus(
       })
       .where(eq(scheduleTasks.id, taskId))
 
-    revalidatePath(`/dashboard/projects/${task.projectId}/schedule`)
+    revalidateSchedulePaths(task.projectId)
     return { success: true }
   } catch (error) {
     console.error("Failed to update task status:", error)

--- a/src/app/api/conversations/attachments/upload/route.ts
+++ b/src/app/api/conversations/attachments/upload/route.ts
@@ -1,0 +1,360 @@
+import { and, eq } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+import { NextRequest, NextResponse } from "next/server"
+
+import { getDb } from "@/db"
+import {
+  channels,
+  channelMembers,
+  messageAttachments,
+  messages,
+} from "@/db/schema-conversations"
+import { googleAuth } from "@/db/schema-google"
+import { projectExternalLinks, projects } from "@/db/schema"
+import { requireAuth } from "@/lib/auth"
+import { decrypt } from "@/lib/crypto"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import { DriveClient } from "@/lib/google/client/drive-client"
+import {
+  getGoogleConfig,
+  getGoogleCryptoSalt,
+  parseServiceAccountKey,
+} from "@/lib/google/config"
+import { requireOrg } from "@/lib/org-scope"
+import { requirePermission } from "@/lib/permissions"
+
+const MAX_ATTACHMENT_COUNT = 10
+const MAX_ATTACHMENT_FILE_BYTES = 25 * 1024 * 1024
+const MAX_ATTACHMENT_BATCH_BYTES = 50 * 1024 * 1024
+const CONVERSATION_FOLDER_NAME = "Compass Message Attachments"
+const DEFAULT_COMPASS_GOOGLE_UPLOAD_USER = "compass@hps-colorado.com"
+const GOOGLE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
+
+type AttachmentUploadResult =
+  | {
+      readonly success: true
+      readonly attachments: readonly {
+        readonly id: string
+        readonly fileName: string
+        readonly mimeType: string
+        readonly fileSize: number
+        readonly storageUrl: string
+      }[]
+    }
+  | {
+      readonly success: false
+      readonly error: string
+    }
+
+function isFile(value: FormDataEntryValue): value is File {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "arrayBuffer" in value &&
+    "name" in value &&
+    "size" in value &&
+    "type" in value
+  )
+}
+
+function safeFileName(value: string): string {
+  const normalized = value.replace(/[/:\\]/g, "-").trim()
+  return normalized.length > 0 ? normalized : "message-attachment"
+}
+
+function escapeDriveQueryValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")
+}
+
+function driveFolderIdFromUrl(value: string | null): string | null {
+  if (!value) return null
+  const folderMatch = value.match(/\/folders\/([^/?#]+)/)
+  if (folderMatch) return folderMatch[1] ?? null
+  const idMatch = value.match(/[?&]id=([^&#]+)/)
+  return idMatch?.[1] ?? null
+}
+
+function uploadEmail(
+  userEmail: string,
+  googleEmail: string | null,
+  env: Record<string, string>
+): string {
+  const configured = env.COMPASS_GOOGLE_UPLOAD_USER?.trim()
+  if (configured) return configured
+  if (googleEmail) return googleEmail
+  if (userEmail.endsWith("@hps-colorado.com")) return userEmail
+  return DEFAULT_COMPASS_GOOGLE_UPLOAD_USER
+}
+
+async function findOrCreateAttachmentFolder(
+  client: DriveClient,
+  googleEmail: string,
+  parentId: string,
+  driveId: string | null
+): Promise<string> {
+  const result = await client.listFiles(googleEmail, {
+    folderId: parentId,
+    driveId: driveId ?? undefined,
+    pageSize: 10,
+    query:
+      `mimeType = '${GOOGLE_FOLDER_MIME_TYPE}' and ` +
+      `name = '${escapeDriveQueryValue(CONVERSATION_FOLDER_NAME)}'`,
+  })
+  const existing = result.files[0]
+  if (existing) return existing.id
+
+  const folder = await client.createFolder(googleEmail, {
+    name: CONVERSATION_FOLDER_NAME,
+    parentId,
+    driveId: driveId ?? undefined,
+  })
+  return folder.id
+}
+
+export async function POST(
+  request: NextRequest
+): Promise<NextResponse<AttachmentUploadResult>> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return NextResponse.json(
+        { success: false, error: "Demo mode is read-only." },
+        { status: 403 }
+      )
+    }
+    requirePermission(user, "document", "create")
+    const organizationId = requireOrg(user)
+    const formData = await request.formData()
+    const messageIdValue = formData.get("messageId")
+    const messageId =
+      typeof messageIdValue === "string" ? messageIdValue.trim() : ""
+    const files = formData.getAll("files").filter(isFile)
+
+    if (!messageId) {
+      return NextResponse.json(
+        { success: false, error: "Message ID is required." },
+        { status: 400 }
+      )
+    }
+    if (files.length === 0) {
+      return NextResponse.json(
+        { success: false, error: "Choose at least one file." },
+        { status: 400 }
+      )
+    }
+    if (files.length > MAX_ATTACHMENT_COUNT) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Choose no more than ${MAX_ATTACHMENT_COUNT} files at once.`,
+        },
+        { status: 400 }
+      )
+    }
+    const oversizedFile = files.find(
+      (file) => file.size > MAX_ATTACHMENT_FILE_BYTES
+    )
+    if (oversizedFile) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `${oversizedFile.name} exceeds the 25 MB per-file limit.`,
+        },
+        { status: 400 }
+      )
+    }
+    const batchBytes = files.reduce((total, file) => total + file.size, 0)
+    if (batchBytes > MAX_ATTACHMENT_BATCH_BYTES) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "The selected files exceed the 50 MB batch limit.",
+        },
+        { status: 400 }
+      )
+    }
+
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const message = await db
+      .select({
+        userId: messages.userId,
+        channelId: messages.channelId,
+        deletedAt: messages.deletedAt,
+        projectId: channels.projectId,
+        organizationId: channels.organizationId,
+      })
+      .from(messages)
+      .innerJoin(channels, eq(channels.id, messages.channelId))
+      .where(eq(messages.id, messageId))
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+
+    if (
+      !message ||
+      message.organizationId !== organizationId ||
+      message.deletedAt ||
+      message.userId !== user.id
+    ) {
+      return NextResponse.json(
+        { success: false, error: "Message not found." },
+        { status: 404 }
+      )
+    }
+
+    const membership = await db
+      .select({ id: channelMembers.id })
+      .from(channelMembers)
+      .where(
+        and(
+          eq(channelMembers.channelId, message.channelId),
+          eq(channelMembers.userId, user.id)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!membership) {
+      return NextResponse.json(
+        { success: false, error: "You do not have access to this channel." },
+        { status: 403 }
+      )
+    }
+
+    const auth = await db
+      .select()
+      .from(googleAuth)
+      .where(eq(googleAuth.organizationId, organizationId))
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!auth) {
+      return NextResponse.json(
+        { success: false, error: "Google Drive is not connected." },
+        { status: 400 }
+      )
+    }
+
+    let parentId = auth.sharedDriveId
+    if (message.projectId) {
+      const project = await db
+        .select({ googleDriveFolderId: projects.googleDriveFolderId })
+        .from(projects)
+        .where(
+          and(
+            eq(projects.id, message.projectId),
+            eq(projects.organizationId, organizationId)
+          )
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null)
+      parentId = project?.googleDriveFolderId ?? null
+
+      if (!parentId) {
+        parentId = await db
+          .select({
+            externalId: projectExternalLinks.externalId,
+            externalUrl: projectExternalLinks.externalUrl,
+          })
+          .from(projectExternalLinks)
+          .where(
+            and(
+              eq(projectExternalLinks.projectId, message.projectId),
+              eq(projectExternalLinks.system, "google_drive")
+            )
+          )
+          .limit(1)
+          .then((rows) => {
+            const link = rows[0]
+            return (
+              link?.externalId ??
+              driveFolderIdFromUrl(link?.externalUrl ?? null)
+            )
+          })
+      }
+    }
+    if (!parentId) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            "No Google Drive folder is available for message attachments.",
+        },
+        { status: 400 }
+      )
+    }
+
+    const envRecord = env as unknown as Record<string, string>
+    const config = getGoogleConfig(envRecord)
+    const keyJson = await decrypt(
+      auth.serviceAccountKeyEncrypted,
+      config.encryptionKey,
+      getGoogleCryptoSalt()
+    )
+    const client = new DriveClient({
+      serviceAccountKey: parseServiceAccountKey(keyJson),
+    })
+    const googleEmail = uploadEmail(user.email, user.googleEmail, envRecord)
+    const folderId = await findOrCreateAttachmentFolder(
+      client,
+      googleEmail,
+      parentId,
+      auth.sharedDriveId
+    )
+    const uploadedAt = new Date().toISOString()
+    const attachments: Array<{
+      readonly id: string
+      readonly fileName: string
+      readonly mimeType: string
+      readonly fileSize: number
+      readonly storageUrl: string
+    }> = []
+
+    for (const file of files) {
+      const mimeType = file.type || "application/octet-stream"
+      const driveFile = await client.uploadFile(googleEmail, {
+        name: safeFileName(file.name),
+        mimeType,
+        parentId: folderId,
+        driveId: auth.sharedDriveId ?? undefined,
+        data: file,
+      })
+      const id = crypto.randomUUID()
+      const storageUrl = `/api/google/download/${driveFile.id}`
+      const fileSize = Number(driveFile.size ?? file.size)
+      await db.insert(messageAttachments).values({
+        id,
+        messageId,
+        fileName: driveFile.name,
+        mimeType: driveFile.mimeType || mimeType,
+        fileSize,
+        r2Path: storageUrl,
+        width: null,
+        height: null,
+        uploadedAt,
+      })
+      attachments.push({
+        id,
+        fileName: driveFile.name,
+        mimeType: driveFile.mimeType || mimeType,
+        fileSize,
+        storageUrl,
+      })
+    }
+
+    revalidatePath("/dashboard/conversations")
+    revalidatePath(`/dashboard/conversations/${message.channelId}`)
+    return NextResponse.json({ success: true, attachments })
+  } catch (error) {
+    console.error("Message attachment upload failed", error)
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unable to upload message attachments.",
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/dashboard/projects/[id]/purchase-orders/page.tsx
+++ b/src/app/dashboard/projects/[id]/purchase-orders/page.tsx
@@ -16,11 +16,18 @@ import { ProjectPurchaseOrderDeleteButton } from "@/components/projects/project-
 import { ProjectPurchaseOrderEmailButton } from "@/components/projects/project-purchase-order-email-button"
 import { ProjectPurchaseOrderCreateForm } from "@/components/projects/project-purchase-order-create-form"
 import { ProjectPurchaseOrderPrintButton } from "@/components/projects/project-purchase-order-print-button"
+import { ProjectOperationStatusSelect } from "@/components/projects/project-operation-status-select"
 import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
 import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
+import {
+  isClosedProjectOperationStatus,
+  parseProjectOperationStatusFilter,
+  projectOperationMatchesStatusFilter,
+  type ProjectOperationStatusFilter,
+} from "@/lib/project-operations/status"
 
 function money(value: number | null): string {
   if (value === null) return "Amount TBD"
@@ -46,6 +53,22 @@ function label(value: string): string {
     .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
     .join(" ")
 }
+
+const PURCHASE_ORDER_FILTERS: readonly {
+  readonly value: ProjectOperationStatusFilter
+  readonly label: string
+}[] = [
+  { value: "open", label: "Open" },
+  { value: "draft", label: "Draft" },
+  { value: "approved", label: "Approved" },
+  { value: "ordered", label: "Ordered" },
+  { value: "partially_received", label: "Partially received" },
+  { value: "received", label: "Received" },
+  { value: "complete", label: "Complete" },
+  { value: "closed", label: "Closed" },
+  { value: "void", label: "Void" },
+  { value: "all", label: "All" },
+]
 
 function purchaseOrderTaskTitle(order: ProjectPurchaseOrderItem): string {
   return `Follow up P.O.: ${order.sourceRecordNumber ?? order.title}`
@@ -102,9 +125,12 @@ function PurchaseOrderCard({
           </div>
           <div className="flex flex-wrap gap-1">
             {isCreated && <Badge variant="secondary">Just created</Badge>}
-            <Badge variant={order.status === "draft" ? "secondary" : "outline"}>
-              {label(order.status)}
-            </Badge>
+            <ProjectOperationStatusSelect
+              projectId={projectId}
+              operationId={order.id}
+              operationKind="purchase_order"
+              status={order.status}
+            />
             <Badge variant="outline">{label(order.syncStatus)}</Badge>
             {order.priority === "high" && (
               <Badge variant="destructive">High</Badge>
@@ -309,6 +335,7 @@ export default async function ProjectPurchaseOrdersPage({
   readonly params: Promise<{ readonly id: string }>
   readonly searchParams: Promise<{
     readonly created?: string | readonly string[]
+    readonly status?: string | readonly string[]
   }>
 }) {
   const { id } = await params
@@ -316,6 +343,7 @@ export default async function ProjectPurchaseOrdersPage({
   const createdPurchaseOrderId = Array.isArray(query.created)
     ? query.created[0] ?? null
     : query.created ?? null
+  const statusFilter = parseProjectOperationStatusFilter(query.status)
   const [projects, purchaseOrders, taskAssigneeOptions] = await Promise.all([
     getProjects(),
     getProjectPurchaseOrders(id),
@@ -327,7 +355,10 @@ export default async function ProjectPurchaseOrdersPage({
     ...taskAssigneeOptions.directoryContacts,
   ]
   const openPurchaseOrders = purchaseOrders.filter(
-    (order) => !["closed", "void", "complete"].includes(order.status)
+    (order) => !isClosedProjectOperationStatus(order.status)
+  )
+  const visiblePurchaseOrders = purchaseOrders.filter((order) =>
+    projectOperationMatchesStatusFilter(order.status, statusFilter)
   )
   const openTotal = openPurchaseOrders.reduce(
     (total, order) => total + (order.amount ?? 0),
@@ -391,8 +422,33 @@ export default async function ProjectPurchaseOrdersPage({
           </div>
         </div>
 
-        {purchaseOrders.length > 0 ? (
-          purchaseOrders.map((order) => (
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <nav
+            aria-label="Filter purchase orders by status"
+            className="flex flex-wrap gap-1"
+          >
+            {PURCHASE_ORDER_FILTERS.map((option) => (
+              <Button
+                key={option.value}
+                asChild
+                size="sm"
+                variant={statusFilter === option.value ? "secondary" : "ghost"}
+              >
+                <Link
+                  href={`/dashboard/projects/${id}/purchase-orders?status=${option.value}`}
+                >
+                  {option.label}
+                </Link>
+              </Button>
+            ))}
+          </nav>
+          <p className="text-xs text-muted-foreground">
+            {visiblePurchaseOrders.length} of {purchaseOrders.length} shown
+          </p>
+        </div>
+
+        {visiblePurchaseOrders.length > 0 ? (
+          visiblePurchaseOrders.map((order) => (
             <PurchaseOrderCard
               key={order.id}
               order={order}
@@ -409,9 +465,15 @@ export default async function ProjectPurchaseOrdersPage({
         ) : (
           <div className="rounded-lg border bg-background p-8 text-center">
             <IconShoppingCart className="mx-auto size-6 text-muted-foreground" />
-            <h2 className="mt-3 text-sm font-semibold">No PO requests yet</h2>
+            <h2 className="mt-3 text-sm font-semibold">
+              {purchaseOrders.length === 0
+                ? "No PO requests yet"
+                : "No purchase orders match this filter"}
+            </h2>
             <p className="mt-1 text-sm text-muted-foreground">
-              Create a PO when a vendor commitment is ready.
+              {purchaseOrders.length === 0
+                ? "Create a PO when a vendor commitment is ready."
+                : "Choose another status to see the rest of the PO queue."}
             </p>
           </div>
         )}

--- a/src/app/dashboard/projects/[id]/rfqs/page.tsx
+++ b/src/app/dashboard/projects/[id]/rfqs/page.tsx
@@ -24,11 +24,18 @@ import { ProjectRfqCreateForm } from "@/components/projects/project-rfq-create-f
 import { ProjectRfqDeleteButton } from "@/components/projects/project-rfq-delete-button"
 import { ProjectRfqEditForm } from "@/components/projects/project-rfq-edit-form"
 import { ProjectRfqShareActions } from "@/components/projects/project-rfq-share-actions"
+import { ProjectOperationStatusSelect } from "@/components/projects/project-operation-status-select"
 import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
 import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
+import {
+  isClosedProjectOperationStatus,
+  parseProjectOperationStatusFilter,
+  projectOperationMatchesStatusFilter,
+  type ProjectOperationStatusFilter,
+} from "@/lib/project-operations/status"
 
 export const dynamic = "force-dynamic"
 
@@ -49,10 +56,24 @@ function label(value: string): string {
 }
 
 function isActiveRfqStatus(status: string): boolean {
-  return !["closed", "complete", "void", "cancelled"].includes(
-    status.toLowerCase()
-  )
+  return !isClosedProjectOperationStatus(status)
 }
+
+const RFQ_FILTERS: readonly {
+  readonly value: ProjectOperationStatusFilter
+  readonly label: string
+}[] = [
+  { value: "open", label: "Open" },
+  { value: "draft", label: "Draft" },
+  { value: "sent", label: "Sent" },
+  { value: "response_received", label: "Response received" },
+  { value: "awarded", label: "Awarded" },
+  { value: "declined", label: "Declined" },
+  { value: "complete", label: "Complete" },
+  { value: "closed", label: "Closed" },
+  { value: "void", label: "Void" },
+  { value: "all", label: "All" },
+]
 
 function rfqTaskTitle(rfq: ProjectRfqItem): string {
   return `Follow up RFQ: ${rfq.sourceRecordNumber ?? rfq.title}`
@@ -144,9 +165,12 @@ function RfqCard({
         </div>
         <div className="flex flex-wrap gap-1">
           {isCreated && <Badge variant="secondary">Just created</Badge>}
-          <Badge variant={isActiveRfqStatus(rfq.status) ? "secondary" : "outline"}>
-            {label(rfq.status)}
-          </Badge>
+          <ProjectOperationStatusSelect
+            projectId={projectId}
+            operationId={rfq.id}
+            operationKind="rfq"
+            status={rfq.status}
+          />
           <Badge variant="outline">{label(rfq.syncStatus)}</Badge>
           {rfq.priority === "high" || rfq.priority === "critical" ? (
             <Badge variant="destructive">{label(rfq.priority)}</Badge>
@@ -268,6 +292,7 @@ export default async function ProjectRfqsPage({
   readonly params: Promise<{ readonly id: string }>
   readonly searchParams: Promise<{
     readonly created?: string | readonly string[]
+    readonly status?: string | readonly string[]
   }>
 }): Promise<React.ReactElement> {
   const { id } = await params
@@ -275,6 +300,7 @@ export default async function ProjectRfqsPage({
   const createdRfqId = Array.isArray(query.created)
     ? query.created[0] ?? null
     : query.created ?? null
+  const statusFilter = parseProjectOperationStatusFilter(query.status)
   const [projects, rfqs, taskAssigneeOptions, selectionsSummary, selectionOptions] =
     await Promise.all([
     getProjects(),
@@ -289,6 +315,9 @@ export default async function ProjectRfqsPage({
     ...taskAssigneeOptions.directoryContacts,
   ]
   const openRfqs = rfqs.filter((rfq) => isActiveRfqStatus(rfq.status))
+  const visibleRfqs = rfqs.filter((rfq) =>
+    projectOperationMatchesStatusFilter(rfq.status, statusFilter)
+  )
   const overdueCount = openRfqs.filter((rfq) => {
     if (!rfq.dueDate) return false
     return rfq.dueDate < new Date().toISOString().slice(0, 10)
@@ -352,8 +381,33 @@ export default async function ProjectRfqsPage({
           />
         </div>
 
-        {rfqs.length > 0 ? (
-          rfqs.map((rfq) => (
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <nav
+            aria-label="Filter RFQs by status"
+            className="flex flex-wrap gap-1"
+          >
+            {RFQ_FILTERS.map((option) => (
+              <Button
+                key={option.value}
+                asChild
+                size="sm"
+                variant={statusFilter === option.value ? "secondary" : "ghost"}
+              >
+                <Link
+                  href={`/dashboard/projects/${id}/rfqs?status=${option.value}`}
+                >
+                  {option.label}
+                </Link>
+              </Button>
+            ))}
+          </nav>
+          <p className="text-xs text-muted-foreground">
+            {visibleRfqs.length} of {rfqs.length} shown
+          </p>
+        </div>
+
+        {visibleRfqs.length > 0 ? (
+          visibleRfqs.map((rfq) => (
             <RfqCard
               key={rfq.id}
               rfq={rfq}
@@ -368,9 +422,13 @@ export default async function ProjectRfqsPage({
         ) : (
           <div className="rounded-lg border bg-background p-8 text-center">
             <IconClock className="mx-auto size-6 text-muted-foreground" />
-            <h2 className="mt-3 text-sm font-semibold">No RFQs yet</h2>
+            <h2 className="mt-3 text-sm font-semibold">
+              {rfqs.length === 0 ? "No RFQs yet" : "No RFQs match this filter"}
+            </h2>
             <p className="mt-1 text-sm text-muted-foreground">
-              Create the first quote request for this project.
+              {rfqs.length === 0
+                ? "Create the first quote request for this project."
+                : "Choose another status to see the rest of the RFQ queue."}
             </p>
           </div>
         )}

--- a/src/app/dashboard/schedule/page.tsx
+++ b/src/app/dashboard/schedule/page.tsx
@@ -4,6 +4,7 @@ import { getWorkCalendar } from "@/app/actions/work-calendar"
 import {
   WorkCalendar,
   type WorkCalendarKindFilter,
+  type WorkCalendarView,
 } from "@/components/schedule/work-calendar"
 
 function kindFilter(
@@ -23,12 +24,29 @@ function kindFilter(
   }
 }
 
+function calendarView(
+  value: string | readonly string[] | undefined
+): WorkCalendarView {
+  const selected = typeof value === "string" ? value : value?.[0]
+
+  switch (selected) {
+    case "today":
+    case "week":
+    case "month":
+    case "list":
+      return selected
+    default:
+      return "week"
+  }
+}
+
 export default async function SchedulePage({
   searchParams,
 }: {
   readonly searchParams: Promise<{
     readonly kind?: string | readonly string[]
     readonly item?: string | readonly string[]
+    readonly view?: string | readonly string[]
   }>
 }): Promise<React.ReactElement> {
   const query = await searchParams
@@ -42,6 +60,7 @@ export default async function SchedulePage({
       data={data}
       initialKind={kindFilter(query.kind)}
       initialItemId={initialItemId}
+      initialView={calendarView(query.view)}
     />
   )
 }

--- a/src/components/conversations/message-composer.tsx
+++ b/src/components/conversations/message-composer.tsx
@@ -15,8 +15,9 @@ import {
   ListOrdered,
   Plus,
   Smile,
-  Sticker,
-  Gift,
+  Paperclip,
+  SendHorizontal,
+  X,
   SendToBack,
   Bell,
   Check,
@@ -107,6 +108,7 @@ type MessageComposerProps = {
   readonly threadId?: string
   readonly placeholder?: string
   readonly onSent?: () => void
+  readonly className?: string
 }
 
 export type ProjectRecipientContact = {
@@ -316,6 +318,7 @@ export function MessageComposer({
   threadId,
   placeholder,
   onSent,
+  className,
 }: MessageComposerProps) {
   const router = useRouter()
   const { resolvedTheme } = useTheme()
@@ -328,7 +331,9 @@ export function MessageComposer({
   const [recipientOpen, setRecipientOpen] = React.useState(false)
   const [recipientValue, setRecipientValue] = React.useState("channel")
   const [importantDelivery, setImportantDelivery] = React.useState(false)
+  const [selectedFiles, setSelectedFiles] = React.useState<readonly File[]>([])
   const hasProjectDelivery = isProjectChannel && !threadId
+  const fileInputRef = React.useRef<HTMLInputElement>(null)
 
   const lastTypingSentRef = React.useRef<number>(0)
   const TYPING_DEBOUNCE_MS = 3000
@@ -427,11 +432,71 @@ export function MessageComposer({
     [editor],
   )
 
+  const handleFileSelection = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(event.target.files ?? [])
+      event.target.value = ""
+      if (files.length === 0) return
+      if (selectedFiles.length + files.length > 10) {
+        setError("Choose no more than 10 attachments at once.")
+        return
+      }
+      const oversized = files.find((file) => file.size > 25 * 1024 * 1024)
+      if (oversized) {
+        setError(`${oversized.name} exceeds the 25 MB per-file limit.`)
+        return
+      }
+      const combined = [...selectedFiles, ...files]
+      const totalBytes = combined.reduce((total, file) => total + file.size, 0)
+      if (totalBytes > 50 * 1024 * 1024) {
+        setError("The selected files exceed the 50 MB batch limit.")
+        return
+      }
+      setSelectedFiles(combined)
+      setError(null)
+    },
+    [selectedFiles]
+  )
+
+  const uploadAttachments = React.useCallback(
+    async (messageId: string): Promise<string | null> => {
+      if (selectedFiles.length === 0) return null
+      const formData = new FormData()
+      formData.set("messageId", messageId)
+      for (const file of selectedFiles) {
+        formData.append("files", file)
+      }
+      const response = await fetch("/api/conversations/attachments/upload", {
+        method: "POST",
+        body: formData,
+      })
+      const result: unknown = await response.json()
+      if (
+        typeof result === "object" &&
+        result !== null &&
+        "success" in result &&
+        result.success === true
+      ) {
+        return null
+      }
+      if (
+        typeof result === "object" &&
+        result !== null &&
+        "error" in result &&
+        typeof result.error === "string"
+      ) {
+        return result.error
+      }
+      return "Unable to upload message attachments."
+    },
+    [selectedFiles]
+  )
+
   const handleSend = React.useCallback(async () => {
     if (!editor || isSending) return
 
     const plainText = editor.getText().trim()
-    if (!plainText) return
+    if (!plainText && selectedFiles.length === 0) return
 
     setIsSending(true)
     setError(null)
@@ -446,7 +511,12 @@ export function MessageComposer({
         string,
         { getMarkdown?: () => string } | undefined
       >
-      const markdown = storage.markdown?.getMarkdown?.() ?? plainText
+      const editorMarkdown = storage.markdown?.getMarkdown?.() ?? plainText
+      const markdown =
+        editorMarkdown.trim() ||
+        `Shared ${selectedFiles.length} attachment${
+          selectedFiles.length === 1 ? "" : "s"
+        }.`
 
       const result =
         recipientValue === "channel" || threadId
@@ -465,7 +535,22 @@ export function MessageComposer({
             })
 
       if (result.success) {
+        let messageId: string | null = null
+        if ("data" in result && result.data) {
+          if ("messageId" in result.data && typeof result.data.messageId === "string") {
+            messageId = result.data.messageId
+          } else if ("id" in result.data && typeof result.data.id === "string") {
+            messageId = result.data.id
+          }
+        }
+        const attachmentError =
+          selectedFiles.length > 0 && messageId
+            ? await uploadAttachments(messageId)
+            : selectedFiles.length > 0
+              ? "The message was sent, but its attachments could not be linked."
+              : null
         editor.commands.clearContent()
+        setSelectedFiles([])
         setImportantDelivery(false)
         if ("data" in result && result.data && "recipientLabel" in result.data) {
           const noteParts = [`Sent to ${result.data.recipientLabel}`]
@@ -486,6 +571,9 @@ export function MessageComposer({
           setDeliveryNote(`${noteParts.join(". ")}.`)
         } else {
           setDeliveryNote("Sent to the channel.")
+        }
+        if (attachmentError) {
+          setError(`Message sent, but attachments failed: ${attachmentError}`)
         }
         router.refresh()
         onSent?.()
@@ -508,6 +596,8 @@ export function MessageComposer({
     isSending,
     recipientValue,
     importantDelivery,
+    selectedFiles,
+    uploadAttachments,
   ])
 
   React.useEffect(() => {
@@ -529,7 +619,7 @@ export function MessageComposer({
   }, [editor, handleSend])
 
   return (
-    <div className="min-h-[68px] px-2 pb-4 pt-2 sm:px-4">
+    <div className={cn("min-h-[68px] px-2 pb-4 pt-2 sm:px-4", className)}>
       {hasProjectDelivery && (
         <div className="mb-2 flex flex-col gap-2 border-y bg-background/80 px-1 py-2 sm:flex-row sm:items-center sm:justify-between sm:border sm:px-3">
           <div className="flex min-w-0 flex-1 items-center gap-2">
@@ -720,6 +810,34 @@ export function MessageComposer({
       )}
 
       {/* main composer bar */}
+      {selectedFiles.length > 0 && (
+        <div className="mb-2 flex flex-wrap gap-2 border-y py-2">
+          {selectedFiles.map((file, index) => (
+            <div
+              key={`${file.name}-${file.size}-${index}`}
+              className="flex min-w-0 max-w-full items-center gap-2 border-l-2 border-primary/40 px-2 py-1 text-xs"
+            >
+              <Paperclip className="size-3.5 shrink-0 text-muted-foreground" />
+              <span className="max-w-56 truncate">{file.name}</span>
+              <button
+                type="button"
+                onClick={() =>
+                  setSelectedFiles((current) =>
+                    current.filter((_, fileIndex) => fileIndex !== index)
+                  )
+                }
+                aria-label={`Remove ${file.name}`}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <X className="size-3.5" />
+              </button>
+            </div>
+          ))}
+          <span className="self-center text-xs text-muted-foreground">
+            25 MB per file · 50 MB total
+          </span>
+        </div>
+      )}
       <div
         className={cn(
           "relative flex items-end rounded-lg",
@@ -755,27 +873,24 @@ export function MessageComposer({
 
         {/* right-side action icons */}
         <div className="flex h-[44px] shrink-0 items-center gap-0 pr-1 sm:pr-1.5">
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            className="sr-only"
+            onChange={handleFileSelection}
+          />
           <button
             type="button"
             className={cn(
-              "hidden sm:flex",
-              "h-8 w-8 items-center justify-center rounded-md",
+              "flex h-8 w-8 items-center justify-center rounded-md",
               "text-muted-foreground hover:text-foreground transition-colors",
             )}
-            aria-label="Stickers"
+            onClick={() => fileInputRef.current?.click()}
+            aria-label="Attach files"
+            title="Attach files"
           >
-            <Sticker className="h-[18px] w-[18px]" />
-          </button>
-          <button
-            type="button"
-            className={cn(
-              "hidden sm:flex",
-              "h-8 w-8 items-center justify-center rounded-md",
-              "text-muted-foreground hover:text-foreground transition-colors",
-            )}
-            aria-label="GIF"
-          >
-            <Gift className="h-[18px] w-[18px]" />
+            <Paperclip className="h-[18px] w-[18px]" />
           </button>
 
           {/* emoji picker */}
@@ -821,6 +936,23 @@ export function MessageComposer({
               </React.Suspense>
             </PopoverContent>
           </Popover>
+          <button
+            type="button"
+            className={cn(
+              "flex h-8 w-8 items-center justify-center rounded-md",
+              "text-muted-foreground hover:text-foreground transition-colors",
+              "disabled:cursor-not-allowed disabled:opacity-40",
+            )}
+            onClick={handleSend}
+            disabled={
+              isSending ||
+              (!editor?.getText().trim() && selectedFiles.length === 0)
+            }
+            aria-label="Send message"
+            title="Send message"
+          >
+            <SendHorizontal className="h-[18px] w-[18px]" />
+          </button>
         </div>
       </div>
 

--- a/src/components/conversations/message-item.tsx
+++ b/src/components/conversations/message-item.tsx
@@ -5,18 +5,25 @@ import { formatDistanceToNow, format, parseISO } from "date-fns"
 import {
   MessageSquare,
   Smile,
-  Edit2,
   Trash2,
-  MoreHorizontal,
+  Paperclip,
 } from "lucide-react"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Textarea } from "@/components/ui/textarea"
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
 import { cn } from "@/lib/utils"
 import { useConversations } from "@/contexts/conversations-context"
-import { editMessage, deleteMessage, addReaction } from "@/app/actions/chat-messages"
+import {
+  addReaction,
+  deleteMessage,
+  removeReaction,
+} from "@/app/actions/chat-messages"
 import { useRouter } from "next/navigation"
 
 type MessageData = {
@@ -31,6 +38,18 @@ type MessageData = {
   readonly replyCount: number
   readonly lastReplyAt: string | null
   readonly createdAt: string
+  readonly attachments?: readonly {
+    readonly id: string
+    readonly fileName: string
+    readonly mimeType: string
+    readonly fileSize: number
+    readonly storageUrl: string
+  }[]
+  readonly reactions?: readonly {
+    readonly emoji: string
+    readonly count: number
+    readonly reactedByCurrentUser: boolean
+  }[]
   readonly user: {
     readonly id: string
     readonly displayName: string | null
@@ -61,15 +80,18 @@ function arePropsEqual(prev: MessageItemProps, next: MessageItemProps): boolean 
     prevMsg.editedAt === nextMsg.editedAt &&
     prevMsg.isPinned === nextMsg.isPinned &&
     prevMsg.replyCount === nextMsg.replyCount &&
-    prevMsg.deletedAt === nextMsg.deletedAt
+    prevMsg.deletedAt === nextMsg.deletedAt &&
+    prevMsg.attachments?.length === nextMsg.attachments?.length &&
+    prevMsg.reactions?.map((reaction) => `${reaction.emoji}:${reaction.count}`).join("|") ===
+      nextMsg.reactions?.map((reaction) => `${reaction.emoji}:${reaction.count}`).join("|")
   )
 }
 
 export const MessageItem = React.memo(function MessageItem({ message }: MessageItemProps) {
-  const [isEditing, setIsEditing] = React.useState(false)
-  const [editContent, setEditContent] = React.useState(message.content)
   const [isHovered, setIsHovered] = React.useState(false)
   const [isFocused, setIsFocused] = React.useState(false)
+  const [reactionOpen, setReactionOpen] = React.useState(false)
+  const [reactionPending, setReactionPending] = React.useState(false)
   const { openThread } = useConversations()
   const router = useRouter()
 
@@ -84,19 +106,6 @@ export const MessageItem = React.memo(function MessageItem({ message }: MessageI
     ? formatDistanceToNow(timestamp, { addSuffix: true })
     : format(timestamp, "MMM d 'at' h:mm a")
 
-  const handleEdit = async () => {
-    if (editContent.trim() === message.content) {
-      setIsEditing(false)
-      return
-    }
-
-    const result = await editMessage(message.id, editContent.trim())
-    if (result.success) {
-      setIsEditing(false)
-      router.refresh()
-    }
-  }
-
   const handleDelete = async () => {
     if (!confirm("Delete this message?")) return
     const result = await deleteMessage(message.id)
@@ -107,6 +116,20 @@ export const MessageItem = React.memo(function MessageItem({ message }: MessageI
 
   const handleReply = () => {
     openThread(message.id, message)
+  }
+
+  async function toggleReaction(
+    emoji: string,
+    reactedByCurrentUser: boolean
+  ): Promise<void> {
+    if (reactionPending) return
+    setReactionPending(true)
+    const result = reactedByCurrentUser
+      ? await removeReaction(message.id, emoji)
+      : await addReaction(message.id, emoji)
+    setReactionPending(false)
+    setReactionOpen(false)
+    if (result.success) router.refresh()
   }
 
   if (message.deletedAt) {
@@ -153,33 +176,56 @@ export const MessageItem = React.memo(function MessageItem({ message }: MessageI
           )}
         </div>
 
-        {isEditing ? (
-          <div className="mt-2 space-y-2">
-            <Textarea
-              value={editContent}
-              onChange={(e) => setEditContent(e.target.value)}
-              className="min-h-[80px]"
-              autoFocus
-            />
-            <div className="flex gap-2">
-              <Button size="sm" onClick={handleEdit}>
-                Save
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => {
-                  setEditContent(message.content)
-                  setIsEditing(false)
-                }}
+        <div className="chat-markdown mt-1 text-sm">
+          <MarkdownRenderer>{message.content}</MarkdownRenderer>
+        </div>
+
+        {message.attachments && message.attachments.length > 0 && (
+          <div className="mt-2 grid gap-1.5">
+            {message.attachments.map((attachment) => (
+              <a
+                key={attachment.id}
+                href={attachment.storageUrl}
+                className="flex min-w-0 items-center gap-2 border-l-2 border-primary/40 px-2 py-1.5 text-xs hover:bg-muted/50"
               >
-                Cancel
-              </Button>
-            </div>
+                <Paperclip className="size-3.5 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 flex-1 truncate font-medium">
+                  {attachment.fileName}
+                </span>
+                <span className="shrink-0 text-muted-foreground">
+                  {attachment.fileSize < 1024 * 1024
+                    ? `${Math.max(1, Math.round(attachment.fileSize / 1024))} KB`
+                    : `${(attachment.fileSize / (1024 * 1024)).toFixed(1)} MB`}
+                </span>
+              </a>
+            ))}
           </div>
-        ) : (
-          <div className="chat-markdown mt-1 text-sm">
-            <MarkdownRenderer>{message.content}</MarkdownRenderer>
+        )}
+
+        {message.reactions && message.reactions.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1">
+            {message.reactions.map((reaction) => (
+              <button
+                key={reaction.emoji}
+                type="button"
+                onClick={() =>
+                  toggleReaction(
+                    reaction.emoji,
+                    reaction.reactedByCurrentUser
+                  )
+                }
+                disabled={reactionPending}
+                className={cn(
+                  "inline-flex h-7 items-center gap-1 rounded-md border px-2 text-xs hover:bg-muted",
+                  reaction.reactedByCurrentUser &&
+                    "border-primary/50 bg-primary/10"
+                )}
+                aria-label={`${reaction.reactedByCurrentUser ? "Remove" : "Add"} ${reaction.emoji} reaction`}
+              >
+                <span>{reaction.emoji}</span>
+                <span>{reaction.count}</span>
+              </button>
+            ))}
           </div>
         )}
 
@@ -199,7 +245,7 @@ export const MessageItem = React.memo(function MessageItem({ message }: MessageI
         )}
       </div>
 
-      {(isHovered || isFocused) && !isEditing && (
+      {(isHovered || isFocused || reactionOpen) && (
         <div className="absolute right-4 top-2 flex gap-1 rounded-md border bg-background p-1 shadow-sm">
           <Button
             variant="ghost"
@@ -210,24 +256,46 @@ export const MessageItem = React.memo(function MessageItem({ message }: MessageI
           >
             <MessageSquare className="h-3.5 w-3.5" />
           </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7"
-            disabled
-            aria-label="Add reaction"
-          >
-            <Smile className="h-3.5 w-3.5" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7"
-            onClick={() => setIsEditing(true)}
-            aria-label="Edit message"
-          >
-            <Edit2 className="h-3.5 w-3.5" />
-          </Button>
+          <Popover open={reactionOpen} onOpenChange={setReactionOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                aria-label="Add reaction"
+              >
+                <Smile className="h-3.5 w-3.5" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              align="end"
+              side="top"
+              className="flex w-auto gap-1 p-1.5"
+            >
+              {["👍", "❤️", "✅", "🎉", "👀", "🙏"].map((emoji) => {
+                const existing = message.reactions?.find(
+                  (reaction) => reaction.emoji === emoji
+                )
+                return (
+                  <button
+                    key={emoji}
+                    type="button"
+                    disabled={reactionPending}
+                    onClick={() =>
+                      toggleReaction(
+                        emoji,
+                        existing?.reactedByCurrentUser ?? false
+                      )
+                    }
+                    className="flex size-8 items-center justify-center rounded-md text-base hover:bg-muted"
+                    aria-label={`React with ${emoji}`}
+                  >
+                    {emoji}
+                  </button>
+                )
+              })}
+            </PopoverContent>
+          </Popover>
           <Button
             variant="ghost"
             size="icon"

--- a/src/components/conversations/message-list.tsx
+++ b/src/components/conversations/message-list.tsx
@@ -1,10 +1,9 @@
 "use client"
 
 import * as React from "react"
-import { formatDistanceToNow, format, isSameDay, parseISO } from "date-fns"
+import { format, parseISO } from "date-fns"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
-import { Skeleton } from "@/components/ui/skeleton"
 import { MessageItem } from "./message-item"
 import { TypingIndicator } from "./typing-indicator"
 import { Button } from "@/components/ui/button"
@@ -23,6 +22,18 @@ type MessageData = {
   readonly replyCount: number
   readonly lastReplyAt: string | null
   readonly createdAt: string
+  readonly attachments?: readonly {
+    readonly id: string
+    readonly fileName: string
+    readonly mimeType: string
+    readonly fileSize: number
+    readonly storageUrl: string
+  }[]
+  readonly reactions?: readonly {
+    readonly emoji: string
+    readonly count: number
+    readonly reactedByCurrentUser: boolean
+  }[]
   readonly user: {
     readonly id: string
     readonly displayName: string | null

--- a/src/components/conversations/thread-panel.tsx
+++ b/src/components/conversations/thread-panel.tsx
@@ -107,7 +107,7 @@ export function ThreadPanel() {
 
       <div
         className={cn(
-          "flex flex-col border-l bg-background",
+          "flex min-h-0 flex-col border-l bg-background",
           "transition-[width,opacity,transform] duration-300 ease-in-out",
           isMobile
             ? "fixed inset-0 z-50"
@@ -142,7 +142,7 @@ export function ThreadPanel() {
           </div>
         ) : (
           <>
-            <ScrollArea className="flex-1">
+            <ScrollArea className="min-h-0 flex-1">
               <div className="p-4">
                 {threadParentMessage && (
                   <>
@@ -181,6 +181,7 @@ export function ThreadPanel() {
                 threadId={threadMessageId ?? undefined}
                 placeholder="Reply to thread..."
                 onSent={refreshReplies}
+                className="shrink-0"
               />
             )}
           </>

--- a/src/components/projects/project-operation-status-select.tsx
+++ b/src/components/projects/project-operation-status-select.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import * as React from "react"
+import { useRouter } from "next/navigation"
+
+import {
+  updateProjectOperationStatus,
+  type ProjectOperationKind,
+} from "@/app/actions/project-operations"
+import {
+  PURCHASE_ORDER_STATUS_OPTIONS,
+  RFQ_STATUS_OPTIONS,
+} from "@/lib/project-operations/status"
+
+export function ProjectOperationStatusSelect({
+  projectId,
+  operationId,
+  operationKind,
+  status,
+}: {
+  readonly projectId: string
+  readonly operationId: string
+  readonly operationKind: ProjectOperationKind
+  readonly status: string
+}): React.ReactElement {
+  const router = useRouter()
+  const [selectedStatus, setSelectedStatus] = React.useState(status)
+  const [error, setError] = React.useState<string | null>(null)
+  const [isPending, startTransition] = React.useTransition()
+  const options =
+    operationKind === "purchase_order"
+      ? PURCHASE_ORDER_STATUS_OPTIONS
+      : RFQ_STATUS_OPTIONS
+  const hasImportedStatus = !options.some(
+    (option) => option.value === selectedStatus
+  )
+
+  function changeStatus(nextStatus: string): void {
+    const previousStatus = selectedStatus
+    setSelectedStatus(nextStatus)
+    setError(null)
+    startTransition(async () => {
+      const result = await updateProjectOperationStatus(
+        projectId,
+        operationId,
+        operationKind,
+        nextStatus
+      )
+      if (!result.success) {
+        setSelectedStatus(previousStatus)
+        setError(result.error)
+        return
+      }
+      router.refresh()
+    })
+  }
+
+  return (
+    <div className="min-w-40">
+      <label
+        className="sr-only"
+        htmlFor={`${operationKind}-status-${operationId}`}
+      >
+        Status
+      </label>
+      <select
+        id={`${operationKind}-status-${operationId}`}
+        value={selectedStatus}
+        disabled={isPending}
+        onChange={(event) => changeStatus(event.target.value)}
+        className="h-8 w-full rounded-md border bg-background px-2 text-xs font-medium"
+        aria-label={`Change ${operationKind === "purchase_order" ? "purchase order" : "RFQ"} status`}
+      >
+        {hasImportedStatus && (
+          <option value={selectedStatus}>
+            {selectedStatus.replaceAll("_", " ")} (imported)
+          </option>
+        )}
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      {error && (
+        <p className="mt-1 text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/schedule/schedule-item-form-dialog.tsx
+++ b/src/components/schedule/schedule-item-form-dialog.tsx
@@ -657,7 +657,7 @@ export function ScheduleItemFormDialog({
                     {pendingPredecessors.map((pred, idx) => (
                       <div
                         key={idx}
-                        className="grid grid-cols-[minmax(0,1fr)_72px_72px_28px] items-center gap-1.5 sm:grid-cols-[minmax(0,1fr)_90px_72px_28px]"
+                        className="grid grid-cols-[minmax(0,1fr)_6.5rem_2rem] items-end gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(10rem,12rem)_6rem_2rem]"
                       >
                         <Select
                           value={pred.taskId}
@@ -665,7 +665,10 @@ export function ScheduleItemFormDialog({
                             updatePendingPredecessor(idx, "taskId", val)
                           }
                         >
-                          <SelectTrigger className="h-8 text-xs">
+                          <SelectTrigger
+                            className="col-span-3 h-8 min-w-0 text-xs sm:col-span-1"
+                            aria-label="Predecessor schedule item"
+                          >
                             <SelectValue placeholder="Select schedule item" />
                           </SelectTrigger>
                           <SelectContent>
@@ -682,7 +685,10 @@ export function ScheduleItemFormDialog({
                             updatePendingPredecessor(idx, "type", val)
                           }
                         >
-                          <SelectTrigger className="h-8 text-xs">
+                          <SelectTrigger
+                            className="h-8 min-w-0 text-xs"
+                            aria-label="Dependency relationship"
+                          >
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent>
@@ -695,9 +701,10 @@ export function ScheduleItemFormDialog({
                         </Select>
                         <Input
                           type="number"
-                          placeholder="Lag/lead"
-                          className="h-8 text-xs text-center"
+                          placeholder="Lag days"
+                          className="h-8 min-w-0 text-center text-xs"
                           value={pred.lagDays || ""}
+                          aria-label="Lag or lead in days"
                           onChange={(e) =>
                             updatePendingPredecessor(
                               idx,
@@ -712,6 +719,8 @@ export function ScheduleItemFormDialog({
                           size="icon"
                           className="size-7 text-muted-foreground hover:text-destructive"
                           onClick={() => removePendingPredecessor(idx)}
+                          aria-label="Remove predecessor"
+                          title="Remove predecessor"
                         >
                           <IconTrash className="size-3" />
                         </Button>

--- a/src/components/schedule/schedule-list-view.tsx
+++ b/src/components/schedule/schedule-list-view.tsx
@@ -22,6 +22,8 @@ import {
   IconPencil,
   IconTrash,
   IconLink,
+  IconCircleCheck,
+  IconX,
 } from "@tabler/icons-react"
 import {
   Select,
@@ -33,7 +35,10 @@ import {
 import { ScheduleItemFormDialog } from "./schedule-item-form-dialog"
 import { DependencyDialog } from "./dependency-dialog"
 import { effectivePercentComplete } from "@/lib/schedule/progress"
-import { deleteTask } from "@/app/actions/schedule"
+import {
+  completeScheduleTasks,
+  deleteScheduleTasks,
+} from "@/app/actions/schedule"
 import type {
   ScheduleTaskData,
   TaskDependencyData,
@@ -50,6 +55,16 @@ import {
   getScheduleItemDisplayColor,
   type DisplayColorPalette,
 } from "@/lib/schedule/appearance"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 
 interface ScheduleListViewProps {
   readonly projectId: string
@@ -132,22 +147,19 @@ export function ScheduleListView({
   const [depDialogOpen, setDepDialogOpen] = useState(false)
   const [localTasks, setLocalTasks] = useState(tasks)
   const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({})
+  const [pendingDeleteTasks, setPendingDeleteTasks] = useState<
+    readonly ScheduleTaskData[]
+  >([])
+  const [isWorking, setIsWorking] = useState(false)
 
   useEffect(() => {
     setLocalTasks(tasks)
   }, [tasks])
 
-  const handleDelete = useCallback(
-    async (taskId: string) => {
-      const result = await deleteTask(taskId)
-      if (result.success) {
-        router.refresh()
-      } else {
-        toast.error(result.error)
-      }
-    },
-    [router]
-  )
+  const handleEdit = useCallback((task: ScheduleTaskData) => {
+    setEditingTask(task)
+    setTaskFormOpen(true)
+  }, [])
 
   const columns: ColumnDef<ScheduleTaskData>[] = useMemo(
     () => [
@@ -159,12 +171,14 @@ export function ScheduleListView({
             onCheckedChange={(value) =>
               table.toggleAllRowsSelected(!!value)
             }
+            aria-label="Select all schedule items"
           />
         ),
         cell: ({ row }) => (
           <Checkbox
             checked={row.getIsSelected()}
             onCheckedChange={(value) => row.toggleSelected(!!value)}
+            aria-label={`Select ${row.original.title}`}
           />
         ),
         size: 32,
@@ -188,9 +202,15 @@ export function ScheduleListView({
               task={row.original}
               palette={displayColorPalette}
             />
-            <span className="font-medium text-sm truncate max-w-[150px] sm:max-w-[200px]">
+            <button
+              type="button"
+              className="max-w-[150px] truncate text-left text-sm font-medium hover:underline sm:max-w-[200px]"
+              onClick={() => handleEdit(row.original)}
+              aria-label={`Edit ${row.original.title}`}
+              title={`Edit ${row.original.title}`}
+            >
               {row.original.title}
-            </span>
+            </button>
           </div>
         ),
       },
@@ -283,10 +303,9 @@ export function ScheduleListView({
               variant="ghost"
               size="icon"
               className="size-7"
-              onClick={() => {
-                setEditingTask(row.original)
-                setTaskFormOpen(true)
-              }}
+              onClick={() => handleEdit(row.original)}
+              aria-label={`Edit ${row.original.title}`}
+              title="Edit schedule item"
             >
               <IconPencil className="size-3.5" />
             </Button>
@@ -294,7 +313,9 @@ export function ScheduleListView({
               variant="ghost"
               size="icon"
               className="size-7"
-              onClick={() => handleDelete(row.original.id)}
+              onClick={() => setPendingDeleteTasks([row.original])}
+              aria-label={`Delete ${row.original.title}`}
+              title="Delete schedule item"
             >
               <IconTrash className="size-3.5" />
             </Button>
@@ -303,7 +324,7 @@ export function ScheduleListView({
         size: 110,
       },
     ],
-    [assigneeOptions, displayColorPalette, handleDelete, projectId]
+    [assigneeOptions, displayColorPalette, handleEdit, projectId]
   )
 
   const table = useReactTable({
@@ -316,6 +337,63 @@ export function ScheduleListView({
     state: { rowSelection },
     initialState: { pagination: { pageSize: 25 } },
   })
+  const selectedTasks = table
+    .getSelectedRowModel()
+    .rows.map((row) => row.original)
+
+  const handleCompleteSelected = async (): Promise<void> => {
+    const selectedIds = selectedTasks.map((task) => task.id)
+    if (selectedIds.length === 0) return
+
+    setIsWorking(true)
+    const result = await completeScheduleTasks(projectId, selectedIds)
+    setIsWorking(false)
+
+    if (!result.success) {
+      toast.error(result.error)
+      return
+    }
+
+    const completedIds = new Set(selectedIds)
+    setLocalTasks((current) =>
+      current.map((task) =>
+        completedIds.has(task.id)
+          ? { ...task, status: "COMPLETE", percentComplete: 100 }
+          : task
+      )
+    )
+    setRowSelection({})
+    toast.success(
+      `${selectedIds.length} schedule item${selectedIds.length === 1 ? "" : "s"} marked complete.`
+    )
+    router.refresh()
+  }
+
+  const handleConfirmDelete = async (): Promise<void> => {
+    const deletingTasks = pendingDeleteTasks
+    const selectedIds = deletingTasks.map((task) => task.id)
+    if (selectedIds.length === 0) return
+
+    setIsWorking(true)
+    const result = await deleteScheduleTasks(projectId, selectedIds)
+    setIsWorking(false)
+
+    if (!result.success) {
+      toast.error(result.error)
+      return
+    }
+
+    const deletedIds = new Set(selectedIds)
+    setLocalTasks((current) =>
+      current.filter((task) => !deletedIds.has(task.id))
+    )
+    setRowSelection({})
+    setPendingDeleteTasks([])
+    toast.success(
+      `${selectedIds.length} schedule item${selectedIds.length === 1 ? "" : "s"} deleted.`
+    )
+    router.refresh()
+  }
 
   useEffect(() => {
     if (!focusTaskId) return
@@ -332,7 +410,7 @@ export function ScheduleListView({
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      <div className="flex gap-2 mb-2">
+      <div className="mb-2 flex flex-wrap items-center gap-2 border-y py-2">
         <Button
           size="sm"
           variant="outline"
@@ -342,6 +420,59 @@ export function ScheduleListView({
           <IconLink className="size-4 mr-1" />
           Add Dependency
         </Button>
+        {selectedTasks.length > 0 && (
+          <>
+            <span
+              className="ml-auto text-sm font-medium"
+              aria-live="polite"
+            >
+              {selectedTasks.length} selected
+            </span>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={selectedTasks.length !== 1 || isWorking}
+              onClick={() => {
+                const task = selectedTasks[0]
+                if (task) handleEdit(task)
+              }}
+            >
+              <IconPencil className="size-4" />
+              Edit selected
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={isWorking}
+              onClick={handleCompleteSelected}
+            >
+              <IconCircleCheck className="size-4" />
+              Mark complete
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="destructive"
+              disabled={isWorking}
+              onClick={() => setPendingDeleteTasks(selectedTasks)}
+            >
+              <IconTrash className="size-4" />
+              Delete selected
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              disabled={isWorking}
+              onClick={() => setRowSelection({})}
+            >
+              <IconX className="size-4" />
+              Clear
+            </Button>
+          </>
+        )}
       </div>
 
       <div className="rounded-md border flex-1 overflow-x-auto -mx-2 sm:mx-0">
@@ -382,7 +513,9 @@ export function ScheduleListView({
                   <TableRow
                     id={`schedule-item-${row.original.id}`}
                     key={row.id}
+                    data-state={row.getIsSelected() ? "selected" : undefined}
                     className={cn(
+                      row.getIsSelected() && "bg-muted/60",
                       row.original.id === focusTaskId &&
                         "bg-primary/5 outline outline-2 outline-primary/30"
                     )}
@@ -472,6 +605,40 @@ export function ScheduleListView({
         tasks={localTasks}
         dependencies={dependencies}
       />
+
+      <AlertDialog
+        open={pendingDeleteTasks.length > 0}
+        onOpenChange={(open) => {
+          if (!open && !isWorking) setPendingDeleteTasks([])
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete {pendingDeleteTasks.length === 1
+                ? "this schedule item"
+                : `${pendingDeleteTasks.length} schedule items`}
+              ?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This also removes dependencies connected to the deleted
+              {pendingDeleteTasks.length === 1 ? " item" : " items"}. This
+              action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isWorking}>
+              Keep {pendingDeleteTasks.length === 1 ? "item" : "items"}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isWorking}
+              onClick={handleConfirmDelete}
+            >
+              {isWorking ? "Deleting..." : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src/components/schedule/work-calendar.tsx
+++ b/src/components/schedule/work-calendar.tsx
@@ -4,8 +4,11 @@ import * as React from "react"
 import Link from "next/link"
 import {
   IconCalendarEvent,
+  IconCalendarMonth,
   IconCalendarPlus,
+  IconCalendarWeek,
   IconClipboardCheck,
+  IconListDetails,
   IconMessageQuestion,
   IconReceipt,
   IconSearch,
@@ -24,6 +27,7 @@ import { workCalendarEntryMatches } from "@/lib/work-calendar"
 import { WorkCalendarEventDialog } from "./work-calendar-event-dialog"
 
 export type WorkCalendarKindFilter = WorkCalendarEntryKind | "all"
+export type WorkCalendarView = "today" | "week" | "month" | "list"
 type CalendarEventEntry = Extract<WorkCalendarEntry, { kind: "event" }>
 
 type KindConfig = {
@@ -65,6 +69,33 @@ const KIND_FILTERS: readonly KindConfig[] = [
   },
 ]
 
+const VIEW_OPTIONS: readonly {
+  readonly id: WorkCalendarView
+  readonly label: string
+  readonly icon: React.ReactNode
+}[] = [
+  {
+    id: "today",
+    label: "Today",
+    icon: <IconCalendarEvent className="size-4" />,
+  },
+  {
+    id: "week",
+    label: "Week",
+    icon: <IconCalendarWeek className="size-4" />,
+  },
+  {
+    id: "month",
+    label: "Month",
+    icon: <IconCalendarMonth className="size-4" />,
+  },
+  {
+    id: "list",
+    label: "List",
+    icon: <IconListDetails className="size-4" />,
+  },
+]
+
 function parseDateKey(date: string): Date {
   return new Date(`${date}T00:00:00`)
 }
@@ -80,6 +111,28 @@ function toDateKey(date: Date): string {
   const month = `${date.getMonth() + 1}`.padStart(2, "0")
   const day = `${date.getDate()}`.padStart(2, "0")
   return `${year}-${month}-${day}`
+}
+
+function startOfWeek(date: Date): Date {
+  const start = new Date(date)
+  const day = start.getDay()
+  const daysSinceMonday = day === 0 ? 6 : day - 1
+  start.setDate(start.getDate() - daysSinceMonday)
+  return start
+}
+
+function monthCalendarDays(date: Date): readonly string[] {
+  const firstOfMonth = new Date(date.getFullYear(), date.getMonth(), 1)
+  const lastOfMonth = new Date(date.getFullYear(), date.getMonth() + 1, 0)
+  const gridStart = startOfWeek(firstOfMonth)
+  const gridEnd = addDays(startOfWeek(lastOfMonth), 6)
+  const length =
+    Math.round(
+      (gridEnd.getTime() - gridStart.getTime()) / (24 * 60 * 60 * 1000)
+    ) + 1
+  return Array.from({ length }, (_, index) =>
+    toDateKey(addDays(gridStart, index))
+  )
 }
 
 function formatShortDate(date: string): string {
@@ -253,24 +306,42 @@ export function WorkCalendar({
   data,
   initialKind = "all",
   initialItemId = null,
+  initialView = "week",
 }: {
   readonly data: WorkCalendarData
   readonly initialKind?: WorkCalendarKindFilter
   readonly initialItemId?: string | null
+  readonly initialView?: WorkCalendarView
 }): React.ReactElement {
   const [query, setQuery] = React.useState("")
   const [editingEvent, setEditingEvent] =
     React.useState<CalendarEventEntry | null>(null)
   const [activeKind, setActiveKind] =
     React.useState<WorkCalendarKindFilter>(initialKind)
+  const [activeView, setActiveView] = React.useState<WorkCalendarView>(
+    initialItemId ? "list" : initialView
+  )
   React.useEffect(() => {
     setActiveKind(initialKind)
   }, [initialKind])
+  React.useEffect(() => {
+    setActiveView(initialItemId ? "list" : initialView)
+  }, [initialItemId, initialView])
   const today = React.useMemo(() => parseDateKey(data.today), [data.today])
-  const days = React.useMemo(
-    () => Array.from({ length: 14 }, (_, index) => toDateKey(addDays(today, index))),
+  const weekDays = React.useMemo(
+    () =>
+      Array.from({ length: 7 }, (_, index) =>
+        toDateKey(addDays(startOfWeek(today), index))
+      ),
     [today]
   )
+  const monthDays = React.useMemo(() => monthCalendarDays(today), [today])
+  const visibleCalendarDays =
+    activeView === "today"
+      ? [data.today]
+      : activeView === "month"
+        ? monthDays
+        : weekDays
   const filteredEntries = data.entries.filter(
     (entry) =>
       (activeKind === "all" || entry.kind === activeKind) &&
@@ -290,7 +361,7 @@ export function WorkCalendar({
     document
       .getElementById(`work-calendar-${initialItemId}`)
       ?.scrollIntoView({ behavior: "smooth", block: "center" })
-  }, [initialItemId])
+  }, [initialItemId, activeView])
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">
@@ -338,7 +409,8 @@ export function WorkCalendar({
       </section>
 
       <div className="mx-auto grid max-w-7xl gap-5 px-4 py-5 md:px-6">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="relative w-full lg:max-w-xl">
             <IconSearch className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
             <Input
@@ -372,28 +444,91 @@ export function WorkCalendar({
               </Button>
             ))}
           </div>
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-3 border-y py-2">
+            <div
+              className="inline-flex overflow-hidden rounded-md border bg-background"
+              role="group"
+              aria-label="Work calendar view"
+            >
+              {VIEW_OPTIONS.map((view) => (
+                <Button
+                  key={view.id}
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  className={cn(
+                    "rounded-none border-r last:border-r-0",
+                    activeView === view.id && "bg-secondary text-secondary-foreground"
+                  )}
+                  onClick={() => setActiveView(view.id)}
+                  aria-pressed={activeView === view.id}
+                >
+                  {view.icon}
+                  {view.label}
+                </Button>
+              ))}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {filteredEntries.length} work item
+              {filteredEntries.length === 1 ? "" : "s"} match the current
+              filters
+            </p>
+          </div>
         </div>
 
-        <section className="rounded-lg border bg-card p-4">
+        {activeView !== "list" && (
+        <section className="border-y bg-card py-4">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div>
-              <h2 className="text-sm font-semibold">Next 14 days</h2>
+              <h2 className="text-sm font-semibold">
+                {activeView === "today"
+                  ? `Today · ${formatShortDate(data.today)}`
+                  : activeView === "week"
+                    ? `Week of ${formatShortDate(weekDays[0] ?? data.today)}`
+                    : new Intl.DateTimeFormat("en-US", {
+                        month: "long",
+                        year: "numeric",
+                      }).format(today)}
+              </h2>
               <p className="mt-1 text-xs text-muted-foreground">
-                {filteredEntries.length} visible work items across project
-                schedule items, RFIs, Sage operations, and Compass to-dos.
+                Select any item to open its source record.
               </p>
             </div>
-            <Badge variant="secondary">{formatShortDate(data.today)} onward</Badge>
+            <Badge variant="secondary">
+              {activeView === "today"
+                ? `${todayEntries.length} today`
+                : activeView === "week"
+                  ? "Monday–Sunday"
+                  : `${visibleCalendarDays.length / 7} weeks`}
+            </Badge>
           </div>
 
-          <div className="mt-4 grid gap-3 lg:grid-cols-7">
-            {days.map((day) => {
+          <div
+            className={cn(
+              "mt-4 grid overflow-hidden border",
+              activeView === "today"
+                ? "grid-cols-1"
+                : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-7"
+            )}
+          >
+            {visibleCalendarDays.map((day) => {
               const dayEntries = filteredEntries.filter((entry) =>
                 entryOnDay(entry, day)
               )
+              const outsideCurrentMonth =
+                activeView === "month" &&
+                parseDateKey(day).getMonth() !== today.getMonth()
 
               return (
-                <div key={day} className="min-h-40 rounded-lg border bg-muted/20 p-2">
+                <div
+                  key={day}
+                  className={cn(
+                    "min-h-40 border-b border-r bg-muted/20 p-2 last:border-r-0",
+                    activeView === "today" && "min-h-0",
+                    outsideCurrentMonth && "bg-muted/50 text-muted-foreground"
+                  )}
+                >
                   <div className="flex items-center justify-between gap-2">
                     <div>
                       <p className="text-xs font-semibold">{formatWeekday(day)}</p>
@@ -404,16 +539,19 @@ export function WorkCalendar({
                     <Badge variant="outline">{dayEntries.length}</Badge>
                   </div>
                   <div className="mt-2 space-y-2">
-                    {dayEntries.slice(0, 3).map((entry) => (
+                    {dayEntries
+                      .slice(0, activeView === "today" ? 50 : 3)
+                      .map((entry) => (
                       <WorkItem
                         key={`${day}-${entry.kind}-${entry.id}`}
                         entry={entry}
-                        compact
+                        compact={activeView !== "today"}
+                        focused={entry.id === initialItemId}
                         onEditEvent={setEditingEvent}
                         canManageEvents={data.canManageEvents}
                       />
                     ))}
-                    {dayEntries.length > 3 && (
+                    {activeView !== "today" && dayEntries.length > 3 && (
                       <p className="px-1 text-xs text-muted-foreground">
                         +{dayEntries.length - 3} more
                       </p>
@@ -424,9 +562,11 @@ export function WorkCalendar({
             })}
           </div>
         </section>
+        )}
 
+        {activeView === "list" && (
         <section className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_24rem]">
-          <div className="rounded-lg border bg-card p-4">
+          <div className="border-y bg-card py-4">
             <div className="flex items-center justify-between gap-3">
               <h2 className="text-sm font-semibold">Work Queue</h2>
               <Badge variant="outline">{filteredEntries.length} items</Badge>
@@ -450,7 +590,7 @@ export function WorkCalendar({
             </div>
           </div>
 
-          <aside className="rounded-lg border bg-card p-4">
+          <aside className="border-y bg-card py-4">
             <h2 className="text-sm font-semibold">To-do Sources</h2>
             <div className="mt-3 grid gap-2">
               <Link
@@ -480,6 +620,7 @@ export function WorkCalendar({
             </div>
           </aside>
         </section>
+        )}
       </div>
       {editingEvent && data.canManageEvents && (
         <WorkCalendarEventDialog

--- a/src/contexts/conversations-context.tsx
+++ b/src/contexts/conversations-context.tsx
@@ -14,6 +14,18 @@ export type ThreadMessage = {
   readonly replyCount: number
   readonly lastReplyAt: string | null
   readonly createdAt: string
+  readonly attachments?: readonly {
+    readonly id: string
+    readonly fileName: string
+    readonly mimeType: string
+    readonly fileSize: number
+    readonly storageUrl: string
+  }[]
+  readonly reactions?: readonly {
+    readonly emoji: string
+    readonly count: number
+    readonly reactedByCurrentUser: boolean
+  }[]
   readonly user: {
     readonly id: string
     readonly displayName: string | null

--- a/src/lib/project-operations/__tests__/status.test.ts
+++ b/src/lib/project-operations/__tests__/status.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isClosedProjectOperationStatus,
+  isPurchaseOrderStatus,
+  isRfqStatus,
+  parseProjectOperationStatusFilter,
+  projectOperationMatchesStatusFilter,
+  statusLabel,
+} from "@/lib/project-operations/status"
+
+describe("project operation statuses", () => {
+  it("normalizes imported labels for display and filtering", () => {
+    expect(statusLabel("Partially Received")).toBe("Partially Received")
+    expect(
+      projectOperationMatchesStatusFilter(
+        "Partially Received",
+        "partially_received"
+      )
+    ).toBe(true)
+  })
+
+  it("keeps open and closed queues consistent", () => {
+    expect(isClosedProjectOperationStatus("complete")).toBe(true)
+    expect(isClosedProjectOperationStatus("Cancelled")).toBe(true)
+    expect(isClosedProjectOperationStatus("ordered")).toBe(false)
+    expect(projectOperationMatchesStatusFilter("ordered", "open")).toBe(true)
+    expect(projectOperationMatchesStatusFilter("void", "closed")).toBe(true)
+  })
+
+  it("accepts only statuses supported by the matching workflow", () => {
+    expect(isPurchaseOrderStatus("partially_received")).toBe(true)
+    expect(isPurchaseOrderStatus("response_received")).toBe(false)
+    expect(isRfqStatus("response_received")).toBe(true)
+    expect(isRfqStatus("partially_received")).toBe(false)
+  })
+
+  it("defaults filters to open and accepts query arrays", () => {
+    expect(parseProjectOperationStatusFilter(undefined)).toBe("open")
+    expect(parseProjectOperationStatusFilter(["Response Received"])).toBe(
+      "response_received"
+    )
+  })
+})

--- a/src/lib/project-operations/status.ts
+++ b/src/lib/project-operations/status.ts
@@ -1,0 +1,110 @@
+export type PurchaseOrderStatus =
+  | "draft"
+  | "approved"
+  | "ordered"
+  | "partially_received"
+  | "received"
+  | "complete"
+  | "closed"
+  | "void"
+
+export type RfqStatus =
+  | "draft"
+  | "sent"
+  | "response_received"
+  | "awarded"
+  | "declined"
+  | "complete"
+  | "closed"
+  | "void"
+
+export type ProjectOperationStatusFilter = "open" | "closed" | "all" | string
+
+export const PURCHASE_ORDER_STATUS_OPTIONS: readonly {
+  readonly value: PurchaseOrderStatus
+  readonly label: string
+}[] = [
+  { value: "draft", label: "Draft" },
+  { value: "approved", label: "Approved" },
+  { value: "ordered", label: "Ordered" },
+  { value: "partially_received", label: "Partially received" },
+  { value: "received", label: "Received" },
+  { value: "complete", label: "Complete" },
+  { value: "closed", label: "Closed" },
+  { value: "void", label: "Void" },
+]
+
+export const RFQ_STATUS_OPTIONS: readonly {
+  readonly value: RfqStatus
+  readonly label: string
+}[] = [
+  { value: "draft", label: "Draft" },
+  { value: "sent", label: "Sent" },
+  { value: "response_received", label: "Response received" },
+  { value: "awarded", label: "Awarded" },
+  { value: "declined", label: "Declined" },
+  { value: "complete", label: "Complete" },
+  { value: "closed", label: "Closed" },
+  { value: "void", label: "Void" },
+]
+
+const CLOSED_STATUSES = new Set([
+  "complete",
+  "completed",
+  "closed",
+  "void",
+  "cancelled",
+  "canceled",
+  "declined",
+])
+
+function normalizedStatus(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_")
+}
+
+export function statusLabel(value: string): string {
+  return normalizedStatus(value)
+    .split("_")
+    .filter((part) => part.length > 0)
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ")
+}
+
+export function isClosedProjectOperationStatus(status: string): boolean {
+  return CLOSED_STATUSES.has(normalizedStatus(status))
+}
+
+export function isPurchaseOrderStatus(
+  status: string
+): status is PurchaseOrderStatus {
+  const normalized = normalizedStatus(status)
+  return PURCHASE_ORDER_STATUS_OPTIONS.some(
+    (option) => option.value === normalized
+  ) && status === normalized
+}
+
+export function isRfqStatus(status: string): status is RfqStatus {
+  const normalized = normalizedStatus(status)
+  return (
+    RFQ_STATUS_OPTIONS.some((option) => option.value === normalized) &&
+    status === normalized
+  )
+}
+
+export function parseProjectOperationStatusFilter(
+  value: string | readonly string[] | undefined
+): ProjectOperationStatusFilter {
+  const selected = typeof value === "string" ? value : value?.[0]
+  const normalized = selected ? normalizedStatus(selected) : "open"
+  return normalized || "open"
+}
+
+export function projectOperationMatchesStatusFilter(
+  status: string,
+  filter: ProjectOperationStatusFilter
+): boolean {
+  if (filter === "all") return true
+  if (filter === "open") return !isClosedProjectOperationStatus(status)
+  if (filter === "closed") return isClosedProjectOperationStatus(status)
+  return normalizedStatus(status) === normalizedStatus(filter)
+}


### PR DESCRIPTION
## Summary
- make long conversation threads scroll independently while keeping the reply composer reachable
- replace placeholder composer controls with real attachments, reactions, an explicit Send action, and immutable sent messages
- add editable and filterable PO and RFQ statuses
- add Today, Week, Month, and List Work Calendar modes

## Root cause
The thread pane lacked a minimum-height boundary, the composer shipped placeholder controls, operation status was display-only, and the calendar rendered a fixed 14-day grid plus queue without view state.

## Verification
- `tsc --noEmit`
- focused ESLint (one pre-existing `next/image` warning in the PO print layout)
- full Vitest: 270 passed, 3 skipped
- production `next build --webpack`

Closes #178