### PR TITLE
fix(schedule): preserve Gantt focus across renders

### DIFF
--- a/src/components/schedule/schedule-gantt-view.tsx
+++ b/src/components/schedule/schedule-gantt-view.tsx
@@ -1,6 +1,13 @@
 "use client"
 
-import { useState, useCallback, useEffect, useRef, type UIEvent } from "react"
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type UIEvent,
+} from "react"
 import {
   ResizableHandle,
   ResizablePanel,
@@ -264,21 +271,28 @@ export function ScheduleGanttView({
 
   const filteredTasks = tasks
 
-  const { frappeTasks, displayItems } = phaseGrouping
-    ? transformWithPhaseGroups(
-        filteredTasks as ScheduleTaskData[],
-        dependencies as TaskDependencyData[],
-        collapsedPhases,
-      )
-    : {
-        frappeTasks: transformToFrappeTasks(
-          filteredTasks as ScheduleTaskData[],
-          dependencies as TaskDependencyData[],
-        ),
-        displayItems: filteredTasks.map(
-          (task): DisplayItem => ({ type: "task", task: task as ScheduleTaskData })
-        ),
-      }
+  const { frappeTasks, displayItems } = useMemo(
+    () =>
+      phaseGrouping
+        ? transformWithPhaseGroups(
+            filteredTasks as ScheduleTaskData[],
+            dependencies as TaskDependencyData[],
+            collapsedPhases,
+          )
+        : {
+            frappeTasks: transformToFrappeTasks(
+              filteredTasks as ScheduleTaskData[],
+              dependencies as TaskDependencyData[],
+            ),
+            displayItems: filteredTasks.map(
+              (task): DisplayItem => ({
+                type: "task",
+                task: task as ScheduleTaskData,
+              })
+            ),
+          },
+    [collapsedPhases, dependencies, filteredTasks, phaseGrouping]
+  )
 
   const togglePhase = (phase: string) => {
     setCollapsedPhases((prev) => {


### PR DESCRIPTION
## Summary
- stabilize transformed Gantt task identities across interaction-only renders
- prevent row focus, highlighting, and the edit dialog from causing Frappe to rebuild and reset the timeline

## Live validation finding
After #199 deployed, selecting a task correctly located its bar, but the focus-state render recreated the transformed task array and immediately reset the chart. Memoizing the transformation keeps the already-rendered chart intact until schedule data, grouping, or dependencies actually change.

## Verification
- TypeScript passed
- targeted ESLint passed
- schedule unit suite: 21 tests passed
- production build passed in the pre-push hook

Follow-up to #199
Refs #185
