### PR TITLE
fix(conversations): enable thread reply send action

### DIFF
--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -199,6 +199,36 @@ test.describe("usable Compass areas", () => {
     }
   })
 
+  test("project conversation replies enable the explicit send action", async ({
+    page,
+  }) => {
+    const path = "/dashboard/conversations/e2e-channel-001"
+    const response = await page.goto(path)
+    await expectHealthyNavigation(page, response, path)
+
+    const message = page.getByText("Regression conversation message", {
+      exact: true,
+    })
+    await message.hover()
+    await page.getByRole("button", { name: "Reply to message" }).click()
+
+    const threadPanel = page
+      .getByRole("heading", { name: "Thread" })
+      .locator("..")
+      .locator("..")
+    const replyEditor = threadPanel.locator('[contenteditable="true"]').last()
+    const sendButton = threadPanel.getByRole("button", {
+      name: "Send message",
+    })
+
+    await expect(replyEditor).toBeVisible()
+    await expect(sendButton).toBeDisabled()
+    await replyEditor.fill("Unsaved regression reply")
+    await expect(sendButton).toBeEnabled()
+    await replyEditor.fill("")
+    await expect(sendButton).toBeDisabled()
+  })
+
   test("schedule list exposes edit and selection actions", async ({ page }) => {
     const path =
       "/dashboard/projects/e2e-project-001/schedule?view=list"

--- a/scripts/seed-e2e-local.mjs
+++ b/scripts/seed-e2e-local.mjs
@@ -2,7 +2,7 @@ import Database from "better-sqlite3"
 import { mkdirSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 
-const databasePath = resolve(process.env.LOCAL_DB_PATH || ".e2e/compass.db")
+const databasePath = resolve(process.env.LOCAL_DB_PATH || "local.db")
 const now = new Date().toISOString()
 const today = now.slice(0, 10)
 
@@ -82,6 +82,45 @@ const upsert = db.transaction(() => {
       status = excluded.status,
       updated_at = excluded.updated_at
   `).run(today, today, now, now)
+
+  db.prepare(`
+    INSERT INTO channels (
+      id, name, type, description, organization_id, project_id, is_private,
+      audience, created_by, sort_order, created_at, updated_at
+    ) VALUES (
+      'e2e-channel-001', 'regression-project-team', 'text',
+      'Project conversation fixture for reply workflow checks.',
+      'demo-org-meridian', 'e2e-project-001', 0, 'staff',
+      'demo-user-001', 1, ?, ?
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      name = excluded.name,
+      project_id = excluded.project_id,
+      updated_at = excluded.updated_at
+  `).run(now, now)
+
+  db.prepare(`
+    INSERT INTO channel_members (
+      id, channel_id, user_id, role, notify_level, joined_at
+    ) VALUES (
+      'e2e-channel-member-001', 'e2e-channel-001', 'demo-user-001',
+      'owner', 'all', ?
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      role = excluded.role,
+      notify_level = excluded.notify_level
+  `).run(now)
+
+  db.prepare(`
+    INSERT INTO messages (
+      id, channel_id, user_id, content, is_pinned, reply_count, created_at
+    ) VALUES (
+      'e2e-message-001', 'e2e-channel-001', 'demo-user-001',
+      'Regression conversation message', 0, 0, ?
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      content = excluded.content
+  `).run(now)
 
   const overflowScheduleItems = [
     ["e2e-schedule-002", "Overflow schedule item two", 2],

--- a/src/components/conversations/message-composer.tsx
+++ b/src/components/conversations/message-composer.tsx
@@ -332,6 +332,7 @@ export function MessageComposer({
   const [recipientValue, setRecipientValue] = React.useState("channel")
   const [importantDelivery, setImportantDelivery] = React.useState(false)
   const [selectedFiles, setSelectedFiles] = React.useState<readonly File[]>([])
+  const [hasMessageContent, setHasMessageContent] = React.useState(false)
   const hasProjectDelivery = isProjectChannel && !threadId
   const fileInputRef = React.useRef<HTMLInputElement>(null)
 
@@ -388,7 +389,10 @@ export function MessageComposer({
         ),
       },
     },
-    onUpdate: () => {
+    onUpdate: ({ editor: updatedEditor }) => {
+      // TipTap mutates its editor state without causing React to render.
+      // Mirror whether content exists so the explicit Send button stays current.
+      setHasMessageContent(updatedEditor.getText().trim().length > 0)
       setError(null)
       sendTypingIndicator()
     },
@@ -550,6 +554,7 @@ export function MessageComposer({
               ? "The message was sent, but its attachments could not be linked."
               : null
         editor.commands.clearContent()
+        setHasMessageContent(false)
         setSelectedFiles([])
         setImportantDelivery(false)
         if ("data" in result && result.data && "recipientLabel" in result.data) {
@@ -946,7 +951,7 @@ export function MessageComposer({
             onClick={handleSend}
             disabled={
               isSending ||
-              (!editor?.getText().trim() && selectedFiles.length === 0)
+              (!hasMessageContent && selectedFiles.length === 0)
             }
             aria-label="Send message"
             title="Send message"


### PR DESCRIPTION
## Summary
- mirror TipTap message content into React state so the explicit Send control enables while typing a channel or thread reply
- reset the content state after successful delivery
- seed a deterministic project conversation and add a focused reply-composer regression
- align the E2E seed default database with the local app database so the regression suite prepares cleanly

## Root cause
PR #179 restored the reply pane, scrolling, attachments, reactions, and explicit Send control. TipTap updates its internal editor state without necessarily re-rendering React; the button read `editor.getText()` only during a render, so it stayed disabled after a user typed a reply.

## Verification
- targeted ESLint
- TypeScript (`bunx tsc --noEmit`)
- focused reply regression: Chromium, Firefox, WebKit, mobile Chrome, mobile Safari
- production Next.js build (push hook)
- live pre-fix reproduction in the Loeffler project and compass-feedback conversations
