### PR TITLE
feat(projects): restore PO selectors and owner update attachments

### DIFF
--- a/src/app/actions/project-operations.ts
+++ b/src/app/actions/project-operations.ts
@@ -11,6 +11,7 @@ import {
   projectOperations,
   projectPurchaseOrderLines,
   projects,
+  sageCostCodes,
   scheduleTasks,
   vendors,
 } from "@/db/schema"
@@ -85,6 +86,23 @@ export type ProjectPurchaseOrderLineItem = {
 export type ProjectPurchaseOrderItem = ProjectOperationItem & {
   readonly lines: readonly ProjectPurchaseOrderLineItem[]
   readonly vendorEmail: string | null
+}
+
+export type ProjectPurchaseOrderPhaseOption = {
+  readonly value: string
+  readonly label: string
+}
+
+export type ProjectPurchaseOrderCostCodeOption = {
+  readonly value: string
+  readonly label: string
+  readonly description: string
+  readonly divisionCode: string
+}
+
+export type ProjectPurchaseOrderFormOptions = {
+  readonly phases: readonly ProjectPurchaseOrderPhaseOption[]
+  readonly costCodes: readonly ProjectPurchaseOrderCostCodeOption[]
 }
 
 export type ProjectRfqScopeLineItem = {
@@ -1510,6 +1528,80 @@ export async function getProjectPurchaseOrders(
     lines: linesByOperation.get(row.id) ?? [],
     vendorEmail: purchaseOrderVendorEmail(row, contactRows, vendorRows),
   }))
+}
+
+export async function getProjectPurchaseOrderFormOptions(
+  projectId: string
+): Promise<ProjectPurchaseOrderFormOptions> {
+  const db = await verifyProjectAccess(projectId, "purchase-orders")
+  const [sageRows, budgetRows] = await Promise.all([
+    db
+      .select({
+        code: sageCostCodes.code,
+        description: sageCostCodes.description,
+        displayLabel: sageCostCodes.displayLabel,
+        divisionCode: sageCostCodes.divisionCode,
+        divisionDisplayLabel: sageCostCodes.divisionDisplayLabel,
+      })
+      .from(sageCostCodes)
+      .where(eq(sageCostCodes.active, true))
+      .orderBy(asc(sageCostCodes.divisionCode), asc(sageCostCodes.displayLabel)),
+    db
+      .select({
+        costCode: projectBudgetLines.costCode,
+        description: projectBudgetLines.description,
+        divisionCode: projectBudgetLines.csiDivision,
+        divisionName: projectBudgetLines.csiDivisionName,
+      })
+      .from(projectBudgetLines)
+      .where(eq(projectBudgetLines.projectId, projectId))
+      .orderBy(
+        asc(projectBudgetLines.csiDivision),
+        asc(projectBudgetLines.costCode)
+      ),
+  ])
+
+  const phaseMap = new Map<string, ProjectPurchaseOrderPhaseOption>()
+  const costCodeMap = new Map<string, ProjectPurchaseOrderCostCodeOption>()
+
+  for (const row of sageRows) {
+    phaseMap.set(row.divisionCode, {
+      value: row.divisionCode,
+      label: row.divisionDisplayLabel,
+    })
+    costCodeMap.set(row.code, {
+      value: row.code,
+      label: row.displayLabel,
+      description: row.description,
+      divisionCode: row.divisionCode,
+    })
+  }
+
+  for (const row of budgetRows) {
+    if (!phaseMap.has(row.divisionCode)) {
+      phaseMap.set(row.divisionCode, {
+        value: row.divisionCode,
+        label: `${row.divisionCode} 00 00 ${row.divisionName}`,
+      })
+    }
+    if (!costCodeMap.has(row.costCode)) {
+      costCodeMap.set(row.costCode, {
+        value: row.costCode,
+        label: `${row.costCode} ${row.description}`,
+        description: row.description,
+        divisionCode: row.divisionCode,
+      })
+    }
+  }
+
+  return {
+    phases: Array.from(phaseMap.values()).sort((left, right) =>
+      left.label.localeCompare(right.label)
+    ),
+    costCodes: Array.from(costCodeMap.values()).sort((left, right) =>
+      left.label.localeCompare(right.label)
+    ),
+  }
 }
 
 export async function getProjectRfqs(

--- a/src/app/dashboard/projects/[id]/purchase-orders/page.tsx
+++ b/src/app/dashboard/projects/[id]/purchase-orders/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tabler/icons-react"
 
 import {
+  getProjectPurchaseOrderFormOptions,
   getProjectPurchaseOrders,
   type ProjectPurchaseOrderItem,
 } from "@/app/actions/project-operations"
@@ -356,10 +357,16 @@ export default async function ProjectPurchaseOrdersPage({
     ? query.created[0] ?? null
     : query.created ?? null
   const statusFilter = parseProjectOperationStatusFilter(query.status)
-  const [projects, purchaseOrders, taskAssigneeOptions] = await Promise.all([
+  const [
+    projects,
+    purchaseOrders,
+    taskAssigneeOptions,
+    purchaseOrderCodingOptions,
+  ] = await Promise.all([
     getProjects(),
     getProjectPurchaseOrders(id),
     getProjectTaskAssigneeOptions(id),
+    getProjectPurchaseOrderFormOptions(id),
   ]).catch((error: unknown) => {
     redirectIfFeaturePermissionDenied(error)
     throw error
@@ -437,7 +444,12 @@ export default async function ProjectPurchaseOrdersPage({
                 <IconExternalLink className="size-4" />
               </Link>
             </Button>
-            <ProjectPurchaseOrderCreateForm projectId={id} />
+            <ProjectPurchaseOrderCreateForm
+              projectId={id}
+              contactOptions={taskAssignees}
+              phaseOptions={purchaseOrderCodingOptions.phases}
+              costCodeOptions={purchaseOrderCodingOptions.costCodes}
+            />
           </div>
         </div>
 

--- a/src/components/projects/owner-update-draft-editor.tsx
+++ b/src/components/projects/owner-update-draft-editor.tsx
@@ -151,6 +151,19 @@ export function OwnerUpdateDraftEditor({
   const selectedPhotoIdSet = new Set(selectedPhotoIds)
   const selectedDocumentIdSet = new Set(selectedDocumentIds)
   const failedImageSet = new Set(failedImageIds)
+  const compassPhotoCount = document.availablePhotos.filter((photo) =>
+    photo.sourceSystem.toLowerCase().includes("compass")
+  ).length
+  const buildertrendPhotoCount = document.availablePhotos.filter((photo) =>
+    photo.sourceSystem.toLowerCase().includes("buildertrend")
+  ).length
+
+  function scrollToSection(id: string): void {
+    globalThis.document.getElementById(id)?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    })
+  }
 
   function toggleId(
     setter: React.Dispatch<React.SetStateAction<readonly string[]>>,
@@ -409,6 +422,68 @@ export function OwnerUpdateDraftEditor({
           schedule items, and to-dos.
         </p>
 
+        <section
+          aria-labelledby="owner-update-attachments-heading"
+          className="border-y bg-muted/20 px-4 py-4"
+        >
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <h3
+                id="owner-update-attachments-heading"
+                className="text-sm font-semibold"
+              >
+                Photos &amp; documents
+              </h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Choose existing Compass or Buildertrend photos, attach existing
+                documents, or upload new files directly to this draft.
+              </p>
+              <p className="mt-2 text-xs text-muted-foreground">
+                {compassPhotoCount} Compass photo
+                {compassPhotoCount === 1 ? "" : "s"} ·{" "}
+                {buildertrendPhotoCount} Buildertrend photo
+                {buildertrendPhotoCount === 1 ? "" : "s"} ·{" "}
+                {document.availableDocuments.length} document
+                {document.availableDocuments.length === 1 ? "" : "s"}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  scrollToSection("owner-update-photo-library")
+                }
+              >
+                <IconPhoto className="size-4" />
+                Choose project photos
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  scrollToSection("owner-update-document-library")
+                }
+              >
+                <IconFile className="size-4" />
+                Choose documents
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                onClick={() =>
+                  scrollToSection("owner-update-file-upload")
+                }
+              >
+                <IconUpload className="size-4" />
+                Upload photos or documents
+              </Button>
+            </div>
+          </div>
+        </section>
+
         <section className="border-t pt-5">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div>
@@ -465,12 +540,15 @@ export function OwnerUpdateDraftEditor({
           )}
         </section>
 
-        <section className="border-t pt-5">
+        <section
+          id="owner-update-photo-library"
+          className="scroll-mt-20 border-t pt-5"
+        >
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="flex items-center gap-2">
               <IconPhoto className="size-4 text-muted-foreground" />
               <h3 className="text-sm font-semibold">
-                Compass and Buildertrend photos
+                Project photo library
               </h3>
             </div>
             <SelectionCount
@@ -479,8 +557,9 @@ export function OwnerUpdateDraftEditor({
             />
           </div>
           <p className="mt-1 text-xs text-muted-foreground">
-            Selecting a photo shares that photo when this update is published;
-            it does not make its whole daily log visible.
+            Choose Compass or Buildertrend photos for this update. Selecting a
+            photo shares only that photo when the update is published; it does
+            not make its whole daily log visible.
           </p>
           {document.availablePhotos.length === 0 ? (
             <p className="mt-3 text-sm text-muted-foreground">
@@ -543,7 +622,10 @@ export function OwnerUpdateDraftEditor({
           )}
         </section>
 
-        <section className="border-t pt-5">
+        <section
+          id="owner-update-document-library"
+          className="scroll-mt-20 border-t pt-5"
+        >
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="flex items-center gap-2">
               <IconFile className="size-4 text-muted-foreground" />
@@ -590,7 +672,10 @@ export function OwnerUpdateDraftEditor({
             </div>
           )}
 
-          <div className="mt-4 grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+          <div
+            id="owner-update-file-upload"
+            className="scroll-mt-20 mt-4 grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
+          >
             <div className="space-y-2">
               <Label htmlFor={`owner-update-files-${document.update.id}`}>
                 Upload photos or documents

--- a/src/components/projects/project-purchase-order-create-form.tsx
+++ b/src/components/projects/project-purchase-order-create-form.tsx
@@ -2,14 +2,37 @@
 
 import * as React from "react"
 import { useRouter } from "next/navigation"
-import { IconPlus, IconShoppingCart, IconTrash } from "@tabler/icons-react"
+import {
+  IconCheck,
+  IconChevronDown,
+  IconPlus,
+  IconShoppingCart,
+  IconTrash,
+} from "@tabler/icons-react"
 
+import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
 import {
   createPurchaseOrderRequest,
   type CreatePurchaseOrderLineInput,
+  type ProjectPurchaseOrderCostCodeOption,
+  type ProjectPurchaseOrderPhaseOption,
 } from "@/app/actions/project-operations"
+import { ProjectAssigneePicker } from "@/components/projects/project-assignee-picker"
 import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
 import { Input } from "@/components/ui/input"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
 import {
   Sheet,
   SheetContent,
@@ -19,6 +42,11 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet"
 import { Textarea } from "@/components/ui/textarea"
+import {
+  purchaseOrderCostCodesForPhase,
+  purchaseOrderInternalOwnerOptions,
+  purchaseOrderVendorOptions,
+} from "@/lib/purchase-orders/form-options"
 
 type DraftPurchaseOrderLine = {
   readonly id: string
@@ -48,6 +76,128 @@ const DOCUMENT_SELECT_CLASS =
   "h-9 w-full rounded-none border-x-0 border-t-0 bg-background px-0 text-sm shadow-none outline-none focus:border-foreground"
 const LINE_INPUT_CLASS =
   "h-8 rounded-none border-0 bg-transparent px-1 shadow-none focus-visible:ring-0 focus-visible:bg-background"
+
+type PurchaseOrderPickerOption = {
+  readonly value: string
+  readonly label: string
+  readonly description?: string
+}
+
+function normalizedOptionText(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+}
+
+function PurchaseOrderOptionPicker({
+  value,
+  options,
+  placeholder,
+  ariaLabel,
+  onValueChange,
+}: {
+  readonly value: string
+  readonly options: readonly PurchaseOrderPickerOption[]
+  readonly placeholder: string
+  readonly ariaLabel: string
+  readonly onValueChange: (value: string) => void
+}): React.ReactElement {
+  const [open, setOpen] = React.useState(false)
+  const [query, setQuery] = React.useState("")
+  const normalizedQuery = normalizedOptionText(query)
+  const selected =
+    options.find((option) => option.value === value) ?? null
+  const filteredOptions = options.filter((option) => {
+    if (normalizedQuery.length === 0) return true
+    return normalizedOptionText(
+      `${option.value} ${option.label} ${option.description ?? ""}`
+    ).includes(normalizedQuery)
+  })
+  const typedValue = query.trim()
+  const canUseTypedValue =
+    typedValue.length > 0 &&
+    normalizedOptionText(typedValue) !== normalizedOptionText(value)
+
+  function chooseValue(nextValue: string): void {
+    onValueChange(nextValue)
+    setQuery("")
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          aria-label={ariaLabel}
+          className="h-8 w-full min-w-0 justify-between rounded-none bg-transparent px-1 text-left text-xs font-normal hover:bg-background"
+        >
+          <span className="truncate">
+            {selected?.label ?? (value || placeholder)}
+          </span>
+          <IconChevronDown className="size-3.5 shrink-0 opacity-60" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[min(26rem,calc(100vw-3rem))] p-0">
+        <Command shouldFilter={false}>
+          <CommandInput
+            value={query}
+            onValueChange={setQuery}
+            placeholder={`Search ${placeholder.toLowerCase()}...`}
+          />
+          <CommandList className="compass-content-scroll max-h-72">
+            <CommandEmpty>No matching options.</CommandEmpty>
+            <CommandGroup>
+              {filteredOptions.map((option) => (
+                <CommandItem
+                  key={option.value}
+                  value={`${option.value} ${option.label}`}
+                  onSelect={() => chooseValue(option.value)}
+                >
+                  <IconCheck
+                    className={
+                      option.value === value ? "size-4 opacity-100" : "size-4 opacity-0"
+                    }
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate">{option.label}</span>
+                    {option.description && (
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {option.description}
+                      </span>
+                    )}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+          <div className="flex items-center justify-between gap-2 border-t p-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => chooseValue("")}
+            >
+              Clear
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={!canUseTypedValue}
+              onClick={() => chooseValue(typedValue)}
+            >
+              Use typed value
+            </Button>
+          </div>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}
 
 function newLine(): DraftPurchaseOrderLine {
   return {
@@ -122,8 +272,14 @@ function Field({
 
 export function ProjectPurchaseOrderCreateForm({
   projectId,
+  contactOptions,
+  phaseOptions,
+  costCodeOptions,
 }: {
   readonly projectId: string
+  readonly contactOptions: readonly ProjectTaskAssigneeOption[]
+  readonly phaseOptions: readonly ProjectPurchaseOrderPhaseOption[]
+  readonly costCodeOptions: readonly ProjectPurchaseOrderCostCodeOption[]
 }): React.ReactElement {
   const router = useRouter()
   const formRef = React.useRef<HTMLFormElement>(null)
@@ -131,9 +287,19 @@ export function ProjectPurchaseOrderCreateForm({
     newLine(),
   ])
   const [sageVendorId, setSageVendorId] = React.useState("")
+  const [companyName, setCompanyName] = React.useState("")
+  const [assigneeName, setAssigneeName] = React.useState("")
   const [submitting, setSubmitting] = React.useState(false)
   const [message, setMessage] = React.useState<string | null>(null)
   const [open, setOpen] = React.useState(false)
+  const vendorOptions = React.useMemo(
+    () => purchaseOrderVendorOptions(contactOptions),
+    [contactOptions]
+  )
+  const internalOwnerOptions = React.useMemo(
+    () => purchaseOrderInternalOwnerOptions(contactOptions),
+    [contactOptions]
+  )
 
   const total = lines.reduce((sum, line) => sum + lineAmount(line), 0)
   const codedLineCount = lines.filter(
@@ -183,9 +349,9 @@ export function ProjectPurchaseOrderCreateForm({
       const result = await createPurchaseOrderRequest(projectId, {
         title: String(formData.get("title") ?? ""),
         description: cleanText(String(formData.get("description") ?? "")),
-        companyName: cleanText(String(formData.get("companyName") ?? "")),
+        companyName: cleanText(companyName),
         sageVendorId: cleanText(String(formData.get("sageVendorId") ?? "")),
-        assigneeName: cleanText(String(formData.get("assigneeName") ?? "")),
+        assigneeName: cleanText(assigneeName),
         shipTo: cleanText(String(formData.get("shipTo") ?? "")),
         orderDate: cleanText(String(formData.get("orderDate") ?? "")),
         dueDate: cleanText(String(formData.get("dueDate") ?? "")),
@@ -200,6 +366,8 @@ export function ProjectPurchaseOrderCreateForm({
       form.reset()
       setLines([newLine()])
       setSageVendorId("")
+      setCompanyName("")
+      setAssigneeName("")
       setMessage("P.O. request saved in Compass.")
       setOpen(false)
       router.push(
@@ -264,10 +432,14 @@ export function ProjectPurchaseOrderCreateForm({
           </Field>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <Field label="Vendor / supplier">
-              <Input
-                name="companyName"
-                placeholder="Vendor or supplier name"
-                className={DOCUMENT_INPUT_CLASS}
+              <ProjectAssigneePicker
+                value={companyName}
+                options={vendorOptions}
+                placeholder="Choose vendor or type a name..."
+                onValueChange={(value, option) =>
+                  setCompanyName(option?.companyName ?? value)
+                }
+                className="rounded-none border-x-0 border-t-0 px-0 shadow-none focus-visible:ring-0"
               />
             </Field>
             <Field label="Accounting vendor ID (optional)">
@@ -280,10 +452,12 @@ export function ProjectPurchaseOrderCreateForm({
               />
             </Field>
             <Field label="Internal owner">
-              <Input
-                name="assigneeName"
-                placeholder="PM/APM responsible"
-                className={DOCUMENT_INPUT_CLASS}
+              <ProjectAssigneePicker
+                value={assigneeName}
+                options={internalOwnerOptions}
+                placeholder="Choose staff member or type a name..."
+                onValueChange={(value) => setAssigneeName(value)}
+                className="rounded-none border-x-0 border-t-0 px-0 shadow-none focus-visible:ring-0"
               />
             </Field>
             <Field label="Ship to / delivery location">
@@ -337,8 +511,8 @@ export function ProjectPurchaseOrderCreateForm({
             </Button>
           </div>
           <div className="overflow-x-auto">
-            <div className="min-w-[920px]">
-              <div className="grid grid-cols-[2rem_minmax(12rem,1fr)_5rem_6rem_5rem_6rem_5rem_6rem_5rem_2.5rem] gap-2 border-b py-2 text-xs font-medium text-muted-foreground">
+            <div className="min-w-[1120px]">
+              <div className="grid grid-cols-[2rem_minmax(12rem,1fr)_11rem_13rem_5rem_6rem_5rem_6rem_5rem_2.5rem] gap-2 border-b py-2 text-xs font-medium text-muted-foreground">
                 <span>#</span>
                 <span>Description</span>
                 <span>Phase</span>
@@ -353,7 +527,7 @@ export function ProjectPurchaseOrderCreateForm({
               {lines.map((line, index) => (
                 <div
                   key={line.id}
-                  className="grid grid-cols-[2rem_minmax(12rem,1fr)_5rem_6rem_5rem_6rem_5rem_6rem_5rem_2.5rem] gap-2 border-b py-2 last:border-b-0"
+                  className="grid grid-cols-[2rem_minmax(12rem,1fr)_11rem_13rem_5rem_6rem_5rem_6rem_5rem_2.5rem] gap-2 border-b py-2 last:border-b-0"
                 >
                   <span className="pt-2 text-xs font-medium text-muted-foreground">
                     {index + 1}
@@ -366,21 +540,28 @@ export function ProjectPurchaseOrderCreateForm({
                     placeholder="Scope or item"
                     className={LINE_INPUT_CLASS}
                   />
-                  <Input
+                  <PurchaseOrderOptionPicker
                     value={line.phaseCode}
-                    onChange={(event) =>
-                      updateLine(line.id, "phaseCode", event.target.value)
-                    }
+                    options={phaseOptions}
                     placeholder="Phase"
-                    className={LINE_INPUT_CLASS}
-                  />
-                  <Input
-                    value={line.costCode}
-                    onChange={(event) =>
-                      updateLine(line.id, "costCode", event.target.value)
+                    ariaLabel={`Choose phase for line ${index + 1}`}
+                    onValueChange={(value) =>
+                      updateLine(line.id, "phaseCode", value)
                     }
-                    placeholder="CSI"
-                    className={LINE_INPUT_CLASS}
+                  />
+                  <PurchaseOrderOptionPicker
+                    value={line.costCode}
+                    options={
+                      purchaseOrderCostCodesForPhase(
+                        costCodeOptions,
+                        line.phaseCode
+                      )
+                    }
+                    placeholder="Cost code"
+                    ariaLabel={`Choose cost code for line ${index + 1}`}
+                    onValueChange={(value) =>
+                      updateLine(line.id, "costCode", value)
+                    }
                   />
                   <Input
                     value={line.quantity}

--- a/src/lib/purchase-orders/__tests__/form-options.test.ts
+++ b/src/lib/purchase-orders/__tests__/form-options.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  purchaseOrderCostCodesForPhase,
+  purchaseOrderInternalOwnerOptions,
+  purchaseOrderVendorOptions,
+} from "@/lib/purchase-orders/form-options"
+
+describe("purchase order form options", () => {
+  const contacts = [
+    { id: "supplier", contactType: "supplier" },
+    { id: "subcontractor", contactType: "subcontractor" },
+    { id: "internal", contactType: "internal" },
+    { id: "owner", contactType: "owner" },
+  ]
+
+  it("keeps suppliers and subcontractors in the vendor selector", () => {
+    expect(purchaseOrderVendorOptions(contacts).map((option) => option.id)).toEqual([
+      "supplier",
+      "subcontractor",
+    ])
+  })
+
+  it("keeps only staff choices in the internal owner selector", () => {
+    expect(
+      purchaseOrderInternalOwnerOptions(contacts).map((option) => option.id)
+    ).toEqual(["internal"])
+  })
+
+  it("filters cost codes to the selected phase while keeping all codes before selection", () => {
+    const costCodes = [
+      { value: "03-100", divisionCode: "03" },
+      { value: "06-100", divisionCode: "06" },
+      { value: "06-200", divisionCode: "06" },
+    ]
+
+    expect(purchaseOrderCostCodesForPhase(costCodes, "")).toHaveLength(3)
+    expect(
+      purchaseOrderCostCodesForPhase(costCodes, "06").map(
+        (option) => option.value
+      )
+    ).toEqual(["06-100", "06-200"])
+  })
+})

--- a/src/lib/purchase-orders/form-options.ts
+++ b/src/lib/purchase-orders/form-options.ts
@@ -1,0 +1,34 @@
+type PurchaseOrderContactOption = {
+  readonly contactType: string
+}
+
+type PurchaseOrderCostCodeOption = {
+  readonly divisionCode: string
+}
+
+export function purchaseOrderVendorOptions<
+  T extends PurchaseOrderContactOption,
+>(options: readonly T[]): readonly T[] {
+  return options.filter(
+    (option) =>
+      option.contactType === "supplier" ||
+      option.contactType === "subcontractor"
+  )
+}
+
+export function purchaseOrderInternalOwnerOptions<
+  T extends PurchaseOrderContactOption,
+>(options: readonly T[]): readonly T[] {
+  return options.filter((option) => option.contactType === "internal")
+}
+
+export function purchaseOrderCostCodesForPhase<
+  T extends PurchaseOrderCostCodeOption,
+>(options: readonly T[], phaseCode: string): readonly T[] {
+  const normalizedPhase = phaseCode.trim()
+  if (normalizedPhase.length === 0) return options
+
+  return options.filter(
+    (option) => option.divisionCode.trim() === normalizedPhase
+  )
+}


### PR DESCRIPTION
## What changed

- Restores searchable Vendor/Supplier and Internal Owner selectors in the new purchase-order form while retaining manual entry.
- Adds searchable Phase and Cost Code selectors sourced from active Sage codes and project budget lines.
- Filters cost codes to the selected phase while retaining manual entry for exceptions.
- Places a prominent Photos & documents section near the top of draft owner updates.
- Provides direct navigation to Compass/Buildertrend photo selection, existing documents, and file upload.
- Clarifies that selecting a photo shares only that photo, not its entire daily log.

## Why

The purchase-order fields had regressed to plain text inputs, and the existing owner-update photo/document controls were buried below daily logs and the photo library, making them difficult to discover.

## Validation

- `bun run test` — 48 files passed; 372 tests passed, 3 skipped
- `bunx tsc --noEmit --pretty false`
- targeted ESLint — no errors (one pre-existing `no-img-element` warning)
- `next build --webpack`
- `git diff --check`

The PO option loader uses the purchase-order feature permission gate and does not depend on finish-selection access.