### PR TITLE
fix(dashboard): share staff office availability

### DIFF
--- a/src/app/actions/presence.ts
+++ b/src/app/actions/presence.ts
@@ -4,8 +4,14 @@ import { getCloudflareContext } from "@/lib/db"
 import { eq, and } from "drizzle-orm"
 import { getDb } from "@/db"
 import { userPresence, channelMembers } from "@/db/schema-conversations"
-import { users } from "@/db/schema"
+import { organizationMembers, users } from "@/db/schema"
 import { getCurrentUser } from "@/lib/auth"
+import {
+  teamAvailabilityFromRows,
+  type TeamAvailabilityMember,
+} from "@/lib/dashboard/office-status"
+import { requireOrg } from "@/lib/org-scope"
+import { isInternalStaffRole } from "@/lib/user-roles"
 
 export type PresenceStatus = "online" | "idle" | "dnd" | "offline"
 
@@ -149,6 +155,64 @@ export async function getCurrentUserPresence(): Promise<
       success: false,
       error:
         err instanceof Error ? err.message : "Failed to get current presence",
+    }
+  }
+}
+
+/**
+ * Read the saved office availability for internal staff in the active
+ * organization. This is intentionally separate from channel membership so
+ * dashboard availability is shared across the whole company.
+ */
+export async function getOrganizationTeamAvailability(): Promise<
+  | { success: true; data: readonly TeamAvailabilityMember[] }
+  | { success: false; error: string }
+> {
+  try {
+    const user = await getCurrentUser()
+    if (!user) {
+      return { success: false, error: "Unauthorized" }
+    }
+    if (!isInternalStaffRole(user.role)) {
+      return { success: false, error: "Access denied" }
+    }
+
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const rows = await db
+      .select({
+        userId: users.id,
+        email: users.email,
+        firstName: users.firstName,
+        lastName: users.lastName,
+        displayName: users.displayName,
+        avatarUrl: users.avatarUrl,
+        role: users.role,
+        statusMessage: userPresence.statusMessage,
+        updatedAt: userPresence.updatedAt,
+      })
+      .from(organizationMembers)
+      .innerJoin(users, eq(organizationMembers.userId, users.id))
+      .leftJoin(userPresence, eq(users.id, userPresence.userId))
+      .where(
+        and(
+          eq(organizationMembers.organizationId, organizationId),
+          eq(users.isActive, true)
+        )
+      )
+
+    return {
+      success: true,
+      data: teamAvailabilityFromRows(rows, user.id),
+    }
+  } catch (err) {
+    return {
+      success: false,
+      error:
+        err instanceof Error
+          ? err.message
+          : "Failed to get team availability",
     }
   }
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,24 +1,37 @@
 import { getDashboardOverview } from "@/app/actions/dashboard-overview"
-import { getCurrentUserPresence } from "@/app/actions/presence"
+import {
+  getCurrentUserPresence,
+  getOrganizationTeamAvailability,
+} from "@/app/actions/presence"
 import { DashboardLaunchpad } from "@/components/dashboard/dashboard-launchpad"
 import { getCurrentUser, toSidebarUser } from "@/lib/auth"
 
 export default async function Page() {
-  const [overview, currentUser, presenceResult] = await Promise.all([
+  const [
+    overview,
+    currentUser,
+    presenceResult,
+    teamAvailabilityResult,
+  ] = await Promise.all([
     getDashboardOverview(),
     getCurrentUser(),
     getCurrentUserPresence(),
+    getOrganizationTeamAvailability(),
   ])
   const sidebarUser = currentUser ? toSidebarUser(currentUser) : null
   const initialDeskStatusMessage = presenceResult.success
     ? presenceResult.data?.statusMessage ?? null
     : null
+  const initialTeamAvailability = teamAvailabilityResult.success
+    ? teamAvailabilityResult.data
+    : []
 
   return (
     <DashboardLaunchpad
       overview={overview}
       user={sidebarUser}
       initialDeskStatusMessage={initialDeskStatusMessage}
+      initialTeamAvailability={initialTeamAvailability}
     />
   )
 }

--- a/src/components/dashboard/dashboard-launchpad.tsx
+++ b/src/components/dashboard/dashboard-launchpad.tsx
@@ -1,6 +1,12 @@
 "use client"
 
-import { useEffect, useMemo, useState, useTransition } from "react"
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from "react"
 import Image from "next/image"
 import Link from "next/link"
 import {
@@ -31,7 +37,10 @@ import {
   submitCherishPulseResponse,
   type CherishPulseResponseType,
 } from "@/app/actions/cherish-pulse"
-import { updatePresence } from "@/app/actions/presence"
+import {
+  getOrganizationTeamAvailability,
+  updatePresence,
+} from "@/app/actions/presence"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -64,6 +73,7 @@ import {
   deskStatusForPresenceMessage,
   isDeskStatus,
   type DeskStatus,
+  type TeamAvailabilityMember,
 } from "@/lib/dashboard/office-status"
 import { cn } from "@/lib/utils"
 
@@ -79,6 +89,7 @@ type LaunchpadTask = {
 
 const MARTINE_DEFAULT_DESK_PHOTO = "/user-desk-photos/martine-desk-photo.jpeg"
 const HIDDEN_DESK_PHOTO = "__hidden__"
+const TEAM_AVAILABILITY_REFRESH_MS = 10_000
 
 function deskPhotoForUser(user: SidebarUser | null): string | null {
   if (!user) return null
@@ -163,11 +174,29 @@ function deskStatusDotClass(status: DeskStatus): string {
   return "bg-emerald-600"
 }
 
-function deskStatusAvailability(status: DeskStatus): string {
-  if (status === "out") return "Unavailable"
-  if (status === "on-site") return "Field"
-  if (status === "remote") return "Remote"
-  return "Available"
+function includeCurrentAvailability(
+  members: readonly TeamAvailabilityMember[],
+  user: SidebarUser | null,
+  status: DeskStatus
+): readonly TeamAvailabilityMember[] {
+  if (!user) return members
+
+  const existing = members.find((member) => member.userId === user.id)
+  const currentMember: TeamAvailabilityMember = {
+    userId: user.id,
+    name: user.name,
+    avatarUrl: user.avatar,
+    status,
+    updatedAt: existing?.updatedAt ?? new Date().toISOString(),
+    isCurrentUser: true,
+  }
+
+  return [
+    currentMember,
+    ...members
+      .filter((member) => member.userId !== user.id)
+      .map((member) => ({ ...member, isCurrentUser: false })),
+  ]
 }
 
 function parseDateKey(value: string): Date {
@@ -698,35 +727,106 @@ function OfficeTaskList({
 }
 
 function OfficePresence({
+  initialAvailability,
+  user,
   status,
 }: {
+  readonly initialAvailability: readonly TeamAvailabilityMember[]
+  readonly user: SidebarUser | null
   readonly status: DeskStatus
 }): React.ReactElement {
+  const [members, setMembers] = useState<readonly TeamAvailabilityMember[]>(
+    () => includeCurrentAvailability(initialAvailability, user, status)
+  )
+  const [isRefreshing, startRefreshTransition] = useTransition()
+
+  const refreshAvailability = useCallback(() => {
+    startRefreshTransition(async () => {
+      const result = await getOrganizationTeamAvailability()
+      if (!result.success) return
+      setMembers(includeCurrentAvailability(result.data, user, status))
+    })
+  }, [status, user])
+
+  useEffect(() => {
+    setMembers((current) => includeCurrentAvailability(current, user, status))
+  }, [status, user])
+
+  useEffect(() => {
+    refreshAvailability()
+    const refreshTimer = window.setInterval(
+      refreshAvailability,
+      TEAM_AVAILABILITY_REFRESH_MS
+    )
+    const handleVisibilityChange = (): void => {
+      if (!document.hidden) refreshAvailability()
+    }
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+
+    return () => {
+      window.clearInterval(refreshTimer)
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+    }
+  }, [refreshAvailability])
+
   return (
     <section className="border-y border-border/70 bg-background">
       <div className="flex items-center justify-between gap-3 px-4 py-3">
         <div>
           <h2 className="text-sm font-semibold">Who&apos;s in today</h2>
-          <p className="text-xs text-muted-foreground">Current team availability</p>
+          <p className="text-xs text-muted-foreground">
+            {isRefreshing ? "Updating team availability..." : "Updates automatically"}
+          </p>
         </div>
         <IconUsers className="size-5 text-muted-foreground" />
       </div>
-      <div className="space-y-3 border-t px-4 py-3">
-        <div className="flex items-center gap-3">
-          <span
-            className={cn("size-2.5 rounded-full", deskStatusDotClass(status))}
-          />
-          <div className="min-w-0 flex-1">
-            <p className="text-sm font-medium">You</p>
-            <p className="text-xs text-muted-foreground">
-              {DESK_STATUS_LABELS[status]}
-            </p>
+      <div className="max-h-64 divide-y overflow-y-auto border-t">
+        {members.map((member) => (
+          <div
+            key={member.userId}
+            data-team-availability-user={member.userId}
+            className="flex items-center gap-3 px-4 py-3"
+          >
+            <div className="relative flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted text-xs font-semibold">
+              {member.avatarUrl ? (
+                <Image
+                  src={member.avatarUrl}
+                  alt=""
+                  fill
+                  sizes="32px"
+                  unoptimized
+                  className="object-cover"
+                />
+              ) : (
+                member.name.slice(0, 1).toUpperCase()
+              )}
+            </div>
+            <span
+              className={cn(
+                "-ml-4 mt-6 size-2.5 shrink-0 rounded-full ring-2 ring-background",
+                deskStatusDotClass(member.status)
+              )}
+            />
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium">
+                {member.name}
+                {member.isCurrentUser ? (
+                  <span className="ml-1 font-normal text-muted-foreground">
+                    (You)
+                  </span>
+                ) : null}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {DESK_STATUS_LABELS[member.status]}
+              </p>
+            </div>
           </div>
-          <Badge variant="secondary">{deskStatusAvailability(status)}</Badge>
-        </div>
-        <p className="border-t pt-3 text-xs leading-5 text-muted-foreground">
-          Team status will populate here as staff update their availability.
-        </p>
+        ))}
+        {members.length === 0 ? (
+          <p className="px-4 py-6 text-sm text-muted-foreground">
+            No team availability has been set yet.
+          </p>
+        ) : null}
       </div>
     </section>
   )
@@ -1060,10 +1160,12 @@ export function DashboardLaunchpad({
   overview,
   user,
   initialDeskStatusMessage,
+  initialTeamAvailability,
 }: {
   readonly overview: DashboardOverview
   readonly user: SidebarUser | null
   readonly initialDeskStatusMessage: string | null
+  readonly initialTeamAvailability: readonly TeamAvailabilityMember[]
 }): React.ReactElement {
   const [mode, setMode] = useState<DashboardMode>("office")
   const [deskStatus, setDeskStatus] = useState<DeskStatus>(() =>
@@ -1128,7 +1230,11 @@ export function DashboardLaunchpad({
         <div className="grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(20rem,0.65fr)]">
           <OfficeTaskList overview={overview} />
           <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-1">
-            <OfficePresence status={deskStatus} />
+            <OfficePresence
+              initialAvailability={initialTeamAvailability}
+              user={user}
+              status={deskStatus}
+            />
             <OfficeAlerts overview={overview} />
             <QuickDock />
           </div>

--- a/src/lib/dashboard/__tests__/office-status.test.ts
+++ b/src/lib/dashboard/__tests__/office-status.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest"
 import {
   DESK_STATUS_LABELS,
   deskStatusForPresenceMessage,
+  deskStatusFromPresenceMessage,
+  teamAvailabilityFromRows,
 } from "@/lib/dashboard/office-status"
 
 describe("deskStatusForPresenceMessage", () => {
@@ -16,5 +18,106 @@ describe("deskStatusForPresenceMessage", () => {
   it("defaults to in-office when no recognized status has been saved", () => {
     expect(deskStatusForPresenceMessage(null)).toBe("in-office")
     expect(deskStatusForPresenceMessage("Heads down")).toBe("in-office")
+  })
+})
+
+describe("deskStatusFromPresenceMessage", () => {
+  it("does not treat an unset or unrelated chat status as office availability", () => {
+    expect(deskStatusFromPresenceMessage(null)).toBeNull()
+    expect(deskStatusFromPresenceMessage("Heads down")).toBeNull()
+  })
+})
+
+describe("teamAvailabilityFromRows", () => {
+  it("shares the newest saved availability between distinct staff users", () => {
+    const availability = teamAvailabilityFromRows(
+      [
+        {
+          userId: "martine",
+          email: "martine@example.com",
+          firstName: "Martine",
+          lastName: "Vogel",
+          displayName: "Martine Vogel",
+          avatarUrl: "/martine.jpg",
+          role: "admin",
+          statusMessage: "In Office",
+          updatedAt: "2026-07-27T15:00:00.000Z",
+        },
+        {
+          userId: "sylvi",
+          email: "sylvi@example.com",
+          firstName: "Sylvi",
+          lastName: "Example",
+          displayName: "Sylvi Example",
+          avatarUrl: null,
+          role: "office",
+          statusMessage: "Out",
+          updatedAt: "2026-07-27T14:00:00.000Z",
+        },
+        {
+          userId: "sylvi",
+          email: "sylvi@example.com",
+          firstName: "Sylvi",
+          lastName: "Example",
+          displayName: "Sylvi Example",
+          avatarUrl: null,
+          role: "office",
+          statusMessage: "Remote",
+          updatedAt: "2026-07-27T16:00:00.000Z",
+        },
+        {
+          userId: "owner",
+          email: "owner@example.com",
+          firstName: "Project",
+          lastName: "Owner",
+          displayName: "Project Owner",
+          avatarUrl: null,
+          role: "client",
+          statusMessage: "In Office",
+          updatedAt: "2026-07-27T16:00:00.000Z",
+        },
+      ],
+      "martine"
+    )
+
+    expect(availability).toEqual([
+      {
+        userId: "martine",
+        name: "Martine Vogel",
+        avatarUrl: "/martine.jpg",
+        status: "in-office",
+        updatedAt: "2026-07-27T15:00:00.000Z",
+        isCurrentUser: true,
+      },
+      {
+        userId: "sylvi",
+        name: "Sylvi Example",
+        avatarUrl: null,
+        status: "remote",
+        updatedAt: "2026-07-27T16:00:00.000Z",
+        isCurrentUser: false,
+      },
+    ])
+  })
+
+  it("omits staff who have not set dashboard availability", () => {
+    expect(
+      teamAvailabilityFromRows(
+        [
+          {
+            userId: "unset",
+            email: "unset@example.com",
+            firstName: null,
+            lastName: null,
+            displayName: null,
+            avatarUrl: null,
+            role: "office",
+            statusMessage: null,
+            updatedAt: null,
+          },
+        ],
+        "martine"
+      )
+    ).toEqual([])
   })
 })

--- a/src/lib/dashboard/office-status.ts
+++ b/src/lib/dashboard/office-status.ts
@@ -1,3 +1,5 @@
+import { isInternalStaffRole } from "@/lib/user-roles"
+
 export type DeskStatus = "in-office" | "on-site" | "remote" | "out"
 
 export const DESK_STATUS_LABELS: Readonly<Record<DeskStatus, string>> = {
@@ -16,13 +18,98 @@ export function isDeskStatus(value: string): value is DeskStatus {
   )
 }
 
-export function deskStatusForPresenceMessage(
+export function deskStatusFromPresenceMessage(
   message: string | null
-): DeskStatus {
+): DeskStatus | null {
   const matchingStatus = Object.entries(DESK_STATUS_LABELS).find(
     ([, label]) => label === message
   )
   return matchingStatus && isDeskStatus(matchingStatus[0])
     ? matchingStatus[0]
-    : "in-office"
+    : null
+}
+
+export function deskStatusForPresenceMessage(
+  message: string | null
+): DeskStatus {
+  return deskStatusFromPresenceMessage(message) ?? "in-office"
+}
+
+export type TeamAvailabilityMember = {
+  readonly userId: string
+  readonly name: string
+  readonly avatarUrl: string | null
+  readonly status: DeskStatus
+  readonly updatedAt: string
+  readonly isCurrentUser: boolean
+}
+
+export type TeamAvailabilityRow = {
+  readonly userId: string
+  readonly email: string
+  readonly firstName: string | null
+  readonly lastName: string | null
+  readonly displayName: string | null
+  readonly avatarUrl: string | null
+  readonly role: string
+  readonly statusMessage: string | null
+  readonly updatedAt: string | null
+}
+
+function availabilityName(row: TeamAvailabilityRow): string {
+  const displayName = row.displayName?.trim()
+  if (displayName) return displayName
+
+  const fullName = [row.firstName, row.lastName]
+    .filter((value) => Boolean(value?.trim()))
+    .join(" ")
+    .trim()
+  if (fullName) return fullName
+
+  return row.email.split("@")[0] ?? "Team member"
+}
+
+function statusRank(status: DeskStatus): number {
+  if (status === "in-office") return 0
+  if (status === "on-site") return 1
+  if (status === "remote") return 2
+  return 3
+}
+
+export function teamAvailabilityFromRows(
+  rows: readonly TeamAvailabilityRow[],
+  currentUserId: string
+): readonly TeamAvailabilityMember[] {
+  const membersById = new Map<string, TeamAvailabilityMember>()
+
+  for (const row of rows) {
+    if (!isInternalStaffRole(row.role)) continue
+
+    const status = deskStatusFromPresenceMessage(row.statusMessage)
+    if (!status) continue
+
+    const member: TeamAvailabilityMember = {
+      userId: row.userId,
+      name: availabilityName(row),
+      avatarUrl: row.avatarUrl,
+      status,
+      updatedAt: row.updatedAt ?? "",
+      isCurrentUser: row.userId === currentUserId,
+    }
+    const existing = membersById.get(row.userId)
+    if (!existing || member.updatedAt >= existing.updatedAt) {
+      membersById.set(row.userId, member)
+    }
+  }
+
+  return [...membersById.values()].sort((left, right) => {
+    if (left.isCurrentUser !== right.isCurrentUser) {
+      return left.isCurrentUser ? -1 : 1
+    }
+
+    const statusDifference =
+      statusRank(left.status) - statusRank(right.status)
+    if (statusDifference !== 0) return statusDifference
+    return left.name.localeCompare(right.name)
+  })
 }


### PR DESCRIPTION
## Summary
- replace the hard-coded “You” presence card with an organization-scoped staff roster
- reuse each person’s persisted availability status and refresh the roster every ten seconds
- exclude external and guest accounts and deduplicate organization memberships

## Root cause
The dashboard selector persisted only the current user’s status. “Who’s in today” never queried other users and rendered a hard-coded placeholder, so staff could not see one another.

## Validation
- `bun run test` (369 passed, 3 skipped)
- `bunx tsc --noEmit --pretty false`
- targeted ESLint
- `bun run build`
- local two-user browser verification: Sylvi changed from On Site to Remote and the open dashboard updated automatically without a reload
