### PR TITLE
fix(compass): restore schedule, owner update, and conversation UX

### DIFF
--- a/scripts/build-buildertrend-daily-log-photo-import.mjs
+++ b/scripts/build-buildertrend-daily-log-photo-import.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env bun
+
+import { readFile, stat, writeFile } from "node:fs/promises"
+
+function usage() {
+  console.error(
+    "Usage: bun scripts/build-buildertrend-daily-log-photo-import.mjs " +
+      "--project-id id --daily-log-id id --buildertrend-daily-log-id id " +
+      "--log-date YYYY-MM-DD --drive-result /absolute/result.json " +
+      "--photo-count number --video-count number --output /absolute/import.sql"
+  )
+}
+
+function parseArgs(argv) {
+  const values = new Map()
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index]
+    const value = argv[index + 1]
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument near ${key ?? "the end"}`)
+    }
+    values.set(key.slice(2), value)
+  }
+
+  const required = [
+    "project-id",
+    "daily-log-id",
+    "buildertrend-daily-log-id",
+    "log-date",
+    "drive-result",
+    "photo-count",
+    "video-count",
+    "output",
+  ]
+  for (const key of required) {
+    if (!values.get(key)) throw new Error(`--${key} is required`)
+  }
+
+  const photoCount = Number.parseInt(values.get("photo-count"), 10)
+  const videoCount = Number.parseInt(values.get("video-count"), 10)
+  if (!Number.isInteger(photoCount) || photoCount < 0) {
+    throw new Error("--photo-count must be a non-negative integer")
+  }
+  if (!Number.isInteger(videoCount) || videoCount < 0) {
+    throw new Error("--video-count must be a non-negative integer")
+  }
+
+  return {
+    projectId: values.get("project-id"),
+    dailyLogId: values.get("daily-log-id"),
+    buildertrendDailyLogId: values.get("buildertrend-daily-log-id"),
+    logDate: values.get("log-date"),
+    driveResult: values.get("drive-result"),
+    photoCount,
+    videoCount,
+    output: values.get("output"),
+  }
+}
+
+function sqlText(value) {
+  if (value === null || value === undefined) return "NULL"
+  return `'${String(value).replaceAll("'", "''")}'`
+}
+
+function sqlInteger(value) {
+  return Number.isInteger(value) ? String(value) : "NULL"
+}
+
+function normalizedDriveFiles(payload) {
+  if (!Array.isArray(payload.files)) {
+    throw new Error("Drive result must contain a files array")
+  }
+
+  return payload.files.map((file, index) => {
+    if (
+      typeof file?.id !== "string" ||
+      file.id.length === 0 ||
+      typeof file?.name !== "string" ||
+      file.name.length === 0 ||
+      typeof file?.mimeType !== "string" ||
+      !file.mimeType.startsWith("image/") ||
+      typeof file?.webViewLink !== "string" ||
+      file.webViewLink.length === 0
+    ) {
+      throw new Error(`Invalid image result at index ${index}`)
+    }
+    return file
+  })
+}
+
+async function fileSize(file) {
+  const path =
+    typeof file.sourcePath === "string"
+      ? file.sourcePath
+      : typeof file.path === "string"
+        ? file.path
+        : null
+  if (path === null) return null
+  try {
+    return (await stat(path)).size
+  } catch {
+    return null
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(options.logDate)) {
+    throw new Error("--log-date must use YYYY-MM-DD")
+  }
+
+  const payload = JSON.parse(await readFile(options.driveResult, "utf8"))
+  const files = normalizedDriveFiles(payload)
+  if (files.length !== options.photoCount) {
+    throw new Error(
+      `Drive result has ${files.length} images; expected ${options.photoCount}`
+    )
+  }
+
+  const now = new Date().toISOString()
+  // Wrangler executes an imported SQL file atomically; explicit BEGIN/COMMIT
+  // statements are rejected by the D1 file-import endpoint.
+  const statements = []
+  for (let index = 0; index < files.length; index += 1) {
+    const file = files[index]
+    const size = await fileSize(file)
+    const id = `bt-dl-photo-${options.buildertrendDailyLogId}-${file.id}`
+    const thumbnailUrl = `/api/google/download/${file.id}`
+
+    statements.push(
+      "INSERT INTO daily_log_photos (" +
+        "id, project_id, daily_log_id, uploaded_by, source_system, " +
+        "source_external_id, file_name, file_size, mime_type, drive_file_id, " +
+        "drive_url, thumbnail_url, caption, captured_at, gps_lat, gps_lng, " +
+        "upload_status, review_status, owner_visible, sub_vendor_visible, " +
+        "public_shareable, photo_kind, schedule_phase_override, sort_order, " +
+        "created_at, updated_at" +
+        ") VALUES (" +
+        [
+          sqlText(id),
+          sqlText(options.projectId),
+          sqlText(options.dailyLogId),
+          "NULL",
+          sqlText("buildertrend"),
+          sqlText(file.id),
+          sqlText(file.name),
+          sqlInteger(size),
+          sqlText(file.mimeType),
+          sqlText(file.id),
+          sqlText(file.webViewLink),
+          sqlText(thumbnailUrl),
+          "NULL",
+          sqlText(options.logDate),
+          "NULL",
+          "NULL",
+          sqlText("uploaded"),
+          sqlText("needs_review"),
+          "0",
+          "0",
+          "0",
+          sqlText("progress"),
+          "NULL",
+          String(index),
+          sqlText(now),
+          sqlText(now),
+        ].join(", ") +
+        ") ON CONFLICT(id) DO UPDATE SET " +
+        "project_id=excluded.project_id, daily_log_id=excluded.daily_log_id, " +
+        "source_system=excluded.source_system, " +
+        "source_external_id=excluded.source_external_id, " +
+        "file_name=excluded.file_name, file_size=excluded.file_size, " +
+        "mime_type=excluded.mime_type, drive_file_id=excluded.drive_file_id, " +
+        "drive_url=excluded.drive_url, thumbnail_url=excluded.thumbnail_url, " +
+        "captured_at=excluded.captured_at, upload_status=excluded.upload_status, " +
+        "sort_order=excluded.sort_order, updated_at=excluded.updated_at;"
+    )
+  }
+
+  statements.push(
+    "UPDATE daily_logs SET tags=json_set(" +
+      "CASE WHEN json_valid(tags) THEN tags ELSE '{}' END, " +
+      `'$.buildertrendPhotoCount', ${options.photoCount}, ` +
+      `'$.buildertrendVideoCount', ${options.videoCount}, ` +
+      `'$.buildertrendMediaCount', ${options.photoCount + options.videoCount}, ` +
+      `'$.buildertrendPhotosArchivedAt', ${sqlText(now)}` +
+      `) WHERE id=${sqlText(options.dailyLogId)} ` +
+      `AND project_id=${sqlText(options.projectId)};`
+  )
+  statements.push("")
+
+  await writeFile(options.output, statements.join("\n"), "utf8")
+  console.log(
+    `Wrote ${files.length} idempotent photo rows for ${options.dailyLogId} to ${options.output}`
+  )
+}
+
+main().catch((error) => {
+  usage()
+  console.error(error instanceof Error ? error.message : error)
+  process.exitCode = 1
+})

--- a/src/app/dashboard/projects/[id]/owner-updates/[updateId]/page.tsx
+++ b/src/app/dashboard/projects/[id]/owner-updates/[updateId]/page.tsx
@@ -1,7 +1,6 @@
 export const dynamic = "force-dynamic"
 
 import type * as React from "react"
-import { headers } from "next/headers"
 import { notFound } from "next/navigation"
 
 import {
@@ -13,20 +12,6 @@ import { redirectIfFeaturePermissionDenied } from "@/lib/permission-redirect"
 
 function hasDigest(error: unknown): error is { readonly digest: string } {
   return typeof error === "object" && error !== null && "digest" in error
-}
-
-function requestOrigin(headerStore: {
-  readonly get: (name: string) => string | null
-}): string | null {
-  const forwardedHost = headerStore.get("x-forwarded-host")
-  const host = forwardedHost ?? headerStore.get("host")
-  if (host === null) return null
-
-  const forwardedProto = headerStore.get("x-forwarded-proto")
-  const proto =
-    forwardedProto ?? (host.startsWith("localhost") ? "http" : "https")
-
-  return `${proto}://${host}`
 }
 
 export default async function OwnerUpdatePage({
@@ -45,17 +30,5 @@ export default async function OwnerUpdatePage({
     notFound()
   }
 
-  const origin = requestOrigin(await headers())
-  const updatePath =
-    `/dashboard/projects/${document.project.id}` +
-    `/owner-updates/${document.update.id}`
-  const absoluteUpdateUrl =
-    origin === null ? undefined : new URL(updatePath, origin).toString()
-
-  return (
-    <OwnerUpdateDocument
-      document={document}
-      absoluteUpdateUrl={absoluteUpdateUrl}
-    />
-  )
+  return <OwnerUpdateDocument document={document} />
 }

--- a/src/components/conversations/message-composer.tsx
+++ b/src/components/conversations/message-composer.tsx
@@ -49,6 +49,7 @@ import { useRouter } from "next/navigation"
 import { useTheme } from "@/components/theme-provider"
 import { cn } from "@/lib/utils"
 import { createMentionSuggestion } from "./mention-suggestion"
+import { normalizeConversationMentions } from "@/lib/conversations/message-content"
 
 // lazy-load emoji picker to keep initial bundle small
 const EmojiPicker = React.lazy(() =>
@@ -517,7 +518,7 @@ export function MessageComposer({
       >
       const editorMarkdown = storage.markdown?.getMarkdown?.() ?? plainText
       const markdown =
-        editorMarkdown.trim() ||
+        normalizeConversationMentions(editorMarkdown).trim() ||
         `Shared ${selectedFiles.length} attachment${
           selectedFiles.length === 1 ? "" : "s"
         }.`

--- a/src/components/conversations/message-item.tsx
+++ b/src/components/conversations/message-item.tsx
@@ -25,6 +25,7 @@ import {
   removeReaction,
 } from "@/app/actions/chat-messages"
 import { useRouter } from "next/navigation"
+import { normalizeConversationMentions } from "@/lib/conversations/message-content"
 
 type MessageData = {
   readonly id: string
@@ -177,7 +178,9 @@ export const MessageItem = React.memo(function MessageItem({ message }: MessageI
         </div>
 
         <div className="chat-markdown mt-1 text-sm">
-          <MarkdownRenderer>{message.content}</MarkdownRenderer>
+          <MarkdownRenderer>
+            {normalizeConversationMentions(message.content)}
+          </MarkdownRenderer>
         </div>
 
         {message.attachments && message.attachments.length > 0 && (

--- a/src/components/conversations/pinned-messages-panel.tsx
+++ b/src/components/conversations/pinned-messages-panel.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { getPinnedMessages, unpinMessage } from "@/app/actions/message-search"
+import { normalizeConversationMentions } from "@/lib/conversations/message-content"
 
 type PinnedMessage = {
   id: string
@@ -190,7 +191,7 @@ export function PinnedMessagesPanel({
                           onClick={() => handleMessageClick(message)}
                         >
                           <p className="line-clamp-3 text-muted-foreground">
-                            {message.content}
+                            {normalizeConversationMentions(message.content)}
                           </p>
                         </button>
 

--- a/src/components/conversations/search-dialog.tsx
+++ b/src/components/conversations/search-dialog.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import { normalizeConversationMentions } from "@/lib/conversations/message-content"
 import { formatDistanceToNow, format, parseISO } from "date-fns"
 import { IconHash, IconUser, IconCalendar, IconSearch, IconLoader2 } from "@tabler/icons-react"
 import {
@@ -313,7 +314,7 @@ export function SearchDialog({
                       </span>
                     </div>
                     <p className="mt-0.5 truncate text-sm text-muted-foreground">
-                      {message.content}
+                      {normalizeConversationMentions(message.content)}
                     </p>
                     <span className="text-xs text-muted-foreground">
                       {timeDisplay}

--- a/src/components/projects/owner-update-actions.tsx
+++ b/src/components/projects/owner-update-actions.tsx
@@ -169,22 +169,26 @@ export function OwnerUpdateActions({
         )}
         {copied === "link" ? "Copied" : "Copy link"}
       </Button>
-      <Button size="sm" variant="outline" onClick={copyEmail}>
-        {copied === "email" ? (
-          <IconCheck className="size-4" />
-        ) : (
-          <IconMail className="size-4" />
-        )}
-        {copied === "email" ? "Copied" : "Copy email draft"}
-      </Button>
-      <Button size="sm" variant="outline" onClick={copyHtmlEmail}>
-        {copied === "html" ? (
-          <IconCheck className="size-4" />
-        ) : (
-          <IconSparkles className="size-4" />
-        )}
-        {copied === "html" ? "Copied" : "Copy HTML email"}
-      </Button>
+      {canManage && (
+        <>
+          <Button size="sm" variant="outline" onClick={copyEmail}>
+            {copied === "email" ? (
+              <IconCheck className="size-4" />
+            ) : (
+              <IconMail className="size-4" />
+            )}
+            {copied === "email" ? "Copied" : "Copy email draft"}
+          </Button>
+          <Button size="sm" variant="outline" onClick={copyHtmlEmail}>
+            {copied === "html" ? (
+              <IconCheck className="size-4" />
+            ) : (
+              <IconSparkles className="size-4" />
+            )}
+            {copied === "html" ? "Copied" : "Copy HTML email"}
+          </Button>
+        </>
+      )}
       {publishError !== null && (
         <p
           className="basis-full border-l-2 border-l-destructive px-3 py-2 text-sm text-destructive"

--- a/src/components/projects/owner-update-document.tsx
+++ b/src/components/projects/owner-update-document.tsx
@@ -3,7 +3,6 @@ import Link from "next/link"
 import {
   IconArrowLeft,
   IconCalendarStats,
-  IconMail,
   IconPhoto,
   IconPhotoUp,
 } from "@tabler/icons-react"
@@ -46,16 +45,13 @@ function projectLabel(document: OwnerProjectUpdateDocument): string {
 
 export function OwnerUpdateDocument({
   document,
-  absoluteUpdateUrl,
 }: {
   readonly document: OwnerProjectUpdateDocument
-  readonly absoluteUpdateUrl?: string
 }): React.ReactElement {
   const label = projectLabel(document)
   const updateUrl =
     `/dashboard/projects/${document.project.id}` +
     `/owner-updates/${document.update.id}`
-  const fullUpdateHref = absoluteUpdateUrl ?? updateUrl
   const emailSubject = `${label} - ${document.update.title}`
   const emailPreview =
     `${document.update.summary} ` +
@@ -323,49 +319,7 @@ export function OwnerUpdateDocument({
             </section>
           )}
 
-          <section className="border-t py-5 print:break-inside-avoid print:border-t print:border-black print:py-4">
-            <h2 className="text-base font-semibold print:text-sm print:uppercase">
-              Full Update
-            </h2>
-            <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground print:text-[11px] print:leading-5 print:text-black">
-              View the full project update and approved photo gallery in
-              Compass:
-            </p>
-            <a
-              href={fullUpdateHref}
-              className="mt-2 inline-block break-all text-sm font-medium text-primary underline underline-offset-4 print:text-[11px] print:text-black"
-            >
-              {fullUpdateHref}
-            </a>
-          </section>
         </article>
-
-        <section
-          id="email-preview"
-          className="bg-background p-5 shadow-sm sm:p-6 print:hidden"
-        >
-          <div className="flex items-center gap-2">
-            <IconMail className="size-4 text-muted-foreground" />
-            <h2 className="text-sm font-semibold">Email Preview</h2>
-          </div>
-          <div className="mt-4 overflow-hidden rounded-md border">
-            <div className="border-b bg-muted/40 px-4 py-3">
-              <p className="text-xs text-muted-foreground">Subject</p>
-              <p className="mt-1 text-sm font-medium">{emailSubject}</p>
-            </div>
-            <div className="px-4 py-4">
-              <p className="text-base font-semibold">
-                New project update for {label}
-              </p>
-              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-                {emailPreview}
-              </p>
-              <Button asChild className="mt-4">
-                <Link href={updateUrl}>View full update</Link>
-              </Button>
-            </div>
-          </div>
-        </section>
       </div>
     </main>
   )

--- a/src/components/schedule/gantt-chart.tsx
+++ b/src/components/schedule/gantt-chart.tsx
@@ -8,6 +8,78 @@ import "./gantt.css"
 
 type ViewMode = "Day" | "Week" | "Month"
 
+function monthYearLabel(date: Date): string {
+  return date.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+  })
+}
+
+function monthYearAtBoundary(date: Date, previousDate: Date | null): string {
+  return previousDate === null ||
+    date.getMonth() !== previousDate.getMonth() ||
+    date.getFullYear() !== previousDate.getFullYear()
+    ? monthYearLabel(date)
+    : ""
+}
+
+function weekLabel(date: Date, previousDate: Date | null): string {
+  const end = new Date(date)
+  end.setDate(end.getDate() + 6)
+  const includeStartMonth =
+    previousDate === null ||
+    date.getMonth() !== previousDate.getMonth() ||
+    date.getFullYear() !== previousDate.getFullYear()
+  const includeEndMonth =
+    end.getMonth() !== date.getMonth() ||
+    end.getFullYear() !== date.getFullYear()
+  const startLabel = includeStartMonth
+    ? date.toLocaleDateString("en-US", { day: "numeric", month: "short" })
+    : date.toLocaleDateString("en-US", { day: "numeric" })
+  const endLabel = includeEndMonth
+    ? end.toLocaleDateString("en-US", { day: "numeric", month: "short" })
+    : end.toLocaleDateString("en-US", { day: "numeric" })
+  return `${startLabel} - ${endLabel}`
+}
+
+const GANTT_VIEW_MODES = [
+  {
+    name: "Day",
+    padding: "7d",
+    date_format: "YYYY-MM-DD",
+    step: "1d",
+    lower_text: "D",
+    upper_text: monthYearAtBoundary,
+    thick_line: (date: Date) => date.getDay() === 1,
+  },
+  {
+    name: "Week",
+    padding: "1m",
+    step: "7d",
+    date_format: "YYYY-MM-DD",
+    column_width: 140,
+    lower_text: weekLabel,
+    upper_text: monthYearAtBoundary,
+    upper_text_frequency: 4,
+    thick_line: (date: Date) => date.getDate() >= 1 && date.getDate() <= 7,
+  },
+  {
+    name: "Month",
+    padding: "2m",
+    step: "1m",
+    column_width: 120,
+    date_format: "YYYY-MM",
+    lower_text: monthYearLabel,
+    upper_text: (date: Date, previousDate: Date | null) =>
+      previousDate === null ||
+      date.getFullYear() !== previousDate.getFullYear()
+        ? date.getFullYear().toString()
+        : "",
+    thick_line: (date: Date) => date.getMonth() % 3 === 0,
+    snap_at: "7d",
+  },
+]
+
 interface GanttChartProps {
   tasks: FrappeTask[]
   viewMode: ViewMode
@@ -160,6 +232,7 @@ export function GanttChart({
 
       ganttRef.current = new Gantt(containerRef.current, ganttTasks, {
         view_mode: viewMode,
+        view_modes: GANTT_VIEW_MODES,
         ...(columnWidth ? { column_width: columnWidth } : {}),
         on_date_change: (task: { id: string }, start: Date, end: Date) => {
           if (onDateChange) {

--- a/src/components/schedule/gantt.css
+++ b/src/components/schedule/gantt.css
@@ -54,8 +54,8 @@
 .gantt-container .upper-header{height:var(--gv-upper-header-height)}
 .gantt-container .lower-header{height:var(--gv-lower-header-height)}
 .gantt-container .lower-text{font-size:12px;position:absolute;width:calc(var(--gv-column-width) * .8);height:calc(var(--gv-lower-header-height) * .8);margin:0 calc(var(--gv-column-width) * .1);align-content:center;text-align:center;color:var(--g-text-muted)}
-.gantt-container .upper-text{position:absolute;width:fit-content;font-weight:500;font-size:14px;color:var(--g-text-dark);height:calc(var(--gv-lower-header-height) * .66)}
-.gantt-container .current-upper{position:sticky;left:0!important;padding-left:17px;background:#fff}
+.gantt-container .upper-text{position:absolute;width:max-content;white-space:nowrap;font-weight:500;font-size:14px;color:var(--g-text-dark);height:calc(var(--gv-lower-header-height) * .66)}
+.gantt-container .current-upper{position:sticky;left:0!important;z-index:2;box-sizing:border-box;padding:0 12px 0 17px;background:var(--g-header-background)}
 .gantt-container .side-header{position:sticky;top:0;right:0;float:right;z-index:1000;line-height:20px;font-weight:400;width:max-content;margin-left:auto;padding-right:10px;padding-top:10px;background:var(--g-header-background);display:flex}
 .gantt-container .side-header *{transition-property:background-color;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s;background-color:var(--g-actions-background);border-radius:.5rem;border:none;padding:5px 8px;color:var(--g-text-dark);font-size:14px;letter-spacing:.02em;font-weight:420;box-sizing:content-box;margin-right:5px}
 .gantt-container .side-header *:last-child{margin-right:0}

--- a/src/lib/conversations/__tests__/message-content.test.ts
+++ b/src/lib/conversations/__tests__/message-content.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest"
+
+import { normalizeConversationMentions } from "../message-content"
+
+describe("normalizeConversationMentions", () => {
+  it("renders TipTap mention spans as their visible labels", () => {
+    expect(
+      normalizeConversationMentions(
+        '<span class="mention" data-type="mention" data-id="user-1" ' +
+          'data-label="Wes Jones">@Wes Jones</span> please refresh Compass.'
+      )
+    ).toBe("@Wes Jones please refresh Compass.")
+  })
+
+  it("supports sanitized attribute ordering and quotes", () => {
+    expect(
+      normalizeConversationMentions(
+        "<span data-id='user-2' data-type='mention' class='mention'>" +
+          "@Martine &amp; team</span>"
+      )
+    ).toBe("@Martine & team")
+  })
+
+  it("does not reinterpret unrelated HTML as a mention", () => {
+    const content = "<span class=\"note\">Keep this literal</span>"
+    expect(normalizeConversationMentions(content)).toBe(content)
+  })
+})

--- a/src/lib/conversations/message-content.ts
+++ b/src/lib/conversations/message-content.ts
@@ -1,0 +1,29 @@
+const MENTION_SPAN_PATTERN =
+  /<span\b(?=[^>]*\bdata-type=(["'])mention\1)[^>]*>([^<]*)<\/span>/gi
+
+const HTML_ENTITIES: Readonly<Record<string, string>> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+}
+
+function decodeBasicHtmlEntities(value: string): string {
+  return value.replace(
+    /&(amp|lt|gt|quot|#39);/g,
+    (entity) => HTML_ENTITIES[entity] ?? entity
+  )
+}
+
+/**
+ * TipTap Markdown serializes custom mention nodes as HTML. Conversations store
+ * Markdown, so convert only those known mention spans back to their visible
+ * text before saving or rendering legacy messages.
+ */
+export function normalizeConversationMentions(content: string): string {
+  return content.replace(
+    MENTION_SPAN_PATTERN,
+    (_match, _quote, label: string) => decodeBasicHtmlEntities(label)
+  )
+}

--- a/src/types/frappe-gantt.d.ts
+++ b/src/types/frappe-gantt.d.ts
@@ -11,6 +11,8 @@ declare module "frappe-gantt" {
 
   interface GanttOptions {
     view_mode?: string
+    view_modes?: readonly GanttViewMode[]
+    column_width?: number
     on_date_change?: (
       task: { id: string },
       start: Date,
@@ -20,6 +22,23 @@ declare module "frappe-gantt" {
       task: { id: string },
       progress: number
     ) => void
+  }
+
+  interface GanttViewMode {
+    readonly name: string
+    readonly padding?: string
+    readonly step?: string
+    readonly date_format?: string
+    readonly column_width?: number
+    readonly lower_text?:
+      | string
+      | ((date: Date, previousDate: Date | null, language: string) => string)
+    readonly upper_text?:
+      | string
+      | ((date: Date, previousDate: Date | null, language: string) => string)
+    readonly upper_text_frequency?: number
+    readonly thick_line?: (date: Date) => boolean
+    readonly snap_at?: string
   }
 
   export default class Gantt {


### PR DESCRIPTION
## What

- show month and year in Gantt timeline headers and stabilize the sticky left header while scrolling
- remove the redundant self-link and email preview from published owner updates
- keep email-draft actions staff-only
- render TipTap mentions as readable @labels in conversations, search, and pinned messages, including existing messages
- add an idempotent Buildertrend daily-log photo import builder for Drive-backed images

## Why

Recent UI regressions made schedule context ambiguous, exposed internal owner-update tooling in the published reader, and displayed mention markup literally. Buildertrend daily-log media metadata also existed without attached photo records.

## Production data remediation

Archived and attached 514 missing daily-log images across the two affected active projects. New records remain needs-review and not owner-visible until staff explicitly approves them. Existing July 22 media counts were reconciled separately.

## Validation

- production build and TypeScript check
- 29 focused conversation, schedule, and owner-update tests
- targeted ESLint (no errors; one pre-existing image optimization warning)
- production D1 reconciliation: expected photo counts equal attached photo counts for all five affected logs
