### PR TITLE
feat(documents): apply project department branding

### DIFF
--- a/src/app/dashboard/projects/[id]/purchase-orders/page.tsx
+++ b/src/app/dashboard/projects/[id]/purchase-orders/page.tsx
@@ -1,4 +1,5 @@
 import type * as React from "react"
+import Image from "next/image"
 import Link from "next/link"
 import {
   IconArrowLeft,
@@ -29,6 +30,10 @@ import {
   projectOperationMatchesStatusFilter,
   type ProjectOperationStatusFilter,
 } from "@/lib/project-operations/status"
+import {
+  projectBrandFor,
+  type ProjectBrand,
+} from "@/lib/project-branding"
 
 function money(value: number | null): string {
   if (value === null) return "Amount TBD"
@@ -94,12 +99,14 @@ function purchaseOrderTaskDescription(order: ProjectPurchaseOrderItem): string {
 }
 
 function PurchaseOrderCard({
+  brand,
   order,
   projectId,
   projectLabel,
   isCreated,
   taskAssigneeOptions,
 }: {
+  readonly brand: ProjectBrand
   readonly order: ProjectPurchaseOrderItem
   readonly projectId: string
   readonly projectLabel: string
@@ -228,17 +235,21 @@ function PurchaseOrderCard({
       <div className="hidden text-[11px] leading-tight text-black print:block">
         <div className="flex items-start justify-between border-b-2 border-black pb-4">
           <div className="flex items-center gap-3">
-            <img
-              src="/department-logos/hps-h-green.svg"
-              alt="HPS logo"
+            <Image
+              src={brand.logoSrc}
+              alt={brand.logoAlt}
+              width={64}
+              height={64}
+              unoptimized
               className="h-16 w-16 shrink-0 object-contain"
             />
             <div>
               <p className="text-sm font-bold uppercase">
-                High Performance Structures, Inc.
+                {brand.companyName}
               </p>
-              <p>P.O. Box 878</p>
-              <p>Woodland Park, CO 80866</p>
+              {brand.mailingAddress.map((line) => (
+                <p key={line}>{line}</p>
+              ))}
             </div>
           </div>
           <div className="text-right">
@@ -354,6 +365,10 @@ export default async function ProjectPurchaseOrdersPage({
     throw error
   })
   const project = projects.find((item) => item.id === id)
+  const brand = projectBrandFor({
+    projectId: id,
+    projectNumber: project?.projectNumber,
+  })
   const taskAssignees = [
     ...taskAssigneeOptions.projectContacts,
     ...taskAssigneeOptions.directoryContacts,
@@ -455,6 +470,7 @@ export default async function ProjectPurchaseOrdersPage({
           visiblePurchaseOrders.map((order) => (
             <PurchaseOrderCard
               key={order.id}
+              brand={brand}
               order={order}
               projectId={id}
               projectLabel={

--- a/src/app/dashboard/projects/[id]/rfqs/page.tsx
+++ b/src/app/dashboard/projects/[id]/rfqs/page.tsx
@@ -37,6 +37,10 @@ import {
   projectOperationMatchesStatusFilter,
   type ProjectOperationStatusFilter,
 } from "@/lib/project-operations/status"
+import {
+  projectBrandFor,
+  type ProjectBrand,
+} from "@/lib/project-branding"
 
 export const dynamic = "force-dynamic"
 
@@ -131,6 +135,7 @@ function rfqTaskDescription(rfq: ProjectRfqItem): string {
 }
 
 function RfqCard({
+  brand,
   rfq,
   projectId,
   projectLabel,
@@ -139,6 +144,7 @@ function RfqCard({
   selectionOptions,
   selectionsSummary,
 }: {
+  readonly brand: ProjectBrand
   readonly rfq: ProjectRfqItem
   readonly projectId: string
   readonly projectLabel: string
@@ -183,6 +189,7 @@ function RfqCard({
             selectionsSummary={selectionsSummary}
           />
           <ProjectRfqShareActions
+            brand={brand}
             projectId={projectId}
             projectLabel={projectLabel}
             rfq={rfq}
@@ -327,6 +334,10 @@ export default async function ProjectRfqsPage({
     return rfq.dueDate < new Date().toISOString().slice(0, 10)
   }).length
   const projectLabel = projectDisplayLabel(project)
+  const brand = projectBrandFor({
+    projectId: id,
+    projectNumber: project?.projectNumber,
+  })
 
   return (
     <div className="flex-1 space-y-6 p-4 pt-6 sm:p-6 md:p-8">
@@ -414,6 +425,7 @@ export default async function ProjectRfqsPage({
           visibleRfqs.map((rfq) => (
             <RfqCard
               key={rfq.id}
+              brand={brand}
               rfq={rfq}
               projectId={id}
               projectLabel={projectLabel}

--- a/src/app/dashboard/projects/[id]/selections/page.tsx
+++ b/src/app/dashboard/projects/[id]/selections/page.tsx
@@ -1,4 +1,5 @@
 import type * as React from "react"
+import Image from "next/image"
 import Link from "next/link"
 import { IconArrowLeft } from "@tabler/icons-react"
 import { notFound } from "next/navigation"
@@ -16,6 +17,7 @@ import { ProjectSelectionsWorkspace } from "@/components/projects/project-select
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { redirectIfFeaturePermissionDenied } from "@/lib/permission-redirect"
+import { projectBrandFor } from "@/lib/project-branding"
 
 export const dynamic = "force-dynamic"
 
@@ -63,6 +65,10 @@ export default async function ProjectSelectionsPage({
   const projects = await getProjects()
   const project = projects.find((item) => item.id === id)
   const label = projectLabel(project)
+  const brand = projectBrandFor({
+    projectId: id,
+    projectNumber: project?.projectNumber,
+  })
 
   return (
     <ProjectContextWatermarkShell>
@@ -75,9 +81,12 @@ export default async function ProjectSelectionsPage({
             </Link>
           </Button>
           <div className="flex items-center gap-3">
-            <img
-              src="/department-logos/orc-mark.png"
-              alt="Open Range Construction"
+            <Image
+              src={brand.logoSrc}
+              alt={brand.logoAlt}
+              width={32}
+              height={32}
+              unoptimized
               className="h-8 w-8 object-contain"
             />
             <h1 className="text-2xl font-semibold tracking-tight">
@@ -119,6 +128,7 @@ export default async function ProjectSelectionsPage({
       </div>
 
       <ProjectSelectionsWorkspace
+        brand={brand}
         clientName={project?.clientName ?? null}
         projectLabel={label}
         projectId={id}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -836,6 +836,18 @@ em-emoji-picker {
     padding-bottom: 0.1in;
   }
 
+  .rfq-print-brand {
+    align-items: flex-start;
+    display: flex;
+    gap: 0.1in;
+  }
+
+  .rfq-print-brand img {
+    height: 0.38in;
+    object-fit: contain;
+    width: 0.38in;
+  }
+
   .rfq-print-header p {
     color: #6f471f;
     font-size: 10px;

--- a/src/components/projects/daily-log-print-document.tsx
+++ b/src/components/projects/daily-log-print-document.tsx
@@ -1,6 +1,8 @@
 import type * as React from "react"
+import Image from "next/image"
 
 import type { ProjectDailyLogItem } from "@/app/actions/project-field"
+import { projectBrandFor } from "@/lib/project-branding"
 
 function formatPrintDate(value: string): string {
   const parsed = new Date(`${value}T12:00:00`)
@@ -60,15 +62,20 @@ function PrintDetail({
 export function DailyLogPrintDocument({
   clientName,
   logs,
+  projectId,
   projectLabel,
   projectName,
+  projectNumber,
 }: {
   readonly clientName: string | null
   readonly logs: readonly ProjectDailyLogItem[]
+  readonly projectId: string
   readonly projectLabel: string
   readonly projectName: string
+  readonly projectNumber: string | null
 }): React.ReactElement | null {
   if (logs.length === 0) return null
+  const brand = projectBrandFor({ projectId, projectNumber })
 
   return (
     <article
@@ -77,13 +84,23 @@ export function DailyLogPrintDocument({
     >
       <header className="border-b-2 border-black pb-4">
         <div className="flex items-start justify-between gap-6">
-          <div>
-            <p className="text-sm font-bold uppercase">
-              High Performance Structures, Inc.
-            </p>
-            <h1 className="mt-1 text-2xl font-semibold">Daily Logs</h1>
-            <p className="mt-1 text-sm">{projectName}</p>
-            {clientName && <p className="text-xs">Client: {clientName}</p>}
+          <div className="flex items-start gap-3">
+            <Image
+              src={brand.logoSrc}
+              alt={brand.logoAlt}
+              width={48}
+              height={48}
+              unoptimized
+              className="h-12 w-12 object-contain"
+            />
+            <div>
+              <p className="text-sm font-bold uppercase">
+                {brand.companyName}
+              </p>
+              <h1 className="mt-1 text-2xl font-semibold">Daily Logs</h1>
+              <p className="mt-1 text-sm">{projectName}</p>
+              {clientName && <p className="text-xs">Client: {clientName}</p>}
+            </div>
           </div>
           <div className="text-right text-xs">
             <p className="font-semibold">{projectLabel}</p>

--- a/src/components/projects/owner-update-document.tsx
+++ b/src/components/projects/owner-update-document.tsx
@@ -1,4 +1,5 @@
 import type * as React from "react"
+import Image from "next/image"
 import Link from "next/link"
 import {
   IconArrowLeft,
@@ -16,6 +17,7 @@ import { Button } from "@/components/ui/button"
 import { OwnerUpdateActions } from "@/components/projects/owner-update-actions"
 import { OwnerUpdateDraftEditor } from "@/components/projects/owner-update-draft-editor"
 import { OwnerUpdatePhotoTile } from "@/components/projects/owner-update-photo-tile"
+import { projectBrandFor } from "@/lib/project-branding"
 
 function formatDate(value: string): string {
   return new Date(`${value}T00:00:00`).toLocaleDateString("en-US", {
@@ -69,6 +71,10 @@ export function OwnerUpdateDocument({
     (document.nextScheduleItem
       ? `Next up: ${document.nextScheduleItem.title}.`
       : "Open Compass to view the full owner update.")
+  const brand = projectBrandFor({
+    projectId: document.project.id,
+    projectNumber: document.project.projectNumber,
+  })
 
   return (
     <main className="min-h-screen bg-muted/30 print:bg-white">
@@ -103,14 +109,17 @@ export function OwnerUpdateDocument({
         >
           <div className="hidden print:mb-6 print:flex print:items-start print:justify-between print:border-b-2 print:border-black print:pb-4">
             <div className="flex items-center gap-3">
-              <img
-                src="/department-logos/hps-h-green.svg"
-                alt="High Performance Structures"
+              <Image
+                src={brand.logoSrc}
+                alt={brand.logoAlt}
+                width={56}
+                height={56}
+                unoptimized
                 className="h-14 w-14 object-contain"
               />
               <div>
                 <p className="text-sm font-bold uppercase">
-                  High Performance Structures, Inc.
+                  {brand.companyName}
                 </p>
                 <p className="text-xs">Project Owner Update</p>
               </div>

--- a/src/components/projects/project-daily-log-workspace.tsx
+++ b/src/components/projects/project-daily-log-workspace.tsx
@@ -1779,8 +1779,10 @@ export function ProjectDailyLogWorkspace({
     <DailyLogPrintDocument
       clientName={workspace.project.clientName}
       logs={printLogs}
+      projectId={workspace.project.id}
       projectLabel={projectLabel}
       projectName={workspace.project.name}
+      projectNumber={workspace.project.projectNumber}
     />
     </>
   )

--- a/src/components/projects/project-rfq-share-actions.tsx
+++ b/src/components/projects/project-rfq-share-actions.tsx
@@ -11,6 +11,7 @@ import {
 
 import type { ProjectRfqItem } from "@/app/actions/project-operations"
 import { Button } from "@/components/ui/button"
+import type { ProjectBrand } from "@/lib/project-branding"
 
 type CopiedState = "link" | "email" | "html" | null
 
@@ -61,10 +62,12 @@ function documentRows(rfq: ProjectRfqItem): string {
 }
 
 function printHtml({
+  brand,
   projectLabel,
   rfq,
   url,
 }: {
+  readonly brand: ProjectBrand
   readonly projectLabel: string
   readonly rfq: ProjectRfqItem
   readonly url: string
@@ -72,9 +75,12 @@ function printHtml({
   return `
     <article class="rfq-printable">
       <header class="rfq-print-header">
-        <div>
-          <p>Open Range Construction</p>
-          <h1>${escapeHtml(rfq.title)}</h1>
+        <div class="rfq-print-brand">
+          <img src="${escapeHtml(brand.logoSrc)}" alt="${escapeHtml(brand.logoAlt)}" />
+          <div>
+            <p>${escapeHtml(brand.companyName)}</p>
+            <h1>${escapeHtml(rfq.title)}</h1>
+          </div>
         </div>
         <div>
           <p>${escapeHtml(projectLabel)}</p>
@@ -128,10 +134,12 @@ function printHtml({
 }
 
 export function ProjectRfqShareActions({
+  brand,
   projectId,
   projectLabel,
   rfq,
 }: {
+  readonly brand: ProjectBrand
   readonly projectId: string
   readonly projectLabel: string
   readonly rfq: ProjectRfqItem
@@ -223,6 +231,7 @@ export function ProjectRfqShareActions({
     const printRoot = document.createElement("article")
     printRoot.setAttribute("data-rfq-print-root", "true")
     printRoot.innerHTML = printHtml({
+      brand,
       projectLabel,
       rfq,
       url: absoluteUrl(),

--- a/src/components/projects/project-selection-share-actions.tsx
+++ b/src/components/projects/project-selection-share-actions.tsx
@@ -19,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import type { ProjectBrand } from "@/lib/project-branding"
 
 type CopiedState = "link" | "email" | "html" | "sheet" | null
 type PrintMode = "packet" | "room_sheets"
@@ -126,6 +127,7 @@ function packetSelectionRows(
 }
 
 function packetHtml({
+  brand,
   projectLabel,
   clientName,
   filterLabel,
@@ -133,6 +135,7 @@ function packetHtml({
   summary,
   mode,
 }: {
+  readonly brand: ProjectBrand
   readonly projectLabel: string
   readonly clientName: string | null
   readonly filterLabel: string | null
@@ -150,9 +153,9 @@ function packetHtml({
   return `
     <header class="selection-print-header">
       <div class="selection-print-brand">
-        <img src="/department-logos/orc-mark.png" alt="Open Range Construction" />
+        <img src="${escapeHtml(brand.logoSrc)}" alt="${escapeHtml(brand.logoAlt)}" />
         <div>
-          <p>Open Range Construction</p>
+          <p>${escapeHtml(brand.companyName)}</p>
           <span>Finish Selection Packet</span>
         </div>
       </div>
@@ -177,12 +180,14 @@ function packetHtml({
 }
 
 export function ProjectSelectionShareActions({
+  brand,
   projectId,
   projectLabel,
   clientName,
   filterLabel = null,
   summary,
 }: {
+  readonly brand: ProjectBrand
   readonly projectId: string
   readonly projectLabel: string
   readonly clientName: string | null
@@ -336,6 +341,7 @@ export function ProjectSelectionShareActions({
     printRoot.setAttribute("data-selection-print-root", "true")
     printRoot.className = "selection-printable bg-white text-black"
     printRoot.innerHTML = packetHtml({
+      brand,
       projectLabel,
       clientName,
       filterLabel,

--- a/src/components/projects/project-selections-workspace.tsx
+++ b/src/components/projects/project-selections-workspace.tsx
@@ -29,6 +29,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import type { ProjectBrand } from "@/lib/project-branding"
 
 type SelectionFilterState = {
   readonly division: string
@@ -441,12 +442,14 @@ function EmptySelectionsState({
 }
 
 export function ProjectSelectionsWorkspace({
+  brand,
   clientName,
   options,
   projectId,
   projectLabel,
   summary,
 }: {
+  readonly brand: ProjectBrand
   readonly clientName: string | null
   readonly options: ProjectSelectionOptions
   readonly projectId: string
@@ -627,6 +630,7 @@ export function ProjectSelectionsWorkspace({
 
       <div className="flex flex-wrap items-center justify-between gap-3">
         <ProjectSelectionShareActions
+          brand={brand}
           clientName={clientName}
           filterLabel={activeFilterLabel}
           projectId={projectId}

--- a/src/lib/__tests__/project-branding.test.ts
+++ b/src/lib/__tests__/project-branding.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+
+import { projectBrandFor, projectDepartment } from "@/lib/project-branding"
+
+describe("project branding", () => {
+  it.each([
+    ["O-202-595", "O"],
+    ["H-OFFICE", "H"],
+    ["N-830-8220", "N"],
+    ["D-18-00", "D"],
+  ])("detects the %s department", (projectNumber, department) => {
+    expect(projectDepartment({ projectNumber })).toBe(department)
+  })
+
+  it("can infer the department from a Compass project id", () => {
+    expect(projectDepartment({ projectId: "proj-bt-o-197-litten" })).toBe("O")
+  })
+
+  it("uses the ORC identity for both ORC and Design projects", () => {
+    const orc = projectBrandFor({ projectNumber: "O-202-595" })
+    const design = projectBrandFor({ projectNumber: "D-18-00" })
+
+    expect(design.companyName).toBe(orc.companyName)
+    expect(design.logoSrc).toBe(orc.logoSrc)
+    expect(design.department).toBe("D")
+  })
+
+  it("uses distinct HPS and Nu-Tech identities", () => {
+    expect(projectBrandFor({ projectNumber: "H-OFFICE" })).toMatchObject({
+      companyName: "High Performance Structures, Inc.",
+      logoSrc: "/department-logos/hps-h-green.svg",
+    })
+    expect(projectBrandFor({ projectNumber: "N-830-8220" })).toMatchObject({
+      companyName: "Nu-Tech Systems",
+      logoSrc: "/department-logos/nu-tech-n.png",
+    })
+  })
+
+  it("keeps HPS as the safe fallback for unnumbered legacy projects", () => {
+    expect(projectBrandFor({})).toMatchObject({
+      department: "H",
+      companyName: "High Performance Structures, Inc.",
+    })
+  })
+})

--- a/src/lib/project-branding.ts
+++ b/src/lib/project-branding.ts
@@ -1,0 +1,85 @@
+export type ProjectDepartment = "O" | "H" | "N" | "D"
+
+export type ProjectBrand = {
+  readonly companyName: string
+  readonly department: ProjectDepartment
+  readonly logoAlt: string
+  readonly logoSrc: string
+  readonly mailingAddress: readonly string[]
+}
+
+type BrandIdentity = Omit<ProjectBrand, "department">
+
+const ORC_BRAND: BrandIdentity = {
+  companyName: "Open Range Construction",
+  logoAlt: "Open Range Construction",
+  logoSrc: "/department-logos/orc-mark.png",
+  mailingAddress: [],
+}
+
+const HPS_BRAND: BrandIdentity = {
+  companyName: "High Performance Structures, Inc.",
+  logoAlt: "High Performance Structures",
+  logoSrc: "/department-logos/hps-h-green.svg",
+  mailingAddress: ["P.O. Box 878", "Woodland Park, CO 80866"],
+}
+
+const NUTECH_BRAND: BrandIdentity = {
+  companyName: "Nu-Tech Systems",
+  logoAlt: "Nu-Tech Systems",
+  logoSrc: "/department-logos/nu-tech-n.png",
+  mailingAddress: [],
+}
+
+function isProjectDepartment(value: string): value is ProjectDepartment {
+  return value === "O" || value === "H" || value === "N" || value === "D"
+}
+
+function departmentFromIdentifier(
+  value: string | null | undefined
+): ProjectDepartment | null {
+  const normalized = value?.trim().toUpperCase() ?? ""
+  if (normalized.length === 0) return null
+
+  const segments = normalized.split(/[^A-Z0-9]+/).filter(Boolean)
+  for (const segment of segments) {
+    if (isProjectDepartment(segment)) return segment
+  }
+
+  return null
+}
+
+export function projectDepartment({
+  projectId,
+  projectNumber,
+}: {
+  readonly projectId?: string | null
+  readonly projectNumber?: string | null
+}): ProjectDepartment {
+  return (
+    departmentFromIdentifier(projectNumber) ??
+    departmentFromIdentifier(projectId) ??
+    "H"
+  )
+}
+
+export function projectBrandFor({
+  projectId,
+  projectNumber,
+}: {
+  readonly projectId?: string | null
+  readonly projectNumber?: string | null
+}): ProjectBrand {
+  const department = projectDepartment({ projectId, projectNumber })
+  const identity =
+    department === "H"
+      ? HPS_BRAND
+      : department === "N"
+        ? NUTECH_BRAND
+        : ORC_BRAND
+
+  return {
+    ...identity,
+    department,
+  }
+}


### PR DESCRIPTION
## Summary
- resolve document branding from the project number or project id
- map ORC and Design projects to the ORC identity, HPS projects to HPS, and Nu-Tech projects to Nu-Tech
- apply the resolved logo and company name to owner updates, daily logs, purchase orders, selection packets, and RFQs
- retain the known HPS mailing address only on HPS purchase orders
- add focused department and fallback coverage

## Verification
- bun test src/lib/__tests__/project-branding.test.ts
- targeted ESLint
- bunx tsc --noEmit --pretty false
- bun run build