### PR TITLE
fix(calendar): persist settings and unify notifications

### DIFF
--- a/drizzle/0068_user_timezone_preference.sql
+++ b/drizzle/0068_user_timezone_preference.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `notification_preferences`
+ADD `time_zone` text NOT NULL DEFAULT 'America/Denver';

--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -192,9 +192,11 @@ test.describe("usable Compass areas", () => {
         .first()
     ).toBeVisible()
 
-    await scheduleRow
-      .getByRole("checkbox", { name: "Select Regression Schedule Item" })
-      .check()
+    const selectionCheckbox = scheduleRow.getByRole("checkbox", {
+      name: "Select Regression Schedule Item",
+    })
+    await selectionCheckbox.click()
+    await expect(selectionCheckbox).toHaveAttribute("aria-checked", "true")
     await expect(page.getByText("1 selected", { exact: true })).toBeVisible()
     await expect(
       page.getByRole("button", { name: "Edit selected" })

--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -209,6 +209,33 @@ test.describe("usable Compass areas", () => {
     await expect(page.getByText("1 selected", { exact: true })).toHaveCount(0)
   })
 
+  test("schedule assignee choices include active organization team members", async ({
+    page,
+  }) => {
+    const path =
+      "/dashboard/projects/e2e-project-001/schedule?view=list"
+    const response = await page.goto(path)
+    await expectHealthyNavigation(
+      page,
+      response,
+      "/dashboard/projects/e2e-project-001/schedule"
+    )
+
+    const scheduleRow = page.locator("#schedule-item-e2e-schedule-001")
+    await scheduleRow.locator('button[title="Edit schedule item"]').click()
+
+    const editDialog = page.getByRole("dialog", {
+      name: "Edit Schedule Item",
+    })
+    await editDialog.getByRole("button", { name: "Demo User" }).click()
+    await expect(
+      page.getByText("Project & team contacts", { exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByRole("button", { name: "Demo User" })
+    ).toHaveCount(2)
+  })
+
   test("work calendar list shows the actual item title", async ({
     page,
   }) => {

--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -142,6 +142,7 @@ test.describe("usable Compass areas", () => {
     const timezone = page.getByRole("combobox", { name: "Timezone" })
     await timezone.click()
     await page.getByRole("option", { name: "Pacific (PT)" }).click()
+    await expect(timezone).toContainText("Pacific (PT)")
     await page.getByRole("button", { name: "Save preferences" }).click()
     await expect(page.getByText("Preferences saved.")).toBeVisible()
 

--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -132,6 +132,25 @@ test.describe("usable Compass areas", () => {
     }
   })
 
+  test("timezone preference persists after reloading settings", async ({
+    page,
+  }) => {
+    const path = "/dashboard/settings"
+    const response = await page.goto(path)
+    await expectHealthyNavigation(page, response, path)
+
+    const timezone = page.getByRole("combobox", { name: "Timezone" })
+    await timezone.click()
+    await page.getByRole("option", { name: "Pacific (PT)" }).click()
+    await page.getByRole("button", { name: "Save preferences" }).click()
+    await expect(page.getByText("Preferences saved.")).toBeVisible()
+
+    await page.reload()
+    await expect(
+      page.getByRole("combobox", { name: "Timezone" })
+    ).toContainText("Pacific (PT)")
+  })
+
   test("schedule switches between calendar, list, and Gantt", async ({
     page,
   }) => {
@@ -213,6 +232,31 @@ test.describe("usable Compass areas", () => {
         exact: true,
       }).first()
     ).toBeVisible()
+  })
+
+  test("work calendar reveals every item hidden behind the overflow count", async ({
+    page,
+  }) => {
+    const response = await page.goto("/dashboard/schedule?view=month")
+    await expectHealthyNavigation(page, response, "/dashboard/schedule")
+
+    const overflowButton = page.getByRole("button", {
+      name: /Show \d+ more items for/,
+    })
+    await expect(overflowButton).toBeVisible()
+    await overflowButton.click()
+
+    const dayDialog = page.getByRole("dialog")
+    await expect(dayDialog).toContainText("5 work items scheduled for this day")
+    for (const title of [
+      "Regression Schedule Item",
+      "Overflow schedule item two",
+      "Overflow schedule item three",
+      "Overflow schedule item four",
+      "Regression follow-up",
+    ]) {
+      await expect(dayDialog.getByText(title, { exact: true })).toBeVisible()
+    }
   })
 
   test("work calendar to-dos open and focus the exact project record", async ({

--- a/scripts/seed-e2e-local.mjs
+++ b/scripts/seed-e2e-local.mjs
@@ -83,6 +83,39 @@ const upsert = db.transaction(() => {
       updated_at = excluded.updated_at
   `).run(today, today, now, now)
 
+  const overflowScheduleItems = [
+    ["e2e-schedule-002", "Overflow schedule item two", 2],
+    ["e2e-schedule-003", "Overflow schedule item three", 3],
+    ["e2e-schedule-004", "Overflow schedule item four", 4],
+  ]
+  const upsertOverflowScheduleItem = db.prepare(`
+    INSERT INTO schedule_tasks (
+      id, project_id, title, start_date, workdays, end_date_calculated, phase,
+      display_color, status, is_critical_path, is_milestone, percent_complete,
+      assigned_to, sort_order, created_at, updated_at
+    ) VALUES (
+      ?, 'e2e-project-001', ?, ?, 1, ?, 'Preconstruction', 'blue',
+      'PENDING', 0, 0, 0, 'Demo User', ?, ?, ?
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      title = excluded.title,
+      start_date = excluded.start_date,
+      end_date_calculated = excluded.end_date_calculated,
+      status = excluded.status,
+      updated_at = excluded.updated_at
+  `)
+  for (const [id, title, sortOrder] of overflowScheduleItems) {
+    upsertOverflowScheduleItem.run(
+      id,
+      title,
+      today,
+      today,
+      sortOrder,
+      now,
+      now
+    )
+  }
+
   db.prepare(`
     INSERT INTO daily_logs (
       id, project_id, author_id, source_system, log_date, weather_source,

--- a/src/app/actions/notifications.ts
+++ b/src/app/actions/notifications.ts
@@ -12,6 +12,7 @@ import {
 import { getCurrentUser, requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { isMissingNotificationTableError } from "@/lib/notifications/events"
+import { isValidTimeZone } from "@/lib/work-calendar"
 
 export type NotificationPreferenceState = {
   readonly inAppEnabled: boolean
@@ -22,6 +23,7 @@ export type NotificationPreferenceState = {
   readonly ownerUpdateEnabled: boolean
   readonly scheduleEnabled: boolean
   readonly poEnabled: boolean
+  readonly timeZone: string
 }
 
 export type NotificationCenterItem = {
@@ -64,6 +66,7 @@ const DEFAULT_PREFERENCES: NotificationPreferenceState = {
   ownerUpdateEnabled: true,
   scheduleEnabled: true,
   poEnabled: true,
+  timeZone: "America/Denver",
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -91,6 +94,7 @@ function preferenceFromRow(
     ownerUpdateEnabled: row.ownerUpdateEnabled,
     scheduleEnabled: row.scheduleEnabled,
     poEnabled: row.poEnabled,
+    timeZone: row.timeZone,
   }
 }
 
@@ -133,6 +137,10 @@ export async function updateNotificationPreferences(
   input: NotificationPreferenceState
 ): Promise<NotificationActionResult> {
   try {
+    const timeZone = input.timeZone.trim()
+    if (!isValidTimeZone(timeZone)) {
+      return { success: false, error: "Choose a valid timezone." }
+    }
     const user = await requireAuth()
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
@@ -143,12 +151,14 @@ export async function updateNotificationPreferences(
       .values({
         userId: user.id,
         ...input,
+        timeZone,
         updatedAt: now,
       })
       .onConflictDoUpdate({
         target: notificationPreferences.userId,
         set: {
           ...input,
+          timeZone,
           updatedAt: now,
         },
       })

--- a/src/app/actions/notifications.ts
+++ b/src/app/actions/notifications.ts
@@ -163,7 +163,6 @@ export async function updateNotificationPreferences(
         },
       })
 
-    revalidatePath("/dashboard/settings")
     return { success: true }
   } catch (error) {
     return {

--- a/src/app/actions/project-contacts.ts
+++ b/src/app/actions/project-contacts.ts
@@ -5,9 +5,11 @@ import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
 import {
+  organizationMembers,
   projectContacts,
   projectContactSourceLinks,
   projects,
+  users,
   vendors,
 } from "@/db/schema"
 import { requireAuth } from "@/lib/auth"
@@ -412,6 +414,33 @@ function directoryContactToTaskAssigneeOption(input: {
   }
 }
 
+function organizationUserToTaskAssigneeOption(input: {
+  readonly id: string
+  readonly email: string
+  readonly displayName: string | null
+  readonly firstName: string | null
+  readonly lastName: string | null
+}): ProjectTaskAssigneeOption {
+  const fullName = [input.firstName, input.lastName]
+    .filter((part): part is string => part !== null && part.trim().length > 0)
+    .join(" ")
+  const name = input.displayName?.trim() || fullName || input.email
+
+  return {
+    id: `team:${input.id}`,
+    label: name,
+    name,
+    companyName: null,
+    email: input.email,
+    phone: null,
+    contactType: "internal",
+    source: "project",
+    projectContactId: null,
+    directoryContactId: null,
+    projectAccess: true,
+  }
+}
+
 export async function getProjectContactsSummary(
   projectId: string,
   audience: ProjectContactAudience = "internal"
@@ -531,6 +560,41 @@ export async function getProjectTaskAssigneeOptions(
       normalizeDirectoryKey(contact.companyName ?? contact.displayName)
     )
   )
+  const projectAssigneeNameKeys = new Set(
+    projectContactItems.map((contact) =>
+      normalizeDirectoryKey(contact.displayName)
+    )
+  )
+  const projectEmailKeys = new Set(
+    projectContactItems
+      .map((contact) => contact.email?.trim().toLowerCase() ?? "")
+      .filter((email) => email.length > 0)
+  )
+
+  const organizationUserRows = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      displayName: users.displayName,
+      firstName: users.firstName,
+      lastName: users.lastName,
+    })
+    .from(organizationMembers)
+    .innerJoin(users, eq(users.id, organizationMembers.userId))
+    .where(
+      and(
+        eq(organizationMembers.organizationId, orgId),
+        eq(users.isActive, true)
+      )
+    )
+    .orderBy(asc(users.displayName), asc(users.email))
+  const organizationUserOptions = organizationUserRows
+    .map(organizationUserToTaskAssigneeOption)
+    .filter(
+      (option) =>
+        !projectAssigneeNameKeys.has(normalizeDirectoryKey(option.name)) &&
+        !projectEmailKeys.has(option.email?.trim().toLowerCase() ?? "")
+    )
 
   const directoryRows = await db
     .select({
@@ -556,7 +620,10 @@ export async function getProjectTaskAssigneeOptions(
     .map(directoryContactToTaskAssigneeOption)
 
   return {
-    projectContacts: projectContactItems.map(projectContactToTaskAssigneeOption),
+    projectContacts: [
+      ...projectContactItems.map(projectContactToTaskAssigneeOption),
+      ...organizationUserOptions,
+    ],
     directoryContacts,
   }
 }

--- a/src/app/actions/work-calendar.ts
+++ b/src/app/actions/work-calendar.ts
@@ -19,6 +19,7 @@ import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { isDemoUser } from "@/lib/demo"
 import { createNotificationEvent } from "@/lib/notifications/events"
+import { eventAttendeeNotificationRecipients } from "@/lib/notifications/audience"
 import { requireOrg } from "@/lib/org-scope"
 import {
   can,
@@ -900,9 +901,7 @@ async function notifyEventParticipants(input: {
   readonly actorName: string
   readonly attendees: readonly WorkCalendarEventAttendee[]
 }): Promise<void> {
-  const recipients = input.attendees.filter(
-    (attendee) => attendee.userId !== input.actorId
-  )
+  const recipients = eventAttendeeNotificationRecipients(input.attendees)
   if (recipients.length === 0) return
 
   const projectName = input.project

--- a/src/components/projects/project-assignee-picker.tsx
+++ b/src/components/projects/project-assignee-picker.tsx
@@ -159,7 +159,7 @@ export function ProjectAssigneePicker({
           {projectOptions.length > 0 && (
             <div className="space-y-1">
               <p className="px-2 py-1 text-xs font-medium text-muted-foreground">
-                Project contacts
+                Project &amp; team contacts
               </p>
               {projectOptions.map((option) => (
                 <AssigneeOption

--- a/src/components/projects/project-rfq-create-form.tsx
+++ b/src/components/projects/project-rfq-create-form.tsx
@@ -659,7 +659,7 @@ export function ProjectRfqCreateForm({
                       {projectRecipientOptions.length > 0 && (
                         <div className="space-y-1">
                           <p className="px-2 py-1 text-xs font-medium text-muted-foreground">
-                            Project contacts
+                            Project &amp; team contacts
                           </p>
                           {projectRecipientOptions.map((option) => (
                             <button

--- a/src/components/projects/project-task-create-button.tsx
+++ b/src/components/projects/project-task-create-button.tsx
@@ -391,7 +391,7 @@ export function ProjectTaskCreateButton({
                     {projectAssigneeOptions.length > 0 && (
                       <div className="space-y-1">
                         <p className="px-2 py-1 text-xs font-medium text-muted-foreground">
-                          Project contacts
+                          Project &amp; team contacts
                         </p>
                         {projectAssigneeOptions.map((option) => (
                           <button

--- a/src/components/projects/project-todo-edit-dialog.tsx
+++ b/src/components/projects/project-todo-edit-dialog.tsx
@@ -38,7 +38,9 @@ import { Textarea } from "@/components/ui/textarea"
 import {
   canonicalProjectTodoRecordType,
   isArchivedProjectTodoStatus,
+  isSelectableProjectTodoStatus,
   normalizeProjectTodoStatus,
+  PROJECT_TODO_SELECTABLE_STATUSES,
   projectTodoStatusLabel,
 } from "@/lib/project-todos"
 
@@ -209,22 +211,23 @@ export function ProjectTodoEditDialog({
                 value={status}
                 onChange={(event) => {
                   const value = event.target.value
-                  if (
-                    value === "open" ||
-                    value === "in_progress" ||
-                    value === "blocked" ||
-                    value === "complete"
-                  ) {
+                  if (isSelectableProjectTodoStatus(value)) {
                     setStatus(value)
                   }
                 }}
                 disabled={archived}
                 className="h-10 w-full rounded-md border bg-background px-3 text-sm"
               >
-                <option value="open">Open</option>
-                <option value="in_progress">In progress</option>
-                <option value="blocked">Blocked</option>
-                <option value="complete">Complete</option>
+                {status === "blocked" && (
+                  <option value="blocked" disabled hidden>
+                    Blocked (legacy)
+                  </option>
+                )}
+                {PROJECT_TODO_SELECTABLE_STATUSES.map((selectableStatus) => (
+                  <option key={selectableStatus} value={selectableStatus}>
+                    {projectTodoStatusLabel(selectableStatus)}
+                  </option>
+                ))}
               </select>
             </div>
             <div className="space-y-2">

--- a/src/components/projects/project-todos-view.tsx
+++ b/src/components/projects/project-todos-view.tsx
@@ -22,7 +22,9 @@ import { cn } from "@/lib/utils"
 import {
   isArchivedProjectTodoStatus,
   isCompletedProjectTodoStatus,
+  isSelectableProjectTodoStatus,
   normalizeProjectTodoStatus,
+  PROJECT_TODO_SELECTABLE_STATUSES,
   projectTodoStatusLabel,
   projectTodoTypeLabel,
   type ProjectTodoStatus,
@@ -137,21 +139,22 @@ function StatusControl({
         disabled={pending}
         onChange={(event) => {
           const value = event.target.value
-          if (
-            value === "open" ||
-            value === "in_progress" ||
-            value === "blocked" ||
-            value === "complete"
-          ) {
+          if (isSelectableProjectTodoStatus(value)) {
             changeStatus(value)
           }
         }}
         className="h-8 rounded-md border bg-background px-2 text-xs"
       >
-        <option value="open">Open</option>
-        <option value="in_progress">In progress</option>
-        <option value="blocked">Blocked</option>
-        <option value="complete">Complete</option>
+        {status === "blocked" && (
+          <option value="blocked" disabled hidden>
+            Blocked (legacy)
+          </option>
+        )}
+        {PROJECT_TODO_SELECTABLE_STATUSES.map((selectableStatus) => (
+          <option key={selectableStatus} value={selectableStatus}>
+            {projectTodoStatusLabel(selectableStatus)}
+          </option>
+        ))}
       </select>
       {error && (
         <p className="mt-1 max-w-56 text-xs text-destructive">{error}</p>

--- a/src/components/schedule/work-calendar.tsx
+++ b/src/components/schedule/work-calendar.tsx
@@ -21,6 +21,13 @@ import type {
 } from "@/app/actions/work-calendar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
 import { workCalendarEntryMatches } from "@/lib/work-calendar"
@@ -145,6 +152,15 @@ function formatShortDate(date: string): string {
 function formatWeekday(date: string): string {
   return new Intl.DateTimeFormat("en-US", {
     weekday: "short",
+  }).format(parseDateKey(date))
+}
+
+function formatFullDate(date: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
   }).format(parseDateKey(date))
 }
 
@@ -316,6 +332,7 @@ export function WorkCalendar({
   const [query, setQuery] = React.useState("")
   const [editingEvent, setEditingEvent] =
     React.useState<CalendarEventEntry | null>(null)
+  const [expandedDay, setExpandedDay] = React.useState<string | null>(null)
   const [activeKind, setActiveKind] =
     React.useState<WorkCalendarKindFilter>(initialKind)
   const [activeView, setActiveView] = React.useState<WorkCalendarView>(
@@ -353,6 +370,9 @@ export function WorkCalendar({
   const todayEntries = filteredEntries.filter((entry) =>
     entryOnDay(entry, data.today)
   )
+  const expandedDayEntries = expandedDay
+    ? filteredEntries.filter((entry) => entryOnDay(entry, expandedDay))
+    : []
   const taskCount = filteredEntries.filter((entry) => entry.kind === "task").length
   const rfiCount = filteredEntries.filter((entry) => entry.kind === "rfi").length
 
@@ -552,9 +572,14 @@ export function WorkCalendar({
                       />
                     ))}
                     {activeView !== "today" && dayEntries.length > 3 && (
-                      <p className="px-1 text-xs text-muted-foreground">
+                      <button
+                        type="button"
+                        className="w-full px-1 py-1 text-left text-xs font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        onClick={() => setExpandedDay(day)}
+                        aria-label={`Show ${dayEntries.length - 3} more items for ${formatFullDate(day)}`}
+                      >
                         +{dayEntries.length - 3} more
-                      </p>
+                      </button>
                     )}
                   </div>
                 </div>
@@ -622,6 +647,39 @@ export function WorkCalendar({
         </section>
         )}
       </div>
+      <Dialog
+        open={expandedDay !== null}
+        onOpenChange={(open) => {
+          if (!open) setExpandedDay(null)
+        }}
+      >
+        <DialogContent className="max-h-[85vh] overflow-hidden sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>
+              {expandedDay ? formatFullDate(expandedDay) : "Calendar items"}
+            </DialogTitle>
+            <DialogDescription>
+              {expandedDayEntries.length} work item
+              {expandedDayEntries.length === 1 ? "" : "s"} scheduled for this
+              day. Select an item to open its source record.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="-mr-2 max-h-[65vh] space-y-2 overflow-y-auto pr-2">
+            {expandedDayEntries.map((entry) => (
+              <WorkItem
+                key={`${expandedDay}-${entry.kind}-${entry.id}`}
+                entry={entry}
+                focused={entry.id === initialItemId}
+                onEditEvent={(event) => {
+                  setExpandedDay(null)
+                  setEditingEvent(event)
+                }}
+                canManageEvents={data.canManageEvents}
+              />
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
       {editingEvent && data.canManageEvents && (
         <WorkCalendarEventDialog
           key={`${editingEvent.id}-${editingEvent.eventDetails.version}`}

--- a/src/components/settings/preferences-tab.tsx
+++ b/src/components/settings/preferences-tab.tsx
@@ -34,6 +34,7 @@ export function PreferencesTab() {
       poEnabled: true,
       timeZone: "America/Denver",
     })
+  const [loading, setLoading] = React.useState(true)
   const [saving, setSaving] = React.useState(false)
   const [message, setMessage] = React.useState<string | null>(null)
   const native = useNative()
@@ -43,8 +44,13 @@ export function PreferencesTab() {
     let cancelled = false
     async function loadPreferences(): Promise<void> {
       const result = await getNotificationPreferences()
-      if (!cancelled && result.success) {
-        setPreferences(result.data)
+      if (!cancelled) {
+        if (result.success) {
+          setPreferences(result.data)
+        } else {
+          setMessage(result.error)
+        }
+        setLoading(false)
       }
     }
     loadPreferences()
@@ -84,6 +90,7 @@ export function PreferencesTab() {
             <Select
               value={preferences.timeZone}
               onValueChange={(value) => updatePreference("timeZone", value)}
+              disabled={loading}
             >
               <SelectTrigger id="timezone" className="h-9 w-full max-w-xs">
                 <SelectValue />
@@ -240,8 +247,16 @@ export function PreferencesTab() {
             </div>
           )}
           <div className="flex flex-wrap items-center gap-3">
-            <Button size="sm" onClick={savePreferences} disabled={saving}>
-              {saving ? "Saving..." : "Save preferences"}
+            <Button
+              size="sm"
+              onClick={savePreferences}
+              disabled={loading || saving}
+            >
+              {loading
+                ? "Loading preferences..."
+                : saving
+                  ? "Saving..."
+                  : "Save preferences"}
             </Button>
             {message && (
               <p className="text-xs text-muted-foreground">{message}</p>

--- a/src/components/settings/preferences-tab.tsx
+++ b/src/components/settings/preferences-tab.tsx
@@ -32,10 +32,10 @@ export function PreferencesTab() {
       ownerUpdateEnabled: true,
       scheduleEnabled: true,
       poEnabled: true,
+      timeZone: "America/Denver",
     })
   const [saving, setSaving] = React.useState(false)
   const [message, setMessage] = React.useState<string | null>(null)
-  const [timezone, setTimezone] = React.useState("America/New_York")
   const native = useNative()
   const biometric = useBiometricAuth()
 
@@ -67,7 +67,7 @@ export function PreferencesTab() {
     setSaving(false)
     setMessage(
       result.success
-        ? "Notification preferences saved."
+        ? "Preferences saved."
         : result.error
     )
   }
@@ -81,7 +81,10 @@ export function PreferencesTab() {
             <Label htmlFor="timezone" className="text-xs">
               Timezone
             </Label>
-            <Select value={timezone} onValueChange={setTimezone}>
+            <Select
+              value={preferences.timeZone}
+              onValueChange={(value) => updatePreference("timeZone", value)}
+            >
               <SelectTrigger id="timezone" className="h-9 w-full max-w-xs">
                 <SelectValue />
               </SelectTrigger>
@@ -238,7 +241,7 @@ export function PreferencesTab() {
           )}
           <div className="flex flex-wrap items-center gap-3">
             <Button size="sm" onClick={savePreferences} disabled={saving}>
-              {saving ? "Saving..." : "Save notification preferences"}
+              {saving ? "Saving..." : "Save preferences"}
             </Button>
             {message && (
               <p className="text-xs text-muted-foreground">{message}</p>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -100,6 +100,7 @@ export const notificationPreferences = sqliteTable("notification_preferences", {
   poEnabled: integer("po_enabled", { mode: "boolean" })
     .notNull()
     .default(true),
+  timeZone: text("time_zone").notNull().default("America/Denver"),
   updatedAt: text("updated_at").notNull(),
 })
 

--- a/src/lib/__tests__/notification-audience.test.ts
+++ b/src/lib/__tests__/notification-audience.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+
+import { eventAttendeeNotificationRecipients } from "@/lib/notifications/audience"
+
+describe("notification audiences", () => {
+  it("keeps the event creator when they selected themselves as an attendee", () => {
+    expect(
+      eventAttendeeNotificationRecipients([
+        { userId: "creator", email: "creator@example.com" },
+        { userId: "coworker", email: "coworker@example.com" },
+      ])
+    ).toEqual([
+      { userId: "creator", email: "creator@example.com" },
+      { userId: "coworker", email: "coworker@example.com" },
+    ])
+  })
+})

--- a/src/lib/__tests__/project-todos.test.ts
+++ b/src/lib/__tests__/project-todos.test.ts
@@ -6,7 +6,9 @@ import {
   isCompletedProjectTodoStatus,
   isProjectTodoRecordType,
   isProjectTodoStatus,
+  isSelectableProjectTodoStatus,
   normalizeProjectTodoStatus,
+  PROJECT_TODO_SELECTABLE_STATUSES,
   projectTodoStatusLabel,
   projectTodoTypeLabel,
 } from "@/lib/project-todos"
@@ -31,9 +33,18 @@ describe("project to-do normalization", () => {
     expect(normalizeProjectTodoStatus("closed")).toBe("complete")
     expect(isCompletedProjectTodoStatus("done")).toBe(true)
     expect(isArchivedProjectTodoStatus("archived")).toBe(true)
+    expect(normalizeProjectTodoStatus("archived")).toBe("archived")
     expect(projectTodoStatusLabel("on-hold")).toBe("Blocked")
     expect(isProjectTodoStatus("in_progress")).toBe(true)
-    expect(isProjectTodoStatus("archived")).toBe(false)
+    expect(isProjectTodoStatus("archived")).toBe(true)
+    expect(PROJECT_TODO_SELECTABLE_STATUSES).toEqual([
+      "open",
+      "in_progress",
+      "complete",
+      "archived",
+    ])
+    expect(isSelectableProjectTodoStatus("archived")).toBe(true)
+    expect(isSelectableProjectTodoStatus("blocked")).toBe(false)
   })
 
   it("uses concise staff-facing type labels", () => {

--- a/src/lib/notifications/audience.ts
+++ b/src/lib/notifications/audience.ts
@@ -11,6 +11,20 @@ type ChannelNotificationMember = {
   readonly notifyLevel: string
 }
 
+type EventNotificationAttendee = {
+  readonly userId: string
+  readonly email: string
+}
+
+export function eventAttendeeNotificationRecipients(
+  attendees: readonly EventNotificationAttendee[]
+): readonly NotificationRecipientInput[] {
+  return attendees.map((attendee) => ({
+    userId: attendee.userId,
+    email: attendee.email,
+  }))
+}
+
 export function channelNotificationRecipients(
   members: readonly ChannelNotificationMember[],
   senderId: string,

--- a/src/lib/project-todos.ts
+++ b/src/lib/project-todos.ts
@@ -15,9 +15,20 @@ export const PROJECT_TODO_STATUSES = [
   "in_progress",
   "blocked",
   "complete",
+  "archived",
 ] as const
 
 export type ProjectTodoStatus = (typeof PROJECT_TODO_STATUSES)[number]
+
+export const PROJECT_TODO_SELECTABLE_STATUSES = [
+  "open",
+  "in_progress",
+  "complete",
+  "archived",
+] as const
+
+export type ProjectTodoSelectableStatus =
+  (typeof PROJECT_TODO_SELECTABLE_STATUSES)[number]
 
 const ARCHIVED_STATUSES = new Set(["archive", "archived", "cancelled"])
 const COMPLETED_STATUSES = new Set(["complete", "completed", "closed", "done"])
@@ -37,6 +48,7 @@ export function canonicalProjectTodoRecordType(
 
 export function normalizeProjectTodoStatus(value: string): ProjectTodoStatus {
   const normalized = value.trim().toLowerCase().replace(/[\s-]+/g, "_")
+  if (isArchivedProjectTodoStatus(normalized)) return "archived"
   if (normalized === "in_progress") return "in_progress"
   if (normalized === "blocked" || normalized === "on_hold") return "blocked"
   if (COMPLETED_STATUSES.has(normalized)) return "complete"
@@ -45,6 +57,12 @@ export function normalizeProjectTodoStatus(value: string): ProjectTodoStatus {
 
 export function isProjectTodoStatus(value: string): value is ProjectTodoStatus {
   return PROJECT_TODO_STATUSES.some((status) => status === value)
+}
+
+export function isSelectableProjectTodoStatus(
+  value: string
+): value is ProjectTodoSelectableStatus {
+  return PROJECT_TODO_SELECTABLE_STATUSES.some((status) => status === value)
 }
 
 export function isArchivedProjectTodoStatus(value: string): boolean {
@@ -67,6 +85,8 @@ export function projectTodoStatusLabel(value: string): string {
       return "Blocked"
     case "complete":
       return "Complete"
+    case "archived":
+      return "Archived"
   }
 }
 

--- a/src/lib/work-calendar.ts
+++ b/src/lib/work-calendar.ts
@@ -66,7 +66,7 @@ function isCanonicalInstant(value: string): boolean {
   )
 }
 
-function isValidTimeZone(value: string): boolean {
+export function isValidTimeZone(value: string): boolean {
   try {
     new Intl.DateTimeFormat("en-US", { timeZone: value }).format(new Date(0))
     return true


### PR DESCRIPTION
## What

- Make Work Calendar `+N more` open a scrollable full-day list.
- Offer Archived instead of Blocked in selectable To-do statuses while preserving legacy blocked records.
- Persist each user's validated timezone instead of resetting Settings to Eastern.
- Notify every selected event attendee, including the creator when they selected themselves.
- Merge active organization users into the shared project assignee source, with name/email de-duplication.

## Why

The existing calendar overflow was inert, archive status was inconsistent, timezone state was never saved, self-selected attendees were filtered from notifications, and organization users were omitted from schedule/To-do assignee choices.

Closes #180
Closes #181

## How to test

- `bun run test` — 271 passed, 3 skipped
- `bunx tsc --noEmit`
- focused ESLint on changed files
- focused Chromium regressions — 5 passed
- `bunx next build --webpack`

## Notes

Apply additive D1 migration `0068_user_timezone_preference.sql` before deploying the application commit so existing notification preference rows gain the timezone column safely.