### PR TITLE
feat(projects): restore project context controls

### DIFF
--- a/src/app/actions/project-field.ts
+++ b/src/app/actions/project-field.ts
@@ -294,7 +294,12 @@ type CreateDailyLogResult =
 
 type UpdateDailyLogInput = CreateDailyLogInput & {
   readonly dailyLogId: string
+  readonly targetProjectId: string
 }
+
+type UpdateDailyLogResult =
+  | { readonly success: true; readonly projectId: string }
+  | { readonly success: false; readonly error: string }
 
 type ProjectWeatherSnapshotResult =
   | { readonly success: true; readonly weather: ProjectWeatherSnapshot }
@@ -1607,13 +1612,17 @@ export async function createProjectDailyLog(
 export async function updateProjectDailyLog(
   projectId: string,
   input: UpdateDailyLogInput
-): Promise<DailyLogMutationResult> {
+): Promise<UpdateDailyLogResult> {
   try {
     const { db } = await verifyDailyLogStaffMutationAccess(projectId)
     const dailyLogId = input.dailyLogId.trim()
+    const targetProjectId = input.targetProjectId.trim()
 
     if (dailyLogId.length === 0) {
       return { success: false, error: "Daily log is required." }
+    }
+    if (targetProjectId.length === 0) {
+      return { success: false, error: "Project is required." }
     }
 
     const [existing] = await db
@@ -1628,10 +1637,81 @@ export async function updateProjectDailyLog(
 
     const logDate = normalizedLogDate(input.logDate)
     const workCompleted = requiredText(input.workCompleted, "Work completed")
+    const now = new Date().toISOString()
+
+    if (targetProjectId !== projectId) {
+      await verifyDailyLogStaffMutationAccess(targetProjectId)
+
+      const attachedPhotoRows = await db
+        .select({ id: dailyLogPhotos.id })
+        .from(dailyLogPhotos)
+        .where(eq(dailyLogPhotos.dailyLogId, dailyLogId))
+      const attachedPhotoIds = new Set(
+        attachedPhotoRows.map((photo) => photo.id)
+      )
+      const updateRows = await db
+        .select({
+          title: ownerProjectUpdates.title,
+          sourceDailyLogIds: ownerProjectUpdates.sourceDailyLogIds,
+          selectedPhotoIds: ownerProjectUpdates.selectedPhotoIds,
+        })
+        .from(ownerProjectUpdates)
+        .where(eq(ownerProjectUpdates.projectId, projectId))
+      const referencedUpdate = updateRows.find(
+        (update) =>
+          parseIdList(update.sourceDailyLogIds).includes(dailyLogId) ||
+          parseIdList(update.selectedPhotoIds).some((photoId) =>
+            attachedPhotoIds.has(photoId)
+          )
+      )
+
+      if (referencedUpdate) {
+        return {
+          success: false,
+          error: `Remove this log and its photos from "${referencedUpdate.title}" before changing projects.`,
+        }
+      }
+
+      await db
+        .update(dailyLogPhotos)
+        .set({
+          projectId: targetProjectId,
+          reviewStatus: "needs_review",
+          ownerVisible: false,
+          subVendorVisible: false,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(dailyLogPhotos.projectId, projectId),
+            eq(dailyLogPhotos.dailyLogId, dailyLogId)
+          )
+        )
+
+      await db
+        .update(projectOperations)
+        .set({
+          projectId: targetProjectId,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(projectOperations.projectId, projectId),
+            eq(projectOperations.sourceRecordId, dailyLogId)
+          )
+        )
+
+      // Schedule items belong to a specific project, so their association
+      // cannot safely follow a daily log that moves to another project.
+      await db
+        .delete(dailyLogTaskLinks)
+        .where(eq(dailyLogTaskLinks.dailyLogId, dailyLogId))
+    }
 
     await db
       .update(dailyLogs)
       .set({
+        projectId: targetProjectId,
         logDate,
         weatherTempF: input.weatherTempF,
         weatherConditions: optionalText(input.weatherConditions),
@@ -1648,15 +1728,22 @@ export async function updateProjectDailyLog(
         isClientVisible: false,
         reviewStatus: "needs_review",
         syncStatus: "pending",
-        updatedAt: new Date().toISOString(),
+        updatedAt: now,
       })
       .where(and(eq(dailyLogs.id, dailyLogId), eq(dailyLogs.projectId, projectId)))
 
     revalidatePath(`/dashboard/projects/${projectId}`)
     revalidatePath(`/dashboard/projects/${projectId}/daily-logs`)
     revalidatePath(`/dashboard/projects/${projectId}/owner-updates`)
+    if (targetProjectId !== projectId) {
+      revalidatePath(`/dashboard/projects/${targetProjectId}`)
+      revalidatePath(`/dashboard/projects/${targetProjectId}/daily-logs`)
+      revalidatePath(
+        `/dashboard/projects/${targetProjectId}/owner-updates`
+      )
+    }
 
-    return { success: true }
+    return { success: true, projectId: targetProjectId }
   } catch (error) {
     return {
       success: false,

--- a/src/components/nav-projects.tsx
+++ b/src/components/nav-projects.tsx
@@ -30,6 +30,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
+import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
 import { cn } from "@/lib/utils"
 import type { ProjectListItem } from "@/app/actions/projects"
 
@@ -157,13 +158,18 @@ const PROJECT_SECTION_ITEMS: readonly ProjectSectionItem[] = [
   },
 ]
 
-function projectDisplay(project: ProjectListItem): string {
-  return project.projectNumber ?? project.name
-}
-
 function projectSectionHref(projectId: string, suffix: string): string {
   const baseHref = `/dashboard/projects/${projectId}`
   return suffix ? `${baseHref}/${suffix}` : baseHref
+}
+
+function projectTargetSection(
+  section: ProjectSectionKey
+): string | undefined {
+  const matchingItem = PROJECT_SECTION_ITEMS.find(
+    (item) => item.section === section
+  )
+  return matchingItem?.hrefSuffix || undefined
 }
 
 function activeProjectSection(pathname: string | null): ProjectSectionKey {
@@ -207,6 +213,7 @@ export function NavProjects({
   )?.[1]
   const activeProject = projects.find((project) => project.id === activeId)
   const activeSection = activeProjectSection(pathname)
+  const activeTargetSection = projectTargetSection(activeSection)
 
   return (
     <>
@@ -226,20 +233,19 @@ export function NavProjects({
       </SidebarGroup>
 
       {activeProject && (
-        <div className="mx-2 mb-2 rounded-lg border border-sidebar-border/70 bg-sidebar-accent/35 px-3 py-2">
-          <div className="flex min-w-0 items-start gap-2">
-            <IconFolder className="mt-0.5 size-4 shrink-0 text-sidebar-foreground/70" />
-            <div className="min-w-0">
-              <p className="truncate text-sm font-semibold">
-                {projectDisplay(activeProject)}
-              </p>
-              {activeProject.projectNumber && (
-                <p className="truncate text-xs text-sidebar-foreground/60">
-                  {activeProject.name}
-                </p>
-              )}
-            </div>
-          </div>
+        <div className="mx-2 mb-2">
+          <ProjectQuickSwitcher
+            projects={projects}
+            currentProjectId={activeProject.id}
+            targetSection={activeTargetSection}
+            placeholder="Switch project..."
+            className="h-10 w-full border-sidebar-border/70 bg-sidebar-accent/35 px-2 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+          />
+          {activeProject.projectNumber && (
+            <p className="mt-1 truncate px-2 text-xs text-sidebar-foreground/60">
+              {activeProject.name}
+            </p>
+          )}
         </div>
       )}
 

--- a/src/components/projects/project-daily-log-workspace.tsx
+++ b/src/components/projects/project-daily-log-workspace.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import { DailyLogPrintDocument } from "@/components/projects/daily-log-print-document"
+import { useProjectList } from "@/components/project-list-provider"
 import { ProjectContextSwitcher } from "@/components/projects/project-context-switcher"
 import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
 import {
@@ -515,6 +516,7 @@ export function ProjectDailyLogWorkspace({
   readonly assigneeOptions: readonly ProjectTaskAssigneeOption[]
 }): React.ReactElement {
   const router = useRouter()
+  const projects = useProjectList()
   const [logs, setLogs] =
     React.useState<readonly ProjectDailyLogItem[]>(workspace.logs)
   const [filter, setFilter] = React.useState<LogFilter>("all")
@@ -522,6 +524,9 @@ export function ProjectDailyLogWorkspace({
   const [showNewLog, setShowNewLog] = React.useState(false)
   const [draft, setDraft] = React.useState<DailyLogDraft>(emptyDailyLogDraft)
   const [editingLogId, setEditingLogId] = React.useState<string | null>(null)
+  const [editProjectId, setEditProjectId] = React.useState(
+    workspace.project.id
+  )
   const [editDraft, setEditDraft] =
     React.useState<DailyLogDraft>(emptyDailyLogDraft)
   const [uploadingLogId, setUploadingLogId] = React.useState<string | null>(null)
@@ -547,8 +552,9 @@ export function ProjectDailyLogWorkspace({
     setLogs(workspace.logs)
     setSelectedIds([])
     setEditingLogId(null)
+    setEditProjectId(workspace.project.id)
     setUploadingLogId(null)
-  }, [workspace.logs])
+  }, [workspace.logs, workspace.project.id])
 
   React.useEffect(() => {
     function finishPrinting(): void {
@@ -629,11 +635,13 @@ export function ProjectDailyLogWorkspace({
     setMessage(null)
     setShowNewLog(false)
     setEditingLogId(log.id)
+    setEditProjectId(workspace.project.id)
     setEditDraft(draftFromLog(log))
   }
 
   function cancelEditingLog(): void {
     setEditingLogId(null)
+    setEditProjectId(workspace.project.id)
     setEditDraft(emptyDailyLogDraft())
   }
 
@@ -853,6 +861,7 @@ export function ProjectDailyLogWorkspace({
     startTransition(async () => {
       const result = await updateProjectDailyLog(workspace.project.id, {
         dailyLogId: log.id,
+        targetProjectId: editProjectId,
         logDate: editDraft.logDate,
         weatherTempF: optionalNumber(editDraft.weatherTempF),
         weatherConditions: editDraft.weatherConditions,
@@ -869,8 +878,14 @@ export function ProjectDailyLogWorkspace({
 
       if (result.success) {
         cancelEditingLog()
-        setMessage("Daily log updated and returned to review.")
-        router.refresh()
+        if (result.projectId === workspace.project.id) {
+          setMessage("Daily log updated and returned to review.")
+          router.refresh()
+        } else {
+          router.push(
+            `/dashboard/projects/${result.projectId}/daily-logs#daily-log-${log.id}`
+          )
+        }
       } else {
         setMessage(result.error)
       }
@@ -1414,6 +1429,35 @@ export function ProjectDailyLogWorkspace({
                         Save edits
                       </Button>
                     </div>
+                  </div>
+                  <div className="grid max-w-xl gap-1.5">
+                    <Label htmlFor={`daily-log-edit-project-${log.id}`}>
+                      Project
+                    </Label>
+                    <Select
+                      value={editProjectId}
+                      onValueChange={setEditProjectId}
+                    >
+                      <SelectTrigger
+                        id={`daily-log-edit-project-${log.id}`}
+                        aria-label="Project"
+                      >
+                        <SelectValue placeholder="Select a project" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {projects.map((project) => (
+                          <SelectItem key={project.id} value={project.id}>
+                            {project.projectNumber
+                              ? `${project.projectNumber} - ${project.name}`
+                              : project.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      Moving a log also moves its files and linked to-dos.
+                      Project-specific schedule links are cleared.
+                    </p>
                   </div>
                   <DailyLogFields
                     draft={editDraft}


### PR DESCRIPTION
## Summary

- restore the searchable project switcher in the sidebar
- preserve the current project section while switching projects, without carrying record-specific IDs into the new project
- add a Project selector to the Daily Log editor
- safely move a daily log, its attachments, and linked to-dos between projects
- clear project-specific schedule links and return moved content to review
- block moves when the log or its photos are already included in an owner update

## Operational correction

The two Office daily logs Cassandra accidentally entered under Litten were moved to H-OFFICE after confirming that neither had photos, schedule links, linked to-dos, or owner-update references. Both remain hidden from clients and were returned to review.

## Validation

- `bunx tsc --noEmit`
- focused ESLint on all changed files
- `bun test src/lib/daily-logs` (7 passed)
- `bun run build`
- full pre-commit lint (0 errors)
