### PR TITLE
fix(schedule): stabilize ordering dependencies and scrolling

### DIFF
--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -12,7 +12,10 @@ import { eq, asc, and, inArray } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { calculateEndDate } from "@/lib/schedule/business-days"
 import { findCriticalPath } from "@/lib/schedule/critical-path"
-import { wouldCreateCycle } from "@/lib/schedule/dependency-validation"
+import {
+  wouldCreateCycle,
+  wouldDependencyUpdateCreateCycle,
+} from "@/lib/schedule/dependency-validation"
 import { propagateDates } from "@/lib/schedule/propagate-dates"
 import {
   effectivePercentComplete,
@@ -688,6 +691,147 @@ export async function createDependency(data: {
   } catch (error) {
     console.error("Failed to create dependency:", error)
     return { success: false, error: "Failed to create dependency" }
+  }
+}
+
+export async function updateDependency(data: {
+  dependencyId: string
+  predecessorId: string
+  successorId: string
+  type: DependencyType
+  lagDays: number
+  projectId: string
+}): Promise<
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string }
+> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    const orgId = requireOrg(user)
+
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const [project] = await db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(
+        and(
+          eq(projects.id, data.projectId),
+          eq(projects.organizationId, orgId)
+        )
+      )
+      .limit(1)
+
+    if (!project) {
+      return { success: false, error: "Project not found or access denied" }
+    }
+    if (data.predecessorId === data.successorId) {
+      return {
+        success: false,
+        error: "A schedule item cannot depend on itself",
+      }
+    }
+
+    const schedule = await getSchedule(data.projectId)
+    const taskIds = new Set(schedule.tasks.map((task) => task.id))
+    const currentDependency = schedule.dependencies.find(
+      (dependency) => dependency.id === data.dependencyId
+    )
+
+    if (!currentDependency) {
+      return { success: false, error: "Dependency not found" }
+    }
+    if (
+      !taskIds.has(data.predecessorId) ||
+      !taskIds.has(data.successorId)
+    ) {
+      return {
+        success: false,
+        error: "Both schedule items must belong to this project",
+      }
+    }
+
+    const otherDependencies = schedule.dependencies.filter(
+      (dependency) => dependency.id !== data.dependencyId
+    )
+    if (
+      otherDependencies.some(
+        (dependency) =>
+          dependency.predecessorId === data.predecessorId &&
+          dependency.successorId === data.successorId
+      )
+    ) {
+      return { success: false, error: "That dependency already exists" }
+    }
+    if (
+      wouldDependencyUpdateCreateCycle(
+        schedule.dependencies,
+        data.dependencyId,
+        data.predecessorId,
+        data.successorId
+      )
+    ) {
+      return { success: false, error: "This dependency would create a cycle" }
+    }
+
+    const updatedDependency = {
+      id: data.dependencyId,
+      predecessorId: data.predecessorId,
+      successorId: data.successorId,
+      type: data.type,
+      lagDays: data.lagDays,
+    }
+    const recalculated = propagateDates(
+      data.predecessorId,
+      schedule.tasks,
+      [...otherDependencies, updatedDependency],
+      schedule.exceptions
+    )
+    const updatedAt = new Date().toISOString()
+    const statements: D1PreparedStatement[] = [
+      env.DB.prepare(
+        `UPDATE task_dependencies
+         SET predecessor_id = ?, successor_id = ?, type = ?, lag_days = ?
+         WHERE id = ?`
+      ).bind(
+        data.predecessorId,
+        data.successorId,
+        data.type,
+        data.lagDays,
+        data.dependencyId
+      ),
+    ]
+
+    for (const [taskId, dates] of recalculated.updatedTasks) {
+      statements.push(
+        env.DB.prepare(
+          `UPDATE schedule_tasks
+           SET start_date = ?, end_date_calculated = ?, updated_at = ?
+           WHERE id = ? AND project_id = ?`
+        ).bind(
+          dates.startDate,
+          dates.endDateCalculated,
+          updatedAt,
+          taskId,
+          data.projectId
+        )
+      )
+    }
+
+    const results = await env.DB.batch(statements)
+    if (results.some((result) => !result.success)) {
+      throw new Error("Dependency update batch failed")
+    }
+
+    await recalcCriticalPath(db, data.projectId)
+    revalidateSchedulePaths(data.projectId)
+    return { success: true }
+  } catch (error) {
+    console.error("Failed to update dependency:", error)
+    return { success: false, error: "Failed to update dependency" }
   }
 }
 

--- a/src/components/schedule/gantt-chart.tsx
+++ b/src/components/schedule/gantt-chart.tsx
@@ -4,6 +4,12 @@ import { useRef, useEffect, useState, useCallback, type CSSProperties } from "re
 import type { FrappeTask } from "@/lib/schedule/gantt-transform"
 import type { DisplayColorPalette } from "@/lib/schedule/appearance"
 import { getScheduleItemClasses } from "@/lib/schedule/appearance"
+import {
+  dominantScrollAxis,
+  lockWheelToDominantAxis,
+  normalizeWheelDelta,
+  type GanttScrollAxis,
+} from "@/lib/schedule/gantt-scroll"
 import "./gantt.css"
 
 type ViewMode = "Day" | "Week" | "Month"
@@ -152,6 +158,7 @@ export function GanttChart({
   const panStartY = useRef(0)
   const panScrollLeft = useRef(0)
   const panScrollTop = useRef(0)
+  const panAxis = useRef<GanttScrollAxis | null>(null)
   const ganttContainerRef = useRef<HTMLElement | null>(null)
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
@@ -165,6 +172,7 @@ export function GanttChart({
     panStartY.current = e.clientY
     panScrollLeft.current = gc.scrollLeft
     panScrollTop.current = gc.scrollTop
+    panAxis.current = null
     const wrapper = wrapperRef.current
     if (wrapper) wrapper.style.cursor = "grabbing"
   }, [panMode])
@@ -173,13 +181,27 @@ export function GanttChart({
     if (!isPanning.current) return
     const gc = ganttContainerRef.current
     if (!gc) return
-    gc.scrollLeft = panScrollLeft.current - (e.clientX - panStartX.current)
-    gc.scrollTop = panScrollTop.current - (e.clientY - panStartY.current)
+    const deltaX = e.clientX - panStartX.current
+    const deltaY = e.clientY - panStartY.current
+    if (
+      panAxis.current === null &&
+      Math.max(Math.abs(deltaX), Math.abs(deltaY)) >= 6
+    ) {
+      panAxis.current = dominantScrollAxis(deltaX, deltaY)
+    }
+    if (panAxis.current === "horizontal") {
+      gc.scrollLeft = panScrollLeft.current - deltaX
+      return
+    }
+    if (panAxis.current === "vertical") {
+      gc.scrollTop = panScrollTop.current - deltaY
+    }
   }, [])
 
   const handleMouseUp = useCallback(() => {
     if (!isPanning.current) return
     isPanning.current = false
+    panAxis.current = null
     const wrapper = wrapperRef.current
     if (wrapper) wrapper.style.cursor = ""
   }, [])
@@ -209,6 +231,27 @@ export function GanttChart({
       interactionCallbacksRef.current.onScrollTopChange?.(
         activeContainer.scrollTop
       )
+    }
+    const handleAxisLockedWheel = (event: WheelEvent) => {
+      if (!activeContainer || event.ctrlKey) return
+
+      const pageSize = Math.max(
+        activeContainer.clientWidth,
+        activeContainer.clientHeight
+      )
+      const rawDeltaX =
+        event.shiftKey && event.deltaX === 0 ? event.deltaY : event.deltaX
+      const rawDeltaY =
+        event.shiftKey && event.deltaX === 0 ? 0 : event.deltaY
+      const locked = lockWheelToDominantAxis(
+        normalizeWheelDelta(rawDeltaX, event.deltaMode, pageSize),
+        normalizeWheelDelta(rawDeltaY, event.deltaMode, pageSize)
+      )
+      if (locked.deltaX === 0 && locked.deltaY === 0) return
+
+      event.preventDefault()
+      activeContainer.scrollLeft += locked.deltaX
+      activeContainer.scrollTop += locked.deltaY
     }
 
     async function initGantt() {
@@ -272,6 +315,9 @@ export function GanttChart({
         activeContainer.addEventListener("scroll", handleScroll, {
           passive: true,
         })
+        activeContainer.addEventListener("wheel", handleAxisLockedWheel, {
+          passive: false,
+        })
         interactionCallbacksRef.current.onContainerReady?.(activeContainer)
       }
 
@@ -282,6 +328,7 @@ export function GanttChart({
     return () => {
       cancelled = true
       activeContainer?.removeEventListener("scroll", handleScroll)
+      activeContainer?.removeEventListener("wheel", handleAxisLockedWheel)
       if (ganttContainerRef.current === activeContainer) {
         ganttContainerRef.current = null
       }

--- a/src/components/schedule/schedule-item-form-dialog.tsx
+++ b/src/components/schedule/schedule-item-form-dialog.tsx
@@ -54,6 +54,7 @@ import {
   createTask,
   updateTask,
   createDependency,
+  updateDependency,
   deleteDependency,
 } from "@/app/actions/schedule"
 import { calculateEndDate } from "@/lib/schedule/business-days"
@@ -135,6 +136,9 @@ export function ScheduleItemFormDialog({
   const [pendingPredecessors, setPendingPredecessors] = useState<
     PendingPredecessor[]
   >([])
+  const [existingPredecessorEdits, setExistingPredecessorEdits] = useState<
+    Record<string, PendingPredecessor>
+  >({})
 
   const existingPredecessors = useMemo(() => {
     if (!editingTask) return []
@@ -195,6 +199,28 @@ export function ScheduleItemFormDialog({
     setPendingPredecessors([])
   }, [editingTask, form])
 
+  useEffect(() => {
+    if (!editingTask) {
+      setExistingPredecessorEdits({})
+      return
+    }
+
+    setExistingPredecessorEdits(
+      Object.fromEntries(
+        dependencies
+          .filter((dependency) => dependency.successorId === editingTask.id)
+          .map((dependency) => [
+            dependency.id,
+            {
+              taskId: dependency.predecessorId,
+              type: dependency.type,
+              lagDays: dependency.lagDays,
+            },
+          ])
+      )
+    )
+  }, [dependencies, editingTask])
+
   const watchedStart = form.watch("startDate")
   const watchedWorkdays = form.watch("workdays")
   const watchedPhase = form.watch("phase")
@@ -234,6 +260,30 @@ export function ScheduleItemFormDialog({
     }
 
     const dependencyErrors: string[] = []
+    for (const dependency of existingPredecessors) {
+      const edit = existingPredecessorEdits[dependency.id]
+      if (
+        !edit ||
+        (edit.taskId === dependency.predecessorId &&
+          edit.type === dependency.type &&
+          edit.lagDays === dependency.lagDays)
+      ) {
+        continue
+      }
+
+      const dependencyResult = await updateDependency({
+        dependencyId: dependency.id,
+        predecessorId: edit.taskId,
+        successorId: savedTaskId,
+        type: edit.type,
+        lagDays: edit.lagDays,
+        projectId,
+      })
+      if (!dependencyResult.success) {
+        dependencyErrors.push(dependencyResult.error)
+      }
+    }
+
     for (const predecessor of pendingPredecessors) {
       if (predecessor.taskId) {
         const dependencyResult = await createDependency({
@@ -249,15 +299,16 @@ export function ScheduleItemFormDialog({
       }
     }
 
-    onOpenChange(false)
     router.refresh()
     if (dependencyErrors.length > 0) {
       toast.warning(
-        `Schedule item saved, but ${dependencyErrors.length} dependency link${
+        `Schedule item saved, but ${dependencyErrors.length} predecessor change${
           dependencyErrors.length === 1 ? "" : "s"
-        } could not be added: ${dependencyErrors.join("; ")}`
+        } could not be saved: ${dependencyErrors.join("; ")}`
       )
+      return
     }
+    onOpenChange(false)
   }
 
   const addPendingPredecessor = () => {
@@ -288,6 +339,21 @@ export function ScheduleItemFormDialog({
     } else {
       toast.error(result.error)
     }
+  }
+
+  const updateExistingPredecessor = (
+    dependencyId: string,
+    field: keyof PendingPredecessor,
+    value: string | number
+  ): void => {
+    setExistingPredecessorEdits((current) => {
+      const existing = current[dependencyId]
+      if (!existing) return current
+      return {
+        ...current,
+        [dependencyId]: { ...existing, [field]: value },
+      }
+    })
   }
 
   const hasPredecessors =
@@ -621,26 +687,80 @@ export function ScheduleItemFormDialog({
                     </span>
 
                     {existingPredecessors.map((dep) => {
-                      const predTask = allTasks.find(
-                        (t) => t.id === dep.predecessorId
-                      )
+                      const edit = existingPredecessorEdits[dep.id] ?? {
+                        taskId: dep.predecessorId,
+                        type: dep.type,
+                        lagDays: dep.lagDays,
+                      }
                       return (
                         <div
                           key={dep.id}
-                          className="flex items-center gap-2 text-sm"
+                          className="grid grid-cols-[minmax(0,1fr)_6.5rem_2rem] items-end gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(9rem,11rem)_5.5rem_2rem]"
                         >
-                          <div className="flex-1 truncate px-2 py-1.5 rounded bg-muted/40 text-xs">
-                            {predTask?.title ?? "Unknown"}
-                          </div>
-                          <span className="text-[10px] text-muted-foreground shrink-0 w-8 text-center">
-                            {dep.type}
-                          </span>
-                          {dep.lagDays !== 0 && (
-                            <span className="text-[10px] text-muted-foreground shrink-0">
-                              {dep.lagDays > 0 ? "+" : ""}
-                              {dep.lagDays}d
-                            </span>
-                          )}
+                          <Select
+                            value={edit.taskId}
+                            onValueChange={(value) =>
+                              updateExistingPredecessor(
+                                dep.id,
+                                "taskId",
+                                value
+                              )
+                            }
+                          >
+                            <SelectTrigger
+                              className="col-span-3 h-8 min-w-0 text-xs sm:col-span-1"
+                              aria-label="Saved predecessor schedule item"
+                            >
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {availableTasks.map((task) => (
+                                <SelectItem key={task.id} value={task.id}>
+                                  {task.title}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <Select
+                            value={edit.type}
+                            onValueChange={(value) =>
+                              updateExistingPredecessor(
+                                dep.id,
+                                "type",
+                                value
+                              )
+                            }
+                          >
+                            <SelectTrigger
+                              className="h-8 min-w-0 text-xs"
+                              aria-label="Saved dependency relationship"
+                            >
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {DEPENDENCY_TYPES.map((dependencyType) => (
+                                <SelectItem
+                                  key={dependencyType.value}
+                                  value={dependencyType.value}
+                                >
+                                  {dependencyType.label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <Input
+                            type="number"
+                            className="h-8 min-w-0 text-center text-xs"
+                            value={edit.lagDays}
+                            aria-label="Saved dependency lag or lead in days"
+                            onChange={(event) =>
+                              updateExistingPredecessor(
+                                dep.id,
+                                "lagDays",
+                                Number(event.target.value) || 0
+                              )
+                            }
+                          />
                           <Button
                             type="button"
                             variant="ghost"

--- a/src/components/schedule/schedule-list-view.tsx
+++ b/src/components/schedule/schedule-list-view.tsx
@@ -188,7 +188,7 @@ export function ScheduleListView({
         header: "#",
         cell: ({ row }) => (
           <span className="text-xs text-muted-foreground">
-            {row.original.sortOrder + 1}
+            {row.index + 1}
           </span>
         ),
         size: 40,

--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useMemo, useRef } from "react"
+import { useState, useMemo, useRef, useEffect } from "react"
 import Link from "next/link"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
@@ -35,6 +35,13 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import {
   IconSearch,
   IconFilter,
@@ -73,6 +80,12 @@ import {
   EMPTY_FILTERS,
   STATUS_OPTIONS,
 } from "@/lib/schedule/types"
+import {
+  isScheduleOrderMode,
+  orderScheduleTasks,
+  scheduleOrderStorageKey,
+  type ScheduleOrderMode,
+} from "@/lib/schedule/task-ordering"
 
 type View = "calendar" | "list" | "gantt"
 
@@ -105,6 +118,8 @@ export function ScheduleView({
 }: ScheduleViewProps) {
   const isMobile = useIsMobile()
   const [view, setView] = useState<View>(initialView)
+  const [orderMode, setOrderMode] =
+    useState<ScheduleOrderMode>("chronological")
   const [taskFormOpen, setTaskFormOpen] = useState(false)
   const [filters, setFilters] = useState<TaskFilters>(EMPTY_FILTERS)
   const [baselinesOpen, setBaselinesOpen] = useState(false)
@@ -112,6 +127,21 @@ export function ScheduleView({
   const [importDialogOpen, setImportDialogOpen] = useState(false)
   const [isImporting, setIsImporting] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    const storedMode = window.localStorage.getItem(
+      scheduleOrderStorageKey(projectId)
+    )
+    setOrderMode(
+      isScheduleOrderMode(storedMode) ? storedMode : "chronological"
+    )
+  }, [projectId])
+
+  const handleOrderModeChange = (value: string): void => {
+    if (!isScheduleOrderMode(value)) return
+    setOrderMode(value)
+    window.localStorage.setItem(scheduleOrderStorageKey(projectId), value)
+  }
 
   const phaseOptions = useMemo(() => {
     const seen = new Set<string>()
@@ -146,8 +176,8 @@ export function ScheduleView({
         t.title.toLowerCase().includes(search)
       )
     }
-    return tasks
-  }, [initialData.tasks, filters])
+    return orderScheduleTasks(tasks, orderMode)
+  }, [initialData.tasks, filters, orderMode])
 
   const activeFilterCount =
     filters.status.length +
@@ -356,7 +386,7 @@ export function ScheduleView({
       {/* Action bar: search, filters, overflow */}
       <div className="flex items-center gap-2 mb-3 print:hidden">
         {/* Search */}
-        <div className="relative flex-1 sm:flex-none sm:w-52">
+        <div className="relative min-w-0 flex-1 sm:flex-none sm:w-52">
           <IconSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground pointer-events-none" />
           <Input
             placeholder="Search schedule items..."
@@ -449,6 +479,19 @@ export function ScheduleView({
             </div>
           </PopoverContent>
         </Popover>
+
+        <Select value={orderMode} onValueChange={handleOrderModeChange}>
+          <SelectTrigger
+            className="h-8 w-[132px] shrink-0 text-xs sm:w-[146px]"
+            aria-label="Schedule ordering"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="chronological">Chronological</SelectItem>
+            <SelectItem value="manual">Manual order</SelectItem>
+          </SelectContent>
+        </Select>
 
         {/* Active filter chips */}
         <div className="hidden sm:flex items-center gap-1 overflow-x-auto min-w-0">

--- a/src/lib/schedule/__tests__/dependency-validation.test.ts
+++ b/src/lib/schedule/__tests__/dependency-validation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import {
+  wouldCreateCycle,
+  wouldDependencyUpdateCreateCycle,
+} from "../dependency-validation"
+import type { TaskDependencyData } from "../types"
+
+function dependency(
+  id: string,
+  predecessorId: string,
+  successorId: string
+): TaskDependencyData {
+  return {
+    id,
+    predecessorId,
+    successorId,
+    type: "FS",
+    lagDays: 0,
+  }
+}
+
+describe("schedule dependency validation", () => {
+  const dependencies = [
+    dependency("a-b", "a", "b"),
+    dependency("b-c", "b", "c"),
+  ]
+
+  it("rejects a dependency that closes a cycle", () => {
+    expect(wouldCreateCycle(dependencies, "c", "a")).toBe(true)
+  })
+
+  it("validates an edited dependency without counting its old edge", () => {
+    expect(
+      wouldDependencyUpdateCreateCycle(dependencies, "a-b", "a", "c")
+    ).toBe(false)
+  })
+
+  it("still rejects a cycle introduced by an edited dependency", () => {
+    expect(
+      wouldDependencyUpdateCreateCycle(dependencies, "a-b", "c", "b")
+    ).toBe(true)
+  })
+})

--- a/src/lib/schedule/__tests__/gantt-scroll.test.ts
+++ b/src/lib/schedule/__tests__/gantt-scroll.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import {
+  dominantScrollAxis,
+  lockWheelToDominantAxis,
+  normalizeWheelDelta,
+} from "../gantt-scroll"
+
+describe("Gantt dominant-axis scrolling", () => {
+  it("removes incidental horizontal movement from a vertical gesture", () => {
+    expect(lockWheelToDominantAxis(9, 64)).toEqual({
+      deltaX: 0,
+      deltaY: 64,
+    })
+  })
+
+  it("preserves intentional horizontal navigation", () => {
+    expect(lockWheelToDominantAxis(-72, 6)).toEqual({
+      deltaX: -72,
+      deltaY: 0,
+    })
+  })
+
+  it("chooses one axis for diagonal drag gestures", () => {
+    expect(dominantScrollAxis(18, 31)).toBe("vertical")
+    expect(dominantScrollAxis(42, 12)).toBe("horizontal")
+  })
+
+  it("normalizes line and page wheel deltas", () => {
+    expect(normalizeWheelDelta(2, 1, 500)).toBe(32)
+    expect(normalizeWheelDelta(-1, 2, 500)).toBe(-500)
+    expect(normalizeWheelDelta(24, 0, 500)).toBe(24)
+  })
+})

--- a/src/lib/schedule/__tests__/task-ordering.test.ts
+++ b/src/lib/schedule/__tests__/task-ordering.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+import { orderScheduleTasks } from "../task-ordering"
+import type { ScheduleTaskData } from "../types"
+
+function task(
+  id: string,
+  startDate: string,
+  endDateCalculated: string,
+  sortOrder: number,
+  title = id
+): ScheduleTaskData {
+  return {
+    id,
+    projectId: "project",
+    title,
+    startDate,
+    workdays: 1,
+    endDateCalculated,
+    phase: "construction",
+    displayColor: null,
+    status: "PENDING",
+    isCriticalPath: false,
+    isMilestone: false,
+    percentComplete: 0,
+    assignedTo: null,
+    sortOrder,
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T00:00:00.000Z",
+  }
+}
+
+describe("schedule task ordering", () => {
+  const tasks = [
+    task("third", "2026-08-01", "2026-08-03", 0),
+    task("second", "2026-07-02", "2026-07-04", 2),
+    task("first", "2026-07-02", "2026-07-03", 1),
+  ]
+
+  it("orders chronologically with stable date and saved-order tie breakers", () => {
+    expect(
+      orderScheduleTasks(tasks, "chronological").map((item) => item.id)
+    ).toEqual(["first", "second", "third"])
+  })
+
+  it("preserves saved manual order", () => {
+    expect(orderScheduleTasks(tasks, "manual").map((item) => item.id)).toEqual([
+      "third",
+      "first",
+      "second",
+    ])
+  })
+
+  it("does not mutate the source array", () => {
+    const originalIds = tasks.map((item) => item.id)
+    orderScheduleTasks(tasks, "chronological")
+    expect(tasks.map((item) => item.id)).toEqual(originalIds)
+  })
+})

--- a/src/lib/schedule/dependency-validation.ts
+++ b/src/lib/schedule/dependency-validation.ts
@@ -44,3 +44,18 @@ export function wouldCreateCycle(
 
   return false
 }
+
+export function wouldDependencyUpdateCreateCycle(
+  existingDependencies: readonly TaskDependencyData[],
+  dependencyId: string,
+  predecessorId: string,
+  successorId: string
+): boolean {
+  return wouldCreateCycle(
+    existingDependencies.filter(
+      (dependency) => dependency.id !== dependencyId
+    ),
+    predecessorId,
+    successorId
+  )
+}

--- a/src/lib/schedule/gantt-scroll.ts
+++ b/src/lib/schedule/gantt-scroll.ts
@@ -1,0 +1,41 @@
+export type GanttScrollAxis = "horizontal" | "vertical"
+
+interface WheelDelta {
+  readonly deltaX: number
+  readonly deltaY: number
+}
+
+export function dominantScrollAxis(
+  deltaX: number,
+  deltaY: number
+): GanttScrollAxis | null {
+  const horizontalDistance = Math.abs(deltaX)
+  const verticalDistance = Math.abs(deltaY)
+
+  if (horizontalDistance === 0 && verticalDistance === 0) return null
+  return horizontalDistance > verticalDistance ? "horizontal" : "vertical"
+}
+
+export function lockWheelToDominantAxis(
+  deltaX: number,
+  deltaY: number
+): WheelDelta {
+  const axis = dominantScrollAxis(deltaX, deltaY)
+  if (axis === "horizontal") {
+    return { deltaX, deltaY: 0 }
+  }
+  if (axis === "vertical") {
+    return { deltaX: 0, deltaY }
+  }
+  return { deltaX: 0, deltaY: 0 }
+}
+
+export function normalizeWheelDelta(
+  delta: number,
+  deltaMode: number,
+  pageSize: number
+): number {
+  if (deltaMode === 1) return delta * 16
+  if (deltaMode === 2) return delta * pageSize
+  return delta
+}

--- a/src/lib/schedule/task-ordering.ts
+++ b/src/lib/schedule/task-ordering.ts
@@ -1,0 +1,44 @@
+import type { ScheduleTaskData } from "./types"
+
+export type ScheduleOrderMode = "chronological" | "manual"
+
+function compareText(left: string, right: string): number {
+  return left.localeCompare(right, undefined, {
+    numeric: true,
+    sensitivity: "base",
+  })
+}
+
+export function isScheduleOrderMode(
+  value: string | null
+): value is ScheduleOrderMode {
+  return value === "chronological" || value === "manual"
+}
+
+export function scheduleOrderStorageKey(projectId: string): string {
+  return `compass-schedule-order:${projectId}`
+}
+
+export function orderScheduleTasks(
+  tasks: readonly ScheduleTaskData[],
+  mode: ScheduleOrderMode
+): ScheduleTaskData[] {
+  return [...tasks].sort((left, right) => {
+    if (mode === "manual") {
+      return (
+        left.sortOrder - right.sortOrder ||
+        compareText(left.startDate, right.startDate) ||
+        compareText(left.title, right.title) ||
+        compareText(left.id, right.id)
+      )
+    }
+
+    return (
+      compareText(left.startDate, right.startDate) ||
+      compareText(left.endDateCalculated, right.endDateCalculated) ||
+      left.sortOrder - right.sortOrder ||
+      compareText(left.title, right.title) ||
+      compareText(left.id, right.id)
+    )
+  })
+}


### PR DESCRIPTION
## What

- Add a project-persistent Chronological / Manual ordering control shared by the schedule List and Gantt views.
- Make saved predecessor, relationship type, and lag fields editable from the schedule-item editor.
- Validate edited links for duplicates and cycles, then batch the dependency and downstream date updates.
- Lock trackpad wheel and middle-button pan gestures to their dominant axis so vertical scrolling cannot nudge the timeline horizontally.
- Add focused regression coverage for ordering, dependency replacement, and scroll-axis behavior.

## Why

Staff reported that schedule items could not be viewed chronologically, existing predecessor details had to be deleted and recreated, and small diagonal trackpad deltas caused horizontal Gantt glitches during vertical scrolling.

## How to test

- `bunx vitest run src/lib/schedule/__tests__/task-ordering.test.ts src/lib/schedule/__tests__/gantt-scroll.test.ts src/lib/schedule/__tests__/dependency-validation.test.ts src/lib/schedule/__tests__/propagate-dates.test.ts`
- `bunx tsc --noEmit`
- Focused ESLint on changed source and tests
- `bun run build`

## Notes

The broad `bun test` command still collects Playwright specs and Bun-incompatible `better-sqlite3` integration tests; those existing harness failures are unrelated to this change.