### PR TITLE
feat(calendar): add period navigation

### DIFF
--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -242,13 +242,9 @@ test.describe("usable Compass areas", () => {
   test("work calendar list shows the actual item title", async ({
     page,
   }) => {
-    const response = await page.goto("/dashboard/schedule")
+    const response = await page.goto("/dashboard/schedule?view=list")
     await expectHealthyNavigation(page, response, "/dashboard/schedule")
 
-    await page
-      .getByRole("group", { name: "Work calendar view" })
-      .getByRole("button", { name: "List" })
-      .click()
     const workQueue = page.locator("section").filter({
       has: page.getByRole("heading", { name: "Work Queue" }),
     })
@@ -262,6 +258,48 @@ test.describe("usable Compass areas", () => {
         exact: true,
       }).first()
     ).toBeVisible()
+  })
+
+  test("work calendar arrows move by the active view period", async ({
+    page,
+  }) => {
+    const periodLabel = page.getByTestId("work-calendar-period-label")
+
+    let response = await page.goto("/dashboard/schedule?view=today")
+    await expectHealthyNavigation(page, response, "/dashboard/schedule")
+    const initialDay = await periodLabel.innerText()
+    await page.getByRole("button", { name: "Events" }).click()
+    await page.getByRole("button", { name: "Next day" }).click()
+    await expect(periodLabel).not.toHaveText(initialDay)
+    await expect(page).toHaveURL(
+      /view=today&date=\d{4}-\d{2}-\d{2}&kind=event/
+    )
+    const nextDayUrl = page.url()
+    await page.getByRole("button", { name: "Previous day" }).click()
+    await expect(periodLabel).toHaveText(initialDay)
+    await expect(page).not.toHaveURL(nextDayUrl)
+
+    response = await page.goto("/dashboard/schedule?view=week")
+    await expectHealthyNavigation(page, response, "/dashboard/schedule")
+    const initialWeek = await periodLabel.innerText()
+    await page.getByRole("button", { name: "Next week" }).click()
+    await expect(periodLabel).not.toHaveText(initialWeek)
+    await expect(page).toHaveURL(/view=week&date=\d{4}-\d{2}-\d{2}/)
+    const nextWeekUrl = page.url()
+    await page.getByRole("button", { name: "Previous week" }).click()
+    await expect(periodLabel).toHaveText(initialWeek)
+    await expect(page).not.toHaveURL(nextWeekUrl)
+
+    response = await page.goto("/dashboard/schedule?view=month")
+    await expectHealthyNavigation(page, response, "/dashboard/schedule")
+    const initialMonth = await periodLabel.innerText()
+    await page.getByRole("button", { name: "Next month" }).click()
+    await expect(periodLabel).not.toHaveText(initialMonth)
+    await expect(page).toHaveURL(/view=month&date=\d{4}-\d{2}-\d{2}/)
+    const nextMonthUrl = page.url()
+    await page.getByRole("button", { name: "Previous month" }).click()
+    await expect(periodLabel).toHaveText(initialMonth)
+    await expect(page).not.toHaveURL(nextMonthUrl)
   })
 
   test("work calendar reveals every item hidden behind the overflow count", async ({
@@ -292,13 +330,9 @@ test.describe("usable Compass areas", () => {
   test("work calendar to-dos open and focus the exact project record", async ({
     page,
   }) => {
-    const response = await page.goto("/dashboard/schedule")
+    const response = await page.goto("/dashboard/schedule?view=list")
     await expectHealthyNavigation(page, response, "/dashboard/schedule")
 
-    await page
-      .getByRole("group", { name: "Work calendar view" })
-      .getByRole("button", { name: "List" })
-      .click()
     const todoLink = page
       .getByRole("link", { name: /Regression follow-up/ })
       .first()

--- a/src/app/actions/work-calendar.ts
+++ b/src/app/actions/work-calendar.ts
@@ -29,6 +29,7 @@ import {
 import {
   dateKeyInTimeZone,
   inclusiveEndDateFromExclusive,
+  isValidDateKey,
   normalizeWorkCalendarEventTiming,
   projectTodoHref,
   resolveHOfficeProjectId,
@@ -197,7 +198,22 @@ function operationSourceLabel(recordType: string, recordNumber: string | null): 
   return recordNumber ? `${label} ${recordNumber}` : label
 }
 
-export async function getWorkCalendar(): Promise<WorkCalendarData> {
+function intersectsCalendarWindow(
+  startDate: string,
+  endDate: string,
+  rangeStart: string,
+  rangeEnd: string,
+  today: string
+): boolean {
+  return (
+    (endDate >= rangeStart && startDate <= rangeEnd) ||
+    (endDate >= today && startDate <= today)
+  )
+}
+
+export async function getWorkCalendar(
+  referenceDate?: string
+): Promise<WorkCalendarData> {
   const user = await requireAuth()
   requirePermission(user, "schedule", "read")
   const orgId = requireOrg(user)
@@ -220,9 +236,11 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
   const defaultTimeZone =
     calendarSettings?.timeZone ?? "America/Denver"
   const today = dateKeyInTimeZone(new Date(), defaultTimeZone)
-  const todayAnchor = new Date(`${today}T12:00:00Z`)
-  const rangeStart = toDateKey(addDays(todayAnchor, -14))
-  const rangeEnd = toDateKey(addDays(todayAnchor, 30))
+  const calendarDate =
+    referenceDate && isValidDateKey(referenceDate) ? referenceDate : today
+  const calendarAnchor = new Date(`${calendarDate}T12:00:00Z`)
+  const rangeStart = toDateKey(addDays(calendarAnchor, -14))
+  const rangeEnd = toDateKey(addDays(calendarAnchor, 45))
   const projectRows = await db
     .select({
       id: projects.id,
@@ -296,7 +314,17 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
 
     for (const task of taskRows) {
       if (isClosedStatus(task.status)) continue
-      if (task.endDate < rangeStart || task.startDate > rangeEnd) continue
+      if (
+        !intersectsCalendarWindow(
+          task.startDate,
+          task.endDate,
+          rangeStart,
+          rangeEnd,
+          today
+        )
+      ) {
+        continue
+      }
 
       entries.push({
         id: task.id,
@@ -334,7 +362,16 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
 
     for (const rfi of rfiRows) {
       if (isClosedStatus(rfi.status) || rfi.status === "complete") continue
-      if (!rfi.dueDate || rfi.dueDate < rangeStart || rfi.dueDate > rangeEnd) {
+      if (
+        !rfi.dueDate ||
+        !intersectsCalendarWindow(
+          rfi.dueDate,
+          rfi.dueDate,
+          rangeStart,
+          rangeEnd,
+          today
+        )
+      ) {
         continue
       }
 
@@ -380,7 +417,17 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
         const startDate = operation.startDate ?? operation.dueDate
         const endDate = operation.dueDate ?? operation.startDate
         if (!startDate || !endDate) continue
-        if (endDate < rangeStart || startDate > rangeEnd) continue
+        if (
+          !intersectsCalendarWindow(
+            startDate,
+            endDate,
+            rangeStart,
+            rangeEnd,
+            today
+          )
+        ) {
+          continue
+        }
 
         // Preserve visibility for a legacy row created in the brief window
         // between the additive schema migration and the new application
@@ -423,7 +470,17 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
       const startDate = operation.startDate ?? operation.dueDate
       const endDate = operation.dueDate ?? operation.startDate
       if (!startDate || !endDate) continue
-      if (endDate < rangeStart || startDate > rangeEnd) continue
+      if (
+        !intersectsCalendarWindow(
+          startDate,
+          endDate,
+          rangeStart,
+          rangeEnd,
+          today
+        )
+      ) {
+        continue
+      }
 
       entries.push({
         id: operation.id,
@@ -519,7 +576,17 @@ export async function getWorkCalendar(): Promise<WorkCalendarData> {
         ? dateKeyInTimeZone(timedEndDisplay, event.timeZone)
         : null
     if (!startDate || !endDate) continue
-    if (endDate < rangeStart || startDate > rangeEnd) continue
+    if (
+      !intersectsCalendarWindow(
+        startDate,
+        endDate,
+        rangeStart,
+        rangeEnd,
+        today
+      )
+    ) {
+      continue
+    }
     const attendees = attendeesByEventId.get(event.id) ?? []
 
     entries.push({

--- a/src/app/dashboard/schedule/page.tsx
+++ b/src/app/dashboard/schedule/page.tsx
@@ -6,6 +6,7 @@ import {
   type WorkCalendarKindFilter,
   type WorkCalendarView,
 } from "@/components/schedule/work-calendar"
+import { isValidDateKey } from "@/lib/work-calendar"
 
 function kindFilter(
   value: string | readonly string[] | undefined
@@ -47,10 +48,15 @@ export default async function SchedulePage({
     readonly kind?: string | readonly string[]
     readonly item?: string | readonly string[]
     readonly view?: string | readonly string[]
+    readonly date?: string | readonly string[]
   }>
 }): Promise<React.ReactElement> {
   const query = await searchParams
-  const data = await getWorkCalendar()
+  const requestedDate =
+    typeof query.date === "string" ? query.date : query.date?.[0]
+  const initialDate =
+    requestedDate && isValidDateKey(requestedDate) ? requestedDate : undefined
+  const data = await getWorkCalendar(initialDate)
 
   const initialItemId =
     typeof query.item === "string" ? query.item : query.item?.[0] ?? null
@@ -61,6 +67,7 @@ export default async function SchedulePage({
       initialKind={kindFilter(query.kind)}
       initialItemId={initialItemId}
       initialView={calendarView(query.view)}
+      initialDate={initialDate}
     />
   )
 }

--- a/src/components/schedule/work-calendar.tsx
+++ b/src/components/schedule/work-calendar.tsx
@@ -2,11 +2,14 @@
 
 import * as React from "react"
 import Link from "next/link"
+import { useRouter, useSearchParams } from "next/navigation"
 import {
   IconCalendarEvent,
   IconCalendarMonth,
   IconCalendarPlus,
   IconCalendarWeek,
+  IconChevronLeft,
+  IconChevronRight,
   IconClipboardCheck,
   IconListDetails,
   IconMessageQuestion,
@@ -113,6 +116,13 @@ function addDays(date: Date, days: number): Date {
   return next
 }
 
+function addMonths(date: Date, months: number): Date {
+  const next = new Date(date)
+  next.setDate(1)
+  next.setMonth(next.getMonth() + months)
+  return next
+}
+
 function toDateKey(date: Date): string {
   const year = date.getFullYear()
   const month = `${date.getMonth() + 1}`.padStart(2, "0")
@@ -162,6 +172,18 @@ function formatFullDate(date: string): string {
     day: "numeric",
     year: "numeric",
   }).format(parseDateKey(date))
+}
+
+function navigationUnit(view: WorkCalendarView): "day" | "week" | "month" {
+  switch (view) {
+    case "today":
+      return "day"
+    case "week":
+      return "week"
+    case "month":
+    case "list":
+      return "month"
+  }
 }
 
 function kindLabel(kind: WorkCalendarEntryKind): string {
@@ -323,12 +345,16 @@ export function WorkCalendar({
   initialKind = "all",
   initialItemId = null,
   initialView = "week",
+  initialDate,
 }: {
   readonly data: WorkCalendarData
   readonly initialKind?: WorkCalendarKindFilter
   readonly initialItemId?: string | null
   readonly initialView?: WorkCalendarView
+  readonly initialDate?: string
 }): React.ReactElement {
+  const router = useRouter()
+  const searchParams = useSearchParams()
   const [query, setQuery] = React.useState("")
   const [editingEvent, setEditingEvent] =
     React.useState<CalendarEventEntry | null>(null)
@@ -338,24 +364,36 @@ export function WorkCalendar({
   const [activeView, setActiveView] = React.useState<WorkCalendarView>(
     initialItemId ? "list" : initialView
   )
+  const [activeDate, setActiveDate] = React.useState(
+    initialDate ?? data.today
+  )
   React.useEffect(() => {
     setActiveKind(initialKind)
   }, [initialKind])
   React.useEffect(() => {
     setActiveView(initialItemId ? "list" : initialView)
   }, [initialItemId, initialView])
-  const today = React.useMemo(() => parseDateKey(data.today), [data.today])
+  React.useEffect(() => {
+    setActiveDate(initialDate ?? data.today)
+  }, [data.today, initialDate])
+  const calendarDate = React.useMemo(
+    () => parseDateKey(activeDate),
+    [activeDate]
+  )
   const weekDays = React.useMemo(
     () =>
       Array.from({ length: 7 }, (_, index) =>
-        toDateKey(addDays(startOfWeek(today), index))
+        toDateKey(addDays(startOfWeek(calendarDate), index))
       ),
-    [today]
+    [calendarDate]
   )
-  const monthDays = React.useMemo(() => monthCalendarDays(today), [today])
+  const monthDays = React.useMemo(
+    () => monthCalendarDays(calendarDate),
+    [calendarDate]
+  )
   const visibleCalendarDays =
     activeView === "today"
-      ? [data.today]
+      ? [activeDate]
       : activeView === "month"
         ? monthDays
         : weekDays
@@ -370,11 +408,36 @@ export function WorkCalendar({
   const todayEntries = filteredEntries.filter((entry) =>
     entryOnDay(entry, data.today)
   )
+  const activeDateEntries = filteredEntries.filter((entry) =>
+    entryOnDay(entry, activeDate)
+  )
   const expandedDayEntries = expandedDay
     ? filteredEntries.filter((entry) => entryOnDay(entry, expandedDay))
     : []
   const taskCount = filteredEntries.filter((entry) => entry.kind === "task").length
   const rfiCount = filteredEntries.filter((entry) => entry.kind === "rfi").length
+
+  function navigateCalendar(direction: -1 | 1): void {
+    const nextDate =
+      activeView === "month"
+        ? addMonths(calendarDate, direction)
+        : addDays(calendarDate, direction * (activeView === "week" ? 7 : 1))
+    const nextDateKey = toDateKey(nextDate)
+    const params = new URLSearchParams(searchParams.toString())
+    params.set("view", activeView)
+    params.set("date", nextDateKey)
+    if (activeKind === "all") {
+      params.delete("kind")
+    } else {
+      params.set("kind", activeKind)
+    }
+    params.delete("item")
+    setActiveDate(nextDateKey)
+    setExpandedDay(null)
+    router.replace(`/dashboard/schedule?${params.toString()}`, {
+      scroll: false,
+    })
+  }
 
   React.useEffect(() => {
     if (!initialItemId) return
@@ -499,25 +562,54 @@ export function WorkCalendar({
 
         {activeView !== "list" && (
         <section className="border-y bg-card py-4">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <div>
-              <h2 className="text-sm font-semibold">
-                {activeView === "today"
-                  ? `Today · ${formatShortDate(data.today)}`
-                  : activeView === "week"
-                    ? `Week of ${formatShortDate(weekDays[0] ?? data.today)}`
-                    : new Intl.DateTimeFormat("en-US", {
-                        month: "long",
-                        year: "numeric",
-                      }).format(today)}
-              </h2>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Select any item to open its source record.
-              </p>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-sm"
+                onClick={() => navigateCalendar(-1)}
+                aria-label={`Previous ${navigationUnit(activeView)}`}
+                title={`Previous ${navigationUnit(activeView)}`}
+              >
+                <IconChevronLeft className="size-4" />
+              </Button>
+              <div className="min-w-40 text-center sm:text-left">
+                <h2
+                  className="text-sm font-semibold"
+                  data-testid="work-calendar-period-label"
+                >
+                  {activeView === "today"
+                    ? activeDate === data.today
+                      ? `Today · ${formatShortDate(activeDate)}`
+                      : formatFullDate(activeDate)
+                    : activeView === "week"
+                      ? `Week of ${formatShortDate(weekDays[0] ?? data.today)}`
+                      : new Intl.DateTimeFormat("en-US", {
+                          month: "long",
+                          year: "numeric",
+                        }).format(calendarDate)}
+                </h2>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Select any item to open its source record.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-sm"
+                onClick={() => navigateCalendar(1)}
+                aria-label={`Next ${navigationUnit(activeView)}`}
+                title={`Next ${navigationUnit(activeView)}`}
+              >
+                <IconChevronRight className="size-4" />
+              </Button>
             </div>
             <Badge variant="secondary">
               {activeView === "today"
-                ? `${todayEntries.length} today`
+                ? `${activeDateEntries.length} item${
+                    activeDateEntries.length === 1 ? "" : "s"
+                  }`
                 : activeView === "week"
                   ? "Monday–Sunday"
                   : `${visibleCalendarDays.length / 7} weeks`}
@@ -538,7 +630,7 @@ export function WorkCalendar({
               )
               const outsideCurrentMonth =
                 activeView === "month" &&
-                parseDateKey(day).getMonth() !== today.getMonth()
+                parseDateKey(day).getMonth() !== calendarDate.getMonth()
 
               return (
                 <div

--- a/src/lib/__tests__/work-calendar.test.ts
+++ b/src/lib/__tests__/work-calendar.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   instantForLocalDateTime,
+  isValidDateKey,
   normalizeWorkCalendarEventTiming,
   projectTodoHref,
   resolveHOfficeProjectId,
@@ -21,6 +22,12 @@ const entry = {
 }
 
 describe("work calendar navigation and search", () => {
+  it("accepts only canonical calendar date keys", () => {
+    expect(isValidDateKey("2026-07-27")).toBe(true)
+    expect(isValidDateKey("2026-02-30")).toBe(false)
+    expect(isValidDateKey("07/27/2026")).toBe(false)
+  })
+
   it("matches a project name even when the display label is its project number", () => {
     expect(workCalendarEntryMatches(entry, "Loeffler")).toBe(true)
     expect(workCalendarEntryMatches(entry, "O-202")).toBe(true)

--- a/src/lib/work-calendar.ts
+++ b/src/lib/work-calendar.ts
@@ -43,7 +43,7 @@ export type WorkCalendarEventTiming =
 const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
 const TIME_KEY_PATTERN = /^(?:[01]\d|2[0-3]):[0-5]\d$/
 
-function isRealDateKey(value: string): boolean {
+export function isValidDateKey(value: string): boolean {
   if (!DATE_KEY_PATTERN.test(value)) return false
   const parsed = new Date(`${value}T00:00:00Z`)
   return (
@@ -120,7 +120,7 @@ export function instantForLocalDateTime(
   time: string,
   timeZone: string
 ): LocalDateTimeResolution {
-  if (!isRealDateKey(date) || !TIME_KEY_PATTERN.test(time)) {
+  if (!isValidDateKey(date) || !TIME_KEY_PATTERN.test(time)) {
     return { success: false, error: "Enter a valid date and time." }
   }
 
@@ -195,7 +195,7 @@ export function inclusiveEndDateFromExclusive(
 export function normalizeWorkCalendarEventTiming(
   input: WorkCalendarEventTimingInput
 ): WorkCalendarEventTiming {
-  if (!isRealDateKey(input.startDate) || !isRealDateKey(input.endDate)) {
+  if (!isValidDateKey(input.startDate) || !isValidDateKey(input.endDate)) {
     return { success: false, error: "Enter valid event dates." }
   }
 


### PR DESCRIPTION
## What

- Add accessible previous/next arrows to Work Calendar Today, Week, and Month views.
- Move by exactly one day, one week, or one month for the active view.
- Store the active view/date in the URL and center server-side calendar data on that period so repeated navigation continues to load real records.
- Preserve the active work-kind filter while navigating.
- Keep today's summary available even when browsing a distant period.
- Initialize existing List-view E2E checks from the URL to remove the client hydration race seen in the post-merge Chromium run for #182.

Closes #183

## How to test

- bun run test — 272 passed, 3 skipped
- bunx tsc --noEmit
- focused ESLint on changed files
- Chromium navigation/list/focused-To-do regressions — 3 passed
- Firefox navigation regression — passed
- bunx next build --webpack — passed

## Notes

No schema or data migration is required.