### PR TITLE
feat(calendar): establish Google sync foundation

### DIFF
--- a/docs/wip/google-calendar-sync-2026-07-27.md
+++ b/docs/wip/google-calendar-sync-2026-07-27.md
@@ -1,0 +1,98 @@
+# Google Calendar Sync
+
+Status: foundation in progress
+
+Owner: Compass product and engineering
+
+Tracking branch: `martinevogel/google-calendar-sync`
+
+## Decision
+
+Google Calendar is the first external calendar integration. Apple-specific
+calendar and reminder work is deferred. Apple users can display their Google
+calendars through the Google account configured on their Apple device.
+
+Compass keeps three operational concepts separate:
+
+1. A schedule item is project work with duration, progress, dependencies, and
+   workday rules.
+2. A to-do is an assignable action with a due date and completion state.
+3. A calendar event is a time-specific meeting, appointment, inspection,
+   delivery, absence, or company event.
+
+The Work Calendar presents these sources together without changing their source
+of truth. H-Office remains the default project for office events and receives
+priority in Office mode.
+
+## First Reviewable Slice
+
+The first slice establishes safe boundaries before external writes:
+
+- per-user Google connection records with encrypted refresh credentials;
+- selected Google calendars and incremental sync/watch metadata;
+- stable mappings between Compass records and Google event IDs;
+- typed OAuth configuration and response parsing;
+- explicit privacy projection and conflict-decision helpers;
+- event type, visibility, and meeting-link fields in the existing scheduler;
+- project-access-aware event projection that hides or reduces private details;
+- an integration status surface that remains safe when Google OAuth is not
+  configured;
+- tests for privacy, idempotency, and two-way conflict behavior.
+
+External calendar writes, staff-wide enablement, and the production migration
+are separate approval points.
+
+## Google Cloud Configuration
+
+Create a Google Cloud OAuth web client for the production Compass hostname and
+the approved local development callback. Configure:
+
+- `GOOGLE_OAUTH_CLIENT_ID`
+- `GOOGLE_OAUTH_CLIENT_SECRET`
+- `GOOGLE_OAUTH_REDIRECT_URI`
+- `GOOGLE_OAUTH_TOKEN_ENCRYPTION_KEY`
+
+The encryption key must be independent from the OAuth client secret. Store all
+production values as Cloudflare secrets. Do not commit them to source control.
+
+The initial consent request is intentionally limited to:
+
+- OpenID email identity;
+- read access to the user's calendar list; and
+- event read/write access.
+
+Google Tasks permissions are added only when the Tasks phase is implemented.
+
+## Privacy Rules
+
+- A project-scoped event is hidden from users without access to that project.
+- Event owners and participants see full details.
+- Participant-only and busy events appear as `Busy` to other authorized staff.
+- Private events are hidden from nonparticipants.
+- Guests cannot connect a Google account or view private staff-calendar data.
+- Tokens, private descriptions, and attendee contact details must never appear
+  in sync logs.
+
+## Synchronization Rules
+
+- Compass-created event IDs are deterministic per Google account and source
+  record, preventing duplicates after retries.
+- Push-only mappings keep Compass authoritative.
+- Pull-only mappings keep Google authoritative.
+- Two-way mappings push Compass-only changes and pull Google-only changes.
+- Concurrent Compass and Google edits become an explicit conflict; neither side
+  is silently overwritten.
+- Incremental sync tokens and renewable watch-channel metadata are stored per
+  selected calendar.
+- A failed webhook is only a signal to run incremental sync; webhook requests
+  are not trusted as event payloads.
+
+## Follow-up Slices
+
+1. Calendar selection and staff-wide enablement of the completed OAuth flow.
+2. Dedicated Compass Google calendar creation and event publishing.
+3. Imported Google events in the user's Work Calendar with busy projection.
+4. Push notifications, incremental sync, retries, and conflict UI.
+5. Remaining robust event fields: recurrence, exceptions, external attendees,
+   reminders, attachments, and related Compass records.
+6. Google Tasks synchronization after calendar behavior is stable.

--- a/drizzle/0071_google_calendar_sync_foundation.sql
+++ b/drizzle/0071_google_calendar_sync_foundation.sql
@@ -1,0 +1,127 @@
+ALTER TABLE `work_calendar_events`
+  ADD COLUMN `event_type` text NOT NULL DEFAULT 'meeting'
+  CHECK (`event_type` IN (
+    'meeting',
+    'appointment',
+    'inspection',
+    'delivery',
+    'company_event',
+    'absence',
+    'other'
+  ));
+--> statement-breakpoint
+ALTER TABLE `work_calendar_events`
+  ADD COLUMN `visibility` text NOT NULL DEFAULT 'organization'
+  CHECK (`visibility` IN ('organization', 'participants', 'busy', 'private'));
+--> statement-breakpoint
+ALTER TABLE `work_calendar_events`
+  ADD COLUMN `meeting_url` text;
+--> statement-breakpoint
+CREATE TABLE `google_calendar_connections` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `user_id` text NOT NULL,
+  `google_account_id` text NOT NULL,
+  `google_account_email` text NOT NULL,
+  `refresh_token_encrypted` text NOT NULL,
+  `granted_scopes` text NOT NULL,
+  `status` text NOT NULL DEFAULT 'connected',
+  `calendar_sync_enabled` integer NOT NULL DEFAULT 0,
+  `tasks_sync_enabled` integer NOT NULL DEFAULT 0,
+  `connected_at` text NOT NULL,
+  `last_synced_at` text,
+  `last_error` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+  CHECK (`status` IN ('connected', 'reauthorization_required', 'paused', 'error')),
+  CHECK (`calendar_sync_enabled` IN (0, 1)),
+  CHECK (`tasks_sync_enabled` IN (0, 1))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `google_calendar_connection_user_unique`
+  ON `google_calendar_connections` (`organization_id`, `user_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `google_calendar_connection_account_unique`
+  ON `google_calendar_connections` (`organization_id`, `google_account_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_google_calendar_connections_status`
+  ON `google_calendar_connections` (`organization_id`, `status`);
+--> statement-breakpoint
+CREATE TABLE `google_calendar_selections` (
+  `id` text PRIMARY KEY NOT NULL,
+  `connection_id` text NOT NULL,
+  `google_calendar_id` text NOT NULL,
+  `summary` text NOT NULL,
+  `description` text,
+  `time_zone` text,
+  `background_color` text,
+  `access_role` text NOT NULL DEFAULT 'reader',
+  `is_primary` integer NOT NULL DEFAULT 0,
+  `selected` integer NOT NULL DEFAULT 0,
+  `import_events` integer NOT NULL DEFAULT 0,
+  `export_compass_events` integer NOT NULL DEFAULT 0,
+  `is_compass_destination` integer NOT NULL DEFAULT 0,
+  `sync_token` text,
+  `watch_channel_id` text,
+  `watch_resource_id` text,
+  `watch_expires_at` text,
+  `last_synced_at` text,
+  `last_error` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`connection_id`) REFERENCES `google_calendar_connections`(`id`) ON UPDATE no action ON DELETE cascade,
+  CHECK (`access_role` IN ('freeBusyReader', 'reader', 'writer', 'owner')),
+  CHECK (`selected` IN (0, 1)),
+  CHECK (`import_events` IN (0, 1)),
+  CHECK (`export_compass_events` IN (0, 1)),
+  CHECK (`is_compass_destination` IN (0, 1))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `google_calendar_selection_unique`
+  ON `google_calendar_selections` (`connection_id`, `google_calendar_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_google_calendar_selections_selected`
+  ON `google_calendar_selections` (`connection_id`, `selected`);
+--> statement-breakpoint
+CREATE TABLE `google_calendar_entity_links` (
+  `id` text PRIMARY KEY NOT NULL,
+  `connection_id` text NOT NULL,
+  `google_calendar_id` text NOT NULL,
+  `google_event_id` text NOT NULL,
+  `google_ical_uid` text,
+  `source_type` text NOT NULL,
+  `source_id` text NOT NULL,
+  `sync_direction` text NOT NULL DEFAULT 'push',
+  `sync_status` text NOT NULL DEFAULT 'pending',
+  `google_etag` text,
+  `google_updated_at` text,
+  `compass_version` integer,
+  `last_synced_at` text,
+  `last_error` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`connection_id`) REFERENCES `google_calendar_connections`(`id`) ON UPDATE no action ON DELETE cascade,
+  CHECK (`source_type` IN ('work_calendar_event', 'schedule_item', 'task')),
+  CHECK (`sync_direction` IN ('push', 'pull', 'two_way')),
+  CHECK (`sync_status` IN ('pending', 'synced', 'conflict', 'error', 'deleted'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `google_calendar_entity_source_unique`
+  ON `google_calendar_entity_links` (
+    `connection_id`,
+    `google_calendar_id`,
+    `source_type`,
+    `source_id`
+  );
+--> statement-breakpoint
+CREATE UNIQUE INDEX `google_calendar_entity_event_unique`
+  ON `google_calendar_entity_links` (
+    `connection_id`,
+    `google_calendar_id`,
+    `google_event_id`
+  );
+--> statement-breakpoint
+CREATE INDEX `idx_google_calendar_entity_sync_status`
+  ON `google_calendar_entity_links` (`connection_id`, `sync_status`);

--- a/src/app/actions/google-calendar.ts
+++ b/src/app/actions/google-calendar.ts
@@ -1,0 +1,154 @@
+"use server"
+
+import { and, eq } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import { googleCalendarConnections } from "@/db/schema"
+import { requireAuth } from "@/lib/auth"
+import { decrypt } from "@/lib/crypto"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import {
+  getGoogleCalendarOAuthConfig,
+  googleCalendarTokenSalt,
+} from "@/lib/google/calendar/config"
+import { requireOrg } from "@/lib/org-scope"
+import { requirePermission } from "@/lib/permissions"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+export type GoogleCalendarConnectionStatus = {
+  readonly configured: boolean
+  readonly canConnect: boolean
+  readonly connected: boolean
+  readonly accountEmail: string | null
+  readonly status: string | null
+  readonly calendarSyncEnabled: boolean
+  readonly tasksSyncEnabled: boolean
+  readonly lastSyncedAt: string | null
+  readonly lastError: string | null
+}
+
+function canConnectGoogleCalendar(input: {
+  readonly userId: string
+  readonly role: string
+}): boolean {
+  return !isDemoUser(input.userId) && isInternalStaffRole(input.role)
+}
+
+export async function getGoogleCalendarConnectionStatus(): Promise<GoogleCalendarConnectionStatus> {
+  const user = await requireAuth()
+  requirePermission(user, "schedule", "read")
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  const configuration = getGoogleCalendarOAuthConfig(env)
+  const db = getDb(env.DB)
+  const connection = await db
+    .select({
+      googleAccountEmail: googleCalendarConnections.googleAccountEmail,
+      status: googleCalendarConnections.status,
+      calendarSyncEnabled: googleCalendarConnections.calendarSyncEnabled,
+      tasksSyncEnabled: googleCalendarConnections.tasksSyncEnabled,
+      lastSyncedAt: googleCalendarConnections.lastSyncedAt,
+      lastError: googleCalendarConnections.lastError,
+    })
+    .from(googleCalendarConnections)
+    .where(
+      and(
+        eq(googleCalendarConnections.organizationId, organizationId),
+        eq(googleCalendarConnections.userId, user.id),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+
+  return {
+    configured: configuration.configured,
+    canConnect: canConnectGoogleCalendar({
+      userId: user.id,
+      role: user.role,
+    }),
+    connected: connection !== null,
+    accountEmail: connection?.googleAccountEmail ?? null,
+    status: connection?.status ?? null,
+    calendarSyncEnabled: connection?.calendarSyncEnabled ?? false,
+    tasksSyncEnabled: connection?.tasksSyncEnabled ?? false,
+    lastSyncedAt: connection?.lastSyncedAt ?? null,
+    lastError: connection?.lastError ?? null,
+  }
+}
+
+export async function disconnectGoogleCalendar(): Promise<
+  | { readonly success: true; readonly revoked: boolean }
+  | { readonly success: false; readonly error: string }
+> {
+  try {
+    const user = await requireAuth()
+    requirePermission(user, "schedule", "read")
+    if (
+      !canConnectGoogleCalendar({
+        userId: user.id,
+        role: user.role,
+      })
+    ) {
+      return { success: false, error: "Google Calendar is staff-only." }
+    }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const connection = await db
+      .select({
+        id: googleCalendarConnections.id,
+        refreshTokenEncrypted:
+          googleCalendarConnections.refreshTokenEncrypted,
+      })
+      .from(googleCalendarConnections)
+      .where(
+        and(
+          eq(googleCalendarConnections.organizationId, organizationId),
+          eq(googleCalendarConnections.userId, user.id),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+
+    if (!connection) return { success: true, revoked: true }
+
+    let revoked = false
+    const configuration = getGoogleCalendarOAuthConfig(env)
+    if (configuration.configured) {
+      try {
+        const refreshToken = await decrypt(
+          connection.refreshTokenEncrypted,
+          configuration.config.tokenEncryptionKey,
+          googleCalendarTokenSalt(user.id),
+        )
+        const response = await fetch(
+          "https://oauth2.googleapis.com/revoke",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: new URLSearchParams({ token: refreshToken }),
+          },
+        )
+        revoked = response.ok
+      } catch {
+        revoked = false
+      }
+    }
+
+    await db
+      .delete(googleCalendarConnections)
+      .where(eq(googleCalendarConnections.id, connection.id))
+      .run()
+    revalidatePath("/dashboard/settings")
+    return { success: true, revoked }
+  } catch {
+    return {
+      success: false,
+      error: "Google Calendar could not be disconnected.",
+    }
+  }
+}

--- a/src/app/actions/work-calendar.ts
+++ b/src/app/actions/work-calendar.ts
@@ -7,6 +7,7 @@ import { getDb } from "@/db"
 import {
   organizationCalendarSettings,
   organizationMembers,
+  projectMembers,
   projectOperations,
   projectRfis,
   projects,
@@ -18,6 +19,7 @@ import {
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { isDemoUser } from "@/lib/demo"
+import { calendarDetailLevel } from "@/lib/google/calendar/sync-policy"
 import { createNotificationEvent } from "@/lib/notifications/events"
 import { eventAttendeeNotificationRecipients } from "@/lib/notifications/audience"
 import { requireOrg } from "@/lib/org-scope"
@@ -29,13 +31,18 @@ import {
 import {
   dateKeyInTimeZone,
   inclusiveEndDateFromExclusive,
+  isWorkCalendarEventType,
+  isWorkCalendarEventVisibility,
   isValidDateKey,
   normalizeWorkCalendarEventTiming,
   projectTodoHref,
   resolveHOfficeProjectId,
   scheduleItemHref,
+  type WorkCalendarEventType,
+  type WorkCalendarEventVisibility,
 } from "@/lib/work-calendar"
 import { isProjectTodoRecordType } from "@/lib/project-todos"
+import { isInternalStaffRole } from "@/lib/user-roles"
 
 export type WorkCalendarEntryKind =
   | "schedule"
@@ -67,6 +74,8 @@ export type WorkCalendarEventAttendee = {
 }
 
 export type WorkCalendarEventDetails = {
+  readonly eventType: WorkCalendarEventType
+  readonly visibility: WorkCalendarEventVisibility
   readonly description: string | null
   readonly startDate: string
   readonly endDate: string
@@ -77,6 +86,7 @@ export type WorkCalendarEventDetails = {
   readonly allDay: boolean
   readonly timeZone: string
   readonly location: string | null
+  readonly meetingUrl: string | null
   readonly attendees: readonly WorkCalendarEventAttendee[]
   readonly version: number
   readonly managed: boolean
@@ -241,15 +251,33 @@ export async function getWorkCalendar(
   const calendarAnchor = new Date(`${calendarDate}T12:00:00Z`)
   const rangeStart = toDateKey(addDays(calendarAnchor, -14))
   const rangeEnd = toDateKey(addDays(calendarAnchor, 45))
-  const projectRows = await db
-    .select({
-      id: projects.id,
-      name: projects.name,
-      projectNumber: projects.projectNumber,
-    })
-    .from(projects)
-    .where(eq(projects.organizationId, orgId))
-    .orderBy(asc(projects.projectNumber), asc(projects.name))
+  const projectRows =
+    user.organizationType === "internal" &&
+    isInternalStaffRole(user.role)
+      ? await db
+          .select({
+            id: projects.id,
+            name: projects.name,
+            projectNumber: projects.projectNumber,
+          })
+          .from(projects)
+          .where(eq(projects.organizationId, orgId))
+          .orderBy(asc(projects.projectNumber), asc(projects.name))
+      : await db
+          .select({
+            id: projects.id,
+            name: projects.name,
+            projectNumber: projects.projectNumber,
+          })
+          .from(projectMembers)
+          .innerJoin(projects, eq(projects.id, projectMembers.projectId))
+          .where(
+            and(
+              eq(projectMembers.userId, user.id),
+              eq(projects.organizationId, orgId),
+            ),
+          )
+          .orderBy(asc(projects.projectNumber), asc(projects.name))
   const projectById = new Map(
     projectRows.map((project) => [project.id, project])
   )
@@ -449,6 +477,8 @@ export async function getWorkCalendar(
           sourceLabel: "Legacy calendar event",
           href: eventHref(operation.id),
           eventDetails: {
+            eventType: "other",
+            visibility: "organization",
             description: null,
             startDate,
             endDate,
@@ -459,6 +489,7 @@ export async function getWorkCalendar(
             allDay: true,
             timeZone: "UTC",
             location: null,
+            meetingUrl: null,
             attendees: [],
             version: 0,
             managed: false,
@@ -588,27 +619,68 @@ export async function getWorkCalendar(
       continue
     }
     const attendees = attendeesByEventId.get(event.id) ?? []
+    const detailLevel = calendarDetailLevel({
+      visibility: isWorkCalendarEventVisibility(event.visibility)
+        ? event.visibility
+        : "organization",
+      viewerIsOwner: event.createdBy === user.id,
+      viewerIsParticipant: attendees.some(
+        (attendee) => attendee.userId === user.id,
+      ),
+      viewerHasProjectAccess:
+        event.projectId === null || projectById.has(event.projectId),
+      hasProjectScope: event.projectId !== null,
+    })
+    if (detailLevel === "hidden") continue
+    const showDetails = detailLevel === "full"
+    const eventType = isWorkCalendarEventType(event.eventType)
+      ? event.eventType
+      : "other"
 
     entries.push({
       id: event.id,
       kind: "event",
-      projectId: project?.id ?? null,
-      projectLabel: project ? projectLabel(project) : "No project",
-      projectName: project?.name ?? "Archived project",
-      title: event.title,
+      projectId: showDetails ? project?.id ?? null : null,
+      projectLabel: showDetails
+        ? project
+          ? projectLabel(project)
+          : "No project"
+        : "Private",
+      projectName: showDetails
+        ? project?.name ?? "Archived project"
+        : "Private",
+      title: showDetails ? event.title : "Busy",
       status: event.status,
       priority: "normal",
       startDate,
       endDate,
       assignedTo:
-        attendees.length > 0
+        showDetails && attendees.length > 0
           ? attendees.map((attendee) => attendee.name).join(", ")
           : null,
       companyName: null,
-      sourceLabel: "Calendar event",
-      href: `/dashboard/schedule?kind=event&item=${encodeURIComponent(event.id)}#work-calendar-${encodeURIComponent(event.id)}`,
+      sourceLabel: showDetails
+        ? eventType
+            .split("_")
+            .map(
+              (part) =>
+                `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`,
+            )
+            .join(" ")
+        : "Private calendar event",
+      href: showDetails
+        ? `/dashboard/schedule?kind=event&item=${encodeURIComponent(event.id)}#work-calendar-${encodeURIComponent(event.id)}`
+        : "/dashboard/schedule",
       eventDetails: {
-        description: event.description,
+        // Busy projections must not leak the underlying category or privacy
+        // choice through the client payload.
+        eventType: showDetails ? eventType : "other",
+        visibility: showDetails
+          ? isWorkCalendarEventVisibility(event.visibility)
+            ? event.visibility
+            : "organization"
+          : "busy",
+        description: showDetails ? event.description : null,
         startDate,
         endDate,
         startTime: event.allDay
@@ -621,10 +693,11 @@ export async function getWorkCalendar(
         endsAt: event.endsAt,
         allDay: event.allDay,
         timeZone: event.timeZone,
-        location: event.location,
-        attendees,
+        location: showDetails ? event.location : null,
+        meetingUrl: showDetails ? event.meetingUrl : null,
+        attendees: showDetails ? attendees : [],
         version: event.version,
-        managed: true,
+        managed: showDetails,
       },
     })
   }
@@ -653,6 +726,8 @@ export async function getWorkCalendar(
 
 export type WorkCalendarEventMutationInput = {
   readonly title: string
+  readonly eventType: WorkCalendarEventType
+  readonly visibility: WorkCalendarEventVisibility
   readonly description: string | null
   readonly projectId: string | null
   readonly allDay: boolean
@@ -664,6 +739,7 @@ export type WorkCalendarEventMutationInput = {
   readonly endsAt: string | null
   readonly timeZone: string
   readonly location: string | null
+  readonly meetingUrl: string | null
   readonly attendeeUserIds: readonly string[]
 }
 
@@ -674,6 +750,8 @@ type WorkCalendarEventMutationResult =
 type ValidatedEventInput = {
   readonly project: ProjectRow
   readonly title: string
+  readonly eventType: WorkCalendarEventType
+  readonly visibility: WorkCalendarEventVisibility
   readonly description: string | null
   readonly startDate: string | null
   readonly endDateExclusive: string | null
@@ -682,6 +760,7 @@ type ValidatedEventInput = {
   readonly allDay: boolean
   readonly timeZone: string
   readonly location: string | null
+  readonly meetingUrl: string | null
   readonly attendees: readonly WorkCalendarEventAttendee[]
 }
 
@@ -708,6 +787,24 @@ function cleanOptionalText(
     throw new Error(`${label} must be ${maxLength} characters or fewer`)
   }
   return cleaned || null
+}
+
+function cleanOptionalUrl(
+  value: string | null,
+  label: string,
+): string | null {
+  const cleaned = cleanOptionalText(value, label, 2_000)
+  if (!cleaned) return null
+
+  try {
+    const parsed = new URL(cleaned)
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      throw new Error()
+    }
+    return parsed.toString()
+  } catch {
+    throw new Error(`${label} must be a valid web address`)
+  }
 }
 
 async function organizationProjects(
@@ -833,10 +930,18 @@ async function validateEventInput(
 
   const timing = normalizeWorkCalendarEventTiming(input)
   if (!timing.success) throw new Error(timing.error)
+  if (!isWorkCalendarEventType(input.eventType)) {
+    throw new Error("Select a valid event type")
+  }
+  if (!isWorkCalendarEventVisibility(input.visibility)) {
+    throw new Error("Select a valid event visibility")
+  }
 
   return {
     project,
     title: cleanRequiredText(input.title, "Event title", 200),
+    eventType: input.eventType,
+    visibility: input.visibility,
     description: cleanOptionalText(input.description, "Description", 5_000),
     startDate: timing.startDate,
     endDateExclusive: timing.endDateExclusive,
@@ -845,6 +950,7 @@ async function validateEventInput(
     allDay: input.allDay,
     timeZone: timing.timeZone,
     location: cleanOptionalText(input.location, "Location", 500),
+    meetingUrl: cleanOptionalUrl(input.meetingUrl, "Meeting link"),
     attendees: await validateAttendees(
       db,
       organizationId,
@@ -1040,6 +1146,8 @@ export async function createWorkCalendarEvent(
       organizationId: orgId,
       projectId: validated.project.id,
       title: validated.title,
+      eventType: validated.eventType,
+      visibility: validated.visibility,
       description: validated.description,
       startDate: validated.startDate,
       endDateExclusive: validated.endDateExclusive,
@@ -1048,6 +1156,7 @@ export async function createWorkCalendarEvent(
       allDay: validated.allDay,
       timeZone: validated.timeZone,
       location: validated.location,
+      meetingUrl: validated.meetingUrl,
       status: "open",
       version: 1,
       createdBy: user.id,
@@ -1145,6 +1254,8 @@ export async function updateWorkCalendarEvent(
       .set({
         projectId: validated.project.id,
         title: validated.title,
+        eventType: validated.eventType,
+        visibility: validated.visibility,
         description: validated.description,
         startDate: validated.startDate,
         endDateExclusive: validated.endDateExclusive,
@@ -1153,6 +1264,7 @@ export async function updateWorkCalendarEvent(
         allDay: validated.allDay,
         timeZone: validated.timeZone,
         location: validated.location,
+        meetingUrl: validated.meetingUrl,
         version: expectedVersion + 1,
         updatedBy: user.id,
         updatedAt: now,

--- a/src/app/api/google/calendar/callback/route.ts
+++ b/src/app/api/google/calendar/callback/route.ts
@@ -1,0 +1,171 @@
+import { and, eq } from "drizzle-orm"
+import { type NextRequest, NextResponse } from "next/server"
+
+import { getDb } from "@/db"
+import { googleCalendarConnections } from "@/db/schema"
+import { getCurrentUser } from "@/lib/auth"
+import { encrypt } from "@/lib/crypto"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import {
+  getGoogleCalendarOAuthConfig,
+  googleCalendarTokenSalt,
+} from "@/lib/google/calendar/config"
+import {
+  exchangeGoogleAuthorizationCode,
+  getGoogleAccountIdentity,
+  hasRequiredGoogleCalendarScopes,
+} from "@/lib/google/calendar/oauth"
+import { can } from "@/lib/permissions"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+const OAUTH_STATE_COOKIE = "compass_google_calendar_oauth_state"
+
+function settingsUrl(request: Request, status: string): URL {
+  const url = new URL("/dashboard/settings", request.url)
+  url.searchParams.set("google-calendar", status)
+  return url
+}
+
+function redirectAndClearState(
+  request: Request,
+  status: string,
+): NextResponse {
+  const response = NextResponse.redirect(settingsUrl(request, status))
+  response.cookies.set(OAUTH_STATE_COOKIE, "", {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+  })
+  return response
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const user = await getCurrentUser()
+  if (
+    !user ||
+    isDemoUser(user.id) ||
+    !isInternalStaffRole(user.role) ||
+    !can(user, "schedule", "read") ||
+    !user.organizationId
+  ) {
+    return redirectAndClearState(request, "unauthorized")
+  }
+
+  const returnedState = request.nextUrl.searchParams.get("state")
+  const expectedState = request.cookies.get(OAUTH_STATE_COOKIE)?.value
+  if (
+    !returnedState ||
+    !expectedState ||
+    returnedState !== expectedState
+  ) {
+    return redirectAndClearState(request, "invalid-state")
+  }
+
+  const oauthError = request.nextUrl.searchParams.get("error")
+  if (oauthError) {
+    return redirectAndClearState(request, "cancelled")
+  }
+  const code = request.nextUrl.searchParams.get("code")
+  if (!code) {
+    return redirectAndClearState(request, "missing-code")
+  }
+
+  try {
+    const { env } = await getCloudflareContext()
+    const configuration = getGoogleCalendarOAuthConfig(env)
+    if (!configuration.configured) {
+      return redirectAndClearState(request, "not-configured")
+    }
+
+    const db = getDb(env.DB)
+    const existingConnection = await db
+      .select({
+        id: googleCalendarConnections.id,
+        refreshTokenEncrypted:
+          googleCalendarConnections.refreshTokenEncrypted,
+        createdAt: googleCalendarConnections.createdAt,
+      })
+      .from(googleCalendarConnections)
+      .where(
+        and(
+          eq(
+            googleCalendarConnections.organizationId,
+            user.organizationId,
+          ),
+          eq(googleCalendarConnections.userId, user.id),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+
+    const grant = await exchangeGoogleAuthorizationCode(
+      configuration.config,
+      code,
+    )
+    if (!hasRequiredGoogleCalendarScopes(grant.scopes)) {
+      return redirectAndClearState(request, "missing-scopes")
+    }
+    const identity = await getGoogleAccountIdentity(grant.accessToken)
+    if (!identity.emailVerified) {
+      return redirectAndClearState(request, "email-not-verified")
+    }
+
+    const encryptedRefreshToken = grant.refreshToken
+      ? await encrypt(
+          grant.refreshToken,
+          configuration.config.tokenEncryptionKey,
+          googleCalendarTokenSalt(user.id),
+        )
+      : existingConnection?.refreshTokenEncrypted ?? null
+    if (!encryptedRefreshToken) {
+      return redirectAndClearState(request, "missing-refresh-token")
+    }
+
+    const now = new Date().toISOString()
+    const connectionId =
+      existingConnection?.id ?? crypto.randomUUID()
+    await db
+      .insert(googleCalendarConnections)
+      .values({
+        id: connectionId,
+        organizationId: user.organizationId,
+        userId: user.id,
+        googleAccountId: identity.subject,
+        googleAccountEmail: identity.email,
+        refreshTokenEncrypted: encryptedRefreshToken,
+        grantedScopes: [...grant.scopes].sort().join(" "),
+        status: "connected",
+        calendarSyncEnabled: false,
+        tasksSyncEnabled: false,
+        connectedAt: now,
+        lastSyncedAt: null,
+        lastError: null,
+        createdAt: existingConnection?.createdAt ?? now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [
+          googleCalendarConnections.organizationId,
+          googleCalendarConnections.userId,
+        ],
+        set: {
+          googleAccountId: identity.subject,
+          googleAccountEmail: identity.email,
+          refreshTokenEncrypted: encryptedRefreshToken,
+          grantedScopes: [...grant.scopes].sort().join(" "),
+          status: "connected",
+          connectedAt: now,
+          lastError: null,
+          updatedAt: now,
+        },
+      })
+      .run()
+
+    return redirectAndClearState(request, "connected")
+  } catch {
+    return redirectAndClearState(request, "error")
+  }
+}

--- a/src/app/api/google/calendar/connect/route.ts
+++ b/src/app/api/google/calendar/connect/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server"
+
+import { getCurrentUser } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import {
+  getGoogleCalendarOAuthConfig,
+} from "@/lib/google/calendar/config"
+import { buildGoogleCalendarAuthorizationUrl } from "@/lib/google/calendar/oauth"
+import { can } from "@/lib/permissions"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+const OAUTH_STATE_COOKIE = "compass_google_calendar_oauth_state"
+
+function settingsUrl(request: Request, status: string): URL {
+  const url = new URL("/dashboard/settings", request.url)
+  url.searchParams.set("google-calendar", status)
+  return url
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const user = await getCurrentUser()
+  if (
+    !user ||
+    isDemoUser(user.id) ||
+    !isInternalStaffRole(user.role) ||
+    !can(user, "schedule", "read") ||
+    !user.organizationId
+  ) {
+    return NextResponse.redirect(settingsUrl(request, "unauthorized"))
+  }
+
+  const { env } = await getCloudflareContext()
+  const configuration = getGoogleCalendarOAuthConfig(env)
+  if (!configuration.configured) {
+    return NextResponse.redirect(settingsUrl(request, "not-configured"))
+  }
+
+  const state = crypto.randomUUID()
+  const authorizationUrl = buildGoogleCalendarAuthorizationUrl(
+    configuration.config,
+    state,
+    user.googleEmail ?? user.email,
+  )
+  const response = NextResponse.redirect(authorizationUrl)
+  response.cookies.set(OAUTH_STATE_COOKIE, state, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 10 * 60,
+  })
+  return response
+}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -29,6 +29,7 @@ import { AgentTab } from "@/components/settings/agent-tab"
 import { NetSuiteConnectionStatus } from "@/components/netsuite/connection-status"
 import { SyncControls } from "@/components/netsuite/sync-controls"
 import { GoogleDriveConnectionStatus } from "@/components/google/connection-status"
+import { GoogleCalendarConnectionCard } from "@/components/google/calendar-connection-status"
 
 const SETTINGS_TABS = [
   { value: "preferences", label: "Preferences", icon: IconAdjustments },
@@ -51,6 +52,8 @@ function IntegrationsSection() {
     <div className="space-y-4">
       <GoogleDriveConnectionStatus />
       <Separator />
+      <GoogleCalendarConnectionCard />
+      <Separator />
       <NetSuiteConnectionStatus />
       <SyncControls />
     </div>
@@ -61,6 +64,13 @@ export default function SettingsPage() {
   const [activeSection, setActiveSection] =
     React.useState<SectionValue>("preferences")
   const isMobile = useIsMobile()
+
+  React.useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (params.has("google-calendar")) {
+      setActiveSection("integrations")
+    }
+  }, [])
 
   const isWide = WIDE_SECTIONS.has(activeSection)
 

--- a/src/components/google/calendar-connection-status.tsx
+++ b/src/components/google/calendar-connection-status.tsx
@@ -1,0 +1,199 @@
+"use client"
+
+import * as React from "react"
+import { IconBrandGoogle, IconCheck, IconLoader2 } from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import {
+  disconnectGoogleCalendar,
+  getGoogleCalendarConnectionStatus,
+  type GoogleCalendarConnectionStatus,
+} from "@/app/actions/google-calendar"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+
+const GOOGLE_CALENDAR_CALLBACK_MESSAGES: Readonly<
+  Record<string, { readonly type: "success" | "error"; readonly message: string }>
+> = {
+  connected: {
+    type: "success",
+    message: "Google Calendar connected. Choose calendars before enabling sync.",
+  },
+  cancelled: {
+    type: "error",
+    message: "Google Calendar connection was cancelled.",
+  },
+  "invalid-state": {
+    type: "error",
+    message: "Google Calendar authorization expired. Please try connecting again.",
+  },
+  "missing-scopes": {
+    type: "error",
+    message: "Compass needs calendar access to complete the connection.",
+  },
+  "email-not-verified": {
+    type: "error",
+    message: "The selected Google account does not have a verified email address.",
+  },
+  "missing-refresh-token": {
+    type: "error",
+    message: "Google did not grant offline access. Remove Compass from your Google Account and try again.",
+  },
+  "not-configured": {
+    type: "error",
+    message: "Google Calendar has not been configured by a Compass administrator.",
+  },
+  unauthorized: {
+    type: "error",
+    message: "Your Compass account cannot connect Google Calendar.",
+  },
+  "missing-code": {
+    type: "error",
+    message: "Google did not return an authorization code. Please try again.",
+  },
+  error: {
+    type: "error",
+    message: "Google Calendar could not be connected. Please try again.",
+  },
+}
+
+export function GoogleCalendarConnectionCard(): React.ReactElement {
+  const [status, setStatus] =
+    React.useState<GoogleCalendarConnectionStatus | null>(null)
+  const [disconnecting, setDisconnecting] = React.useState(false)
+
+  const loadStatus = React.useCallback(async (): Promise<void> => {
+    const result = await getGoogleCalendarConnectionStatus()
+    setStatus(result)
+  }, [])
+
+  React.useEffect(() => {
+    void loadStatus()
+  }, [loadStatus])
+
+  React.useEffect(() => {
+    const url = new URL(window.location.href)
+    const callbackStatus = url.searchParams.get("google-calendar")
+    if (!callbackStatus) return
+
+    const feedback = GOOGLE_CALENDAR_CALLBACK_MESSAGES[callbackStatus]
+    if (feedback?.type === "success") {
+      toast.success(feedback.message)
+    } else if (feedback) {
+      toast.error(feedback.message)
+    }
+
+    url.searchParams.delete("google-calendar")
+    window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`)
+  }, [])
+
+  async function disconnect(): Promise<void> {
+    setDisconnecting(true)
+    const result = await disconnectGoogleCalendar()
+    setDisconnecting(false)
+    if (!result.success) {
+      toast.error(result.error)
+      return
+    }
+    toast.success(
+      result.revoked
+        ? "Google Calendar disconnected."
+        : "Google Calendar disconnected from Compass. Google access may also need to be removed from your Google Account.",
+    )
+    await loadStatus()
+  }
+
+  if (!status) {
+    return (
+      <div className="flex items-center gap-3 border p-4">
+        <IconLoader2 className="size-5 animate-spin text-muted-foreground" />
+        <span className="text-sm text-muted-foreground">
+          Checking Google Calendar connection...
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <section className="space-y-3 border p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2.5">
+          <IconBrandGoogle className="size-5" />
+          <div>
+            <p className="text-sm font-medium">Google Calendar</p>
+            <p className="text-xs text-muted-foreground">
+              Display selected Google calendars alongside Compass work.
+            </p>
+          </div>
+        </div>
+        {status.connected ? (
+          <Badge variant="outline" className="gap-1 text-green-700">
+            <IconCheck className="size-3" />
+            Connected
+          </Badge>
+        ) : (
+          <Badge variant="outline">Not connected</Badge>
+        )}
+      </div>
+
+      {status.connected ? (
+        <>
+          <dl className="grid gap-1 text-xs text-muted-foreground">
+            <div className="flex gap-2">
+              <dt>Account:</dt>
+              <dd className="text-foreground">{status.accountEmail}</dd>
+            </div>
+            <div className="flex gap-2">
+              <dt>Calendar sync:</dt>
+              <dd className="text-foreground">
+                {status.calendarSyncEnabled
+                  ? "Enabled"
+                  : "Calendar selection required"}
+              </dd>
+            </div>
+          </dl>
+          {status.lastError ? (
+            <p className="text-xs text-destructive">
+              Last sync issue: {status.lastError}
+            </p>
+          ) : null}
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={disconnecting}
+            onClick={() => void disconnect()}
+          >
+            {disconnecting ? "Disconnecting..." : "Disconnect"}
+          </Button>
+        </>
+      ) : (
+        <>
+          {!status.configured ? (
+            <p className="text-xs text-muted-foreground">
+              Google OAuth must be configured by a Compass administrator
+              before staff can connect.
+            </p>
+          ) : null}
+          {!status.canConnect ? (
+            <p className="text-xs text-muted-foreground">
+              Google Calendar connections are available to internal staff
+              accounts.
+            </p>
+          ) : null}
+          {status.configured && status.canConnect ? (
+            <Button size="sm" asChild>
+              <a href="/api/google/calendar/connect">
+                Connect Google Calendar
+              </a>
+            </Button>
+          ) : (
+            <Button size="sm" disabled>
+              Connect Google Calendar
+            </Button>
+          )}
+        </>
+      )}
+    </section>
+  )
+}

--- a/src/components/schedule/work-calendar-event-dialog.tsx
+++ b/src/components/schedule/work-calendar-event-dialog.tsx
@@ -49,7 +49,13 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
-import { instantForLocalDateTime } from "@/lib/work-calendar"
+import {
+  instantForLocalDateTime,
+  isWorkCalendarEventType,
+  isWorkCalendarEventVisibility,
+  type WorkCalendarEventType,
+  type WorkCalendarEventVisibility,
+} from "@/lib/work-calendar"
 
 const DEFAULT_PROJECT_VALUE = "__h_office_default__"
 
@@ -78,6 +84,8 @@ type WorkCalendarEventDialogProps = CommonProps &
 
 type EventFormSeed = {
   readonly title: string
+  readonly eventType: WorkCalendarEventType
+  readonly visibility: WorkCalendarEventVisibility
   readonly description: string
   readonly projectValue: string
   readonly allDay: boolean
@@ -87,6 +95,7 @@ type EventFormSeed = {
   readonly endTime: string
   readonly timeZone: string
   readonly location: string
+  readonly meetingUrl: string
   readonly attendeeUserIds: readonly string[]
 }
 
@@ -103,6 +112,8 @@ function formSeed(
     const details = props.event.eventDetails
     return {
       title: props.event.title,
+      eventType: details.eventType,
+      visibility: details.visibility,
       description: details.description ?? "",
       projectValue:
         props.event.projectId ??
@@ -114,6 +125,7 @@ function formSeed(
       endTime: details.endTime || "10:00",
       timeZone: details.timeZone,
       location: details.location ?? "",
+      meetingUrl: details.meetingUrl ?? "",
       attendeeUserIds: details.attendees.map(
         (attendee) => attendee.userId
       ),
@@ -122,6 +134,8 @@ function formSeed(
 
   return {
     title: "",
+    eventType: "meeting",
+    visibility: "organization",
     description: "",
     projectValue: props.defaultProjectId
       ? DEFAULT_PROJECT_VALUE
@@ -133,6 +147,7 @@ function formSeed(
     endTime: "10:00",
     timeZone: props.defaultTimeZone,
     location: "",
+    meetingUrl: "",
     attendeeUserIds: [],
   }
 }
@@ -145,6 +160,8 @@ export function WorkCalendarEventDialog(
   const [createOpen, setCreateOpen] = React.useState(false)
   const [pending, startTransition] = React.useTransition()
   const [title, setTitle] = React.useState(seed.title)
+  const [eventType, setEventType] = React.useState(seed.eventType)
+  const [visibility, setVisibility] = React.useState(seed.visibility)
   const [description, setDescription] = React.useState(seed.description)
   const [projectValue, setProjectValue] = React.useState(seed.projectValue)
   const [allDay, setAllDay] = React.useState(seed.allDay)
@@ -154,6 +171,7 @@ export function WorkCalendarEventDialog(
   const [endTime, setEndTime] = React.useState(seed.endTime)
   const [timeZone, setTimeZone] = React.useState(seed.timeZone)
   const [location, setLocation] = React.useState(seed.location)
+  const [meetingUrl, setMeetingUrl] = React.useState(seed.meetingUrl)
   const [attendeeUserIds, setAttendeeUserIds] = React.useState<
     readonly string[]
   >(seed.attendeeUserIds)
@@ -163,6 +181,8 @@ export function WorkCalendarEventDialog(
   function reset(): void {
     const next = formSeed(props)
     setTitle(next.title)
+    setEventType(next.eventType)
+    setVisibility(next.visibility)
     setDescription(next.description)
     setProjectValue(next.projectValue)
     setAllDay(next.allDay)
@@ -172,6 +192,7 @@ export function WorkCalendarEventDialog(
     setEndTime(next.endTime)
     setTimeZone(next.timeZone)
     setLocation(next.location)
+    setMeetingUrl(next.meetingUrl)
     setAttendeeUserIds(next.attendeeUserIds)
   }
 
@@ -217,6 +238,8 @@ export function WorkCalendarEventDialog(
     }
     const input = {
       title,
+      eventType,
+      visibility,
       description: description || null,
       projectId,
       allDay,
@@ -228,6 +251,7 @@ export function WorkCalendarEventDialog(
       endsAt: endResolution?.instant ?? null,
       timeZone,
       location: location || null,
+      meetingUrl: meetingUrl || null,
       attendeeUserIds,
     }
 
@@ -310,6 +334,68 @@ export function WorkCalendarEventDialog(
                 maxLength={200}
                 required
               />
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="grid gap-2">
+                <Label htmlFor={`work-calendar-event-type-${props.variant}`}>
+                  Event type
+                </Label>
+                <Select
+                  value={eventType}
+                  onValueChange={(value) => {
+                    if (isWorkCalendarEventType(value)) setEventType(value)
+                  }}
+                >
+                  <SelectTrigger
+                    id={`work-calendar-event-type-${props.variant}`}
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="meeting">Meeting</SelectItem>
+                    <SelectItem value="appointment">Appointment</SelectItem>
+                    <SelectItem value="inspection">Inspection</SelectItem>
+                    <SelectItem value="delivery">Delivery</SelectItem>
+                    <SelectItem value="company_event">
+                      Company event
+                    </SelectItem>
+                    <SelectItem value="absence">Absence / time off</SelectItem>
+                    <SelectItem value="other">Other</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-2">
+                <Label
+                  htmlFor={`work-calendar-event-visibility-${props.variant}`}
+                >
+                  Visibility
+                </Label>
+                <Select
+                  value={visibility}
+                  onValueChange={(value) => {
+                    if (isWorkCalendarEventVisibility(value)) {
+                      setVisibility(value)
+                    }
+                  }}
+                >
+                  <SelectTrigger
+                    id={`work-calendar-event-visibility-${props.variant}`}
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="organization">
+                      Company details
+                    </SelectItem>
+                    <SelectItem value="participants">
+                      Participants only
+                    </SelectItem>
+                    <SelectItem value="busy">Busy to others</SelectItem>
+                    <SelectItem value="private">Private</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
             </div>
 
             <div className="grid gap-2">
@@ -417,6 +503,22 @@ export function WorkCalendarEventDialog(
                 onChange={(event) => setLocation(event.target.value)}
                 placeholder="Office, job site, or video link"
                 maxLength={500}
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label
+                htmlFor={`work-calendar-event-meeting-link-${props.variant}`}
+              >
+                Meeting link
+              </Label>
+              <Input
+                id={`work-calendar-event-meeting-link-${props.variant}`}
+                type="url"
+                value={meetingUrl}
+                onChange={(event) => setMeetingUrl(event.target.value)}
+                placeholder="https://meet.google.com/..."
+                maxLength={2_000}
               />
             </div>
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -554,6 +554,8 @@ export const workCalendarEvents = sqliteTable(
       onDelete: "set null",
     }),
     title: text("title").notNull(),
+    eventType: text("event_type").notNull().default("meeting"),
+    visibility: text("visibility").notNull().default("organization"),
     description: text("description"),
     startDate: text("start_date"),
     endDateExclusive: text("end_date_exclusive"),
@@ -564,6 +566,7 @@ export const workCalendarEvents = sqliteTable(
       .default(false),
     timeZone: text("time_zone").notNull().default("UTC"),
     location: text("location"),
+    meetingUrl: text("meeting_url"),
     status: text("status").notNull().default("open"),
     version: integer("version").notNull().default(1),
     createdBy: text("created_by").references(() => users.id, {
@@ -615,6 +618,149 @@ export const workCalendarEventAttendees = sqliteTable(
       table.userId,
     ),
     index("idx_work_calendar_event_attendees_user").on(table.userId),
+  ],
+)
+
+export const googleCalendarConnections = sqliteTable(
+  "google_calendar_connections",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    googleAccountId: text("google_account_id").notNull(),
+    googleAccountEmail: text("google_account_email").notNull(),
+    refreshTokenEncrypted: text("refresh_token_encrypted").notNull(),
+    grantedScopes: text("granted_scopes").notNull(),
+    status: text("status").notNull().default("connected"),
+    calendarSyncEnabled: integer("calendar_sync_enabled", {
+      mode: "boolean",
+    })
+      .notNull()
+      .default(false),
+    tasksSyncEnabled: integer("tasks_sync_enabled", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    connectedAt: text("connected_at").notNull(),
+    lastSyncedAt: text("last_synced_at"),
+    lastError: text("last_error"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("google_calendar_connection_user_unique").on(
+      table.organizationId,
+      table.userId,
+    ),
+    uniqueIndex("google_calendar_connection_account_unique").on(
+      table.organizationId,
+      table.googleAccountId,
+    ),
+    index("idx_google_calendar_connections_status").on(
+      table.organizationId,
+      table.status,
+    ),
+  ],
+)
+
+export const googleCalendarSelections = sqliteTable(
+  "google_calendar_selections",
+  {
+    id: text("id").primaryKey(),
+    connectionId: text("connection_id")
+      .notNull()
+      .references(() => googleCalendarConnections.id, {
+        onDelete: "cascade",
+      }),
+    googleCalendarId: text("google_calendar_id").notNull(),
+    summary: text("summary").notNull(),
+    description: text("description"),
+    timeZone: text("time_zone"),
+    backgroundColor: text("background_color"),
+    accessRole: text("access_role").notNull().default("reader"),
+    isPrimary: integer("is_primary", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    selected: integer("selected", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    importEvents: integer("import_events", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    exportCompassEvents: integer("export_compass_events", {
+      mode: "boolean",
+    })
+      .notNull()
+      .default(false),
+    isCompassDestination: integer("is_compass_destination", {
+      mode: "boolean",
+    })
+      .notNull()
+      .default(false),
+    syncToken: text("sync_token"),
+    watchChannelId: text("watch_channel_id"),
+    watchResourceId: text("watch_resource_id"),
+    watchExpiresAt: text("watch_expires_at"),
+    lastSyncedAt: text("last_synced_at"),
+    lastError: text("last_error"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("google_calendar_selection_unique").on(
+      table.connectionId,
+      table.googleCalendarId,
+    ),
+    index("idx_google_calendar_selections_selected").on(
+      table.connectionId,
+      table.selected,
+    ),
+  ],
+)
+
+export const googleCalendarEntityLinks = sqliteTable(
+  "google_calendar_entity_links",
+  {
+    id: text("id").primaryKey(),
+    connectionId: text("connection_id")
+      .notNull()
+      .references(() => googleCalendarConnections.id, {
+        onDelete: "cascade",
+      }),
+    googleCalendarId: text("google_calendar_id").notNull(),
+    googleEventId: text("google_event_id").notNull(),
+    googleICalUid: text("google_ical_uid"),
+    sourceType: text("source_type").notNull(),
+    sourceId: text("source_id").notNull(),
+    syncDirection: text("sync_direction").notNull().default("push"),
+    syncStatus: text("sync_status").notNull().default("pending"),
+    googleEtag: text("google_etag"),
+    googleUpdatedAt: text("google_updated_at"),
+    compassVersion: integer("compass_version"),
+    lastSyncedAt: text("last_synced_at"),
+    lastError: text("last_error"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("google_calendar_entity_source_unique").on(
+      table.connectionId,
+      table.googleCalendarId,
+      table.sourceType,
+      table.sourceId,
+    ),
+    uniqueIndex("google_calendar_entity_event_unique").on(
+      table.connectionId,
+      table.googleCalendarId,
+      table.googleEventId,
+    ),
+    index("idx_google_calendar_entity_sync_status").on(
+      table.connectionId,
+      table.syncStatus,
+    ),
   ],
 )
 
@@ -1088,6 +1234,18 @@ export type WorkCalendarEventAttendee =
   typeof workCalendarEventAttendees.$inferSelect
 export type NewWorkCalendarEventAttendee =
   typeof workCalendarEventAttendees.$inferInsert
+export type GoogleCalendarConnection =
+  typeof googleCalendarConnections.$inferSelect
+export type NewGoogleCalendarConnection =
+  typeof googleCalendarConnections.$inferInsert
+export type GoogleCalendarSelection =
+  typeof googleCalendarSelections.$inferSelect
+export type NewGoogleCalendarSelection =
+  typeof googleCalendarSelections.$inferInsert
+export type GoogleCalendarEntityLink =
+  typeof googleCalendarEntityLinks.$inferSelect
+export type NewGoogleCalendarEntityLink =
+  typeof googleCalendarEntityLinks.$inferInsert
 export type ProjectPurchaseOrderLine =
   typeof projectPurchaseOrderLines.$inferSelect
 export type NewProjectPurchaseOrderLine =

--- a/src/lib/__tests__/google-calendar-sync.test.ts
+++ b/src/lib/__tests__/google-calendar-sync.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  GOOGLE_CALENDAR_SCOPES,
+  getGoogleCalendarOAuthConfig,
+} from "@/lib/google/calendar/config"
+import {
+  buildGoogleCalendarAuthorizationUrl,
+  hasRequiredGoogleCalendarScopes,
+} from "@/lib/google/calendar/oauth"
+import {
+  calendarDetailLevel,
+  decideGoogleCalendarSyncAction,
+  googleEventIdForCompass,
+} from "@/lib/google/calendar/sync-policy"
+
+describe("Google Calendar OAuth configuration", () => {
+  it("fails closed when required secrets are missing", () => {
+    const result = getGoogleCalendarOAuthConfig({
+      GOOGLE_OAUTH_CLIENT_ID: "",
+      GOOGLE_OAUTH_CLIENT_SECRET: "",
+      GOOGLE_OAUTH_REDIRECT_URI: "",
+      GOOGLE_OAUTH_TOKEN_ENCRYPTION_KEY: "",
+    })
+
+    expect(result.configured).toBe(false)
+    if (!result.configured) {
+      expect(result.missing).toContain("GOOGLE_OAUTH_CLIENT_ID")
+      expect(result.missing).toContain("GOOGLE_OAUTH_TOKEN_ENCRYPTION_KEY")
+    }
+  })
+
+  it("builds a consent URL with state and calendar-only scopes", () => {
+    const url = new URL(
+      buildGoogleCalendarAuthorizationUrl(
+        {
+          clientId: "client-id",
+          clientSecret: "client-secret",
+          redirectUri: "https://compass.example/api/google/calendar/callback",
+          tokenEncryptionKey: "encryption-key",
+        },
+        "csrf-state",
+        "staff@example.com",
+      ),
+    )
+
+    expect(url.searchParams.get("state")).toBe("csrf-state")
+    expect(url.searchParams.get("access_type")).toBe("offline")
+    expect(url.searchParams.get("login_hint")).toBe("staff@example.com")
+    expect(url.searchParams.get("scope")?.split(" ")).toEqual([
+      ...GOOGLE_CALENDAR_SCOPES,
+    ])
+    expect(url.searchParams.get("scope")).not.toContain(
+      "https://www.googleapis.com/auth/tasks",
+    )
+  })
+
+  it("rejects partial Google grants", () => {
+    expect(hasRequiredGoogleCalendarScopes([...GOOGLE_CALENDAR_SCOPES])).toBe(
+      true,
+    )
+    expect(
+      hasRequiredGoogleCalendarScopes(
+        GOOGLE_CALENDAR_SCOPES.filter(
+          (scope) =>
+            scope !==
+            "https://www.googleapis.com/auth/calendar.events",
+        ),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe("calendar privacy", () => {
+  it("hides project events from users without project access", () => {
+    expect(
+      calendarDetailLevel({
+        visibility: "organization",
+        viewerIsOwner: false,
+        viewerIsParticipant: false,
+        viewerHasProjectAccess: false,
+        hasProjectScope: true,
+      }),
+    ).toBe("hidden")
+  })
+
+  it("shows private details to an attendee", () => {
+    expect(
+      calendarDetailLevel({
+        visibility: "private",
+        viewerIsOwner: false,
+        viewerIsParticipant: true,
+        viewerHasProjectAccess: true,
+        hasProjectScope: false,
+      }),
+    ).toBe("full")
+  })
+
+  it("reduces participant-only details to busy for other staff", () => {
+    expect(
+      calendarDetailLevel({
+        visibility: "participants",
+        viewerIsOwner: false,
+        viewerIsParticipant: false,
+        viewerHasProjectAccess: true,
+        hasProjectScope: false,
+      }),
+    ).toBe("busy")
+  })
+})
+
+describe("Google Calendar sync decisions", () => {
+  it("pushes Compass-only changes in two-way mode", () => {
+    expect(
+      decideGoogleCalendarSyncAction({
+        direction: "two_way",
+        compassChanged: true,
+        googleChanged: false,
+        googleDeleted: false,
+      }),
+    ).toBe("push")
+  })
+
+  it("pulls Google-only changes in two-way mode", () => {
+    expect(
+      decideGoogleCalendarSyncAction({
+        direction: "two_way",
+        compassChanged: false,
+        googleChanged: true,
+        googleDeleted: false,
+      }),
+    ).toBe("pull")
+  })
+
+  it("restores Google-authoritative records after local drift", () => {
+    expect(
+      decideGoogleCalendarSyncAction({
+        direction: "pull",
+        compassChanged: true,
+        googleChanged: false,
+        googleDeleted: false,
+      }),
+    ).toBe("pull")
+  })
+
+  it("does not silently overwrite concurrent edits", () => {
+    expect(
+      decideGoogleCalendarSyncAction({
+        direction: "two_way",
+        compassChanged: true,
+        googleChanged: true,
+        googleDeleted: false,
+      }),
+    ).toBe("conflict")
+  })
+})
+
+describe("Google Calendar event IDs", () => {
+  it("creates deterministic Google-compatible IDs", async () => {
+    const first = await googleEventIdForCompass(
+      "work_calendar_event",
+      "event-123",
+      "connection-456",
+    )
+    const second = await googleEventIdForCompass(
+      "work_calendar_event",
+      "event-123",
+      "connection-456",
+    )
+
+    expect(first).toBe(second)
+    expect(first).toMatch(/^[0-9a-v]{5,1024}$/)
+  })
+
+  it("separates IDs by connection and source type", async () => {
+    const eventId = await googleEventIdForCompass(
+      "work_calendar_event",
+      "record-1",
+      "connection-1",
+    )
+    const taskId = await googleEventIdForCompass(
+      "task",
+      "record-1",
+      "connection-1",
+    )
+    const otherAccountId = await googleEventIdForCompass(
+      "work_calendar_event",
+      "record-1",
+      "connection-2",
+    )
+
+    expect(new Set([eventId, taskId, otherAccountId]).size).toBe(3)
+  })
+})

--- a/src/lib/google/calendar/config.ts
+++ b/src/lib/google/calendar/config.ts
@@ -1,0 +1,92 @@
+export const GOOGLE_CALENDAR_SCOPES = [
+  "openid",
+  "email",
+  "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+  "https://www.googleapis.com/auth/calendar.events",
+] as const
+
+export const GOOGLE_OAUTH_AUTHORIZATION_URL =
+  "https://accounts.google.com/o/oauth2/v2/auth"
+export const GOOGLE_OAUTH_TOKEN_URL =
+  "https://oauth2.googleapis.com/token"
+export const GOOGLE_OPENID_USERINFO_URL =
+  "https://openidconnect.googleapis.com/v1/userinfo"
+
+export type GoogleCalendarOAuthConfig = {
+  readonly clientId: string
+  readonly clientSecret: string
+  readonly redirectUri: string
+  readonly tokenEncryptionKey: string
+}
+
+export type GoogleCalendarOAuthConfigResult =
+  | {
+      readonly configured: true
+      readonly config: GoogleCalendarOAuthConfig
+    }
+  | {
+      readonly configured: false
+      readonly missing: readonly string[]
+    }
+
+function environmentValue(env: object, key: string): string | null {
+  const descriptor = Object.getOwnPropertyDescriptor(env, key)
+  if (descriptor) {
+    const directValue = descriptor.value
+    return typeof directValue === "string" &&
+      directValue.trim().length > 0
+      ? directValue.trim()
+      : null
+  }
+
+  const value = process.env[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null
+}
+
+export function getGoogleCalendarOAuthConfig(
+  env: object,
+): GoogleCalendarOAuthConfigResult {
+  const values = {
+    clientId: environmentValue(env, "GOOGLE_OAUTH_CLIENT_ID"),
+    clientSecret: environmentValue(env, "GOOGLE_OAUTH_CLIENT_SECRET"),
+    redirectUri: environmentValue(env, "GOOGLE_OAUTH_REDIRECT_URI"),
+    tokenEncryptionKey: environmentValue(
+      env,
+      "GOOGLE_OAUTH_TOKEN_ENCRYPTION_KEY",
+    ),
+  }
+  const missing = [
+    values.clientId ? null : "GOOGLE_OAUTH_CLIENT_ID",
+    values.clientSecret ? null : "GOOGLE_OAUTH_CLIENT_SECRET",
+    values.redirectUri ? null : "GOOGLE_OAUTH_REDIRECT_URI",
+    values.tokenEncryptionKey
+      ? null
+      : "GOOGLE_OAUTH_TOKEN_ENCRYPTION_KEY",
+  ].filter((value): value is string => value !== null)
+
+  if (
+    missing.length > 0 ||
+    !values.clientId ||
+    !values.clientSecret ||
+    !values.redirectUri ||
+    !values.tokenEncryptionKey
+  ) {
+    return { configured: false, missing }
+  }
+
+  return {
+    configured: true,
+    config: {
+      clientId: values.clientId,
+      clientSecret: values.clientSecret,
+      redirectUri: values.redirectUri,
+      tokenEncryptionKey: values.tokenEncryptionKey,
+    },
+  }
+}
+
+export function googleCalendarTokenSalt(userId: string): string {
+  return `compass-google-calendar:${userId}`
+}

--- a/src/lib/google/calendar/oauth.ts
+++ b/src/lib/google/calendar/oauth.ts
@@ -1,0 +1,146 @@
+import {
+  GOOGLE_CALENDAR_SCOPES,
+  GOOGLE_OAUTH_AUTHORIZATION_URL,
+  GOOGLE_OAUTH_TOKEN_URL,
+  GOOGLE_OPENID_USERINFO_URL,
+  type GoogleCalendarOAuthConfig,
+} from "./config"
+
+type JsonRecord = Record<string, unknown>
+
+export type GoogleTokenGrant = {
+  readonly accessToken: string
+  readonly refreshToken: string | null
+  readonly expiresIn: number
+  readonly scopes: readonly string[]
+}
+
+export type GoogleAccountIdentity = {
+  readonly subject: string
+  readonly email: string
+  readonly emailVerified: boolean
+}
+
+export function hasRequiredGoogleCalendarScopes(
+  scopes: readonly string[],
+): boolean {
+  const granted = new Set(scopes)
+  return GOOGLE_CALENDAR_SCOPES.every((scope) => granted.has(scope))
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function requiredString(
+  record: JsonRecord,
+  key: string,
+): string | null {
+  const value = record[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null
+}
+
+function optionalString(
+  record: JsonRecord,
+  key: string,
+): string | null {
+  const value = record[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null
+}
+
+async function responseJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json()
+  } catch {
+    return null
+  }
+}
+
+export function buildGoogleCalendarAuthorizationUrl(
+  config: GoogleCalendarOAuthConfig,
+  state: string,
+  loginHint: string,
+): string {
+  const url = new URL(GOOGLE_OAUTH_AUTHORIZATION_URL)
+  url.searchParams.set("client_id", config.clientId)
+  url.searchParams.set("redirect_uri", config.redirectUri)
+  url.searchParams.set("response_type", "code")
+  url.searchParams.set("access_type", "offline")
+  url.searchParams.set("include_granted_scopes", "true")
+  url.searchParams.set("prompt", "consent")
+  url.searchParams.set("scope", GOOGLE_CALENDAR_SCOPES.join(" "))
+  url.searchParams.set("state", state)
+  url.searchParams.set("login_hint", loginHint)
+  return url.toString()
+}
+
+export async function exchangeGoogleAuthorizationCode(
+  config: GoogleCalendarOAuthConfig,
+  code: string,
+): Promise<GoogleTokenGrant> {
+  const response = await fetch(GOOGLE_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      code,
+      grant_type: "authorization_code",
+      redirect_uri: config.redirectUri,
+    }),
+  })
+  const payload = await responseJson(response)
+  if (!response.ok || !isRecord(payload)) {
+    throw new Error(`Google token exchange failed (${response.status}).`)
+  }
+
+  const accessToken = requiredString(payload, "access_token")
+  const refreshToken = optionalString(payload, "refresh_token")
+  const expiresIn = payload.expires_in
+  const scope = optionalString(payload, "scope")
+  if (
+    !accessToken ||
+    typeof expiresIn !== "number" ||
+    !Number.isFinite(expiresIn)
+  ) {
+    throw new Error("Google returned an incomplete token grant.")
+  }
+
+  return {
+    accessToken,
+    refreshToken,
+    expiresIn,
+    scopes: scope
+      ? scope.split(/\s+/).filter(Boolean)
+      : [...GOOGLE_CALENDAR_SCOPES],
+  }
+}
+
+export async function getGoogleAccountIdentity(
+  accessToken: string,
+): Promise<GoogleAccountIdentity> {
+  const response = await fetch(GOOGLE_OPENID_USERINFO_URL, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  })
+  const payload = await responseJson(response)
+  if (!response.ok || !isRecord(payload)) {
+    throw new Error(`Google account lookup failed (${response.status}).`)
+  }
+
+  const subject = requiredString(payload, "sub")
+  const email = requiredString(payload, "email")
+  const emailVerified = payload.email_verified
+  if (!subject || !email || typeof emailVerified !== "boolean") {
+    throw new Error("Google returned an incomplete account identity.")
+  }
+
+  return { subject, email, emailVerified }
+}

--- a/src/lib/google/calendar/sync-policy.ts
+++ b/src/lib/google/calendar/sync-policy.ts
@@ -1,0 +1,104 @@
+export type CompassCalendarVisibility =
+  | "organization"
+  | "participants"
+  | "private"
+  | "busy"
+
+export type CalendarDetailLevel = "full" | "busy" | "hidden"
+
+export type CalendarPrivacyContext = {
+  readonly visibility: CompassCalendarVisibility
+  readonly viewerIsOwner: boolean
+  readonly viewerIsParticipant: boolean
+  readonly viewerHasProjectAccess: boolean
+  readonly hasProjectScope: boolean
+}
+
+export function calendarDetailLevel(
+  context: CalendarPrivacyContext,
+): CalendarDetailLevel {
+  if (context.hasProjectScope && !context.viewerHasProjectAccess) {
+    return "hidden"
+  }
+  if (context.viewerIsOwner || context.viewerIsParticipant) {
+    return "full"
+  }
+  if (context.visibility === "organization") return "full"
+  if (
+    context.visibility === "participants" ||
+    context.visibility === "busy"
+  ) {
+    return "busy"
+  }
+  return "hidden"
+}
+
+export type GoogleCalendarSyncDirection = "push" | "pull" | "two_way"
+export type GoogleCalendarSyncAction =
+  | "noop"
+  | "push"
+  | "pull"
+  | "conflict"
+
+export type GoogleCalendarChangeState = {
+  readonly direction: GoogleCalendarSyncDirection
+  readonly compassChanged: boolean
+  readonly googleChanged: boolean
+  readonly googleDeleted: boolean
+}
+
+export function decideGoogleCalendarSyncAction(
+  state: GoogleCalendarChangeState,
+): GoogleCalendarSyncAction {
+  if (state.direction === "push") {
+    return state.compassChanged || state.googleChanged || state.googleDeleted
+      ? "push"
+      : "noop"
+  }
+  if (state.direction === "pull") {
+    return state.compassChanged || state.googleChanged || state.googleDeleted
+      ? "pull"
+      : "noop"
+  }
+  if (state.compassChanged && (state.googleChanged || state.googleDeleted)) {
+    return "conflict"
+  }
+  if (state.compassChanged) return "push"
+  if (state.googleChanged || state.googleDeleted) return "pull"
+  return "noop"
+}
+
+const BASE32_HEX_ALPHABET = "0123456789abcdefghijklmnopqrstuv"
+
+function base32Hex(bytes: Uint8Array): string {
+  let buffer = 0
+  let bits = 0
+  let output = ""
+
+  for (const byte of bytes) {
+    buffer = (buffer << 8) | byte
+    bits += 8
+    while (bits >= 5) {
+      bits -= 5
+      output += BASE32_HEX_ALPHABET[(buffer >>> bits) & 31]
+      buffer &= (1 << bits) - 1
+    }
+  }
+  if (bits > 0) {
+    output += BASE32_HEX_ALPHABET[(buffer << (5 - bits)) & 31]
+  }
+  return output
+}
+
+export async function googleEventIdForCompass(
+  sourceType: "work_calendar_event" | "schedule_item" | "task",
+  sourceId: string,
+  connectionId: string,
+): Promise<string> {
+  const seed = `compass:${sourceType}:${connectionId}:${sourceId}`
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(seed),
+  )
+  return `cmp${base32Hex(new Uint8Array(digest)).slice(0, 29)}`
+}

--- a/src/lib/work-calendar.ts
+++ b/src/lib/work-calendar.ts
@@ -4,6 +4,43 @@ export type WorkCalendarProjectIdentity = {
   readonly projectNumber: string | null
 }
 
+export const WORK_CALENDAR_EVENT_TYPES = [
+  "meeting",
+  "appointment",
+  "inspection",
+  "delivery",
+  "company_event",
+  "absence",
+  "other",
+] as const
+
+export type WorkCalendarEventType =
+  (typeof WORK_CALENDAR_EVENT_TYPES)[number]
+
+export const WORK_CALENDAR_EVENT_VISIBILITIES = [
+  "organization",
+  "participants",
+  "busy",
+  "private",
+] as const
+
+export type WorkCalendarEventVisibility =
+  (typeof WORK_CALENDAR_EVENT_VISIBILITIES)[number]
+
+export function isWorkCalendarEventType(
+  value: string,
+): value is WorkCalendarEventType {
+  return WORK_CALENDAR_EVENT_TYPES.some((candidate) => candidate === value)
+}
+
+export function isWorkCalendarEventVisibility(
+  value: string,
+): value is WorkCalendarEventVisibility {
+  return WORK_CALENDAR_EVENT_VISIBILITIES.some(
+    (candidate) => candidate === value,
+  )
+}
+
 export type WorkCalendarSearchableEntry = {
   readonly projectLabel: string
   readonly projectName: string


### PR DESCRIPTION
## What changed

- adds per-user Google Calendar OAuth connect/callback/disconnect foundations
- encrypts refresh credentials at rest with a dedicated production secret
- adds calendar selection and stable Compass↔Google entity-link schema for later sync workers
- adds event type, visibility, and meeting-link fields to Compass Work Calendar events
- enforces project access and private/busy detail projection
- adds deterministic Google-compatible event IDs and explicit two-way conflict decisions
- exposes a safe Settings integration card that remains disabled when OAuth is not configured

## Review fixes

- renumbered the migration to `0071` after the feedback migration landed
- reduced busy client payloads so they cannot reveal the underlying event category or visibility choice
- made Cloudflare config resolution fail closed for explicitly empty bindings
- replaced unsupported test environment helpers so the configured Bun test runner executes the suite
- corrected the phase document to distinguish the completed OAuth flow from future calendar selection/sync work

## Scope

This is the reviewed foundation. It does not yet import or publish Google events, enable staff-wide sync, or request Google Tasks access.

## Validation

- 22 focused Google Calendar and Work Calendar tests passed
- targeted ESLint passed
- TypeScript passed
- complete migration chain passed on a fresh local D1 database
- `git diff --check` passed
