### PR TITLE
fix(owner-updates): preserve drafts across deploys

### DIFF
--- a/src/app/actions/project-field.ts
+++ b/src/app/actions/project-field.ts
@@ -311,6 +311,7 @@ type OwnerUpdateDraftResult =
 
 export type OwnerProjectUpdateDocument = {
   readonly canManage: boolean
+  readonly viewerId: string
   readonly project: OwnerUpdateProject
   readonly update: {
     readonly id: string
@@ -321,6 +322,7 @@ export type OwnerProjectUpdateDocument = {
     readonly channel: string
     readonly publishedAt: string | null
     readonly sentAt: string | null
+    readonly updatedAt: string
     readonly sourceDailyLogIds: readonly string[]
     readonly selectedPhotoIds: readonly string[]
     readonly selectedDocumentIds: readonly string[]
@@ -2172,6 +2174,7 @@ export async function getOwnerProjectUpdateDocument(
       scheduleSnapshot: ownerProjectUpdates.scheduleSnapshot,
       publishedAt: ownerProjectUpdates.publishedAt,
       sentAt: ownerProjectUpdates.sentAt,
+      updatedAt: ownerProjectUpdates.updatedAt,
     })
     .from(ownerProjectUpdates)
     .where(
@@ -2449,6 +2452,7 @@ export async function getOwnerProjectUpdateDocument(
 
   return {
     canManage,
+    viewerId: viewer.id,
     project,
     update: {
       id: update.id,
@@ -2459,6 +2463,7 @@ export async function getOwnerProjectUpdateDocument(
       channel: update.channel,
       publishedAt: update.publishedAt,
       sentAt: update.sentAt,
+      updatedAt: update.updatedAt,
       sourceDailyLogIds: selectedDailyLogIds,
       selectedPhotoIds,
       selectedDocumentIds,

--- a/src/app/api/projects/[id]/owner-updates/[updateId]/draft/route.ts
+++ b/src/app/api/projects/[id]/owner-updates/[updateId]/draft/route.ts
@@ -1,0 +1,41 @@
+import { updateOwnerProjectUpdateDraft } from "@/app/actions/project-field"
+import { ownerUpdateDraftEditSchema } from "@/lib/owner-updates/draft-recovery"
+
+export async function PUT(
+  request: Request,
+  {
+    params,
+  }: {
+    readonly params: Promise<{
+      readonly id: string
+      readonly updateId: string
+    }>
+  }
+): Promise<Response> {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json(
+      { success: false, error: "Invalid draft data." },
+      { status: 400 }
+    )
+  }
+
+  const parsed = ownerUpdateDraftEditSchema.safeParse(body)
+  if (!parsed.success) {
+    return Response.json(
+      { success: false, error: "The draft contains invalid data." },
+      { status: 400 }
+    )
+  }
+
+  const { id, updateId } = await params
+  const result = await updateOwnerProjectUpdateDraft(
+    id,
+    updateId,
+    parsed.data
+  )
+
+  return Response.json(result, { status: result.success ? 200 : 400 })
+}

--- a/src/components/projects/owner-update-draft-editor.tsx
+++ b/src/components/projects/owner-update-draft-editor.tsx
@@ -16,7 +16,6 @@ import {
 
 import {
   draftOwnerProjectUpdateWithJarvis,
-  updateOwnerProjectUpdateDraft,
   type OwnerProjectUpdateDocument,
 } from "@/app/actions/project-field"
 import { Badge } from "@/components/ui/badge"
@@ -39,6 +38,12 @@ import {
   PHOTO_UPLOAD_LIMIT_LABEL,
 } from "@/lib/photos/upload-limits"
 import { resolvePhotoImageSource } from "@/lib/photo-sources"
+import {
+  ownerUpdateDraftStorageKey,
+  parseRecoverableOwnerUpdateDraft,
+  serializeOwnerUpdateDraftBackup,
+  type OwnerUpdateDraftEdit,
+} from "@/lib/owner-updates/draft-recovery"
 
 type DraftStatus =
   | { readonly kind: "idle" }
@@ -91,6 +96,30 @@ function parseUploadedFiles(value: unknown): readonly UploadedFile[] {
         : null
     return [{ id: file.id, fileName: file.fileName, mimeType }]
   })
+}
+
+function parseDraftSaveResult(
+  value: unknown
+):
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string } {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "success" in value &&
+    value.success === true
+  ) {
+    return { success: true }
+  }
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "error" in value &&
+    typeof value.error === "string"
+  ) {
+    return { success: false, error: value.error }
+  }
+  return { success: false, error: "Compass returned an invalid save response." }
 }
 
 function SelectionCount({
@@ -147,6 +176,57 @@ export function OwnerUpdateDraftEditor({
   const [uploadFiles, setUploadFiles] = React.useState<readonly File[]>([])
   const [uploadCaption, setUploadCaption] = React.useState("")
   const [isUploading, setIsUploading] = React.useState(false)
+  const [draftRecoveryReady, setDraftRecoveryReady] = React.useState(false)
+  const draftStorageKey = ownerUpdateDraftStorageKey(
+    document.viewerId,
+    document.project.id,
+    document.update.id
+  )
+  const serverDraft = React.useMemo<OwnerUpdateDraftEdit>(
+    () => ({
+      title: document.update.title,
+      updateDate: document.update.updateDate,
+      periodStart: document.update.periodStart ?? document.update.updateDate,
+      periodEnd: document.update.periodEnd ?? document.update.updateDate,
+      summary: document.update.summary,
+      sourceDailyLogIds: document.update.sourceDailyLogIds,
+      selectedPhotoIds: document.update.selectedPhotoIds,
+      selectedDocumentIds: document.update.selectedDocumentIds,
+      completedScheduleItems: document.completedScheduleItems,
+      lookAheadScheduleItems: document.lookAheadScheduleItems,
+      todos: document.todos,
+    }),
+    [document]
+  )
+  const initialServerDraftJson = React.useRef(JSON.stringify(serverDraft))
+  const currentDraft = React.useMemo<OwnerUpdateDraftEdit>(
+    () => ({
+      title,
+      updateDate,
+      periodStart,
+      periodEnd,
+      summary,
+      sourceDailyLogIds,
+      selectedPhotoIds,
+      selectedDocumentIds,
+      completedScheduleItems,
+      lookAheadScheduleItems,
+      todos,
+    }),
+    [
+      completedScheduleItems,
+      lookAheadScheduleItems,
+      periodEnd,
+      periodStart,
+      selectedDocumentIds,
+      selectedPhotoIds,
+      sourceDailyLogIds,
+      summary,
+      title,
+      todos,
+      updateDate,
+    ]
+  )
   const selectedDailyLogIdSet = new Set(sourceDailyLogIds)
   const selectedPhotoIdSet = new Set(selectedPhotoIds)
   const selectedDocumentIdSet = new Set(selectedDocumentIds)
@@ -157,6 +237,77 @@ export function OwnerUpdateDraftEditor({
   const buildertrendPhotoCount = document.availablePhotos.filter((photo) =>
     photo.sourceSystem.toLowerCase().includes("buildertrend")
   ).length
+
+  React.useEffect(() => {
+    try {
+      const backup = parseRecoverableOwnerUpdateDraft(
+        globalThis.localStorage.getItem(draftStorageKey),
+        document.update.updatedAt
+      )
+      if (
+        backup !== null &&
+        JSON.stringify(backup.draft) !== initialServerDraftJson.current
+      ) {
+        setTitle(backup.draft.title)
+        setUpdateDate(backup.draft.updateDate)
+        setPeriodStart(backup.draft.periodStart)
+        setPeriodEnd(backup.draft.periodEnd)
+        setSummary(backup.draft.summary)
+        setSourceDailyLogIds(backup.draft.sourceDailyLogIds)
+        setSelectedPhotoIds(backup.draft.selectedPhotoIds)
+        setSelectedDocumentIds(backup.draft.selectedDocumentIds)
+        setCompletedScheduleItems(backup.draft.completedScheduleItems)
+        setLookAheadScheduleItems(backup.draft.lookAheadScheduleItems)
+        setTodos(backup.draft.todos)
+        setStatus({
+          kind: "saved",
+          message:
+            "Recovered unsaved edits from this browser. Review them, then save the draft.",
+        })
+      } else {
+        globalThis.localStorage.removeItem(draftStorageKey)
+      }
+    } catch {
+      // Browser storage can be unavailable in private or locked-down contexts.
+    } finally {
+      setDraftRecoveryReady(true)
+    }
+  }, [document.update.updatedAt, draftStorageKey])
+
+  React.useEffect(() => {
+    if (!draftRecoveryReady) return
+
+    const currentDraftJson = JSON.stringify(currentDraft)
+    if (currentDraftJson === initialServerDraftJson.current) {
+      try {
+        globalThis.localStorage.removeItem(draftStorageKey)
+      } catch {
+        // Browser storage is an extra recovery layer, not a save requirement.
+      }
+      return
+    }
+
+    const timeoutId = globalThis.setTimeout(() => {
+      try {
+        globalThis.localStorage.setItem(
+          draftStorageKey,
+          serializeOwnerUpdateDraftBackup({
+            draft: currentDraft,
+            serverUpdatedAt: document.update.updatedAt,
+          })
+        )
+      } catch {
+        // The server save remains available if browser storage is unavailable.
+      }
+    }, 250)
+
+    return () => globalThis.clearTimeout(timeoutId)
+  }, [
+    currentDraft,
+    document.update.updatedAt,
+    draftRecoveryReady,
+    draftStorageKey,
+  ])
 
   function scrollToSection(id: string): void {
     globalThis.document.getElementById(id)?.scrollIntoView({
@@ -265,29 +416,28 @@ export function OwnerUpdateDraftEditor({
   async function saveDraft(): Promise<boolean> {
     setStatus({ kind: "saving", message: "Saving curated sources..." })
     try {
-      const result = await updateOwnerProjectUpdateDraft(
-        document.project.id,
-        document.update.id,
+      const response = await fetch(
+        `/api/projects/${document.project.id}/owner-updates/${document.update.id}/draft`,
         {
-          title,
-          updateDate,
-          periodStart,
-          periodEnd,
-          summary,
-          sourceDailyLogIds,
-          selectedPhotoIds,
-          selectedDocumentIds,
-          completedScheduleItems,
-          lookAheadScheduleItems,
-          todos,
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(currentDraft),
         }
       )
+      const result = parseDraftSaveResult(await response.json())
 
       if (!result.success) {
         setStatus({ kind: "error", message: result.error })
         return false
       }
 
+      try {
+        globalThis.localStorage.removeItem(draftStorageKey)
+      } catch {
+        // The server save succeeded even if browser storage cleanup fails.
+      }
+      initialServerDraftJson.current = JSON.stringify(currentDraft)
+      setDraftRecoveryReady(false)
       setStatus({
         kind: "saved",
         message: "Draft saved. Choices were refreshed for this period.",
@@ -297,7 +447,8 @@ export function OwnerUpdateDraftEditor({
     } catch {
       setStatus({
         kind: "error",
-        message: "Unable to save this draft. Please try again.",
+        message:
+          "Unable to reach Compass. Your edits are backed up in this browser; do not close this page until the connection returns.",
       })
       return false
     }

--- a/src/lib/owner-updates/__tests__/draft-recovery.test.ts
+++ b/src/lib/owner-updates/__tests__/draft-recovery.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ownerUpdateDraftStorageKey,
+  parseRecoverableOwnerUpdateDraft,
+  serializeOwnerUpdateDraftBackup,
+  type OwnerUpdateDraftEdit,
+} from "@/lib/owner-updates/draft-recovery"
+
+const draft: OwnerUpdateDraftEdit = {
+  title: "Weekly update",
+  updateDate: "2026-07-28",
+  periodStart: "2026-07-20",
+  periodEnd: "2026-07-28",
+  summary: "Drywall is moving forward.",
+  sourceDailyLogIds: ["log-1"],
+  selectedPhotoIds: ["photo-1"],
+  selectedDocumentIds: [],
+  completedScheduleItems: [],
+  lookAheadScheduleItems: [],
+  todos: [],
+}
+
+describe("owner update draft recovery", () => {
+  it("uses a project- and update-specific browser key", () => {
+    expect(ownerUpdateDraftStorageKey("user-1", "project-1", "update-1")).toBe(
+      "compass:owner-update-draft:user-1:project-1:update-1"
+    )
+  })
+
+  it("recovers a browser draft saved after the server version", () => {
+    const serialized = serializeOwnerUpdateDraftBackup({
+      draft,
+      serverUpdatedAt: "2026-07-28T14:20:14.659Z",
+      savedAt: "2026-07-28T14:30:00.000Z",
+    })
+
+    expect(
+      parseRecoverableOwnerUpdateDraft(
+        serialized,
+        "2026-07-28T14:20:14.659Z"
+      )?.draft
+    ).toEqual(draft)
+  })
+
+  it("does not restore a backup based on a different server version", () => {
+    const serialized = serializeOwnerUpdateDraftBackup({
+      draft,
+      serverUpdatedAt: "2026-07-28T14:19:00.000Z",
+      savedAt: "2026-07-28T14:30:00.000Z",
+    })
+
+    expect(
+      parseRecoverableOwnerUpdateDraft(
+        serialized,
+        "2026-07-28T14:20:14.659Z"
+      )
+    ).toBeNull()
+  })
+
+  it("ignores malformed browser data", () => {
+    expect(
+      parseRecoverableOwnerUpdateDraft(
+        "{not-json",
+        "2026-07-28T14:20:14.659Z"
+      )
+    ).toBeNull()
+  })
+})

--- a/src/lib/owner-updates/draft-recovery.ts
+++ b/src/lib/owner-updates/draft-recovery.ts
@@ -1,0 +1,121 @@
+import { z } from "zod/v4"
+
+import type {
+  OwnerUpdateScheduleSelection,
+  OwnerUpdateTodoSelection,
+} from "@/lib/owner-updates/snapshot"
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+const scheduleSelectionSchema = z.object({
+  id: z.string().trim().min(1),
+  title: z.string(),
+  startDate: z.string().regex(ISO_DATE_PATTERN),
+  endDate: z.string().regex(ISO_DATE_PATTERN),
+  assignedTo: z.string().nullable(),
+  status: z.string(),
+  percentComplete: z.number().min(0).max(100),
+  notes: z.string(),
+})
+
+const todoSelectionSchema = z.object({
+  id: z.string().trim().min(1),
+  title: z.string(),
+  description: z.string(),
+  status: z.string(),
+  priority: z.string(),
+  assigneeName: z.string().nullable(),
+  companyName: z.string().nullable(),
+  dueDate: z.string().nullable(),
+  timing: z.union([z.literal("reporting_period"), z.literal("upcoming")]),
+  notes: z.string(),
+})
+
+export const ownerUpdateDraftEditSchema = z.object({
+  title: z.string(),
+  updateDate: z.string(),
+  periodStart: z.string(),
+  periodEnd: z.string(),
+  summary: z.string(),
+  sourceDailyLogIds: z.array(z.string()),
+  selectedPhotoIds: z.array(z.string()),
+  selectedDocumentIds: z.array(z.string()),
+  completedScheduleItems: z.array(scheduleSelectionSchema),
+  lookAheadScheduleItems: z.array(scheduleSelectionSchema),
+  todos: z.array(todoSelectionSchema),
+})
+
+const ownerUpdateDraftBackupSchema = z.object({
+  version: z.literal(1),
+  savedAt: z.string(),
+  serverUpdatedAt: z.string(),
+  draft: ownerUpdateDraftEditSchema,
+})
+
+export type OwnerUpdateDraftEdit = {
+  readonly title: string
+  readonly updateDate: string
+  readonly periodStart: string
+  readonly periodEnd: string
+  readonly summary: string
+  readonly sourceDailyLogIds: readonly string[]
+  readonly selectedPhotoIds: readonly string[]
+  readonly selectedDocumentIds: readonly string[]
+  readonly completedScheduleItems: readonly OwnerUpdateScheduleSelection[]
+  readonly lookAheadScheduleItems: readonly OwnerUpdateScheduleSelection[]
+  readonly todos: readonly OwnerUpdateTodoSelection[]
+}
+
+export type OwnerUpdateDraftBackup = {
+  readonly version: 1
+  readonly savedAt: string
+  readonly serverUpdatedAt: string
+  readonly draft: OwnerUpdateDraftEdit
+}
+
+export function ownerUpdateDraftStorageKey(
+  userId: string,
+  projectId: string,
+  updateId: string
+): string {
+  return `compass:owner-update-draft:${userId}:${projectId}:${updateId}`
+}
+
+export function serializeOwnerUpdateDraftBackup(input: {
+  readonly draft: OwnerUpdateDraftEdit
+  readonly serverUpdatedAt: string
+  readonly savedAt?: string
+}): string {
+  return JSON.stringify({
+    version: 1,
+    savedAt: input.savedAt ?? new Date().toISOString(),
+    serverUpdatedAt: input.serverUpdatedAt,
+    draft: input.draft,
+  })
+}
+
+export function parseRecoverableOwnerUpdateDraft(
+  value: string | null,
+  currentServerUpdatedAt: string
+): OwnerUpdateDraftBackup | null {
+  if (value === null || value.trim().length === 0) return null
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch {
+    return null
+  }
+
+  const result = ownerUpdateDraftBackupSchema.safeParse(parsed)
+  if (!result.success) return null
+
+  if (
+    !Number.isFinite(Date.parse(result.data.savedAt)) ||
+    result.data.serverUpdatedAt !== currentServerUpdatedAt
+  ) {
+    return null
+  }
+
+  return result.data
+}


### PR DESCRIPTION
## Root cause

Sylvi's Loomis editor remained open across a production deployment. Its Save button still referenced the previous build's Server Action, so saves after the deployment failed at the browser transport layer even though the draft itself remained intact through 8:20 AM Mountain Time.

## Fix

- save owner-update drafts through a stable authenticated HTTP endpoint instead of a deployment-specific client Server Action reference
- retain all existing project, organization, feature-permission, draft-status, attachment-scope, and reporting-period validation
- back up changed text, source selections, photos/documents, schedule items, and to-dos in browser storage after 250 ms
- scope browser recovery data by user, project, and update
- automatically restore an unsaved backup when the server draft is still the same version
- clear the backup after a confirmed server save
- replace the generic failure message with explicit do-not-close recovery guidance

## Validation

- Vitest: 56 files passed; 396 tests passed, 3 skipped
- focused draft/snapshot recovery tests: 11 passed
- TypeScript: clean
- ESLint: 0 errors (80 existing warnings)
- production Next.js build: passed with the stable draft route in the manifest
- read-only production D1 verification confirmed the Loomis draft and its last successful save timestamp
