### PR TITLE
fix(ui): restore Owner Update logos and compact project cards

### DIFF
--- a/src/components/org-switcher.tsx
+++ b/src/components/org-switcher.tsx
@@ -37,6 +37,21 @@ type OrgInfo = {
   readonly role: string
 }
 
+const COMPASS_COMPANY_NAME = "High Performance Structures, Inc."
+
+function sidebarCompanyName(activeOrgName: string | null): string {
+  // Project department branding belongs in project documents. It must never
+  // replace the main Compass company identity in global navigation.
+  if (
+    activeOrgName === null ||
+    activeOrgName === "Open Range Construction" ||
+    activeOrgName.startsWith("High Performance Structures")
+  ) {
+    return COMPASS_COMPANY_NAME
+  }
+  return activeOrgName
+}
+
 export function OrgSwitcher({
   activeOrgId,
   activeOrgName,
@@ -71,7 +86,7 @@ export function OrgSwitcher({
     }
   }
 
-  const displayName = activeOrgName ?? "Compass"
+  const displayName = sidebarCompanyName(activeOrgName)
   const hasOrgs = orgs.length > 1
 
   return (

--- a/src/components/projects/owner-update-actions.tsx
+++ b/src/components/projects/owner-update-actions.tsx
@@ -18,6 +18,54 @@ import {
 } from "@/app/actions/project-field"
 import { Button } from "@/components/ui/button"
 
+const PRINT_IMAGE_TIMEOUT_MS = 3_000
+
+async function waitForPrintableImage(
+  image: HTMLImageElement
+): Promise<void> {
+  if (image.complete) {
+    if (image.naturalWidth > 0) {
+      try {
+        await image.decode()
+      } catch {
+        // A decoded resource can still be available to the browser's print
+        // renderer even when decode() rejects for a cached image.
+      }
+    }
+    return
+  }
+
+  await new Promise<void>((resolve) => {
+    let settled = false
+    const finish = (): void => {
+      if (settled) return
+      settled = true
+      window.clearTimeout(timeoutId)
+      image.removeEventListener("load", finish)
+      image.removeEventListener("error", finish)
+      resolve()
+    }
+    const timeoutId = window.setTimeout(finish, PRINT_IMAGE_TIMEOUT_MS)
+
+    image.addEventListener("load", finish, { once: true })
+    image.addEventListener("error", finish, { once: true })
+  })
+}
+
+async function waitForPrintLayout(root: HTMLElement): Promise<void> {
+  await Promise.all(
+    Array.from(root.querySelectorAll("img")).map(waitForPrintableImage)
+  )
+
+  // Give the cloned print tree two layout frames after its image dimensions
+  // settle so PNG logos are present when the print snapshot is captured.
+  await new Promise<void>((resolve) => {
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => resolve())
+    })
+  })
+}
+
 export function OwnerUpdateActions({
   canManage,
   projectId,
@@ -106,7 +154,7 @@ export function OwnerUpdateActions({
     setCopied("email")
   }
 
-  function printOwnerUpdate(): void {
+  async function printOwnerUpdate(): Promise<void> {
     const selected = document.querySelector(
       `[data-owner-update-id="${updateId}"]`
     )
@@ -135,6 +183,7 @@ export function OwnerUpdateActions({
     }
 
     window.addEventListener("afterprint", resetPrintState)
+    await waitForPrintLayout(printRoot)
     window.print()
     window.setTimeout(resetPrintState, 5000)
   }

--- a/src/components/projects/owner-update-document.tsx
+++ b/src/components/projects/owner-update-document.tsx
@@ -114,7 +114,10 @@ export function OwnerUpdateDocument({
                 alt={brand.logoAlt}
                 width={56}
                 height={56}
+                priority
                 unoptimized
+                sizes="56px"
+                data-owner-update-brand-logo="true"
                 className="h-14 w-14 object-contain"
               />
               <div>

--- a/src/components/projects/project-hub-launchpad.tsx
+++ b/src/components/projects/project-hub-launchpad.tsx
@@ -236,43 +236,56 @@ function ProjectCard({
       )}
     >
       {photo ? (
-        <Link href={`/dashboard/projects/${project.id}`} className="relative block aspect-[16/7] overflow-hidden bg-muted">
+        <Link
+          href={`/dashboard/projects/${project.id}`}
+          className="relative block h-20 overflow-hidden bg-muted sm:h-24"
+        >
           <Image
             src={photo.imageUrl}
             alt={photo.caption ?? photo.fileName}
             fill
-            sizes="(min-width: 1280px) 30vw, (min-width: 768px) 45vw, 100vw"
+            sizes="(min-width: 1536px) 18vw, (min-width: 1280px) 23vw, (min-width: 1024px) 30vw, (min-width: 640px) 45vw, 100vw"
             unoptimized
             className="object-cover transition-transform duration-300 group-hover:scale-[1.02]"
           />
         </Link>
       ) : (
-        <div className="flex aspect-[16/7] items-center justify-center bg-gradient-to-br from-muted to-muted/40">
-          <IconBuilding className="size-8 text-muted-foreground/40" />
+        <div className="flex h-20 items-center justify-center bg-gradient-to-br from-muted to-muted/40 sm:h-24">
+          <IconBuilding className="size-6 text-muted-foreground/40" />
         </div>
       )}
 
-      <div className="p-4">
-        <div className="flex items-start justify-between gap-3">
+      <div className="p-3">
+        <div className="flex items-start justify-between gap-2">
           <div className="min-w-0">
-            <p className="truncate text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <p className="truncate text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
               {project.projectNumber ?? "Compass project"}
             </p>
-            <h2 className="mt-1 truncate text-base font-semibold">{project.name}</h2>
+            <h2 className="mt-0.5 truncate text-sm font-semibold">
+              {project.name}
+            </h2>
           </div>
-          <Badge variant="outline">
+          <Badge
+            variant="outline"
+            className="shrink-0 px-1.5 py-0 text-[10px]"
+          >
             {department === "OTHER" ? "Other" : department}
           </Badge>
         </div>
 
-        <p className="mt-3 truncate text-sm text-muted-foreground">
+        <p className="mt-2 truncate text-xs text-muted-foreground">
           {health?.nextTask ? `Next: ${health.nextTask.title}` : project.clientName ?? "No next phase recorded"}
         </p>
-        <div className="mt-3">
+        <div className="mt-2">
           <ProjectHealth projectId={project.id} overview={overview} />
         </div>
 
-        <Button asChild variant="ghost" size="sm" className="mt-4 w-full justify-between px-0 hover:bg-transparent">
+        <Button
+          asChild
+          variant="ghost"
+          size="sm"
+          className="mt-2 h-7 w-full justify-between px-0 text-xs hover:bg-transparent"
+        >
           <Link href={`/dashboard/projects/${project.id}`}>
             Open project hub
             <span aria-hidden="true">→</span>
@@ -642,7 +655,7 @@ export function ProjectHubLaunchpad({
           className={cn(
             "mt-3",
             layout === "cards"
-              ? "grid gap-4 sm:grid-cols-2 2xl:grid-cols-3"
+              ? "grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5"
               : "divide-y border-y"
           )}
         >


### PR DESCRIPTION
## What changed

- eagerly loads and waits for Owner Update print images before opening the browser PDF dialog
- restores ORC marks for O and Design PDFs and the Nu-Tech mark for N PDFs
- preserves the global left-navigation company identity as High Performance Structures, Inc.
- reduces Project Hub card footprint with a short photo strip, tighter typography and spacing, and up to five desktop columns

## Root cause

The Owner Update print header is hidden on screen and cloned immediately before printing. The larger ORC and Nu-Tech PNG assets had not finished loading when that clone was captured, while the lightweight HPS SVG usually had. Department names therefore changed correctly but the PNG logos were absent.

## Validation

- targeted ESLint: pass
- TypeScript: pass
- project branding tests: 8 pass
- production Next.js build: pass
- rendered and visually inspected Letter-size ORC, Nu-Tech, and Design PDFs through the actual Save PDF preparation path
- visually inspected compact Project Hub with realistic O, H, N, D, and unassigned project fixtures
- verified global navigation branding remains independent of document department branding
