### PR TITLE
fix(portals): show genuinely upcoming schedule work

### DIFF
--- a/src/components/projects/__tests__/project-audience-preview.test.ts
+++ b/src/components/projects/__tests__/project-audience-preview.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+
+import type { AudienceScheduleItem } from "@/app/actions/project-audience-preview"
+import { selectUpcomingScheduleItems } from "@/lib/project-audience-schedule-selection"
+
+function scheduleItem(
+  id: string,
+  startDate: string,
+  endDate: string,
+  percentComplete: number,
+  status = "scheduled"
+): AudienceScheduleItem {
+  return {
+    id,
+    title: id,
+    startDate,
+    endDate,
+    status,
+    phase: "Construction",
+    assignedTo: null,
+    percentComplete,
+    isMilestone: false,
+  }
+}
+
+describe("selectUpcomingScheduleItems", () => {
+  it("shows current and future incomplete work instead of completed history", () => {
+    const selected = selectUpcomingScheduleItems(
+      [
+        scheduleItem("future-later", "2026-08-03", "2026-08-05", 0),
+        scheduleItem("past-incomplete", "2026-07-01", "2026-07-10", 50),
+        scheduleItem("completed-future", "2026-07-30", "2026-07-30", 100),
+        scheduleItem("active-now", "2026-07-27", "2026-07-29", 50),
+        scheduleItem("future-next", "2026-07-30", "2026-08-01", 0),
+      ],
+      "2026-07-28"
+    )
+
+    expect(selected.map((item) => item.id)).toEqual([
+      "active-now",
+      "future-next",
+      "future-later",
+    ])
+  })
+
+  it("excludes records marked complete even when their percentage is stale", () => {
+    const selected = selectUpcomingScheduleItems(
+      [
+        scheduleItem("stale-complete", "2026-07-29", "2026-07-29", 0, "complete"),
+        scheduleItem("visible", "2026-07-30", "2026-07-30", 0),
+      ],
+      "2026-07-28"
+    )
+
+    expect(selected.map((item) => item.id)).toEqual(["visible"])
+  })
+})

--- a/src/components/projects/project-audience-preview.tsx
+++ b/src/components/projects/project-audience-preview.tsx
@@ -41,6 +41,7 @@ import {
   projectAudienceConversationHref,
   projectAudiencePreviewHref,
 } from "@/lib/project-audience-preview-routes"
+import { selectUpcomingScheduleItems } from "@/lib/project-audience-schedule-selection"
 
 function formatDate(value: string | null): string {
   if (!value) return "Unscheduled"
@@ -455,7 +456,11 @@ function OwnerProjectPreview({
 }): React.ReactElement {
   const latestUpdate = data.ownerUpdates[0]
   const olderUpdates = data.ownerUpdates.slice(1)
-  const nextScheduleItem = data.scheduleItems[0]
+  const upcomingScheduleItems = selectUpcomingScheduleItems(
+    data.scheduleItems,
+    new Date().toISOString().slice(0, 10)
+  )
+  const nextScheduleItem = upcomingScheduleItems[0]
 
   return (
     <main className="min-h-screen bg-[oklch(0.96_0.018_115)]">
@@ -543,9 +548,9 @@ function OwnerProjectPreview({
                 <IconCalendarStats className="size-4 text-muted-foreground" />
                 <h2 className="text-sm font-semibold">What happens next</h2>
               </div>
-              {data.scheduleItems.length > 0 ? (
+              {upcomingScheduleItems.length > 0 ? (
                 <div className="mt-4 space-y-3">
-                  {data.scheduleItems.slice(0, 3).map((item) => (
+                  {upcomingScheduleItems.map((item) => (
                     <OwnerScheduleCard key={item.id} item={item} />
                   ))}
                 </div>

--- a/src/lib/project-audience-schedule-selection.ts
+++ b/src/lib/project-audience-schedule-selection.ts
@@ -1,0 +1,30 @@
+type ScheduleSelectionItem = {
+  readonly id: string
+  readonly startDate: string
+  readonly endDate: string
+  readonly status: string
+  readonly percentComplete: number
+}
+
+export function selectUpcomingScheduleItems<
+  ScheduleItem extends ScheduleSelectionItem,
+>(
+  items: readonly ScheduleItem[],
+  today: string,
+  limit = 3
+): readonly ScheduleItem[] {
+  return [...items]
+    .filter(
+      (item) =>
+        item.endDate >= today &&
+        item.percentComplete < 100 &&
+        item.status.toLowerCase() !== "complete"
+    )
+    .sort(
+      (left, right) =>
+        left.startDate.localeCompare(right.startDate) ||
+        left.endDate.localeCompare(right.endDate) ||
+        left.id.localeCompare(right.id)
+    )
+    .slice(0, limit)
+}


### PR DESCRIPTION
## Summary
- select current and future incomplete work for the owner hero and “What happens next”
- exclude completed and expired historical schedule items
- add regression coverage for stale completion percentages and chronological ordering

## Verification
- `bun test src/components/projects/__tests__/project-audience-preview.test.ts src/lib/__tests__/project-audience-conversations.test.ts src/lib/__tests__/project-audience-preview-routes.test.ts`
- `bunx tsc --noEmit`
- focused ESLint
- production build via pre-push hook

## Context
This follow-up was found during live production verification of PR #229 before the Loomis/Loeffler soft opening.