### PR TITLE
fix(schedule): preserve selected gantt view

### DIFF
--- a/src/components/schedule/gantt-chart.tsx
+++ b/src/components/schedule/gantt-chart.tsx
@@ -247,6 +247,9 @@ export function GanttChart({
           }
         },
       })
+      // Frappe resets a custom view-mode collection to its first entry during
+      // construction, so explicitly restore the React-selected mode.
+      ganttRef.current.change_view_mode(viewMode)
 
       const tasksById = new Map(tasks.map((task) => [task.id, task]))
       for (const wrapper of containerRef.current.querySelectorAll<HTMLElement>(


### PR DESCRIPTION
## what
- keep Frappe Gantt synchronized with the selected Day, Week, or Month view

## why
Frappe resets custom view modes to the first entry during construction. A React reinitialization race could therefore leave Month selected while the chart displayed Day headers.

## how to test
- bun test src/lib/schedule/__tests__/appearance.test.ts src/lib/conversations/__tests__/message-content.test.ts
- bunx eslint src/components/schedule/gantt-chart.tsx
- bunx tsc --noEmit
- verify Day, Week, and Month headers in production