### PR TITLE
feat(owner-updates): add manual drafts and deletion

### DIFF
--- a/src/app/actions/project-field.ts
+++ b/src/app/actions/project-field.ts
@@ -1763,6 +1763,139 @@ export async function draftOwnerUpdateFromDailyLogs(
   }
 }
 
+export async function createManualOwnerProjectUpdateDraft(
+  projectId: string,
+  updateDate: string
+): Promise<OwnerUpdateDraftResult> {
+  try {
+    const { db, userId } = await verifyProjectMutationAccess(
+      projectId,
+      "owner-updates"
+    )
+    const normalizedDate = updateDate.trim()
+    if (!isValidOwnerUpdatePeriod(normalizedDate, normalizedDate)) {
+      return { success: false, error: "Enter a valid update date." }
+    }
+
+    const [project] = await db
+      .select({
+        id: projects.id,
+        name: projects.name,
+        projectNumber: projects.projectNumber,
+      })
+      .from(projects)
+      .where(eq(projects.id, projectId))
+      .limit(1)
+
+    if (!project) {
+      return { success: false, error: "Project not found." }
+    }
+
+    const updateId = crypto.randomUUID()
+    const now = new Date().toISOString()
+    const label = project.projectNumber ?? project.name
+    const scheduleSnapshot = await captureOwnerUpdateSchedule(
+      db,
+      projectId,
+      normalizedDate
+    )
+
+    await db.insert(ownerProjectUpdates).values({
+      id: updateId,
+      projectId,
+      createdBy: userId,
+      title: `${label} Owner Update - ${normalizedDate}`,
+      updateDate: normalizedDate,
+      summary: "",
+      status: "draft",
+      channel: "compass",
+      sourceDailyLogIds: "[]",
+      selectedPhotoIds: "[]",
+      periodStart: normalizedDate,
+      periodEnd: normalizedDate,
+      scheduleSnapshot:
+        serializeOwnerUpdateScheduleSnapshot(scheduleSnapshot),
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    revalidatePath(`/dashboard/projects/${projectId}`)
+    revalidatePath(`/dashboard/projects/${projectId}/owner-updates`)
+    revalidatePath(`/dashboard/projects/${projectId}/owner-updates/${updateId}`)
+
+    return { success: true, updateId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to create owner update.",
+    }
+  }
+}
+
+export async function deleteOwnerProjectUpdateDraft(
+  projectId: string,
+  updateId: string
+): Promise<
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string }
+> {
+  try {
+    const { db } = await verifyProjectMutationAccess(
+      projectId,
+      "owner-updates"
+    )
+    const [update] = await db
+      .select({
+        id: ownerProjectUpdates.id,
+        status: ownerProjectUpdates.status,
+      })
+      .from(ownerProjectUpdates)
+      .where(
+        and(
+          eq(ownerProjectUpdates.id, updateId),
+          eq(ownerProjectUpdates.projectId, projectId)
+        )
+      )
+      .limit(1)
+
+    if (!update) {
+      return { success: false, error: "Owner update not found." }
+    }
+    if (update.status !== "draft") {
+      return {
+        success: false,
+        error: "Only draft owner updates can be deleted.",
+      }
+    }
+
+    await db
+      .delete(ownerProjectUpdates)
+      .where(
+        and(
+          eq(ownerProjectUpdates.id, updateId),
+          eq(ownerProjectUpdates.projectId, projectId),
+          eq(ownerProjectUpdates.status, "draft")
+        )
+      )
+
+    revalidatePath(`/dashboard/projects/${projectId}`)
+    revalidatePath(`/dashboard/projects/${projectId}/owner-updates`)
+
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to delete owner update.",
+    }
+  }
+}
+
 export async function getOwnerProjectUpdateDocument(
   projectId: string,
   updateId: string
@@ -2063,7 +2196,7 @@ export async function updateOwnerProjectUpdateDraft(
 
     const sourceDailyLogIds = parseIdList(update.sourceDailyLogIds)
     if (sourceDailyLogIds.length > 0) {
-      const eligibleLogs = await db
+      const selectedLogs = await db
         .select({
           id: dailyLogs.id,
           logDate: dailyLogs.logDate,
@@ -2072,22 +2205,19 @@ export async function updateOwnerProjectUpdateDraft(
         .where(
           and(
             eq(dailyLogs.projectId, projectId),
-            inArray(dailyLogs.id, sourceDailyLogIds),
-            eq(dailyLogs.reviewStatus, "approved"),
-            eq(dailyLogs.isClientVisible, true)
+            inArray(dailyLogs.id, sourceDailyLogIds)
           )
         )
 
-      if (eligibleLogs.length !== sourceDailyLogIds.length) {
+      if (selectedLogs.length !== sourceDailyLogIds.length) {
         return {
           success: false,
-          error:
-            "Every source daily log must remain approved and owner-visible.",
+          error: "One or more source daily logs could not be found.",
         }
       }
 
       if (
-        eligibleLogs.some(
+        selectedLogs.some(
           (log) =>
             !isDateWithinOwnerUpdatePeriod(
               log.logDate,
@@ -2245,7 +2375,7 @@ export async function publishOwnerProjectUpdate(
 
   const sourceDailyLogIds = parseIdList(update.sourceDailyLogIds)
   const selectedPhotoIds = parseIdList(update.selectedPhotoIds)
-  const eligibleLogs =
+  const selectedLogs =
     sourceDailyLogIds.length === 0
       ? []
       : await db
@@ -2257,22 +2387,19 @@ export async function publishOwnerProjectUpdate(
           .where(
             and(
               eq(dailyLogs.projectId, projectId),
-              inArray(dailyLogs.id, sourceDailyLogIds),
-              eq(dailyLogs.reviewStatus, "approved"),
-              eq(dailyLogs.isClientVisible, true)
+              inArray(dailyLogs.id, sourceDailyLogIds)
             )
           )
 
-  if (eligibleLogs.length !== sourceDailyLogIds.length) {
+  if (selectedLogs.length !== sourceDailyLogIds.length) {
     return {
       success: false,
-      error:
-        "Every source daily log must be approved and owner-visible before publishing.",
+      error: "One or more source daily logs could not be found.",
     }
   }
 
   const derivedPeriod = dateRangeFromDates(
-    eligibleLogs.map((log) => log.logDate)
+    selectedLogs.map((log) => log.logDate)
   )
   const periodStart =
     update.periodStart ?? derivedPeriod?.startDate ?? update.updateDate
@@ -2287,7 +2414,7 @@ export async function publishOwnerProjectUpdate(
   }
 
   if (
-    eligibleLogs.some(
+    selectedLogs.some(
       (log) =>
         !isDateWithinOwnerUpdatePeriod(
           log.logDate,

--- a/src/app/dashboard/projects/[id]/owner-updates/page.tsx
+++ b/src/app/dashboard/projects/[id]/owner-updates/page.tsx
@@ -27,6 +27,7 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { ProjectContextSwitcher } from "@/components/projects/project-context-switcher"
+import { OwnerUpdateCreateButton } from "@/components/projects/owner-update-create-button"
 import { getCurrentUser } from "@/lib/auth"
 import { redirectIfFeaturePermissionDenied } from "@/lib/permission-redirect"
 import { isInternalStaffRole } from "@/lib/user-roles"
@@ -178,6 +179,7 @@ export default async function ProjectOwnerUpdatesPage({
                   Build From Logs
                 </Link>
               </Button>
+              <OwnerUpdateCreateButton projectId={project.id} />
               <Button asChild variant="outline">
                 <Link href={`/dashboard/projects/${project.id}/photos`}>
                   <IconPhoto className="size-4" />

--- a/src/components/projects/owner-update-actions.tsx
+++ b/src/components/projects/owner-update-actions.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 import {
   IconCheck,
   IconCopy,
@@ -8,9 +9,13 @@ import {
   IconPrinter,
   IconSparkles,
   IconSend,
+  IconTrash,
 } from "@tabler/icons-react"
 
-import { publishOwnerProjectUpdate } from "@/app/actions/project-field"
+import {
+  deleteOwnerProjectUpdateDraft,
+  publishOwnerProjectUpdate,
+} from "@/app/actions/project-field"
 import { Button } from "@/components/ui/button"
 
 export function OwnerUpdateActions({
@@ -34,7 +39,9 @@ export function OwnerUpdateActions({
   readonly projectLabel: string
   readonly updateTitle: string
 }): React.ReactElement {
+  const router = useRouter()
   const [isPublishing, setIsPublishing] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
   const [publishError, setPublishError] = useState<string | null>(null)
   const [copied, setCopied] = useState<"link" | "email" | "html" | null>(null)
 
@@ -149,12 +156,47 @@ export function OwnerUpdateActions({
     }
   }
 
+  async function deleteDraft(): Promise<void> {
+    const confirmed = window.confirm(
+      "Delete this owner update draft? This cannot be undone."
+    )
+    if (!confirmed) return
+
+    setPublishError(null)
+    setIsDeleting(true)
+    try {
+      const result = await deleteOwnerProjectUpdateDraft(projectId, updateId)
+      if (!result.success) {
+        setPublishError(result.error)
+        return
+      }
+
+      router.push(`/dashboard/projects/${projectId}/owner-updates`)
+      router.refresh()
+    } catch {
+      setPublishError("Unable to delete this draft. Please try again.")
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
   return (
     <div className="flex flex-wrap items-center gap-2 print:hidden">
       {canManage && status !== "published" && (
         <Button size="sm" onClick={publish} disabled={isPublishing}>
           <IconSend className="size-4" />
           {isPublishing ? "Publishing..." : "Publish"}
+        </Button>
+      )}
+      {canManage && status === "draft" && (
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={deleteDraft}
+          disabled={isDeleting}
+        >
+          <IconTrash className="size-4" />
+          {isDeleting ? "Deleting..." : "Delete draft"}
         </Button>
       )}
       <Button size="sm" onClick={printOwnerUpdate}>

--- a/src/components/projects/owner-update-create-button.tsx
+++ b/src/components/projects/owner-update-create-button.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import * as React from "react"
+import { useRouter } from "next/navigation"
+import { IconFilePlus } from "@tabler/icons-react"
+
+import { createManualOwnerProjectUpdateDraft } from "@/app/actions/project-field"
+import { Button } from "@/components/ui/button"
+
+function localDateValue(): string {
+  const now = new Date()
+  const offsetMs = now.getTimezoneOffset() * 60_000
+  return new Date(now.getTime() - offsetMs).toISOString().slice(0, 10)
+}
+
+export function OwnerUpdateCreateButton({
+  projectId,
+}: {
+  readonly projectId: string
+}): React.ReactElement {
+  const router = useRouter()
+  const [isPending, startTransition] = React.useTransition()
+  const [error, setError] = React.useState<string | null>(null)
+
+  function createDraft(): void {
+    setError(null)
+    startTransition(async () => {
+      const result = await createManualOwnerProjectUpdateDraft(
+        projectId,
+        localDateValue()
+      )
+      if (!result.success) {
+        setError(result.error)
+        return
+      }
+
+      router.push(
+        `/dashboard/projects/${projectId}/owner-updates/${result.updateId}`
+      )
+    })
+  }
+
+  return (
+    <div>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={createDraft}
+        disabled={isPending}
+      >
+        <IconFilePlus className="size-4" />
+        {isPending ? "Creating..." : "New Manual Update"}
+      </Button>
+      {error !== null && (
+        <p className="mt-1 max-w-64 text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/projects/owner-update-draft-editor.tsx
+++ b/src/components/projects/owner-update-draft-editor.tsx
@@ -172,9 +172,10 @@ export function OwnerUpdateDraftEditor({
           </div>
         </div>
         <p className="text-xs text-muted-foreground">
-          {document.update.sourceDailyLogIds.length} approved owner-visible daily
+          {document.update.sourceDailyLogIds.length} source daily
           {document.update.sourceDailyLogIds.length === 1 ? " log is" : " logs are"}{" "}
-          included. Saving refreshes the Looking Ahead schedule for the end of
+          included. Owner-hidden logs can seed this draft without exposing the
+          full log. Saving refreshes the Looking Ahead schedule for the end of
           this period.
         </p>
 


### PR DESCRIPTION
## what
- add a New Manual Update action that opens a blank staff-only draft
- allow only draft owner updates to be deleted, with confirmation and server-side status enforcement
- let owner-hidden source logs seed draft summaries and owner-visible photos without exposing the full daily log
- preserve approved/owner-visible enforcement for every selected photo

## why
Staff need to prepare updates without daily logs, discard unused drafts, and use selected owner-facing photos without publishing the underlying internal log.

## how to test
- focused owner-update and photo-visibility tests
- targeted ESLint and TypeScript
- production Next.js build
- live manual-draft and draft-only action verification