### PR TITLE
fix(owner-updates): restore build from logs

### DIFF
--- a/src/app/actions/project-field.ts
+++ b/src/app/actions/project-field.ts
@@ -1680,9 +1680,7 @@ export async function draftOwnerUpdateFromDailyLogs(
       .where(
         and(
           eq(dailyLogs.projectId, projectId),
-          inArray(dailyLogs.id, dailyLogIds),
-          eq(dailyLogs.reviewStatus, "approved"),
-          eq(dailyLogs.isClientVisible, true)
+          inArray(dailyLogs.id, dailyLogIds)
         )
       )
       .orderBy(asc(dailyLogs.logDate), asc(dailyLogs.createdAt))
@@ -1690,8 +1688,7 @@ export async function draftOwnerUpdateFromDailyLogs(
     if (selectedLogs.length !== dailyLogIds.length) {
       return {
         success: false,
-        error:
-          "Every selected daily log must be approved and owner-visible before drafting.",
+        error: "One or more selected daily logs could not be found.",
       }
     }
 
@@ -1751,6 +1748,7 @@ export async function draftOwnerUpdateFromDailyLogs(
 
     revalidatePath(`/dashboard/projects/${projectId}`)
     revalidatePath(`/dashboard/projects/${projectId}/daily-logs`)
+    revalidatePath(`/dashboard/projects/${projectId}/owner-updates`)
     revalidatePath(`/dashboard/projects/${projectId}/owner-updates/${updateId}`)
 
     return { success: true, updateId }

--- a/src/app/dashboard/projects/[id]/owner-updates/page.tsx
+++ b/src/app/dashboard/projects/[id]/owner-updates/page.tsx
@@ -171,7 +171,9 @@ export default async function ProjectOwnerUpdatesPage({
           {internalViewer && (
             <div className="flex flex-wrap justify-end gap-2">
               <Button asChild>
-                <Link href={`/dashboard/projects/${project.id}/daily-logs`}>
+                <Link
+                  href={`/dashboard/projects/${project.id}/daily-logs#owner-update-builder`}
+                >
                   <IconClipboardText className="size-4" />
                   Build From Logs
                 </Link>

--- a/src/components/projects/project-daily-log-workspace.tsx
+++ b/src/components/projects/project-daily-log-workspace.tsx
@@ -241,10 +241,6 @@ function selectedLogIds(
   return selectedIds.filter((id) => availableIds.has(id))
 }
 
-function isOwnerUpdateEligibleLog(log: ProjectDailyLogItem): boolean {
-  return log.reviewStatus === "approved" && log.isClientVisible
-}
-
 function LogMetric({
   label,
   value,
@@ -576,9 +572,7 @@ export function ProjectDailyLogWorkspace({
     () => logs.filter((log) => selectedIds.includes(log.id)),
     [logs, selectedIds]
   )
-  const ownerUpdateSelectedIds = selectedLogs
-    .filter(isOwnerUpdateEligibleLog)
-    .map((log) => log.id)
+  const ownerUpdateSelectedIds = selectedLogs.map((log) => log.id)
   const printAuthorOptions = React.useMemo(
     () =>
       [...new Set(logs.map((log) => log.authorName).filter(
@@ -1203,7 +1197,10 @@ export function ProjectDailyLogWorkspace({
           </section>
         )}
 
-        <section className="rounded-lg border p-3 sm:p-4">
+        <section
+          id="owner-update-builder"
+          className="scroll-mt-4 rounded-lg border p-3 sm:p-4"
+        >
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="flex flex-wrap items-center gap-2">
               <select
@@ -1223,18 +1220,28 @@ export function ProjectDailyLogWorkspace({
                 Clear
               </Button>
             </div>
-            <div className="text-sm text-muted-foreground">
-              {selectedLogs.length} selected
-              {selectedLogs.length !== selectedIdsInView.length
-                ? ` · ${selectedIdsInView.length} in view`
-                : ""}{" "}
-              · {filteredLogs.length} shown · {ownerUpdateSelectedIds.length}{" "}
-              owner-update ready
+            <div className="flex flex-wrap items-center justify-end gap-3">
+              <div className="text-sm text-muted-foreground">
+                {selectedLogs.length} selected
+                {selectedLogs.length !== selectedIdsInView.length
+                  ? ` · ${selectedIdsInView.length} in view`
+                  : ""}{" "}
+                · {filteredLogs.length} shown
+              </div>
+              <Button
+                size="sm"
+                onClick={draftOwnerUpdate}
+                disabled={isPending || ownerUpdateSelectedIds.length === 0}
+              >
+                <IconMailForward className="size-4" />
+                Build draft from selected
+              </Button>
             </div>
           </div>
           <p className="mt-2 text-xs text-muted-foreground">
-            Any checked log can be printed. Owner updates include only checked
-            logs that are approved and marked Owner visible.
+            Selected logs create a staff-only owner update draft. Only photos
+            that have been approved and marked Owner visible are attached, and
+            nothing is shared with the owner until the draft is published.
           </p>
           {message && (
             <p className="mt-3 rounded-md border bg-muted/30 px-3 py-2 text-sm">
@@ -1603,7 +1610,8 @@ export function ProjectDailyLogWorkspace({
                       </div>
                       <p className="mt-1 text-xs text-muted-foreground">
                         Shared uploads are approved immediately. Leave both
-                        unchecked to keep them in staff review.
+                        unchecked to keep them in staff review. Marking a file
+                        for Owners does not make the daily log owner-visible.
                       </p>
                     </fieldset>
                     <div className="flex items-end">


### PR DESCRIPTION
## what
- restore a visible Build draft from selected action beside daily-log selection controls
- allow staff-selected logs to seed a staff-only owner update draft without first exposing the logs to owners
- attach only photos separately approved and marked owner-visible
- preserve independent photo and daily-log visibility

## why
The former eligibility filter silently discarded selected logs and left the only draft action disabled above the working area, making Build From Logs appear broken.

## how to test
- focused owner-update and daily-log unit tests
- targeted ESLint and TypeScript
- production Next.js build
- live verification of selection, draft action, and visibility copy