### PR TITLE
feat(feedback): track origins and requester updates

### DIFF
--- a/docs/architecture/jarvis-feedback-bridge.md
+++ b/docs/architecture/jarvis-feedback-bridge.md
@@ -47,7 +47,7 @@ Data flow
 Compass conversation / feedback widget
                  |
                  v
-       D1 feedback desk + outbox
+       D1 feedback desk + private provenance/outbox
                  |
           signed pull / ack
                  |
@@ -115,6 +115,36 @@ The bridge intake endpoint accepts `telegram`, `jarvis-email`, and
 `ask-jarvis` events from the private adapter. All message content is marked
 and treated as untrusted user content. Message text must never be interpreted
 as bridge configuration or permission to perform an external action.
+
+`jarvis-email` is the existing Jarvis mailbox adapter for
+`jarvis@hps-colorado.com`; it is not a separate public email integration.
+Compass stores the sender address and adapter routing data only in the
+Feedback Desk's protected record and bridge payloads.
+
+GitHub issue and privacy boundary
+---
+
+Every Feedback Desk item is mirrored to a GitHub issue and added to the
+`Compass Development & Feedback` GitHub Project. GitHub is deliberately a
+minimal engineering tracker, not the system of record for a request. Its
+title and body contain only the request kind and an opaque `CFD-<UUID>`
+correlation reference. They never contain the submitted title or message,
+reporter name, email address, Telegram identifier, source event identifier,
+page URL, user agent, or bridge metadata.
+
+The corresponding request content, source provenance, requester identity,
+and reply target stay in Compass D1 and the signed private bridge. Configure
+`GITHUB_FEEDBACK_PROJECT_ID` with the node ID of the `Compass Development &
+Feedback` Project for deterministic project insertion. When it is absent,
+Compass attempts a title lookup among the token owner's projects and logs a
+configuration error rather than exporting private data.
+
+The prior feedback-widget issue formatter included the optional reporter name
+and email in GitHub issue bodies. It has been removed: new widget submissions
+now use the same sanitized export as Telegram, Jarvis email, and Compass
+conversation feedback. Any historical issue created by the former formatter
+must be edited in GitHub to remove the reporter line before the issue is
+shared further.
 
 Guest policy
 ---
@@ -277,7 +307,7 @@ POST /api/integrations/jarvis/feedback/<feedback-desk-item-id>/status
 The signed lifecycle endpoint accepts an idempotency key, one of the visible
 request states (`new`, `triaged`, `needs_info`, `planned`, `in_progress`,
 `testing`, `deployed`, or `closed`), an optional staff-facing message,
-priority, and GitHub issue URL. Compass updates the durable Feedback Desk
+priority, GitHub issue URL, and optional `draftPullRequestUrl`. Compass updates the durable Feedback Desk
 record and creates:
 
 - an in-app notification for the matching authenticated requester;
@@ -285,6 +315,24 @@ record and creates:
   deployment milestones; and
 - a `feedback.status_changed` outbound bridge event so Telegram, email, and
   originating Compass-thread adapters can reply through the source channel.
+
+Compass creates a neutral receipt event when the item is first recorded.
+Subsequent triage, planned, and in-progress events use the same source-aware
+payload. A new `draftPullRequestUrl` sets `notificationKind` to
+`draft_pull_request_opened`; the bridge delivers the human-readable pull
+request link only to the originating private channel. Compass-thread replies
+are posted through the existing signed reply endpoint, which derives the
+stored original thread instead of trusting a callback-supplied destination.
+Compass suppresses repeated callbacks that leave both the lifecycle status and
+draft pull request unchanged. Requesters receive only receipt, a meaningful
+status transition (triage, information needed, planned, implementation,
+testing, deployment, or closure), or a newly opened/materially updated draft
+pull request.
+The event's `source` is always the original source (`telegram`,
+`jarvis-email`, or `compass-conversation`), never a generic fallback route:
+the adapter must send Telegram updates only through Telegram, Jarvis mailbox
+updates only through email, and Compass updates only to the stored Compass
+thread/request. Cross-channel delivery requires a separate product decision.
 
 The notification links to `/dashboard/requests`, where authenticated users
 see only requests matching their organization and account email. GitHub

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -114,6 +114,7 @@ decision reactivates NetSuite for a specific workflow.
 |----------|-------------|
 | `GITHUB_TOKEN` | GitHub repo token for automatic deployments. |
 | `GITHUB_REPO` | Repository in `owner/repo` format. Default: `High-Performance-Structures/compass`. |
+| `GITHUB_FEEDBACK_PROJECT_ID` | GitHub Project node ID for `Compass Development & Feedback`; used to add sanitized Feedback Desk issues to the project. |
 
 ### Jarvis / Signet feedback bridge (optional)
 

--- a/drizzle/0070_feedback_draft_pull_request.sql
+++ b/drizzle/0070_feedback_draft_pull_request.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `feedback_desk_items`
+  ADD COLUMN `github_issue_node_id` text;
+
+ALTER TABLE `feedback_desk_items`
+  ADD COLUMN `github_draft_pull_request_url` text;

--- a/src/app/actions/chat-messages.ts
+++ b/src/app/actions/chat-messages.ts
@@ -37,6 +37,7 @@ import { isDemoUser } from "@/lib/demo"
 import { requireOrg } from "@/lib/org-scope"
 import { revalidatePath } from "next/cache"
 import { enqueueFeedbackDeskItem } from "@/lib/jarvis/feedback-desk"
+import { linkFeedbackDeskItemToGithub } from "@/lib/jarvis/feedback-github"
 import {
   createNotificationEvent,
   notifyChannelMessage,
@@ -572,7 +573,7 @@ export async function sendMessage(data: {
 
     if (channel && (asksCompass || isFeedbackChannel)) {
       try {
-        await enqueueFeedbackDeskItem(db, {
+        const feedbackItem = await enqueueFeedbackDeskItem(db, {
           organizationId: channel.organizationId,
           source: "compass-conversation",
           sourceId: messageId,
@@ -591,6 +592,7 @@ export async function sendMessage(data: {
             channelName: channel.name,
           },
         })
+        await linkFeedbackDeskItemToGithub(db, env, feedbackItem)
       } catch (error) {
         console.error("conversation_feedback_enqueue_failed", {
           messageId,

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -3,6 +3,7 @@ import { getDb } from "@/db"
 import { feedback } from "@/db/schema"
 import { sql } from "drizzle-orm"
 import { enqueueFeedbackDeskItem } from "@/lib/jarvis/feedback-desk"
+import { linkFeedbackDeskItemToGithub } from "@/lib/jarvis/feedback-github"
 import { getJarvisEnvValue } from "@/lib/jarvis/auth"
 
 const FEEDBACK_TYPES = ["bug", "feature", "question", "general"] as const
@@ -86,20 +87,8 @@ export async function POST(request: Request) {
     createdAt,
   })
 
-  const githubIssueUrl = await createGithubIssue(env, db, id, {
-    type,
-    message: message.trim(),
-    name: name?.trim(),
-    email: email?.trim(),
-    pageUrl,
-    userAgent,
-    viewportWidth,
-    viewportHeight,
-    createdAt,
-  })
-
   try {
-    await enqueueFeedbackDeskItem(db, {
+    const item = await enqueueFeedbackDeskItem(db, {
       organizationId: getJarvisEnvValue(
         env,
         "JARVIS_BRIDGE_ORGANIZATION_ID",
@@ -111,7 +100,6 @@ export async function POST(request: Request) {
       description: message.trim(),
       reporterName: name?.trim(),
       reporterEmail: email?.trim(),
-      githubIssueUrl,
       metadata: {
         pageUrl: pageUrl ?? null,
         userAgent: userAgent ?? null,
@@ -120,6 +108,13 @@ export async function POST(request: Request) {
         untrustedUserContent: true,
       },
     })
+    const githubIssueUrl = await linkFeedbackDeskItemToGithub(db, env, item)
+    if (githubIssueUrl) {
+      await db
+        .update(feedback)
+        .set({ githubIssueUrl })
+        .where(sql`${feedback.id} = ${id}`)
+    }
   } catch (error) {
     console.error("feedback_desk_enqueue_failed", {
       feedbackId: id,
@@ -137,99 +132,4 @@ async function hashIp(ip: string): Promise<string> {
   const hashBuffer = await crypto.subtle.digest("SHA-256", data)
   const hashArray = Array.from(new Uint8Array(hashBuffer))
   return hashArray.map(b => b.toString(16).padStart(2, "0")).join("")
-}
-
-const LABEL_MAP: Record<string, string> = {
-  bug: "bug",
-  feature: "enhancement",
-  question: "question",
-  general: "feedback",
-}
-
-async function createGithubIssue(
-  env: CloudflareEnv,
-  db: ReturnType<typeof getDb>,
-  feedbackId: string,
-  data: {
-    type: string
-    message: string
-    name?: string
-    email?: string
-    pageUrl?: string
-    userAgent?: string
-    viewportWidth?: number
-    viewportHeight?: number
-    createdAt: string
-  },
-): Promise<string | null> {
-  const token =
-    getJarvisEnvValue(env, "GITHUB_TOKEN") ??
-    process.env.GITHUB_TOKEN
-  const repo =
-    getJarvisEnvValue(env, "GITHUB_REPO") ??
-    process.env.GITHUB_REPO
-  if (!token || !repo) return null
-
-  const titlePrefix = `[${data.type}]`
-  const titleMessage = data.message.slice(0, 60) + (data.message.length > 60 ? "..." : "")
-  const title = `${titlePrefix} ${titleMessage}`
-
-  const fromLine = data.name
-    ? `${data.name}${data.email ? ` (${data.email})` : ""}`
-    : `Anonymous${data.email ? ` (${data.email})` : ""}`
-
-  const body = `## Feedback: ${data.type}
-
-${data.message}
-
----
-
-**From:** ${fromLine}
-**Page:** ${data.pageUrl || "Unknown"}
-**Viewport:** ${data.viewportWidth || "?"}x${data.viewportHeight || "?"}
-**User Agent:** ${data.userAgent || "Unknown"}
-**Timestamp:** ${data.createdAt}`
-
-  try {
-    const res = await fetch(`https://api.github.com/repos/${repo}/issues`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-        "User-Agent": "compass-feedback-widget",
-      },
-      body: JSON.stringify({
-        title,
-        body,
-        labels: [LABEL_MAP[data.type] || "feedback"],
-      }),
-    })
-
-    if (res.ok) {
-      const issue: unknown = await res.json()
-      const issueUrl =
-        typeof issue === "object" &&
-        issue !== null &&
-        "html_url" in issue &&
-        typeof issue.html_url === "string"
-          ? issue.html_url
-          : null
-      if (!issueUrl) return null
-
-      await db
-        .update(feedback)
-        .set({ githubIssueUrl: issueUrl })
-        .where(sql`${feedback.id} = ${feedbackId}`)
-      return issueUrl
-    }
-  } catch (error) {
-    // non-blocking: don't fail the feedback submission
-    console.error("feedback_github_issue_failed", {
-      feedbackId,
-      error:
-        error instanceof Error ? error.message : "Unknown error",
-    })
-  }
-
-  return null
 }

--- a/src/app/api/integrations/jarvis/events/route.ts
+++ b/src/app/api/integrations/jarvis/events/route.ts
@@ -11,6 +11,8 @@ import {
   readBoundedBody,
   verifyJarvisRequest,
 } from "@/lib/jarvis/auth"
+import { linkFeedbackDeskItemToGithub } from "@/lib/jarvis/feedback-github"
+import { enqueueFeedbackReceipt } from "@/lib/jarvis/feedback-desk"
 
 const CLAIM_RETRY_MILLISECONDS = 5 * 60 * 1000
 const MAX_EVENT_BATCH = 50
@@ -235,7 +237,7 @@ export async function POST(request: Request): Promise<Response> {
     .onConflictDoNothing()
 
   const item = await db
-    .select({ id: feedbackDeskItems.id })
+    .select()
     .from(feedbackDeskItems)
     .where(
       and(
@@ -270,6 +272,9 @@ export async function POST(request: Request): Promise<Response> {
       updatedAt: now,
     })
     .onConflictDoNothing()
+
+  await enqueueFeedbackReceipt(db, item)
+  await linkFeedbackDeskItemToGithub(db, env, item)
 
   return Response.json(
     { success: true, feedbackDeskItemId: item.id },

--- a/src/app/api/integrations/jarvis/feedback/[id]/status/route.ts
+++ b/src/app/api/integrations/jarvis/feedback/[id]/status/route.ts
@@ -16,6 +16,8 @@ import {
 import {
   FEEDBACK_DESK_STATUSES,
   feedbackStatusLabel,
+  feedbackDraftPullRequestMessage,
+  feedbackRequesterUpdateKind,
   feedbackStatusMessage,
   feedbackStatusUsesEmail,
 } from "@/lib/jarvis/feedback-lifecycle"
@@ -27,6 +29,9 @@ const statusUpdateSchema = z.object({
   message: z.string().min(1).max(2_000).optional(),
   priority: z.enum(["low", "normal", "high", "urgent"]).optional(),
   githubIssueUrl: z.union([z.url().max(2_048), z.null()]).optional(),
+  draftPullRequestUrl: z
+    .union([z.url().max(2_048), z.null()])
+    .optional(),
 })
 
 function metadataActorId(metadata: string | null): string | null {
@@ -172,10 +177,25 @@ export async function POST(
         )
     : []
 
+  const draftPullRequestUrl =
+    parsed.data.draftPullRequestUrl === undefined
+      ? item.githubDraftPullRequestUrl
+      : parsed.data.draftPullRequestUrl
+  const requesterUpdateKind = feedbackRequesterUpdateKind(
+    item.status,
+    parsed.data.status,
+    item.githubDraftPullRequestUrl,
+    draftPullRequestUrl,
+  )
+  const hasDraftPullRequestUpdate =
+    draftPullRequestUrl !== null &&
+    draftPullRequestUrl !== item.githubDraftPullRequestUrl
   const now = new Date().toISOString()
   const message =
     parsed.data.message ??
-    feedbackStatusMessage(parsed.data.status, item.title)
+    (hasDraftPullRequestUpdate
+      ? feedbackDraftPullRequestMessage(item.title, draftPullRequestUrl)
+      : feedbackStatusMessage(parsed.data.status, item.title))
   await db
     .update(feedbackDeskItems)
     .set({
@@ -185,11 +205,12 @@ export async function POST(
         parsed.data.githubIssueUrl === undefined
           ? item.githubIssueUrl
           : parsed.data.githubIssueUrl,
+      githubDraftPullRequestUrl: draftPullRequestUrl,
       updatedAt: now,
     })
     .where(eq(feedbackDeskItems.id, id))
 
-  if (recipients.length > 0) {
+  if (requesterUpdateKind && recipients.length > 0) {
     try {
       await createSystemNotificationEvent({
         organizationId,
@@ -245,6 +266,8 @@ export async function POST(
       parsed.data.githubIssueUrl === undefined
         ? item.githubIssueUrl
         : parsed.data.githubIssueUrl,
+    draftPullRequestUrl,
+    notificationKind: requesterUpdateKind,
     updatedAt: now,
   })
 
@@ -264,27 +287,30 @@ export async function POST(
     createdAt: now,
     updatedAt: now,
   })
-  await db
-    .insert(jarvisBridgeEvents)
-    .values({
-      id: crypto.randomUUID(),
-      organizationId,
-      direction: "outbound",
-      source: "feedback-lifecycle",
-      eventType: "feedback.status_changed",
-      idempotencyKey: `notify:${eventKey}`,
-      feedbackDeskItemId: id,
-      payload: statusPayload,
-      availableAt: now,
-      createdAt: now,
-      updatedAt: now,
-    })
-    .onConflictDoNothing()
+  if (requesterUpdateKind) {
+    await db
+      .insert(jarvisBridgeEvents)
+      .values({
+        id: crypto.randomUUID(),
+        organizationId,
+        direction: "outbound",
+        source: item.source,
+        eventType: "feedback.status_changed",
+        idempotencyKey: `notify:${eventKey}`,
+        feedbackDeskItemId: id,
+        payload: statusPayload,
+        availableAt: now,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoNothing()
+  }
 
   return Response.json({
     success: true,
     feedbackDeskItemId: id,
     status: parsed.data.status,
-    notifiedUserCount: recipients.length,
+    notifiedUserCount: requesterUpdateKind ? recipients.length : 0,
+    requesterUpdateQueued: requesterUpdateKind !== null,
   })
 }

--- a/src/app/api/integrations/jarvis/replies/route.ts
+++ b/src/app/api/integrations/jarvis/replies/route.ts
@@ -122,6 +122,7 @@ export async function POST(request: Request): Promise<Response> {
     .select({
       id: jarvisBridgeEvents.id,
       eventType: jarvisBridgeEvents.eventType,
+      source: jarvisBridgeEvents.source,
       payload: jarvisBridgeEvents.payload,
     })
     .from(jarvisBridgeEvents)
@@ -135,18 +136,29 @@ export async function POST(request: Request): Promise<Response> {
 
   if (
     !sourceEvent ||
-    sourceEvent.eventType !== "assistance.requested"
+    (sourceEvent.eventType !== "assistance.requested" &&
+      sourceEvent.eventType !== "feedback.status_changed")
   ) {
     return Response.json(
-      { error: "Assistance request not found" },
+      { error: "Replyable request not found" },
       { status: 404 },
+    )
+  }
+
+  if (
+    sourceEvent.eventType === "feedback.status_changed" &&
+    sourceEvent.source !== "compass-conversation"
+  ) {
+    return Response.json(
+      { error: "Feedback update belongs to a non-Compass source" },
+      { status: 409 },
     )
   }
 
   const target = replyTarget(sourceEvent.payload)
   if (!target) {
     return Response.json(
-      { error: "Assistance request has no reply target" },
+      { error: "Request has no Compass reply target" },
       { status: 409 },
     )
   }

--- a/src/db/schema-jarvis.ts
+++ b/src/db/schema-jarvis.ts
@@ -24,6 +24,8 @@ export const feedbackDeskItems = sqliteTable(
     messageId: text("message_id"),
     threadId: text("thread_id"),
     githubIssueUrl: text("github_issue_url"),
+    githubIssueNodeId: text("github_issue_node_id"),
+    githubDraftPullRequestUrl: text("github_draft_pull_request_url"),
     metadata: text("metadata"),
     createdAt: text("created_at").notNull(),
     updatedAt: text("updated_at").notNull(),

--- a/src/lib/jarvis/__tests__/feedback-github.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-github.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  feedbackReference,
+  githubFeedbackIssueContent,
+} from "@/lib/jarvis/feedback-github-content"
+
+describe("Feedback Desk GitHub export", () => {
+  it("uses only a kind and opaque reference in a GitHub issue", () => {
+    const issue = githubFeedbackIssueContent({
+      id: "f43e6e9a-1889-4ce0-9d16-6b6f13d57b58",
+      kind: "bug",
+    })
+
+    expect(issue.title).toBe(
+      "[Compass feedback] bug · CFD-f43e6e9a-1889-4ce0-9d16-6b6f13d57b58",
+    )
+    expect(issue.body).toContain(feedbackReference("f43e6e9a-1889-4ce0-9d16-6b6f13d57b58"))
+    expect(issue.body).not.toContain("telegram")
+    expect(issue.body).not.toContain("@example.com")
+    expect(issue.labels).toEqual(["bug", "feedback"])
+  })
+})

--- a/src/lib/jarvis/__tests__/feedback-lifecycle.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-lifecycle.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest"
 
 import {
   feedbackStatusLabel,
+  feedbackDraftPullRequestMessage,
+  feedbackRequesterUpdateKind,
   feedbackStatusMessage,
   feedbackStatusUsesEmail,
 } from "@/lib/jarvis/feedback-lifecycle"
@@ -34,5 +36,39 @@ describe("Feedback Desk lifecycle", () => {
     expect(feedbackStatusUsesEmail("needs_info")).toBe(true)
     expect(feedbackStatusUsesEmail("testing")).toBe(true)
     expect(feedbackStatusUsesEmail("deployed")).toBe(true)
+  })
+
+  it("keeps a draft pull request link in the requester-only update", () => {
+    expect(
+      feedbackDraftPullRequestMessage(
+        "Daily Log printing",
+        "https://github.com/High-Performance-Structures/compass/pull/42",
+      ),
+    ).toContain("/pull/42")
+  })
+
+  it("only emits private requester updates for lifecycle or draft-PR changes", () => {
+    expect(
+      feedbackRequesterUpdateKind("triaged", "triaged", null, null),
+    ).toBeNull()
+    expect(
+      feedbackRequesterUpdateKind("triaged", "planned", null, null),
+    ).toBe("status_changed")
+    expect(
+      feedbackRequesterUpdateKind(
+        "in_progress",
+        "in_progress",
+        null,
+        "https://github.com/High-Performance-Structures/compass/pull/42",
+      ),
+    ).toBe("draft_pull_request_opened")
+    expect(
+      feedbackRequesterUpdateKind(
+        "in_progress",
+        "in_progress",
+        "https://github.com/High-Performance-Structures/compass/pull/42",
+        "https://github.com/High-Performance-Structures/compass/pull/43",
+      ),
+    ).toBe("draft_pull_request_updated")
   })
 })

--- a/src/lib/jarvis/feedback-desk.ts
+++ b/src/lib/jarvis/feedback-desk.ts
@@ -38,6 +38,46 @@ type CreateFeedbackDeskItemInput = {
   readonly metadata?: Readonly<Record<string, unknown>>
 }
 
+export async function enqueueFeedbackReceipt(
+  db: CompassDb,
+  item: FeedbackDeskItem,
+): Promise<void> {
+  const now = new Date().toISOString()
+  const receiptPayload = {
+    schemaVersion: 1,
+    feedbackDeskItemId: item.id,
+    source: item.source,
+    sourceId: item.sourceId,
+    status: "new",
+    title: item.title,
+    message: `Your request “${item.title}” has been received.`,
+    compass: {
+      organizationId: item.organizationId,
+      channelId: item.channelId,
+      messageId: item.messageId,
+      threadId: item.threadId,
+    },
+    createdAt: item.createdAt,
+  }
+
+  await db
+    .insert(jarvisBridgeEvents)
+    .values({
+      id: crypto.randomUUID(),
+      organizationId: item.organizationId,
+      direction: "outbound",
+      source: item.source,
+      eventType: "feedback.status_changed",
+      idempotencyKey: `receipt:${item.id}`,
+      feedbackDeskItemId: item.id,
+      payload: JSON.stringify(receiptPayload),
+      availableAt: now,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing()
+}
+
 export async function enqueueFeedbackDeskItem(
   db: CompassDb,
   input: CreateFeedbackDeskItemInput,
@@ -129,6 +169,8 @@ export async function enqueueFeedbackDeskItem(
       updatedAt: now,
     })
     .onConflictDoNothing()
+
+  await enqueueFeedbackReceipt(db, item)
 
   return item
 }

--- a/src/lib/jarvis/feedback-github-content.ts
+++ b/src/lib/jarvis/feedback-github-content.ts
@@ -1,0 +1,41 @@
+const PROJECT_TITLE = "Compass Development & Feedback"
+
+export const GITHUB_FEEDBACK_PROJECT_TITLE = PROJECT_TITLE
+
+type FeedbackIssueIdentity = Readonly<{
+  id: string
+  kind: string
+}>
+
+export function feedbackReference(id: string): string {
+  return `CFD-${id}`
+}
+
+/**
+ * GitHub is an engineering work tracker, not a requester directory. This
+ * intentionally contains no submitted title, message, source ID, or metadata.
+ */
+export function githubFeedbackIssueContent(
+  item: FeedbackIssueIdentity,
+): Readonly<{ title: string; body: string; labels: readonly string[] }> {
+  const reference = feedbackReference(item.id)
+  const kindLabel = githubLabel(item.kind)
+  return {
+    title: `[Compass feedback] ${item.kind} · ${reference}`,
+    body: `## Compass feedback request\n\n- Kind: ${item.kind}\n- Private correlation: ${reference}\n\nThe requester identity, original channel, and full request content are retained only in Compass's protected Feedback Desk. Do not add requester names, email addresses, messaging identifiers, or other personal data to this issue.`,
+    labels: kindLabel === "feedback" ? [kindLabel] : [kindLabel, "feedback"],
+  }
+}
+
+function githubLabel(kind: string): string {
+  switch (kind) {
+    case "bug":
+      return "bug"
+    case "feature":
+      return "enhancement"
+    case "question":
+      return "question"
+    default:
+      return "feedback"
+  }
+}

--- a/src/lib/jarvis/feedback-github.ts
+++ b/src/lib/jarvis/feedback-github.ts
@@ -1,0 +1,187 @@
+import { eq } from "drizzle-orm"
+
+import type { getDb } from "@/db"
+import {
+  feedbackDeskItems,
+  type FeedbackDeskItem,
+} from "@/db/schema-jarvis"
+import { getJarvisEnvValue } from "@/lib/jarvis/auth"
+import {
+  GITHUB_FEEDBACK_PROJECT_TITLE,
+  githubFeedbackIssueContent,
+} from "@/lib/jarvis/feedback-github-content"
+
+type CompassDb = ReturnType<typeof getDb>
+
+type GitHubFeedbackConfig = Readonly<{
+  token: string
+  repo: string
+  projectId: string | null
+}>
+
+type GitHubIssueResponse = Readonly<{
+  html_url?: unknown
+  node_id?: unknown
+}>
+
+type GraphqlResponse = Readonly<{
+  errors?: ReadonlyArray<Readonly<{ message?: unknown }>>
+  data?: Readonly<{
+    viewer?: Readonly<{
+      projectsV2?: Readonly<{
+        nodes?: ReadonlyArray<Readonly<{ id?: unknown; title?: unknown }>>
+      }>
+    }>
+  }>
+}>
+
+function githubConfig(env: CloudflareEnv): GitHubFeedbackConfig | null {
+  const token = getJarvisEnvValue(env, "GITHUB_TOKEN")
+  const repo = getJarvisEnvValue(env, "GITHUB_REPO")
+  if (!token || !repo) return null
+
+  return {
+    token,
+    repo,
+    projectId: getJarvisEnvValue(env, "GITHUB_FEEDBACK_PROJECT_ID"),
+  }
+}
+
+function githubHeaders(token: string): Readonly<Record<string, string>> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "Content-Type": "application/json",
+    "User-Agent": "compass-feedback-desk",
+  }
+}
+
+async function githubGraphql(
+  config: GitHubFeedbackConfig,
+  query: string,
+  variables: Readonly<Record<string, string | number>>,
+): Promise<GraphqlResponse | null> {
+  try {
+    const response = await fetch("https://api.github.com/graphql", {
+      method: "POST",
+      headers: githubHeaders(config.token),
+      body: JSON.stringify({ query, variables }),
+    })
+    if (!response.ok) return null
+    return await response.json() as GraphqlResponse
+  } catch {
+    return null
+  }
+}
+
+async function feedbackProjectId(
+  config: GitHubFeedbackConfig,
+): Promise<string | null> {
+  if (config.projectId) return config.projectId
+
+  const result = await githubGraphql(
+    config,
+    `query FeedbackProject($first: Int!) {
+      viewer {
+        projectsV2(first: $first) { nodes { id title } }
+      }
+    }`,
+    { first: 100 },
+  )
+  const projects = result?.data?.viewer?.projectsV2?.nodes ?? []
+  const matchingProject = projects.find(
+    (project) => project.title === GITHUB_FEEDBACK_PROJECT_TITLE,
+  )
+  return typeof matchingProject?.id === "string"
+    ? matchingProject.id
+    : null
+}
+
+async function addIssueToFeedbackProject(
+  config: GitHubFeedbackConfig,
+  issueNodeId: string,
+): Promise<void> {
+  const projectId = await feedbackProjectId(config)
+  if (!projectId) {
+    console.error("feedback_github_project_not_found", {
+      projectTitle: GITHUB_FEEDBACK_PROJECT_TITLE,
+    })
+    return
+  }
+
+  const result = await githubGraphql(
+    config,
+    `mutation AddFeedbackIssue($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+        item { id }
+      }
+    }`,
+    { projectId, contentId: issueNodeId },
+  )
+  if (result?.errors?.length || !result?.data) {
+    console.error("feedback_github_project_add_failed", {
+      error:
+        typeof result?.errors?.[0]?.message === "string"
+          ? result.errors[0].message
+          : "GitHub Project mutation did not return data",
+    })
+  }
+}
+
+export async function linkFeedbackDeskItemToGithub(
+  db: CompassDb,
+  env: CloudflareEnv,
+  item: FeedbackDeskItem,
+): Promise<string | null> {
+  const config = githubConfig(env)
+  if (!config) return null
+
+  if (item.githubIssueUrl) {
+    if (item.githubIssueNodeId) {
+      await addIssueToFeedbackProject(config, item.githubIssueNodeId)
+    }
+    return item.githubIssueUrl
+  }
+
+  const issueContent = githubFeedbackIssueContent(item)
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${config.repo}/issues`,
+      {
+        method: "POST",
+        headers: githubHeaders(config.token),
+        body: JSON.stringify(issueContent),
+      },
+    )
+    if (!response.ok) {
+      console.error("feedback_github_issue_failed", {
+        feedbackDeskItemId: item.id,
+        status: response.status,
+      })
+      return null
+    }
+    const issue = await response.json() as GitHubIssueResponse
+    if (typeof issue.html_url !== "string") return null
+
+    await db
+      .update(feedbackDeskItems)
+      .set({
+        githubIssueUrl: issue.html_url,
+        githubIssueNodeId:
+          typeof issue.node_id === "string" ? issue.node_id : null,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(feedbackDeskItems.id, item.id))
+
+    if (typeof issue.node_id === "string") {
+      await addIssueToFeedbackProject(config, issue.node_id)
+    }
+    return issue.html_url
+  } catch (error) {
+    console.error("feedback_github_issue_failed", {
+      feedbackDeskItemId: item.id,
+      error: error instanceof Error ? error.message : "Unknown error",
+    })
+    return null
+  }
+}

--- a/src/lib/jarvis/feedback-lifecycle.ts
+++ b/src/lib/jarvis/feedback-lifecycle.ts
@@ -12,6 +12,28 @@ export const FEEDBACK_DESK_STATUSES = [
 export type FeedbackDeskStatus =
   (typeof FEEDBACK_DESK_STATUSES)[number]
 
+export type FeedbackRequesterUpdateKind =
+  | "status_changed"
+  | "draft_pull_request_opened"
+  | "draft_pull_request_updated"
+
+export function feedbackRequesterUpdateKind(
+  previousStatus: string,
+  nextStatus: string,
+  previousDraftPullRequestUrl: string | null,
+  nextDraftPullRequestUrl: string | null,
+): FeedbackRequesterUpdateKind | null {
+  if (
+    nextDraftPullRequestUrl !== null &&
+    nextDraftPullRequestUrl !== previousDraftPullRequestUrl
+  ) {
+    return previousDraftPullRequestUrl === null
+      ? "draft_pull_request_opened"
+      : "draft_pull_request_updated"
+  }
+  return previousStatus === nextStatus ? null : "status_changed"
+}
+
 export function feedbackStatusLabel(status: string): string {
   switch (status) {
     case "new":
@@ -59,6 +81,13 @@ export function feedbackStatusMessage(
     case "closed":
       return `Your request “${title}” has been completed and closed.`
   }
+}
+
+export function feedbackDraftPullRequestMessage(
+  title: string,
+  draftPullRequestUrl: string,
+): string {
+  return `A draft pull request for “${title}” is available for review: ${draftPullRequestUrl}`
 }
 
 export function feedbackStatusUsesEmail(


### PR DESCRIPTION
## What changed

- records private feedback provenance for Compass conversations, the feedback widget, Telegram, and the existing Jarvis email bridge
- creates deliberately PII-free GitHub issues and adds them to the Compass Development & Feedback project
- sends receipt, lifecycle, and draft-PR updates back through the original private source channel
- prevents Compass reply callbacks from crossing into Telegram or email-origin requests
- removes reporter identity and request content from new GitHub issue payloads
- documents the bridge contract and deployment prerequisites

## Why

Staff need timely status updates without exposing names, email addresses, Telegram identifiers, or other personal information in GitHub. Compass remains the protected system of record while GitHub receives only an opaque correlation reference.

## Deployment requirements

- apply migration `0070_feedback_draft_pull_request.sql`
- configure `JARVIS_BRIDGE_SECRET`, organization/service-user values, and the existing private Telegram and Jarvis email adapters
- configure `GITHUB_TOKEN`, `GITHUB_REPO`, and preferably `GITHUB_FEEDBACK_PROJECT_ID`
- the GitHub token needs issue write access and Projects v2 access

## Validation

- 6 focused tests passed (22 assertions)
- targeted ESLint passed
- TypeScript passed
- production build passed
- `git diff --check` passed
