### PR TITLE
fix(sidebar): use account photo fallback

### DIFF
--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -53,9 +53,6 @@ import { cn } from "@/lib/utils"
 import { getInitials } from "@/lib/utils"
 import type { SidebarUser } from "@/lib/auth"
 
-const MARTINE_DEFAULT_SIDEBAR_PHOTO =
-  "/user-desk-photos/martine-desk-photo.jpeg"
-
 function stopEvent(e: React.MouseEvent | React.PointerEvent): void {
   e.stopPropagation()
   e.preventDefault()
@@ -66,8 +63,6 @@ function stopPropagation(e: React.MouseEvent | React.PointerEvent): void {
 }
 
 function defaultSidebarPhoto(user: SidebarUser): string | null {
-  const identity = `${user.name} ${user.email}`.toLowerCase()
-  if (identity.includes("martine")) return MARTINE_DEFAULT_SIDEBAR_PHOTO
   return user.avatar
 }
 


### PR DESCRIPTION
## Summary

- use the signed-in user's account/Google photo when no custom sidebar photo is set
- remove the reference to a nonexistent static default image
- keep custom sidebar and dashboard desk photos independent

## Verification

- `bunx tsc --noEmit`
- focused ESLint for the changed component and storage helper
- `bun run test -- src/lib/__tests__/user-photo-storage.test.ts`
- production build completed successfully in the pre-push hook
- live signed-in verification identified the missing fallback asset
