### PR TITLE
fix(schedule): keep gantt navigation in sync

### DIFF
--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -462,6 +462,82 @@ export async function completeScheduleTasks(
   }
 }
 
+export async function assignScheduleTasks(
+  projectId: string,
+  taskIds: readonly string[],
+  assignedTo: string | null
+): Promise<
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string }
+> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    const orgId = requireOrg(user)
+    const ids = [...new Set(taskIds.map((id) => id.trim()).filter(Boolean))]
+
+    if (ids.length === 0) {
+      return { success: false, error: "Select at least one schedule item" }
+    }
+    if (ids.length > 200) {
+      return {
+        success: false,
+        error: "Update no more than 200 schedule items at a time",
+      }
+    }
+
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const [project] = await db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(and(eq(projects.id, projectId), eq(projects.organizationId, orgId)))
+      .limit(1)
+
+    if (!project) {
+      return { success: false, error: "Project not found or access denied" }
+    }
+
+    const matchingTasks = await db
+      .select({ id: scheduleTasks.id })
+      .from(scheduleTasks)
+      .where(
+        and(
+          eq(scheduleTasks.projectId, projectId),
+          inArray(scheduleTasks.id, ids)
+        )
+      )
+
+    if (matchingTasks.length !== ids.length) {
+      return {
+        success: false,
+        error: "One or more schedule items could not be found",
+      }
+    }
+
+    await db
+      .update(scheduleTasks)
+      .set({
+        assignedTo: assignedTo?.trim() || null,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(
+        and(
+          eq(scheduleTasks.projectId, projectId),
+          inArray(scheduleTasks.id, ids)
+        )
+      )
+
+    revalidateSchedulePaths(projectId)
+    return { success: true }
+  } catch (error) {
+    console.error("Failed to assign schedule items:", error)
+    return { success: false, error: "Failed to assign schedule items" }
+  }
+}
+
 export async function deleteScheduleTasks(
   projectId: string,
   taskIds: readonly string[]

--- a/src/components/projects/project-assignee-picker.tsx
+++ b/src/components/projects/project-assignee-picker.tsx
@@ -27,6 +27,7 @@ type ProjectAssigneePickerProps = {
   readonly placeholder?: string
   readonly className?: string
   readonly disabled?: boolean
+  readonly clearLabel?: string
 }
 
 function normalizeChoice(value: string): string {
@@ -91,6 +92,7 @@ export function ProjectAssigneePicker({
   placeholder = "Choose contact or type a name...",
   className,
   disabled = false,
+  clearLabel = "Clear",
 }: ProjectAssigneePickerProps): React.ReactElement {
   const [open, setOpen] = React.useState(false)
   const [query, setQuery] = React.useState("")
@@ -205,7 +207,7 @@ export function ProjectAssigneePicker({
               setOpen(false)
             }}
           >
-            Clear
+            {clearLabel}
           </Button>
           <Button
             type="button"

--- a/src/components/schedule/gantt-chart.tsx
+++ b/src/components/schedule/gantt-chart.tsx
@@ -8,11 +8,57 @@ import {
   dominantScrollAxis,
   lockWheelToDominantAxis,
   normalizeWheelDelta,
+  paddingToIncludeDate,
   type GanttScrollAxis,
 } from "@/lib/schedule/gantt-scroll"
 import "./gantt.css"
 
 type ViewMode = "Day" | "Week" | "Month"
+
+export interface GanttScrollPosition {
+  readonly left: number
+  readonly top: number
+  readonly anchorDate?: string
+}
+
+function differenceInUnits(date: Date, start: Date, unit: string): number {
+  if (unit === "month") {
+    const yearDifference = date.getFullYear() - start.getFullYear()
+    let monthDifference = date.getMonth() - start.getMonth()
+    monthDifference += date.getDate() / 31
+    if (date.getDate() < start.getDate()) monthDifference -= 1
+    return yearDifference * 12 + monthDifference
+  }
+
+  const timezoneOffset = start.getTimezoneOffset() - date.getTimezoneOffset()
+  const milliseconds = date.getTime() - start.getTime() + timezoneOffset * 60_000
+  return milliseconds / 86_400_000
+}
+
+function addUnits(start: Date, amount: number, unit: string): Date {
+  const date = new Date(start)
+  if (unit === "month") {
+    const wholeMonths = Math.trunc(amount)
+    date.setMonth(date.getMonth() + wholeMonths)
+    date.setTime(date.getTime() + (amount - wholeMonths) * 30 * 86_400_000)
+    return date
+  }
+  date.setTime(date.getTime() + amount * 86_400_000)
+  return date
+}
+
+function dateKey(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+function basePaddingDays(viewMode: ViewMode): number {
+  if (viewMode === "Day") return 7
+  if (viewMode === "Week") return 31
+  return 62
+}
 
 function monthYearLabel(date: Date): string {
   return date.toLocaleDateString("en-US", {
@@ -102,7 +148,12 @@ interface GanttChartProps {
   onZoom?: (direction: "in" | "out") => void
   onTaskDoubleClick?: (task: FrappeTask) => void
   onContainerReady?: (container: HTMLElement | null) => void
-  onScrollTopChange?: (top: number) => void
+  onScrollPositionChange?: (position: GanttScrollPosition) => void
+  onTodayScrollReady?: (handler: (() => void) | null) => void
+  onDateScrollReady?: (handler: ((date: string) => void) | null) => void
+  onTaskVisibilityReady?: (
+    handler: ((taskId: string) => void) | null
+  ) => void
 }
 
 export function GanttChart({
@@ -117,7 +168,10 @@ export function GanttChart({
   onZoom,
   onTaskDoubleClick,
   onContainerReady,
-  onScrollTopChange,
+  onScrollPositionChange,
+  onTodayScrollReady,
+  onDateScrollReady,
+  onTaskVisibilityReady,
 }: GanttChartProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const wrapperRef = useRef<HTMLDivElement>(null)
@@ -129,12 +183,18 @@ export function GanttChart({
   const interactionCallbacksRef = useRef({
     onTaskDoubleClick,
     onContainerReady,
-    onScrollTopChange,
+    onScrollPositionChange,
+    onTodayScrollReady,
+    onDateScrollReady,
+    onTaskVisibilityReady,
   })
   interactionCallbacksRef.current = {
     onTaskDoubleClick,
     onContainerReady,
-    onScrollTopChange,
+    onScrollPositionChange,
+    onTodayScrollReady,
+    onDateScrollReady,
+    onTaskVisibilityReady,
   }
 
   const taskForEventTarget = useCallback((target: EventTarget): FrappeTask | null => {
@@ -228,9 +288,23 @@ export function GanttChart({
     let activeContainer: HTMLElement | null = null
     const handleScroll = () => {
       if (!activeContainer) return
-      interactionCallbacksRef.current.onScrollTopChange?.(
-        activeContainer.scrollTop
-      )
+      const gantt = ganttRef.current
+      const centerUnits = gantt
+        ? ((activeContainer.scrollLeft + activeContainer.clientWidth / 2) /
+            gantt.config.column_width) *
+          gantt.config.step
+        : 0
+      interactionCallbacksRef.current.onScrollPositionChange?.({
+        left: activeContainer.scrollLeft,
+        top: activeContainer.scrollTop,
+        ...(gantt
+          ? {
+              anchorDate: dateKey(
+                addUnits(gantt.gantt_start, centerUnits, gantt.config.unit)
+              ),
+            }
+          : {}),
+      })
     }
     const handleAxisLockedWheel = (event: WheelEvent) => {
       if (!activeContainer || event.ctrlKey) return
@@ -272,10 +346,31 @@ export function GanttChart({
         dependencies: t.dependencies,
         custom_class: t.custom_class,
       }))
+      const earliestStart = tasks
+        .map((task) => task.start)
+        .sort((left, right) => left.localeCompare(right))[0]
+      const latestEnd = tasks
+        .map((task) => task.end)
+        .sort((left, right) => right.localeCompare(left))[0]
+      const today = dateKey(new Date())
+      const viewModes = GANTT_VIEW_MODES.map((mode) =>
+        mode.name === viewMode
+          ? {
+              ...mode,
+              padding: paddingToIncludeDate(
+                earliestStart,
+                latestEnd,
+                today,
+                basePaddingDays(viewMode)
+              ),
+            }
+          : mode
+      )
 
       ganttRef.current = new Gantt(containerRef.current, ganttTasks, {
         view_mode: viewMode,
-        view_modes: GANTT_VIEW_MODES,
+        view_modes: viewModes,
+        infinite_padding: false,
         ...(columnWidth ? { column_width: columnWidth } : {}),
         on_date_change: (task: { id: string }, start: Date, end: Date) => {
           if (onDateChange) {
@@ -293,6 +388,45 @@ export function GanttChart({
       // Frappe resets a custom view-mode collection to its first entry during
       // construction, so explicitly restore the React-selected mode.
       ganttRef.current.change_view_mode(viewMode)
+      const gantt = ganttRef.current
+      interactionCallbacksRef.current.onTodayScrollReady?.(() => {
+        const container = ganttContainerRef.current
+        if (!container) return
+        const todayDate = new Date()
+        todayDate.setHours(0, 0, 0, 0)
+        const units = differenceInUnits(
+          todayDate,
+          gantt.gantt_start,
+          gantt.config.unit
+        )
+        const left =
+          (units / gantt.config.step) * gantt.config.column_width -
+          container.clientWidth / 2
+        container.scrollTo({
+          left: Math.max(
+            0,
+            Math.min(left, container.scrollWidth - container.clientWidth)
+          ),
+          behavior: "smooth",
+        })
+      })
+      interactionCallbacksRef.current.onDateScrollReady?.((date) => {
+        const container = ganttContainerRef.current
+        if (!container) return
+        const anchor = new Date(`${date}T00:00:00`)
+        const units = differenceInUnits(
+          anchor,
+          gantt.gantt_start,
+          gantt.config.unit
+        )
+        const left =
+          (units / gantt.config.step) * gantt.config.column_width -
+          container.clientWidth / 2
+        container.scrollLeft = Math.max(
+          0,
+          Math.min(left, container.scrollWidth - container.clientWidth)
+        )
+      })
 
       const tasksById = new Map(tasks.map((task) => [task.id, task]))
       for (const wrapper of containerRef.current.querySelectorAll<HTMLElement>(
@@ -318,6 +452,35 @@ export function GanttChart({
         activeContainer.addEventListener("wheel", handleAxisLockedWheel, {
           passive: false,
         })
+        interactionCallbacksRef.current.onTaskVisibilityReady?.((taskId) => {
+          const root = containerRef.current
+          const container = ganttContainerRef.current
+          if (!root || !container) return
+          const bar = root.querySelector<SVGRectElement>(
+            `.gantt .bar-wrapper[data-id="${CSS.escape(taskId)}"] .bar`
+          )
+          if (!bar) return
+          const barLeft = Number(bar.getAttribute("x"))
+          const barWidth = Number(bar.getAttribute("width"))
+          if (!Number.isFinite(barLeft) || !Number.isFinite(barWidth)) return
+          const safeLeft = container.scrollLeft + 32
+          const safeRight =
+            container.scrollLeft + container.clientWidth - 32
+          const barRight = barLeft + barWidth
+          if (barRight >= safeLeft && barLeft <= safeRight) return
+          const centeredLeft =
+            barLeft + barWidth / 2 - container.clientWidth / 2
+          container.scrollTo({
+            left: Math.max(
+              0,
+              Math.min(
+                centeredLeft,
+                container.scrollWidth - container.clientWidth
+              )
+            ),
+            behavior: "auto",
+          })
+        })
         interactionCallbacksRef.current.onContainerReady?.(activeContainer)
       }
 
@@ -333,6 +496,9 @@ export function GanttChart({
         ganttContainerRef.current = null
       }
       interactionCallbacksRef.current.onContainerReady?.(null)
+      interactionCallbacksRef.current.onTodayScrollReady?.(null)
+      interactionCallbacksRef.current.onDateScrollReady?.(null)
+      interactionCallbacksRef.current.onTaskVisibilityReady?.(null)
     }
   }, [tasks, viewMode, columnWidth, onDateChange, onProgressChange])
 

--- a/src/components/schedule/gantt.css
+++ b/src/components/schedule/gantt.css
@@ -10,6 +10,7 @@
   height: 100% !important;
   max-height: 100%;
   min-height: 0;
+  overscroll-behavior: contain;
   scrollbar-gutter: stable;
   scrollbar-width: thin;
   scrollbar-color: oklch(0.72 0.02 95 / 0.7) transparent;

--- a/src/components/schedule/schedule-gantt-view.tsx
+++ b/src/components/schedule/schedule-gantt-view.tsx
@@ -51,7 +51,10 @@ import {
 } from "@/components/ui/select"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
-import { GanttChart } from "./gantt-chart"
+import {
+  GanttChart,
+  type GanttScrollPosition,
+} from "./gantt-chart"
 import { ScheduleItemFormDialog } from "./schedule-item-form-dialog"
 import {
   transformToFrappeTasks,
@@ -81,6 +84,10 @@ import { ProjectTaskCreateButton } from "@/components/projects/project-task-crea
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { format } from "date-fns"
+import {
+  ganttRowIndexForScrollTop,
+  synchronizedScrollTop,
+} from "@/lib/schedule/gantt-scroll"
 
 type ViewMode = "Day" | "Week" | "Month"
 
@@ -129,6 +136,15 @@ export function ScheduleGanttView({
   const [panMode] = useState(false)
   const taskListRef = useRef<HTMLDivElement>(null)
   const ganttContainerRef = useRef<HTMLElement | null>(null)
+  const scrollPositionRef = useRef<GanttScrollPosition>({ left: 0, top: 0 })
+  const scrollStorageTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const scrollToTodayRef = useRef<(() => void) | null>(null)
+  const scrollToDateRef = useRef<((date: string) => void) | null>(null)
+  const scrollTaskIntoViewRef = useRef<((taskId: string) => void) | null>(null)
+  const displayItemsRef = useRef<readonly DisplayItem[]>([])
+  const followedListItemRef = useRef<string | null>(null)
+  const scrollRestoredProjectRef = useRef<string | null>(null)
+  const scrollStorageKey = `compass:schedule-scroll:${projectId}`
 
   const [hasLoadedPalette, setHasLoadedPalette] = useState(false)
 
@@ -192,32 +208,171 @@ export function ScheduleGanttView({
     setColumnWidth(defaultWidths[mode])
   }
 
+  const rememberScrollPosition = useCallback(
+    (position: GanttScrollPosition) => {
+      scrollPositionRef.current = position
+      if (scrollStorageTimerRef.current) {
+        clearTimeout(scrollStorageTimerRef.current)
+      }
+      scrollStorageTimerRef.current = setTimeout(() => {
+        try {
+          window.sessionStorage.setItem(
+            scrollStorageKey,
+            JSON.stringify(scrollPositionRef.current)
+          )
+        } catch {
+          // In-memory state still preserves this visit.
+        }
+      }, 150)
+    },
+    [scrollStorageKey]
+  )
+
+  const flushScrollPosition = useCallback(() => {
+    if (scrollStorageTimerRef.current) {
+      clearTimeout(scrollStorageTimerRef.current)
+      scrollStorageTimerRef.current = null
+    }
+    try {
+      window.sessionStorage.setItem(
+        scrollStorageKey,
+        JSON.stringify(scrollPositionRef.current)
+      )
+    } catch {
+      // Persisting the position is optional.
+    }
+  }, [scrollStorageKey])
+
+  useEffect(() => {
+    return flushScrollPosition
+  }, [flushScrollPosition])
+
   const handleGanttContainerReady = useCallback(
     (container: HTMLElement | null) => {
       ganttContainerRef.current = container
-      if (container && taskListRef.current) {
-        container.scrollTop = taskListRef.current.scrollTop
+      if (!container) return
+
+      let position = scrollPositionRef.current
+      if (scrollRestoredProjectRef.current !== projectId) {
+        try {
+          const stored = window.sessionStorage.getItem(scrollStorageKey)
+          if (stored) {
+            const parsed: unknown = JSON.parse(stored)
+            if (
+              parsed &&
+              typeof parsed === "object" &&
+              "left" in parsed &&
+              "top" in parsed &&
+              typeof parsed.left === "number" &&
+              typeof parsed.top === "number" &&
+              (!("anchorDate" in parsed) ||
+                typeof parsed.anchorDate === "string")
+            ) {
+              const anchorDate =
+                "anchorDate" in parsed &&
+                typeof parsed.anchorDate === "string"
+                  ? parsed.anchorDate
+                  : null
+              position = {
+                left: parsed.left,
+                top: parsed.top,
+                ...(anchorDate ? { anchorDate } : {}),
+              }
+            }
+          }
+        } catch {
+          // Use the current in-memory position.
+        }
+        scrollRestoredProjectRef.current = projectId
       }
+
+      scrollPositionRef.current = position
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (position.anchorDate && scrollToDateRef.current) {
+            scrollToDateRef.current(position.anchorDate)
+          } else {
+            container.scrollLeft = position.left
+          }
+          container.scrollTop = position.top
+          if (taskListRef.current) {
+            taskListRef.current.scrollTop = synchronizedScrollTop(
+              position.top,
+              container.scrollHeight,
+              container.clientHeight,
+              taskListRef.current.scrollHeight,
+              taskListRef.current.clientHeight
+            )
+          }
+        })
+      })
     },
-    []
+    [projectId, scrollStorageKey]
   )
 
-  const handleGanttScroll = useCallback((top: number) => {
-    const taskList = taskListRef.current
-    if (taskList && Math.abs(taskList.scrollTop - top) > 1) {
-      taskList.scrollTop = top
-    }
-  }, [])
+  const handleGanttScroll = useCallback(
+    (position: GanttScrollPosition) => {
+      const taskList = taskListRef.current
+      const ganttContainer = ganttContainerRef.current
+      if (taskList && ganttContainer) {
+        const synchronizedTop = synchronizedScrollTop(
+          position.top,
+          ganttContainer.scrollHeight,
+          ganttContainer.clientHeight,
+          taskList.scrollHeight,
+          taskList.clientHeight
+        )
+        if (Math.abs(taskList.scrollTop - synchronizedTop) > 1) {
+          taskList.scrollTop = synchronizedTop
+        }
+      }
+      rememberScrollPosition(position)
+    },
+    [rememberScrollPosition]
+  )
 
   const handleTaskListScroll = useCallback(
     (event: UIEvent<HTMLDivElement>) => {
       const top = event.currentTarget.scrollTop
       const ganttContainer = ganttContainerRef.current
-      if (ganttContainer && Math.abs(ganttContainer.scrollTop - top) > 1) {
-        ganttContainer.scrollTop = top
+      if (ganttContainer) {
+        const synchronizedTop = synchronizedScrollTop(
+          top,
+          event.currentTarget.scrollHeight,
+          event.currentTarget.clientHeight,
+          ganttContainer.scrollHeight,
+          ganttContainer.clientHeight
+        )
+        if (Math.abs(ganttContainer.scrollTop - synchronizedTop) > 1) {
+          ganttContainer.scrollTop = synchronizedTop
+        }
+
+        const itemIndex = ganttRowIndexForScrollTop(
+          top,
+          displayItemsRef.current.length
+        )
+        const item =
+          itemIndex === null ? undefined : displayItemsRef.current[itemIndex]
+        const itemKey =
+          item?.type === "task" ? item.task.id : item?.phase ?? null
+        if (item && itemKey && followedListItemRef.current !== itemKey) {
+          followedListItemRef.current = itemKey
+          if (item.type === "task") {
+            scrollTaskIntoViewRef.current?.(item.task.id)
+          } else {
+            scrollToDateRef.current?.(item.group.startDate)
+          }
+        }
       }
+      rememberScrollPosition({
+        left: ganttContainer?.scrollLeft ?? scrollPositionRef.current.left,
+        top: ganttContainer?.scrollTop ?? top,
+        ...(scrollPositionRef.current.anchorDate
+          ? { anchorDate: scrollPositionRef.current.anchorDate }
+          : {}),
+      })
     },
-    []
+    [rememberScrollPosition]
   )
 
   const openTaskEditor = useCallback(
@@ -293,6 +448,7 @@ export function ScheduleGanttView({
           },
     [collapsedPhases, dependencies, filteredTasks, phaseGrouping]
   )
+  displayItemsRef.current = displayItems
 
   const togglePhase = (phase: string) => {
     setCollapsedPhases((prev) => {
@@ -337,14 +493,30 @@ export function ScheduleGanttView({
     [exceptions, router]
   )
 
-  const scrollToToday = () => {
-    const todayEl = document.querySelector(
-      ".gantt-container .today-highlight"
-    )
-    if (todayEl) {
-      todayEl.scrollIntoView({ behavior: "smooth", inline: "center" })
-    }
-  }
+  const handleTodayScrollReady = useCallback(
+    (handler: (() => void) | null) => {
+      scrollToTodayRef.current = handler
+    },
+    []
+  )
+
+  const handleDateScrollReady = useCallback(
+    (handler: ((date: string) => void) | null) => {
+      scrollToDateRef.current = handler
+    },
+    []
+  )
+
+  const handleTaskVisibilityReady = useCallback(
+    (handler: ((taskId: string) => void) | null) => {
+      scrollTaskIntoViewRef.current = handler
+    },
+    []
+  )
+
+  const scrollToToday = useCallback(() => {
+    scrollToTodayRef.current?.()
+  }, [])
 
   const taskTable = (
     <Table className="table-fixed">
@@ -732,7 +904,10 @@ export function ScheduleGanttView({
                 onZoom={handleZoom}
                 onTaskDoubleClick={openTaskEditor}
                 onContainerReady={handleGanttContainerReady}
-                onScrollTopChange={handleGanttScroll}
+                onScrollPositionChange={handleGanttScroll}
+                onTodayScrollReady={handleTodayScrollReady}
+                onDateScrollReady={handleDateScrollReady}
+                onTaskVisibilityReady={handleTaskVisibilityReady}
               />
               {scheduleKey}
             </div>
@@ -768,7 +943,10 @@ export function ScheduleGanttView({
                 onZoom={handleZoom}
                 onTaskDoubleClick={openTaskEditor}
                 onContainerReady={handleGanttContainerReady}
-                onScrollTopChange={handleGanttScroll}
+                onScrollPositionChange={handleGanttScroll}
+                onTodayScrollReady={handleTodayScrollReady}
+                onDateScrollReady={handleDateScrollReady}
+                onTaskVisibilityReady={handleTaskVisibilityReady}
               />
               {scheduleKey}
             </div>

--- a/src/components/schedule/schedule-list-view.tsx
+++ b/src/components/schedule/schedule-list-view.tsx
@@ -36,9 +36,11 @@ import { ScheduleItemFormDialog } from "./schedule-item-form-dialog"
 import { DependencyDialog } from "./dependency-dialog"
 import { effectivePercentComplete } from "@/lib/schedule/progress"
 import {
+  assignScheduleTasks,
   completeScheduleTasks,
   deleteScheduleTasks,
 } from "@/app/actions/schedule"
+import { addDirectoryContactToProjectForTask } from "@/app/actions/project-contacts"
 import type {
   ScheduleTaskData,
   TaskDependencyData,
@@ -55,6 +57,7 @@ import {
   getScheduleItemDisplayColor,
   type DisplayColorPalette,
 } from "@/lib/schedule/appearance"
+import { ProjectAssigneePicker } from "@/components/projects/project-assignee-picker"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -369,6 +372,57 @@ export function ScheduleListView({
     router.refresh()
   }
 
+  const handleAssignSelected = async (
+    value: string,
+    option: ProjectTaskAssigneeOption | null
+  ): Promise<void> => {
+    const selectedIds = selectedTasks.map((task) => task.id)
+    if (selectedIds.length === 0) return
+
+    setIsWorking(true)
+    let assignedName = value.trim()
+    if (option?.source === "directory" && option.directoryContactId) {
+      const contactResult = await addDirectoryContactToProjectForTask(
+        projectId,
+        option.directoryContactId
+      )
+      if (!contactResult.success) {
+        setIsWorking(false)
+        toast.error(contactResult.error)
+        return
+      }
+      assignedName = contactResult.contact.name
+    }
+
+    const result = await assignScheduleTasks(
+      projectId,
+      selectedIds,
+      assignedName || null
+    )
+    setIsWorking(false)
+
+    if (!result.success) {
+      toast.error(result.error)
+      return
+    }
+
+    const assignedIds = new Set(selectedIds)
+    setLocalTasks((current) =>
+      current.map((task) =>
+        assignedIds.has(task.id)
+          ? { ...task, assignedTo: assignedName || null }
+          : task
+      )
+    )
+    setRowSelection({})
+    toast.success(
+      assignedName
+        ? `${selectedIds.length} schedule item${selectedIds.length === 1 ? "" : "s"} assigned to ${assignedName}.`
+        : `${selectedIds.length} schedule item${selectedIds.length === 1 ? "" : "s"} unassigned.`
+    )
+    router.refresh()
+  }
+
   const handleConfirmDelete = async (): Promise<void> => {
     const deletingTasks = pendingDeleteTasks
     const selectedIds = deletingTasks.map((task) => task.id)
@@ -451,6 +505,19 @@ export function ScheduleListView({
               <IconCircleCheck className="size-4" />
               Mark complete
             </Button>
+            <div className="w-[220px]">
+              <ProjectAssigneePicker
+                value=""
+                options={assigneeOptions}
+                disabled={isWorking}
+                placeholder="Assign / reassign"
+                clearLabel="Unassign selected"
+                className="h-8 text-xs"
+                onValueChange={(value, option) => {
+                  void handleAssignSelected(value, option)
+                }}
+              />
+            </div>
             <Button
               type="button"
               size="sm"

--- a/src/lib/schedule/__tests__/gantt-scroll.test.ts
+++ b/src/lib/schedule/__tests__/gantt-scroll.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest"
 import {
   dominantScrollAxis,
+  ganttRowIndexForScrollTop,
   lockWheelToDominantAxis,
   normalizeWheelDelta,
+  paddingToIncludeDate,
+  synchronizedScrollTop,
 } from "../gantt-scroll"
 
 describe("Gantt dominant-axis scrolling", () => {
@@ -29,5 +32,27 @@ describe("Gantt dominant-axis scrolling", () => {
     expect(normalizeWheelDelta(2, 1, 500)).toBe(32)
     expect(normalizeWheelDelta(-1, 2, 500)).toBe(-500)
     expect(normalizeWheelDelta(24, 0, 500)).toBe(24)
+  })
+
+  it("maps independently sized scroll panes to the same relative row", () => {
+    expect(synchronizedScrollTop(450, 1_100, 200, 900, 100)).toBe(400)
+    expect(synchronizedScrollTop(900, 1_100, 200, 900, 100)).toBe(800)
+  })
+
+  it("extends the timeline enough for Today to be reachable", () => {
+    expect(
+      paddingToIncludeDate("2026-08-01", "2026-09-01", "2026-07-28", 7)
+    ).toEqual(["11d", "7d"])
+    expect(
+      paddingToIncludeDate("2025-08-01", "2025-09-01", "2026-07-28", 7)
+    ).toEqual(["7d", "337d"])
+  })
+
+  it("follows the row below the fixed Gantt header", () => {
+    expect(ganttRowIndexForScrollTop(0, 10)).toBe(0)
+    expect(ganttRowIndexForScrollTop(84, 10)).toBe(0)
+    expect(ganttRowIndexForScrollTop(133, 10)).toBe(1)
+    expect(ganttRowIndexForScrollTop(10_000, 10)).toBe(9)
+    expect(ganttRowIndexForScrollTop(0, 0)).toBeNull()
   })
 })

--- a/src/lib/schedule/gantt-scroll.ts
+++ b/src/lib/schedule/gantt-scroll.ts
@@ -39,3 +39,56 @@ export function normalizeWheelDelta(
   if (deltaMode === 2) return delta * pageSize
   return delta
 }
+
+export function synchronizedScrollTop(
+  sourceTop: number,
+  sourceScrollHeight: number,
+  sourceClientHeight: number,
+  targetScrollHeight: number,
+  targetClientHeight: number
+): number {
+  const sourceRange = Math.max(0, sourceScrollHeight - sourceClientHeight)
+  const targetRange = Math.max(0, targetScrollHeight - targetClientHeight)
+  if (sourceRange === 0 || targetRange === 0) return 0
+  const progress = Math.min(1, Math.max(0, sourceTop / sourceRange))
+  return progress * targetRange
+}
+
+export function paddingToIncludeDate(
+  startDate: string,
+  endDate: string,
+  targetDate: string,
+  basePaddingDays: number
+): [string, string] {
+  const parseCalendarDate = (value: string): number => {
+    const [year = 0, month = 1, day = 1] = value.split("-").map(Number)
+    return Date.UTC(year, month - 1, day)
+  }
+  const start = parseCalendarDate(startDate)
+  const end = parseCalendarDate(endDate)
+  const target = parseCalendarDate(targetDate)
+  const millisecondsPerDay = 86_400_000
+  const daysBefore = Math.max(
+    0,
+    Math.ceil((start - target) / millisecondsPerDay)
+  )
+  const daysAfter = Math.max(
+    0,
+    Math.ceil((target - end) / millisecondsPerDay)
+  )
+  return [
+    `${basePaddingDays + daysBefore}d`,
+    `${basePaddingDays + daysAfter}d`,
+  ]
+}
+
+export function ganttRowIndexForScrollTop(
+  scrollTop: number,
+  itemCount: number,
+  headerHeight = 85,
+  rowHeight = 48
+): number | null {
+  if (itemCount === 0) return null
+  const rowOffset = Math.max(0, scrollTop - headerHeight)
+  return Math.min(itemCount - 1, Math.floor(rowOffset / rowHeight))
+}

--- a/src/types/frappe-gantt.d.ts
+++ b/src/types/frappe-gantt.d.ts
@@ -13,6 +13,7 @@ declare module "frappe-gantt" {
     view_mode?: string
     view_modes?: readonly GanttViewMode[]
     column_width?: number
+    infinite_padding?: boolean
     on_date_change?: (
       task: { id: string },
       start: Date,
@@ -26,7 +27,7 @@ declare module "frappe-gantt" {
 
   interface GanttViewMode {
     readonly name: string
-    readonly padding?: string
+    readonly padding?: string | readonly [string, string]
     readonly step?: string
     readonly date_format?: string
     readonly column_width?: number
@@ -47,5 +48,12 @@ declare module "frappe-gantt" {
       tasks: GanttTask[],
       options?: GanttOptions
     )
+    change_view_mode(viewMode?: string, maintainPosition?: boolean): void
+    readonly gantt_start: Date
+    readonly config: {
+      readonly column_width: number
+      readonly step: number
+      readonly unit: string
+    }
   }
 }


### PR DESCRIPTION
## What

- Makes the Gantt Today control include and center the current date even when scheduled work falls outside the normal chart padding.
- Keeps the task list and timeline vertically synchronized across different scroll heights.
- Follows the visible list row horizontally when its Gantt bar is outside the viewport.
- Preserves the timeline's date anchor when changing Day, Week, and Month views.
- Adds bulk assign, reassign, and unassign using the existing project/directory contact picker.

## Why

The Today control was targeting a nonexistent DOM marker, and raw scroll-top mirroring allowed the independently sized panes to drift. Later-dated tasks could also move offscreen horizontally while users scrolled the task list.

## How to test

1. Open a project schedule with enough rows to scroll.
2. Click Today in Day, Week, and Month views and confirm the current date is centered.
3. Scroll the left task list vertically and confirm timeline rows stay aligned and the visible row's bar remains in view.
4. Switch time scales and confirm the same date region remains visible.
5. Select several list rows and assign, reassign, and unassign them.

## Validation

- 34 schedule tests passed.
- Focused ESLint passed with no errors.
- Production build and the repository pre-push build both passed.