### PR TITLE
feat(owner-updates): add curated update composer

### DIFF
--- a/src/app/actions/project-field.ts
+++ b/src/app/actions/project-field.ts
@@ -24,16 +24,35 @@ import {
   dateRangeFromDates,
   isDateWithinOwnerUpdatePeriod,
   isValidOwnerUpdatePeriod,
-  parseOwnerUpdateScheduleSnapshot,
+  parseOwnerUpdateComposerSnapshot,
   selectRowsByIdOrder,
-  serializeOwnerUpdateScheduleSnapshot,
-  type OwnerUpdateScheduleItem,
+  serializeOwnerUpdateComposerSnapshot,
+  type OwnerUpdateComposerSnapshot,
+  type OwnerUpdateDocumentSelection,
+  type OwnerUpdateScheduleSelection,
+  type OwnerUpdateTodoSelection,
 } from "@/lib/owner-updates/snapshot"
+import {
+  buildOwnerUpdateDraftPrompt,
+  cleanOwnerUpdateDraft,
+  defaultOwnerUpdatePeriod,
+  isCompletedScheduleCandidate,
+  isLookAheadScheduleCandidate,
+  ownerUpdateTodoTiming,
+} from "@/lib/owner-updates/composer"
 import { isOwnerUpdateVisibleToRole } from "@/lib/owner-updates/history"
 import { can } from "@/lib/permissions"
 import { requireFeaturePermission } from "@/lib/permission-enforcement"
 import { assertProjectAccess } from "@/lib/project-access"
 import { canUseProjectAudience } from "@/lib/project-audience-access"
+import {
+  PROJECT_TODO_RECORD_TYPES,
+  isArchivedProjectTodoStatus,
+} from "@/lib/project-todos"
+import {
+  isJarvisAgentBridgeEnabled,
+  relayAgentRequest,
+} from "@/lib/jarvis/agent-relay"
 import { isInternalStaffRole } from "@/lib/user-roles"
 import { revalidatePath } from "next/cache"
 
@@ -93,6 +112,7 @@ type OwnerUpdateProject = {
 
 type OwnerUpdateDailyLog = {
   readonly id: string
+  readonly sourceSystem: string
   readonly logDate: string
   readonly workCompleted: string
   readonly weather: string | null
@@ -101,16 +121,22 @@ type OwnerUpdateDailyLog = {
   readonly issues: string | null
   readonly nextSteps: string | null
   readonly authorName: string | null
+  readonly reviewStatus: string
+  readonly isClientVisible: boolean
 }
 
 type OwnerUpdatePhoto = {
   readonly id: string
+  readonly sourceSystem: string
   readonly fileName: string
+  readonly mimeType: string | null
   readonly driveFileId: string | null
   readonly driveUrl: string | null
   readonly thumbnailUrl: string | null
   readonly caption: string | null
   readonly capturedAt: string | null
+  readonly reviewStatus: string
+  readonly ownerVisible: boolean
 }
 
 type OwnerUpdatePhotoFolder = {
@@ -250,7 +276,12 @@ export type OwnerUpdateDraftEditInput = {
   readonly periodStart: string
   readonly periodEnd: string
   readonly summary: string
+  readonly sourceDailyLogIds: readonly string[]
   readonly selectedPhotoIds: readonly string[]
+  readonly selectedDocumentIds: readonly string[]
+  readonly completedScheduleItems: readonly OwnerUpdateScheduleSelection[]
+  readonly lookAheadScheduleItems: readonly OwnerUpdateScheduleSelection[]
+  readonly todos: readonly OwnerUpdateTodoSelection[]
 }
 
 type DailyLogMutationResult =
@@ -287,12 +318,16 @@ export type OwnerProjectUpdateDocument = {
     readonly sentAt: string | null
     readonly sourceDailyLogIds: readonly string[]
     readonly selectedPhotoIds: readonly string[]
+    readonly selectedDocumentIds: readonly string[]
     readonly periodStart: string | null
     readonly periodEnd: string | null
   }
   readonly dailyLogs: readonly OwnerUpdateDailyLog[]
+  readonly availableDailyLogs: readonly OwnerUpdateDailyLog[]
   readonly photos: readonly OwnerUpdatePhoto[]
   readonly availablePhotos: readonly OwnerUpdatePhoto[]
+  readonly documents: readonly OwnerUpdateDocumentSelection[]
+  readonly availableDocuments: readonly OwnerUpdateDocumentSelection[]
   readonly photoFolder: OwnerUpdatePhotoFolder | null
   readonly nextScheduleItem: {
     readonly title: string
@@ -301,11 +336,20 @@ export type OwnerProjectUpdateDocument = {
     readonly assignedTo: string | null
   } | null
   readonly lookAheadScheduleItems: readonly {
+    readonly id: string
     readonly title: string
     readonly startDate: string
     readonly endDate: string
     readonly assignedTo: string | null
+    readonly status: string
+    readonly percentComplete: number
+    readonly notes: string
   }[]
+  readonly completedScheduleItems: readonly OwnerUpdateScheduleSelection[]
+  readonly availableCompletedScheduleItems: readonly OwnerUpdateScheduleSelection[]
+  readonly availableLookAheadScheduleItems: readonly OwnerUpdateScheduleSelection[]
+  readonly todos: readonly OwnerUpdateTodoSelection[]
+  readonly availableTodos: readonly OwnerUpdateTodoSelection[]
 }
 
 export type ProjectFieldSummary = {
@@ -348,27 +392,115 @@ function parseIdList(value: string | null): readonly string[] {
   }
 }
 
-async function captureOwnerUpdateSchedule(
+async function getOwnerUpdateComposerCandidates(
   db: ReturnType<typeof getDb>,
   projectId: string,
-  startingOn: string
-): Promise<readonly OwnerUpdateScheduleItem[]> {
-  return db
-    .select({
-      title: scheduleTasks.title,
-      startDate: scheduleTasks.startDate,
-      endDate: scheduleTasks.endDateCalculated,
-      assignedTo: scheduleTasks.assignedTo,
-    })
-    .from(scheduleTasks)
-    .where(
-      and(
-        eq(scheduleTasks.projectId, projectId),
-        gte(scheduleTasks.endDateCalculated, startingOn)
+  periodStart: string,
+  periodEnd: string
+): Promise<{
+  readonly completedScheduleItems: readonly OwnerUpdateScheduleSelection[]
+  readonly lookAheadScheduleItems: readonly OwnerUpdateScheduleSelection[]
+  readonly todos: readonly OwnerUpdateTodoSelection[]
+}> {
+  const [scheduleRows, todoRows] = await Promise.all([
+    db
+      .select({
+        id: scheduleTasks.id,
+        title: scheduleTasks.title,
+        startDate: scheduleTasks.startDate,
+        endDate: scheduleTasks.endDateCalculated,
+        assignedTo: scheduleTasks.assignedTo,
+        status: scheduleTasks.status,
+        percentComplete: scheduleTasks.percentComplete,
+      })
+      .from(scheduleTasks)
+      .where(eq(scheduleTasks.projectId, projectId))
+      .orderBy(asc(scheduleTasks.startDate), asc(scheduleTasks.sortOrder)),
+    db
+      .select({
+        id: projectOperations.id,
+        title: projectOperations.title,
+        description: projectOperations.description,
+        status: projectOperations.status,
+        priority: projectOperations.priority,
+        assigneeName: projectOperations.assigneeName,
+        companyName: projectOperations.companyName,
+        dueDate: projectOperations.dueDate,
+        sourceRecordType: projectOperations.sourceRecordType,
+      })
+      .from(projectOperations)
+      .where(
+        and(
+          eq(projectOperations.projectId, projectId),
+          inArray(projectOperations.sourceRecordType, [
+            ...PROJECT_TODO_RECORD_TYPES,
+          ])
+        )
       )
+      .orderBy(asc(projectOperations.dueDate), asc(projectOperations.title)),
+  ])
+
+  const scheduleSelections = scheduleRows.map((item) => ({
+    ...item,
+    notes: "",
+  }))
+  const completedScheduleItems = scheduleSelections
+    .filter((item) =>
+      isCompletedScheduleCandidate(item, periodStart, periodEnd)
     )
-    .orderBy(asc(scheduleTasks.startDate), asc(scheduleTasks.sortOrder))
-    .limit(8)
+    .slice(0, 20)
+  const lookAheadScheduleItems = scheduleSelections
+    .filter((item) => isLookAheadScheduleCandidate(item, periodEnd))
+    .slice(0, 20)
+  const todos = todoRows.flatMap((item) => {
+    if (isArchivedProjectTodoStatus(item.status)) return []
+    const timing = ownerUpdateTodoTiming(item.dueDate, periodStart, periodEnd)
+    if (timing === null) return []
+    return [
+      {
+        id: item.id,
+        title: item.title,
+        description: item.description ?? "",
+        status: item.status,
+        priority: item.priority,
+        assigneeName: item.assigneeName,
+        companyName: item.companyName,
+        dueDate: item.dueDate,
+        timing,
+        notes: "",
+      },
+    ]
+  })
+
+  return {
+    completedScheduleItems,
+    lookAheadScheduleItems,
+    todos,
+  }
+}
+
+function ownerUpdateDocumentSelection(
+  row: {
+    readonly id: string
+    readonly sourceSystem: string
+    readonly fileName: string
+    readonly mimeType: string | null
+    readonly driveFileId: string | null
+    readonly driveUrl: string | null
+    readonly caption: string | null
+    readonly capturedAt: string | null
+  }
+): OwnerUpdateDocumentSelection {
+  return {
+    id: row.id,
+    sourceSystem: row.sourceSystem,
+    fileName: row.fileName,
+    mimeType: row.mimeType,
+    driveFileId: row.driveFileId,
+    driveUrl: row.driveUrl,
+    caption: row.caption,
+    capturedAt: row.capturedAt,
+  }
 }
 
 function isPhotoInOwnerUpdateScope(
@@ -513,6 +645,7 @@ async function verifyProjectMutationAccess(
 ): Promise<{
   readonly db: ReturnType<typeof getDb>
   readonly userId: string
+  readonly user: Awaited<ReturnType<typeof requireAuth>>
 }> {
   const user = await requireAuth()
   if (isDemoUser(user.id)) {
@@ -534,7 +667,7 @@ async function verifyProjectMutationAccess(
     throw new Error("Project not found")
   }
 
-  return { db, userId: user.id }
+  return { db, userId: user.id, user }
 }
 
 async function verifyDailyLogStaffMutationAccess(
@@ -1721,11 +1854,17 @@ export async function draftOwnerUpdateFromDailyLogs(
       .slice(0, 900)
     const updateId = crypto.randomUUID()
     const now = new Date().toISOString()
-    const scheduleSnapshot = await captureOwnerUpdateSchedule(
+    const composerCandidates = await getOwnerUpdateComposerCandidates(
       db,
       projectId,
+      firstLog.logDate,
       lastLog.logDate
     )
+    const scheduleSnapshot = serializeOwnerUpdateComposerSnapshot({
+      version: 2,
+      ...composerCandidates,
+      documents: [],
+    })
 
     await db.insert(ownerProjectUpdates).values({
       id: updateId,
@@ -1740,8 +1879,7 @@ export async function draftOwnerUpdateFromDailyLogs(
       selectedPhotoIds: JSON.stringify(ownerPhotos.map((photo) => photo.id)),
       periodStart: firstLog.logDate,
       periodEnd: lastLog.logDate,
-      scheduleSnapshot:
-        serializeOwnerUpdateScheduleSnapshot(scheduleSnapshot),
+      scheduleSnapshot,
       createdAt: now,
       updatedAt: now,
     })
@@ -1794,11 +1932,18 @@ export async function createManualOwnerProjectUpdateDraft(
     const updateId = crypto.randomUUID()
     const now = new Date().toISOString()
     const label = project.projectNumber ?? project.name
-    const scheduleSnapshot = await captureOwnerUpdateSchedule(
+    const defaultPeriod = defaultOwnerUpdatePeriod(normalizedDate)
+    const composerCandidates = await getOwnerUpdateComposerCandidates(
       db,
       projectId,
+      defaultPeriod.startDate,
       normalizedDate
     )
+    const scheduleSnapshot = serializeOwnerUpdateComposerSnapshot({
+      version: 2,
+      ...composerCandidates,
+      documents: [],
+    })
 
     await db.insert(ownerProjectUpdates).values({
       id: updateId,
@@ -1811,10 +1956,9 @@ export async function createManualOwnerProjectUpdateDraft(
       channel: "compass",
       sourceDailyLogIds: "[]",
       selectedPhotoIds: "[]",
-      periodStart: normalizedDate,
+      periodStart: defaultPeriod.startDate,
       periodEnd: normalizedDate,
-      scheduleSnapshot:
-        serializeOwnerUpdateScheduleSnapshot(scheduleSnapshot),
+      scheduleSnapshot,
       createdAt: now,
       updatedAt: now,
     })
@@ -1950,10 +2094,15 @@ export async function getOwnerProjectUpdateDocument(
 
   const selectedDailyLogIds = parseIdList(update.sourceDailyLogIds)
   const selectedPhotoIds = parseIdList(update.selectedPhotoIds)
+  const composerSnapshot = parseOwnerUpdateComposerSnapshot(
+    update.scheduleSnapshot
+  )
+  const canManage = can(viewer, "project", "update")
 
   const allLogRows = await db
     .select({
       id: dailyLogs.id,
+      sourceSystem: dailyLogs.sourceSystem,
       logDate: dailyLogs.logDate,
       workCompleted: dailyLogs.workCompleted,
       weatherTempF: dailyLogs.weatherTempF,
@@ -1962,6 +2111,8 @@ export async function getOwnerProjectUpdateDocument(
       safetyIncidents: dailyLogs.safetyIncidents,
       issues: dailyLogs.issues,
       notes: dailyLogs.notes,
+      reviewStatus: dailyLogs.reviewStatus,
+      isClientVisible: dailyLogs.isClientVisible,
       authorDisplayName: users.displayName,
       authorFirstName: users.firstName,
       authorLastName: users.lastName,
@@ -1969,19 +2120,14 @@ export async function getOwnerProjectUpdateDocument(
     })
     .from(dailyLogs)
     .leftJoin(users, eq(dailyLogs.authorId, users.id))
-    .where(
-      and(
-        eq(dailyLogs.projectId, projectId),
-        eq(dailyLogs.reviewStatus, "approved"),
-        eq(dailyLogs.isClientVisible, true)
-      )
-    )
+    .where(eq(dailyLogs.projectId, projectId))
     .orderBy(asc(dailyLogs.logDate), asc(dailyLogs.createdAt))
 
   const allPhotoRows = await db
     .select({
       id: dailyLogPhotos.id,
       dailyLogId: dailyLogPhotos.dailyLogId,
+      sourceSystem: dailyLogPhotos.sourceSystem,
       fileName: dailyLogPhotos.fileName,
       driveFileId: dailyLogPhotos.driveFileId,
       driveUrl: dailyLogPhotos.driveUrl,
@@ -2009,23 +2155,23 @@ export async function getOwnerProjectUpdateDocument(
     )
     .limit(1)
 
-  const dailyLogIds = new Set(selectedDailyLogIds)
-  const photoIds = new Set(selectedPhotoIds)
-  const lookAheadTasks =
-    parseOwnerUpdateScheduleSnapshot(update.scheduleSnapshot)
-  const dailyLogsForUpdate = selectRowsByIdOrder(
-    allLogRows,
-    selectedDailyLogIds
-  )
-    .filter((row) =>
-      isDateWithinOwnerUpdatePeriod(
-        row.logDate,
-        update.periodStart,
-        update.periodEnd
+  const attachmentScopeDailyLogIds = new Set(
+    allLogRows
+      .filter((row) =>
+        isDateWithinOwnerUpdatePeriod(
+          row.logDate,
+          update.periodStart,
+          update.periodEnd
+        )
       )
-    )
-    .map((row) => ({
+      .map((row) => row.id)
+  )
+  const photoIds = new Set(selectedPhotoIds)
+  const mapDailyLog = (
+    row: (typeof allLogRows)[number]
+  ): OwnerUpdateDailyLog => ({
       id: row.id,
+      sourceSystem: row.sourceSystem,
       logDate: row.logDate,
       workCompleted: row.workCompleted,
       weather: [
@@ -2046,62 +2192,166 @@ export async function getOwnerProjectUpdateDocument(
         lastName: row.authorLastName,
         email: row.authorEmail,
       }),
-    }))
-
-  const eligiblePhotoRows = allPhotoRows
-    .filter((row) => {
-      const isImage =
-        row.thumbnailUrl !== null || row.mimeType?.startsWith("image/") === true
-      return isImage && row.ownerVisible && row.reviewStatus === "approved"
+      reviewStatus: row.reviewStatus,
+      isClientVisible: row.isClientVisible,
     })
+  const dailyLogsForUpdate = selectRowsByIdOrder(
+    allLogRows,
+    selectedDailyLogIds
+  )
+    .filter(
+      (row) =>
+        row.reviewStatus === "approved" &&
+        row.isClientVisible &&
+        isDateWithinOwnerUpdatePeriod(
+          row.logDate,
+          update.periodStart,
+          update.periodEnd
+        )
+    )
+    .map(mapDailyLog)
+  const availableDailyLogs = canManage
+    ? allLogRows
+        .filter((row) =>
+          isDateWithinOwnerUpdatePeriod(
+            row.logDate,
+            update.periodStart,
+            update.periodEnd
+          )
+        )
+        .slice(0, 100)
+        .map(mapDailyLog)
+    : []
+
+  const imageRows = allPhotoRows.filter(
+    (row) =>
+      row.thumbnailUrl !== null || row.mimeType?.startsWith("image/") === true
+  )
+  const documentRows = allPhotoRows.filter(
+    (row) =>
+      row.thumbnailUrl === null && row.mimeType?.startsWith("image/") !== true
+  )
 
   const photosForUpdate = selectRowsByIdOrder(
-    eligiblePhotoRows,
+    imageRows,
     selectedPhotoIds
   )
     .map((row) => ({
       id: row.id,
+      sourceSystem: row.sourceSystem,
       fileName: row.fileName,
+      mimeType: row.mimeType,
       driveUrl: row.driveUrl,
       driveFileId: row.driveFileId,
       thumbnailUrl: row.thumbnailUrl,
       caption: row.caption,
       capturedAt: row.capturedAt,
+      reviewStatus: row.reviewStatus,
+      ownerVisible: row.ownerVisible,
     }))
 
   const selectedEligiblePhotoRows = selectRowsByIdOrder(
-    eligiblePhotoRows,
+    imageRows,
     selectedPhotoIds
   )
-  const scopedUnselectedPhotoRows = eligiblePhotoRows.filter(
+  const scopedUnselectedPhotoRows = imageRows.filter(
     (row) =>
       !photoIds.has(row.id) &&
       update.periodStart !== null &&
       update.periodEnd !== null &&
       isPhotoInOwnerUpdateScope(
         row,
-        dailyLogIds,
+        attachmentScopeDailyLogIds,
         update.periodStart,
         update.periodEnd
       )
   )
-  const availablePhotos = [
-    ...selectedEligiblePhotoRows,
-    ...scopedUnselectedPhotoRows,
-  ]
-    .slice(0, 80)
-    .map((row) => ({
-      id: row.id,
-      fileName: row.fileName,
-      driveUrl: row.driveUrl,
-      driveFileId: row.driveFileId,
-      thumbnailUrl: row.thumbnailUrl,
-      caption: row.caption,
-      capturedAt: row.capturedAt,
-    }))
+  const availablePhotos = canManage
+    ? [...selectedEligiblePhotoRows, ...scopedUnselectedPhotoRows]
+        .slice(0, 120)
+        .map((row) => ({
+          id: row.id,
+          sourceSystem: row.sourceSystem,
+          fileName: row.fileName,
+          mimeType: row.mimeType,
+          driveUrl: row.driveUrl,
+          driveFileId: row.driveFileId,
+          thumbnailUrl: row.thumbnailUrl,
+          caption: row.caption,
+          capturedAt: row.capturedAt,
+          reviewStatus: row.reviewStatus,
+          ownerVisible: row.ownerVisible,
+        }))
+    : []
+
+  const selectedDocumentIds = composerSnapshot.documents.map(
+    (document) => document.id
+  )
+  const selectedDocumentIdSet = new Set(selectedDocumentIds)
+  const scopedDocumentRows = documentRows.filter(
+    (row) =>
+      !selectedDocumentIdSet.has(row.id) &&
+      update.periodStart !== null &&
+      update.periodEnd !== null &&
+      isPhotoInOwnerUpdateScope(
+        row,
+        attachmentScopeDailyLogIds,
+        update.periodStart,
+        update.periodEnd
+      )
+  )
+  const availableDocuments = canManage
+    ? [
+        ...composerSnapshot.documents,
+        ...scopedDocumentRows.map(ownerUpdateDocumentSelection),
+      ].slice(0, 120)
+    : []
+  const currentCandidates =
+    canManage &&
+    update.status !== "published" &&
+    update.periodStart !== null &&
+    update.periodEnd !== null
+      ? await getOwnerUpdateComposerCandidates(
+          db,
+          projectId,
+          update.periodStart,
+          update.periodEnd
+        )
+      : {
+          completedScheduleItems: [],
+          lookAheadScheduleItems: [],
+          todos: [],
+        }
+  function reconciledScheduleItems(
+    selected: readonly OwnerUpdateScheduleSelection[],
+    available: readonly OwnerUpdateScheduleSelection[]
+  ): readonly OwnerUpdateScheduleSelection[] {
+    const availableById = new Map(available.map((item) => [item.id, item]))
+    return selected.map((item) => {
+      const candidate =
+        availableById.get(item.id) ??
+        available.find(
+          (availableItem) =>
+            availableItem.title === item.title &&
+            availableItem.startDate === item.startDate &&
+            availableItem.endDate === item.endDate
+        )
+      return candidate === undefined
+        ? item
+        : { ...candidate, title: item.title, notes: item.notes }
+    })
+  }
+  const completedScheduleItems = reconciledScheduleItems(
+    composerSnapshot.completedScheduleItems,
+    currentCandidates.completedScheduleItems
+  )
+  const lookAheadScheduleItems = reconciledScheduleItems(
+    composerSnapshot.lookAheadScheduleItems,
+    currentCandidates.lookAheadScheduleItems
+  )
 
   return {
-    canManage: can(viewer, "project", "update"),
+    canManage,
     project,
     update: {
       id: update.id,
@@ -2114,20 +2364,31 @@ export async function getOwnerProjectUpdateDocument(
       sentAt: update.sentAt,
       sourceDailyLogIds: selectedDailyLogIds,
       selectedPhotoIds,
+      selectedDocumentIds,
       periodStart: update.periodStart,
       periodEnd: update.periodEnd,
     },
     dailyLogs: dailyLogsForUpdate,
+    availableDailyLogs,
     photos: photosForUpdate,
     availablePhotos,
+    documents: composerSnapshot.documents,
+    availableDocuments,
     photoFolder:
       photoFolder
         ? {
             label: photoFolder.label,
           }
         : null,
-    nextScheduleItem: lookAheadTasks[0] ?? null,
-    lookAheadScheduleItems: lookAheadTasks,
+    nextScheduleItem: lookAheadScheduleItems[0] ?? null,
+    completedScheduleItems,
+    lookAheadScheduleItems,
+    availableCompletedScheduleItems:
+      currentCandidates.completedScheduleItems,
+    availableLookAheadScheduleItems:
+      currentCandidates.lookAheadScheduleItems,
+    todos: composerSnapshot.todos,
+    availableTodos: currentCandidates.todos,
   }
 }
 
@@ -2149,7 +2410,13 @@ export async function updateOwnerProjectUpdateDraft(
     const periodStart = input.periodStart.trim()
     const periodEnd = input.periodEnd.trim()
     const summary = input.summary.trim()
+    const sourceDailyLogIds = [...new Set(input.sourceDailyLogIds)]
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0)
     const selectedPhotoIds = [...new Set(input.selectedPhotoIds)]
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0)
+    const selectedDocumentIds = [...new Set(input.selectedDocumentIds)]
       .map((id) => id.trim())
       .filter((id) => id.length > 0)
 
@@ -2165,15 +2432,11 @@ export async function updateOwnerProjectUpdateDraft(
         error: "The reporting period must have valid start and end dates.",
       }
     }
-    if (summary.length === 0) {
-      return { success: false, error: "Summary is required." }
-    }
 
     const [update] = await db
       .select({
         id: ownerProjectUpdates.id,
         status: ownerProjectUpdates.status,
-        sourceDailyLogIds: ownerProjectUpdates.sourceDailyLogIds,
       })
       .from(ownerProjectUpdates)
       .where(
@@ -2194,7 +2457,6 @@ export async function updateOwnerProjectUpdateDraft(
       }
     }
 
-    const sourceDailyLogIds = parseIdList(update.sourceDailyLogIds)
     if (sourceDailyLogIds.length > 0) {
       const selectedLogs = await db
         .select({
@@ -2233,36 +2495,63 @@ export async function updateOwnerProjectUpdateDraft(
       }
     }
 
-    if (selectedPhotoIds.length > 0) {
-      const eligiblePhotos = await db
+    const selectedAttachmentIds = [
+      ...selectedPhotoIds,
+      ...selectedDocumentIds,
+    ]
+    let documentSelections: readonly OwnerUpdateDocumentSelection[] = []
+    if (selectedAttachmentIds.length > 0) {
+      const selectedAttachments = await db
         .select({
           id: dailyLogPhotos.id,
           dailyLogId: dailyLogPhotos.dailyLogId,
+          sourceSystem: dailyLogPhotos.sourceSystem,
+          fileName: dailyLogPhotos.fileName,
+          mimeType: dailyLogPhotos.mimeType,
+          driveFileId: dailyLogPhotos.driveFileId,
+          driveUrl: dailyLogPhotos.driveUrl,
+          thumbnailUrl: dailyLogPhotos.thumbnailUrl,
+          caption: dailyLogPhotos.caption,
           capturedAt: dailyLogPhotos.capturedAt,
         })
         .from(dailyLogPhotos)
         .where(
           and(
             eq(dailyLogPhotos.projectId, projectId),
-            inArray(dailyLogPhotos.id, selectedPhotoIds),
-            eq(dailyLogPhotos.ownerVisible, true),
-            eq(dailyLogPhotos.reviewStatus, "approved")
+            inArray(dailyLogPhotos.id, selectedAttachmentIds)
           )
         )
 
-      if (eligiblePhotos.length !== selectedPhotoIds.length) {
+      if (selectedAttachments.length !== selectedAttachmentIds.length) {
         return {
           success: false,
-          error: "Only approved owner-visible photos can be selected.",
+          error: "One or more selected files could not be found.",
         }
       }
 
-      const sourceDailyLogIdSet = new Set(sourceDailyLogIds)
+      const attachmentScopeRows = await db
+        .select({
+          id: dailyLogs.id,
+          logDate: dailyLogs.logDate,
+        })
+        .from(dailyLogs)
+        .where(eq(dailyLogs.projectId, projectId))
+      const sourceDailyLogIdSet = new Set(
+        attachmentScopeRows
+          .filter((log) =>
+            isDateWithinOwnerUpdatePeriod(
+              log.logDate,
+              periodStart,
+              periodEnd
+            )
+          )
+          .map((log) => log.id)
+      )
       if (
-        eligiblePhotos.some(
-          (photo) =>
+        selectedAttachments.some(
+          (attachment) =>
             !isPhotoInOwnerUpdateScope(
-              photo,
+              attachment,
               sourceDailyLogIdSet,
               periodStart,
               periodEnd
@@ -2272,16 +2561,114 @@ export async function updateOwnerProjectUpdateDraft(
         return {
           success: false,
           error:
-            "Selected photos must be tied to a source log or captured during the reporting period.",
+            "Selected files must be tied to a source log or captured during the reporting period.",
         }
       }
+
+      const selectedPhotoIdSet = new Set(selectedPhotoIds)
+      if (
+        selectedAttachments.some((attachment) => {
+          const isImage =
+            attachment.thumbnailUrl !== null ||
+            attachment.mimeType?.startsWith("image/") === true
+          return selectedPhotoIdSet.has(attachment.id) !== isImage
+        })
+      ) {
+        return {
+          success: false,
+          error: "Photos and documents must be selected in the correct section.",
+        }
+      }
+
+      const attachmentsById = new Map(
+        selectedAttachments.map((attachment) => [
+          attachment.id,
+          attachment,
+        ])
+      )
+      documentSelections = selectedDocumentIds.flatMap((id) => {
+        const attachment = attachmentsById.get(id)
+        return attachment === undefined
+          ? []
+          : [ownerUpdateDocumentSelection(attachment)]
+      })
     }
 
-    const scheduleSnapshot = await captureOwnerUpdateSchedule(
+    const candidates = await getOwnerUpdateComposerCandidates(
       db,
       projectId,
+      periodStart,
       periodEnd
     )
+    const completedById = new Map(
+      candidates.completedScheduleItems.map((item) => [item.id, item])
+    )
+    const lookAheadById = new Map(
+      candidates.lookAheadScheduleItems.map((item) => [item.id, item])
+    )
+    const todosById = new Map(
+      candidates.todos.map((item) => [item.id, item])
+    )
+
+    function selectedScheduleItems(
+      selected: readonly OwnerUpdateScheduleSelection[],
+      candidatesById: ReadonlyMap<string, OwnerUpdateScheduleSelection>
+    ): readonly OwnerUpdateScheduleSelection[] {
+      const seen = new Set<string>()
+      return selected.flatMap((item) => {
+        if (seen.has(item.id)) return []
+        seen.add(item.id)
+        const candidate =
+          candidatesById.get(item.id) ??
+          [...candidatesById.values()].find(
+            (candidateItem) =>
+              candidateItem.title === item.title &&
+              candidateItem.startDate === item.startDate &&
+              candidateItem.endDate === item.endDate
+          )
+        if (candidate === undefined) return []
+        const editedTitle = item.title.trim()
+        return [
+          {
+            ...candidate,
+            title: editedTitle.length > 0 ? editedTitle : candidate.title,
+            notes: item.notes.trim(),
+          },
+        ]
+      })
+    }
+
+    const completedScheduleItems = selectedScheduleItems(
+      input.completedScheduleItems,
+      completedById
+    )
+    const lookAheadScheduleItems = selectedScheduleItems(
+      input.lookAheadScheduleItems,
+      lookAheadById
+    )
+    const seenTodoIds = new Set<string>()
+    const todos = input.todos.flatMap((item) => {
+      if (seenTodoIds.has(item.id)) return []
+      seenTodoIds.add(item.id)
+      const candidate = todosById.get(item.id)
+      if (candidate === undefined) return []
+      const editedTitle = item.title.trim()
+      return [
+        {
+          ...candidate,
+          title: editedTitle.length > 0 ? editedTitle : candidate.title,
+          description: item.description.trim(),
+          notes: item.notes.trim(),
+        },
+      ]
+    })
+    const composerSnapshot: OwnerUpdateComposerSnapshot = {
+      version: 2,
+      completedScheduleItems,
+      lookAheadScheduleItems,
+      todos,
+      documents: documentSelections,
+    }
 
     await db
       .update(ownerProjectUpdates)
@@ -2291,9 +2678,10 @@ export async function updateOwnerProjectUpdateDraft(
         periodStart,
         periodEnd,
         summary,
+        sourceDailyLogIds: JSON.stringify(sourceDailyLogIds),
         selectedPhotoIds: JSON.stringify(selectedPhotoIds),
         scheduleSnapshot:
-          serializeOwnerUpdateScheduleSnapshot(scheduleSnapshot),
+          serializeOwnerUpdateComposerSnapshot(composerSnapshot),
         updatedAt: new Date().toISOString(),
       })
       .where(eq(ownerProjectUpdates.id, updateId))
@@ -2312,6 +2700,220 @@ export async function updateOwnerProjectUpdateDraft(
         error instanceof Error
           ? error.message
           : "Unable to update owner draft.",
+    }
+  }
+}
+
+export async function draftOwnerProjectUpdateWithJarvis(
+  projectId: string,
+  updateId: string
+): Promise<
+  | { readonly success: true; readonly summary: string }
+  | { readonly success: false; readonly error: string }
+> {
+  try {
+    const { db, user } = await verifyProjectMutationAccess(
+      projectId,
+      "owner-updates"
+    )
+    const [update] = await db
+      .select({
+        id: ownerProjectUpdates.id,
+        title: ownerProjectUpdates.title,
+        status: ownerProjectUpdates.status,
+        periodStart: ownerProjectUpdates.periodStart,
+        periodEnd: ownerProjectUpdates.periodEnd,
+        sourceDailyLogIds: ownerProjectUpdates.sourceDailyLogIds,
+        selectedPhotoIds: ownerProjectUpdates.selectedPhotoIds,
+        scheduleSnapshot: ownerProjectUpdates.scheduleSnapshot,
+        projectName: projects.name,
+        projectNumber: projects.projectNumber,
+      })
+      .from(ownerProjectUpdates)
+      .innerJoin(projects, eq(ownerProjectUpdates.projectId, projects.id))
+      .where(
+        and(
+          eq(ownerProjectUpdates.id, updateId),
+          eq(ownerProjectUpdates.projectId, projectId)
+        )
+      )
+      .limit(1)
+
+    if (!update || update.status === "published") {
+      return {
+        success: false,
+        error: "Only an owner update draft can be drafted with Jarvis.",
+      }
+    }
+    if (
+      update.periodStart === null ||
+      update.periodEnd === null ||
+      !isValidOwnerUpdatePeriod(update.periodStart, update.periodEnd)
+    ) {
+      return {
+        success: false,
+        error: "Save a valid reporting period before asking Jarvis.",
+      }
+    }
+
+    const sourceDailyLogIds = parseIdList(update.sourceDailyLogIds)
+    const selectedLogs =
+      sourceDailyLogIds.length === 0
+        ? []
+        : await db
+            .select({
+              id: dailyLogs.id,
+              logDate: dailyLogs.logDate,
+              workCompleted: dailyLogs.workCompleted,
+              issues: dailyLogs.issues,
+              notes: dailyLogs.notes,
+            })
+            .from(dailyLogs)
+            .where(
+              and(
+                eq(dailyLogs.projectId, projectId),
+                inArray(dailyLogs.id, sourceDailyLogIds)
+              )
+            )
+            .orderBy(asc(dailyLogs.logDate), asc(dailyLogs.createdAt))
+    const selectedLogById = new Map(
+      selectedLogs.map((log) => [log.id, log])
+    )
+    const orderedLogs = sourceDailyLogIds.flatMap((id) => {
+      const log = selectedLogById.get(id)
+      return log === undefined ? [] : [log]
+    })
+    const composerSnapshot = parseOwnerUpdateComposerSnapshot(
+      update.scheduleSnapshot
+    )
+    const selectedAttachmentIds = [
+      ...parseIdList(update.selectedPhotoIds),
+      ...composerSnapshot.documents.map((document) => document.id),
+    ]
+    const selectedAttachments =
+      selectedAttachmentIds.length === 0
+        ? []
+        : await db
+            .select({
+              id: dailyLogPhotos.id,
+              fileName: dailyLogPhotos.fileName,
+              mimeType: dailyLogPhotos.mimeType,
+              thumbnailUrl: dailyLogPhotos.thumbnailUrl,
+              caption: dailyLogPhotos.caption,
+            })
+            .from(dailyLogPhotos)
+            .where(
+              and(
+                eq(dailyLogPhotos.projectId, projectId),
+                inArray(dailyLogPhotos.id, selectedAttachmentIds)
+              )
+            )
+    const selectedAttachmentById = new Map(
+      selectedAttachments.map((attachment) => [
+        attachment.id,
+        attachment,
+      ])
+    )
+    const orderedAttachments = selectedAttachmentIds.flatMap((id) => {
+      const attachment = selectedAttachmentById.get(id)
+      if (attachment === undefined) return []
+      const isImage =
+        attachment.thumbnailUrl !== null ||
+        attachment.mimeType?.startsWith("image/") === true
+      const kind: "photo" | "document" = isImage ? "photo" : "document"
+      return [
+        {
+          fileName: attachment.fileName,
+          caption: attachment.caption,
+          kind,
+        },
+      ]
+    })
+    const prompt = buildOwnerUpdateDraftPrompt({
+      projectLabel: update.projectNumber ?? update.projectName,
+      periodStart: update.periodStart,
+      periodEnd: update.periodEnd,
+      dailyLogs: orderedLogs,
+      attachments: orderedAttachments,
+      completedScheduleItems:
+        composerSnapshot.completedScheduleItems,
+      lookAheadScheduleItems:
+        composerSnapshot.lookAheadScheduleItems,
+      todos: composerSnapshot.todos,
+    }).slice(0, 3_950)
+
+    const { env } = await getCloudflareContext()
+    const configuredBridgeEnabled = Reflect.get(
+      env,
+      "JARVIS_AGENT_BRIDGE_ENABLED"
+    )
+    const configuredBridgeSecret = Reflect.get(env, "JARVIS_BRIDGE_SECRET")
+    if (
+      !isJarvisAgentBridgeEnabled(
+        typeof configuredBridgeEnabled === "string"
+          ? configuredBridgeEnabled
+          : undefined
+      ) ||
+      typeof configuredBridgeSecret !== "string" ||
+      configuredBridgeSecret.length === 0
+    ) {
+      return {
+        success: false,
+        error: "Jarvis drafting is not configured in this deployment.",
+      }
+    }
+
+    const result = await relayAgentRequest({
+      db,
+      organizationId: user.organizationId,
+      user: {
+        id: user.id,
+        displayName: user.displayName,
+        email: user.email,
+        role: user.role,
+      },
+      sessionId: `owner-update:${updateId}:${Date.now()}`,
+      currentPage:
+        `/dashboard/projects/${projectId}/owner-updates/${updateId}`,
+      timezone: "America/Denver",
+      messages: [{ role: "user", content: prompt }],
+    })
+    if (!result.success) {
+      return { success: false, error: result.error }
+    }
+
+    const summary = cleanOwnerUpdateDraft(result.content)
+    if (summary.length === 0) {
+      return { success: false, error: "Jarvis returned an empty draft." }
+    }
+
+    await db
+      .update(ownerProjectUpdates)
+      .set({
+        summary,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(
+        and(
+          eq(ownerProjectUpdates.id, updateId),
+          eq(ownerProjectUpdates.projectId, projectId),
+          eq(ownerProjectUpdates.status, "draft")
+        )
+      )
+
+    revalidatePath(`/dashboard/projects/${projectId}/owner-updates`)
+    revalidatePath(
+      `/dashboard/projects/${projectId}/owner-updates/${updateId}`
+    )
+
+    return { success: true, summary }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Jarvis could not draft this owner update.",
     }
   }
 }
@@ -2342,6 +2944,7 @@ export async function publishOwnerProjectUpdate(
       selectedPhotoIds: ownerProjectUpdates.selectedPhotoIds,
       periodStart: ownerProjectUpdates.periodStart,
       periodEnd: ownerProjectUpdates.periodEnd,
+      scheduleSnapshot: ownerProjectUpdates.scheduleSnapshot,
     })
     .from(ownerProjectUpdates)
     .innerJoin(projects, eq(ownerProjectUpdates.projectId, projects.id))
@@ -2375,6 +2978,12 @@ export async function publishOwnerProjectUpdate(
 
   const sourceDailyLogIds = parseIdList(update.sourceDailyLogIds)
   const selectedPhotoIds = parseIdList(update.selectedPhotoIds)
+  const composerSnapshot = parseOwnerUpdateComposerSnapshot(
+    update.scheduleSnapshot
+  )
+  const selectedDocumentIds = composerSnapshot.documents.map(
+    (document) => document.id
+  )
   const selectedLogs =
     sourceDailyLogIds.length === 0
       ? []
@@ -2429,8 +3038,12 @@ export async function publishOwnerProjectUpdate(
     }
   }
 
-  if (selectedPhotoIds.length > 0) {
-    const eligiblePhotos = await db
+  const selectedAttachmentIds = [
+    ...selectedPhotoIds,
+    ...selectedDocumentIds,
+  ]
+  if (selectedAttachmentIds.length > 0) {
+    const selectedAttachments = await db
       .select({
         id: dailyLogPhotos.id,
         dailyLogId: dailyLogPhotos.dailyLogId,
@@ -2440,26 +3053,41 @@ export async function publishOwnerProjectUpdate(
       .where(
         and(
           eq(dailyLogPhotos.projectId, projectId),
-          inArray(dailyLogPhotos.id, selectedPhotoIds),
-          eq(dailyLogPhotos.ownerVisible, true),
-          eq(dailyLogPhotos.reviewStatus, "approved")
+          inArray(dailyLogPhotos.id, selectedAttachmentIds)
         )
       )
 
-    if (eligiblePhotos.length !== selectedPhotoIds.length) {
+    if (selectedAttachments.length !== selectedAttachmentIds.length) {
       return {
         success: false,
         error:
-          "Every selected photo must remain approved and owner-visible before publishing.",
+          "Every selected photo and document must still belong to this project before publishing.",
       }
     }
 
-    const sourceDailyLogIdSet = new Set(sourceDailyLogIds)
+    const attachmentScopeRows = await db
+      .select({
+        id: dailyLogs.id,
+        logDate: dailyLogs.logDate,
+      })
+      .from(dailyLogs)
+      .where(eq(dailyLogs.projectId, projectId))
+    const sourceDailyLogIdSet = new Set(
+      attachmentScopeRows
+        .filter((log) =>
+          isDateWithinOwnerUpdatePeriod(
+            log.logDate,
+            periodStart,
+            periodEnd
+          )
+        )
+        .map((log) => log.id)
+    )
     if (
-      eligiblePhotos.some(
-        (photo) =>
+      selectedAttachments.some(
+        (attachment) =>
           !isPhotoInOwnerUpdateScope(
-            photo,
+            attachment,
             sourceDailyLogIdSet,
             periodStart,
             periodEnd
@@ -2469,16 +3097,25 @@ export async function publishOwnerProjectUpdate(
       return {
         success: false,
         error:
-          "Selected photos must be tied to a source log or captured during the reporting period.",
+          "Selected files must be tied to a source log or captured during the reporting period.",
       }
     }
+
+    await db
+      .update(dailyLogPhotos)
+      .set({
+        reviewStatus: "approved",
+        ownerVisible: true,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(
+        and(
+          eq(dailyLogPhotos.projectId, projectId),
+          inArray(dailyLogPhotos.id, selectedAttachmentIds)
+        )
+      )
   }
 
-  const scheduleSnapshot = await captureOwnerUpdateSchedule(
-    db,
-    projectId,
-    periodEnd
-  )
   const now = new Date().toISOString()
 
   await db
@@ -2490,7 +3127,7 @@ export async function publishOwnerProjectUpdate(
       sourceDailyLogIds: JSON.stringify(sourceDailyLogIds),
       selectedPhotoIds: JSON.stringify(selectedPhotoIds),
       scheduleSnapshot:
-        serializeOwnerUpdateScheduleSnapshot(scheduleSnapshot),
+        serializeOwnerUpdateComposerSnapshot(composerSnapshot),
       publishedAt: now,
       updatedAt: now,
     })

--- a/src/app/api/projects/[id]/photos/upload/route.ts
+++ b/src/app/api/projects/[id]/photos/upload/route.ts
@@ -37,6 +37,11 @@ type UploadPhotoResult =
   | {
       readonly success: true
       readonly uploadedCount: number
+      readonly files: readonly {
+        readonly id: string
+        readonly fileName: string
+        readonly mimeType: string | null
+      }[]
     }
   | {
       readonly success: false
@@ -401,6 +406,11 @@ export async function POST(
       auth.sharedDriveId
     )
 
+    const uploadedFiles: {
+      readonly id: string
+      readonly fileName: string
+      readonly mimeType: string | null
+    }[] = []
     for (const file of files) {
       const mimeType = file.type || "application/octet-stream"
       const driveFile = await client.uploadFile(googleEmail, {
@@ -410,9 +420,10 @@ export async function POST(
         driveId: auth.sharedDriveId ?? undefined,
         data: file,
       })
+      const uploadedFileId = crypto.randomUUID()
 
       await db.insert(dailyLogPhotos).values({
-        id: crypto.randomUUID(),
+        id: uploadedFileId,
         projectId,
         dailyLogId: validatedDailyLogId,
         uploadedBy: user.id,
@@ -439,6 +450,11 @@ export async function POST(
         createdAt: now,
         updatedAt: now,
       })
+      uploadedFiles.push({
+        id: uploadedFileId,
+        fileName: driveFile.name,
+        mimeType: driveFile.mimeType,
+      })
     }
 
     revalidatePath(`/dashboard/projects/${projectId}`)
@@ -449,6 +465,7 @@ export async function POST(
     return NextResponse.json({
       success: true,
       uploadedCount: files.length,
+      files: uploadedFiles,
     })
   } catch (error) {
     console.error("Daily-log file upload failed", error)

--- a/src/app/dashboard/projects/[id]/owner-updates/page.tsx
+++ b/src/app/dashboard/projects/[id]/owner-updates/page.tsx
@@ -171,14 +171,6 @@ export default async function ProjectOwnerUpdatesPage({
           />
           {internalViewer && (
             <div className="flex flex-wrap justify-end gap-2">
-              <Button asChild>
-                <Link
-                  href={`/dashboard/projects/${project.id}/daily-logs#owner-update-builder`}
-                >
-                  <IconClipboardText className="size-4" />
-                  Build From Logs
-                </Link>
-              </Button>
               <OwnerUpdateCreateButton projectId={project.id} />
               <Button asChild variant="outline">
                 <Link href={`/dashboard/projects/${project.id}/photos`}>

--- a/src/components/projects/owner-update-create-button.tsx
+++ b/src/components/projects/owner-update-create-button.tsx
@@ -44,12 +44,11 @@ export function OwnerUpdateCreateButton({
     <div>
       <Button
         type="button"
-        variant="outline"
         onClick={createDraft}
         disabled={isPending}
       >
         <IconFilePlus className="size-4" />
-        {isPending ? "Creating..." : "New Manual Update"}
+        {isPending ? "Creating..." : "Create Owner Update"}
       </Button>
       {error !== null && (
         <p className="mt-1 max-w-64 text-xs text-destructive" role="alert">

--- a/src/components/projects/owner-update-document.tsx
+++ b/src/components/projects/owner-update-document.tsx
@@ -2,7 +2,10 @@ import type * as React from "react"
 import Link from "next/link"
 import {
   IconArrowLeft,
+  IconCalendarCheck,
   IconCalendarStats,
+  IconChecklist,
+  IconFile,
   IconPhoto,
   IconPhotoUp,
 } from "@tabler/icons-react"
@@ -41,6 +44,14 @@ function statusLabel(value: string): string {
 
 function projectLabel(document: OwnerProjectUpdateDocument): string {
   return document.project.projectNumber ?? document.project.name
+}
+
+function ownerUpdateDocumentHref(input: {
+  readonly driveFileId: string | null
+  readonly driveUrl: string | null
+}): string | null {
+  if (input.driveFileId) return `/api/google/download/${input.driveFileId}`
+  return input.driveUrl
 }
 
 export function OwnerUpdateDocument({
@@ -169,7 +180,7 @@ export function OwnerUpdateDocument({
             <h2 className="text-base font-semibold print:text-sm print:uppercase">
               Summary
             </h2>
-            <p className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground print:max-w-none print:text-[12px] print:leading-5 print:text-black">
+            <p className="mt-3 max-w-3xl whitespace-pre-wrap text-sm leading-6 text-muted-foreground print:max-w-none print:text-[12px] print:leading-5 print:text-black">
               {document.update.summary}
             </p>
           </section>
@@ -283,6 +294,127 @@ export function OwnerUpdateDocument({
             </section>
           )}
 
+          {document.documents.length > 0 && (
+            <section className="border-t py-6 print:break-inside-avoid print:border-t print:border-black print:py-4">
+              <div className="flex items-center gap-2">
+                <IconFile className="size-4 text-muted-foreground print:hidden" />
+                <h2 className="text-base font-semibold print:text-sm print:uppercase">
+                  Documents
+                </h2>
+              </div>
+              <div className="mt-3 divide-y border-y print:border-black">
+                {document.documents.map((file) => {
+                  const href = ownerUpdateDocumentHref(file)
+                  return (
+                    <div
+                      key={file.id}
+                      className="flex items-center gap-3 py-3 print:py-2"
+                    >
+                      <IconFile className="size-4 shrink-0 text-muted-foreground print:hidden" />
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium print:text-[12px]">
+                          {file.caption ?? file.fileName}
+                        </p>
+                        {file.caption && (
+                          <p className="mt-1 truncate text-xs text-muted-foreground print:text-[10px] print:text-black">
+                            {file.fileName}
+                          </p>
+                        )}
+                      </div>
+                      {href && (
+                        <Button
+                          asChild
+                          variant="outline"
+                          size="sm"
+                          className="print:hidden"
+                        >
+                          <a href={href} target="_blank" rel="noreferrer">
+                            Open
+                          </a>
+                        </Button>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            </section>
+          )}
+
+          {document.completedScheduleItems.length > 0 && (
+            <section className="border-t py-6 print:break-inside-avoid print:border-t print:border-black print:py-4">
+              <div className="flex items-center gap-2">
+                <IconCalendarCheck className="size-4 text-muted-foreground print:hidden" />
+                <h2 className="text-base font-semibold print:text-sm print:uppercase">
+                  Completed This Period
+                </h2>
+              </div>
+              <div className="mt-4 divide-y border-y print:border-black">
+                {document.completedScheduleItems.map((item) => (
+                  <div
+                    key={item.id}
+                    className="grid gap-2 py-3 sm:grid-cols-[8rem_minmax(0,1fr)] print:grid-cols-[6.75rem_minmax(0,1fr)] print:py-2"
+                  >
+                    <p className="text-xs font-medium text-muted-foreground print:text-[10px] print:text-black">
+                      {formatDate(item.startDate)}
+                      {item.endDate !== item.startDate
+                        ? ` - ${formatDate(item.endDate)}`
+                        : ""}
+                    </p>
+                    <div>
+                      <p className="text-sm font-medium print:text-[12px]">
+                        {item.title}
+                      </p>
+                      {(item.notes || item.assignedTo) && (
+                        <p className="mt-1 text-xs text-muted-foreground print:text-[10px] print:text-black">
+                          {[item.notes, item.assignedTo]
+                            .filter(
+                              (value) =>
+                                value !== null && value.trim().length > 0
+                            )
+                            .join(" · ")}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {document.todos.length > 0 && (
+            <section className="border-t py-6 print:break-inside-avoid print:border-t print:border-black print:py-4">
+              <div className="flex items-center gap-2">
+                <IconChecklist className="size-4 text-muted-foreground print:hidden" />
+                <h2 className="text-base font-semibold print:text-sm print:uppercase">
+                  To-dos
+                </h2>
+              </div>
+              <div className="mt-4 divide-y border-y print:border-black">
+                {document.todos.map((item) => (
+                  <div key={item.id} className="py-3 print:py-2">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <p className="text-sm font-medium print:text-[12px]">
+                        {item.title}
+                      </p>
+                      <p className="text-xs text-muted-foreground print:text-[10px] print:text-black">
+                        {item.dueDate
+                          ? `Due ${formatDate(item.dueDate)}`
+                          : statusLabel(item.status)}
+                      </p>
+                    </div>
+                    {(item.description || item.notes) && (
+                      <p className="mt-1 text-sm text-muted-foreground print:text-[11px] print:text-black">
+                        {[item.description, item.notes]
+                          .filter((value) => value.trim().length > 0)
+                          .join(" ")}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
           {document.lookAheadScheduleItems.length > 0 && (
             <section className="border-t py-6 print:break-inside-avoid print:border-t print:border-black print:py-4">
               <div className="flex items-center gap-2">
@@ -294,7 +426,7 @@ export function OwnerUpdateDocument({
               <div className="mt-4 overflow-hidden rounded-md border bg-muted/20 print:rounded-none print:border-black print:bg-white">
                 {document.lookAheadScheduleItems.map((item, index) => (
                   <div
-                    key={`${item.title}-${item.startDate}-${index}`}
+                    key={item.id || `${item.title}-${item.startDate}-${index}`}
                     className="grid gap-2 border-b px-4 py-3 last:border-b-0 sm:grid-cols-[8rem_minmax(0,1fr)] print:grid-cols-[6.75rem_minmax(0,1fr)] print:px-3 print:py-2"
                   >
                     <p className="text-xs font-medium text-muted-foreground print:text-[10px] print:text-black">
@@ -310,6 +442,11 @@ export function OwnerUpdateDocument({
                       {item.assignedTo && (
                         <p className="mt-1 text-xs text-muted-foreground print:text-[10px] print:text-black">
                           {item.assignedTo}
+                        </p>
+                      )}
+                      {item.notes && (
+                        <p className="mt-1 text-xs text-muted-foreground print:text-[10px] print:text-black">
+                          {item.notes}
                         </p>
                       )}
                     </div>

--- a/src/components/projects/owner-update-draft-editor.tsx
+++ b/src/components/projects/owner-update-draft-editor.tsx
@@ -2,24 +2,110 @@
 
 import * as React from "react"
 import { useRouter } from "next/navigation"
-import { IconCheck, IconPhoto, IconRefresh, IconX } from "@tabler/icons-react"
+import {
+  IconCalendarCheck,
+  IconCalendarStats,
+  IconCheck,
+  IconFile,
+  IconPhoto,
+  IconRefresh,
+  IconRobot,
+  IconUpload,
+  IconX,
+} from "@tabler/icons-react"
 
 import {
+  draftOwnerProjectUpdateWithJarvis,
   updateOwnerProjectUpdateDraft,
   type OwnerProjectUpdateDocument,
 } from "@/app/actions/project-field"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import {
+  OwnerUpdateScheduleSelector,
+  OwnerUpdateTodoSelector,
+} from "@/components/projects/owner-update-item-selectors"
+import type {
+  OwnerUpdateScheduleSelection,
+  OwnerUpdateTodoSelection,
+} from "@/lib/owner-updates/snapshot"
+import {
+  MAX_PHOTO_UPLOAD_BATCH_BYTES,
+  MAX_PHOTO_UPLOAD_FILE_BYTES,
+  PHOTO_UPLOAD_LIMIT_LABEL,
+} from "@/lib/photos/upload-limits"
 import { resolvePhotoImageSource } from "@/lib/photo-sources"
 
 type DraftStatus =
   | { readonly kind: "idle" }
-  | { readonly kind: "saving" }
+  | { readonly kind: "saving"; readonly message: string }
   | { readonly kind: "saved"; readonly message: string }
   | { readonly kind: "error"; readonly message: string }
+
+type UploadedFile = {
+  readonly id: string
+  readonly fileName: string
+  readonly mimeType: string | null
+}
+
+function sourceLabel(value: string): string {
+  if (value.toLowerCase().includes("buildertrend")) return "Buildertrend"
+  if (value.toLowerCase().includes("compass")) return "Compass"
+  return value
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024) return `${value} B`
+  if (value < 1024 * 1024) return `${Math.round(value / 1024)} KB`
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function uniqueIds(values: readonly string[]): readonly string[] {
+  return [...new Set(values)]
+}
+
+function parseUploadedFiles(value: unknown): readonly UploadedFile[] {
+  if (typeof value !== "object" || value === null || !("files" in value)) {
+    return []
+  }
+  if (!Array.isArray(value.files)) return []
+
+  return value.files.flatMap((file) => {
+    if (
+      typeof file !== "object" ||
+      file === null ||
+      !("id" in file) ||
+      typeof file.id !== "string" ||
+      !("fileName" in file) ||
+      typeof file.fileName !== "string"
+    ) {
+      return []
+    }
+    const mimeType =
+      "mimeType" in file && typeof file.mimeType === "string"
+        ? file.mimeType
+        : null
+    return [{ id: file.id, fileName: file.fileName, mimeType }]
+  })
+}
+
+function SelectionCount({
+  selected,
+  total,
+}: {
+  readonly selected: number
+  readonly total: number
+}): React.ReactElement {
+  return (
+    <span className="text-xs text-muted-foreground">
+      {selected} selected · {total} available
+    </span>
+  )
+}
 
 export function OwnerUpdateDraftEditor({
   document,
@@ -36,44 +122,135 @@ export function OwnerUpdateDraftEditor({
     document.update.periodEnd ?? document.update.updateDate
   )
   const [summary, setSummary] = React.useState(document.update.summary)
-  const [selectedPhotoIds, setSelectedPhotoIds] = React.useState<readonly string[]>(
-    document.update.selectedPhotoIds
+  const [sourceDailyLogIds, setSourceDailyLogIds] = React.useState<
+    readonly string[]
+  >(document.update.sourceDailyLogIds)
+  const [selectedPhotoIds, setSelectedPhotoIds] = React.useState<
+    readonly string[]
+  >(document.update.selectedPhotoIds)
+  const [selectedDocumentIds, setSelectedDocumentIds] = React.useState<
+    readonly string[]
+  >(document.update.selectedDocumentIds)
+  const [completedScheduleItems, setCompletedScheduleItems] = React.useState<
+    readonly OwnerUpdateScheduleSelection[]
+  >(document.completedScheduleItems)
+  const [lookAheadScheduleItems, setLookAheadScheduleItems] = React.useState<
+    readonly OwnerUpdateScheduleSelection[]
+  >(document.lookAheadScheduleItems)
+  const [todos, setTodos] = React.useState<readonly OwnerUpdateTodoSelection[]>(
+    document.todos
   )
   const [status, setStatus] = React.useState<DraftStatus>({ kind: "idle" })
   const [failedImageIds, setFailedImageIds] = React.useState<readonly string[]>(
     []
   )
+  const [uploadFiles, setUploadFiles] = React.useState<readonly File[]>([])
+  const [uploadCaption, setUploadCaption] = React.useState("")
+  const [isUploading, setIsUploading] = React.useState(false)
+  const selectedDailyLogIdSet = new Set(sourceDailyLogIds)
   const selectedPhotoIdSet = new Set(selectedPhotoIds)
+  const selectedDocumentIdSet = new Set(selectedDocumentIds)
   const failedImageSet = new Set(failedImageIds)
 
-  function togglePhoto(photoId: string, checked: boolean): void {
-    setSelectedPhotoIds((current) => {
-      if (checked) return Array.from(new Set([...current, photoId]))
-      return current.filter((id) => id !== photoId)
-    })
+  function toggleId(
+    setter: React.Dispatch<React.SetStateAction<readonly string[]>>,
+    id: string,
+    checked: boolean
+  ): void {
+    setter((current) =>
+      checked ? uniqueIds([...current, id]) : current.filter((value) => value !== id)
+    )
   }
 
-  function selectAllPhotos(): void {
-    setSelectedPhotoIds(document.availablePhotos.map((photo) => photo.id))
+  function chooseUploadFiles(fileList: FileList | null): void {
+    const files = fileList === null ? [] : Array.from(fileList)
+    setUploadFiles(files)
+    const oversized = files.find(
+      (file) => file.size > MAX_PHOTO_UPLOAD_FILE_BYTES
+    )
+    const totalBytes = files.reduce((total, file) => total + file.size, 0)
+    if (oversized) {
+      setStatus({
+        kind: "error",
+        message: `${oversized.name} is too large. ${PHOTO_UPLOAD_LIMIT_LABEL}`,
+      })
+    } else if (totalBytes > MAX_PHOTO_UPLOAD_BATCH_BYTES) {
+      setStatus({
+        kind: "error",
+        message: `${formatBytes(totalBytes)} selected. ${PHOTO_UPLOAD_LIMIT_LABEL}`,
+      })
+    } else {
+      setStatus({ kind: "idle" })
+    }
   }
 
-  function clearPhotos(): void {
-    setSelectedPhotoIds([])
+  async function uploadOwnerUpdateFiles(): Promise<void> {
+    if (uploadFiles.length === 0) return
+    setIsUploading(true)
+    setStatus({ kind: "saving", message: "Uploading files..." })
+
+    try {
+      const formData = new FormData()
+      for (const file of uploadFiles) formData.append("files", file)
+      formData.set("caption", uploadCaption)
+      formData.set("capturedDate", periodEnd)
+      formData.set("photoKind", "progress")
+      formData.set("ownerVisible", "false")
+      formData.set("subVendorVisible", "false")
+
+      const response = await fetch(
+        `/api/projects/${document.project.id}/photos/upload`,
+        { method: "POST", body: formData }
+      )
+      const result: unknown = await response.json()
+      if (
+        !response.ok ||
+        typeof result !== "object" ||
+        result === null ||
+        !("success" in result) ||
+        result.success !== true
+      ) {
+        const message =
+          typeof result === "object" &&
+          result !== null &&
+          "error" in result &&
+          typeof result.error === "string"
+            ? result.error
+            : "Unable to upload the selected files."
+        setStatus({ kind: "error", message })
+        return
+      }
+
+      const uploaded = parseUploadedFiles(result)
+      const photoIds = uploaded
+        .filter((file) => file.mimeType?.startsWith("image/") === true)
+        .map((file) => file.id)
+      const documentIds = uploaded
+        .filter((file) => file.mimeType?.startsWith("image/") !== true)
+        .map((file) => file.id)
+      setSelectedPhotoIds((current) => uniqueIds([...current, ...photoIds]))
+      setSelectedDocumentIds((current) =>
+        uniqueIds([...current, ...documentIds])
+      )
+      setUploadFiles([])
+      setUploadCaption("")
+      setStatus({
+        kind: "saved",
+        message: `${uploaded.length} file${uploaded.length === 1 ? "" : "s"} uploaded and selected.`,
+      })
+      router.refresh()
+    } catch {
+      setStatus({
+        kind: "error",
+        message: "Unable to upload the selected files.",
+      })
+    } finally {
+      setIsUploading(false)
+    }
   }
 
-  function markImageFailed(photoId: string): void {
-    setFailedImageIds((current) => {
-      if (current.includes(photoId)) return current
-      return [...current, photoId]
-    })
-  }
-
-  async function saveDraft(
-    event: React.FormEvent<HTMLFormElement>
-  ): Promise<void> {
-    event.preventDefault()
-    setStatus({ kind: "saving" })
-
+  async function saveDraft(): Promise<boolean> {
+    setStatus({ kind: "saving", message: "Saving curated sources..." })
     try {
       const result = await updateOwnerProjectUpdateDraft(
         document.project.id,
@@ -84,43 +261,99 @@ export function OwnerUpdateDraftEditor({
           periodStart,
           periodEnd,
           summary,
+          sourceDailyLogIds,
           selectedPhotoIds,
+          selectedDocumentIds,
+          completedScheduleItems,
+          lookAheadScheduleItems,
+          todos,
         }
       )
 
       if (!result.success) {
         setStatus({ kind: "error", message: result.error })
-        return
+        return false
       }
 
-      setStatus({ kind: "saved", message: "Draft updated." })
+      setStatus({
+        kind: "saved",
+        message: "Draft saved. Choices were refreshed for this period.",
+      })
       router.refresh()
+      return true
     } catch {
       setStatus({
         kind: "error",
         message: "Unable to save this draft. Please try again.",
+      })
+      return false
+    }
+  }
+
+  async function draftWithJarvis(): Promise<void> {
+    const saved = await saveDraft()
+    if (!saved) return
+    setStatus({ kind: "saving", message: "Jarvis is drafting the update..." })
+
+    try {
+      const result = await draftOwnerProjectUpdateWithJarvis(
+        document.project.id,
+        document.update.id
+      )
+      if (!result.success) {
+        setStatus({ kind: "error", message: result.error })
+        return
+      }
+      setSummary(result.summary)
+      setStatus({
+        kind: "saved",
+        message: "Jarvis drafted the summary. Review and edit it before publishing.",
+      })
+      router.refresh()
+    } catch {
+      setStatus({
+        kind: "error",
+        message: "Jarvis could not draft this update. Your selections are saved.",
       })
     }
   }
 
   return (
     <section className="bg-background p-5 shadow-sm sm:p-6 print:hidden">
-      <form onSubmit={saveDraft} className="space-y-5">
-        <div className="flex flex-wrap items-start justify-between gap-3 border-b pb-3">
+      <form
+        onSubmit={(event) => {
+          event.preventDefault()
+          void saveDraft()
+        }}
+        className="space-y-6"
+      >
+        <div className="flex flex-wrap items-start justify-between gap-3 border-b pb-4">
           <div>
-            <h2 className="text-sm font-semibold">Edit Draft</h2>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Adjust the owner-facing text and selected photos before publishing.
+            <h2 className="text-base font-semibold">Create Owner Update</h2>
+            <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+              Choose the source material, ask Jarvis for a draft, then edit
+              every owner-facing section before publishing.
             </p>
           </div>
-          <Button type="submit" disabled={status.kind === "saving"}>
-            {status.kind === "saved" ? (
-              <IconCheck className="size-4" />
-            ) : (
-              <IconRefresh className="size-4" />
-            )}
-            {status.kind === "saving" ? "Saving..." : "Save draft"}
-          </Button>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void draftWithJarvis()}
+              disabled={status.kind === "saving"}
+            >
+              <IconRobot className="size-4" />
+              Draft with Jarvis
+            </Button>
+            <Button type="submit" disabled={status.kind === "saving"}>
+              {status.kind === "saved" ? (
+                <IconCheck className="size-4" />
+              ) : (
+                <IconRefresh className="size-4" />
+              )}
+              Save draft
+            </Button>
+          </div>
         </div>
 
         <div className="grid gap-4 sm:grid-cols-[1fr_12rem]">
@@ -129,7 +362,7 @@ export function OwnerUpdateDraftEditor({
             <Input
               id="owner-update-title"
               value={title}
-              onChange={(event) => setTitle(event.target.value)}
+              onChange={(event) => setTitle(event.currentTarget.value)}
               required
             />
           </div>
@@ -139,7 +372,7 @@ export function OwnerUpdateDraftEditor({
               id="owner-update-date"
               type="date"
               value={updateDate}
-              onChange={(event) => setUpdateDate(event.target.value)}
+              onChange={(event) => setUpdateDate(event.currentTarget.value)}
               required
             />
           </div>
@@ -154,7 +387,7 @@ export function OwnerUpdateDraftEditor({
               id="owner-update-period-start"
               type="date"
               value={periodStart}
-              onChange={(event) => setPeriodStart(event.target.value)}
+              onChange={(event) => setPeriodStart(event.currentTarget.value)}
               required
             />
           </div>
@@ -166,90 +399,115 @@ export function OwnerUpdateDraftEditor({
               id="owner-update-period-end"
               type="date"
               value={periodEnd}
-              onChange={(event) => setPeriodEnd(event.target.value)}
+              onChange={(event) => setPeriodEnd(event.currentTarget.value)}
               required
             />
           </div>
         </div>
         <p className="text-xs text-muted-foreground">
-          {document.update.sourceDailyLogIds.length} source daily
-          {document.update.sourceDailyLogIds.length === 1 ? " log is" : " logs are"}{" "}
-          included. Owner-hidden logs can seed this draft without exposing the
-          full log. Saving refreshes the Looking Ahead schedule for the end of
-          this period.
+          Save after changing the dates to refresh the available logs, files,
+          schedule items, and to-dos.
         </p>
 
-        <div className="space-y-2">
-          <Label htmlFor="owner-update-summary">Summary</Label>
-          <Textarea
-            id="owner-update-summary"
-            value={summary}
-            onChange={(event) => setSummary(event.target.value)}
-            className="min-h-36"
-            required
-          />
-        </div>
-
-        <div className="space-y-3 border-t pt-4">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="flex items-center gap-2">
-              <IconPhoto className="size-4 text-muted-foreground" />
-              <h3 className="text-sm font-semibold">Photos</h3>
-              <span className="text-sm text-muted-foreground">
-                {selectedPhotoIds.length} selected
-              </span>
+        <section className="border-t pt-5">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <h3 className="text-sm font-semibold">Daily logs</h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Selected hidden logs may inform Jarvis without exposing the full
+                log to the owner.
+              </p>
             </div>
-            {(document.availablePhotos.length > 0 ||
-              selectedPhotoIds.length > 0) && (
-              <div className="flex flex-wrap gap-2">
-                {document.availablePhotos.length > 0 && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={selectAllPhotos}
-                  >
-                    Select all
-                  </Button>
-                )}
-                {selectedPhotoIds.length > 0 && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={clearPhotos}
-                  >
-                    <IconX className="size-4" />
-                    Clear
-                  </Button>
-                )}
-              </div>
-            )}
+            <SelectionCount
+              selected={sourceDailyLogIds.length}
+              total={document.availableDailyLogs.length}
+            />
           </div>
-
-          {document.availablePhotos.length === 0 ? (
-            <p className="border px-3 py-3 text-sm text-muted-foreground">
-              No approved owner-visible photos are available yet.
+          {document.availableDailyLogs.length === 0 ? (
+            <p className="mt-3 text-sm text-muted-foreground">
+              No daily logs fall within this reporting period.
             </p>
           ) : (
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+            <div className="mt-3 divide-y border-y">
+              {document.availableDailyLogs.map((log) => (
+                <label
+                  key={log.id}
+                  className="flex cursor-pointer items-start gap-3 py-3"
+                >
+                  <Checkbox
+                    checked={selectedDailyLogIdSet.has(log.id)}
+                    onCheckedChange={(value) =>
+                      toggleId(
+                        setSourceDailyLogIds,
+                        log.id,
+                        value === true
+                      )
+                    }
+                    aria-label={`Include daily log from ${log.logDate}`}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-medium">{log.logDate}</span>
+                      <Badge variant="outline">
+                        {sourceLabel(log.sourceSystem)}
+                      </Badge>
+                      {!log.isClientVisible && (
+                        <Badge variant="secondary">Staff-only log</Badge>
+                      )}
+                    </span>
+                    <span className="mt-1 line-clamp-2 block text-sm text-muted-foreground">
+                      {log.workCompleted}
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="border-t pt-5">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <IconPhoto className="size-4 text-muted-foreground" />
+              <h3 className="text-sm font-semibold">
+                Compass and Buildertrend photos
+              </h3>
+            </div>
+            <SelectionCount
+              selected={selectedPhotoIds.length}
+              total={document.availablePhotos.length}
+            />
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Selecting a photo shares that photo when this update is published;
+            it does not make its whole daily log visible.
+          </p>
+          {document.availablePhotos.length === 0 ? (
+            <p className="mt-3 text-sm text-muted-foreground">
+              No photos are available for the selected period.
+            </p>
+          ) : (
+            <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
               {document.availablePhotos.map((photo) => {
                 const checked = selectedPhotoIdSet.has(photo.id)
                 const resolvedImage = resolvePhotoImageSource(photo)
                 const src = failedImageSet.has(photo.id)
                   ? null
                   : resolvedImage.src
-
                 return (
                   <label
                     key={photo.id}
                     className="group relative cursor-pointer overflow-hidden border bg-muted/20"
                   >
-                    <div className="absolute left-2 top-2 z-10 rounded-sm bg-background/90 p-1 shadow-sm">
+                    <div className="absolute left-2 top-2 z-10 bg-background/90 p-1 shadow-sm">
                       <Checkbox
                         checked={checked}
                         onCheckedChange={(value) =>
-                          togglePhoto(photo.id, value === true)
+                          toggleId(
+                            setSelectedPhotoIds,
+                            photo.id,
+                            value === true
+                          )
                         }
                         aria-label={`Select ${photo.fileName}`}
                       />
@@ -259,17 +517,23 @@ export function OwnerUpdateDraftEditor({
                         src={src}
                         alt={photo.caption ?? photo.fileName}
                         className="aspect-[4/3] w-full object-cover"
-                        onError={() => markImageFailed(photo.id)}
+                        onError={() =>
+                          setFailedImageIds((current) =>
+                            uniqueIds([...current, photo.id])
+                          )
+                        }
                       />
                     ) : (
-                      <div className="flex aspect-[4/3] w-full flex-col items-center justify-center gap-2 p-3 text-center text-xs text-muted-foreground">
-                        <IconPhoto className="size-6" />
+                      <div className="flex aspect-[4/3] items-center justify-center p-3 text-xs text-muted-foreground">
                         {resolvedImage.label}
                       </div>
                     )}
-                    <div className="border-t bg-background px-2 py-1.5">
+                    <div className="border-t bg-background px-2 py-2">
                       <p className="truncate text-xs font-medium">
                         {photo.caption ?? photo.fileName}
+                      </p>
+                      <p className="mt-1 text-[11px] text-muted-foreground">
+                        {sourceLabel(photo.sourceSystem)}
                       </p>
                     </div>
                   </label>
@@ -277,15 +541,170 @@ export function OwnerUpdateDraftEditor({
               })}
             </div>
           )}
-        </div>
+        </section>
 
-        {status.kind === "saved" && (
-          <p className="border-l-2 border-l-brand-hps-primary px-3 py-2 text-sm text-brand-hps-primary">
-            {status.message}
-          </p>
-        )}
-        {status.kind === "error" && (
-          <p className="border-l-2 border-l-destructive px-3 py-2 text-sm text-destructive">
+        <section className="border-t pt-5">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <IconFile className="size-4 text-muted-foreground" />
+              <h3 className="text-sm font-semibold">Documents</h3>
+            </div>
+            <SelectionCount
+              selected={selectedDocumentIds.length}
+              total={document.availableDocuments.length}
+            />
+          </div>
+          {document.availableDocuments.length === 0 ? (
+            <p className="mt-3 text-sm text-muted-foreground">
+              No documents are available for this period.
+            </p>
+          ) : (
+            <div className="mt-3 divide-y border-y">
+              {document.availableDocuments.map((file) => (
+                <label
+                  key={file.id}
+                  className="flex cursor-pointer items-center gap-3 py-3"
+                >
+                  <Checkbox
+                    checked={selectedDocumentIdSet.has(file.id)}
+                    onCheckedChange={(value) =>
+                      toggleId(
+                        setSelectedDocumentIds,
+                        file.id,
+                        value === true
+                      )
+                    }
+                    aria-label={`Include ${file.fileName}`}
+                  />
+                  <IconFile className="size-4 text-muted-foreground" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium">
+                      {file.caption ?? file.fileName}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {sourceLabel(file.sourceSystem)}
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          )}
+
+          <div className="mt-4 grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+            <div className="space-y-2">
+              <Label htmlFor={`owner-update-files-${document.update.id}`}>
+                Upload photos or documents
+              </Label>
+              <Input
+                id={`owner-update-files-${document.update.id}`}
+                type="file"
+                multiple
+                accept="image/*,.pdf,.doc,.docx,.xls,.xlsx,.csv,.txt"
+                onChange={(event) =>
+                  chooseUploadFiles(event.currentTarget.files)
+                }
+              />
+              <p className="text-xs text-muted-foreground">
+                {PHOTO_UPLOAD_LIMIT_LABEL}
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={`owner-update-caption-${document.update.id}`}>
+                Caption / note
+              </Label>
+              <Input
+                id={`owner-update-caption-${document.update.id}`}
+                value={uploadCaption}
+                onChange={(event) =>
+                  setUploadCaption(event.currentTarget.value)
+                }
+                placeholder="Optional note for this batch"
+              />
+            </div>
+            <div className="flex items-end">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void uploadOwnerUpdateFiles()}
+                disabled={isUploading || uploadFiles.length === 0}
+              >
+                <IconUpload className="size-4" />
+                {isUploading ? "Uploading..." : "Upload and select"}
+              </Button>
+            </div>
+          </div>
+          {uploadFiles.length > 0 && (
+            <p className="mt-2 text-xs text-muted-foreground">
+              {uploadFiles.length} selected ·{" "}
+              {formatBytes(
+                uploadFiles.reduce((total, file) => total + file.size, 0)
+              )}
+            </p>
+          )}
+        </section>
+
+        <OwnerUpdateScheduleSelector
+          title="Completed during this period"
+          icon={
+            <IconCalendarCheck className="size-4 text-muted-foreground" />
+          }
+          available={document.availableCompletedScheduleItems}
+          selected={completedScheduleItems}
+          setSelected={setCompletedScheduleItems}
+        />
+        <OwnerUpdateScheduleSelector
+          title="Looking ahead"
+          icon={
+            <IconCalendarStats className="size-4 text-muted-foreground" />
+          }
+          available={document.availableLookAheadScheduleItems}
+          selected={lookAheadScheduleItems}
+          setSelected={setLookAheadScheduleItems}
+        />
+        <OwnerUpdateTodoSelector
+          available={document.availableTodos}
+          selected={todos}
+          setSelected={setTodos}
+        />
+
+        <section className="border-t pt-5">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <Label htmlFor="owner-update-summary">Editable summary</Label>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Jarvis writes only from the sources selected above. You remain
+                in control of the final wording.
+              </p>
+            </div>
+            {summary.length > 0 && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setSummary("")}
+              >
+                <IconX className="size-4" />
+                Clear
+              </Button>
+            )}
+          </div>
+          <Textarea
+            id="owner-update-summary"
+            value={summary}
+            onChange={(event) => setSummary(event.currentTarget.value)}
+            className="mt-3 min-h-44"
+            placeholder="Write the update manually or use Draft with Jarvis."
+          />
+        </section>
+
+        {status.kind !== "idle" && (
+          <p
+            className={
+              status.kind === "error"
+                ? "border-l-2 border-l-destructive px-3 py-2 text-sm text-destructive"
+                : "border-l-2 border-l-brand-hps-primary px-3 py-2 text-sm text-brand-hps-primary"
+            }
+          >
             {status.message}
           </p>
         )}

--- a/src/components/projects/owner-update-item-selectors.tsx
+++ b/src/components/projects/owner-update-item-selectors.tsx
@@ -1,0 +1,299 @@
+"use client"
+
+import type * as React from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import type {
+  OwnerUpdateScheduleSelection,
+  OwnerUpdateTodoSelection,
+} from "@/lib/owner-updates/snapshot"
+
+function mergeScheduleItems(
+  selected: readonly OwnerUpdateScheduleSelection[],
+  available: readonly OwnerUpdateScheduleSelection[]
+): readonly OwnerUpdateScheduleSelection[] {
+  const byId = new Map(
+    [...selected, ...available].map((item) => [item.id, item])
+  )
+  return [...byId.values()]
+}
+
+function mergeTodoItems(
+  selected: readonly OwnerUpdateTodoSelection[],
+  available: readonly OwnerUpdateTodoSelection[]
+): readonly OwnerUpdateTodoSelection[] {
+  const byId = new Map(
+    [...selected, ...available].map((item) => [item.id, item])
+  )
+  return [...byId.values()]
+}
+
+function SelectionCount({
+  selected,
+  total,
+}: {
+  readonly selected: number
+  readonly total: number
+}): React.ReactElement {
+  return (
+    <span className="text-xs text-muted-foreground">
+      {selected} selected · {total} available
+    </span>
+  )
+}
+
+export function OwnerUpdateScheduleSelector({
+  title,
+  icon,
+  available,
+  selected,
+  setSelected,
+}: {
+  readonly title: string
+  readonly icon: React.ReactNode
+  readonly available: readonly OwnerUpdateScheduleSelection[]
+  readonly selected: readonly OwnerUpdateScheduleSelection[]
+  readonly setSelected: React.Dispatch<
+    React.SetStateAction<readonly OwnerUpdateScheduleSelection[]>
+  >
+}): React.ReactElement {
+  const choices = mergeScheduleItems(selected, available)
+  const selectedIds = new Set(selected.map((item) => item.id))
+
+  function toggle(item: OwnerUpdateScheduleSelection, checked: boolean): void {
+    setSelected((current) =>
+      checked
+        ? [...current, item]
+        : current.filter((candidate) => candidate.id !== item.id)
+    )
+  }
+
+  function updateSelected(
+    id: string,
+    field: "title" | "notes",
+    value: string
+  ): void {
+    setSelected((current) =>
+      current.map((item) =>
+        item.id === id ? { ...item, [field]: value } : item
+      )
+    )
+  }
+
+  return (
+    <section className="border-t pt-5">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          {icon}
+          <h3 className="text-sm font-semibold">{title}</h3>
+        </div>
+        <SelectionCount selected={selected.length} total={choices.length} />
+      </div>
+      {choices.length === 0 ? (
+        <p className="mt-3 text-sm text-muted-foreground">
+          No matching schedule items for this reporting period.
+        </p>
+      ) : (
+        <div className="mt-3 divide-y border-y">
+          {choices.map((item) => {
+            const checked = selectedIds.has(item.id)
+            const edited = selected.find(
+              (candidate) => candidate.id === item.id
+            )
+            return (
+              <div key={item.id} className="py-3">
+                <label className="flex cursor-pointer items-start gap-3">
+                  <Checkbox
+                    checked={checked}
+                    onCheckedChange={(value) =>
+                      toggle(item, value === true)
+                    }
+                    aria-label={`Include ${item.title}`}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-sm font-medium">
+                      {item.title}
+                    </span>
+                    <span className="mt-1 block text-xs text-muted-foreground">
+                      {item.startDate} – {item.endDate} ·{" "}
+                      {item.percentComplete}% complete
+                      {item.assignedTo ? ` · ${item.assignedTo}` : ""}
+                    </span>
+                  </span>
+                </label>
+                {checked && (
+                  <div className="ml-7 mt-3 grid gap-2 md:grid-cols-2">
+                    <Input
+                      value={edited?.title ?? item.title}
+                      onChange={(event) =>
+                        updateSelected(
+                          item.id,
+                          "title",
+                          event.currentTarget.value
+                        )
+                      }
+                      aria-label={`Owner-facing title for ${item.title}`}
+                    />
+                    <Input
+                      value={edited?.notes ?? ""}
+                      onChange={(event) =>
+                        updateSelected(
+                          item.id,
+                          "notes",
+                          event.currentTarget.value
+                        )
+                      }
+                      placeholder="Optional owner-facing note"
+                      aria-label={`Owner-facing note for ${item.title}`}
+                    />
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}
+
+export function OwnerUpdateTodoSelector({
+  available,
+  selected,
+  setSelected,
+}: {
+  readonly available: readonly OwnerUpdateTodoSelection[]
+  readonly selected: readonly OwnerUpdateTodoSelection[]
+  readonly setSelected: React.Dispatch<
+    React.SetStateAction<readonly OwnerUpdateTodoSelection[]>
+  >
+}): React.ReactElement {
+  const choices = mergeTodoItems(selected, available)
+  const selectedIds = new Set(selected.map((item) => item.id))
+
+  function toggle(item: OwnerUpdateTodoSelection, checked: boolean): void {
+    setSelected((current) =>
+      checked
+        ? [...current, item]
+        : current.filter((candidate) => candidate.id !== item.id)
+    )
+  }
+
+  function updateSelected(
+    id: string,
+    field: "title" | "description" | "notes",
+    value: string
+  ): void {
+    setSelected((current) =>
+      current.map((item) =>
+        item.id === id ? { ...item, [field]: value } : item
+      )
+    )
+  }
+
+  return (
+    <section className="border-t pt-5">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold">To-dos</h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Due during the reporting period or the following seven days.
+          </p>
+        </div>
+        <SelectionCount selected={selected.length} total={choices.length} />
+      </div>
+      {choices.length === 0 ? (
+        <p className="mt-3 text-sm text-muted-foreground">
+          No matching to-dos for this period.
+        </p>
+      ) : (
+        <div className="mt-3 divide-y border-y">
+          {choices.map((item) => {
+            const checked = selectedIds.has(item.id)
+            const edited = selected.find(
+              (candidate) => candidate.id === item.id
+            )
+            return (
+              <div key={item.id} className="py-3">
+                <label className="flex cursor-pointer items-start gap-3">
+                  <Checkbox
+                    checked={checked}
+                    onCheckedChange={(value) =>
+                      toggle(item, value === true)
+                    }
+                    aria-label={`Include ${item.title}`}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-medium">{item.title}</span>
+                      <Badge variant="outline">
+                        {item.timing === "upcoming"
+                          ? "Upcoming week"
+                          : "Reporting period"}
+                      </Badge>
+                    </span>
+                    <span className="mt-1 block text-xs text-muted-foreground">
+                      {item.status}
+                      {item.dueDate ? ` · Due ${item.dueDate}` : ""}
+                      {item.assigneeName
+                        ? ` · ${item.assigneeName}`
+                        : item.companyName
+                          ? ` · ${item.companyName}`
+                          : ""}
+                    </span>
+                  </span>
+                </label>
+                {checked && (
+                  <div className="ml-7 mt-3 grid gap-2">
+                    <Input
+                      value={edited?.title ?? item.title}
+                      onChange={(event) =>
+                        updateSelected(
+                          item.id,
+                          "title",
+                          event.currentTarget.value
+                        )
+                      }
+                      aria-label={`Owner-facing title for ${item.title}`}
+                    />
+                    <div className="grid gap-2 md:grid-cols-2">
+                      <Textarea
+                        value={edited?.description ?? item.description}
+                        onChange={(event) =>
+                          updateSelected(
+                            item.id,
+                            "description",
+                            event.currentTarget.value
+                          )
+                        }
+                        className="min-h-20"
+                        placeholder="Owner-facing description"
+                        aria-label={`Owner-facing description for ${item.title}`}
+                      />
+                      <Textarea
+                        value={edited?.notes ?? item.notes}
+                        onChange={(event) =>
+                          updateSelected(
+                            item.id,
+                            "notes",
+                            event.currentTarget.value
+                          )
+                        }
+                        className="min-h-20"
+                        placeholder="Optional update note"
+                        aria-label={`Owner-facing note for ${item.title}`}
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/lib/owner-updates/__tests__/composer.test.ts
+++ b/src/lib/owner-updates/__tests__/composer.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  addDaysToIsoDate,
+  buildOwnerUpdateDraftPrompt,
+  cleanOwnerUpdateDraft,
+  defaultOwnerUpdatePeriod,
+  isCompletedScheduleCandidate,
+  isLookAheadScheduleCandidate,
+  ownerUpdateTodoTiming,
+} from "@/lib/owner-updates/composer"
+
+describe("owner update composer", () => {
+  it("defaults to a seven-day reporting window", () => {
+    expect(defaultOwnerUpdatePeriod("2026-07-27")).toEqual({
+      startDate: "2026-07-21",
+      endDate: "2026-07-27",
+    })
+    expect(addDaysToIsoDate("2026-07-31", 1)).toBe("2026-08-01")
+  })
+
+  it("separates completed and look-ahead schedule candidates", () => {
+    expect(
+      isCompletedScheduleCandidate(
+        {
+          status: "COMPLETE",
+          percentComplete: 100,
+          endDate: "2026-07-24",
+        },
+        "2026-07-20",
+        "2026-07-26"
+      )
+    ).toBe(true)
+    expect(
+      isLookAheadScheduleCandidate(
+        {
+          status: "IN_PROGRESS",
+          percentComplete: 40,
+          startDate: "2026-07-27",
+          endDate: "2026-07-31",
+        },
+        "2026-07-26"
+      )
+    ).toBe(true)
+  })
+
+  it("includes to-dos from the reporting period and following week", () => {
+    expect(
+      ownerUpdateTodoTiming(
+        "2026-07-24",
+        "2026-07-20",
+        "2026-07-26"
+      )
+    ).toBe("reporting_period")
+    expect(
+      ownerUpdateTodoTiming(
+        "2026-08-02",
+        "2026-07-20",
+        "2026-07-26"
+      )
+    ).toBe("upcoming")
+    expect(
+      ownerUpdateTodoTiming(
+        "2026-08-03",
+        "2026-07-20",
+        "2026-07-26"
+      )
+    ).toBeNull()
+  })
+
+  it("builds a bounded source-only Jarvis instruction", () => {
+    const prompt = buildOwnerUpdateDraftPrompt({
+      projectLabel: "O-202 Loeffler",
+      periodStart: "2026-07-20",
+      periodEnd: "2026-07-26",
+      dailyLogs: [
+        {
+          logDate: "2026-07-24",
+          workCompleted: "Installed cabinets.",
+          issues: null,
+          notes: "Countertop template next.",
+        },
+      ],
+      attachments: [
+        {
+          fileName: "kitchen.jpg",
+          caption: "Kitchen cabinets installed",
+          kind: "photo",
+        },
+      ],
+      completedScheduleItems: [],
+      lookAheadScheduleItems: [],
+      todos: [],
+    })
+
+    expect(prompt).toContain("Use only the supplied information")
+    expect(prompt).toContain("Installed cabinets.")
+    expect(prompt).toContain("Countertop template next.")
+    expect(prompt).toContain("Kitchen cabinets installed")
+    expect(cleanOwnerUpdateDraft("```text\nDraft summary\n```")).toBe(
+      "Draft summary"
+    )
+  })
+})

--- a/src/lib/owner-updates/__tests__/snapshot.test.ts
+++ b/src/lib/owner-updates/__tests__/snapshot.test.ts
@@ -4,9 +4,12 @@ import {
   dateRangeFromDates,
   isDateWithinOwnerUpdatePeriod,
   isValidOwnerUpdatePeriod,
+  parseOwnerUpdateComposerSnapshot,
   parseOwnerUpdateScheduleSnapshot,
   selectRowsByIdOrder,
+  serializeOwnerUpdateComposerSnapshot,
   serializeOwnerUpdateScheduleSnapshot,
+  type OwnerUpdateComposerSnapshot,
 } from "@/lib/owner-updates/snapshot"
 
 describe("owner update snapshots", () => {
@@ -56,6 +59,57 @@ describe("owner update snapshots", () => {
         JSON.stringify([{ title: "Missing dates" }])
       )
     ).toEqual([])
+  })
+
+  it("round-trips curated schedule, to-do, and document selections", () => {
+    const snapshot: OwnerUpdateComposerSnapshot = {
+      version: 2,
+      completedScheduleItems: [
+        {
+          id: "schedule-complete",
+          title: "Framing completed",
+          startDate: "2026-07-20",
+          endDate: "2026-07-24",
+          assignedTo: "Framing crew",
+          status: "COMPLETE",
+          percentComplete: 100,
+          notes: "Ready for inspection.",
+        },
+      ],
+      lookAheadScheduleItems: [],
+      todos: [
+        {
+          id: "todo-one",
+          title: "Confirm appliance delivery",
+          description: "Coordinate delivery window.",
+          status: "open",
+          priority: "normal",
+          assigneeName: "Rebekah",
+          companyName: null,
+          dueDate: "2026-07-29",
+          timing: "upcoming",
+          notes: "",
+        },
+      ],
+      documents: [
+        {
+          id: "document-one",
+          fileName: "selection.pdf",
+          mimeType: "application/pdf",
+          driveFileId: "drive-one",
+          driveUrl: null,
+          caption: "Approved selection",
+          capturedAt: "2026-07-24T12:00:00.000Z",
+          sourceSystem: "compass_upload",
+        },
+      ],
+    }
+
+    expect(
+      parseOwnerUpdateComposerSnapshot(
+        serializeOwnerUpdateComposerSnapshot(snapshot)
+      )
+    ).toEqual(snapshot)
   })
 
   it("derives reporting periods from selected log dates", () => {

--- a/src/lib/owner-updates/composer.ts
+++ b/src/lib/owner-updates/composer.ts
@@ -1,0 +1,183 @@
+import type {
+  OwnerUpdateScheduleSelection,
+  OwnerUpdateTodoSelection,
+} from "@/lib/owner-updates/snapshot"
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+function isoDateFromUtc(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+export function addDaysToIsoDate(value: string, days: number): string {
+  if (!ISO_DATE_PATTERN.test(value)) return value
+  const date = new Date(`${value}T12:00:00.000Z`)
+  date.setUTCDate(date.getUTCDate() + days)
+  return isoDateFromUtc(date)
+}
+
+export function defaultOwnerUpdatePeriod(updateDate: string): {
+  readonly startDate: string
+  readonly endDate: string
+} {
+  return {
+    startDate: addDaysToIsoDate(updateDate, -6),
+    endDate: updateDate,
+  }
+}
+
+export function isCompletedScheduleCandidate(
+  item: {
+    readonly status: string
+    readonly percentComplete: number
+    readonly endDate: string
+  },
+  periodStart: string,
+  periodEnd: string
+): boolean {
+  const completed =
+    item.percentComplete >= 100 ||
+    ["COMPLETE", "COMPLETED", "DONE"].includes(item.status.toUpperCase())
+  return (
+    completed &&
+    item.endDate >= periodStart &&
+    item.endDate <= periodEnd
+  )
+}
+
+export function isLookAheadScheduleCandidate(
+  item: {
+    readonly status: string
+    readonly percentComplete: number
+    readonly endDate: string
+    readonly startDate: string
+  },
+  periodEnd: string
+): boolean {
+  const completed =
+    item.percentComplete >= 100 ||
+    ["COMPLETE", "COMPLETED", "DONE"].includes(item.status.toUpperCase())
+  return !completed && item.endDate >= periodEnd
+}
+
+export function ownerUpdateTodoTiming(
+  dueDate: string | null,
+  periodStart: string,
+  periodEnd: string
+): "reporting_period" | "upcoming" | null {
+  if (dueDate === null) return null
+  if (dueDate >= periodStart && dueDate <= periodEnd) {
+    return "reporting_period"
+  }
+  if (dueDate > periodEnd && dueDate <= addDaysToIsoDate(periodEnd, 7)) {
+    return "upcoming"
+  }
+  return null
+}
+
+function scheduleLines(
+  items: readonly OwnerUpdateScheduleSelection[]
+): string {
+  if (items.length === 0) return "- None selected"
+  return items
+    .map(
+      (item) =>
+        `- ${item.title} (${item.startDate} to ${item.endDate}; ` +
+        `${item.percentComplete}% complete)` +
+        (item.notes.trim().length > 0 ? ` — ${item.notes.trim()}` : "")
+    )
+    .join("\n")
+}
+
+function todoLines(items: readonly OwnerUpdateTodoSelection[]): string {
+  if (items.length === 0) return "- None selected"
+  return items
+    .map(
+      (item) =>
+        `- ${item.title} (${item.status}` +
+        (item.dueDate ? `; due ${item.dueDate}` : "") +
+        (item.assigneeName ? `; ${item.assigneeName}` : "") +
+        `)` +
+        (item.description.trim().length > 0
+          ? ` — ${item.description.trim()}`
+          : "") +
+        (item.notes.trim().length > 0 ? ` — ${item.notes.trim()}` : "")
+    )
+    .join("\n")
+}
+
+export function buildOwnerUpdateDraftPrompt(input: {
+  readonly projectLabel: string
+  readonly periodStart: string
+  readonly periodEnd: string
+  readonly dailyLogs: readonly {
+    readonly logDate: string
+    readonly workCompleted: string
+    readonly issues: string | null
+    readonly notes: string | null
+  }[]
+  readonly attachments: readonly {
+    readonly fileName: string
+    readonly caption: string | null
+    readonly kind: "photo" | "document"
+  }[]
+  readonly completedScheduleItems: readonly OwnerUpdateScheduleSelection[]
+  readonly lookAheadScheduleItems: readonly OwnerUpdateScheduleSelection[]
+  readonly todos: readonly OwnerUpdateTodoSelection[]
+}): string {
+  const logLines =
+    input.dailyLogs.length === 0
+      ? "- None selected"
+      : input.dailyLogs
+          .map(
+            (log) =>
+              `- ${log.logDate}: ${log.workCompleted}` +
+              (log.issues ? ` Issues: ${log.issues}` : "") +
+              (log.notes ? ` Notes/next: ${log.notes}` : "")
+          )
+          .join("\n")
+  const attachmentLines =
+    input.attachments.length === 0
+      ? "- None selected"
+      : input.attachments
+          .map(
+            (attachment) =>
+              `- ${attachment.kind}: ` +
+              `${attachment.caption ?? attachment.fileName}`
+          )
+          .join("\n")
+
+  return [
+    "Draft the concise owner-facing Summary section for a construction project update.",
+    "Use only the supplied information. Do not invent facts, dates, completion percentages, commitments, or names.",
+    "Write in a clear, confident, professional tone. Avoid internal jargon and avoid mentioning that you are an AI.",
+    "Return only the editable summary text, using short paragraphs and no markdown heading.",
+    `Project: ${input.projectLabel}`,
+    `Reporting period: ${input.periodStart} through ${input.periodEnd}`,
+    "",
+    "Selected daily logs:",
+    logLines,
+    "",
+    "Selected photos and documents:",
+    attachmentLines,
+    "",
+    "Selected schedule items completed during the period:",
+    scheduleLines(input.completedScheduleItems),
+    "",
+    "Selected schedule items looking ahead:",
+    scheduleLines(input.lookAheadScheduleItems),
+    "",
+    "Selected to-dos:",
+    todoLines(input.todos),
+  ].join("\n")
+}
+
+export function cleanOwnerUpdateDraft(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed.startsWith("```") || !trimmed.endsWith("```")) return trimmed
+
+  return trimmed
+    .replace(/^```(?:text|markdown)?\s*/i, "")
+    .replace(/\s*```$/, "")
+    .trim()
+}

--- a/src/lib/owner-updates/snapshot.ts
+++ b/src/lib/owner-updates/snapshot.ts
@@ -11,11 +11,149 @@ const scheduleItemSchema = z.object({
 
 const scheduleSnapshotSchema = z.array(scheduleItemSchema)
 
+const scheduleSelectionSchema = scheduleItemSchema.extend({
+  id: z.string().trim().min(1),
+  status: z.string(),
+  percentComplete: z.number().min(0).max(100),
+  notes: z.string(),
+})
+
+const todoSelectionSchema = z.object({
+  id: z.string().trim().min(1),
+  title: z.string().trim().min(1),
+  description: z.string(),
+  status: z.string(),
+  priority: z.string(),
+  assigneeName: z.string().nullable(),
+  companyName: z.string().nullable(),
+  dueDate: z.string().nullable(),
+  timing: z.union([z.literal("reporting_period"), z.literal("upcoming")]),
+  notes: z.string(),
+})
+
+const documentSelectionSchema = z.object({
+  id: z.string().trim().min(1),
+  fileName: z.string().trim().min(1),
+  mimeType: z.string().nullable(),
+  driveFileId: z.string().nullable(),
+  driveUrl: z.string().nullable(),
+  caption: z.string().nullable(),
+  capturedAt: z.string().nullable(),
+  sourceSystem: z.string(),
+})
+
+const composerSnapshotSchema = z.object({
+  version: z.literal(2),
+  completedScheduleItems: z.array(scheduleSelectionSchema),
+  lookAheadScheduleItems: z.array(scheduleSelectionSchema),
+  todos: z.array(todoSelectionSchema),
+  documents: z.array(documentSelectionSchema),
+})
+
 export type OwnerUpdateScheduleItem = {
   readonly title: string
   readonly startDate: string
   readonly endDate: string
   readonly assignedTo: string | null
+}
+
+export type OwnerUpdateScheduleSelection = OwnerUpdateScheduleItem & {
+  readonly id: string
+  readonly status: string
+  readonly percentComplete: number
+  readonly notes: string
+}
+
+export type OwnerUpdateTodoSelection = {
+  readonly id: string
+  readonly title: string
+  readonly description: string
+  readonly status: string
+  readonly priority: string
+  readonly assigneeName: string | null
+  readonly companyName: string | null
+  readonly dueDate: string | null
+  readonly timing: "reporting_period" | "upcoming"
+  readonly notes: string
+}
+
+export type OwnerUpdateDocumentSelection = {
+  readonly id: string
+  readonly fileName: string
+  readonly mimeType: string | null
+  readonly driveFileId: string | null
+  readonly driveUrl: string | null
+  readonly caption: string | null
+  readonly capturedAt: string | null
+  readonly sourceSystem: string
+}
+
+export type OwnerUpdateComposerSnapshot = {
+  readonly version: 2
+  readonly completedScheduleItems: readonly OwnerUpdateScheduleSelection[]
+  readonly lookAheadScheduleItems: readonly OwnerUpdateScheduleSelection[]
+  readonly todos: readonly OwnerUpdateTodoSelection[]
+  readonly documents: readonly OwnerUpdateDocumentSelection[]
+}
+
+export function emptyOwnerUpdateComposerSnapshot(): OwnerUpdateComposerSnapshot {
+  return {
+    version: 2,
+    completedScheduleItems: [],
+    lookAheadScheduleItems: [],
+    todos: [],
+    documents: [],
+  }
+}
+
+export function parseOwnerUpdateComposerSnapshot(
+  value: string | null
+): OwnerUpdateComposerSnapshot {
+  if (value === null || value.trim().length === 0) {
+    return emptyOwnerUpdateComposerSnapshot()
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(value)
+    const composerResult = composerSnapshotSchema.safeParse(parsed)
+    if (composerResult.success) {
+      return {
+        version: 2,
+        completedScheduleItems: composerResult.data.completedScheduleItems,
+        lookAheadScheduleItems: composerResult.data.lookAheadScheduleItems,
+        todos: composerResult.data.todos,
+        documents: composerResult.data.documents,
+      }
+    }
+
+    const legacyResult = scheduleSnapshotSchema.safeParse(parsed)
+    if (!legacyResult.success) return emptyOwnerUpdateComposerSnapshot()
+
+    return {
+      version: 2,
+      completedScheduleItems: [],
+      lookAheadScheduleItems: legacyResult.data.map((item, index) => ({
+        id: `legacy-${index}`,
+        title: item.title,
+        startDate: item.startDate,
+        endDate: item.endDate,
+        assignedTo: item.assignedTo,
+        status: "PENDING",
+        percentComplete: 0,
+        notes: "",
+      })),
+      todos: [],
+      documents: [],
+    }
+  } catch {
+    return emptyOwnerUpdateComposerSnapshot()
+  }
+}
+
+export function serializeOwnerUpdateComposerSnapshot(
+  snapshot: OwnerUpdateComposerSnapshot
+): string {
+  return JSON.stringify(snapshot)
 }
 
 type IdentifiedRow = {
@@ -25,21 +163,14 @@ type IdentifiedRow = {
 export function parseOwnerUpdateScheduleSnapshot(
   value: string | null
 ): readonly OwnerUpdateScheduleItem[] {
-  if (value === null || value.trim().length === 0) return []
-
-  try {
-    const result = scheduleSnapshotSchema.safeParse(JSON.parse(value))
-    if (!result.success) return []
-
-    return result.data.map((item) => ({
+  return parseOwnerUpdateComposerSnapshot(value).lookAheadScheduleItems.map(
+    (item) => ({
       title: item.title,
       startDate: item.startDate,
       endDate: item.endDate,
       assignedTo: item.assignedTo,
-    }))
-  } catch {
-    return []
-  }
+    })
+  )
 }
 
 export function serializeOwnerUpdateScheduleSnapshot(


### PR DESCRIPTION
## What changed

- replaces separate manual and build-from-logs entry points with one **Create Owner Update** workflow
- lets staff curate daily logs, Compass and Buildertrend photos, uploaded photos and documents, completed schedule work, look-ahead schedule work, and prior/upcoming to-dos
- keeps each selected schedule item and to-do editable without changing its source record
- adds **Draft with Jarvis** using only the sources selected for that update
- freezes the curated selections in the owner-update snapshot so later source changes do not silently alter a published update
- allows photos from staff-only daily logs to be published independently without exposing the full daily log
- adds completed-work, to-do, document, and expanded look-ahead sections to the published owner update

## Why

The prior workflow split manual authoring from log-based authoring and did not provide one place to curate all of the information needed for a weekly owner update. Staff need to assemble the update first, then let Jarvis help draft from the approved source material while retaining full editorial control.

## Validation

- `bunx tsc --noEmit`
- `bun lint` (0 errors; repository warnings only)
- owner-update, photo, and Jarvis focused tests: 28 passed
- `bun run build`
- full `bun test`: 293 passed; known repository harness failures remain from Bun collecting Playwright specs, unavailable `better-sqlite3` native bindings, and Vitest-only helpers when invoked through Bun
