### PR TITLE
feat(portals): add dedicated external workspace pages

### DIFF
--- a/src/app/preview/projects/[id]/owner/conversations/page.tsx
+++ b/src/app/preview/projects/[id]/owner/conversations/page.tsx
@@ -1,0 +1,20 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+
+import { ProjectAudienceWorkspaceRoute } from "@/components/projects/project-audience-workspace-route"
+
+export default async function OwnerConversationsPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  return (
+    <ProjectAudienceWorkspaceRoute
+      projectId={id}
+      audience="owner"
+      section="conversations"
+    />
+  )
+}

--- a/src/app/preview/projects/[id]/owner/photos/page.tsx
+++ b/src/app/preview/projects/[id]/owner/photos/page.tsx
@@ -1,0 +1,20 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+
+import { ProjectAudienceWorkspaceRoute } from "@/components/projects/project-audience-workspace-route"
+
+export default async function OwnerPhotosPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  return (
+    <ProjectAudienceWorkspaceRoute
+      projectId={id}
+      audience="owner"
+      section="photos"
+    />
+  )
+}

--- a/src/app/preview/projects/[id]/owner/schedule/page.tsx
+++ b/src/app/preview/projects/[id]/owner/schedule/page.tsx
@@ -1,0 +1,20 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+
+import { ProjectAudienceWorkspaceRoute } from "@/components/projects/project-audience-workspace-route"
+
+export default async function OwnerSchedulePage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  return (
+    <ProjectAudienceWorkspaceRoute
+      projectId={id}
+      audience="owner"
+      section="schedule"
+    />
+  )
+}

--- a/src/app/preview/projects/[id]/owner/team/page.tsx
+++ b/src/app/preview/projects/[id]/owner/team/page.tsx
@@ -1,0 +1,20 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+
+import { ProjectAudienceWorkspaceRoute } from "@/components/projects/project-audience-workspace-route"
+
+export default async function OwnerTeamPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  return (
+    <ProjectAudienceWorkspaceRoute
+      projectId={id}
+      audience="owner"
+      section="team"
+    />
+  )
+}

--- a/src/app/preview/projects/[id]/owner/updates/[updateId]/page.tsx
+++ b/src/app/preview/projects/[id]/owner/updates/[updateId]/page.tsx
@@ -13,7 +13,10 @@ import {
 } from "@/app/actions/project-field"
 import { OwnerUpdateDocument } from "@/components/projects/owner-update-document"
 import { ProjectAudiencePreviewShell } from "@/components/projects/project-audience-preview-shell"
-import { projectAudiencePreviewHref } from "@/lib/project-audience-preview-routes"
+import {
+  projectAudiencePreviewHref,
+  projectAudienceSectionHref,
+} from "@/lib/project-audience-preview-routes"
 
 function hasDigest(error: unknown): error is { readonly digest: string } {
   return typeof error === "object" && error !== null && "digest" in error
@@ -64,12 +67,13 @@ export default async function OwnerUpdatePreviewPage({
       projectOptions={preview.projectOptions}
       viewer={preview.viewer}
       viewerIsInternal={preview.viewerIsInternal}
+      activeSection="updates"
     >
       <OwnerUpdateDocument
         document={document}
         previewMode={{
           homeHref,
-          photosHref: `${homeHref}#photos`,
+          photosHref: projectAudienceSectionHref(id, "owner", "photos"),
         }}
       />
     </ProjectAudiencePreviewShell>

--- a/src/app/preview/projects/[id]/owner/updates/page.tsx
+++ b/src/app/preview/projects/[id]/owner/updates/page.tsx
@@ -1,0 +1,20 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+
+import { ProjectAudienceWorkspaceRoute } from "@/components/projects/project-audience-workspace-route"
+
+export default async function OwnerUpdatesPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  return (
+    <ProjectAudienceWorkspaceRoute
+      projectId={id}
+      audience="owner"
+      section="updates"
+    />
+  )
+}

--- a/src/app/preview/projects/[id]/sub-vendor/commitments/page.tsx
+++ b/src/app/preview/projects/[id]/sub-vendor/commitments/page.tsx
@@ -1,0 +1,20 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+
+import { ProjectAudienceWorkspaceRoute } from "@/components/projects/project-audience-workspace-route"
+
+export default async function PartnerCommitmentsPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  return (
+    <ProjectAudienceWorkspaceRoute
+      projectId={id}
+      audience="sub_vendor"
+      section="commitments"
+    />
+  )
+}

--- a/src/app/preview/projects/[id]/sub-vendor/conversations/page.tsx
+++ b/src/app/preview/projects/[id]/sub-vendor/conversations/page.tsx
@@ -1,0 +1,20 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+
+import { ProjectAudienceWorkspaceRoute } from "@/components/projects/project-audience-workspace-route"
+
+export default async function PartnerConversationsPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  return (
+    <ProjectAudienceWorkspaceRoute
+      projectId={id}
+      audience="sub_vendor"
+      section="conversations"
+    />
+  )
+}

--- a/src/app/preview/projects/[id]/sub-vendor/photos/page.tsx
+++ b/src/app/preview/projects/[id]/sub-vendor/photos/page.tsx
@@ -1,0 +1,20 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+
+import { ProjectAudienceWorkspaceRoute } from "@/components/projects/project-audience-workspace-route"
+
+export default async function PartnerPhotosPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  return (
+    <ProjectAudienceWorkspaceRoute
+      projectId={id}
+      audience="sub_vendor"
+      section="photos"
+    />
+  )
+}

--- a/src/app/preview/projects/[id]/sub-vendor/rfis/page.tsx
+++ b/src/app/preview/projects/[id]/sub-vendor/rfis/page.tsx
@@ -1,0 +1,20 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+
+import { ProjectAudienceWorkspaceRoute } from "@/components/projects/project-audience-workspace-route"
+
+export default async function PartnerRfisPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  return (
+    <ProjectAudienceWorkspaceRoute
+      projectId={id}
+      audience="sub_vendor"
+      section="rfis"
+    />
+  )
+}

--- a/src/app/preview/projects/[id]/sub-vendor/schedule/page.tsx
+++ b/src/app/preview/projects/[id]/sub-vendor/schedule/page.tsx
@@ -1,0 +1,20 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+
+import { ProjectAudienceWorkspaceRoute } from "@/components/projects/project-audience-workspace-route"
+
+export default async function PartnerSchedulePage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  return (
+    <ProjectAudienceWorkspaceRoute
+      projectId={id}
+      audience="sub_vendor"
+      section="schedule"
+    />
+  )
+}

--- a/src/app/preview/projects/[id]/sub-vendor/team/page.tsx
+++ b/src/app/preview/projects/[id]/sub-vendor/team/page.tsx
@@ -1,0 +1,20 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+
+import { ProjectAudienceWorkspaceRoute } from "@/components/projects/project-audience-workspace-route"
+
+export default async function PartnerTeamPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  return (
+    <ProjectAudienceWorkspaceRoute
+      projectId={id}
+      audience="sub_vendor"
+      section="team"
+    />
+  )
+}

--- a/src/components/projects/owner-cover-photo-control.tsx
+++ b/src/components/projects/owner-cover-photo-control.tsx
@@ -63,6 +63,8 @@ type OwnerCoverPhotoControlProps = {
     | null
   readonly approvedPhotos: readonly OwnerCoverPhotoOption[]
   readonly latestUpdateHref: string | null
+  readonly photoGalleryHref?: string
+  readonly workspaceLabel?: string
   readonly editable?: boolean
 }
 
@@ -210,6 +212,8 @@ export function OwnerCoverPhotoControl({
   nextScheduleItem,
   approvedPhotos,
   latestUpdateHref,
+  photoGalleryHref = "#photos",
+  workspaceLabel = "Owner project home",
   editable = true,
 }: OwnerCoverPhotoControlProps): React.ReactElement {
   const [open, setOpen] = React.useState(false)
@@ -421,7 +425,7 @@ export function OwnerCoverPhotoControl({
           <div className="flex flex-col gap-6">
             <div className="max-w-3xl">
               <Badge className="bg-white/90 text-[#17231c] hover:bg-white">
-                Owner project home
+                {workspaceLabel}
               </Badge>
               <h1 className="mt-4 text-3xl font-semibold tracking-tight sm:text-5xl">
                 {projectTitle}
@@ -481,7 +485,7 @@ export function OwnerCoverPhotoControl({
                   {approvedPhotos.length} approved project photos
                 </p>
                 <a
-                  href="#photos"
+                  href={photoGalleryHref}
                   className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-white hover:underline"
                 >
                   View photos

--- a/src/components/projects/owner-update-document.tsx
+++ b/src/components/projects/owner-update-document.tsx
@@ -18,7 +18,7 @@ import { OwnerUpdateActions } from "@/components/projects/owner-update-actions"
 import { OwnerUpdateDraftEditor } from "@/components/projects/owner-update-draft-editor"
 import { OwnerUpdatePhotoTile } from "@/components/projects/owner-update-photo-tile"
 import { projectBrandFor } from "@/lib/project-branding"
-import { projectAudiencePreviewHref } from "@/lib/project-audience-preview-routes"
+import { projectAudienceSectionHref } from "@/lib/project-audience-preview-routes"
 
 function formatDate(value: string): string {
   return new Date(`${value}T00:00:00`).toLocaleDateString("en-US", {
@@ -294,7 +294,11 @@ export function OwnerUpdateDocument({
                     <Link
                       href={
                         previewMode?.photosHref ??
-                        `${projectAudiencePreviewHref(document.project.id, "owner")}#photos`
+                        projectAudienceSectionHref(
+                          document.project.id,
+                          "owner",
+                          "photos"
+                        )
                       }
                       target={previewMode ? undefined : "_blank"}
                       rel={previewMode ? undefined : "noopener noreferrer"}

--- a/src/components/projects/project-audience-conversation.tsx
+++ b/src/components/projects/project-audience-conversation.tsx
@@ -97,6 +97,7 @@ export async function ProjectAudienceConversation({
       projectOptions={preview.projectOptions}
       viewer={preview.viewer}
       viewerIsInternal={preview.viewerIsInternal}
+      activeSection="conversations"
     >
       <main className="h-[calc(100vh-3.5rem)] min-h-[34rem] bg-background md:h-screen">
         <ConversationsProvider>

--- a/src/components/projects/project-audience-preview-shell.tsx
+++ b/src/components/projects/project-audience-preview-shell.tsx
@@ -15,7 +15,11 @@ import {
 
 import type { AudienceProjectOption } from "@/app/actions/project-audience-preview"
 import type { ProjectAudience } from "@/lib/project-audience-access"
-import { projectAudiencePreviewHref } from "@/lib/project-audience-preview-routes"
+import {
+  projectAudiencePreviewHref,
+  projectAudienceSectionHref,
+  type ProjectAudienceWorkspaceSection,
+} from "@/lib/project-audience-preview-routes"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -30,35 +34,39 @@ import { cn } from "@/lib/utils"
 
 type PreviewNavigationItem = {
   readonly label: string
-  readonly anchor: string
+  readonly section: ProjectAudienceWorkspaceSection
   readonly icon: React.ReactElement
 }
 
 const OWNER_NAVIGATION: readonly PreviewNavigationItem[] = [
   {
     label: "Overview",
-    anchor: "overview",
+    section: "overview",
     icon: <IconHome className="size-4" />,
   },
   {
     label: "Owner Updates",
-    anchor: "updates",
+    section: "updates",
     icon: <IconClipboardCheck className="size-4" />,
   },
   {
     label: "Schedule",
-    anchor: "schedule",
+    section: "schedule",
     icon: <IconCalendar className="size-4" />,
   },
   {
     label: "Conversations",
-    anchor: "messages",
+    section: "conversations",
     icon: <IconMessageCircle className="size-4" />,
   },
-  { label: "Photos", anchor: "photos", icon: <IconPhoto className="size-4" /> },
+  {
+    label: "Photos",
+    section: "photos",
+    icon: <IconPhoto className="size-4" />,
+  },
   {
     label: "Project Team",
-    anchor: "team",
+    section: "team",
     icon: <IconUsers className="size-4" />,
   },
 ]
@@ -66,33 +74,37 @@ const OWNER_NAVIGATION: readonly PreviewNavigationItem[] = [
 const SUB_VENDOR_NAVIGATION: readonly PreviewNavigationItem[] = [
   {
     label: "Overview",
-    anchor: "overview",
+    section: "overview",
     icon: <IconHome className="size-4" />,
   },
   {
     label: "Schedule",
-    anchor: "schedule",
+    section: "schedule",
     icon: <IconCalendar className="size-4" />,
   },
   {
     label: "Commitments",
-    anchor: "commitments",
+    section: "commitments",
     icon: <IconClipboardCheck className="size-4" />,
   },
   {
     label: "RFIs",
-    anchor: "rfis",
+    section: "rfis",
     icon: <IconQuestionMark className="size-4" />,
   },
   {
     label: "Conversations",
-    anchor: "messages",
+    section: "conversations",
     icon: <IconMessageCircle className="size-4" />,
   },
-  { label: "Photos", anchor: "photos", icon: <IconPhoto className="size-4" /> },
+  {
+    label: "Photos",
+    section: "photos",
+    icon: <IconPhoto className="size-4" />,
+  },
   {
     label: "Project Team",
-    anchor: "team",
+    section: "team",
     icon: <IconUsers className="size-4" />,
   },
 ]
@@ -115,6 +127,7 @@ export function ProjectAudiencePreviewShell({
   projectOptions,
   viewer,
   viewerIsInternal,
+  activeSection = "overview",
   children,
 }: {
   readonly audience: ProjectAudience
@@ -128,6 +141,7 @@ export function ProjectAudiencePreviewShell({
     readonly avatarUrl: string | null
   }
   readonly viewerIsInternal: boolean
+  readonly activeSection?: ProjectAudienceWorkspaceSection
   readonly children: React.ReactNode
 }): React.ReactElement {
   const routeAudience = audienceRoute(audience)
@@ -177,9 +191,10 @@ export function ProjectAudiencePreviewShell({
                 {projectOptions.map((project) => (
                   <DropdownMenuItem key={project.id} asChild>
                     <Link
-                      href={projectAudiencePreviewHref(
+                      href={projectAudienceSectionHref(
                         project.id,
-                        routeAudience
+                        routeAudience,
+                        activeSection
                       )}
                     >
                       {projectOptionLabel(project)}
@@ -206,9 +221,19 @@ export function ProjectAudiencePreviewShell({
         >
           {navigation.map((item) => (
             <Link
-              key={item.anchor}
-              href={`${homeHref}#${item.anchor}`}
-              className="flex items-center gap-3 px-3 py-2 text-sm text-sidebar-foreground/75 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+              key={item.section}
+              href={projectAudienceSectionHref(
+                projectId,
+                routeAudience,
+                item.section
+              )}
+              aria-current={activeSection === item.section ? "page" : undefined}
+              className={cn(
+                "flex items-center gap-3 px-3 py-2 text-sm transition-colors",
+                activeSection === item.section
+                  ? "bg-sidebar-accent font-medium text-sidebar-accent-foreground"
+                  : "text-sidebar-foreground/75 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+              )}
             >
               {item.icon}
               {item.label}
@@ -269,11 +294,20 @@ export function ProjectAudiencePreviewShell({
           <nav className="mt-3 flex gap-1 overflow-x-auto border-t pt-2">
             {navigation.map((item) => (
               <Link
-                key={item.anchor}
-                href={`${homeHref}#${item.anchor}`}
+                key={item.section}
+                href={projectAudienceSectionHref(
+                  projectId,
+                  routeAudience,
+                  item.section
+                )}
+                aria-current={
+                  activeSection === item.section ? "page" : undefined
+                }
                 className={cn(
                   "flex shrink-0 items-center gap-1.5 px-2 py-1.5 text-xs",
-                  "text-muted-foreground hover:bg-accent hover:text-foreground"
+                  activeSection === item.section
+                    ? "bg-accent font-medium text-foreground"
+                    : "text-muted-foreground hover:bg-accent hover:text-foreground"
                 )}
               >
                 {item.icon}

--- a/src/components/projects/project-audience-preview.tsx
+++ b/src/components/projects/project-audience-preview.tsx
@@ -5,7 +5,6 @@ import {
   IconCalendarStats,
   IconChevronDown,
   IconClipboardCheck,
-  IconExternalLink,
   IconFolder,
   IconMessageCircle,
   IconQuestionMark,
@@ -40,6 +39,8 @@ import {
   ownerUpdatePreviewHref,
   projectAudienceConversationHref,
   projectAudiencePreviewHref,
+  projectAudienceSectionHref,
+  type ProjectAudienceWorkspaceSection,
 } from "@/lib/project-audience-preview-routes"
 import { selectUpcomingScheduleItems } from "@/lib/project-audience-schedule-selection"
 
@@ -57,12 +58,6 @@ function statusLabel(value: string): string {
     .split("_")
     .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
     .join(" ")
-}
-
-function audienceDescription(value: ProjectAudience): string {
-  return value === "owner"
-    ? "Approved updates, schedule items, and owner-visible photos."
-    : "Visible commitments, schedule items, RFIs, and project photos."
 }
 
 function projectLabel(data: ProjectAudiencePreviewData): string {
@@ -451,8 +446,10 @@ function OwnerScheduleCard({
 
 function OwnerProjectPreview({
   data,
+  section,
 }: {
   readonly data: ProjectAudiencePreviewData
+  readonly section: ProjectAudienceWorkspaceSection
 }): React.ReactElement {
   const latestUpdate = data.ownerUpdates[0]
   const olderUpdates = data.ownerUpdates.slice(1)
@@ -465,7 +462,8 @@ function OwnerProjectPreview({
   return (
     <main className="min-h-screen bg-[oklch(0.96_0.018_115)]">
       <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 sm:px-6 lg:px-8">
-        <div id="overview" className="scroll-mt-36">
+        {section === "overview" && (
+        <div>
           <OwnerCoverPhotoControl
             projectId={data.project.id}
             projectTitle={ownerHeroTitle(data)}
@@ -501,12 +499,25 @@ function OwnerProjectPreview({
                 ? ownerUpdatePreviewHref(data.project.id, latestUpdate.id)
                 : null
             }
+            photoGalleryHref={projectAudienceSectionHref(
+              data.project.id,
+              "owner",
+              "photos"
+            )}
             editable={false}
           />
         </div>
+        )}
 
-        <section className="grid gap-4 lg:grid-cols-[1.15fr_0.85fr]">
-          <div id="updates" className="scroll-mt-36 space-y-4">
+        {(section === "overview" || section === "updates") && (
+        <section
+          className={
+            section === "overview"
+              ? "grid gap-4 lg:grid-cols-[1.15fr_0.85fr]"
+              : "space-y-4"
+          }
+        >
+          <div className="space-y-4">
             <div className="flex items-center justify-between gap-3">
               <div>
                 <p className="text-xs font-medium uppercase text-muted-foreground">
@@ -540,6 +551,7 @@ function OwnerProjectPreview({
             )}
           </div>
 
+          {section === "overview" && (
           <aside className="space-y-4">
             <section
               className="rounded-lg border bg-background p-5"
@@ -561,10 +573,7 @@ function OwnerProjectPreview({
               )}
             </section>
 
-            <section
-              id="team"
-              className="scroll-mt-36 rounded-lg border bg-background p-5"
-            >
+            <section className="rounded-lg border bg-background p-5">
               <div className="flex items-center gap-2">
                 <IconSparkles className="size-4 text-muted-foreground" />
                 <h2 className="text-sm font-semibold">Your project team</h2>
@@ -604,19 +613,55 @@ function OwnerProjectPreview({
               </div>
             </section>
           </aside>
+          )}
         </section>
+        )}
 
+        {section === "team" && (
+          <section className="rounded-lg border bg-background p-4 sm:p-5">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <IconUsers className="size-4 text-muted-foreground" />
+                <div>
+                  <p className="text-xs font-medium uppercase text-muted-foreground">
+                    Project directory
+                  </p>
+                  <h1 className="text-xl font-semibold">Your project team</h1>
+                </div>
+              </div>
+              <Badge variant="outline">{data.contacts.length} contacts</Badge>
+            </div>
+            {data.contacts.length > 0 ? (
+              <div className="mt-4 grid gap-3 md:grid-cols-2">
+                {data.contacts.map((contact) => (
+                  <ContactRow key={contact.id} contact={contact} />
+                ))}
+              </div>
+            ) : (
+              <p className="mt-4 text-sm text-muted-foreground">
+                No approved project contacts yet.
+              </p>
+            )}
+          </section>
+        )}
+
+        {section === "schedule" && (
         <ProjectAudienceSchedule items={data.scheduleItems} />
+        )}
 
+        {section === "conversations" && (
         <AudienceConversationSection data={data} />
+        )}
 
-        <div id="photos" className="scroll-mt-36">
+        {section === "photos" && (
+        <div>
           <ProjectAudiencePhotoGallery
             photos={data.photos}
             title="Approved Photo Gallery"
             emptyMessage="No photos have been approved for this audience yet."
           />
         </div>
+        )}
       </div>
     </main>
   )
@@ -624,8 +669,10 @@ function OwnerProjectPreview({
 
 export function ProjectAudiencePreview({
   data,
+  section = "overview",
 }: {
   readonly data: ProjectAudiencePreviewData
+  readonly section?: ProjectAudienceWorkspaceSection
 }): React.ReactElement {
   const label = projectLabel(data)
   const isOwner = data.audience === "owner"
@@ -635,6 +682,11 @@ export function ProjectAudiencePreview({
     projectNumber: data.project.projectNumber,
     status: "OPEN",
   })
+  const partnerUpcomingScheduleItems = selectUpcomingScheduleItems(
+    data.scheduleItems,
+    new Date().toISOString().slice(0, 10)
+  )
+  const partnerNextScheduleItem = partnerUpcomingScheduleItems[0]
 
   if (isOwner) {
     return (
@@ -646,8 +698,9 @@ export function ProjectAudiencePreview({
         projectOptions={data.projectOptions}
         viewer={data.viewer}
         viewerIsInternal={data.viewerIsInternal}
+        activeSection={section}
       >
-        <OwnerProjectPreview data={data} />
+        <OwnerProjectPreview data={data} section={section} />
       </ProjectAudiencePreviewShell>
     )
   }
@@ -661,38 +714,46 @@ export function ProjectAudiencePreview({
       projectOptions={data.projectOptions}
       viewer={data.viewer}
       viewerIsInternal={data.viewerIsInternal}
+      activeSection={section}
     >
       <main className="min-h-screen bg-muted/30">
         <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 sm:px-6 lg:px-8">
-        <section
-          id="overview"
-          className="scroll-mt-36 rounded-lg border bg-background p-5 sm:p-6"
-        >
-          <div className="flex flex-wrap items-start justify-between gap-4">
-            <div>
-              <Badge variant="secondary">Partner project home</Badge>
-              <h1 className="mt-3 text-2xl font-semibold tracking-tight">
-                {data.project.name}
-              </h1>
-              <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
-                {audienceDescription(data.audience)}
-              </p>
-            </div>
-            <div className="text-left sm:text-right">
-              <p className="text-sm font-medium">{label}</p>
-              <p className="mt-1 text-sm text-muted-foreground">
-                {data.project.name}
-              </p>
-              {data.project.address && (
-                <p className="mt-1 text-xs text-muted-foreground">
-                  {data.project.address}
-                </p>
-              )}
-            </div>
-          </div>
-        </section>
+        {section === "overview" && (
+          <OwnerCoverPhotoControl
+            projectId={data.project.id}
+            projectTitle={data.project.name}
+            projectLabel={label}
+            projectAddress={data.project.address}
+            latestUpdate={null}
+            nextScheduleItem={
+              partnerNextScheduleItem
+                ? {
+                    title: partnerNextScheduleItem.title,
+                    dateRange:
+                      `${formatDate(partnerNextScheduleItem.startDate)} - ` +
+                      formatDate(partnerNextScheduleItem.endDate),
+                  }
+                : null
+            }
+            approvedPhotos={data.photos.map((photo) => ({
+              id: photo.id,
+              fileName: photo.fileName,
+              driveFileId: photo.driveFileId,
+              thumbnailUrl: photo.thumbnailUrl,
+              caption: photo.caption,
+            }))}
+            latestUpdateHref={null}
+            photoGalleryHref={projectAudienceSectionHref(
+              data.project.id,
+              "sub-vendor",
+              "photos"
+            )}
+            workspaceLabel="Partner project home"
+            editable={false}
+          />
+        )}
 
-        {!isOwner && (
+        {section === "overview" && (
           <section className="rounded-lg border bg-background/80 px-3 py-2">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div className="flex min-w-0 items-center gap-2">
@@ -742,11 +803,11 @@ export function ProjectAudiencePreview({
           </section>
         )}
 
-        {!isOwner && <AudienceMetricStrip data={data} />}
+        {section === "overview" && <AudienceMetricStrip data={data} />}
 
+        {(section === "overview" || section === "team") && (
         <section
-          id="team"
-          className="scroll-mt-36 rounded-lg border bg-background p-4 sm:p-5"
+          className="rounded-lg border bg-background p-4 sm:p-5"
         >
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="flex items-center gap-2">
@@ -767,91 +828,25 @@ export function ProjectAudiencePreview({
             </p>
           )}
         </section>
-
-        {isOwner && (
-          <section className="rounded-lg border bg-background p-4 sm:p-5">
-            <div className="flex items-center gap-2">
-              <IconClipboardCheck className="size-4 text-muted-foreground" />
-              <h2 className="text-sm font-semibold">Owner Updates</h2>
-            </div>
-            {data.ownerUpdates.length > 0 ? (
-              <div className="mt-4 grid gap-3 md:grid-cols-2">
-                {data.ownerUpdates.map((update) => (
-                  <article key={update.id} className="rounded-md border p-3">
-                    <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                      <span>{formatDate(update.updateDate)}</span>
-                      {update.publishedAt && (
-                        <>
-                          <span>&middot;</span>
-                          <span>Published</span>
-                        </>
-                      )}
-                    </div>
-                    <h3 className="mt-2 line-clamp-2 text-sm font-medium">
-                      {update.title}
-                    </h3>
-                    <p className="mt-2 line-clamp-3 text-sm text-muted-foreground">
-                      {update.summary}
-                    </p>
-                    <Link
-                      href={
-                        `/dashboard/projects/${data.project.id}` +
-                        `/owner-updates/${update.id}`
-                      }
-                      className="mt-3 inline-flex items-center gap-1 text-xs text-primary hover:underline"
-                    >
-                      <IconExternalLink className="size-3" />
-                      Open update
-                    </Link>
-                  </article>
-                ))}
-              </div>
-            ) : (
-              <p className="mt-4 rounded-md border p-3 text-sm text-muted-foreground">
-                No published owner updates are visible to owners yet.
-              </p>
-            )}
-          </section>
         )}
 
-        <ProjectAudienceSchedule items={data.scheduleItems} />
+        {section === "schedule" && (
+          <ProjectAudienceSchedule items={data.scheduleItems} />
+        )}
 
+        {section === "commitments" && (
         <section>
           <div
-            id="commitments"
-            className="scroll-mt-36 rounded-lg border bg-background p-4 sm:p-5"
+            className="rounded-lg border bg-background p-4 sm:p-5"
           >
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div className="flex items-center gap-2">
                 <IconUsers className="size-4 text-muted-foreground" />
-                <h2 className="text-sm font-semibold">
-                  {isOwner ? "Project Contacts" : "Commitments"}
-                </h2>
+                <h2 className="text-sm font-semibold">Commitments</h2>
               </div>
-              {!isOwner && (
-                <Badge variant="outline">{data.operations.length} active</Badge>
-              )}
+              <Badge variant="outline">{data.operations.length} active</Badge>
             </div>
-            {isOwner ? (
-              <div className="mt-4 space-y-3 text-sm">
-                {data.project.projectManager && (
-                  <div className="rounded-md border p-3">
-                    <p className="text-xs font-medium uppercase text-muted-foreground">
-                      Project manager
-                    </p>
-                    <p className="mt-1">{data.project.projectManager}</p>
-                  </div>
-                )}
-                {data.project.clientName && (
-                  <div className="rounded-md border p-3">
-                    <p className="text-xs font-medium uppercase text-muted-foreground">
-                      Owner
-                    </p>
-                    <p className="mt-1">{data.project.clientName}</p>
-                  </div>
-                )}
-              </div>
-            ) : data.operations.length > 0 ? (
+            {data.operations.length > 0 ? (
               <div className="mt-4 grid gap-3">
                 {data.operations.map((item) => (
                   <OperationRow key={item.id} item={item} />
@@ -864,12 +859,12 @@ export function ProjectAudiencePreview({
             )}
           </div>
         </section>
+        )}
 
-        {!isOwner && (
-          <section className="grid gap-4 lg:grid-cols-[1fr_0.85fr]">
+        {section === "rfis" && (
+          <section>
             <div
-              id="rfis"
-              className="scroll-mt-36 rounded-lg border bg-background p-4 sm:p-5"
+              className="rounded-lg border bg-background p-4 sm:p-5"
             >
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="flex items-center gap-2">
@@ -890,18 +885,22 @@ export function ProjectAudiencePreview({
                 </p>
               )}
             </div>
-
-            <AudienceConversationSection data={data} />
           </section>
         )}
 
-        <div id="photos" className="scroll-mt-36">
+        {section === "conversations" && (
+          <AudienceConversationSection data={data} />
+        )}
+
+        {section === "photos" && (
+        <div>
           <ProjectAudiencePhotoGallery
             photos={data.photos}
             title="Visible Photos"
             emptyMessage="No photos have been approved for this audience yet."
           />
         </div>
+        )}
         </div>
       </main>
     </ProjectAudiencePreviewShell>

--- a/src/components/projects/project-audience-workspace-route.tsx
+++ b/src/components/projects/project-audience-workspace-route.tsx
@@ -1,0 +1,35 @@
+import type * as React from "react"
+import { notFound } from "next/navigation"
+
+import {
+  getProjectAudiencePreview,
+  type ProjectAudiencePreview as ProjectAudiencePreviewData,
+} from "@/app/actions/project-audience-preview"
+import { ProjectAudiencePreview } from "@/components/projects/project-audience-preview"
+import type { ProjectAudience } from "@/lib/project-audience-access"
+import type { ProjectAudienceWorkspaceSection } from "@/lib/project-audience-preview-routes"
+
+function hasDigest(error: unknown): error is { readonly digest: string } {
+  return typeof error === "object" && error !== null && "digest" in error
+}
+
+export async function ProjectAudienceWorkspaceRoute({
+  projectId,
+  audience,
+  section,
+}: {
+  readonly projectId: string
+  readonly audience: ProjectAudience
+  readonly section: ProjectAudienceWorkspaceSection
+}): Promise<React.ReactElement> {
+  let data: ProjectAudiencePreviewData
+
+  try {
+    data = await getProjectAudiencePreview(projectId, audience)
+  } catch (error) {
+    if (hasDigest(error) && error.digest === "NEXT_NOT_FOUND") throw error
+    notFound()
+  }
+
+  return <ProjectAudiencePreview data={data} section={section} />
+}

--- a/src/components/schedule/schedule-item-form-dialog.tsx
+++ b/src/components/schedule/schedule-item-form-dialog.tsx
@@ -695,7 +695,7 @@ export function ScheduleItemFormDialog({
                       return (
                         <div
                           key={dep.id}
-                          className="grid grid-cols-[minmax(0,1fr)_6.5rem_2rem] items-end gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(9rem,11rem)_5.5rem_2rem]"
+                          className="space-y-2 border-b border-border/70 pb-3 last:border-b-0 last:pb-0"
                         >
                           <Select
                             value={edit.taskId}
@@ -708,7 +708,7 @@ export function ScheduleItemFormDialog({
                             }
                           >
                             <SelectTrigger
-                              className="col-span-3 h-8 min-w-0 text-xs sm:col-span-1"
+                              className="h-9 w-full min-w-0 text-xs [&_[data-slot=select-value]]:truncate"
                               aria-label="Saved predecessor schedule item"
                             >
                               <SelectValue />
@@ -721,55 +721,69 @@ export function ScheduleItemFormDialog({
                               ))}
                             </SelectContent>
                           </Select>
-                          <Select
-                            value={edit.type}
-                            onValueChange={(value) =>
-                              updateExistingPredecessor(
-                                dep.id,
-                                "type",
-                                value
-                              )
-                            }
-                          >
-                            <SelectTrigger
-                              className="h-8 min-w-0 text-xs"
-                              aria-label="Saved dependency relationship"
-                            >
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {DEPENDENCY_TYPES.map((dependencyType) => (
-                                <SelectItem
-                                  key={dependencyType.value}
-                                  value={dependencyType.value}
+                          <div className="grid grid-cols-[minmax(0,1fr)_7rem_2rem] items-end gap-2">
+                            <div className="min-w-0 space-y-1">
+                              <span className="block text-[10px] text-muted-foreground">
+                                Relationship
+                              </span>
+                              <Select
+                                value={edit.type}
+                                onValueChange={(value) =>
+                                  updateExistingPredecessor(
+                                    dep.id,
+                                    "type",
+                                    value
+                                  )
+                                }
+                              >
+                                <SelectTrigger
+                                  className="h-9 w-full min-w-0 text-xs [&_[data-slot=select-value]]:truncate"
+                                  aria-label="Saved dependency relationship"
                                 >
-                                  {dependencyType.label}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                          <Input
-                            type="number"
-                            className="h-8 min-w-0 text-center text-xs"
-                            value={edit.lagDays}
-                            aria-label="Saved dependency lag or lead in days"
-                            onChange={(event) =>
-                              updateExistingPredecessor(
-                                dep.id,
-                                "lagDays",
-                                Number(event.target.value) || 0
-                              )
-                            }
-                          />
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon"
-                            className="size-7 shrink-0 text-muted-foreground hover:text-destructive"
-                            onClick={() => handleDeleteExistingDep(dep.id)}
-                          >
-                            <IconTrash className="size-3" />
-                          </Button>
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {DEPENDENCY_TYPES.map((dependencyType) => (
+                                    <SelectItem
+                                      key={dependencyType.value}
+                                      value={dependencyType.value}
+                                    >
+                                      {dependencyType.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </div>
+                            <div className="min-w-0 space-y-1">
+                              <span className="block text-[10px] text-muted-foreground">
+                                Lag / lead days
+                              </span>
+                              <Input
+                                type="number"
+                                className="h-9 min-w-0 text-center text-xs"
+                                value={edit.lagDays}
+                                aria-label="Saved dependency lag or lead in days"
+                                onChange={(event) =>
+                                  updateExistingPredecessor(
+                                    dep.id,
+                                    "lagDays",
+                                    Number(event.target.value) || 0
+                                  )
+                                }
+                              />
+                            </div>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              className="mb-0.5 size-8 shrink-0 text-muted-foreground hover:text-destructive"
+                              onClick={() => handleDeleteExistingDep(dep.id)}
+                              aria-label="Remove saved predecessor"
+                              title="Remove predecessor"
+                            >
+                              <IconTrash className="size-3" />
+                            </Button>
+                          </div>
                         </div>
                       )
                     })}
@@ -777,7 +791,7 @@ export function ScheduleItemFormDialog({
                     {pendingPredecessors.map((pred, idx) => (
                       <div
                         key={idx}
-                        className="grid grid-cols-[minmax(0,1fr)_6.5rem_2rem] items-end gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(10rem,12rem)_6rem_2rem]"
+                        className="space-y-2 border-b border-border/70 pb-3 last:border-b-0 last:pb-0"
                       >
                         <Select
                           value={pred.taskId}
@@ -786,7 +800,7 @@ export function ScheduleItemFormDialog({
                           }
                         >
                           <SelectTrigger
-                            className="col-span-3 h-8 min-w-0 text-xs sm:col-span-1"
+                            className="h-9 w-full min-w-0 text-xs [&_[data-slot=select-value]]:truncate"
                             aria-label="Predecessor schedule item"
                           >
                             <SelectValue placeholder="Select schedule item" />
@@ -799,51 +813,62 @@ export function ScheduleItemFormDialog({
                             ))}
                           </SelectContent>
                         </Select>
-                        <Select
-                          value={pred.type}
-                          onValueChange={(val) =>
-                            updatePendingPredecessor(idx, "type", val)
-                          }
-                        >
-                          <SelectTrigger
-                            className="h-8 min-w-0 text-xs"
-                            aria-label="Dependency relationship"
+                        <div className="grid grid-cols-[minmax(0,1fr)_7rem_2rem] items-end gap-2">
+                          <div className="min-w-0 space-y-1">
+                            <span className="block text-[10px] text-muted-foreground">
+                              Relationship
+                            </span>
+                            <Select
+                              value={pred.type}
+                              onValueChange={(val) =>
+                                updatePendingPredecessor(idx, "type", val)
+                              }
+                            >
+                              <SelectTrigger
+                                className="h-9 w-full min-w-0 text-xs [&_[data-slot=select-value]]:truncate"
+                                aria-label="Dependency relationship"
+                              >
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {DEPENDENCY_TYPES.map((d) => (
+                                  <SelectItem key={d.value} value={d.value}>
+                                    {d.label}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </div>
+                          <div className="min-w-0 space-y-1">
+                            <span className="block text-[10px] text-muted-foreground">
+                              Lag / lead days
+                            </span>
+                            <Input
+                              type="number"
+                              className="h-9 min-w-0 text-center text-xs"
+                              value={pred.lagDays || ""}
+                              aria-label="Lag or lead in days"
+                              onChange={(e) =>
+                                updatePendingPredecessor(
+                                  idx,
+                                  "lagDays",
+                                  Number(e.target.value) || 0
+                                )
+                              }
+                            />
+                          </div>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="mb-0.5 size-8 text-muted-foreground hover:text-destructive"
+                            onClick={() => removePendingPredecessor(idx)}
+                            aria-label="Remove predecessor"
+                            title="Remove predecessor"
                           >
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {DEPENDENCY_TYPES.map((d) => (
-                              <SelectItem key={d.value} value={d.value}>
-                                {d.label}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <Input
-                          type="number"
-                          placeholder="Lag days"
-                          className="h-8 min-w-0 text-center text-xs"
-                          value={pred.lagDays || ""}
-                          aria-label="Lag or lead in days"
-                          onChange={(e) =>
-                            updatePendingPredecessor(
-                              idx,
-                              "lagDays",
-                              Number(e.target.value) || 0
-                            )
-                          }
-                        />
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          className="size-7 text-muted-foreground hover:text-destructive"
-                          onClick={() => removePendingPredecessor(idx)}
-                          aria-label="Remove predecessor"
-                          title="Remove predecessor"
-                        >
-                          <IconTrash className="size-3" />
-                        </Button>
+                            <IconTrash className="size-3" />
+                          </Button>
+                        </div>
                       </div>
                     ))}
 

--- a/src/lib/__tests__/project-audience-preview-routes.test.ts
+++ b/src/lib/__tests__/project-audience-preview-routes.test.ts
@@ -4,6 +4,7 @@ import {
   ownerUpdatePreviewHref,
   projectAudienceConversationHref,
   projectAudiencePreviewHref,
+  projectAudienceSectionHref,
 } from "@/lib/project-audience-preview-routes"
 
 describe("project audience preview routes", () => {
@@ -20,6 +21,18 @@ describe("project audience preview routes", () => {
     expect(ownerUpdatePreviewHref("project/one", "update/two")).toBe(
       "/preview/projects/project%2Fone/owner/updates/update%2Ftwo"
     )
+  })
+
+  it("uses real guarded pages for workspace navigation", () => {
+    expect(
+      projectAudienceSectionHref("project/one", "owner", "schedule")
+    ).toBe("/preview/projects/project%2Fone/owner/schedule")
+    expect(
+      projectAudienceSectionHref("project/one", "sub-vendor", "rfis")
+    ).toBe("/preview/projects/project%2Fone/sub-vendor/rfis")
+    expect(
+      projectAudienceSectionHref("project/one", "owner", "overview")
+    ).toBe("/preview/projects/project%2Fone/owner")
   })
 
   it("keeps conversations inside the guarded audience workspace", () => {

--- a/src/lib/project-audience-preview-routes.ts
+++ b/src/lib/project-audience-preview-routes.ts
@@ -1,10 +1,28 @@
 export type ProjectAudiencePreviewRoute = "owner" | "sub-vendor"
+export type ProjectAudienceWorkspaceSection =
+  | "overview"
+  | "updates"
+  | "schedule"
+  | "commitments"
+  | "rfis"
+  | "conversations"
+  | "photos"
+  | "team"
 
 export function projectAudiencePreviewHref(
   projectId: string,
   audience: ProjectAudiencePreviewRoute
 ): string {
   return `/preview/projects/${encodeURIComponent(projectId)}/${audience}`
+}
+
+export function projectAudienceSectionHref(
+  projectId: string,
+  audience: ProjectAudiencePreviewRoute,
+  section: ProjectAudienceWorkspaceSection
+): string {
+  const homeHref = projectAudiencePreviewHref(projectId, audience)
+  return section === "overview" ? homeHref : `${homeHref}/${section}`
 }
 
 export function ownerUpdatePreviewHref(


### PR DESCRIPTION
## Summary

- replace anchor-scrolling owner and partner previews with dedicated, guarded Compass pages
- retain the photo-led project overview while routing updates, schedule, conversations, photos, team, commitments, and RFIs to real pages
- preserve the active destination when switching projects and highlight the current section in desktop and mobile navigation
- reorganize predecessor controls into readable two-row layouts so relationship and lag fields no longer overlap

## Safety

- all external pages reuse the existing audience-access action and server-side owner/partner visibility rules
- no internal dashboard routes or cross-audience conversations are exposed
- owner and partner destinations remain scoped to the selected project and audience

## Validation

- `bun test`: 55 files; 392 passed, 3 skipped
- `bunx tsc --noEmit`
- `bun lint`: 0 errors (80 pre-existing warnings)
- `bun run build`
- route and audience-access regression tests
