### PR TITLE
fix(daily-logs): support large project workspaces

### DIFF
--- a/src/app/actions/project-field.ts
+++ b/src/app/actions/project-field.ts
@@ -1405,10 +1405,14 @@ export async function getProjectDailyLogWorkspace(
           })
           .from(dailyLogTaskLinks)
           .innerJoin(
+            dailyLogs,
+            eq(dailyLogTaskLinks.dailyLogId, dailyLogs.id)
+          )
+          .innerJoin(
             scheduleTasks,
             eq(dailyLogTaskLinks.scheduleTaskId, scheduleTasks.id)
           )
-          .where(inArray(dailyLogTaskLinks.dailyLogId, logIds))
+          .where(eq(dailyLogs.projectId, projectId))
           .orderBy(asc(scheduleTasks.startDate), asc(scheduleTasks.sortOrder))
 
   const todoRows =
@@ -1426,10 +1430,16 @@ export async function getProjectDailyLogWorkspace(
             dueDate: projectOperations.dueDate,
           })
           .from(projectOperations)
+          .innerJoin(
+            dailyLogs,
+            and(
+              eq(projectOperations.sourceRecordId, dailyLogs.id),
+              eq(dailyLogs.projectId, projectId)
+            )
+          )
           .where(
             and(
               eq(projectOperations.projectId, projectId),
-              inArray(projectOperations.sourceRecordId, logIds),
               inArray(projectOperations.sourceRecordType, [
                 "staff_task",
                 "subcontractor_task",


### PR DESCRIPTION
## Summary

- fix Daily Logs workspaces for projects with more records than D1 permits in one bound-parameter query
- replace the large daily-log ID lists with project-scoped joins for schedule links and linked to-dos
- restore access to H-OFFICE Daily Logs, which currently has 254 historical logs

## Root cause

The workspace loader selected all daily-log IDs, then passed the entire list into two `IN (...)` predicates. H-OFFICE exceeded D1's bound-parameter limit, and the route converted the loader failure into a 404.

## Validation

- `bunx tsc --noEmit`
- focused ESLint
- daily-log tests (7 passed)
- production build
- production data confirmed H-OFFICE and Litten share the same organization; this was not an access-control issue
