### PR TITLE
feat(dashboard): launch cleaner office and project workspaces

### DIFF
--- a/src/app/actions/projects.ts
+++ b/src/app/actions/projects.ts
@@ -33,6 +33,7 @@ export type ProjectListItem = {
   readonly projectNumber: string | null
   readonly clientName: string | null
   readonly googleDriveFolderId: string | null
+  readonly status: string
   readonly createdAt: string
 }
 
@@ -109,6 +110,7 @@ export async function getProjects(): Promise<ProjectListItem[]> {
           projectNumber: projects.projectNumber,
           clientName: projects.clientName,
           googleDriveFolderId: projects.googleDriveFolderId,
+          status: projects.status,
           createdAt: projects.createdAt,
         })
         .from(projects)
@@ -123,6 +125,7 @@ export async function getProjects(): Promise<ProjectListItem[]> {
         projectNumber: projects.projectNumber,
         clientName: projects.clientName,
         googleDriveFolderId: projects.googleDriveFolderId,
+        status: projects.status,
         createdAt: projects.createdAt,
       })
       .from(projectMembers)

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,8 +1,13 @@
 import { getDashboardOverview } from "@/app/actions/dashboard-overview"
-import { OperationalDashboard } from "@/components/dashboard/operational-dashboard"
+import { DashboardLaunchpad } from "@/components/dashboard/dashboard-launchpad"
+import { getCurrentUser, toSidebarUser } from "@/lib/auth"
 
 export default async function Page() {
-  const overview = await getDashboardOverview()
+  const [overview, currentUser] = await Promise.all([
+    getDashboardOverview(),
+    getCurrentUser(),
+  ])
+  const sidebarUser = currentUser ? toSidebarUser(currentUser) : null
 
-  return <OperationalDashboard overview={overview} />
+  return <DashboardLaunchpad overview={overview} user={sidebarUser} />
 }

--- a/src/app/dashboard/projects/page.tsx
+++ b/src/app/dashboard/projects/page.tsx
@@ -2,9 +2,12 @@ export const dynamic = "force-dynamic"
 
 import { and, asc, eq, inArray } from "drizzle-orm"
 
+import { getDashboardOverview } from "@/app/actions/dashboard-overview"
+import { getProjects } from "@/app/actions/projects"
 import { getDb } from "@/db"
 import { projectExternalLinks, projects } from "@/db/schema"
 import { ProjectsHub } from "@/components/projects/projects-hub"
+import { ProjectHubLaunchpad } from "@/components/projects/project-hub-launchpad"
 import { getCurrentUser } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { canManageProjectRegistry } from "@/lib/permissions"
@@ -31,7 +34,35 @@ export type ProjectsHubProject = {
   readonly createdAt: string
 }
 
-export default async function ProjectsPage(): Promise<React.ReactElement> {
+export default async function ProjectsPage({
+  searchParams,
+}: {
+  readonly searchParams: Promise<
+    Record<string, string | readonly string[] | undefined>
+  >
+}): Promise<React.ReactElement> {
+  const params = await searchParams
+  const showRegistry =
+    params.manage !== undefined ||
+    params.department !== undefined ||
+    params.status !== undefined
+
+  if (!showRegistry) {
+    const [projectList, overview, currentUser] = await Promise.all([
+      getProjects(),
+      getDashboardOverview(),
+      getCurrentUser(),
+    ])
+
+    return (
+      <ProjectHubLaunchpad
+        projects={projectList}
+        overview={overview}
+        canManageProjects={canManageProjectRegistry(currentUser)}
+      />
+    )
+  }
+
   let hubProjects: ProjectsHubProject[] = []
   let canCreateOrUpdateProjects = false
 

--- a/src/components/dashboard/dashboard-launchpad.tsx
+++ b/src/components/dashboard/dashboard-launchpad.tsx
@@ -1,0 +1,1028 @@
+"use client"
+
+import { useEffect, useMemo, useState, useTransition } from "react"
+import Image from "next/image"
+import Link from "next/link"
+import {
+  IconAlertTriangle,
+  IconArrowRight,
+  IconBuilding,
+  IconBuildingSkyscraper,
+  IconCalendarWeek,
+  IconCheck,
+  IconChecklist,
+  IconClipboardText,
+  IconFileInvoice,
+  IconHeartHandshake,
+  IconHome2,
+  IconMapPin,
+  IconMessageCircleQuestion,
+  IconPhoto,
+  IconPlus,
+  IconReceipt,
+  IconSparkles,
+  IconUserHeart,
+  IconUsers,
+} from "@tabler/icons-react"
+
+import type { DashboardOverview } from "@/app/actions/dashboard-overview"
+import {
+  submitCherishPulseResponse,
+  type CherishPulseResponseType,
+} from "@/app/actions/cherish-pulse"
+import { updatePresence } from "@/app/actions/presence"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
+import { Textarea } from "@/components/ui/textarea"
+import type { SidebarUser } from "@/lib/auth"
+import { cn } from "@/lib/utils"
+
+type DashboardMode = "office" | "project"
+type DeskStatus = "in-office" | "on-site" | "remote" | "out"
+
+type LaunchpadTask = {
+  readonly id: string
+  readonly title: string
+  readonly detail: string
+  readonly href: string
+  readonly category: "Schedule" | "Invoice" | "Owner update" | "Field review"
+}
+
+const MARTINE_DEFAULT_DESK_PHOTO = "/user-desk-photos/martine-desk-photo.jpeg"
+const HIDDEN_DESK_PHOTO = "__hidden__"
+
+const DESK_STATUS_LABELS: Record<DeskStatus, string> = {
+  "in-office": "In Office",
+  "on-site": "On Site",
+  remote: "Remote",
+  out: "Out",
+}
+
+function deskPhotoForUser(user: SidebarUser | null): string | null {
+  if (!user) return null
+
+  try {
+    const storedPhoto = window.localStorage.getItem(
+      `compass-desk-photo:${user.email}`
+    )
+    if (storedPhoto === HIDDEN_DESK_PHOTO) return null
+    if (storedPhoto) return storedPhoto
+  } catch {
+    // The default photo still works when browser storage is unavailable.
+  }
+
+  const identity = `${user.name} ${user.email}`.toLowerCase()
+  return identity.includes("martine") ? MARTINE_DEFAULT_DESK_PHOTO : null
+}
+
+function isDeskStatus(value: string): value is DeskStatus {
+  return value === "in-office" || value === "on-site" || value === "remote" || value === "out"
+}
+
+function presenceStatusForDeskStatus(
+  status: DeskStatus
+): "online" | "offline" {
+  return status === "out" ? "offline" : "online"
+}
+
+function parseDateKey(value: string): Date {
+  return new Date(`${value}T00:00:00`)
+}
+
+function addDays(date: Date, amount: number): Date {
+  const next = new Date(date)
+  next.setDate(next.getDate() + amount)
+  return next
+}
+
+function dateKey(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+function formatDay(value: string): string {
+  return new Intl.DateTimeFormat("en-US", { weekday: "short" })
+    .format(parseDateKey(value))
+    .toUpperCase()
+}
+
+function formatMonthDay(value: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+  }).format(parseDateKey(value))
+}
+
+function formatLongDate(value: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  }).format(parseDateKey(value))
+}
+
+function taskFallsOnDay(
+  task: DashboardOverview["upcomingTasks"][number],
+  day: string
+): boolean {
+  return task.startDate <= day && task.endDate >= day
+}
+
+function belongsToOfficeProject(projectLabel: string): boolean {
+  const normalized = projectLabel
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+  return normalized === "h-office" || normalized.startsWith("h-office-")
+}
+
+function compareOfficePriority(
+  left: { readonly projectLabel: string },
+  right: { readonly projectLabel: string }
+): number {
+  const leftIsOffice = belongsToOfficeProject(left.projectLabel)
+  const rightIsOffice = belongsToOfficeProject(right.projectLabel)
+  if (leftIsOffice === rightIsOffice) return 0
+  return leftIsOffice ? -1 : 1
+}
+
+function greetingForNow(): string {
+  const hour = new Date().getHours()
+  if (hour < 12) return "Good morning"
+  if (hour < 17) return "Good afternoon"
+  return "Good evening"
+}
+
+function Horizon({
+  overview,
+  mode,
+}: {
+  readonly overview: DashboardOverview
+  readonly mode: DashboardMode
+}): React.ReactElement {
+  const days = useMemo(
+    () =>
+      Array.from({ length: 5 }, (_, index) =>
+        dateKey(addDays(parseDateKey(overview.today), index))
+      ),
+    [overview.today]
+  )
+
+  return (
+    <section className="min-w-0 border-y border-border/70 bg-background">
+      <div className="flex items-center justify-between gap-3 px-4 py-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <IconCalendarWeek className="size-4 shrink-0 text-[#2f5963]" />
+          <div>
+            <h2 className="text-sm font-semibold">Five-day horizon</h2>
+            <p className="text-xs text-muted-foreground">
+              {mode === "office"
+                ? "H-Office commitments first, then company-wide work"
+                : "The next commitments across active projects"}
+            </p>
+          </div>
+        </div>
+        <Button asChild variant="ghost" size="sm" className="shrink-0">
+          <Link href="/dashboard/schedule">
+            Full calendar
+            <IconArrowRight className="size-4" />
+          </Link>
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-2 border-t sm:grid-cols-3 xl:grid-cols-5">
+        {days.map((day, index) => {
+          const dayTasks = overview.upcomingTasks
+            .filter((task) => taskFallsOnDay(task, day))
+            .sort((left, right) =>
+              mode === "office" ? compareOfficePriority(left, right) : 0
+            )
+
+          return (
+            <div
+              key={day}
+              className={cn(
+                "min-h-36 border-border/60 px-3 py-2.5",
+                index > 0 && "border-l",
+                index === 0 && "bg-[#2f5963]/[0.06]"
+              )}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <p className="text-[11px] font-semibold tracking-wide text-muted-foreground">
+                    {formatDay(day)}
+                  </p>
+                  <p className="text-sm font-semibold">{formatMonthDay(day)}</p>
+                </div>
+                {index === 0 ? (
+                  <span className="text-[10px] font-semibold uppercase text-[#2f5963]">
+                    Today
+                  </span>
+                ) : null}
+              </div>
+
+              <div className="mt-2.5 space-y-2">
+                {dayTasks.slice(0, 2).map((task) => (
+                  <Link
+                    key={`${day}-${task.id}`}
+                    href={`/dashboard/projects/${task.projectId}/schedule?task=${encodeURIComponent(task.id)}`}
+                    className="block border-l-2 border-[#2f5963] pl-2 text-xs transition-colors hover:text-primary"
+                  >
+                    <span className="line-clamp-1 font-medium">{task.title}</span>
+                    <span className="mt-0.5 block truncate text-[11px] text-muted-foreground">
+                      {task.projectLabel}
+                    </span>
+                  </Link>
+                ))}
+                {dayTasks.length === 0 ? (
+                  <p className="pt-1 text-xs text-muted-foreground/70">Open</p>
+                ) : null}
+                {dayTasks.length > 2 ? (
+                  <p className="text-[11px] font-medium text-muted-foreground">
+                    +{dayTasks.length - 2} more
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+function DeskHero({
+  user,
+  today,
+}: {
+  readonly user: SidebarUser | null
+  readonly today: string
+}): React.ReactElement {
+  const [deskPhotoFailed, setDeskPhotoFailed] = useState(false)
+  const [deskPhotoUrl, setDeskPhotoUrl] = useState<string | null>(null)
+  const [status, setStatus] = useState<DeskStatus>("in-office")
+  const [statusMessage, setStatusMessage] = useState<string | null>(null)
+  const [isStatusPending, startStatusTransition] = useTransition()
+  const firstName = user?.firstName ?? user?.name.split(" ")[0] ?? "there"
+
+  useEffect(() => {
+    setDeskPhotoFailed(false)
+    setDeskPhotoUrl(deskPhotoForUser(user))
+  }, [user])
+
+  function handleStatusChange(nextStatus: DeskStatus): void {
+    setStatus(nextStatus)
+    setStatusMessage(null)
+    startStatusTransition(async () => {
+      const result = await updatePresence(
+        presenceStatusForDeskStatus(nextStatus),
+        DESK_STATUS_LABELS[nextStatus]
+      )
+      if (!result.success) {
+        setStatusMessage(result.error)
+      }
+    })
+  }
+
+  return (
+    <section className="grid min-h-52 overflow-hidden border-y border-border/70 bg-background sm:grid-cols-[minmax(10rem,0.8fr)_minmax(0,1.2fr)]">
+      <div className="relative min-h-40 overflow-hidden bg-muted">
+        {deskPhotoUrl && !deskPhotoFailed ? (
+          <Image
+            src={deskPhotoUrl}
+            alt={`${firstName}'s desk`}
+            fill
+            sizes="(min-width: 1024px) 260px, 50vw"
+            unoptimized
+            className="object-cover"
+            onError={() => setDeskPhotoFailed(true)}
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center bg-gradient-to-br from-[#2f5963]/15 via-muted to-[#9d832c]/10">
+            <IconHome2 className="size-10 text-[#2f5963]/60" />
+          </div>
+        )}
+      </div>
+
+      <div className="flex min-w-0 flex-col justify-center px-5 py-4">
+        <p className="text-xs text-muted-foreground">{formatLongDate(today)}</p>
+        <h1 className="mt-1 text-2xl font-semibold tracking-tight">
+          {greetingForNow()}, {firstName}
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Here is what needs your attention today.
+        </p>
+
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <Select
+            value={status}
+            onValueChange={(value) => {
+              if (isDeskStatus(value)) handleStatusChange(value)
+            }}
+          >
+            <SelectTrigger className="h-8 w-36 bg-background text-xs">
+              <span
+                className={cn(
+                  "size-2 rounded-full",
+                  status === "out"
+                    ? "bg-muted-foreground"
+                    : status === "on-site"
+                      ? "bg-amber-500"
+                      : "bg-emerald-600"
+                )}
+              />
+              <SelectValue>{DESK_STATUS_LABELS[status]}</SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              {Object.entries(DESK_STATUS_LABELS).map(([value, label]) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <IconHeartHandshake className="size-4 text-[#9d832c]" />
+            {isStatusPending
+              ? "Saving status..."
+              : statusMessage ?? "CHERISH notes will appear here"}
+          </span>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function CherishComposer(): React.ReactElement {
+  const [open, setOpen] = useState(false)
+  const [responseType, setResponseType] =
+    useState<CherishPulseResponseType>("shoutout")
+  const [message, setMessage] = useState("")
+  const [resultMessage, setResultMessage] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+  const isPrivate = responseType === "concern"
+
+  function handleSubmit(): void {
+    const trimmedMessage = message.trim()
+    if (trimmedMessage.length === 0) return
+
+    startTransition(async () => {
+      const result = await submitCherishPulseResponse({
+        cherishValue: "Reliability",
+        responseType,
+        message: trimmedMessage,
+        source: "compass_dashboard",
+      })
+
+      if (!result.success) {
+        setResultMessage(result.error)
+        return
+      }
+
+      setMessage("")
+      setResultMessage(
+        isPrivate
+          ? "Your private concern was sent for leadership review."
+          : "Your feedback was added to the CHERISH review queue."
+      )
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" className="bg-[#2f5963] hover:bg-[#244750]">
+          <IconPlus className="size-4" />
+          Give CHERISH feedback
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Give CHERISH feedback</DialogTitle>
+          <DialogDescription>
+            Share team recognition or send a private concern to leadership.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-2 border">
+          <button
+            type="button"
+            onClick={() => setResponseType("shoutout")}
+            className={cn(
+              "px-3 py-2 text-sm font-medium transition-colors",
+              responseType !== "concern" && "bg-[#2f5963] text-white"
+            )}
+          >
+            Team recognition
+          </button>
+          <button
+            type="button"
+            onClick={() => setResponseType("concern")}
+            className={cn(
+              "border-l px-3 py-2 text-sm font-medium transition-colors",
+              responseType === "concern" && "bg-[#9d832c] text-white"
+            )}
+          >
+            Private concern
+          </button>
+        </div>
+
+        <Textarea
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          placeholder={
+            isPrivate
+              ? "What should leadership know?"
+              : "Who deserves recognition, and what did they do?"
+          }
+          className="min-h-28"
+        />
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs text-muted-foreground">
+            {isPrivate ? "Private to leadership" : "Team-visible after review"}
+          </p>
+          <Button
+            onClick={handleSubmit}
+            disabled={message.trim().length === 0 || isPending}
+          >
+            {isPending ? "Sending..." : "Send feedback"}
+          </Button>
+        </div>
+        {resultMessage ? (
+          <p className="border-l-2 border-emerald-700 pl-2 text-xs text-muted-foreground">
+            {resultMessage}
+          </p>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function OfficeTaskList({
+  overview,
+}: {
+  readonly overview: DashboardOverview
+}): React.ReactElement {
+  const tasks = useMemo<readonly LaunchpadTask[]>(() => {
+    const scheduleTasks: readonly LaunchpadTask[] = overview.upcomingTasks
+      .slice()
+      .sort((left, right) => {
+        const officePriority = compareOfficePriority(left, right)
+        if (officePriority !== 0) return officePriority
+        return left.startDate.localeCompare(right.startDate)
+      })
+      .slice(0, 3)
+      .map((task) => ({
+        id: `schedule-${task.id}`,
+        title: task.title,
+        detail: `${task.projectLabel} · ${formatMonthDay(task.startDate)}`,
+        href: `/dashboard/projects/${task.projectId}/schedule?task=${encodeURIComponent(task.id)}`,
+        category: "Schedule",
+      }))
+    const operationTasks: readonly LaunchpadTask[] = overview.operations
+      .slice()
+      .sort(compareOfficePriority)
+      .slice(0, 3)
+      .map((operation) => ({
+        id: `operation-${operation.id}`,
+        title: operation.title,
+        detail: `${operation.projectLabel}${operation.companyName ? ` · ${operation.companyName}` : ""}`,
+        href:
+          operation.type === "purchase_order"
+            ? `/dashboard/projects/${operation.projectId}/purchase-orders`
+            : `/dashboard/projects/${operation.projectId}`,
+        category: "Invoice",
+      }))
+    const ownerUpdateTasks: readonly LaunchpadTask[] =
+      overview.metrics.draftOwnerUpdates > 0
+        ? [{
+            id: "draft-owner-updates",
+            title: `Review ${overview.metrics.draftOwnerUpdates} draft owner update${overview.metrics.draftOwnerUpdates === 1 ? "" : "s"}`,
+            detail: "Publication queue",
+            href: "/dashboard/projects",
+            category: "Owner update",
+          }]
+        : []
+    const photoTasks: readonly LaunchpadTask[] =
+      overview.metrics.photosToReview > 0
+        ? [{
+            id: "field-photo-review",
+            title: `Review ${overview.metrics.photosToReview} field photo${overview.metrics.photosToReview === 1 ? "" : "s"}`,
+            detail: "Visibility decisions",
+            href: "/dashboard/projects/select?target=photos",
+            category: "Field review",
+          }]
+        : []
+
+    return [
+      ...scheduleTasks,
+      ...ownerUpdateTasks,
+      ...operationTasks,
+      ...photoTasks,
+    ].slice(0, 6)
+  }, [overview])
+
+  return (
+    <section className="min-w-0 border-y border-border/70 bg-background">
+      <div className="flex items-center justify-between gap-3 px-4 py-3">
+        <div>
+          <h2 className="text-sm font-semibold">Office priorities</h2>
+          <p className="text-xs text-muted-foreground">
+            Reviews and follow-ups requiring action
+          </p>
+        </div>
+        <Button asChild variant="ghost" size="sm">
+          <Link href="/dashboard/schedule?focus=tasks">All to-dos</Link>
+        </Button>
+      </div>
+
+      <div className="divide-y border-t">
+        {tasks.map((task) => (
+          <Link
+            key={task.id}
+            href={task.href}
+            className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/50"
+          >
+            <span className="flex size-5 shrink-0 items-center justify-center border text-muted-foreground">
+              <IconArrowRight className="size-3" />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm font-medium">
+                {task.title}
+              </span>
+              <span className="block truncate text-xs text-muted-foreground">
+                {task.detail}
+              </span>
+            </span>
+            <Badge variant="outline" className="hidden shrink-0 sm:inline-flex">
+              {task.category}
+            </Badge>
+          </Link>
+        ))}
+        {tasks.length === 0 ? (
+          <div className="px-4 py-8 text-center">
+            <IconCheck className="mx-auto size-5 text-emerald-700" />
+            <p className="mt-2 text-sm font-medium">Office queue is clear</p>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  )
+}
+
+function OfficePresence(): React.ReactElement {
+  return (
+    <section className="border-y border-border/70 bg-background">
+      <div className="flex items-center justify-between gap-3 px-4 py-3">
+        <div>
+          <h2 className="text-sm font-semibold">Who&apos;s in today</h2>
+          <p className="text-xs text-muted-foreground">Current team availability</p>
+        </div>
+        <IconUsers className="size-5 text-muted-foreground" />
+      </div>
+      <div className="space-y-3 border-t px-4 py-3">
+        <div className="flex items-center gap-3">
+          <span className="size-2.5 rounded-full bg-emerald-600" />
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium">You</p>
+            <p className="text-xs text-muted-foreground">In Office</p>
+          </div>
+          <Badge variant="secondary">Available</Badge>
+        </div>
+        <p className="border-t pt-3 text-xs leading-5 text-muted-foreground">
+          Team status will populate here as staff update their availability.
+        </p>
+      </div>
+    </section>
+  )
+}
+
+function OfficeAlerts({
+  overview,
+}: {
+  readonly overview: DashboardOverview
+}): React.ReactElement {
+  const alerts = [
+    {
+      label: "Open RFIs",
+      value: overview.metrics.openRfis,
+      href: "/dashboard/rfis",
+      icon: <IconMessageCircleQuestion className="size-4" />,
+    },
+    {
+      label: "Draft owner updates",
+      value: overview.metrics.draftOwnerUpdates,
+      href: "/dashboard/projects",
+      icon: <IconClipboardText className="size-4" />,
+    },
+    {
+      label: "Photos to review",
+      value: overview.metrics.photosToReview,
+      href: "/dashboard/projects/select?target=photos",
+      icon: <IconPhoto className="size-4" />,
+    },
+  ]
+
+  return (
+    <section className="border-y border-border/70 bg-background">
+      <div className="flex items-center gap-2 px-4 py-3">
+        <IconAlertTriangle className="size-4 text-[#9d832c]" />
+        <div>
+          <h2 className="text-sm font-semibold">Office alerts</h2>
+          <p className="text-xs text-muted-foreground">Items that may need escalation</p>
+        </div>
+      </div>
+      <div className="divide-y border-t">
+        {alerts.map((alert) => (
+          <Link
+            key={alert.label}
+            href={alert.href}
+            className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/50"
+          >
+            <span className="text-muted-foreground">{alert.icon}</span>
+            <span className="flex-1 text-sm">{alert.label}</span>
+            <span className="font-semibold tabular-nums">{alert.value}</span>
+            <IconArrowRight className="size-4 text-muted-foreground" />
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function QuickDock(): React.ReactElement {
+  const actions = [
+    {
+      label: "Review POs",
+      href: "/dashboard/purchase-orders",
+      icon: <IconReceipt className="size-4" />,
+    },
+    {
+      label: "Create to-do",
+      href: "/dashboard/schedule?focus=tasks",
+      icon: <IconChecklist className="size-4" />,
+    },
+    {
+      label: "Daily logs",
+      href: "/dashboard/projects/select?target=daily-logs",
+      icon: <IconClipboardText className="size-4" />,
+    },
+    {
+      label: "Files",
+      href: "/dashboard/files",
+      icon: <IconFileInvoice className="size-4" />,
+    },
+  ]
+
+  return (
+    <section className="border-y border-border/70 bg-background">
+      <div className="px-4 py-3">
+        <h2 className="text-sm font-semibold">Quick dock</h2>
+        <p className="text-xs text-muted-foreground">Frequent office actions</p>
+      </div>
+      <div className="grid grid-cols-2 border-t">
+        {actions.map((action, index) => (
+          <Link
+            key={action.label}
+            href={action.href}
+            className={cn(
+              "flex items-center gap-2 px-4 py-3 text-sm font-medium transition-colors hover:bg-muted/50",
+              index % 2 === 1 && "border-l",
+              index > 1 && "border-t"
+            )}
+          >
+            <span className="text-[#2f5963]">{action.icon}</span>
+            {action.label}
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function ProjectWorkspace({
+  overview,
+}: {
+  readonly overview: DashboardOverview
+}): React.ReactElement {
+  const priorityProjects = useMemo(
+    () =>
+      overview.projects
+        .map((project) => ({
+          project,
+          score:
+            project.openRfiCount * 5 +
+            project.photosToReview * 3 +
+            project.openPoCount * 2 +
+            (project.nextTask ? 1 : 0),
+        }))
+        .filter((entry) => entry.score > 0)
+        .sort((left, right) => right.score - left.score)
+        .slice(0, 5),
+    [overview.projects]
+  )
+
+  return (
+    <div className="grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(20rem,0.75fr)]">
+      <section className="min-w-0 border-y border-border/70 bg-background">
+        <div className="flex items-center justify-between gap-3 px-4 py-3">
+          <div>
+            <h2 className="text-sm font-semibold">Projects needing attention</h2>
+            <p className="text-xs text-muted-foreground">
+              Ranked by decisions, reviews, and active commitments
+            </p>
+          </div>
+          <Badge variant="outline">{priorityProjects.length}</Badge>
+        </div>
+        <div className="divide-y border-t">
+          {priorityProjects.map(({ project }) => (
+            <Link
+              key={project.id}
+              href={`/dashboard/projects/${project.id}`}
+              className="grid gap-3 px-4 py-3 transition-colors hover:bg-muted/50 sm:grid-cols-[minmax(0,1fr)_auto]"
+            >
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-sm font-semibold">
+                    {project.projectNumber ?? project.name}
+                  </span>
+                  <span className="truncate text-xs text-muted-foreground">
+                    {project.name}
+                  </span>
+                </div>
+                <p className="mt-1 truncate text-xs text-muted-foreground">
+                  {project.nextTask?.title ?? "No upcoming schedule item"}
+                </p>
+              </div>
+              <div className="flex items-center gap-3 text-xs">
+                <span><strong>{project.openRfiCount}</strong> RFIs</span>
+                <span><strong>{project.photosToReview}</strong> photos</span>
+                <span><strong>{project.progress}%</strong></span>
+                <IconArrowRight className="size-4 text-muted-foreground" />
+              </div>
+            </Link>
+          ))}
+          {priorityProjects.length === 0 ? (
+            <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+              No active project exceptions.
+            </p>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="min-w-0 border-y border-border/70 bg-background">
+        <div className="flex items-center gap-2 px-4 py-3">
+          <IconMessageCircleQuestion className="size-4 text-[#9d832c]" />
+          <div>
+            <h2 className="text-sm font-semibold">Decision queue</h2>
+            <p className="text-xs text-muted-foreground">Open RFIs requiring follow-up</p>
+          </div>
+        </div>
+        <div className="divide-y border-t">
+          {overview.openRfis.slice(0, 5).map((rfi) => (
+            <Link
+              key={rfi.id}
+              href={`/dashboard/projects/${rfi.projectId}/rfis`}
+              className="block px-4 py-3 transition-colors hover:bg-muted/50"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-xs font-semibold">{rfi.rfiNumber}</span>
+                <span className="text-[11px] text-muted-foreground">
+                  {rfi.dueDate ? formatMonthDay(rfi.dueDate) : "No due date"}
+                </span>
+              </div>
+              <p className="mt-1 line-clamp-1 text-sm font-medium">{rfi.subject}</p>
+              <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                {rfi.projectLabel}
+              </p>
+            </Link>
+          ))}
+          {overview.openRfis.length === 0 ? (
+            <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+              The decision queue is clear.
+            </p>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="min-w-0 border-y border-border/70 bg-background xl:col-span-2">
+        <div className="flex items-center justify-between gap-3 px-4 py-3">
+          <div className="flex items-center gap-2">
+            <IconPhoto className="size-4 text-[#2f5963]" />
+            <div>
+              <h2 className="text-sm font-semibold">Recent site activity</h2>
+              <p className="text-xs text-muted-foreground">
+                Approved field photos across active projects
+              </p>
+            </div>
+          </div>
+          <Button asChild variant="ghost" size="sm">
+            <Link href="/dashboard/projects/select?target=photos">All photos</Link>
+          </Button>
+        </div>
+        <div className="grid gap-px border-t bg-border sm:grid-cols-2 lg:grid-cols-4">
+          {overview.fieldPhotos.slice(0, 4).map((photo) => (
+            <Link
+              key={photo.id}
+              href={`/dashboard/projects/${photo.projectId}/photos`}
+              className="group bg-background"
+            >
+              <div className="relative aspect-[16/9] overflow-hidden bg-muted">
+                <Image
+                  src={photo.imageUrl}
+                  alt={photo.caption ?? photo.fileName}
+                  fill
+                  sizes="(min-width: 1024px) 25vw, 50vw"
+                  unoptimized
+                  className="object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+                />
+              </div>
+              <div className="px-3 py-2">
+                <p className="truncate text-xs font-medium">
+                  {photo.caption ?? photo.fileName}
+                </p>
+                <p className="truncate text-[11px] text-muted-foreground">
+                  {photo.projectLabel}
+                </p>
+              </div>
+            </Link>
+          ))}
+          {overview.fieldPhotos.length === 0 ? (
+            <div className="col-span-full px-4 py-8 text-center text-sm text-muted-foreground">
+              No approved field photos are available.
+            </div>
+          ) : null}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function TeamPulseDrawer({
+  overview,
+}: {
+  readonly overview: DashboardOverview
+}): React.ReactElement {
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline" size="sm">
+          <IconUsers className="size-4" />
+          Team Pulse
+        </Button>
+      </SheetTrigger>
+      <SheetContent className="w-full overflow-y-auto sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle>Team Pulse</SheetTitle>
+          <SheetDescription>
+            Team recognition, field activity, and current availability.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="space-y-5 px-4 pb-6">
+          <div className="border-y py-4">
+            <div className="flex items-center gap-2">
+              <IconUserHeart className="size-5 text-emerald-700" />
+              <h3 className="text-sm font-semibold">CHERISH</h3>
+            </div>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              Recognize a teammate or privately let leadership know where help
+              is needed.
+            </p>
+            <div className="mt-3">
+              <CherishComposer />
+            </div>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Today at a glance
+            </p>
+            <div className="mt-3 divide-y border-y">
+              <div className="flex items-center justify-between py-3 text-sm">
+                <span>Active projects</span>
+                <strong>{overview.metrics.activeProjects}</strong>
+              </div>
+              <div className="flex items-center justify-between py-3 text-sm">
+                <span>Upcoming commitments</span>
+                <strong>{overview.metrics.upcomingTasks}</strong>
+              </div>
+              <div className="flex items-center justify-between py-3 text-sm">
+                <span>Photos to review</span>
+                <strong>{overview.metrics.photosToReview}</strong>
+              </div>
+            </div>
+          </div>
+          <p className="text-xs leading-5 text-muted-foreground">
+            Public team recognition will appear here after review. Private
+            concerns remain visible only to authorized leadership.
+          </p>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+export function DashboardLaunchpad({
+  overview,
+  user,
+}: {
+  readonly overview: DashboardOverview
+  readonly user: SidebarUser | null
+}): React.ReactElement {
+  const [mode, setMode] = useState<DashboardMode>("office")
+
+  return (
+    <main className="mx-auto w-full max-w-[1500px] space-y-4 p-3 sm:p-4 lg:p-5">
+      <div className="flex flex-col gap-3 border-b pb-3 lg:grid lg:grid-cols-[1fr_auto_1fr] lg:items-center">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <IconSparkles className="size-4 text-[#9d832c]" />
+            <p className="text-sm font-semibold">Morning launchpad</p>
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            A focused start to the workday
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 border bg-muted/30 p-0.5">
+          <button
+            type="button"
+            onClick={() => setMode("office")}
+            className={cn(
+              "flex h-8 items-center justify-center gap-2 px-4 text-sm font-medium transition-colors",
+              mode === "office" && "bg-background text-foreground shadow-sm"
+            )}
+          >
+            <IconBuilding className="size-4" />
+            Office
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode("project")}
+            className={cn(
+              "flex h-8 items-center justify-center gap-2 px-4 text-sm font-medium transition-colors",
+              mode === "project" && "bg-background text-foreground shadow-sm"
+            )}
+          >
+            <IconBuildingSkyscraper className="size-4" />
+            Projects
+          </button>
+        </div>
+
+        <div className="flex items-center gap-2 lg:justify-end">
+          <CherishComposer />
+          <TeamPulseDrawer overview={overview} />
+        </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(20rem,0.72fr)_minmax(0,1.28fr)]">
+        <DeskHero user={user} today={overview.today} />
+        <Horizon overview={overview} mode={mode} />
+      </div>
+
+      {mode === "office" ? (
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(20rem,0.65fr)]">
+          <OfficeTaskList overview={overview} />
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-1">
+            <OfficePresence />
+            <OfficeAlerts overview={overview} />
+            <QuickDock />
+          </div>
+        </div>
+      ) : (
+        <ProjectWorkspace overview={overview} />
+      )}
+
+      <div className="flex flex-wrap items-center justify-between gap-2 border-t pt-3 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1.5">
+          <IconMapPin className="size-3.5" />
+          Live Compass dashboard data
+        </span>
+        <Link href="/dashboard/projects" className="font-medium hover:text-foreground">
+          Open Project Hub
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/src/components/projects/project-hub-launchpad.tsx
+++ b/src/components/projects/project-hub-launchpad.tsx
@@ -1,0 +1,675 @@
+"use client"
+
+import { useMemo, useState, useTransition } from "react"
+import Image from "next/image"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import {
+  IconAlertTriangle,
+  IconBuilding,
+  IconBuildingCommunity,
+  IconCheck,
+  IconLayoutCards,
+  IconList,
+  IconPaint,
+  IconPlus,
+  IconSettings,
+  IconTool,
+} from "@tabler/icons-react"
+
+import type { DashboardOverview } from "@/app/actions/dashboard-overview"
+import {
+  createProjectShell,
+  type ProjectListItem,
+} from "@/app/actions/projects"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
+import { cn } from "@/lib/utils"
+
+type DepartmentFilter = "ALL" | "O" | "H" | "N" | "D" | "OTHER"
+type NewProjectDepartment = "O" | "H" | "N" | "D" | "UNASSIGNED"
+type StatusFilter = "active" | "warranty" | "complete" | "all"
+type ProjectLayout = "cards" | "list"
+
+type DepartmentDefinition = {
+  readonly id: DepartmentFilter
+  readonly label: string
+  readonly icon: React.ReactNode
+}
+
+const DEPARTMENTS: readonly DepartmentDefinition[] = [
+  { id: "ALL", label: "All", icon: <IconBuilding className="size-4" /> },
+  { id: "O", label: "ORC", icon: <IconBuilding className="size-4" /> },
+  { id: "H", label: "HPS", icon: <IconBuildingCommunity className="size-4" /> },
+  { id: "N", label: "Nu-Tech", icon: <IconTool className="size-4" /> },
+  { id: "D", label: "Design", icon: <IconPaint className="size-4" /> },
+  { id: "OTHER", label: "Other", icon: <IconSettings className="size-4" /> },
+]
+
+const STATUS_OPTIONS: readonly {
+  readonly value: StatusFilter
+  readonly label: string
+}[] = [
+  { value: "active", label: "Active" },
+  { value: "warranty", label: "Warranty" },
+  { value: "complete", label: "Complete" },
+  { value: "all", label: "All" },
+]
+
+function departmentForProject(project: ProjectListItem): DepartmentFilter {
+  const prefix = project.projectNumber?.trim().slice(0, 1).toUpperCase()
+  if (prefix === "O" || prefix === "H" || prefix === "N" || prefix === "D") {
+    return prefix
+  }
+  return "OTHER"
+}
+
+function isNewProjectDepartment(value: string): value is NewProjectDepartment {
+  return (
+    value === "O" ||
+    value === "H" ||
+    value === "N" ||
+    value === "D" ||
+    value === "UNASSIGNED"
+  )
+}
+
+function formText(formData: FormData, name: string): string | null {
+  const value = formData.get(name)
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function statusForProject(project: ProjectListItem): StatusFilter {
+  const status = project.status.trim().toLowerCase().replace(/[^a-z0-9]+/g, " ")
+  if (
+    status === "open" ||
+    status === "active" ||
+    status === "current" ||
+    status === "construction" ||
+    status === "in progress" ||
+    status === "scheduled" ||
+    status === "preconstruction"
+  ) {
+    return "active"
+  }
+  if (status.includes("warranty") || status.includes("service")) {
+    return "warranty"
+  }
+  if (status === "closed" || status === "complete" || status === "completed") {
+    return "complete"
+  }
+  return "all"
+}
+
+function departmentAccent(department: DepartmentFilter): string {
+  if (department === "O" || department === "D") return "border-l-[#6f471f]"
+  if (department === "H") return "border-l-[#3f7d4d]"
+  if (department === "N") return "border-l-[#9d832c]"
+  return "border-l-muted-foreground"
+}
+
+function projectDisplayName(project: ProjectListItem): string {
+  return project.projectNumber ?? project.name
+}
+
+function projectSubtitle(project: ProjectListItem): string {
+  if (project.projectNumber) return project.name
+  return project.clientName ?? "Project"
+}
+
+function ProjectHealth({
+  projectId,
+  overview,
+}: {
+  readonly projectId: string
+  readonly overview: DashboardOverview
+}): React.ReactElement {
+  const health = overview.projects.find((project) => project.id === projectId)
+
+  if (!health) {
+    return (
+      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <IconCheck className="size-3.5 text-emerald-700" />
+        No priority flags
+      </span>
+    )
+  }
+
+  if (health.openRfiCount > 0) {
+    return (
+      <span className="flex items-center gap-1.5 text-xs font-medium text-[#8a3a2e]">
+        <IconAlertTriangle className="size-3.5" />
+        {health.openRfiCount} pending RFI{health.openRfiCount === 1 ? "" : "s"}
+      </span>
+    )
+  }
+
+  if (health.openPoCount > 0) {
+    return (
+      <span className="flex items-center gap-1.5 text-xs font-medium text-[#715d1c]">
+        <IconAlertTriangle className="size-3.5" />
+        {health.openPoCount} open PO{health.openPoCount === 1 ? "" : "s"}
+      </span>
+    )
+  }
+
+  return (
+    <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <IconCheck className="size-3.5 text-emerald-700" />
+      On track · {health.progress}%
+    </span>
+  )
+}
+
+function ProjectCard({
+  project,
+  overview,
+  layout,
+}: {
+  readonly project: ProjectListItem
+  readonly overview: DashboardOverview
+  readonly layout: ProjectLayout
+}): React.ReactElement {
+  const department = departmentForProject(project)
+  const health = overview.projects.find((item) => item.id === project.id)
+  const photo = overview.fieldPhotos.find((item) => item.projectId === project.id)
+
+  if (layout === "list") {
+    return (
+      <Link
+        href={`/dashboard/projects/${project.id}`}
+        className={cn(
+          "grid min-w-0 gap-3 border-l-4 bg-background px-4 py-3 transition-colors hover:bg-muted/50 lg:grid-cols-[minmax(13rem,0.8fr)_minmax(14rem,1fr)_auto]",
+          departmentAccent(department)
+        )}
+      >
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold">{projectDisplayName(project)}</p>
+          <p className="truncate text-xs text-muted-foreground">{projectSubtitle(project)}</p>
+        </div>
+        <div className="min-w-0">
+          <p className="truncate text-sm">
+            {health?.nextTask?.title ?? project.clientName ?? "No next schedule item"}
+          </p>
+          <p className="truncate text-xs text-muted-foreground">
+            {department === "OTHER" ? "Unassigned department" : department}
+          </p>
+        </div>
+        <ProjectHealth projectId={project.id} overview={overview} />
+      </Link>
+    )
+  }
+
+  return (
+    <article
+      className={cn(
+        "group min-w-0 overflow-hidden border border-l-4 bg-background transition-shadow hover:shadow-md",
+        departmentAccent(department)
+      )}
+    >
+      {photo ? (
+        <Link href={`/dashboard/projects/${project.id}`} className="relative block aspect-[16/7] overflow-hidden bg-muted">
+          <Image
+            src={photo.imageUrl}
+            alt={photo.caption ?? photo.fileName}
+            fill
+            sizes="(min-width: 1280px) 30vw, (min-width: 768px) 45vw, 100vw"
+            unoptimized
+            className="object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+          />
+        </Link>
+      ) : (
+        <div className="flex aspect-[16/7] items-center justify-center bg-gradient-to-br from-muted to-muted/40">
+          <IconBuilding className="size-8 text-muted-foreground/40" />
+        </div>
+      )}
+
+      <div className="p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="truncate text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {project.projectNumber ?? "Compass project"}
+            </p>
+            <h2 className="mt-1 truncate text-base font-semibold">{project.name}</h2>
+          </div>
+          <Badge variant="outline">
+            {department === "OTHER" ? "Other" : department}
+          </Badge>
+        </div>
+
+        <p className="mt-3 truncate text-sm text-muted-foreground">
+          {health?.nextTask ? `Next: ${health.nextTask.title}` : project.clientName ?? "No next phase recorded"}
+        </p>
+        <div className="mt-3">
+          <ProjectHealth projectId={project.id} overview={overview} />
+        </div>
+
+        <Button asChild variant="ghost" size="sm" className="mt-4 w-full justify-between px-0 hover:bg-transparent">
+          <Link href={`/dashboard/projects/${project.id}`}>
+            Open project hub
+            <span aria-hidden="true">→</span>
+          </Link>
+        </Button>
+      </div>
+    </article>
+  )
+}
+
+function MaintenanceDrawer({
+  projects,
+}: {
+  readonly projects: readonly ProjectListItem[]
+}): React.ReactElement {
+  const cleanupCount = projects.filter((project) => statusForProject(project) === "all").length
+  const accountingLinked = projects.filter((project) => project.googleDriveFolderId !== null).length
+  const departmentNeeded = projects.filter((project) => departmentForProject(project) === "OTHER").length
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline" size="sm">
+          <IconSettings className="size-4" />
+          Office maintenance
+        </Button>
+      </SheetTrigger>
+      <SheetContent className="w-full sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle>Office maintenance</SheetTitle>
+          <SheetDescription>
+            Project registry cleanup and integration housekeeping.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="divide-y border-y px-4">
+          <div className="flex items-center justify-between py-4 text-sm">
+            <span>Statuses needing cleanup</span>
+            <strong>{cleanupCount}</strong>
+          </div>
+          <div className="flex items-center justify-between py-4 text-sm">
+            <span>Drive-linked projects</span>
+            <strong>{accountingLinked}</strong>
+          </div>
+          <div className="flex items-center justify-between py-4 text-sm">
+            <span>Department assignment needed</span>
+            <strong>{departmentNeeded}</strong>
+          </div>
+        </div>
+        <div className="px-4">
+          <Button asChild className="w-full">
+            <Link href="/dashboard/projects?manage=1">
+              Open advanced registry tools
+            </Link>
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function NewProjectDialog({
+  activeDepartment,
+}: {
+  readonly activeDepartment: DepartmentFilter
+}): React.ReactElement {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [department, setDepartment] = useState<NewProjectDepartment>(
+    isNewProjectDepartment(activeDepartment) ? activeDepartment : "O"
+  )
+  const [status, setStatus] = useState("OPEN")
+  const [message, setMessage] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function handleOpenChange(nextOpen: boolean): void {
+    if (nextOpen && isNewProjectDepartment(activeDepartment)) {
+      setDepartment(activeDepartment)
+    }
+    setMessage(null)
+    setOpen(nextOpen)
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    const name = formText(formData, "name")
+    if (!name) {
+      setMessage("Project name is required.")
+      return
+    }
+
+    startTransition(async () => {
+      setMessage(null)
+      const result = await createProjectShell({
+        projectNumber: formText(formData, "projectNumber"),
+        name,
+        department,
+        clientName: formText(formData, "clientName"),
+        address: formText(formData, "address"),
+        status,
+      })
+
+      if (!result.success) {
+        setMessage(result.error)
+        return
+      }
+
+      setOpen(false)
+      router.push(`/dashboard/projects/${result.id}`)
+      router.refresh()
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button size="sm">
+          <IconPlus className="size-4" />
+          New project
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Create project</DialogTitle>
+          <DialogDescription>
+            Start the Compass project shell. Integration IDs can be added later
+            in advanced registry tools.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="space-y-1.5 text-sm font-medium">
+              Project name
+              <Input name="name" required placeholder="Loeffler Residence" />
+            </label>
+            <label className="space-y-1.5 text-sm font-medium">
+              Project number
+              <Input name="projectNumber" placeholder="O-202-595" />
+            </label>
+            <label className="space-y-1.5 text-sm font-medium">
+              Department
+              <Select
+                value={department}
+                onValueChange={(value) => {
+                  if (isNewProjectDepartment(value)) setDepartment(value)
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="O">ORC</SelectItem>
+                  <SelectItem value="H">HPS</SelectItem>
+                  <SelectItem value="N">Nu-Tech</SelectItem>
+                  <SelectItem value="D">Design</SelectItem>
+                  <SelectItem value="UNASSIGNED">Unassigned</SelectItem>
+                </SelectContent>
+              </Select>
+            </label>
+            <label className="space-y-1.5 text-sm font-medium">
+              Status
+              <Select value={status} onValueChange={setStatus}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="OPEN">Active</SelectItem>
+                  <SelectItem value="LEAD">Lead</SelectItem>
+                  <SelectItem value="WARRANTY">Warranty</SelectItem>
+                </SelectContent>
+              </Select>
+            </label>
+            <label className="space-y-1.5 text-sm font-medium">
+              Client
+              <Input name="clientName" placeholder="Client name" />
+            </label>
+            <label className="space-y-1.5 text-sm font-medium">
+              Address
+              <Input name="address" placeholder="Job site address" />
+            </label>
+          </div>
+          {message ? (
+            <p className="text-sm text-destructive">{message}</p>
+          ) : null}
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? "Creating..." : "Create project"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function ProjectHubLaunchpad({
+  projects,
+  overview,
+  canManageProjects,
+}: {
+  readonly projects: readonly ProjectListItem[]
+  readonly overview: DashboardOverview
+  readonly canManageProjects: boolean
+}): React.ReactElement {
+  const [department, setDepartment] = useState<DepartmentFilter>("ALL")
+  const [status, setStatus] = useState<StatusFilter>("active")
+  const [layout, setLayout] = useState<ProjectLayout>("cards")
+
+  const statusCounts = useMemo(
+    () => ({
+      active: projects.filter((project) => statusForProject(project) === "active").length,
+      warranty: projects.filter((project) => statusForProject(project) === "warranty").length,
+      complete: projects.filter((project) => statusForProject(project) === "complete").length,
+      all: projects.length,
+    }),
+    [projects]
+  )
+
+  const departmentCounts = useMemo(() => {
+    const inStatus = projects.filter(
+      (project) => status === "all" || statusForProject(project) === status
+    )
+    return new Map(
+      DEPARTMENTS.map((item) => [
+        item.id,
+        item.id === "ALL"
+          ? inStatus.length
+          : inStatus.filter((project) => departmentForProject(project) === item.id).length,
+      ])
+    )
+  }, [projects, status])
+
+  const visibleProjects = useMemo(
+    () =>
+      projects.filter(
+        (project) =>
+          (status === "all" || statusForProject(project) === status) &&
+          (department === "ALL" || departmentForProject(project) === department)
+      ),
+    [department, projects, status]
+  )
+
+  return (
+    <main className="mx-auto w-full max-w-[1500px] space-y-4 p-3 sm:p-4 lg:p-5">
+      <header className="flex flex-col gap-3 border-b pb-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-xl font-semibold tracking-tight">Project Hub</h1>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Active jobs and the issues that need attention
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {canManageProjects ? <MaintenanceDrawer projects={projects} /> : null}
+          {canManageProjects ? (
+            <NewProjectDialog activeDepartment={department} />
+          ) : null}
+        </div>
+      </header>
+
+      <section className="space-y-3 border-b pb-4">
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-center">
+          <p className="w-24 shrink-0 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Departments
+          </p>
+          <div className="flex min-w-0 flex-1 gap-px overflow-x-auto border bg-border">
+            {DEPARTMENTS.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => setDepartment(item.id)}
+                className={cn(
+                  "flex h-10 shrink-0 items-center gap-2 bg-background px-3 text-sm font-medium transition-colors hover:bg-muted",
+                  department === item.id && "bg-[#2f5963] text-white hover:bg-[#2f5963]"
+                )}
+              >
+                {item.icon}
+                {item.label}
+                <span className={cn("text-xs tabular-nums text-muted-foreground", department === item.id && "text-white/75")}>
+                  {departmentCounts.get(item.id) ?? 0}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-center">
+          <p className="w-24 shrink-0 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Status
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {STATUS_OPTIONS.map(({ value, label }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setStatus(value)}
+                className={cn(
+                  "flex h-8 items-center gap-2 border px-3 text-sm transition-colors hover:bg-muted",
+                  status === value && "border-[#2f5963] bg-[#2f5963]/[0.07] font-semibold"
+                )}
+              >
+                <span
+                  className={cn(
+                    "size-2 rounded-full border",
+                    status === value && "border-[#2f5963] bg-[#2f5963]"
+                  )}
+                />
+                {label}
+                <span className="text-xs tabular-nums text-muted-foreground">
+                  {statusCounts[value]}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-sm font-semibold">
+              {status === "all" ? "All" : status.charAt(0).toUpperCase() + status.slice(1)} projects
+            </h2>
+            <p className="text-xs text-muted-foreground">
+              {visibleProjects.length} project{visibleProjects.length === 1 ? "" : "s"} shown · use ⌘K for global search
+            </p>
+          </div>
+          <div className="grid grid-cols-2 border p-0.5">
+            <button
+              type="button"
+              onClick={() => setLayout("list")}
+              className={cn("flex size-8 items-center justify-center", layout === "list" && "bg-muted")}
+              aria-label="List view"
+            >
+              <IconList className="size-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => setLayout("cards")}
+              className={cn("flex size-8 items-center justify-center", layout === "cards" && "bg-muted")}
+              aria-label="Card view"
+            >
+              <IconLayoutCards className="size-4" />
+            </button>
+          </div>
+        </div>
+
+        <div
+          className={cn(
+            "mt-3",
+            layout === "cards"
+              ? "grid gap-4 sm:grid-cols-2 2xl:grid-cols-3"
+              : "divide-y border-y"
+          )}
+        >
+          {visibleProjects.map((project) => (
+            <ProjectCard
+              key={project.id}
+              project={project}
+              overview={overview}
+              layout={layout}
+            />
+          ))}
+        </div>
+
+        {visibleProjects.length === 0 ? (
+          <div className="mt-3 border-y px-4 py-12 text-center">
+            <p className="text-sm font-medium">No projects match these filters.</p>
+            <button
+              type="button"
+              onClick={() => {
+                setDepartment("ALL")
+                setStatus("all")
+              }}
+              className="mt-2 text-sm font-medium text-primary hover:underline"
+            >
+              Clear filters
+            </button>
+          </div>
+        ) : null}
+      </section>
+
+      <footer className="flex flex-wrap items-center justify-between gap-2 border-t pt-3 text-xs text-muted-foreground">
+        <span>Live Compass project and job-health data</span>
+        <div className="flex gap-4">
+          <Link href="/dashboard" className="font-medium hover:text-foreground">
+            Dashboard
+          </Link>
+        </div>
+      </footer>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

- replace the primary dashboard with the approved Office / Projects launchpad, five-day horizon, desk photo, CHERISH workflow, team presence, and quick actions
- prioritize H-Office schedule items and operational work whenever Office mode is selected
- replace the default Project Hub directory barrier with immediate project cards, department/status filters, project health, card/list views, and direct project creation
- preserve the left-nav quick project switcher and move legacy registry maintenance behind an admin-only advanced tools drawer

## Validation

- targeted ESLint on all changed files
- `bunx tsc --noEmit --pretty false`
- `bun run build` (twice, including the pre-push hook)
- `git diff --check`
- manual localhost design review and approval
