### PR TITLE
fix(calendar): accept Google email scope alias

### DIFF
--- a/src/lib/__tests__/google-calendar-sync.test.ts
+++ b/src/lib/__tests__/google-calendar-sync.test.ts
@@ -69,6 +69,17 @@ describe("Google Calendar OAuth configuration", () => {
       ),
     ).toBe(false)
   })
+
+  it("accepts Google's canonical userinfo email scope", () => {
+    expect(
+      hasRequiredGoogleCalendarScopes([
+        "openid",
+        "https://www.googleapis.com/auth/userinfo.email",
+        "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+        "https://www.googleapis.com/auth/calendar.events",
+      ]),
+    ).toBe(true)
+  })
 })
 
 describe("calendar privacy", () => {

--- a/src/lib/google/calendar/oauth.ts
+++ b/src/lib/google/calendar/oauth.ts
@@ -21,11 +21,23 @@ export type GoogleAccountIdentity = {
   readonly emailVerified: boolean
 }
 
+const GOOGLE_SCOPE_EQUIVALENTS: Readonly<
+  Record<string, readonly string[]>
+> = {
+  email: [
+    "email",
+    "https://www.googleapis.com/auth/userinfo.email",
+  ],
+}
+
 export function hasRequiredGoogleCalendarScopes(
   scopes: readonly string[],
 ): boolean {
   const granted = new Set(scopes)
-  return GOOGLE_CALENDAR_SCOPES.every((scope) => granted.has(scope))
+  return GOOGLE_CALENDAR_SCOPES.every((scope) => {
+    const equivalents = GOOGLE_SCOPE_EQUIVALENTS[scope] ?? [scope]
+    return equivalents.some((candidate) => granted.has(candidate))
+  })
 }
 
 function isRecord(value: unknown): value is JsonRecord {


### PR DESCRIPTION
## What changed

- Treat Google's canonical `https://www.googleapis.com/auth/userinfo.email` grant as equivalent to the requested `email` scope.
- Add a regression test using the exact scope shape returned by the production OAuth callback.

## Root cause

Google granted every requested Calendar permission, but canonicalized the short `email` scope. Compass required an exact literal match, incorrectly redirected to `google-calendar=missing-scopes`, and never saved the connection.

## User impact

Completing Google consent can now persist the Calendar connection instead of silently returning to Compass without a connected state.

## Validation

- `bunx vitest run src/lib/__tests__/google-calendar-sync.test.ts` — 13 tests passed
- `bunx tsc --noEmit --pretty false`
- `bunx eslint src/lib/google/calendar/oauth.ts src/lib/__tests__/google-calendar-sync.test.ts`
- `git diff --check`