### PR TITLE
fix(auth): accept reset query tokens

### DIFF
--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,6 +1,35 @@
-import { ResetPasswordForm } from "@/components/auth/reset-password-form";
+import { ResetPasswordForm } from "@/components/auth/reset-password-form"
+import { SetPasswordForm } from "@/components/auth/set-password-form"
 
-export default function ResetPasswordPage() {
+type ResetPasswordPageProps = {
+  readonly searchParams: Promise<{
+    readonly token?: string | readonly string[]
+  }>
+}
+
+export default async function ResetPasswordPage({
+  searchParams,
+}: ResetPasswordPageProps): Promise<React.ReactElement> {
+  const { token: tokenParam } = await searchParams
+  const token = Array.isArray(tokenParam) ? tokenParam[0] : tokenParam
+
+  if (token) {
+    return (
+      <div className="space-y-2">
+        <div className="space-y-1">
+          <h2 className="text-2xl font-semibold tracking-tight">
+            Set new password
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Enter your new password below
+          </p>
+        </div>
+
+        <SetPasswordForm token={token} />
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-2">
       <div className="space-y-1">
@@ -14,5 +43,5 @@ export default function ResetPasswordPage() {
 
       <ResetPasswordForm />
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## What changed

- Reads the WorkOS reset token from `/reset-password?token=...`.
- Renders the existing `SetPasswordForm` when a token is present.
- Preserves the reset-email request form when no token is present.

## Why

Valid WorkOS reset links were landing on the wrong form, blocking staff from completing password recovery.

## Validation

- `bunx tsc --noEmit`
- `bunx eslint 'src/app/(auth)/reset-password/page.tsx'`

Closes #189.
