### PR TITLE
fix(schedule): restore percentage panel sizing

### DIFF
--- a/src/components/schedule/schedule-gantt-view.tsx
+++ b/src/components/schedule/schedule-gantt-view.tsx
@@ -743,7 +743,7 @@ export function ScheduleGanttView({
           orientation="horizontal"
           className="min-w-0 flex-1 min-h-[300px] overflow-hidden border"
         >
-          <ResizablePanel defaultSize={30} minSize={20}>
+          <ResizablePanel defaultSize="30%" minSize="20%">
             <div
               ref={taskListRef}
               className="h-full min-w-0 overflow-auto"
@@ -755,7 +755,7 @@ export function ScheduleGanttView({
 
           <ResizableHandle withHandle />
 
-          <ResizablePanel defaultSize={70} minSize={40}>
+          <ResizablePanel defaultSize="70%" minSize="40%">
             <div className="relative h-full min-w-0 overflow-hidden">
               <GanttChart
                 tasks={frappeTasks}


### PR DESCRIPTION
## Summary
- restore the intended 30/70 desktop schedule split using explicit percentage units
- keep the task list and Gantt visible after the react-resizable-panels v4 sizing semantics change
- unblock live verification of synchronized scrolling and Gantt interactions

## Verification
- targeted ESLint
- TypeScript (`bunx tsc --noEmit`)
- 21 schedule unit tests
- production build (push hook)
