### PR TITLE
feat(preview): keep audience views in standalone window

### DIFF
--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -119,6 +119,7 @@ export type AudienceContact = {
 
 export type ProjectAudiencePreview = {
   readonly audience: ProjectAudience
+  readonly viewerIsInternal: boolean
   readonly projectOptions: readonly AudienceProjectOption[]
   readonly project: {
     readonly id: string
@@ -143,6 +144,7 @@ async function verifyProjectAccess(
 ): Promise<{
   readonly db: ReturnType<typeof getDb>
   readonly organizationId: string
+  readonly viewerIsInternal: boolean
 }> {
   const user = await requireAuth()
   requirePermission(user, "project", "read")
@@ -154,7 +156,8 @@ async function verifyProjectAccess(
   if (!project.organizationId) {
     throw new Error("Project organization is missing")
   }
-  if (!isInternalStaffRole(user.role)) {
+  const viewerIsInternal = isInternalStaffRole(user.role)
+  if (!viewerIsInternal) {
     const membership = await db
       .select({ role: projectMembers.role })
       .from(projectMembers)
@@ -170,7 +173,11 @@ async function verifyProjectAccess(
     }
   }
 
-  return { db, organizationId: project.organizationId }
+  return {
+    db,
+    organizationId: project.organizationId,
+    viewerIsInternal,
+  }
 }
 
 function isActiveStatus(value: string): boolean {
@@ -212,7 +219,7 @@ export async function getProjectAudiencePreview(
   projectId: string,
   audience: ProjectAudience
 ): Promise<ProjectAudiencePreview> {
-  const { db, organizationId } = await verifyProjectAccess(
+  const { db, organizationId, viewerIsInternal } = await verifyProjectAccess(
     projectId,
     audience
   )
@@ -438,6 +445,7 @@ export async function getProjectAudiencePreview(
 
   return {
     audience,
+    viewerIsInternal,
     projectOptions,
     project,
     ownerUpdates: ownerUpdateRows,

--- a/src/app/dashboard/projects/[id]/page.tsx
+++ b/src/app/dashboard/projects/[id]/page.tsx
@@ -12,6 +12,7 @@ import {
 import { getCurrentUser } from "@/lib/auth"
 import { canManageProjectRegistry } from "@/lib/permissions"
 import { getProjectAccessRecord } from "@/lib/project-access"
+import { projectAudiencePreviewHref } from "@/lib/project-audience-preview-routes"
 import { and, eq } from "drizzle-orm"
 import { notFound, redirect } from "next/navigation"
 import Link from "next/link"
@@ -157,13 +158,13 @@ export default async function ProjectSummaryPage({
       .get()
     projectRole = routeMembership?.role ?? null
     if (projectRole === "client" || projectRole === "owner") {
-      redirect(`/dashboard/projects/${id}/owner-updates`)
+      redirect(projectAudiencePreviewHref(id, "owner"))
     }
     if (
       projectRole === "subcontractor" ||
       projectRole === "supplier"
     ) {
-      redirect(`/dashboard/projects/${id}/preview/sub-vendor`)
+      redirect(projectAudiencePreviewHref(id, "sub-vendor"))
     }
 
     const [found] = await db

--- a/src/app/dashboard/projects/[id]/preview/owner/page.tsx
+++ b/src/app/dashboard/projects/[id]/preview/owner/page.tsx
@@ -1,32 +1,11 @@
-export const dynamic = "force-dynamic"
-
-import type * as React from "react"
-import { notFound } from "next/navigation"
-
-import {
-  getProjectAudiencePreview,
-  type ProjectAudiencePreview as ProjectAudiencePreviewData,
-} from "@/app/actions/project-audience-preview"
-import { ProjectAudiencePreview } from "@/components/projects/project-audience-preview"
-
-function hasDigest(error: unknown): error is { readonly digest: string } {
-  return typeof error === "object" && error !== null && "digest" in error
-}
+import { redirect } from "next/navigation"
+import { projectAudiencePreviewHref } from "@/lib/project-audience-preview-routes"
 
 export default async function OwnerPreviewPage({
   params,
 }: {
   params: Promise<{ id: string }>
-}): Promise<React.ReactElement> {
+}): Promise<never> {
   const { id } = await params
-  let data: ProjectAudiencePreviewData
-
-  try {
-    data = await getProjectAudiencePreview(id, "owner")
-  } catch (error) {
-    if (hasDigest(error) && error.digest === "NEXT_NOT_FOUND") throw error
-    notFound()
-  }
-
-  return <ProjectAudiencePreview data={data} />
+  redirect(projectAudiencePreviewHref(id, "owner"))
 }

--- a/src/app/dashboard/projects/[id]/preview/sub-vendor/page.tsx
+++ b/src/app/dashboard/projects/[id]/preview/sub-vendor/page.tsx
@@ -1,32 +1,11 @@
-export const dynamic = "force-dynamic"
-
-import type * as React from "react"
-import { notFound } from "next/navigation"
-
-import {
-  getProjectAudiencePreview,
-  type ProjectAudiencePreview as ProjectAudiencePreviewData,
-} from "@/app/actions/project-audience-preview"
-import { ProjectAudiencePreview } from "@/components/projects/project-audience-preview"
-
-function hasDigest(error: unknown): error is { readonly digest: string } {
-  return typeof error === "object" && error !== null && "digest" in error
-}
+import { redirect } from "next/navigation"
+import { projectAudiencePreviewHref } from "@/lib/project-audience-preview-routes"
 
 export default async function SubVendorPreviewPage({
   params,
 }: {
   params: Promise<{ id: string }>
-}): Promise<React.ReactElement> {
+}): Promise<never> {
   const { id } = await params
-  let data: ProjectAudiencePreviewData
-
-  try {
-    data = await getProjectAudiencePreview(id, "sub_vendor")
-  } catch (error) {
-    if (hasDigest(error) && error.digest === "NEXT_NOT_FOUND") throw error
-    notFound()
-  }
-
-  return <ProjectAudiencePreview data={data} />
+  redirect(projectAudiencePreviewHref(id, "sub-vendor"))
 }

--- a/src/app/preview/projects/[id]/owner/page.tsx
+++ b/src/app/preview/projects/[id]/owner/page.tsx
@@ -1,0 +1,32 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+import { notFound } from "next/navigation"
+
+import {
+  getProjectAudiencePreview,
+  type ProjectAudiencePreview as ProjectAudiencePreviewData,
+} from "@/app/actions/project-audience-preview"
+import { ProjectAudiencePreview } from "@/components/projects/project-audience-preview"
+
+function hasDigest(error: unknown): error is { readonly digest: string } {
+  return typeof error === "object" && error !== null && "digest" in error
+}
+
+export default async function OwnerPreviewPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  let data: ProjectAudiencePreviewData
+
+  try {
+    data = await getProjectAudiencePreview(id, "owner")
+  } catch (error) {
+    if (hasDigest(error) && error.digest === "NEXT_NOT_FOUND") throw error
+    notFound()
+  }
+
+  return <ProjectAudiencePreview data={data} />
+}

--- a/src/app/preview/projects/[id]/owner/updates/[updateId]/page.tsx
+++ b/src/app/preview/projects/[id]/owner/updates/[updateId]/page.tsx
@@ -1,0 +1,75 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+import { notFound } from "next/navigation"
+
+import {
+  getProjectAudiencePreview,
+  type ProjectAudiencePreview,
+} from "@/app/actions/project-audience-preview"
+import {
+  getOwnerProjectUpdateDocument,
+  type OwnerProjectUpdateDocument,
+} from "@/app/actions/project-field"
+import { OwnerUpdateDocument } from "@/components/projects/owner-update-document"
+import { ProjectAudiencePreviewShell } from "@/components/projects/project-audience-preview-shell"
+import { projectAudiencePreviewHref } from "@/lib/project-audience-preview-routes"
+
+function hasDigest(error: unknown): error is { readonly digest: string } {
+  return typeof error === "object" && error !== null && "digest" in error
+}
+
+async function loadOwnerUpdatePreview(
+  projectId: string,
+  updateId: string
+): Promise<{
+  readonly document: OwnerProjectUpdateDocument
+  readonly preview: ProjectAudiencePreview
+}> {
+  try {
+    const [document, preview] = await Promise.all([
+      getOwnerProjectUpdateDocument(projectId, updateId),
+      getProjectAudiencePreview(projectId, "owner"),
+    ])
+
+    if (document.update.status !== "published") {
+      notFound()
+    }
+
+    return { document, preview }
+  } catch (error) {
+    if (hasDigest(error) && error.digest === "NEXT_NOT_FOUND") throw error
+    notFound()
+  }
+}
+
+export default async function OwnerUpdatePreviewPage({
+  params,
+}: {
+  readonly params: Promise<{
+    readonly id: string
+    readonly updateId: string
+  }>
+}): Promise<React.ReactElement> {
+  const { id, updateId } = await params
+  const { document, preview } = await loadOwnerUpdatePreview(id, updateId)
+  const homeHref = projectAudiencePreviewHref(id, "owner")
+
+  return (
+    <ProjectAudiencePreviewShell
+      audience="owner"
+      projectId={preview.project.id}
+      projectName={preview.project.name}
+      projectNumber={preview.project.projectNumber}
+      viewerIsInternal={preview.viewerIsInternal}
+    >
+      <OwnerUpdateDocument
+        document={document}
+        previewMode={{
+          homeHref,
+          photosHref: `${homeHref}#photos`,
+        }}
+      />
+    </ProjectAudiencePreviewShell>
+  )
+}

--- a/src/app/preview/projects/[id]/sub-vendor/page.tsx
+++ b/src/app/preview/projects/[id]/sub-vendor/page.tsx
@@ -1,0 +1,32 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+import { notFound } from "next/navigation"
+
+import {
+  getProjectAudiencePreview,
+  type ProjectAudiencePreview as ProjectAudiencePreviewData,
+} from "@/app/actions/project-audience-preview"
+import { ProjectAudiencePreview } from "@/components/projects/project-audience-preview"
+
+function hasDigest(error: unknown): error is { readonly digest: string } {
+  return typeof error === "object" && error !== null && "digest" in error
+}
+
+export default async function SubVendorPreviewPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  let data: ProjectAudiencePreviewData
+
+  try {
+    data = await getProjectAudiencePreview(id, "sub_vendor")
+  } catch (error) {
+    if (hasDigest(error) && error.digest === "NEXT_NOT_FOUND") throw error
+    notFound()
+  }
+
+  return <ProjectAudiencePreview data={data} />
+}

--- a/src/components/nav-projects.tsx
+++ b/src/components/nav-projects.tsx
@@ -33,6 +33,7 @@ import {
 import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
 import { cn } from "@/lib/utils"
 import type { ProjectListItem } from "@/app/actions/projects"
+import { projectAudiencePreviewHref } from "@/lib/project-audience-preview-routes"
 
 type ProjectSectionKey =
   | "overview"
@@ -159,8 +160,19 @@ const PROJECT_SECTION_ITEMS: readonly ProjectSectionItem[] = [
 ]
 
 function projectSectionHref(projectId: string, suffix: string): string {
+  if (suffix === "preview/owner") {
+    return projectAudiencePreviewHref(projectId, "owner")
+  }
+  if (suffix === "preview/sub-vendor") {
+    return projectAudiencePreviewHref(projectId, "sub-vendor")
+  }
+
   const baseHref = `/dashboard/projects/${projectId}`
   return suffix ? `${baseHref}/${suffix}` : baseHref
+}
+
+function isPreviewSection(section: ProjectSectionKey): boolean {
+  return section === "preview-owner" || section === "preview-sub-vendor"
 }
 
 function projectTargetSection(
@@ -270,7 +282,15 @@ export function NavProjects({
                         "bg-sidebar-foreground/10 font-medium"
                     )}
                   >
-                    <Link href={projectSectionHref(activeId, item.hrefSuffix)}>
+                    <Link
+                      href={projectSectionHref(activeId, item.hrefSuffix)}
+                      target={isPreviewSection(item.section) ? "_blank" : undefined}
+                      rel={
+                        isPreviewSection(item.section)
+                          ? "noopener noreferrer"
+                          : undefined
+                      }
+                    >
                       <item.icon />
                       <span>{item.title}</span>
                     </Link>

--- a/src/components/projects/owner-cover-photo-control.tsx
+++ b/src/components/projects/owner-cover-photo-control.tsx
@@ -62,6 +62,8 @@ type OwnerCoverPhotoControlProps = {
       }
     | null
   readonly approvedPhotos: readonly OwnerCoverPhotoOption[]
+  readonly latestUpdateHref: string | null
+  readonly editable?: boolean
 }
 
 function storageKey(projectId: string): string {
@@ -207,6 +209,8 @@ export function OwnerCoverPhotoControl({
   latestUpdate,
   nextScheduleItem,
   approvedPhotos,
+  latestUpdateHref,
+  editable = true,
 }: OwnerCoverPhotoControlProps): React.ReactElement {
   const [open, setOpen] = React.useState(false)
   const [selection, setSelection] =
@@ -215,8 +219,8 @@ export function OwnerCoverPhotoControl({
   const [message, setMessage] = React.useState<string | null>(null)
 
   React.useEffect(() => {
-    setSelection(readCoverSelection(projectId))
-  }, [projectId])
+    setSelection(editable ? readCoverSelection(projectId) : null)
+  }, [editable, projectId])
 
   const coverUrl = approvedCoverPhotoUrl(selection, approvedPhotos)
 
@@ -297,19 +301,20 @@ export function OwnerCoverPhotoControl({
         )}
         <div className="absolute inset-0 bg-black/45" />
         <div className="relative flex min-h-[370px] flex-col justify-between gap-6 p-5 sm:p-8">
-          <div className="flex justify-end">
-            <Dialog open={open} onOpenChange={setOpen}>
-              <DialogTrigger asChild>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  className="bg-white/90 text-[#17231c] hover:bg-white"
-                >
-                  <IconPhotoEdit className="size-4" />
-                  Change cover
-                </Button>
-              </DialogTrigger>
-              <DialogContent className="max-h-[88vh] overflow-y-auto sm:max-w-3xl">
+          {editable && (
+            <div className="flex justify-end">
+              <Dialog open={open} onOpenChange={setOpen}>
+                <DialogTrigger asChild>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="bg-white/90 text-[#17231c] hover:bg-white"
+                  >
+                    <IconPhotoEdit className="size-4" />
+                    Change cover
+                  </Button>
+                </DialogTrigger>
+                <DialogContent className="max-h-[88vh] overflow-y-auto sm:max-w-3xl">
                 <DialogHeader>
                   <DialogTitle>Choose a cover photo</DialogTitle>
                   <DialogDescription>
@@ -408,9 +413,10 @@ export function OwnerCoverPhotoControl({
                     Use latest approved photo
                   </Button>
                 </DialogFooter>
-              </DialogContent>
-            </Dialog>
-          </div>
+                </DialogContent>
+              </Dialog>
+            </div>
+          )}
 
           <div className="flex flex-col gap-6">
             <div className="max-w-3xl">
@@ -443,9 +449,9 @@ export function OwnerCoverPhotoControl({
                   {latestUpdate?.title ??
                     "Your next project update is being prepared."}
                 </p>
-                {latestUpdate && (
+                {latestUpdate && latestUpdateHref && (
                   <a
-                    href={`/dashboard/projects/${projectId}/owner-updates/${latestUpdate.id}`}
+                    href={latestUpdateHref}
                     className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-white hover:underline"
                   >
                     Read update

--- a/src/components/projects/owner-update-document.tsx
+++ b/src/components/projects/owner-update-document.tsx
@@ -18,6 +18,7 @@ import { OwnerUpdateActions } from "@/components/projects/owner-update-actions"
 import { OwnerUpdateDraftEditor } from "@/components/projects/owner-update-draft-editor"
 import { OwnerUpdatePhotoTile } from "@/components/projects/owner-update-photo-tile"
 import { projectBrandFor } from "@/lib/project-branding"
+import { projectAudiencePreviewHref } from "@/lib/project-audience-preview-routes"
 
 function formatDate(value: string): string {
   return new Date(`${value}T00:00:00`).toLocaleDateString("en-US", {
@@ -58,8 +59,13 @@ function ownerUpdateDocumentHref(input: {
 
 export function OwnerUpdateDocument({
   document,
+  previewMode,
 }: {
   readonly document: OwnerProjectUpdateDocument
+  readonly previewMode?: {
+    readonly homeHref: string
+    readonly photosHref: string
+  }
 }): React.ReactElement {
   const label = projectLabel(document)
   const updateUrl =
@@ -81,25 +87,34 @@ export function OwnerUpdateDocument({
       <div className="mx-auto flex max-w-5xl flex-col gap-4 px-4 py-4 sm:px-6 lg:px-8 print:max-w-none print:px-0">
         <div className="flex flex-wrap items-center justify-between gap-3 print:hidden">
           <Button asChild variant="ghost" size="sm">
-            <Link href={`/dashboard/projects/${document.project.id}`}>
+            <Link
+              href={
+                previewMode?.homeHref ??
+                `/dashboard/projects/${document.project.id}`
+              }
+            >
               <IconArrowLeft className="size-4" />
-              Project
+              {previewMode ? "Owner Compass" : "Project"}
             </Link>
           </Button>
-          <OwnerUpdateActions
-            canManage={document.canManage}
-            projectId={document.project.id}
-            updateId={document.update.id}
-            status={document.update.status}
-            emailSubject={emailSubject}
-            emailPreview={emailPreview}
-            updatePath={updateUrl}
-            projectLabel={label}
-            updateTitle={document.update.title}
-          />
+          {!previewMode && (
+            <OwnerUpdateActions
+              canManage={document.canManage}
+              projectId={document.project.id}
+              updateId={document.update.id}
+              status={document.update.status}
+              emailSubject={emailSubject}
+              emailPreview={emailPreview}
+              updatePath={updateUrl}
+              projectLabel={label}
+              updateTitle={document.update.title}
+            />
+          )}
         </div>
 
-        {document.canManage && document.update.status !== "published" && (
+        {!previewMode &&
+          document.canManage &&
+          document.update.status !== "published" && (
           <OwnerUpdateDraftEditor document={document} />
         )}
 
@@ -277,7 +292,12 @@ export function OwnerUpdateDocument({
                     className="print:hidden"
                   >
                     <Link
-                      href={`/dashboard/projects/${document.project.id}/preview/owner#photos`}
+                      href={
+                        previewMode?.photosHref ??
+                        `${projectAudiencePreviewHref(document.project.id, "owner")}#photos`
+                      }
+                      target={previewMode ? undefined : "_blank"}
+                      rel={previewMode ? undefined : "noopener noreferrer"}
                     >
                       <IconPhotoUp className="size-4" />
                       View all approved photos

--- a/src/components/projects/project-actions-menu.tsx
+++ b/src/components/projects/project-actions-menu.tsx
@@ -20,6 +20,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { projectAudiencePreviewHref } from "@/lib/project-audience-preview-routes"
 
 export function ProjectActionsMenu({
   projectId,
@@ -88,13 +89,21 @@ export function ProjectActionsMenu({
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild>
-          <Link href={`/dashboard/projects/${projectId}/preview/owner`}>
+          <Link
+            href={projectAudiencePreviewHref(projectId, "owner")}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <IconEye />
             Owner preview
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild>
-          <Link href={`/dashboard/projects/${projectId}/preview/sub-vendor`}>
+          <Link
+            href={projectAudiencePreviewHref(projectId, "sub-vendor")}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <IconUsers />
             Sub/vendor preview
           </Link>

--- a/src/components/projects/project-audience-preview-shell.tsx
+++ b/src/components/projects/project-audience-preview-shell.tsx
@@ -1,0 +1,145 @@
+import type * as React from "react"
+import Link from "next/link"
+import { IconBuilding, IconEye } from "@tabler/icons-react"
+
+import type { ProjectAudience } from "@/lib/project-audience-access"
+import { projectAudiencePreviewHref } from "@/lib/project-audience-preview-routes"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { ProjectAudiencePreviewWindowControls } from "@/components/projects/project-audience-preview-window-controls"
+import { cn } from "@/lib/utils"
+
+type PreviewNavigationItem = {
+  readonly label: string
+  readonly anchor: string
+}
+
+const OWNER_NAVIGATION: readonly PreviewNavigationItem[] = [
+  { label: "Home", anchor: "overview" },
+  { label: "Updates", anchor: "updates" },
+  { label: "Schedule", anchor: "schedule" },
+  { label: "Photos", anchor: "photos" },
+  { label: "Team", anchor: "team" },
+]
+
+const SUB_VENDOR_NAVIGATION: readonly PreviewNavigationItem[] = [
+  { label: "Home", anchor: "overview" },
+  { label: "Schedule", anchor: "schedule" },
+  { label: "Commitments", anchor: "commitments" },
+  { label: "RFIs", anchor: "rfis" },
+  { label: "Messages", anchor: "messages" },
+  { label: "Photos", anchor: "photos" },
+  { label: "Team", anchor: "team" },
+]
+
+function audienceRoute(audience: ProjectAudience): "owner" | "sub-vendor" {
+  return audience === "owner" ? "owner" : "sub-vendor"
+}
+
+export function ProjectAudiencePreviewShell({
+  audience,
+  projectId,
+  projectName,
+  projectNumber,
+  viewerIsInternal,
+  children,
+}: {
+  readonly audience: ProjectAudience
+  readonly projectId: string
+  readonly projectName: string
+  readonly projectNumber: string | null
+  readonly viewerIsInternal: boolean
+  readonly children: React.ReactNode
+}): React.ReactElement {
+  const routeAudience = audienceRoute(audience)
+  const homeHref = projectAudiencePreviewHref(projectId, routeAudience)
+  const navigation =
+    audience === "owner" ? OWNER_NAVIGATION : SUB_VENDOR_NAVIGATION
+
+  return (
+    <div className="min-h-screen bg-muted/20 text-foreground">
+      <header className="sticky top-0 z-40 border-b bg-background/95 shadow-sm backdrop-blur">
+        {viewerIsInternal && (
+          <div className="border-b bg-amber-50 px-4 py-2 text-amber-950 dark:bg-amber-950 dark:text-amber-50">
+            <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-2">
+              <p className="flex items-center gap-2 text-xs font-medium">
+                <IconEye className="size-4" />
+                Preview mode — this is the Compass experience visible to{" "}
+                {audience === "owner" ? "owners" : "subcontractors and vendors"}.
+              </p>
+              <div className="flex items-center gap-2">
+                <Button
+                  asChild
+                  size="sm"
+                  variant={audience === "owner" ? "default" : "outline"}
+                >
+                  <Link href={projectAudiencePreviewHref(projectId, "owner")}>
+                    Owner
+                  </Link>
+                </Button>
+                <Button
+                  asChild
+                  size="sm"
+                  variant={audience === "sub_vendor" ? "default" : "outline"}
+                >
+                  <Link
+                    href={projectAudiencePreviewHref(projectId, "sub-vendor")}
+                  >
+                    Sub/vendor
+                  </Link>
+                </Button>
+                <ProjectAudiencePreviewWindowControls />
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="mx-auto flex max-w-7xl flex-wrap items-center gap-x-6 gap-y-3 px-4 py-3 sm:px-6">
+          <Link href={homeHref} className="flex min-w-0 items-center gap-3">
+            <span className="grid size-9 shrink-0 place-items-center rounded-md bg-primary text-primary-foreground">
+              <IconBuilding className="size-5" />
+            </span>
+            <span className="min-w-0">
+              <span className="block truncate text-sm font-semibold">
+                Compass
+              </span>
+              <span className="block truncate text-xs text-muted-foreground">
+                {projectNumber ? `${projectNumber} · ` : ""}
+                {projectName}
+              </span>
+            </span>
+          </Link>
+
+          <nav
+            aria-label={`${audience === "owner" ? "Owner" : "Subcontractor and vendor"} preview`}
+            className="order-3 flex w-full gap-1 overflow-x-auto border-t pt-3 sm:order-none sm:w-auto sm:flex-1 sm:border-0 sm:pt-0"
+          >
+            {navigation.map((item) => (
+              <Link
+                key={item.anchor}
+                href={`${homeHref}#${item.anchor}`}
+                className="whitespace-nowrap rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+
+          <Badge
+            variant="outline"
+            className={cn(
+              "ml-auto",
+              audience === "owner"
+                ? "border-emerald-700/30 text-emerald-800 dark:text-emerald-300"
+                : "border-sky-700/30 text-sky-800 dark:text-sky-300"
+            )}
+          >
+            {audience === "owner" ? "Owner Compass" : "Partner Compass"}
+          </Badge>
+        </div>
+      </header>
+
+      {children}
+    </div>
+  )
+}

--- a/src/components/projects/project-audience-preview-window-controls.tsx
+++ b/src/components/projects/project-audience-preview-window-controls.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import { IconX } from "@tabler/icons-react"
+
+import { Button } from "@/components/ui/button"
+
+export function ProjectAudiencePreviewWindowControls(): React.ReactElement {
+  function closePreview(): void {
+    window.close()
+  }
+
+  return (
+    <Button type="button" variant="outline" size="sm" onClick={closePreview}>
+      <IconX className="size-4" />
+      Close preview
+    </Button>
+  )
+}

--- a/src/components/projects/project-audience-preview.tsx
+++ b/src/components/projects/project-audience-preview.tsx
@@ -1,7 +1,6 @@
 import type * as React from "react"
 import Link from "next/link"
 import {
-  IconArrowLeft,
   IconArrowRight,
   IconCalendarStats,
   IconChevronDown,
@@ -35,6 +34,11 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { OwnerCoverPhotoControl } from "@/components/projects/owner-cover-photo-control"
 import { ProjectAudiencePhotoGallery } from "@/components/projects/project-audience-photo-gallery"
+import { ProjectAudiencePreviewShell } from "@/components/projects/project-audience-preview-shell"
+import {
+  ownerUpdatePreviewHref,
+  projectAudiencePreviewHref,
+} from "@/lib/project-audience-preview-routes"
 
 function formatDate(value: string | null): string {
   if (!value) return "Unscheduled"
@@ -50,10 +54,6 @@ function statusLabel(value: string): string {
     .split("_")
     .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
     .join(" ")
-}
-
-function audienceLabel(value: ProjectAudience): string {
-  return value === "owner" ? "Owner Preview" : "Sub/Vendor Preview"
 }
 
 function audienceDescription(value: ProjectAudience): string {
@@ -74,8 +74,8 @@ function projectOptionLabel(project: AudienceProjectOption): string {
 
 function previewPath(projectId: string, audience: ProjectAudience): string {
   return audience === "owner"
-    ? `/dashboard/projects/${projectId}/preview/owner`
-    : `/dashboard/projects/${projectId}/preview/sub-vendor`
+    ? projectAudiencePreviewHref(projectId, "owner")
+    : projectAudiencePreviewHref(projectId, "sub-vendor")
 }
 
 function recordTypeLabel(value: string): string {
@@ -214,12 +214,14 @@ function RfiRow({
 
 function MessageChannelRow({
   channel,
+  previewHref,
 }: {
   readonly channel: AudienceMessageChannel
+  readonly previewHref: string
 }): React.ReactElement {
   return (
     <Link
-      href={`/dashboard/conversations/${channel.id}`}
+      href={`${previewHref}?channel=${encodeURIComponent(channel.id)}#messages`}
       className="block rounded-md border bg-background p-3 transition-colors hover:bg-accent"
     >
       <div className="flex items-center justify-between gap-3">
@@ -284,35 +286,6 @@ function ownerHeroTitle(data: ProjectAudiencePreviewData): string {
     : projectLabel(data)
 }
 
-function OwnerPreviewControls({
-  projectId,
-}: {
-  readonly projectId: string
-}): React.ReactElement {
-  return (
-    <div className="flex flex-wrap items-center justify-between gap-3">
-      <Button asChild variant="ghost" size="sm">
-        <Link href={`/dashboard/projects/${projectId}`}>
-          <IconArrowLeft className="size-4" />
-          Project
-        </Link>
-      </Button>
-      <div className="flex flex-wrap gap-2">
-        <Button asChild variant="default" size="sm">
-          <Link href={`/dashboard/projects/${projectId}/preview/owner`}>
-            Owner
-          </Link>
-        </Button>
-        <Button asChild variant="outline" size="sm">
-          <Link href={`/dashboard/projects/${projectId}/preview/sub-vendor`}>
-            Sub/vendor
-          </Link>
-        </Button>
-      </div>
-    </div>
-  )
-}
-
 function OwnerUpdateCard({
   projectId,
   update,
@@ -355,7 +328,7 @@ function OwnerUpdateCard({
         size="sm"
         className="mt-4"
       >
-        <Link href={`/dashboard/projects/${projectId}/owner-updates/${update.id}`}>
+        <Link href={ownerUpdatePreviewHref(projectId, update.id)}>
           Open update
           <IconArrowRight className="size-4" />
         </Link>
@@ -466,41 +439,48 @@ function OwnerProjectPreview({
   return (
     <main className="min-h-screen bg-[oklch(0.96_0.018_115)]">
       <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 sm:px-6 lg:px-8">
-        <OwnerPreviewControls projectId={data.project.id} />
-        <OwnerCoverPhotoControl
-          projectId={data.project.id}
-          projectTitle={ownerHeroTitle(data)}
-          projectLabel={projectLabel(data)}
-          projectAddress={data.project.address}
-          latestUpdate={
-            latestUpdate
-              ? {
-                  id: latestUpdate.id,
-                  title: latestUpdate.title,
-                }
-              : null
-          }
-          nextScheduleItem={
-            nextScheduleItem
-              ? {
-                  title: nextScheduleItem.title,
-                  dateRange:
-                    `${formatDate(nextScheduleItem.startDate)} - ` +
-                    formatDate(nextScheduleItem.endDate),
-                }
-              : null
-          }
-          approvedPhotos={data.photos.map((photo) => ({
-            id: photo.id,
-            fileName: photo.fileName,
-            driveFileId: photo.driveFileId,
-            thumbnailUrl: photo.thumbnailUrl,
-            caption: photo.caption,
-          }))}
-        />
+        <div id="overview" className="scroll-mt-36">
+          <OwnerCoverPhotoControl
+            projectId={data.project.id}
+            projectTitle={ownerHeroTitle(data)}
+            projectLabel={projectLabel(data)}
+            projectAddress={data.project.address}
+            latestUpdate={
+              latestUpdate
+                ? {
+                    id: latestUpdate.id,
+                    title: latestUpdate.title,
+                  }
+                : null
+            }
+            nextScheduleItem={
+              nextScheduleItem
+                ? {
+                    title: nextScheduleItem.title,
+                    dateRange:
+                      `${formatDate(nextScheduleItem.startDate)} - ` +
+                      formatDate(nextScheduleItem.endDate),
+                  }
+                : null
+            }
+            approvedPhotos={data.photos.map((photo) => ({
+              id: photo.id,
+              fileName: photo.fileName,
+              driveFileId: photo.driveFileId,
+              thumbnailUrl: photo.thumbnailUrl,
+              caption: photo.caption,
+            }))}
+            latestUpdateHref={
+              latestUpdate
+                ? ownerUpdatePreviewHref(data.project.id, latestUpdate.id)
+                : null
+            }
+            editable={false}
+          />
+        </div>
 
         <section className="grid gap-4 lg:grid-cols-[1.15fr_0.85fr]">
-          <div className="space-y-4">
+          <div id="updates" className="scroll-mt-36 space-y-4">
             <div className="flex items-center justify-between gap-3">
               <div>
                 <p className="text-xs font-medium uppercase text-muted-foreground">
@@ -535,7 +515,10 @@ function OwnerProjectPreview({
           </div>
 
           <aside className="space-y-4">
-            <section className="rounded-lg border bg-background p-5">
+            <section
+              id="schedule"
+              className="scroll-mt-36 rounded-lg border bg-background p-5"
+            >
               <div className="flex items-center gap-2">
                 <IconCalendarStats className="size-4 text-muted-foreground" />
                 <h2 className="text-sm font-semibold">What happens next</h2>
@@ -553,7 +536,10 @@ function OwnerProjectPreview({
               )}
             </section>
 
-            <section className="rounded-lg border bg-background p-5">
+            <section
+              id="team"
+              className="scroll-mt-36 rounded-lg border bg-background p-5"
+            >
               <div className="flex items-center gap-2">
                 <IconSparkles className="size-4 text-muted-foreground" />
                 <h2 className="text-sm font-semibold">Your project team</h2>
@@ -595,11 +581,13 @@ function OwnerProjectPreview({
           </aside>
         </section>
 
-        <ProjectAudiencePhotoGallery
-          photos={data.photos}
-          title="Approved Photo Gallery"
-          emptyMessage="No photos have been approved for this audience yet."
-        />
+        <div id="photos" className="scroll-mt-36">
+          <ProjectAudiencePhotoGallery
+            photos={data.photos}
+            title="Approved Photo Gallery"
+            emptyMessage="No photos have been approved for this audience yet."
+          />
+        </div>
       </div>
     </main>
   )
@@ -620,49 +608,38 @@ export function ProjectAudiencePreview({
   })
 
   if (isOwner) {
-    return <OwnerProjectPreview data={data} />
+    return (
+      <ProjectAudiencePreviewShell
+        audience={data.audience}
+        projectId={data.project.id}
+        projectName={data.project.name}
+        projectNumber={data.project.projectNumber}
+        viewerIsInternal={data.viewerIsInternal}
+      >
+        <OwnerProjectPreview data={data} />
+      </ProjectAudiencePreviewShell>
+    )
   }
 
   return (
-    <main className="min-h-screen bg-muted/30">
-      <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 sm:px-6 lg:px-8">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <Button asChild variant="ghost" size="sm">
-            <Link href={`/dashboard/projects/${data.project.id}`}>
-              <IconArrowLeft className="size-4" />
-              Project
-            </Link>
-          </Button>
-          <div className="flex flex-wrap gap-2">
-            <Button
-              asChild
-              variant={isOwner ? "default" : "outline"}
-              size="sm"
-            >
-              <Link href={`/dashboard/projects/${data.project.id}/preview/owner`}>
-                Owner
-              </Link>
-            </Button>
-            <Button
-              asChild
-              variant={isOwner ? "outline" : "default"}
-              size="sm"
-            >
-              <Link
-                href={`/dashboard/projects/${data.project.id}/preview/sub-vendor`}
-              >
-                Sub/vendor
-              </Link>
-            </Button>
-          </div>
-        </div>
-
-        <section className="rounded-lg border bg-background p-5 sm:p-6">
+    <ProjectAudiencePreviewShell
+      audience={data.audience}
+      projectId={data.project.id}
+      projectName={data.project.name}
+      projectNumber={data.project.projectNumber}
+      viewerIsInternal={data.viewerIsInternal}
+    >
+      <main className="min-h-screen bg-muted/30">
+        <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 sm:px-6 lg:px-8">
+        <section
+          id="overview"
+          className="scroll-mt-36 rounded-lg border bg-background p-5 sm:p-6"
+        >
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div>
-              <Badge variant="secondary">Internal preview</Badge>
+              <Badge variant="secondary">Partner project home</Badge>
               <h1 className="mt-3 text-2xl font-semibold tracking-tight">
-                {audienceLabel(data.audience)}
+                {data.project.name}
               </h1>
               <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
                 {audienceDescription(data.audience)}
@@ -734,7 +711,10 @@ export function ProjectAudiencePreview({
 
         {!isOwner && <AudienceMetricStrip data={data} />}
 
-        <section className="rounded-lg border bg-background p-4 sm:p-5">
+        <section
+          id="team"
+          className="scroll-mt-36 rounded-lg border bg-background p-4 sm:p-5"
+        >
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="flex items-center gap-2">
               <IconUsers className="size-4 text-muted-foreground" />
@@ -802,7 +782,10 @@ export function ProjectAudiencePreview({
         )}
 
         <section className="grid gap-4 lg:grid-cols-[1fr_0.85fr]">
-          <div className="rounded-lg border bg-background p-4 sm:p-5">
+          <div
+            id="schedule"
+            className="scroll-mt-36 rounded-lg border bg-background p-4 sm:p-5"
+          >
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div className="flex items-center gap-2">
                 <IconCalendarStats className="size-4 text-muted-foreground" />
@@ -825,7 +808,10 @@ export function ProjectAudiencePreview({
             )}
           </div>
 
-          <div className="rounded-lg border bg-background p-4 sm:p-5">
+          <div
+            id="commitments"
+            className="scroll-mt-36 rounded-lg border bg-background p-4 sm:p-5"
+          >
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div className="flex items-center gap-2">
                 <IconUsers className="size-4 text-muted-foreground" />
@@ -872,7 +858,10 @@ export function ProjectAudiencePreview({
 
         {!isOwner && (
           <section className="grid gap-4 lg:grid-cols-[1fr_0.85fr]">
-            <div className="rounded-lg border bg-background p-4 sm:p-5">
+            <div
+              id="rfis"
+              className="scroll-mt-36 rounded-lg border bg-background p-4 sm:p-5"
+            >
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="flex items-center gap-2">
                   <IconQuestionMark className="size-4 text-muted-foreground" />
@@ -893,7 +882,10 @@ export function ProjectAudiencePreview({
               )}
             </div>
 
-            <div className="rounded-lg border bg-background p-4 sm:p-5">
+            <div
+              id="messages"
+              className="scroll-mt-36 rounded-lg border bg-background p-4 sm:p-5"
+            >
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="flex items-center gap-2">
                   <IconMessageCircle className="size-4 text-muted-foreground" />
@@ -906,7 +898,11 @@ export function ProjectAudiencePreview({
               {data.messageChannels.length > 0 ? (
                 <div className="mt-4 grid gap-3">
                   {data.messageChannels.map((channel) => (
-                    <MessageChannelRow key={channel.id} channel={channel} />
+                    <MessageChannelRow
+                      key={channel.id}
+                      channel={channel}
+                      previewHref={previewPath(data.project.id, data.audience)}
+                    />
                   ))}
                 </div>
               ) : (
@@ -923,12 +919,15 @@ export function ProjectAudiencePreview({
           </section>
         )}
 
-        <ProjectAudiencePhotoGallery
-          photos={data.photos}
-          title="Visible Photos"
-          emptyMessage="No photos have been approved for this audience yet."
-        />
-      </div>
-    </main>
+        <div id="photos" className="scroll-mt-36">
+          <ProjectAudiencePhotoGallery
+            photos={data.photos}
+            title="Visible Photos"
+            emptyMessage="No photos have been approved for this audience yet."
+          />
+        </div>
+        </div>
+      </main>
+    </ProjectAudiencePreviewShell>
   )
 }

--- a/src/components/projects/project-rfi-panel.tsx
+++ b/src/components/projects/project-rfi-panel.tsx
@@ -6,6 +6,7 @@ import {
   IconMessageQuestion,
   IconUsers,
 } from "@tabler/icons-react"
+import { projectAudiencePreviewHref } from "@/lib/project-audience-preview-routes"
 
 import type {
   ProjectRfiItem,
@@ -148,14 +149,18 @@ export function ProjectRfiPanel({
             <IconExternalLink className="size-4" />
           </Link>
           <Link
-            href={`/dashboard/projects/${projectId}/preview/sub-vendor`}
+            href={projectAudiencePreviewHref(projectId, "sub-vendor")}
+            target="_blank"
+            rel="noopener noreferrer"
             className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent"
           >
             <IconUsers className="size-4" />
             Sub/vendor view
           </Link>
           <Link
-            href={`/dashboard/projects/${projectId}/preview/owner`}
+            href={projectAudiencePreviewHref(projectId, "owner")}
+            target="_blank"
+            rel="noopener noreferrer"
             className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent"
           >
             <IconEye className="size-4" />

--- a/src/lib/__tests__/project-audience-preview-routes.test.ts
+++ b/src/lib/__tests__/project-audience-preview-routes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ownerUpdatePreviewHref,
+  projectAudiencePreviewHref,
+} from "@/lib/project-audience-preview-routes"
+
+describe("project audience preview routes", () => {
+  it("keeps owner and sub/vendor navigation in standalone preview mode", () => {
+    expect(projectAudiencePreviewHref("proj 123", "owner")).toBe(
+      "/preview/projects/proj%20123/owner"
+    )
+    expect(projectAudiencePreviewHref("proj 123", "sub-vendor")).toBe(
+      "/preview/projects/proj%20123/sub-vendor"
+    )
+  })
+
+  it("keeps owner update details under the owner preview route", () => {
+    expect(ownerUpdatePreviewHref("project/one", "update/two")).toBe(
+      "/preview/projects/project%2Fone/owner/updates/update%2Ftwo"
+    )
+  })
+})

--- a/src/lib/project-audience-preview-routes.ts
+++ b/src/lib/project-audience-preview-routes.ts
@@ -1,0 +1,15 @@
+export type ProjectAudiencePreviewRoute = "owner" | "sub-vendor"
+
+export function projectAudiencePreviewHref(
+  projectId: string,
+  audience: ProjectAudiencePreviewRoute
+): string {
+  return `/preview/projects/${encodeURIComponent(projectId)}/${audience}`
+}
+
+export function ownerUpdatePreviewHref(
+  projectId: string,
+  updateId: string
+): string {
+  return `${projectAudiencePreviewHref(projectId, "owner")}/updates/${encodeURIComponent(updateId)}`
+}


### PR DESCRIPTION
## Summary

- open owner and sub/vendor previews in a separate browser window
- move audience previews outside the staff dashboard shell
- add role-specific Compass navigation that keeps links inside preview mode
- keep published owner-update details inside the owner preview route
- preserve project and audience permission checks and prevent draft updates from opening in preview
- redirect legacy preview URLs and real owner/partner project entry points to the standalone experience

## Verification

- `bun run test` — 53 files passed, 386 tests passed, 3 skipped
- `bunx tsc --noEmit`
- focused ESLint on all changed preview files
- `bun run build`
- local source review of permission boundaries and every preview navigation link

## Review note

The repository autoreview helper was attempted, but the safety layer blocked transmitting the uncommitted code bundle to its external review workflow. No workaround was used; the source review was completed locally.
