### PR TITLE
fix(schedule): restore direct gantt scrolling

### DIFF
--- a/src/components/schedule/gantt-chart.tsx
+++ b/src/components/schedule/gantt-chart.tsx
@@ -266,15 +266,39 @@ export function GanttChart({
     if (wrapper) wrapper.style.cursor = ""
   }, [])
 
-  // ctrl+scroll zoom
+  // Keep wheel handling on the stable React wrapper. Frappe may rebuild its
+  // generated scroll element when the view changes, but the wrapper survives.
   useEffect(() => {
     const wrapper = wrapperRef.current
-    if (!wrapper || !onZoom) return
+    if (!wrapper) return
 
     const handleWheel = (e: WheelEvent) => {
-      if (!e.ctrlKey) return
+      if (e.ctrlKey) {
+        if (!onZoom) return
+        e.preventDefault()
+        onZoom(e.deltaY < 0 ? "in" : "out")
+        return
+      }
+
+      const container = ganttContainerRef.current
+      if (!container) return
+      const pageSize = Math.max(
+        container.clientWidth,
+        container.clientHeight
+      )
+      const rawDeltaX =
+        e.shiftKey && e.deltaX === 0 ? e.deltaY : e.deltaX
+      const rawDeltaY =
+        e.shiftKey && e.deltaX === 0 ? 0 : e.deltaY
+      const locked = lockWheelToDominantAxis(
+        normalizeWheelDelta(rawDeltaX, e.deltaMode, pageSize),
+        normalizeWheelDelta(rawDeltaY, e.deltaMode, pageSize)
+      )
+      if (locked.deltaX === 0 && locked.deltaY === 0) return
+
       e.preventDefault()
-      onZoom(e.deltaY < 0 ? "in" : "out")
+      container.scrollLeft += locked.deltaX
+      container.scrollTop += locked.deltaY
     }
 
     wrapper.addEventListener("wheel", handleWheel, { passive: false })
@@ -306,28 +330,6 @@ export function GanttChart({
           : {}),
       })
     }
-    const handleAxisLockedWheel = (event: WheelEvent) => {
-      if (!activeContainer || event.ctrlKey) return
-
-      const pageSize = Math.max(
-        activeContainer.clientWidth,
-        activeContainer.clientHeight
-      )
-      const rawDeltaX =
-        event.shiftKey && event.deltaX === 0 ? event.deltaY : event.deltaX
-      const rawDeltaY =
-        event.shiftKey && event.deltaX === 0 ? 0 : event.deltaY
-      const locked = lockWheelToDominantAxis(
-        normalizeWheelDelta(rawDeltaX, event.deltaMode, pageSize),
-        normalizeWheelDelta(rawDeltaY, event.deltaMode, pageSize)
-      )
-      if (locked.deltaX === 0 && locked.deltaY === 0) return
-
-      event.preventDefault()
-      activeContainer.scrollLeft += locked.deltaX
-      activeContainer.scrollTop += locked.deltaY
-    }
-
     async function initGantt() {
       const { default: Gantt } = await import("frappe-gantt")
       if (cancelled || !containerRef.current) return
@@ -449,9 +451,6 @@ export function GanttChart({
         activeContainer.addEventListener("scroll", handleScroll, {
           passive: true,
         })
-        activeContainer.addEventListener("wheel", handleAxisLockedWheel, {
-          passive: false,
-        })
         interactionCallbacksRef.current.onTaskVisibilityReady?.((taskId) => {
           const root = containerRef.current
           const container = ganttContainerRef.current
@@ -491,7 +490,6 @@ export function GanttChart({
     return () => {
       cancelled = true
       activeContainer?.removeEventListener("scroll", handleScroll)
-      activeContainer?.removeEventListener("wheel", handleAxisLockedWheel)
       if (ganttContainerRef.current === activeContainer) {
         ganttContainerRef.current = null
       }

--- a/src/components/schedule/gantt.css
+++ b/src/components/schedule/gantt.css
@@ -16,6 +16,13 @@
   scrollbar-color: oklch(0.72 0.02 95 / 0.7) transparent;
 }
 
+.schedule-gantt-task-list {
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: oklch(0.72 0.02 95 / 0.7) transparent;
+}
+
 .gantt .bar-wrapper.schedule-focused .bar {
   filter: brightness(1.08);
   stroke: oklch(0.28 0.03 160) !important;
@@ -27,6 +34,11 @@
   height: 10px;
 }
 
+.schedule-gantt-task-list::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
 .gantt-container::-webkit-scrollbar-thumb {
   background: oklch(0.72 0.02 95 / 0.7);
   border: 3px solid transparent;
@@ -34,7 +46,18 @@
   background-clip: content-box;
 }
 
+.schedule-gantt-task-list::-webkit-scrollbar-thumb {
+  background: oklch(0.72 0.02 95 / 0.7);
+  border: 3px solid transparent;
+  border-radius: 999px;
+  background-clip: content-box;
+}
+
 .gantt-container::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.schedule-gantt-task-list::-webkit-scrollbar-track {
   background: transparent;
 }
 

--- a/src/components/schedule/schedule-gantt-view.tsx
+++ b/src/components/schedule/schedule-gantt-view.tsx
@@ -86,6 +86,8 @@ import { toast } from "sonner"
 import { format } from "date-fns"
 import {
   ganttRowIndexForScrollTop,
+  lockWheelToDominantAxis,
+  normalizeWheelDelta,
   synchronizedScrollTop,
 } from "@/lib/schedule/gantt-scroll"
 
@@ -246,6 +248,38 @@ export function ScheduleGanttView({
   useEffect(() => {
     return flushScrollPosition
   }, [flushScrollPosition])
+
+  useEffect(() => {
+    const taskList = taskListRef.current
+    if (!taskList) return
+
+    // The resizable layout can consume trackpad wheel gestures before the
+    // browser applies its default nested-scroll behavior. Own the gesture on
+    // the task pane just as the timeline does so either side remains usable.
+    const handleTaskListWheel = (event: WheelEvent) => {
+      if (event.ctrlKey) return
+
+      const pageSize = Math.max(taskList.clientWidth, taskList.clientHeight)
+      const rawDeltaX =
+        event.shiftKey && event.deltaX === 0 ? event.deltaY : event.deltaX
+      const rawDeltaY =
+        event.shiftKey && event.deltaX === 0 ? 0 : event.deltaY
+      const locked = lockWheelToDominantAxis(
+        normalizeWheelDelta(rawDeltaX, event.deltaMode, pageSize),
+        normalizeWheelDelta(rawDeltaY, event.deltaMode, pageSize)
+      )
+      if (locked.deltaX === 0 && locked.deltaY === 0) return
+
+      event.preventDefault()
+      taskList.scrollLeft += locked.deltaX
+      taskList.scrollTop += locked.deltaY
+    }
+
+    taskList.addEventListener("wheel", handleTaskListWheel, {
+      passive: false,
+    })
+    return () => taskList.removeEventListener("wheel", handleTaskListWheel)
+  }, [isMobile])
 
   const handleGanttContainerReady = useCallback(
     (container: HTMLElement | null) => {
@@ -921,7 +955,7 @@ export function ScheduleGanttView({
           <ResizablePanel defaultSize="30%" minSize="20%">
             <div
               ref={taskListRef}
-              className="h-full min-w-0 overflow-auto"
+              className="schedule-gantt-task-list h-full min-w-0 overflow-auto"
               onScroll={handleTaskListScroll}
             >
               {taskTable}


### PR DESCRIPTION
## What
- Handles mouse-wheel and trackpad scrolling from stable React-owned elements on both Gantt panes.
- Keeps dominant-axis locking so vertical scrolling no longer nudges the timeline horizontally.
- Adds a stable, visible scrollbar treatment to the task list.

## Why
The timeline wheel listener was attached to a Frappe-generated element that can be rebuilt during chart initialization and view changes. The left task pane relied entirely on browser nested-scroll chaining. The result was that Day, Week, Month, and Today could move the chart while direct scrolling on either side appeared inert.

## How to test
1. Open a project Gantt with enough rows to overflow.
2. Scroll vertically over the left task list and confirm both panes advance together.
3. Scroll vertically over the timeline and confirm both panes remain aligned.
4. Use a horizontal trackpad gesture over the timeline and confirm the date range moves without vertical drift.
5. Switch Day, Week, and Month, then repeat direct scrolling.

## Validation
- 34 schedule tests passed.
- Focused ESLint passed with no errors.
- Production build and pre-push production build passed.
- Direct source review found no listener lifecycle or cleanup issue.