### PR TITLE
feat(access): restore project-scoped invitations

### DIFF
--- a/drizzle/0069_project_access_invitations.sql
+++ b/drizzle/0069_project_access_invitations.sql
@@ -1,0 +1,31 @@
+CREATE TABLE `project_access_invitations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`project_id` text NOT NULL,
+	`project_contact_id` text,
+	`email` text NOT NULL,
+	`role` text NOT NULL,
+	`status` text DEFAULT 'sent' NOT NULL,
+	`workos_invitation_id` text,
+	`workos_expires_at` text,
+	`email_provider` text,
+	`email_provider_message_id` text,
+	`email_error` text,
+	`invited_by` text NOT NULL,
+	`invited_at` text NOT NULL,
+	`accepted_by` text,
+	`accepted_at` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`project_contact_id`) REFERENCES `project_contacts`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`invited_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`accepted_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `idx_project_access_invites_project` ON `project_access_invitations` (`project_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_project_access_invites_email` ON `project_access_invitations` (`email`);
+--> statement-breakpoint
+CREATE INDEX `idx_project_access_invites_status` ON `project_access_invitations` (`status`);

--- a/src/app/actions/project-access-invitations.ts
+++ b/src/app/actions/project-access-invitations.ts
@@ -1,0 +1,377 @@
+"use server"
+
+import { and, eq, sql } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+import { z } from "zod/v4"
+
+import { getDb } from "@/db"
+import {
+  projectAccessInvitations,
+  projectContacts,
+  projectMembers,
+  organizationMembers,
+  organizations,
+  projects,
+  users,
+} from "@/db/schema"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import { sendCompassEmail } from "@/lib/email/compass-email"
+import { buildProjectAccessWelcomeHtml } from "@/lib/email/project-access-welcome"
+import { requirePermission } from "@/lib/permissions"
+import {
+  isExternalProjectRole,
+  isInternalStaffRole,
+} from "@/lib/user-roles"
+
+const invitationSchema = z.object({
+  projectId: z.string().trim().min(1),
+  contactId: z.string().trim().min(1),
+  subject: z.string().trim().min(1).max(180),
+  message: z.string().trim().min(1).max(8000),
+})
+
+export type SendProjectAccessInvitationInput = z.infer<
+  typeof invitationSchema
+>
+
+export type SendProjectAccessInvitationResult =
+  | {
+      readonly success: true
+      readonly accessStatus: "invited" | "access_granted"
+      readonly warning: string | null
+    }
+  | { readonly success: false; readonly error: string }
+
+function projectRoleForContactType(contactType: string): string | null {
+  if (contactType === "owner") return "owner"
+  if (contactType === "subcontractor") return "subcontractor"
+  if (contactType === "supplier") return "supplier"
+  if (contactType === "internal") return "office"
+  return null
+}
+
+function appBaseUrl(env: unknown): string {
+  if (typeof env === "object" && env !== null) {
+    const value = Reflect.get(env, "COMPASS_APP_URL")
+    if (typeof value === "string" && value.trim()) {
+      return value.trim().replace(/\/$/, "")
+    }
+  }
+  return "https://compass.openrangeconstruction.ltd"
+}
+
+function environmentString(env: unknown, key: string): string | null {
+  if (typeof env !== "object" || env === null) return null
+  const value = Reflect.get(env, key)
+  return typeof value === "string" && value.trim() ? value.trim() : null
+}
+
+async function ensureProjectMembership(input: {
+  readonly db: ReturnType<typeof getDb>
+  readonly userId: string
+  readonly projectId: string
+  readonly role: string
+  readonly now: string
+}): Promise<void> {
+  const existing = await input.db
+    .select({ id: projectMembers.id })
+    .from(projectMembers)
+    .where(
+      and(
+        eq(projectMembers.userId, input.userId),
+        eq(projectMembers.projectId, input.projectId)
+      )
+    )
+    .get()
+
+  if (existing) {
+    await input.db
+      .update(projectMembers)
+      .set({ role: input.role })
+      .where(eq(projectMembers.id, existing.id))
+      .run()
+    return
+  }
+
+  await input.db
+    .insert(projectMembers)
+    .values({
+      id: crypto.randomUUID(),
+      userId: input.userId,
+      projectId: input.projectId,
+      role: input.role,
+      assignedAt: input.now,
+    })
+    .run()
+}
+
+export async function sendProjectAccessInvitation(
+  input: SendProjectAccessInvitationInput
+): Promise<SendProjectAccessInvitationResult> {
+  const parsed = invitationSchema.safeParse(input)
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: parsed.error.issues[0]?.message ?? "Please review the invitation.",
+    }
+  }
+
+  try {
+    const currentUser = await requireAuth()
+    if (isDemoUser(currentUser.id)) {
+      return { success: false, error: "Invitations are unavailable in demo mode." }
+    }
+    requirePermission(currentUser, "project", "update")
+    if (
+      currentUser.organizationType !== "internal" ||
+      !currentUser.organizationId ||
+      !isInternalStaffRole(currentUser.role)
+    ) {
+      return {
+        success: false,
+        error: "Only authorized staff can invite project contacts.",
+      }
+    }
+
+    const { env } = await getCloudflareContext()
+    if (!env?.DB) return { success: false, error: "Database not available." }
+    const db = getDb(env.DB)
+    const row = await db
+      .select({
+        contact: projectContacts,
+        projectName: projects.name,
+        projectNumber: projects.projectNumber,
+        organizationId: projects.organizationId,
+      })
+      .from(projectContacts)
+      .innerJoin(projects, eq(projects.id, projectContacts.projectId))
+      .where(
+        and(
+          eq(projectContacts.id, parsed.data.contactId),
+          eq(projectContacts.projectId, parsed.data.projectId),
+          eq(projectContacts.active, true),
+          eq(projects.organizationId, currentUser.organizationId)
+        )
+      )
+      .get()
+
+    if (!row || !row.organizationId) {
+      return { success: false, error: "Project contact not found." }
+    }
+
+    const email = row.contact.email?.trim().toLowerCase() ?? ""
+    if (!email) {
+      return {
+        success: false,
+        error: "Add an email address before inviting this contact.",
+      }
+    }
+    const requestedRole = projectRoleForContactType(row.contact.contactType)
+    if (!requestedRole) {
+      return { success: false, error: "This contact type cannot be invited." }
+    }
+
+    const now = new Date().toISOString()
+    const existingUser = await db
+      .select({
+        id: users.id,
+        role: users.role,
+        isActive: users.isActive,
+      })
+      .from(users)
+      .where(sql`lower(trim(${users.email})) = ${email}`)
+      .get()
+    const activeExistingUser = existingUser?.isActive ? existingUser : null
+    const pendingPlaceholder =
+      existingUser !== undefined &&
+      !existingUser.isActive &&
+      !existingUser.id.startsWith("user_")
+    if (existingUser && !existingUser.isActive && !pendingPlaceholder) {
+      return {
+        success: false,
+        error:
+          "This Compass account is deactivated. Reactivate it in People before assigning project access.",
+      }
+    }
+    const internalMembership = activeExistingUser
+      ? await db
+          .select({ role: organizationMembers.role })
+          .from(organizationMembers)
+          .innerJoin(
+            organizations,
+            eq(organizations.id, organizationMembers.organizationId)
+          )
+          .where(
+            and(
+              eq(organizationMembers.userId, activeExistingUser.id),
+              eq(organizations.id, row.organizationId),
+              eq(organizations.type, "internal")
+            )
+          )
+          .get()
+      : null
+    const preservedOrganizationRole =
+      internalMembership &&
+      !isExternalProjectRole(internalMembership.role)
+        ? internalMembership.role
+        : null
+    const verifiedOrganizationMembership =
+      preservedOrganizationRole !== null
+    const membershipRole = preservedOrganizationRole ?? requestedRole
+    if (
+      row.contact.contactType === "internal" &&
+      !verifiedOrganizationMembership
+    ) {
+      return {
+        success: false,
+        error:
+          "Add internal staff through People before assigning project access.",
+      }
+    }
+    let workosInvitationId: string | null = null
+    let workosExpiresAt: string | null = null
+    const destinationPath =
+      requestedRole === "owner"
+        ? `/dashboard/projects/${parsed.data.projectId}/owner-updates`
+        : requestedRole === "subcontractor" || requestedRole === "supplier"
+          ? `/dashboard/projects/${parsed.data.projectId}/preview/sub-vendor`
+          : `/dashboard/projects/${parsed.data.projectId}`
+    let actionUrl = `${appBaseUrl(env)}/login?from=${encodeURIComponent(
+      destinationPath
+    )}`
+    let accessStatus: "invited" | "access_granted" = "invited"
+
+    if (activeExistingUser) {
+      if (!verifiedOrganizationMembership) {
+        await db
+          .delete(organizationMembers)
+          .where(
+            and(
+              eq(organizationMembers.userId, activeExistingUser.id),
+              eq(organizationMembers.organizationId, row.organizationId)
+            )
+          )
+          .run()
+      }
+      await ensureProjectMembership({
+        db,
+        userId: activeExistingUser.id,
+        projectId: parsed.data.projectId,
+        role: membershipRole,
+        now,
+      })
+      accessStatus = "access_granted"
+    } else if (!existingUser) {
+      const workosApiKey = environmentString(env, "WORKOS_API_KEY")
+      if (!workosApiKey || workosApiKey.includes("placeholder")) {
+        return { success: false, error: "WorkOS invitations are not configured." }
+      }
+      const { WorkOS } = await import("@workos-inc/node")
+      const workos = new WorkOS(workosApiKey)
+      const invitation = await workos.userManagement.sendInvitation({
+        email,
+        expiresInDays: 14,
+      })
+      workosInvitationId = invitation.id
+      workosExpiresAt = invitation.expiresAt
+      actionUrl = invitation.acceptInvitationUrl
+    } else if (pendingPlaceholder) {
+      workosExpiresAt = new Date(
+        Date.now() + 14 * 24 * 60 * 60 * 1000
+      ).toISOString()
+    }
+
+    const visibility =
+      row.contact.contactType === "owner"
+        ? { ownerPortalVisible: true, updatedAt: now }
+        : row.contact.contactType === "internal"
+          ? { internalVisible: true, updatedAt: now }
+          : { subVendorPortalVisible: true, updatedAt: now }
+    await db
+      .update(projectContacts)
+      .set(visibility)
+      .where(eq(projectContacts.id, row.contact.id))
+      .run()
+
+    const projectLabel = row.projectNumber
+      ? `${row.projectNumber} - ${row.projectName}`
+      : row.projectName
+    let emailResult: Awaited<ReturnType<typeof sendCompassEmail>>
+    try {
+      emailResult = await sendCompassEmail({
+        env,
+        db,
+        organizationId: row.organizationId,
+        to: [email],
+        replyTo: "compass@hps-colorado.com",
+        subject: parsed.data.subject,
+        text: `${parsed.data.message}\n\nOpen Compass: ${actionUrl}`,
+        html: buildProjectAccessWelcomeHtml({
+          message: parsed.data.message,
+          actionUrl,
+          actionLabel:
+            accessStatus === "access_granted"
+              ? "Open Compass"
+              : "Set Up Compass Access",
+          projectLabel,
+        }),
+      })
+    } catch (error) {
+      emailResult = {
+        status: "failed",
+        provider: "gmail",
+        providerMessageId: null,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Welcome email provider failed.",
+      }
+    }
+
+    await db
+      .insert(projectAccessInvitations)
+      .values({
+        id: crypto.randomUUID(),
+        organizationId: row.organizationId,
+        projectId: parsed.data.projectId,
+        projectContactId: row.contact.id,
+        email,
+        role: membershipRole,
+        status: accessStatus === "access_granted" ? "accepted" : "sent",
+        workosInvitationId,
+        workosExpiresAt,
+        emailProvider: emailResult.provider,
+        emailProviderMessageId: emailResult.providerMessageId,
+        emailError: emailResult.error,
+        invitedBy: currentUser.id,
+        invitedAt: now,
+        acceptedBy: activeExistingUser?.id ?? null,
+        acceptedAt: activeExistingUser ? now : null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run()
+
+    revalidatePath(`/dashboard/projects/${parsed.data.projectId}/contacts`)
+    revalidatePath("/dashboard/people")
+    return {
+      success: true,
+      accessStatus,
+      warning:
+        emailResult.status === "sent"
+          ? null
+          : `Project access was prepared, but the welcome email could not be sent: ${emailResult.error ?? "email provider unavailable"}`,
+    }
+  } catch (error) {
+    console.error("Project access invitation failed", error)
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to send the project invitation.",
+    }
+  }
+}

--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -8,6 +8,7 @@ import {
   dailyLogs,
   ownerProjectUpdates,
   projectContacts,
+  projectMembers,
   projectOperations,
   projectRfis,
   projects,
@@ -16,10 +17,15 @@ import {
 import { channels } from "@/db/schema-conversations"
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
-import { requireOrg } from "@/lib/org-scope"
 import { requirePermission } from "@/lib/permissions"
+import { assertProjectAccess } from "@/lib/project-access"
+import {
+  canUseProjectAudience,
+  type ProjectAudience,
+} from "@/lib/project-audience-access"
+import { isInternalStaffRole } from "@/lib/user-roles"
 
-export type ProjectAudience = "owner" | "sub_vendor"
+export type { ProjectAudience } from "@/lib/project-audience-access"
 
 export type AudiencePhoto = {
   readonly id: string
@@ -132,29 +138,39 @@ export type ProjectAudiencePreview = {
 }
 
 async function verifyProjectAccess(
-  projectId: string
+  projectId: string,
+  audience: ProjectAudience
 ): Promise<{
   readonly db: ReturnType<typeof getDb>
   readonly organizationId: string
 }> {
   const user = await requireAuth()
   requirePermission(user, "project", "read")
-  const orgId = requireOrg(user)
 
   const { env } = await getCloudflareContext()
   const db = getDb(env.DB)
 
-  const existing = await db
-    .select({ id: projects.id })
-    .from(projects)
-    .where(and(eq(projects.id, projectId), eq(projects.organizationId, orgId)))
-    .limit(1)
-
-  if (!existing[0]) {
-    throw new Error("Project not found")
+  const project = await assertProjectAccess(db, user, projectId)
+  if (!project.organizationId) {
+    throw new Error("Project organization is missing")
+  }
+  if (!isInternalStaffRole(user.role)) {
+    const membership = await db
+      .select({ role: projectMembers.role })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.projectId, projectId),
+          eq(projectMembers.userId, user.id)
+        )
+      )
+      .get()
+    if (!canUseProjectAudience(membership?.role ?? null, audience)) {
+      throw new Error("Project not found")
+    }
   }
 
-  return { db, organizationId: orgId }
+  return { db, organizationId: project.organizationId }
 }
 
 function isActiveStatus(value: string): boolean {
@@ -196,7 +212,10 @@ export async function getProjectAudiencePreview(
   projectId: string,
   audience: ProjectAudience
 ): Promise<ProjectAudiencePreview> {
-  const { db, organizationId } = await verifyProjectAccess(projectId)
+  const { db, organizationId } = await verifyProjectAccess(
+    projectId,
+    audience
+  )
   const today = new Date().toISOString().slice(0, 10)
 
   const [project] = await db

--- a/src/app/actions/project-field.ts
+++ b/src/app/actions/project-field.ts
@@ -9,6 +9,7 @@ import {
   dailyLogTaskLinks,
   ownerProjectUpdates,
   projectExternalLinks,
+  projectMembers,
   projectOperations,
   scheduleTasks,
   projects,
@@ -31,6 +32,8 @@ import {
 import { isOwnerUpdateVisibleToRole } from "@/lib/owner-updates/history"
 import { can } from "@/lib/permissions"
 import { requireFeaturePermission } from "@/lib/permission-enforcement"
+import { assertProjectAccess } from "@/lib/project-access"
+import { canUseProjectAudience } from "@/lib/project-audience-access"
 import { isInternalStaffRole } from "@/lib/user-roles"
 import { revalidatePath } from "next/cache"
 
@@ -475,6 +478,33 @@ async function verifyProjectAccess(
   }
 
   return db
+}
+
+async function verifyOwnerUpdateReadAccess(projectId: string): Promise<{
+  readonly db: ReturnType<typeof getDb>
+  readonly viewer: Awaited<ReturnType<typeof requireAuth>>
+}> {
+  const viewer = await requireAuth()
+  await requireFeaturePermission(viewer, "owner-updates", "read")
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  await assertProjectAccess(db, viewer, projectId)
+  if (!isInternalStaffRole(viewer.role)) {
+    const membership = await db
+      .select({ role: projectMembers.role })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.projectId, projectId),
+          eq(projectMembers.userId, viewer.id)
+        )
+      )
+      .get()
+    if (!canUseProjectAudience(membership?.role ?? null, "owner")) {
+      throw new Error("Project not found")
+    }
+  }
+  return { db, viewer }
 }
 
 async function verifyProjectMutationAccess(
@@ -1089,8 +1119,7 @@ export async function getProjectFieldSummary(
 export async function getProjectOwnerUpdates(
   projectId: string
 ): Promise<readonly ProjectOwnerUpdateListItem[]> {
-  const viewer = await requireAuth()
-  const db = await verifyProjectAccess(projectId, "owner-updates")
+  const { db, viewer } = await verifyOwnerUpdateReadAccess(projectId)
 
   const updateRows = await db
     .select({
@@ -1115,6 +1144,26 @@ export async function getProjectOwnerUpdates(
   return updateRows.filter((update) =>
     isOwnerUpdateVisibleToRole(update.status, viewer.role)
   )
+}
+
+export async function getOwnerUpdateProjectHeader(projectId: string): Promise<{
+  readonly id: string
+  readonly name: string
+  readonly projectNumber: string | null
+}> {
+  const { db } = await verifyOwnerUpdateReadAccess(projectId)
+  const project = await db
+    .select({
+      id: projects.id,
+      name: projects.name,
+      projectNumber: projects.projectNumber,
+    })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .limit(1)
+    .get()
+  if (!project) throw new Error("Project not found")
+  return project
 }
 
 export async function getProjectDailyLogWorkspace(
@@ -1720,8 +1769,7 @@ export async function getOwnerProjectUpdateDocument(
   projectId: string,
   updateId: string
 ): Promise<OwnerProjectUpdateDocument> {
-  const viewer = await requireAuth()
-  const db = await verifyProjectAccess(projectId, "owner-updates")
+  const { db, viewer } = await verifyOwnerUpdateReadAccess(projectId)
 
   const [project] = await db
     .select({

--- a/src/app/actions/projects.ts
+++ b/src/app/actions/projects.ts
@@ -2,12 +2,13 @@
 
 import { getCloudflareContext } from "@/lib/db"
 import { getDb } from "@/db"
-import { projectExternalLinks, projects } from "@/db/schema"
+import { projectExternalLinks, projectMembers, projects } from "@/db/schema"
 import { and, asc, eq } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { requireAuth } from "@/lib/auth"
 import { requireOrg } from "@/lib/org-scope"
 import { requirePermission } from "@/lib/permissions"
+import { canUseOrganizationProjectScopeRole } from "@/lib/user-roles"
 
 export type ProjectStatusValue =
   | "OPEN"
@@ -89,13 +90,33 @@ function isProjectStatusValue(value: string): value is ProjectStatusValue {
 export async function getProjects(): Promise<ProjectListItem[]> {
   try {
     const user = await requireAuth()
-    const orgId = requireOrg(user)
+    requirePermission(user, "project", "read")
 
     const { env } = await getCloudflareContext()
     if (!env?.DB) return []
 
     const db = getDb(env.DB)
-    const allProjects = await db
+
+    if (
+      user.organizationId &&
+      user.organizationType === "internal" &&
+      canUseOrganizationProjectScopeRole(user.role)
+    ) {
+      return await db
+        .select({
+          id: projects.id,
+          name: projects.name,
+          projectNumber: projects.projectNumber,
+          clientName: projects.clientName,
+          googleDriveFolderId: projects.googleDriveFolderId,
+          createdAt: projects.createdAt,
+        })
+        .from(projects)
+        .where(eq(projects.organizationId, user.organizationId))
+        .orderBy(asc(projects.projectNumber), asc(projects.name))
+    }
+
+    return await db
       .select({
         id: projects.id,
         name: projects.name,
@@ -104,11 +125,10 @@ export async function getProjects(): Promise<ProjectListItem[]> {
         googleDriveFolderId: projects.googleDriveFolderId,
         createdAt: projects.createdAt,
       })
-      .from(projects)
-      .where(eq(projects.organizationId, orgId))
+      .from(projectMembers)
+      .innerJoin(projects, eq(projects.id, projectMembers.projectId))
+      .where(eq(projectMembers.userId, user.id))
       .orderBy(asc(projects.projectNumber), asc(projects.name))
-
-    return allProjects
   } catch {
     return []
   }

--- a/src/app/dashboard/projects/[id]/contacts/page.tsx
+++ b/src/app/dashboard/projects/[id]/contacts/page.tsx
@@ -12,6 +12,7 @@ import {
   getProjectContactsSummary,
   type ProjectContactsSummary,
 } from "@/app/actions/project-contacts"
+import { getProjects } from "@/app/actions/projects"
 import {
   ProjectContactsDirectory,
   ProjectContactsPanel,
@@ -27,9 +28,20 @@ export default async function ProjectContactsPage({
   const { id } = await params
 
   let contacts: ProjectContactsSummary | null = null
+  let projectLabel = "This project"
 
   try {
-    contacts = await getProjectContactsSummary(id, "internal")
+    const [contactSummary, projectList] = await Promise.all([
+      getProjectContactsSummary(id, "internal"),
+      getProjects(),
+    ])
+    contacts = contactSummary
+    const project = projectList.find((item) => item.id === id)
+    if (project) {
+      projectLabel = project.projectNumber
+        ? `${project.projectNumber} - ${project.name}`
+        : project.name
+    }
   } catch (error) {
     console.warn("Project contacts unavailable", error)
   }
@@ -78,12 +90,19 @@ export default async function ProjectContactsPage({
       <div className="mb-6">
         <ProjectContactsPanel
           projectId={id}
+          projectLabel={projectLabel}
           summary={contacts}
           showOpenLink={false}
         />
       </div>
 
-      {contacts && <ProjectContactsDirectory summary={contacts} />}
+      {contacts && (
+        <ProjectContactsDirectory
+          projectId={id}
+          projectLabel={projectLabel}
+          summary={contacts}
+        />
+      )}
     </div>
   )
 }

--- a/src/app/dashboard/projects/[id]/owner-updates/page.tsx
+++ b/src/app/dashboard/projects/[id]/owner-updates/page.tsx
@@ -13,6 +13,7 @@ import {
 import {
   getProjectDailyLogWorkspace,
   getProjectFieldSummary,
+  getOwnerUpdateProjectHeader,
   getProjectOwnerUpdates,
   type ProjectOwnerUpdateListItem,
 } from "@/app/actions/project-field"
@@ -26,7 +27,9 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { ProjectContextSwitcher } from "@/components/projects/project-context-switcher"
+import { getCurrentUser } from "@/lib/auth"
 import { redirectIfFeaturePermissionDenied } from "@/lib/permission-redirect"
+import { isInternalStaffRole } from "@/lib/user-roles"
 
 function hasDigest(error: unknown): error is { readonly digest: string } {
   return typeof error === "object" && error !== null && "digest" in error
@@ -81,16 +84,44 @@ export default async function ProjectOwnerUpdatesPage({
   readonly params: Promise<{ readonly id: string }>
 }): Promise<React.ReactElement> {
   const { id } = await params
-  let workspace: Awaited<ReturnType<typeof getProjectDailyLogWorkspace>>
-  let summary: Awaited<ReturnType<typeof getProjectFieldSummary>>
+  const currentUser = await getCurrentUser()
+  const internalViewer =
+    currentUser !== null && isInternalStaffRole(currentUser.role)
+  let project: {
+    readonly id: string
+    readonly name: string
+    readonly projectNumber: string | null
+  }
+  let summary: {
+    readonly ownerUpdateCount: number
+    readonly draftOwnerUpdateCount: number
+    readonly ownerVisiblePhotoCount: number
+  }
   let ownerUpdates: Awaited<ReturnType<typeof getProjectOwnerUpdates>>
 
   try {
-    ;[workspace, summary, ownerUpdates] = await Promise.all([
-      getProjectDailyLogWorkspace(id),
-      getProjectFieldSummary(id),
-      getProjectOwnerUpdates(id),
-    ])
+    if (internalViewer) {
+      const [workspace, fieldSummary, updates] = await Promise.all([
+        getProjectDailyLogWorkspace(id),
+        getProjectFieldSummary(id),
+        getProjectOwnerUpdates(id),
+      ])
+      project = workspace.project
+      summary = fieldSummary
+      ownerUpdates = updates
+    } else {
+      const [header, updates] = await Promise.all([
+        getOwnerUpdateProjectHeader(id),
+        getProjectOwnerUpdates(id),
+      ])
+      project = header
+      ownerUpdates = updates
+      summary = {
+        ownerUpdateCount: updates.length,
+        draftOwnerUpdateCount: 0,
+        ownerVisiblePhotoCount: 0,
+      }
+    }
   } catch (error) {
     if (hasDigest(error) && error.digest === "NEXT_NOT_FOUND") throw error
     redirectIfFeaturePermissionDenied(error)
@@ -98,8 +129,8 @@ export default async function ProjectOwnerUpdatesPage({
   }
 
   const projectLabel =
-    workspace.project.projectNumber ?? workspace.project.name
-  const baseHref = `/dashboard/projects/${workspace.project.id}/owner-updates`
+    project.projectNumber ?? project.name
+  const baseHref = `/dashboard/projects/${project.id}/owner-updates`
   const draftUpdates = ownerUpdates.filter(
     (update) => update.status === "draft"
   )
@@ -113,7 +144,7 @@ export default async function ProjectOwnerUpdatesPage({
         <div>
           <div className="flex flex-wrap items-center gap-2">
             <Link
-              href={`/dashboard/projects/${workspace.project.id}`}
+              href={`/dashboard/projects/${project.id}`}
               className="text-sm text-muted-foreground hover:text-foreground"
             >
               {projectLabel}
@@ -125,30 +156,34 @@ export default async function ProjectOwnerUpdatesPage({
             Owner Updates
           </h1>
           <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-            Draft, review, and publish owner-facing updates.
+            {internalViewer
+              ? "Draft, review, and publish owner-facing updates."
+              : "View published project updates and progress history."}
           </p>
         </div>
         <div className="flex flex-col items-stretch gap-2 sm:items-end">
           <ProjectContextSwitcher
-            currentProjectId={workspace.project.id}
+            currentProjectId={project.id}
             targetSection="owner-updates"
             placeholder="Switch owner update project..."
             className="w-full sm:w-[280px]"
           />
-          <div className="flex flex-wrap justify-end gap-2">
-            <Button asChild>
-              <Link href={`/dashboard/projects/${workspace.project.id}/daily-logs`}>
-                <IconClipboardText className="size-4" />
-                Build From Logs
-              </Link>
-            </Button>
-            <Button asChild variant="outline">
-              <Link href={`/dashboard/projects/${workspace.project.id}/photos`}>
-                <IconPhoto className="size-4" />
-                Review Photos
-              </Link>
-            </Button>
-          </div>
+          {internalViewer && (
+            <div className="flex flex-wrap justify-end gap-2">
+              <Button asChild>
+                <Link href={`/dashboard/projects/${project.id}/daily-logs`}>
+                  <IconClipboardText className="size-4" />
+                  Build From Logs
+                </Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link href={`/dashboard/projects/${project.id}/photos`}>
+                  <IconPhoto className="size-4" />
+                  Review Photos
+                </Link>
+              </Button>
+            </div>
+          )}
         </div>
       </div>
 
@@ -170,12 +205,25 @@ export default async function ProjectOwnerUpdatesPage({
           </p>
         </div>
         <div>
-          <p className="text-xl font-semibold tabular-nums">
-            {summary.ownerVisiblePhotoCount}
-          </p>
-          <p className="text-xs font-medium uppercase text-muted-foreground">
-            Owner photos
-          </p>
+          {internalViewer ? (
+            <>
+              <p className="text-xl font-semibold tabular-nums">
+                {summary.ownerVisiblePhotoCount}
+              </p>
+              <p className="text-xs font-medium uppercase text-muted-foreground">
+                Owner photos
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="text-xl font-semibold tabular-nums">
+                {summary.ownerUpdateCount}
+              </p>
+              <p className="text-xs font-medium uppercase text-muted-foreground">
+                Published
+              </p>
+            </>
+          )}
         </div>
       </section>
 

--- a/src/app/dashboard/projects/[id]/page.tsx
+++ b/src/app/dashboard/projects/[id]/page.tsx
@@ -11,8 +11,9 @@ import {
 } from "@/db/schema"
 import { getCurrentUser } from "@/lib/auth"
 import { canManageProjectRegistry } from "@/lib/permissions"
+import { getProjectAccessRecord } from "@/lib/project-access"
 import { and, eq } from "drizzle-orm"
-import { notFound } from "next/navigation"
+import { notFound, redirect } from "next/navigation"
 import Link from "next/link"
 import { MobileProjectSwitcher } from "@/components/mobile-project-switcher"
 import {
@@ -141,6 +142,29 @@ export default async function ProjectSummaryPage({
     if (!env?.DB) throw new Error("D1 not available")
 
     const db = getDb(env.DB)
+    if (!currentUser || !(await getProjectAccessRecord(db, currentUser, id))) {
+      notFound()
+    }
+    const routeMembership = await db
+      .select({ role: projectMembers.role })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.projectId, id),
+          eq(projectMembers.userId, currentUser.id),
+        ),
+      )
+      .get()
+    projectRole = routeMembership?.role ?? null
+    if (projectRole === "client" || projectRole === "owner") {
+      redirect(`/dashboard/projects/${id}/owner-updates`)
+    }
+    if (
+      projectRole === "subcontractor" ||
+      projectRole === "supplier"
+    ) {
+      redirect(`/dashboard/projects/${id}/preview/sub-vendor`)
+    }
 
     const [found] = await db
       .select()
@@ -180,19 +204,6 @@ export default async function ProjectSummaryPage({
       .from(scheduleTasks)
       .where(eq(scheduleTasks.projectId, id))
     if (currentUser) {
-      const membership = await db
-        .select({ role: projectMembers.role })
-        .from(projectMembers)
-        .where(
-          and(
-            eq(projectMembers.projectId, id),
-            eq(projectMembers.userId, currentUser.id),
-          ),
-        )
-        .get()
-
-      projectRole = membership?.role ?? null
-
       if (!projectRole) {
         const internalContacts = await db
           .select({
@@ -256,7 +267,13 @@ export default async function ProjectSummaryPage({
     operationsSummary = await getProjectOperationsSummary(id)
     rfiSummary = await getProjectRfiSummary(id)
   } catch (error) {
-    if (hasDigest(error) && error.digest === "NEXT_NOT_FOUND") throw error
+    if (
+      hasDigest(error) &&
+      (error.digest === "NEXT_NOT_FOUND" ||
+        error.digest.startsWith("NEXT_REDIRECT"))
+    ) {
+      throw error
+    }
     console.warn("D1 unavailable in dev mode, using empty data")
   }
 

--- a/src/components/projects/project-contact-invite-button.tsx
+++ b/src/components/projects/project-contact-invite-button.tsx
@@ -1,0 +1,192 @@
+"use client"
+
+import * as React from "react"
+import { IconMailForward } from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import { sendProjectAccessInvitation } from "@/app/actions/project-access-invitations"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import { Textarea } from "@/components/ui/textarea"
+import { projectAccessWelcomeTemplate } from "@/lib/email/project-access-welcome"
+
+type InvitableContactType = "owner" | "subcontractor" | "supplier" | "internal"
+
+function accessLabel(contactType: InvitableContactType): string {
+  if (contactType === "owner") return "Owner / Client"
+  if (contactType === "supplier") return "Supplier"
+  if (contactType === "subcontractor") return "Subcontractor"
+  return "Internal Staff"
+}
+
+export function ProjectContactInviteButton({
+  projectId,
+  projectLabel,
+  contactId,
+  contactName,
+  contactEmail,
+  contactType,
+}: {
+  readonly projectId: string
+  readonly projectLabel: string
+  readonly contactId: string
+  readonly contactName: string
+  readonly contactEmail: string
+  readonly contactType: InvitableContactType
+}): React.ReactElement {
+  const template = projectAccessWelcomeTemplate({
+    recipientName: contactName,
+    projectLabel,
+  })
+  const [open, setOpen] = React.useState(false)
+  const [subject, setSubject] = React.useState(template.subject)
+  const [message, setMessage] = React.useState(template.message)
+  const [sending, setSending] = React.useState(false)
+
+  const handleOpenChange = (nextOpen: boolean): void => {
+    setOpen(nextOpen)
+    if (nextOpen) {
+      const nextTemplate = projectAccessWelcomeTemplate({
+        recipientName: contactName,
+        projectLabel,
+      })
+      setSubject(nextTemplate.subject)
+      setMessage(nextTemplate.message)
+    }
+  }
+
+  const handleSend = async (): Promise<void> => {
+    setSending(true)
+    try {
+      const result = await sendProjectAccessInvitation({
+        projectId,
+        contactId,
+        subject,
+        message,
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+
+      if (result.warning) toast.warning(result.warning)
+      else if (result.accessStatus === "access_granted") {
+        toast.success("Project access granted and welcome email sent")
+      } else {
+        toast.success("Compass invitation and welcome email sent")
+      }
+      setOpen(false)
+    } catch {
+      toast.error("Unable to send the Compass invitation")
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-7"
+        onClick={() => setOpen(true)}
+      >
+        <IconMailForward className="size-3.5" />
+        Invite to Compass
+      </Button>
+
+      <Sheet open={open} onOpenChange={handleOpenChange}>
+        <SheetContent className="flex w-full flex-col overflow-y-auto sm:max-w-xl">
+          <SheetHeader className="border-b pb-4 text-left">
+            <SheetTitle>Invite to Compass</SheetTitle>
+            <SheetDescription>
+              Send project-specific access and an editable welcome email.
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="flex-1 space-y-5 py-5">
+            <div className="grid gap-x-5 gap-y-3 border-b pb-4 sm:grid-cols-2">
+              <div>
+                <p className="text-xs font-medium text-muted-foreground">
+                  Recipient
+                </p>
+                <p className="mt-1 text-sm font-medium">{contactName}</p>
+                <p className="text-xs text-muted-foreground">{contactEmail}</p>
+              </div>
+              <div>
+                <p className="text-xs font-medium text-muted-foreground">
+                  Access
+                </p>
+                <p className="mt-1 text-sm font-medium">
+                  {accessLabel(contactType)}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {projectLabel} only
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor={`invite-subject-${contactId}`}>
+                Email subject
+              </Label>
+              <Input
+                id={`invite-subject-${contactId}`}
+                value={subject}
+                onChange={(event) => setSubject(event.target.value)}
+                disabled={sending}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor={`invite-message-${contactId}`}>
+                Welcome message
+              </Label>
+              <Textarea
+                id={`invite-message-${contactId}`}
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+                disabled={sending}
+                className="min-h-[390px] resize-y leading-relaxed"
+              />
+            </div>
+
+            <p className="border-t pt-4 text-xs text-muted-foreground">
+              New users receive a secure WorkOS account invitation. Existing
+              Compass users receive this project assignment immediately. No
+              other project access is added.
+            </p>
+          </div>
+
+          <SheetFooter className="border-t pt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={sending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSend}
+              disabled={sending || !subject.trim() || !message.trim()}
+            >
+              {sending ? "Sending..." : "Send Welcome and Access"}
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </>
+  )
+}

--- a/src/components/projects/project-contact-invite-launcher.tsx
+++ b/src/components/projects/project-contact-invite-launcher.tsx
@@ -1,0 +1,308 @@
+"use client"
+
+import * as React from "react"
+import { Check, ChevronsUpDown } from "lucide-react"
+import { IconMailForward } from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import { sendProjectAccessInvitation } from "@/app/actions/project-access-invitations"
+import type { ProjectContactItem } from "@/app/actions/project-contacts"
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import { Textarea } from "@/components/ui/textarea"
+import { projectAccessWelcomeTemplate } from "@/lib/email/project-access-welcome"
+import { cn } from "@/lib/utils"
+
+type InvitableContact = ProjectContactItem & {
+  readonly email: string
+}
+
+function isInvitableContact(
+  contact: ProjectContactItem
+): contact is InvitableContact {
+  return Boolean(contact.email?.trim())
+}
+
+function accessLabel(contactType: ProjectContactItem["contactType"]): string {
+  if (contactType === "owner") return "Owner / Client"
+  if (contactType === "supplier") return "Supplier"
+  if (contactType === "subcontractor") return "Subcontractor"
+  return "Internal Staff"
+}
+
+export function ProjectContactInviteLauncher({
+  projectId,
+  projectLabel,
+  contacts,
+}: {
+  readonly projectId: string
+  readonly projectLabel: string
+  readonly contacts: readonly ProjectContactItem[]
+}): React.ReactElement | null {
+  const eligibleContacts = contacts.filter(isInvitableContact)
+  const [sheetOpen, setSheetOpen] = React.useState(false)
+  const [contactPickerOpen, setContactPickerOpen] = React.useState(false)
+  const [selectedContactId, setSelectedContactId] = React.useState("")
+  const [subject, setSubject] = React.useState("")
+  const [message, setMessage] = React.useState("")
+  const [sending, setSending] = React.useState(false)
+  const selectedContact =
+    eligibleContacts.find((contact) => contact.id === selectedContactId) ?? null
+
+  if (eligibleContacts.length === 0) return null
+
+  const selectContact = (contact: InvitableContact): void => {
+    const template = projectAccessWelcomeTemplate({
+      recipientName: contact.displayName,
+      projectLabel,
+    })
+    setSelectedContactId(contact.id)
+    setSubject(template.subject)
+    setMessage(template.message)
+    setContactPickerOpen(false)
+  }
+
+  const handleOpenChange = (open: boolean): void => {
+    setSheetOpen(open)
+    if (!open) {
+      setContactPickerOpen(false)
+      setSelectedContactId("")
+      setSubject("")
+      setMessage("")
+    }
+  }
+
+  const handleSend = async (): Promise<void> => {
+    if (!selectedContact) return
+
+    setSending(true)
+    try {
+      const result = await sendProjectAccessInvitation({
+        projectId,
+        contactId: selectedContact.id,
+        subject,
+        message,
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+
+      if (result.warning) toast.warning(result.warning)
+      else if (result.accessStatus === "access_granted") {
+        toast.success("Project access granted and welcome email sent")
+      } else {
+        toast.success("Compass invitation and welcome email sent")
+      }
+      handleOpenChange(false)
+    } catch {
+      toast.error("Unable to send the Compass invitation")
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <>
+      <Button type="button" size="sm" onClick={() => setSheetOpen(true)}>
+        <IconMailForward className="size-4" />
+        Invite contact
+      </Button>
+
+      <Sheet open={sheetOpen} onOpenChange={handleOpenChange}>
+        <SheetContent className="flex w-full flex-col overflow-y-auto sm:max-w-xl">
+          <SheetHeader className="border-b pb-4 text-left">
+            <SheetTitle>Invite a project contact</SheetTitle>
+            <SheetDescription>
+              Choose a contact, review the welcome email, and grant access to
+              this project only.
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="flex-1 space-y-5 py-5">
+            <div className="space-y-2 border-b pb-5">
+              <Label>Contact</Label>
+              <Popover
+                open={contactPickerOpen}
+                onOpenChange={setContactPickerOpen}
+              >
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    role="combobox"
+                    aria-expanded={contactPickerOpen}
+                    className="w-full justify-between font-normal"
+                    disabled={sending}
+                  >
+                    <span
+                      className={cn(
+                        "truncate",
+                        !selectedContact && "text-muted-foreground"
+                      )}
+                    >
+                      {selectedContact
+                        ? `${selectedContact.displayName} - ${accessLabel(selectedContact.contactType)}`
+                        : "Search project contacts..."}
+                    </span>
+                    <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent
+                  align="start"
+                  className="w-[var(--radix-popover-trigger-width)] p-0"
+                >
+                  <Command>
+                    <CommandInput placeholder="Search name, company, or email..." />
+                    <CommandList className="max-h-[320px]">
+                      <CommandEmpty>
+                        No eligible project contacts found.
+                      </CommandEmpty>
+                      <CommandGroup>
+                        {eligibleContacts.map((contact) => (
+                          <CommandItem
+                            key={contact.id}
+                            value={[
+                              contact.displayName,
+                              contact.companyName,
+                              contact.email,
+                              accessLabel(contact.contactType),
+                            ]
+                              .filter(Boolean)
+                              .join(" ")}
+                            onSelect={() => selectContact(contact)}
+                          >
+                            <Check
+                              className={cn(
+                                "size-4",
+                                selectedContactId === contact.id
+                                  ? "opacity-100"
+                                  : "opacity-0"
+                              )}
+                            />
+                            <span className="min-w-0 flex-1">
+                              <span className="block truncate font-medium">
+                                {contact.displayName}
+                              </span>
+                              <span className="block truncate text-xs text-muted-foreground">
+                                {accessLabel(contact.contactType)} ·{" "}
+                                {contact.email}
+                              </span>
+                            </span>
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+            </div>
+
+            {selectedContact && (
+              <>
+                <div className="grid gap-x-5 gap-y-3 border-b pb-4 sm:grid-cols-2">
+                  <div>
+                    <p className="text-xs font-medium text-muted-foreground">
+                      Recipient
+                    </p>
+                    <p className="mt-1 text-sm font-medium">
+                      {selectedContact.displayName}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {selectedContact.email}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs font-medium text-muted-foreground">
+                      Access
+                    </p>
+                    <p className="mt-1 text-sm font-medium">
+                      {accessLabel(selectedContact.contactType)}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {projectLabel} only
+                    </p>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="project-invite-subject">Email subject</Label>
+                  <Input
+                    id="project-invite-subject"
+                    value={subject}
+                    onChange={(event) => setSubject(event.target.value)}
+                    disabled={sending}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="project-invite-message">
+                    Welcome message
+                  </Label>
+                  <Textarea
+                    id="project-invite-message"
+                    value={message}
+                    onChange={(event) => setMessage(event.target.value)}
+                    disabled={sending}
+                    className="min-h-[360px] resize-y leading-relaxed"
+                  />
+                </div>
+              </>
+            )}
+
+            <p className="border-t pt-4 text-xs text-muted-foreground">
+              Existing Compass users receive this project assignment
+              immediately. New users receive a secure account invitation. No
+              other project access is added.
+            </p>
+          </div>
+
+          <SheetFooter className="border-t pt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={sending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSend}
+              disabled={
+                sending ||
+                !selectedContact ||
+                !subject.trim() ||
+                !message.trim()
+              }
+            >
+              {sending ? "Sending..." : "Send Welcome and Access"}
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    </>
+  )
+}

--- a/src/components/projects/project-contacts-panel.tsx
+++ b/src/components/projects/project-contacts-panel.tsx
@@ -15,6 +15,8 @@ import type {
   ProjectContactItem,
   ProjectContactsSummary,
 } from "@/app/actions/project-contacts"
+import { ProjectContactInviteButton } from "@/components/projects/project-contact-invite-button"
+import { ProjectContactInviteLauncher } from "@/components/projects/project-contact-invite-launcher"
 import { Badge } from "@/components/ui/badge"
 
 type ProjectContactDisplayGroupId = "customers" | "vendors" | "internal"
@@ -86,9 +88,13 @@ function csiLabel(contact: ProjectContactItem): string | null {
 
 function ContactCard({
   contact,
+  projectId,
+  projectLabel,
   compact = false,
 }: {
   readonly contact: ProjectContactItem
+  readonly projectId: string
+  readonly projectLabel: string
   readonly compact?: boolean
 }): React.ReactElement {
   return (
@@ -135,16 +141,31 @@ function ContactCard({
           {contact.notes}
         </p>
       )}
+
+      {!compact && contact.email && (
+        <div className="mt-3 flex justify-end">
+          <ProjectContactInviteButton
+            projectId={projectId}
+            projectLabel={projectLabel}
+            contactId={contact.id}
+            contactName={contact.displayName}
+            contactEmail={contact.email}
+            contactType={contact.contactType}
+          />
+        </div>
+      )}
     </article>
   )
 }
 
 export function ProjectContactsPanel({
   projectId,
+  projectLabel = "This project",
   summary,
   showOpenLink = true,
 }: {
   readonly projectId: string
+  readonly projectLabel?: string
   readonly summary: ProjectContactsSummary | null
   readonly showOpenLink?: boolean
 }): React.ReactElement {
@@ -179,6 +200,13 @@ export function ProjectContactsPanel({
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          {!showOpenLink && (
+            <ProjectContactInviteLauncher
+              projectId={projectId}
+              projectLabel={projectLabel}
+              contacts={summary.allContacts}
+            />
+          )}
           <Badge variant="secondary">{summary.totalCount} contacts</Badge>
           <Badge variant="outline">
             {summary.matchedSourceCount} Sage/schedule links
@@ -250,7 +278,13 @@ export function ProjectContactsPanel({
       {previewContacts.length > 0 ? (
         <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-2">
           {previewContacts.map((contact) => (
-            <ContactCard key={contact.id} contact={contact} compact />
+            <ContactCard
+              key={contact.id}
+              contact={contact}
+              projectId={projectId}
+              projectLabel={projectLabel}
+              compact
+            />
           ))}
         </div>
       ) : (
@@ -271,8 +305,12 @@ export function ProjectContactsPanel({
 }
 
 export function ProjectContactsDirectory({
+  projectId,
+  projectLabel,
   summary,
 }: {
+  readonly projectId: string
+  readonly projectLabel: string
   readonly summary: ProjectContactsSummary
 }): React.ReactElement {
   const displayGroups = buildDisplayGroups(summary.allContacts)
@@ -291,7 +329,12 @@ export function ProjectContactsDirectory({
           {group.contacts.length > 0 ? (
             <div className="mt-4 grid gap-3 lg:grid-cols-2">
               {group.contacts.map((contact) => (
-                <ContactCard key={contact.id} contact={contact} />
+                <ContactCard
+                  key={contact.id}
+                  contact={contact}
+                  projectId={projectId}
+                  projectLabel={projectLabel}
+                />
               ))}
             </div>
           ) : (

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -898,6 +898,46 @@ export const projectMembers = sqliteTable("project_members", {
   assignedAt: text("assigned_at").notNull(),
 })
 
+export const projectAccessInvitations = sqliteTable(
+  "project_access_invitations",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    projectContactId: text("project_contact_id").references(
+      () => projectContacts.id,
+      { onDelete: "set null" }
+    ),
+    email: text("email").notNull(),
+    role: text("role").notNull(),
+    status: text("status").notNull().default("sent"),
+    workosInvitationId: text("workos_invitation_id"),
+    workosExpiresAt: text("workos_expires_at"),
+    emailProvider: text("email_provider"),
+    emailProviderMessageId: text("email_provider_message_id"),
+    emailError: text("email_error"),
+    invitedBy: text("invited_by")
+      .notNull()
+      .references(() => users.id, { onDelete: "restrict" }),
+    invitedAt: text("invited_at").notNull(),
+    acceptedBy: text("accepted_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    acceptedAt: text("accepted_at"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    index("idx_project_access_invites_project").on(table.projectId),
+    index("idx_project_access_invites_email").on(table.email),
+    index("idx_project_access_invites_status").on(table.status),
+  ]
+)
+
 export const scheduleTasks = sqliteTable("schedule_tasks", {
   id: text("id").primaryKey(),
   projectId: text("project_id")
@@ -1140,6 +1180,10 @@ export type GroupMember = typeof groupMembers.$inferSelect
 export type NewGroupMember = typeof groupMembers.$inferInsert
 export type ProjectMember = typeof projectMembers.$inferSelect
 export type NewProjectMember = typeof projectMembers.$inferInsert
+export type ProjectAccessInvitation =
+  typeof projectAccessInvitations.$inferSelect
+export type NewProjectAccessInvitation =
+  typeof projectAccessInvitations.$inferInsert
 
 // Agent memory tables for ElizaOS
 export const agentConversations = sqliteTable("agent_conversations", {

--- a/src/lib/__tests__/project-audience-access.test.ts
+++ b/src/lib/__tests__/project-audience-access.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+
+import { canUseProjectAudience } from "@/lib/project-audience-access"
+
+describe("project audience access", () => {
+  it.each(["client", "owner"])("allows %s to use the owner view", (role) => {
+    expect(canUseProjectAudience(role, "owner")).toBe(true)
+    expect(canUseProjectAudience(role, "sub_vendor")).toBe(false)
+  })
+
+  it.each(["subcontractor", "supplier"])(
+    "allows %s to use only the sub/vendor view",
+    (role) => {
+      expect(canUseProjectAudience(role, "sub_vendor")).toBe(true)
+      expect(canUseProjectAudience(role, "owner")).toBe(false)
+    }
+  )
+
+  it.each(["guest", "unknown", null])(
+    "does not infer an audience for %s",
+    (role) => {
+      expect(canUseProjectAudience(role, "owner")).toBe(false)
+      expect(canUseProjectAudience(role, "sub_vendor")).toBe(false)
+    }
+  )
+})

--- a/src/lib/__tests__/project-scope-roles.test.ts
+++ b/src/lib/__tests__/project-scope-roles.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  canUseOrganizationProjectScopeRole,
+  isExternalProjectRole,
+} from "@/lib/user-roles"
+
+describe("organization-wide project scope", () => {
+  it.each([
+    "admin",
+    "secondary_admin",
+    "project_manager",
+    "office",
+    "field_superintendent",
+  ])("allows internal staff role %s", (role) => {
+    expect(canUseOrganizationProjectScopeRole(role)).toBe(true)
+  })
+
+  it.each([
+    "client",
+    "owner",
+    "subcontractor",
+    "supplier",
+    "guest",
+    "developer",
+    "unknown",
+  ])("denies project-wide scope to %s", (role) => {
+    expect(canUseOrganizationProjectScopeRole(role)).toBe(false)
+  })
+})
+
+describe("external project roles", () => {
+  it.each(["client", "owner", "subcontractor", "supplier", "guest"])(
+    "recognizes %s as project-scoped",
+    (role) => {
+      expect(isExternalProjectRole(role)).toBe(true)
+    }
+  )
+
+  it.each(["admin", "office", "developer", "unknown"])(
+    "does not classify %s as external",
+    (role) => {
+      expect(isExternalProjectRole(role)).toBe(false)
+    }
+  )
+})

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,15 +1,24 @@
 import { withAuth, signOut } from "@workos-inc/authkit-nextjs"
 import { getCloudflareContext } from "@/lib/db"
 import { getDb } from "@/db"
-import { users, organizations, organizationMembers } from "@/db/schema"
+import {
+  users,
+  organizations,
+  organizationMembers,
+  projectAccessInvitations,
+  projectMembers,
+} from "@/db/schema"
 import type { User } from "@/db/schema"
-import { eq } from "drizzle-orm"
+import { and, desc, eq, sql } from "drizzle-orm"
 import { cookies } from "next/headers"
 import { DEMO_USER } from "@/lib/demo"
 import {
   isDevAuthFallbackAllowed,
   isWorkOSConfigured,
 } from "@/lib/auth-config"
+import {
+  isExternalProjectRole,
+} from "@/lib/user-roles"
 
 export type AuthUser = {
   readonly id: string
@@ -53,6 +62,155 @@ export function toSidebarUser(user: AuthUser): SidebarUser {
     firstName: user.firstName,
     lastName: user.lastName,
   }
+}
+
+function normalizedExternalProjectRole(role: string): string {
+  return role === "owner" ? "client" : role
+}
+
+async function setActiveOrgCookie(orgId: string): Promise<void> {
+  try {
+    const cookieStore = await cookies()
+    cookieStore.set("compass-active-org", orgId, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: 60 * 60 * 24 * 365,
+    })
+  } catch {
+    // Cookies are not writable from every server-rendering context.
+  }
+}
+
+async function claimProjectAccessInvitations(
+  db: ReturnType<typeof getDb>,
+  userId: string,
+  email: string,
+  now: string
+): Promise<{ readonly organizationId: string; readonly role: string } | null> {
+  const normalizedEmail = email.trim().toLowerCase()
+  if (!normalizedEmail) return null
+
+  const invitations = await db
+    .select({
+      id: projectAccessInvitations.id,
+      organizationId: projectAccessInvitations.organizationId,
+      projectId: projectAccessInvitations.projectId,
+      role: projectAccessInvitations.role,
+      workosExpiresAt: projectAccessInvitations.workosExpiresAt,
+    })
+    .from(projectAccessInvitations)
+    .where(
+      and(
+        eq(projectAccessInvitations.status, "sent"),
+        sql`lower(trim(${projectAccessInvitations.email})) = ${normalizedEmail}`
+      )
+    )
+    .orderBy(desc(projectAccessInvitations.invitedAt))
+
+  let claimedInvitation: {
+    readonly organizationId: string
+    readonly role: string
+  } | null = null
+  for (const invitation of invitations) {
+    if (
+      invitation.workosExpiresAt &&
+      invitation.workosExpiresAt <= now
+    ) {
+      await db
+        .update(projectAccessInvitations)
+        .set({ status: "expired", updatedAt: now })
+        .where(eq(projectAccessInvitations.id, invitation.id))
+        .run()
+      continue
+    }
+
+    const organizationMembership = await db
+      .select({ role: organizationMembers.role })
+      .from(organizationMembers)
+      .where(
+        and(
+          eq(organizationMembers.userId, userId),
+          eq(
+            organizationMembers.organizationId,
+            invitation.organizationId
+          )
+        )
+      )
+      .get()
+    const preservedOrganizationRole =
+      organizationMembership &&
+      !isExternalProjectRole(organizationMembership.role)
+        ? organizationMembership.role
+        : null
+    const assignedRole = preservedOrganizationRole ?? invitation.role
+
+    if (
+      isExternalProjectRole(invitation.role) &&
+      !preservedOrganizationRole
+    ) {
+      await db
+        .delete(organizationMembers)
+        .where(
+          and(
+            eq(organizationMembers.userId, userId),
+            eq(
+              organizationMembers.organizationId,
+              invitation.organizationId
+            )
+          )
+        )
+        .run()
+    }
+
+    const projectMembership = await db
+      .select({ id: projectMembers.id })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.projectId, invitation.projectId),
+          eq(projectMembers.userId, userId)
+        )
+      )
+      .get()
+
+    if (!projectMembership) {
+      await db
+        .insert(projectMembers)
+        .values({
+          id: crypto.randomUUID(),
+          projectId: invitation.projectId,
+          userId,
+          role: assignedRole,
+          assignedAt: now,
+        })
+        .run()
+    } else {
+      await db
+        .update(projectMembers)
+        .set({ role: assignedRole })
+        .where(eq(projectMembers.id, projectMembership.id))
+        .run()
+    }
+
+    await db
+      .update(projectAccessInvitations)
+      .set({
+        status: "accepted",
+        acceptedBy: userId,
+        acceptedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(projectAccessInvitations.id, invitation.id))
+      .run()
+    claimedInvitation ??= {
+      organizationId: invitation.organizationId,
+      role: assignedRole,
+    }
+  }
+
+  return claimedInvitation
 }
 
 export async function getCurrentUser(): Promise<AuthUser | null> {
@@ -123,6 +281,44 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
       .where(eq(users.id, workosUser.id))
       .get()
 
+    if (!dbUser) {
+      const emailMatch = await db
+        .select()
+        .from(users)
+        .where(
+          sql`lower(trim(${users.email})) = ${workosUser.email
+            .trim()
+            .toLowerCase()}`
+        )
+        .get()
+      const isPendingPlaceholder =
+        emailMatch !== undefined &&
+        !emailMatch.isActive &&
+        !emailMatch.id.startsWith("user_")
+      if (emailMatch && (emailMatch.isActive || isPendingPlaceholder)) {
+        await db
+          .update(users)
+          .set({
+            firstName: workosUser.firstName ?? emailMatch.firstName,
+            lastName: workosUser.lastName ?? emailMatch.lastName,
+            displayName:
+              workosUser.firstName && workosUser.lastName
+                ? `${workosUser.firstName} ${workosUser.lastName}`
+                : emailMatch.displayName,
+            avatarUrl: workosUser.profilePictureUrl ?? emailMatch.avatarUrl,
+            isActive: isPendingPlaceholder ? true : emailMatch.isActive,
+            updatedAt: new Date().toISOString(),
+          })
+          .where(eq(users.id, emailMatch.id))
+          .run()
+        dbUser = await db
+          .select()
+          .from(users)
+          .where(eq(users.id, emailMatch.id))
+          .get()
+      }
+    }
+
     // if user doesn't exist, create them with default role
     if (!dbUser) {
       dbUser = await ensureUserExists(workosUser)
@@ -130,10 +326,16 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
 
     // update last login timestamp
     const now = new Date().toISOString()
+    await claimProjectAccessInvitations(
+      db,
+      dbUser.id,
+      dbUser.email,
+      now
+    )
     await db
       .update(users)
       .set({ lastLoginAt: now })
-      .where(eq(users.id, workosUser.id))
+      .where(eq(users.id, dbUser.id))
       .run()
 
     // query org memberships
@@ -170,6 +372,24 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
       }
     }
 
+    const projectMembership = await db
+      .select({ role: projectMembers.role })
+      .from(projectMembers)
+      .where(eq(projectMembers.userId, dbUser.id))
+      .limit(1)
+      .get()
+    const hasInternalStaffOrganization = orgMemberships.some(
+      (membership) =>
+        membership.orgType === "internal" &&
+        !isExternalProjectRole(membership.memberRole)
+    )
+    const effectiveRole =
+      !hasInternalStaffOrganization &&
+      projectMembership &&
+      isExternalProjectRole(projectMembership.role)
+        ? normalizedExternalProjectRole(projectMembership.role)
+        : activeOrg?.memberRole ?? dbUser.role
+
     return {
       id: dbUser.id,
       email: dbUser.email,
@@ -177,7 +397,7 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
       lastName: dbUser.lastName,
       displayName: dbUser.displayName,
       avatarUrl: dbUser.avatarUrl,
-      role: activeOrg?.memberRole ?? dbUser.role,
+      role: effectiveRole,
       googleEmail: dbUser.googleEmail ?? null,
       isActive: dbUser.isActive,
       lastLoginAt: now,
@@ -217,6 +437,23 @@ export async function ensureUserExists(workosUser: {
   if (existing) return existing
 
   const now = new Date().toISOString()
+  const pendingInvitation = await db
+    .select({
+      role: projectAccessInvitations.role,
+    })
+    .from(projectAccessInvitations)
+    .where(
+      and(
+        eq(projectAccessInvitations.status, "sent"),
+        sql`lower(trim(${projectAccessInvitations.email})) = ${workosUser.email
+          .trim()
+          .toLowerCase()}`,
+        sql`(${projectAccessInvitations.workosExpiresAt} IS NULL OR ${projectAccessInvitations.workosExpiresAt} > ${now})`
+      )
+    )
+    .orderBy(desc(projectAccessInvitations.invitedAt))
+    .limit(1)
+    .get()
 
   const newUser = {
     id: workosUser.id,
@@ -228,7 +465,9 @@ export async function ensureUserExists(workosUser: {
         ? `${workosUser.firstName} ${workosUser.lastName}`
         : workosUser.email.split("@")[0],
     avatarUrl: workosUser.profilePictureUrl ?? null,
-    role: "office", // default role
+    // Project invitation roles remain project-scoped. The effective role is
+    // derived from project_members after authentication.
+    role: pendingInvitation ? "guest" : "office",
     isActive: true,
     lastLoginAt: now,
     createdAt: now,
@@ -237,6 +476,12 @@ export async function ensureUserExists(workosUser: {
 
   await db.insert(users).values(newUser).run()
 
+  await claimProjectAccessInvitations(
+    db,
+    workosUser.id,
+    workosUser.email,
+    now
+  )
   // create personal org
   const personalOrgId = crypto.randomUUID()
   const personalSlug = `${workosUser.id.slice(0, 8)}-personal`
@@ -267,19 +512,7 @@ export async function ensureUserExists(workosUser: {
     })
     .run()
 
-  // set active org cookie
-  try {
-    const cookieStore = await cookies()
-    cookieStore.set("compass-active-org", personalOrgId, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      path: "/",
-      maxAge: 60 * 60 * 24 * 365, // 1 year
-    })
-  } catch {
-    // may not be in request context
-  }
+  await setActiveOrgCookie(personalOrgId)
 
   return newUser as User
 }

--- a/src/lib/email/__tests__/project-access-welcome.test.ts
+++ b/src/lib/email/__tests__/project-access-welcome.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildProjectAccessWelcomeHtml,
+  projectAccessWelcomeTemplate,
+} from "@/lib/email/project-access-welcome"
+
+describe("project access welcome email", () => {
+  it("builds an editable project-specific message", () => {
+    const result = projectAccessWelcomeTemplate({
+      recipientName: "Alex Owner",
+      projectLabel: "O-202 - Loeffler",
+    })
+
+    expect(result.subject).toContain("O-202 - Loeffler")
+    expect(result.message).toContain("Hi Alex Owner")
+    expect(result.message).toContain("outside your approved project access")
+  })
+
+  it("escapes message and link content in HTML", () => {
+    const html = buildProjectAccessWelcomeHtml({
+      message: "Hi <Owner>\n\nUse Compass:",
+      actionUrl: 'https://example.com/?value="unsafe"',
+      actionLabel: "Open <Compass>",
+      projectLabel: "Project & Home",
+    })
+
+    expect(html).toContain("Hi &lt;Owner&gt;")
+    expect(html).toContain("Project &amp; Home")
+    expect(html).toContain("Open &lt;Compass&gt;")
+    expect(html).not.toContain('href="https://example.com/?value="unsafe""')
+  })
+})

--- a/src/lib/email/compass-email.ts
+++ b/src/lib/email/compass-email.ts
@@ -1,0 +1,275 @@
+import "server-only"
+
+import { eq } from "drizzle-orm"
+
+import { getDb } from "@/db"
+import { googleAuth } from "@/db/schema-google"
+import { decrypt } from "@/lib/crypto"
+import {
+  getGoogleConfig,
+  getGoogleCryptoSalt,
+  parseServiceAccountKey,
+} from "@/lib/google/config"
+import {
+  createServiceAccountJWT,
+  exchangeJWTForAccessToken,
+} from "@/lib/google/auth/service-account"
+
+export type CompassEmailInput = {
+  readonly env: unknown
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string | null
+  readonly to: readonly string[]
+  readonly replyTo?: string
+  readonly subject: string
+  readonly text: string
+  readonly html?: string
+}
+
+export type CompassEmailDeliveryResult = {
+  readonly status: string
+  readonly provider: string
+  readonly providerMessageId: string | null
+  readonly error: string | null
+}
+
+const GMAIL_SEND_SCOPE = "https://www.googleapis.com/auth/gmail.send"
+const DEFAULT_COMPASS_EMAIL_FROM = "Compass <compass@hps-colorado.com>"
+const DEFAULT_COMPASS_GMAIL_USER = "compass@hps-colorado.com"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function envString(env: unknown, key: string): string | null {
+  if (!isRecord(env)) return process.env[key] ?? null
+  const value = env[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : process.env[key] ?? null
+}
+
+function googleConfigEnv(env: unknown): Record<string, string | undefined> {
+  const values: Record<string, string | undefined> = {}
+  if (!isRecord(env)) return values
+
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value === "string") values[key] = value
+  }
+  return values
+}
+
+function escapeHeader(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").trim()
+}
+
+function extractEmailAddress(value: string): string {
+  const match = /<([^<>]+)>/.exec(value)
+  return (match?.[1] ?? value).trim()
+}
+
+function base64urlString(value: string): string {
+  const bytes = new TextEncoder().encode(value)
+  let binary = ""
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
+function buildMimeMessage(input: {
+  readonly from: string
+  readonly to: readonly string[]
+  readonly replyTo: string | null
+  readonly subject: string
+  readonly text: string
+  readonly html: string | null
+}): string {
+  const headers = [
+    `From: ${escapeHeader(input.from)}`,
+    `To: ${input.to.map(escapeHeader).join(", ")}`,
+    input.replyTo ? `Reply-To: ${escapeHeader(input.replyTo)}` : null,
+    `Subject: ${escapeHeader(input.subject)}`,
+    "MIME-Version: 1.0",
+  ].filter((line): line is string => line !== null)
+
+  if (!input.html) {
+    return [
+      ...headers,
+      'Content-Type: text/plain; charset="UTF-8"',
+      "Content-Transfer-Encoding: 8bit",
+      "",
+      input.text,
+    ].join("\r\n")
+  }
+
+  const boundary = `compass-${crypto.randomUUID()}`
+  return [
+    ...headers,
+    `Content-Type: multipart/alternative; boundary="${boundary}"`,
+    "",
+    `--${boundary}`,
+    'Content-Type: text/plain; charset="UTF-8"',
+    "Content-Transfer-Encoding: 8bit",
+    "",
+    input.text,
+    `--${boundary}`,
+    'Content-Type: text/html; charset="UTF-8"',
+    "Content-Transfer-Encoding: 8bit",
+    "",
+    input.html,
+    `--${boundary}--`,
+    "",
+  ].join("\r\n")
+}
+
+function providerMessageId(value: unknown): string | null {
+  if (!isRecord(value)) return null
+  const id = value.id
+  if (typeof id === "string") return id
+  const messageId = value.messageId
+  return typeof messageId === "string" ? messageId : null
+}
+
+async function sendGmail(
+  input: CompassEmailInput
+): Promise<CompassEmailDeliveryResult> {
+  const config = getGoogleConfig(googleConfigEnv(input.env))
+  const rows = input.organizationId
+    ? await input.db
+        .select()
+        .from(googleAuth)
+        .where(eq(googleAuth.organizationId, input.organizationId))
+        .limit(1)
+    : await input.db.select().from(googleAuth).limit(1)
+  const row = rows[0]
+  if (!row) {
+    return {
+      status: "pending_provider",
+      provider: "gmail",
+      providerMessageId: null,
+      error: "Google Workspace service account is not connected.",
+    }
+  }
+
+  const keyJson = await decrypt(
+    row.serviceAccountKeyEncrypted,
+    config.encryptionKey,
+    getGoogleCryptoSalt()
+  )
+  const from =
+    envString(input.env, "COMPASS_EMAIL_FROM") ?? DEFAULT_COMPASS_EMAIL_FROM
+  const sender =
+    envString(input.env, "COMPASS_GMAIL_SENDER") ??
+    extractEmailAddress(from) ??
+    DEFAULT_COMPASS_GMAIL_USER
+  const serviceAccountKey = parseServiceAccountKey(keyJson)
+  const jwt = await createServiceAccountJWT(serviceAccountKey, sender, [
+    GMAIL_SEND_SCOPE,
+  ])
+  const token = await exchangeJWTForAccessToken(jwt)
+  const raw = base64urlString(
+    buildMimeMessage({
+      from,
+      to: input.to,
+      replyTo: input.replyTo ?? null,
+      subject: input.subject,
+      text: input.text,
+      html: input.html ?? null,
+    })
+  )
+
+  const response = await fetch(
+    "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token.access_token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ raw }),
+    }
+  )
+  const responseText = await response.text()
+  let id: string | null = null
+  try {
+    id = providerMessageId(JSON.parse(responseText))
+  } catch {
+    id = null
+  }
+
+  return {
+    status: response.ok ? "sent" : "failed",
+    provider: "gmail",
+    providerMessageId: id,
+    error: response.ok ? null : responseText.slice(0, 500),
+  }
+}
+
+async function sendResend(
+  input: CompassEmailInput
+): Promise<CompassEmailDeliveryResult> {
+  const apiKey = envString(input.env, "RESEND_API_KEY")
+  if (!apiKey) {
+    return {
+      status: "pending_provider",
+      provider: "resend",
+      providerMessageId: null,
+      error: "RESEND_API_KEY is not configured.",
+    }
+  }
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from:
+        envString(input.env, "COMPASS_EMAIL_FROM") ??
+        DEFAULT_COMPASS_EMAIL_FROM,
+      to: input.to,
+      reply_to: input.replyTo,
+      subject: input.subject,
+      text: input.text,
+      html: input.html,
+    }),
+  })
+  const responseText = await response.text()
+  let id: string | null = null
+  try {
+    id = providerMessageId(JSON.parse(responseText))
+  } catch {
+    id = null
+  }
+
+  return {
+    status: response.ok ? "sent" : "failed",
+    provider: "resend",
+    providerMessageId: id,
+    error: response.ok ? null : responseText.slice(0, 500),
+  }
+}
+
+export async function sendCompassEmail(
+  input: CompassEmailInput
+): Promise<CompassEmailDeliveryResult> {
+  const preferredProvider =
+    envString(input.env, "COMPASS_EMAIL_PROVIDER") ?? "gmail"
+  if (preferredProvider === "resend") return sendResend(input)
+
+  const gmailDelivery = await sendGmail(input)
+  if (gmailDelivery.status === "sent") return gmailDelivery
+
+  const resendDelivery = await sendResend(input)
+  if (resendDelivery.status === "sent") return resendDelivery
+  if (gmailDelivery.status !== "pending_provider") return gmailDelivery
+
+  return {
+    status: "pending_provider",
+    provider: "gmail",
+    providerMessageId: null,
+    error: `${gmailDelivery.error ?? "Gmail unavailable"} ${
+      resendDelivery.error ?? "Resend unavailable"
+    }`.trim(),
+  }
+}

--- a/src/lib/email/project-access-welcome.ts
+++ b/src/lib/email/project-access-welcome.ts
@@ -1,0 +1,114 @@
+export type ProjectAccessWelcomeTemplateInput = {
+  readonly recipientName: string
+  readonly projectLabel: string
+  readonly companyName?: string
+}
+
+export type ProjectAccessWelcomeTemplate = {
+  readonly subject: string
+  readonly message: string
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#039;")
+}
+
+export function projectAccessWelcomeTemplate(
+  input: ProjectAccessWelcomeTemplateInput
+): ProjectAccessWelcomeTemplate {
+  const companyName = input.companyName ?? "High Performance Structures Inc."
+  return {
+    subject: `Welcome to Compass for ${input.projectLabel}`,
+    message: `Hi ${input.recipientName},
+
+We are moving project communication and collaboration from Buildertrend to Compass, our project workspace for ${input.projectLabel}.
+
+What is changing:
+- Compass will be the place to view the information shared with you for this project, including updates, messages, schedules, approved photos, documents, and selections as they become available.
+- Project notifications will come from Compass, and you can choose your email, text, and in-app notification preferences after signing in.
+
+What is staying the same:
+- You will continue working with the same ${companyName} team.
+- Existing project records remain part of the project history.
+- Private accounting, internal notes, and information outside your approved project access remain restricted.
+
+Use the secure button below to set up or open your Compass account. If you need help, reply to this email and our team will assist you.
+
+Thank you,
+${companyName}`,
+  }
+}
+
+function messageHtml(message: string): string {
+  const lines = message.replace(/\r\n/g, "\n").split("\n")
+  const parts: string[] = []
+  let listItems: string[] = []
+
+  const flushList = (): void => {
+    if (listItems.length === 0) return
+    parts.push(
+      `<ul style="margin:0 0 18px;padding-left:22px;color:#292b27;line-height:1.6">${listItems
+        .map((item) => `<li style="margin:0 0 7px">${escapeHtml(item)}</li>`)
+        .join("")}</ul>`
+    )
+    listItems = []
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim()
+    if (line.startsWith("- ")) {
+      listItems.push(line.slice(2))
+      continue
+    }
+
+    flushList()
+    if (!line) continue
+    if (line.endsWith(":")) {
+      parts.push(
+        `<h2 style="margin:22px 0 8px;font-size:15px;color:#173b2a">${escapeHtml(line)}</h2>`
+      )
+      continue
+    }
+    parts.push(
+      `<p style="margin:0 0 14px;color:#292b27;line-height:1.6">${escapeHtml(line)}</p>`
+    )
+  }
+
+  flushList()
+  return parts.join("")
+}
+
+export function buildProjectAccessWelcomeHtml(input: {
+  readonly message: string
+  readonly actionUrl: string
+  readonly actionLabel: string
+  readonly projectLabel: string
+}): string {
+  return `<!doctype html>
+<html lang="en">
+  <body style="margin:0;background:#f3f4f1;font-family:Arial,Helvetica,sans-serif;color:#292b27">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f3f4f1;padding:28px 12px">
+      <tr><td align="center">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:680px;background:#ffffff;border:1px solid #d8ddd7">
+          <tr><td style="padding:22px 28px;background:#173b2a;color:#ffffff">
+            <div style="font-size:12px;font-weight:700;letter-spacing:.08em;text-transform:uppercase">Compass</div>
+            <div style="margin-top:6px;font-size:22px;font-weight:700">${escapeHtml(input.projectLabel)}</div>
+          </td></tr>
+          <tr><td style="padding:28px">
+            ${messageHtml(input.message)}
+            <div style="margin:26px 0 20px">
+              <a href="${escapeHtml(input.actionUrl)}" style="display:inline-block;background:#3f7d4d;color:#ffffff;text-decoration:none;font-weight:700;padding:12px 18px;border-radius:4px">${escapeHtml(input.actionLabel)}</a>
+            </div>
+            <p style="margin:0;color:#6b706a;font-size:12px;line-height:1.5">This invitation only grants access to projects explicitly assigned to your account.</p>
+          </td></tr>
+        </table>
+      </td></tr>
+    </table>
+  </body>
+</html>`
+}

--- a/src/lib/owner-updates/__tests__/history.test.ts
+++ b/src/lib/owner-updates/__tests__/history.test.ts
@@ -6,7 +6,15 @@ import {
 } from "@/lib/owner-updates/history"
 
 describe("owner update history access", () => {
-  it.each(["admin", "secondary_admin", "office", "field"])(
+  it.each([
+    "admin",
+    "secondary_admin",
+    "office",
+    "project_manager",
+    "project_administrator",
+    "field_superintendent",
+    "field",
+  ])(
     "allows %s staff to see drafts",
     (role) => {
       expect(canViewOwnerUpdateDrafts(role)).toBe(true)

--- a/src/lib/owner-updates/history.ts
+++ b/src/lib/owner-updates/history.ts
@@ -1,13 +1,7 @@
+import { isInternalStaffRole } from "@/lib/user-roles"
+
 export function canViewOwnerUpdateDrafts(role: string): boolean {
-  switch (role) {
-    case "admin":
-    case "secondary_admin":
-    case "office":
-    case "field":
-      return true
-    default:
-      return false
-  }
+  return isInternalStaffRole(role)
 }
 
 export function isOwnerUpdateVisibleToRole(

--- a/src/lib/project-access.ts
+++ b/src/lib/project-access.ts
@@ -1,0 +1,74 @@
+import { and, eq } from "drizzle-orm"
+
+import type { getDb } from "@/db"
+import { projectMembers, projects } from "@/db/schema"
+import type { AuthUser } from "@/lib/auth"
+import { canUseOrganizationProjectScopeRole } from "@/lib/user-roles"
+
+type Db = ReturnType<typeof getDb>
+
+export type ProjectAccessRecord = {
+  readonly id: string
+  readonly organizationId: string | null
+  readonly projectNumber: string | null
+}
+
+export function usesOrganizationProjectScope(
+  user: AuthUser,
+  projectOrganizationId: string
+): boolean {
+  return (
+    user.organizationType === "internal" &&
+    user.organizationId === projectOrganizationId &&
+    canUseOrganizationProjectScopeRole(user.role)
+  )
+}
+
+export async function getProjectAccessRecord(
+  db: Db,
+  user: AuthUser,
+  projectId: string
+): Promise<ProjectAccessRecord | null> {
+  const project = await db
+    .select({
+      id: projects.id,
+      organizationId: projects.organizationId,
+      projectNumber: projects.projectNumber,
+    })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .limit(1)
+    .get()
+
+  if (!project) return null
+  if (
+    project.organizationId &&
+    usesOrganizationProjectScope(user, project.organizationId)
+  ) {
+    return project
+  }
+
+  const membership = await db
+    .select({ id: projectMembers.id })
+    .from(projectMembers)
+    .where(
+      and(
+        eq(projectMembers.projectId, projectId),
+        eq(projectMembers.userId, user.id)
+      )
+    )
+    .limit(1)
+    .get()
+
+  return membership ? project : null
+}
+
+export async function assertProjectAccess(
+  db: Db,
+  user: AuthUser,
+  projectId: string
+): Promise<ProjectAccessRecord> {
+  const project = await getProjectAccessRecord(db, user, projectId)
+  if (!project) throw new Error("Project not found")
+  return project
+}

--- a/src/lib/project-audience-access.ts
+++ b/src/lib/project-audience-access.ts
@@ -1,0 +1,11 @@
+export type ProjectAudience = "owner" | "sub_vendor"
+
+export function canUseProjectAudience(
+  projectRole: string | null,
+  audience: ProjectAudience
+): boolean {
+  if (audience === "owner") {
+    return projectRole === "client" || projectRole === "owner"
+  }
+  return projectRole === "subcontractor" || projectRole === "supplier"
+}

--- a/src/lib/user-roles.ts
+++ b/src/lib/user-roles.ts
@@ -193,7 +193,17 @@ export function canManageUserAccessRole(role: string | null | undefined): boolea
 export function canUseOrganizationProjectScopeRole(
   role: string | null | undefined
 ): boolean {
-  return role !== "developer"
+  return role !== null && role !== undefined && isInternalStaffRole(role)
+}
+
+export function isExternalProjectRole(role: string): boolean {
+  return [
+    "client",
+    "owner",
+    "subcontractor",
+    "supplier",
+    "guest",
+  ].includes(role)
 }
 
 export function isInternalStaffRole(role: string): boolean {


### PR DESCRIPTION
## Summary
- restore the visible project-contact invitation workflow
- provision new recipients through WorkOS and send a Compass welcome message
- grant existing users immediate project-scoped membership
- preserve internal staff access while keeping owner and subcontractor/vendor audiences separated
- reconcile safe email placeholders on first verified login and reject expired or deactivated accounts
- restore owner-update access for project owners while keeping drafts internal

## Safety
- no invitations are sent by this change
- production contact candidates remain unchanged until a staff member explicitly sends an invitation
- project membership is checked on every external-facing route

## Verification
- TypeScript passed
- focused test suite: 83 tests passed
- targeted lint passed
- production build passed
- autoreview: no accepted/actionable findings

Refs #156
Refs #185
