### PR TITLE
feat(schedule): unify project scheduling

### DIFF
--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -25,12 +25,17 @@ import { requireAuth } from "@/lib/auth"
 import { requireOrg } from "@/lib/org-scope"
 import { isDemoUser } from "@/lib/demo"
 import { notifyProjectAssignment } from "@/lib/notifications/events"
+import { getProjects } from "@/app/actions/projects"
+import { projectDepartment } from "@/lib/project-branding"
+import { projectScheduleColor } from "@/lib/schedule/project-scope"
+import { requirePermission } from "@/lib/permissions"
 import type {
   TaskStatus,
   DependencyType,
   ExceptionCategory,
   ExceptionRecurrence,
   ScheduleData,
+  ScopedScheduleData,
   WorkdayExceptionData,
   WorkdayExceptionType,
 } from "@/lib/schedule/types"
@@ -38,6 +43,14 @@ import type {
 function revalidateSchedulePaths(projectId: string): void {
   revalidatePath(`/dashboard/projects/${projectId}/schedule`)
   revalidatePath("/dashboard/schedule")
+}
+
+function chunkValues<T>(values: readonly T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let index = 0; index < values.length; index += size) {
+    chunks.push(values.slice(index, index + size))
+  }
+  return chunks
 }
 
 async function fetchExceptions(
@@ -61,7 +74,12 @@ export async function getSchedule(
   projectId: string
 ): Promise<ScheduleData> {
   const user = await requireAuth()
+  requirePermission(user, "schedule", "read")
   const orgId = requireOrg(user)
+  const accessibleProjects = await getProjects()
+  if (!accessibleProjects.some((project) => project.id === projectId)) {
+    throw new Error("Project not found or access denied")
+  }
 
   const { env } = await getCloudflareContext()
   const db = getDb(env.DB)
@@ -106,6 +124,156 @@ export async function getSchedule(
       type: d.type as DependencyType,
     })),
     exceptions,
+  }
+}
+
+export async function getScopedSchedule(
+  requestedProjectIds?: readonly string[]
+): Promise<ScopedScheduleData> {
+  const user = await requireAuth()
+  requirePermission(user, "schedule", "read")
+  const orgId = requireOrg(user)
+  const accessibleProjects = await getProjects()
+  const requestedIds = new Set(
+    requestedProjectIds
+      ?.map((projectId) => projectId.trim())
+      .filter(Boolean) ?? []
+  )
+  const selectedProjects =
+    requestedIds.size === 0
+      ? accessibleProjects
+      : accessibleProjects.filter((project) => requestedIds.has(project.id))
+
+  const scopedProjects = selectedProjects.map((project) => ({
+    id: project.id,
+    name: project.name,
+    projectNumber: project.projectNumber,
+    department: projectDepartment({
+      projectId: project.id,
+      projectNumber: project.projectNumber,
+    }),
+    color: projectScheduleColor(project.id),
+  }))
+
+  if (scopedProjects.length === 0) {
+    return {
+      projects: [],
+      tasks: [],
+      dependencies: [],
+      exceptions: [],
+    }
+  }
+
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const projectIds = scopedProjects.map((project) => project.id)
+  const verifiedProjects = (
+    await Promise.all(
+      chunkValues(projectIds, 50).map((projectIdChunk) =>
+        db
+          .select({ id: projects.id })
+          .from(projects)
+          .where(
+            and(
+              eq(projects.organizationId, orgId),
+              inArray(projects.id, projectIdChunk)
+            )
+          )
+      )
+    )
+  ).flat()
+  const verifiedProjectIds = new Set(
+    verifiedProjects.map((project) => project.id)
+  )
+  const safeProjectIds = projectIds.filter((projectId) =>
+    verifiedProjectIds.has(projectId)
+  )
+
+  if (safeProjectIds.length === 0) {
+    return {
+      projects: [],
+      tasks: [],
+      dependencies: [],
+      exceptions: [],
+    }
+  }
+
+  const [taskChunks, exceptionChunks] = await Promise.all([
+    Promise.all(
+      chunkValues(safeProjectIds, 50).map((projectIdChunk) =>
+        db
+          .select()
+          .from(scheduleTasks)
+          .where(inArray(scheduleTasks.projectId, projectIdChunk))
+          .orderBy(
+            asc(scheduleTasks.startDate),
+            asc(scheduleTasks.sortOrder),
+            asc(scheduleTasks.title)
+          )
+      )
+    ),
+    Promise.all(
+      chunkValues(safeProjectIds, 50).map((projectIdChunk) =>
+        db
+          .select()
+          .from(workdayExceptions)
+          .where(inArray(workdayExceptions.projectId, projectIdChunk))
+      )
+    ),
+  ])
+  const tasks = taskChunks
+    .flat()
+    .sort(
+      (left, right) =>
+        left.startDate.localeCompare(right.startDate) ||
+        left.sortOrder - right.sortOrder ||
+        left.title.localeCompare(right.title)
+    )
+  const exceptions = exceptionChunks.flat()
+  const taskIds = tasks.map((task) => task.id)
+  const dependencies = (
+    await Promise.all(
+      chunkValues(taskIds, 50).map((taskIdChunk) =>
+        db
+          .select()
+          .from(taskDependencies)
+          .where(inArray(taskDependencies.successorId, taskIdChunk))
+      )
+    )
+  ).flat()
+  const taskIdSet = new Set(taskIds)
+
+  return {
+    projects: scopedProjects.filter((project) =>
+      verifiedProjectIds.has(project.id)
+    ),
+    tasks: tasks.map((task) => {
+      const status = task.status as TaskStatus
+      return {
+        ...task,
+        status,
+        percentComplete: effectivePercentComplete(
+          status,
+          task.percentComplete
+        ),
+      }
+    }),
+    dependencies: dependencies
+      .filter(
+        (dependency) =>
+          taskIdSet.has(dependency.predecessorId) &&
+          taskIdSet.has(dependency.successorId)
+      )
+      .map((dependency) => ({
+        ...dependency,
+        type: dependency.type as DependencyType,
+      })),
+    exceptions: exceptions.map((exception) => ({
+      ...exception,
+      type: exception.type as WorkdayExceptionType,
+      category: exception.category as ExceptionCategory,
+      recurrence: exception.recurrence as ExceptionRecurrence,
+    })),
   }
 }
 

--- a/src/app/dashboard/schedule/page.tsx
+++ b/src/app/dashboard/schedule/page.tsx
@@ -1,12 +1,21 @@
 export const dynamic = "force-dynamic"
 
 import { getWorkCalendar } from "@/app/actions/work-calendar"
+import { getScopedSchedule } from "@/app/actions/schedule"
+import { getProjects } from "@/app/actions/projects"
 import {
   WorkCalendar,
   type WorkCalendarKindFilter,
   type WorkCalendarView,
 } from "@/components/schedule/work-calendar"
+import { ScheduleView } from "@/components/schedule/schedule-view"
 import { isValidDateKey } from "@/lib/work-calendar"
+import { projectDepartment } from "@/lib/project-branding"
+import type {
+  ScheduleScope,
+  ScheduleScopeKind,
+} from "@/lib/schedule/project-scope"
+import type { ProjectDepartment } from "@/lib/project-branding"
 
 function kindFilter(
   value: string | readonly string[] | undefined
@@ -41,6 +50,27 @@ function calendarView(
   }
 }
 
+function firstValue(
+  value: string | readonly string[] | undefined
+): string | undefined {
+  return typeof value === "string" ? value : value?.[0]
+}
+
+function isScopeKind(value: string | undefined): value is ScheduleScopeKind {
+  return (
+    value === "project" ||
+    value === "selected" ||
+    value === "department" ||
+    value === "all"
+  )
+}
+
+function isDepartment(
+  value: string | undefined
+): value is ProjectDepartment {
+  return value === "O" || value === "H" || value === "N" || value === "D"
+}
+
 export default async function SchedulePage({
   searchParams,
 }: {
@@ -49,9 +79,111 @@ export default async function SchedulePage({
     readonly item?: string | readonly string[]
     readonly view?: string | readonly string[]
     readonly date?: string | readonly string[]
+    readonly mode?: string | readonly string[]
+    readonly scope?: string | readonly string[]
+    readonly project?: string | readonly string[]
+    readonly projects?: string | readonly string[]
+    readonly department?: string | readonly string[]
   }>
 }): Promise<React.ReactElement> {
   const query = await searchParams
+  if (firstValue(query.mode) === "projects") {
+    const allProjects = await getProjects()
+    const requestedScope = firstValue(query.scope)
+    const scopeKind = isScopeKind(requestedScope) ? requestedScope : "all"
+    const requestedProjectId = firstValue(query.project)
+    const requestedProjectIds = (firstValue(query.projects) ?? "")
+      .split(",")
+      .map((projectId) => projectId.trim())
+      .filter(Boolean)
+    const requestedDepartment = firstValue(query.department)
+    const department = isDepartment(requestedDepartment)
+      ? requestedDepartment
+      : "O"
+    const accessibleIds = new Set(allProjects.map((project) => project.id))
+    const scopeProjectIds =
+      scopeKind === "project"
+        ? requestedProjectId && accessibleIds.has(requestedProjectId)
+          ? [requestedProjectId]
+          : allProjects[0]
+            ? [allProjects[0].id]
+            : []
+        : scopeKind === "selected"
+          ? requestedProjectIds.filter((projectId) =>
+              accessibleIds.has(projectId)
+            )
+          : scopeKind === "department"
+            ? allProjects
+                .filter(
+                  (project) =>
+                    projectDepartment({
+                      projectId: project.id,
+                      projectNumber: project.projectNumber,
+                    }) === department
+                )
+                .map((project) => project.id)
+            : allProjects.map((project) => project.id)
+    const safeProjectIds =
+      scopeKind === "selected" && scopeProjectIds.length === 0
+        ? allProjects[0]
+          ? [allProjects[0].id]
+          : []
+        : scopeProjectIds
+    const data = await getScopedSchedule(safeProjectIds)
+    const scope: ScheduleScope =
+      scopeKind === "project" && safeProjectIds[0]
+        ? {
+            kind: "project",
+            projectIds: [safeProjectIds[0]],
+            department: null,
+          }
+        : scopeKind === "selected"
+          ? {
+              kind: "selected",
+              projectIds: safeProjectIds,
+              department: null,
+            }
+          : scopeKind === "department"
+            ? {
+                kind: "department",
+                projectIds: safeProjectIds,
+                department,
+              }
+            : {
+                kind: "all",
+                projectIds: safeProjectIds,
+                department: null,
+              }
+    const requestedView = firstValue(query.view)
+    const initialView =
+      requestedView === "calendar" ||
+      requestedView === "list" ||
+      requestedView === "gantt"
+        ? requestedView
+        : "gantt"
+    const primaryProject = data.projects[0] ?? null
+
+    return (
+      <div className="flex min-h-0 flex-1 flex-col px-4 py-2">
+        <ScheduleView
+          projectId={scope.kind === "project" ? primaryProject?.id ?? null : null}
+          projectName={
+            primaryProject
+              ? primaryProject.projectNumber ?? primaryProject.name
+              : "Project schedules"
+          }
+          initialData={data}
+          baselines={[]}
+          allProjects={allProjects}
+          scheduleProjects={data.projects}
+          scope={scope}
+          initialView={initialView}
+          globalMode
+        />
+      </div>
+    )
+  }
+
   const requestedDate =
     typeof query.date === "string" ? query.date : query.date?.[0]
   const initialDate =

--- a/src/components/schedule/gantt-chart.tsx
+++ b/src/components/schedule/gantt-chart.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/lib/schedule/gantt-scroll"
 import "./gantt.css"
 
-type ViewMode = "Day" | "Week" | "Month"
+type ViewMode = "Day" | "Week" | "Month" | "Year"
 
 export interface GanttScrollPosition {
   readonly left: number
@@ -57,7 +57,8 @@ function dateKey(date: Date): string {
 function basePaddingDays(viewMode: ViewMode): number {
   if (viewMode === "Day") return 7
   if (viewMode === "Week") return 31
-  return 62
+  if (viewMode === "Month") return 62
+  return 183
 }
 
 function monthYearLabel(date: Date): string {
@@ -129,6 +130,21 @@ const GANTT_VIEW_MODES = [
         : "",
     thick_line: (date: Date) => date.getMonth() % 3 === 0,
     snap_at: "7d",
+  },
+  {
+    name: "Year",
+    padding: "6m",
+    step: "3m",
+    column_width: 160,
+    date_format: "YYYY-MM",
+    lower_text: (date: Date) => `Q${Math.floor(date.getMonth() / 3) + 1}`,
+    upper_text: (date: Date, previousDate: Date | null) =>
+      previousDate === null ||
+      date.getFullYear() !== previousDate.getFullYear()
+        ? date.getFullYear().toString()
+        : "",
+    thick_line: (date: Date) => date.getMonth() === 0,
+    snap_at: "1m",
   },
 ]
 
@@ -437,6 +453,13 @@ export function GanttChart({
         const task = tasksById.get(wrapper.dataset.id ?? "")
         if (!task || task.id.startsWith("phase-")) continue
         wrapper.classList.add(...getScheduleItemClasses(task))
+        if (task.projectColor) {
+          wrapper.classList.add("project-color")
+          wrapper.style.setProperty(
+            "--schedule-project-color",
+            task.projectColor
+          )
+        }
       }
 
       // constrain gantt-container to wrapper height so content overflows

--- a/src/components/schedule/gantt.css
+++ b/src/components/schedule/gantt.css
@@ -147,6 +147,16 @@
 .gantt .bar-wrapper.display-color-teal .bar-progress { fill: color-mix(in srgb, var(--schedule-display-teal, #14b8a6) 68%, black); }
 .gantt .bar-wrapper.display-color-gray .bar-progress { fill: color-mix(in srgb, var(--schedule-display-gray, #6b7280) 68%, black); }
 
+/* Multi-project schedules use a stable project color across every view. */
+.gantt .bar-wrapper.project-color .bar {
+  fill: var(--schedule-project-color);
+  stroke: color-mix(in srgb, var(--schedule-project-color) 78%, black);
+}
+
+.gantt .bar-wrapper.project-color .bar-progress {
+  fill: color-mix(in srgb, var(--schedule-project-color) 68%, black);
+}
+
 /* Buildertrend's Critical Path view: blue time-sensitive work, grey float. */
 .gantt-wrapper.critical-path-mode .gantt .bar-wrapper:not([data-id^="phase-"]) .bar {
   fill: oklch(0.67 0.01 260);

--- a/src/components/schedule/schedule-calendar-view.tsx
+++ b/src/components/schedule/schedule-calendar-view.tsx
@@ -1,342 +1,509 @@
 "use client"
 
-import { useState, useMemo } from "react"
+import { useMemo, useState } from "react"
+import Link from "next/link"
 import {
-  startOfMonth,
-  endOfMonth,
-  startOfWeek,
-  endOfWeek,
-  eachDayOfInterval,
-  format,
+  addDays,
   addMonths,
-  subMonths,
-  isToday,
+  addWeeks,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  format,
   isSameMonth,
+  isToday,
   parseISO,
-  differenceInCalendarDays,
+  startOfMonth,
+  startOfWeek,
+  subDays,
+  subMonths,
+  subWeeks,
 } from "date-fns"
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
 import {
+  IconCalendar,
   IconChevronLeft,
   IconChevronRight,
+  IconList,
 } from "@tabler/icons-react"
-import type {
-  ScheduleTaskData,
-  WorkdayExceptionData,
-} from "@/lib/schedule/types"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { cn } from "@/lib/utils"
 import { useScheduleDisplayPalette } from "@/hooks/use-schedule-display-palette"
 import { getScheduleItemDisplayColor } from "@/lib/schedule/appearance"
 import { isNonWorkday } from "@/lib/schedule/business-days"
 import { effectivePercentComplete } from "@/lib/schedule/progress"
+import {
+  projectScheduleLabel,
+  type ScheduleProjectData,
+} from "@/lib/schedule/project-scope"
+import type {
+  ScheduleTaskData,
+  WorkdayExceptionData,
+} from "@/lib/schedule/types"
+
+type CalendarMode = "month" | "week" | "day" | "agenda"
 
 interface ScheduleCalendarViewProps {
   readonly projectId: string
   readonly tasks: readonly ScheduleTaskData[]
   readonly exceptions: readonly WorkdayExceptionData[]
+  readonly projects?: readonly ScheduleProjectData[]
 }
 
-// How many task lanes to show before "+N more"
-const MAX_LANES = 3
-const LANE_HEIGHT = 22
-const DAY_HEADER_HEIGHT = 24
+function taskIncludesDay(task: ScheduleTaskData, day: Date): boolean {
+  const start = parseISO(task.startDate)
+  const end = parseISO(task.endDateCalculated)
+  return day >= start && day <= end
+}
 
-interface WeekTask {
+function taskHref(task: ScheduleTaskData): string {
+  return `/dashboard/projects/${encodeURIComponent(task.projectId)}/schedule?view=list&item=${encodeURIComponent(task.id)}#schedule-item-${encodeURIComponent(task.id)}`
+}
+
+function dateRangeLabel(mode: CalendarMode, date: Date): string {
+  if (mode === "month") return format(date, "MMMM yyyy")
+  if (mode === "week") {
+    const start = startOfWeek(date)
+    const end = endOfWeek(date)
+    return `${format(start, "MMM d")} – ${format(end, "MMM d, yyyy")}`
+  }
+  if (mode === "day") return format(date, "EEEE, MMMM d, yyyy")
+  return "Schedule agenda"
+}
+
+function ProjectIdentity({
+  project,
+}: {
+  readonly project: ScheduleProjectData
+}): React.ReactElement {
+  return (
+    <span
+      className="inline-flex min-w-0 items-center gap-1"
+      title={projectScheduleLabel(project)}
+    >
+      <span
+        className="size-2 shrink-0 rounded-full"
+        style={{ backgroundColor: project.color }}
+      />
+      <span className="truncate">
+        {project.projectNumber ?? project.name}
+      </span>
+    </span>
+  )
+}
+
+function ScheduleTaskCard({
+  task,
+  project,
+  color,
+  compact = false,
+  showProject,
+}: {
   readonly task: ScheduleTaskData
-  readonly startCol: number
-  readonly span: number
-  readonly lane: number
-  readonly isStart: boolean
-  readonly isEnd: boolean
-}
+  readonly project: ScheduleProjectData | null
+  readonly color: string
+  readonly compact?: boolean
+  readonly showProject: boolean
+}): React.ReactElement {
+  const percent = effectivePercentComplete(task.status, task.percentComplete)
 
-interface WeekRow {
-  readonly days: readonly Date[]
-  readonly tasks: WeekTask[]
-  readonly maxLane: number
-  readonly overflowByDay: readonly number[]
-}
-
-function buildWeekRows(
-  calendarDays: readonly Date[],
-  tasks: readonly ScheduleTaskData[]
-): WeekRow[] {
-  const weeks: {
-    days: Date[]
-    tasks: {
-      task: ScheduleTaskData
-      startCol: number
-      span: number
-      lane: number
-      isStart: boolean
-      isEnd: boolean
-    }[]
-  }[] = []
-
-  for (let i = 0; i < calendarDays.length; i += 7) {
-    weeks.push({
-      days: calendarDays.slice(i, i + 7) as Date[],
-      tasks: [],
-    })
-  }
-
-  // Place each task into the weeks it overlaps
-  for (const task of tasks) {
-    const taskStart = parseISO(task.startDate)
-    const taskEnd = parseISO(task.endDateCalculated)
-
-    for (const week of weeks) {
-      const weekStart = week.days[0]
-      const weekEnd = week.days[6]
-
-      // Check overlap: task must start on or before weekEnd,
-      // and end on or after weekStart
-      if (taskStart > weekEnd || taskEnd < weekStart) continue
-
-      const startCol = Math.max(
-        0,
-        differenceInCalendarDays(taskStart, weekStart)
-      )
-      const endCol = Math.min(
-        6,
-        differenceInCalendarDays(taskEnd, weekStart)
-      )
-      const span = endCol - startCol + 1
-
-      week.tasks.push({
-        task,
-        startCol,
-        span,
-        lane: 0,
-        isStart: taskStart >= weekStart,
-        isEnd: taskEnd <= weekEnd,
-      })
-    }
-  }
-
-  // Assign lanes using first-fit
-  return weeks.map((week) => {
-    // Sort: earlier start first, then longer tasks first (they anchor better)
-    week.tasks.sort(
-      (a, b) => a.startCol - b.startCol || b.span - a.span
-    )
-
-    const lanes: boolean[][] = []
-    for (const wt of week.tasks) {
-      let lane = 0
-      while (true) {
-        if (!lanes[lane]) lanes[lane] = Array(7).fill(false) as boolean[]
-        const cols = lanes[lane].slice(wt.startCol, wt.startCol + wt.span)
-        if (cols.every((occupied) => !occupied)) break
-        lane++
-      }
-      wt.lane = lane
-      if (!lanes[lane]) lanes[lane] = Array(7).fill(false) as boolean[]
-      for (let c = wt.startCol; c < wt.startCol + wt.span; c++) {
-        lanes[lane][c] = true
-      }
-    }
-
-    // Count overflow per day (tasks in lanes >= MAX_LANES)
-    const overflowByDay = Array(7).fill(0) as number[]
-    for (const wt of week.tasks) {
-      if (wt.lane >= MAX_LANES) {
-        for (let c = wt.startCol; c < wt.startCol + wt.span; c++) {
-          overflowByDay[c]++
-        }
-      }
-    }
-
-    const maxLane = week.tasks.reduce(
-      (max, wt) => Math.max(max, wt.lane),
-      -1
-    )
-
-    return {
-      days: week.days,
-      tasks: week.tasks,
-      maxLane: Math.min(maxLane, MAX_LANES - 1),
-      overflowByDay,
-    }
-  })
+  return (
+    <Link
+      href={taskHref(task)}
+      className={cn(
+        "block min-w-0 border-l-[3px] bg-card transition-colors hover:bg-accent",
+        compact ? "px-1.5 py-1" : "rounded-r-md border-y border-r px-3 py-2"
+      )}
+      style={{ borderLeftColor: color }}
+      title={`${task.title} — ${percent}% complete`}
+    >
+      {showProject && project && (
+        <span className="mb-0.5 block truncate text-[10px] font-medium text-muted-foreground">
+          <ProjectIdentity project={project} />
+        </span>
+      )}
+      <span
+        className={cn(
+          "block truncate font-medium",
+          compact ? "text-[10px]" : "text-sm"
+        )}
+      >
+        {task.title}
+      </span>
+      {!compact && (
+        <span className="mt-1 block text-xs text-muted-foreground">
+          {format(parseISO(task.startDate), "MMM d")} –{" "}
+          {format(parseISO(task.endDateCalculated), "MMM d")} · {percent}%
+        </span>
+      )}
+    </Link>
+  )
 }
 
 export function ScheduleCalendarView({
   projectId,
   tasks,
   exceptions,
-}: ScheduleCalendarViewProps) {
+  projects = [],
+}: ScheduleCalendarViewProps): React.ReactElement {
   const [currentDate, setCurrentDate] = useState(new Date())
+  const [mode, setMode] = useState<CalendarMode>("month")
+  const [expandedDay, setExpandedDay] = useState<Date | null>(null)
   const displayColorPalette = useScheduleDisplayPalette(projectId)
-
-  const calendarDays = useMemo(() => {
-    const monthStart = startOfMonth(currentDate)
-    const monthEnd = endOfMonth(currentDate)
-    return eachDayOfInterval({
-      start: startOfWeek(monthStart),
-      end: endOfWeek(monthEnd),
-    })
-  }, [currentDate])
-
-  const weekRows = useMemo(
-    () => buildWeekRows(calendarDays, tasks),
-    [calendarDays, tasks]
+  const projectById = useMemo(
+    () => new Map(projects.map((project) => [project.id, project])),
+    [projects]
   )
+  const multipleProjects = projectById.size > 1
+  const sortedTasks = useMemo(
+    () =>
+      [...tasks].sort(
+        (left, right) =>
+          left.startDate.localeCompare(right.startDate) ||
+          left.endDateCalculated.localeCompare(right.endDateCalculated) ||
+          left.title.localeCompare(right.title)
+      ),
+    [tasks]
+  )
+  const monthDays = useMemo(() => {
+    const start = startOfWeek(startOfMonth(currentDate))
+    const end = endOfWeek(endOfMonth(currentDate))
+    return eachDayOfInterval({ start, end })
+  }, [currentDate])
+  const weekDays = useMemo(
+    () =>
+      eachDayOfInterval({
+        start: startOfWeek(currentDate),
+        end: endOfWeek(currentDate),
+      }),
+    [currentDate]
+  )
+  const agendaGroups = useMemo(() => {
+    const groups = new Map<string, ScheduleTaskData[]>()
+    for (const task of sortedTasks) {
+      const current = groups.get(task.startDate) ?? []
+      current.push(task)
+      groups.set(task.startDate, current)
+    }
+    return [...groups]
+  }, [sortedTasks])
+
+  function colorFor(task: ScheduleTaskData): string {
+    const project = projectById.get(task.projectId)
+    return multipleProjects && project
+      ? project.color
+      : getScheduleItemDisplayColor(task, displayColorPalette)
+  }
+
+  function tasksForDay(day: Date): readonly ScheduleTaskData[] {
+    return sortedTasks.filter((task) => taskIncludesDay(task, day))
+  }
+
+  function navigate(direction: -1 | 1): void {
+    setExpandedDay(null)
+    setCurrentDate((date) => {
+      if (mode === "month") {
+        return direction === 1 ? addMonths(date, 1) : subMonths(date, 1)
+      }
+      if (mode === "week") {
+        return direction === 1 ? addWeeks(date, 1) : subWeeks(date, 1)
+      }
+      return direction === 1 ? addDays(date, 1) : subDays(date, 1)
+    })
+  }
+
+  function nonWorkday(day: Date): boolean {
+    return !multipleProjects && isNonWorkday(day, exceptions)
+  }
+
+  const expandedTasks = expandedDay ? tasksForDay(expandedDay) : []
 
   return (
-    <div className="flex flex-col flex-1 min-h-0">
-      {/* Calendar controls */}
-      <div className="flex items-center gap-2 mb-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setCurrentDate(new Date())}
-          className="h-8 text-xs"
-        >
-          Today
-        </Button>
-        <div className="flex items-center">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-8"
-            onClick={() => setCurrentDate(subMonths(currentDate, 1))}
-          >
-            <IconChevronLeft className="size-4" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-8"
-            onClick={() => setCurrentDate(addMonths(currentDate, 1))}
-          >
-            <IconChevronRight className="size-4" />
-          </Button>
-        </div>
-        <h2 className="text-sm font-medium">
-          {format(currentDate, "MMMM yyyy")}
-        </h2>
-      </div>
-
-      {/* Calendar grid */}
-      <div className="border rounded-md overflow-hidden flex flex-col flex-1 min-h-0">
-        {/* Weekday headers */}
-        <div className="grid grid-cols-7 border-b bg-muted/30">
-          {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((day) => (
-            <div
-              key={day}
-              className="text-center text-[11px] font-medium text-muted-foreground py-1.5 border-r last:border-r-0"
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        {mode !== "agenda" && (
+          <>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setCurrentDate(new Date())}
+              className="h-8 text-xs"
             >
-              {day}
+              Today
+            </Button>
+            <div className="flex items-center">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-8"
+                onClick={() => navigate(-1)}
+                aria-label={`Previous ${mode}`}
+              >
+                <IconChevronLeft className="size-4" />
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-8"
+                onClick={() => navigate(1)}
+                aria-label={`Next ${mode}`}
+              >
+                <IconChevronRight className="size-4" />
+              </Button>
             </div>
+          </>
+        )}
+        <h2 className="min-w-[180px] text-sm font-medium">
+          {dateRangeLabel(mode, currentDate)}
+        </h2>
+        <div
+          className="ml-auto inline-flex overflow-hidden rounded-md border"
+          role="group"
+          aria-label="Schedule calendar view"
+        >
+          {(
+            [
+              ["month", "Month", IconCalendar],
+              ["week", "Week", IconCalendar],
+              ["day", "Day", IconCalendar],
+              ["agenda", "Agenda", IconList],
+            ] as const
+          ).map(([value, label, Icon]) => (
+            <Button
+              key={value}
+              type="button"
+              size="sm"
+              variant="ghost"
+              className={cn(
+                "h-8 rounded-none border-r px-2.5 text-xs last:border-r-0",
+                mode === value && "bg-secondary text-secondary-foreground"
+              )}
+              onClick={() => setMode(value)}
+              aria-pressed={mode === value}
+            >
+              <Icon className="size-3.5" />
+              <span className="hidden sm:inline">{label}</span>
+            </Button>
           ))}
         </div>
+      </div>
 
-        {/* Week rows */}
-        <div className="flex flex-col flex-1 min-h-0">
-          {weekRows.map((week, weekIdx) => {
-            const visibleLanes = Math.min(week.maxLane + 1, MAX_LANES)
-            const contentHeight = DAY_HEADER_HEIGHT + visibleLanes * LANE_HEIGHT
-            const hasOverflow = week.overflowByDay.some((n) => n > 0)
-            const totalHeight = contentHeight + (hasOverflow ? 16 : 0)
-
-            return (
-              <div
-                key={weekIdx}
-                className="relative border-b last:border-b-0 flex-1"
-                style={{ minHeight: `${Math.max(totalHeight, 60)}px` }}
-              >
-                {/* Day cells (background + day numbers) */}
-                <div className="grid grid-cols-7 absolute inset-0">
-                  {week.days.map((day) => {
-                    const inMonth = isSameMonth(day, currentDate)
-                    const nonWorkday = isNonWorkday(day, exceptions)
-
-                    return (
-                      <div
-                        key={format(day, "yyyy-MM-dd")}
-                        className={cn(
-                          "border-r last:border-r-0 p-1",
-                          !inMonth && "bg-muted/20",
-                          nonWorkday && inMonth && "bg-muted/40",
-                        )}
-                      >
-                        <span
-                          className={cn(
-                            "text-[11px] leading-none",
-                            isToday(day)
-                              ? "bg-primary text-primary-foreground rounded-full size-5 inline-flex items-center justify-center font-bold"
-                              : inMonth
-                                ? "text-foreground/80"
-                                : "text-muted-foreground/50",
-                          )}
-                        >
-                          {format(day, "d")}
-                        </span>
-                      </div>
-                    )
-                  })}
+      {mode === "month" && (
+        <div className="min-h-0 flex-1 overflow-auto rounded-md border">
+          <div className="grid min-w-[760px] grid-cols-7 border-b bg-muted/30">
+            {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map(
+              (day) => (
+                <div
+                  key={day}
+                  className="border-r py-1.5 text-center text-[11px] font-medium text-muted-foreground last:border-r-0"
+                >
+                  {day}
                 </div>
-
-                {/* Task bars (overlaid) */}
-                {week.tasks
-                  .filter((wt) => wt.lane < MAX_LANES)
-                  .map((wt) => (
-                    <div
-                      key={`${wt.task.id}-${weekIdx}`}
-                      className={cn(
-                        "absolute text-[10px] text-white font-medium truncate px-1.5 leading-[20px] cursor-default",
-                        wt.isStart && wt.isEnd && "rounded",
-                        wt.isStart && !wt.isEnd && "rounded-l",
-                        !wt.isStart && wt.isEnd && "rounded-r",
-                        !wt.isStart && !wt.isEnd && "rounded-none",
-                      )}
-                      style={{
-                        backgroundColor: getScheduleItemDisplayColor(
-                          wt.task,
-                          displayColorPalette
-                        ),
-                        top: `${DAY_HEADER_HEIGHT + wt.lane * LANE_HEIGHT}px`,
-                        left: `${(wt.startCol / 7) * 100}%`,
-                        width: `${(wt.span / 7) * 100}%`,
-                        height: `${LANE_HEIGHT - 2}px`,
-                        paddingLeft: wt.isStart ? "6px" : "2px",
-                      }}
-                      title={`${wt.task.title} — ${effectivePercentComplete(
-                        wt.task.status,
-                        wt.task.percentComplete
-                      )}% complete (${wt.task.startDate} - ${wt.task.endDateCalculated})`}
-                    >
-                      {wt.isStart
-                        ? `${effectivePercentComplete(
-                            wt.task.status,
-                            wt.task.percentComplete
-                          )}% · ${wt.task.title}`
-                        : ""}
-                    </div>
-                  ))}
-
-                {/* Overflow indicators */}
-                {hasOverflow && (
-                  <div
-                    className="grid grid-cols-7 absolute left-0 right-0"
-                    style={{ top: `${contentHeight}px` }}
+              )
+            )}
+          </div>
+          <div className="grid min-w-[760px] grid-cols-7">
+            {monthDays.map((day) => {
+              const dayTasks = tasksForDay(day)
+              return (
+                <div
+                  key={format(day, "yyyy-MM-dd")}
+                  className={cn(
+                    "min-h-[112px] border-b border-r p-1.5",
+                    !isSameMonth(day, currentDate) && "bg-muted/20",
+                    nonWorkday(day) && "bg-muted/35"
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "mb-1 inline-flex size-5 items-center justify-center rounded-full text-[11px]",
+                      isToday(day)
+                        ? "bg-primary font-semibold text-primary-foreground"
+                        : "text-muted-foreground"
+                    )}
                   >
-                    {week.overflowByDay.map((count, dayIdx) => (
-                      <div
-                        key={dayIdx}
-                        className="text-[10px] text-primary px-1 border-r last:border-r-0"
-                      >
-                        {count > 0 ? `+${count} more` : ""}
-                      </div>
+                    {format(day, "d")}
+                  </span>
+                  <div className="space-y-1">
+                    {dayTasks.slice(0, 3).map((task) => (
+                      <ScheduleTaskCard
+                        key={task.id}
+                        task={task}
+                        project={projectById.get(task.projectId) ?? null}
+                        color={colorFor(task)}
+                        compact
+                        showProject={multipleProjects}
+                      />
                     ))}
+                    {dayTasks.length > 3 && (
+                      <button
+                        type="button"
+                        className="w-full px-1 text-left text-[10px] font-medium text-primary hover:underline"
+                        onClick={() => setExpandedDay(day)}
+                      >
+                        +{dayTasks.length - 3} more
+                      </button>
+                    )}
                   </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {mode === "week" && (
+        <div className="grid min-h-0 flex-1 grid-cols-1 overflow-auto rounded-md border sm:grid-cols-7">
+          {weekDays.map((day) => {
+            const dayTasks = tasksForDay(day)
+            return (
+              <section
+                key={format(day, "yyyy-MM-dd")}
+                className={cn(
+                  "min-h-[180px] border-b p-2 sm:border-b-0 sm:border-r sm:last:border-r-0",
+                  nonWorkday(day) && "bg-muted/35"
                 )}
-              </div>
+              >
+                <button
+                  type="button"
+                  className="mb-2 flex w-full items-center justify-between text-left"
+                  onClick={() => {
+                    setCurrentDate(day)
+                    setMode("day")
+                  }}
+                >
+                  <span className="text-xs font-medium">
+                    {format(day, "EEE")}
+                  </span>
+                  <span
+                    className={cn(
+                      "inline-flex size-6 items-center justify-center rounded-full text-xs",
+                      isToday(day) &&
+                        "bg-primary font-semibold text-primary-foreground"
+                    )}
+                  >
+                    {format(day, "d")}
+                  </span>
+                </button>
+                <div className="space-y-1.5">
+                  {dayTasks.map((task) => (
+                    <ScheduleTaskCard
+                      key={task.id}
+                      task={task}
+                      project={projectById.get(task.projectId) ?? null}
+                      color={colorFor(task)}
+                      compact
+                      showProject={multipleProjects}
+                    />
+                  ))}
+                  {dayTasks.length === 0 && (
+                    <p className="text-[11px] text-muted-foreground">No items</p>
+                  )}
+                </div>
+              </section>
             )
           })}
         </div>
-      </div>
+      )}
+
+      {mode === "day" && (
+        <div className="min-h-0 flex-1 overflow-auto rounded-md border p-3">
+          <div className="mx-auto max-w-3xl space-y-2">
+            {tasksForDay(currentDate).map((task) => (
+              <ScheduleTaskCard
+                key={task.id}
+                task={task}
+                project={projectById.get(task.projectId) ?? null}
+                color={colorFor(task)}
+                showProject={multipleProjects}
+              />
+            ))}
+            {tasksForDay(currentDate).length === 0 && (
+              <div className="py-16 text-center text-sm text-muted-foreground">
+                No schedule items on this day.
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {mode === "agenda" && (
+        <div className="min-h-0 flex-1 overflow-auto rounded-md border">
+          <div className="divide-y">
+            {agendaGroups.map(([date, groupedTasks]) => (
+              <section
+                key={date}
+                className="grid gap-3 p-3 sm:grid-cols-[9rem_minmax(0,1fr)]"
+              >
+                <div>
+                  <p className="text-sm font-medium">
+                    {format(parseISO(date), "EEE, MMM d")}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {groupedTasks.length} item
+                    {groupedTasks.length === 1 ? "" : "s"} starting
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  {groupedTasks.map((task) => (
+                    <ScheduleTaskCard
+                      key={task.id}
+                      task={task}
+                      project={projectById.get(task.projectId) ?? null}
+                      color={colorFor(task)}
+                      showProject={multipleProjects}
+                    />
+                  ))}
+                </div>
+              </section>
+            ))}
+            {agendaGroups.length === 0 && (
+              <div className="py-16 text-center text-sm text-muted-foreground">
+                No schedule items match the current scope and filters.
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      <Dialog
+        open={expandedDay !== null}
+        onOpenChange={(open) => {
+          if (!open) setExpandedDay(null)
+        }}
+      >
+        <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>
+              {expandedDay ? format(expandedDay, "EEEE, MMMM d, yyyy") : "Day"}
+            </DialogTitle>
+            <DialogDescription>
+              All schedule items active on this date.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            {expandedTasks.map((task) => (
+              <ScheduleTaskCard
+                key={task.id}
+                task={task}
+                project={projectById.get(task.projectId) ?? null}
+                color={colorFor(task)}
+                showProject={multipleProjects}
+              />
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/src/components/schedule/schedule-gantt-view.tsx
+++ b/src/components/schedule/schedule-gantt-view.tsx
@@ -84,6 +84,8 @@ import { ProjectTaskCreateButton } from "@/components/projects/project-task-crea
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { format } from "date-fns"
+import type { ScheduleProjectData } from "@/lib/schedule/project-scope"
+import { projectScheduleLabel } from "@/lib/schedule/project-scope"
 import {
   ganttRowIndexForScrollTop,
   lockWheelToDominantAxis,
@@ -91,7 +93,7 @@ import {
   synchronizedScrollTop,
 } from "@/lib/schedule/gantt-scroll"
 
-type ViewMode = "Day" | "Week" | "Month"
+type ViewMode = "Day" | "Week" | "Month" | "Year"
 
 const COLOR_PICKER_SWATCHES = [
   "#ef4444", "#f97316", "#eab308", "#22c55e", "#14b8a6", "#06b6d4",
@@ -99,11 +101,12 @@ const COLOR_PICKER_SWATCHES = [
 ] as const
 
 interface ScheduleGanttViewProps {
-  readonly projectId: string
+  readonly projectId: string | null
   readonly tasks: readonly ScheduleTaskData[]
   readonly dependencies: readonly TaskDependencyData[]
   readonly exceptions: readonly WorkdayExceptionData[]
   readonly assigneeOptions: readonly ProjectTaskAssigneeOption[]
+  readonly projects?: readonly ScheduleProjectData[]
 }
 
 export function ScheduleGanttView({
@@ -112,6 +115,7 @@ export function ScheduleGanttView({
   dependencies,
   exceptions,
   assigneeOptions,
+  projects = [],
 }: ScheduleGanttViewProps) {
   const router = useRouter()
   const isMobile = useIsMobile()
@@ -146,14 +150,24 @@ export function ScheduleGanttView({
   const displayItemsRef = useRef<readonly DisplayItem[]>([])
   const followedListItemRef = useRef<string | null>(null)
   const scrollRestoredProjectRef = useRef<string | null>(null)
-  const scrollStorageKey = `compass:schedule-scroll:${projectId}`
+  const preferenceScopeKey = projectId ?? "unified"
+  const scrollStorageKey = `compass:schedule-scroll:${preferenceScopeKey}`
+  const projectById = useMemo(
+    () => new Map(projects.map((project) => [project.id, project])),
+    [projects]
+  )
+  const multipleProjects = projectById.size > 1
 
   const [hasLoadedPalette, setHasLoadedPalette] = useState(false)
 
   useEffect(() => {
     try {
-      const storedPalette = window.localStorage.getItem(schedulePaletteStorageKey(projectId))
-      const storedLabels = window.localStorage.getItem(schedulePaletteLabelStorageKey(projectId))
+      const storedPalette = window.localStorage.getItem(
+        schedulePaletteStorageKey(preferenceScopeKey)
+      )
+      const storedLabels = window.localStorage.getItem(
+        schedulePaletteLabelStorageKey(preferenceScopeKey)
+      )
       if (storedPalette) {
         setDisplayColorPalette(normalizeDisplayColorPalette(JSON.parse(storedPalette)))
       }
@@ -171,19 +185,24 @@ export function ScheduleGanttView({
     } finally {
       setHasLoadedPalette(true)
     }
-  }, [projectId])
+  }, [preferenceScopeKey])
 
   useEffect(() => {
     if (!hasLoadedPalette) return
     window.localStorage.setItem(
-      schedulePaletteStorageKey(projectId),
+      schedulePaletteStorageKey(preferenceScopeKey),
       JSON.stringify(displayColorPalette)
     )
     window.localStorage.setItem(
-      schedulePaletteLabelStorageKey(projectId),
+      schedulePaletteLabelStorageKey(preferenceScopeKey),
       JSON.stringify(displayColorLabels)
     )
-  }, [displayColorLabels, displayColorPalette, hasLoadedPalette, projectId])
+  }, [
+    displayColorLabels,
+    displayColorPalette,
+    hasLoadedPalette,
+    preferenceScopeKey,
+  ])
 
   const updatePaletteColor = (color: DisplayColor, value: string) => {
     setDisplayColorPalette((palette) => ({ ...palette, [color]: value }))
@@ -194,7 +213,10 @@ export function ScheduleGanttView({
   }
 
   const defaultWidths: Record<ViewMode, number> = {
-    Day: 38, Week: 140, Month: 120,
+    Day: 38,
+    Week: 140,
+    Month: 120,
+    Year: 160,
   }
   const [columnWidth, setColumnWidth] = useState(defaultWidths[viewMode])
 
@@ -460,28 +482,46 @@ export function ScheduleGanttView({
 
   const filteredTasks = tasks
 
-  const { frappeTasks, displayItems } = useMemo(
-    () =>
-      phaseGrouping
-        ? transformWithPhaseGroups(
+  const { frappeTasks, displayItems } = useMemo(() => {
+    const transformed = phaseGrouping
+      ? transformWithPhaseGroups(
+          filteredTasks as ScheduleTaskData[],
+          dependencies as TaskDependencyData[],
+          collapsedPhases,
+        )
+      : {
+          frappeTasks: transformToFrappeTasks(
             filteredTasks as ScheduleTaskData[],
             dependencies as TaskDependencyData[],
-            collapsedPhases,
-          )
-        : {
-            frappeTasks: transformToFrappeTasks(
-              filteredTasks as ScheduleTaskData[],
-              dependencies as TaskDependencyData[],
-            ),
-            displayItems: filteredTasks.map(
-              (task): DisplayItem => ({
-                type: "task",
-                task: task as ScheduleTaskData,
-              })
-            ),
-          },
-    [collapsedPhases, dependencies, filteredTasks, phaseGrouping]
-  )
+          ),
+          displayItems: filteredTasks.map(
+            (task): DisplayItem => ({
+              type: "task",
+              task: task as ScheduleTaskData,
+            })
+          ),
+        }
+
+    if (!multipleProjects) return transformed
+    const taskById = new Map(filteredTasks.map((task) => [task.id, task]))
+    return {
+      ...transformed,
+      frappeTasks: transformed.frappeTasks.map((task) => {
+        const scheduleTask = taskById.get(task.id)
+        const project = scheduleTask
+          ? projectById.get(scheduleTask.projectId)
+          : null
+        return project ? { ...task, projectColor: project.color } : task
+      }),
+    }
+  }, [
+    collapsedPhases,
+    dependencies,
+    filteredTasks,
+    multipleProjects,
+    phaseGrouping,
+    projectById,
+  ])
   displayItemsRef.current = displayItems
 
   const togglePhase = (phase: string) => {
@@ -511,7 +551,19 @@ export function ScheduleGanttView({
       if (task.id.startsWith("phase-")) return
       const startDate = format(start, "yyyy-MM-dd")
       const endDate = format(end, "yyyy-MM-dd")
-      const workdays = countBusinessDays(startDate, endDate, exceptions)
+      const scheduleTask = tasks.find(
+        (candidate) => candidate.id === task.id
+      )
+      const taskExceptions = scheduleTask
+        ? exceptions.filter(
+            (exception) => exception.projectId === scheduleTask.projectId
+          )
+        : []
+      const workdays = countBusinessDays(
+        startDate,
+        endDate,
+        taskExceptions
+      )
 
       const result = await updateTask(task.id, {
         startDate,
@@ -524,7 +576,7 @@ export function ScheduleGanttView({
         toast.error(result.error)
       }
     },
-    [exceptions, router]
+    [exceptions, router, tasks]
   )
 
   const handleTodayScrollReady = useCallback(
@@ -607,6 +659,7 @@ export function ScheduleGanttView({
           }
 
           const { task } = item
+          const taskProject = projectById.get(task.projectId)
           return (
             <TableRow
               key={task.id}
@@ -619,8 +672,27 @@ export function ScheduleGanttView({
               title="Show this item on the timeline"
             >
               <TableCell className="h-[48px] py-0 text-xs truncate max-w-[140px]">
-                <span className={phaseGrouping ? "pl-4" : ""}>
-                  {task.title}
+                <span
+                  className={cn(
+                    "flex min-w-0 items-center gap-1.5",
+                    phaseGrouping && "pl-4"
+                  )}
+                >
+                  {multipleProjects && taskProject && (
+                    <span
+                      className="inline-flex max-w-[72px] shrink-0 items-center gap-1 rounded-sm bg-muted px-1 py-0.5 text-[9px] font-medium"
+                      title={projectScheduleLabel(taskProject)}
+                    >
+                      <span
+                        className="size-2 shrink-0 rounded-full"
+                        style={{ backgroundColor: taskProject.color }}
+                      />
+                      <span className="truncate">
+                        {taskProject.projectNumber ?? taskProject.name}
+                      </span>
+                    </span>
+                  )}
+                  <span className="truncate">{task.title}</span>
                 </span>
               </TableCell>
               <TableCell className="h-[48px] py-0 text-xs text-muted-foreground">
@@ -639,11 +711,11 @@ export function ScheduleGanttView({
                 >
                   <ProjectTaskCreateButton
                     compact
-                    projectId={projectId}
+                    projectId={task.projectId}
                     sourceLabel="Schedule item"
                     sourceRecordId={task.id}
                     sourceRecordNumber={null}
-                    sourceHref={`/dashboard/projects/${projectId}/schedule`}
+                    sourceHref={`/dashboard/projects/${task.projectId}/schedule`}
                     defaultTitle={`Follow up: ${task.title}`}
                     defaultDescription={`${task.phase} schedule item.`}
                     defaultAssigneeName={task.assignedTo}
@@ -657,6 +729,7 @@ export function ScheduleGanttView({
                     variant="ghost"
                     size="icon"
                     className="size-6"
+                    aria-label={`Edit ${task.title}`}
                     onClick={() => {
                       setFocusedTaskId(task.id)
                       setEditingTask(task)
@@ -670,22 +743,24 @@ export function ScheduleGanttView({
             </TableRow>
           )
         })}
-        <TableRow>
-          <TableCell colSpan={5} className="py-1">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="text-xs w-full justify-start"
-              onClick={() => {
-                setEditingTask(null)
-                setTaskFormOpen(true)
-              }}
-            >
-              <IconPlus className="size-3 mr-1" />
-              Add Schedule Item
-            </Button>
-          </TableCell>
-        </TableRow>
+        {projectId && (
+          <TableRow>
+            <TableCell colSpan={5} className="py-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-xs w-full justify-start"
+                onClick={() => {
+                  setEditingTask(null)
+                  setTaskFormOpen(true)
+                }}
+              >
+                <IconPlus className="size-3 mr-1" />
+                Add Schedule Item
+              </Button>
+            </TableCell>
+          </TableRow>
+        )}
       </TableBody>
     </Table>
   )
@@ -828,9 +903,9 @@ export function ScheduleGanttView({
             </Select>
           )}
 
-          {/* Day / Week / Month */}
+          {/* Day / Week / Month / Year */}
           <div className="flex items-center rounded-md border bg-muted/40 p-0.5">
-            {(["Day", "Week", "Month"] as const).map((mode) => (
+            {(["Day", "Week", "Month", "Year"] as const).map((mode) => (
               <button
                 key={mode}
                 onClick={() => handleViewModeChange(mode)}
@@ -988,16 +1063,24 @@ export function ScheduleGanttView({
         </ResizablePanelGroup>
       )}
 
-      <ScheduleItemFormDialog
-        open={taskFormOpen}
-        onOpenChange={setTaskFormOpen}
-        projectId={projectId}
-        editingTask={editingTask}
-        allTasks={tasks}
-        dependencies={dependencies}
-        exceptions={exceptions}
-        assigneeOptions={assigneeOptions}
-      />
+      {(editingTask || projectId) && (
+        <ScheduleItemFormDialog
+          open={taskFormOpen}
+          onOpenChange={setTaskFormOpen}
+          projectId={editingTask?.projectId ?? projectId ?? ""}
+          editingTask={editingTask}
+          allTasks={tasks.filter(
+            (task) =>
+              task.projectId === (editingTask?.projectId ?? projectId)
+          )}
+          dependencies={dependencies}
+          exceptions={exceptions.filter(
+            (exception) =>
+              exception.projectId === (editingTask?.projectId ?? projectId)
+          )}
+          assigneeOptions={assigneeOptions}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/schedule/schedule-list-view.tsx
+++ b/src/components/schedule/schedule-list-view.tsx
@@ -47,6 +47,8 @@ import type {
   WorkdayExceptionData,
 } from "@/lib/schedule/types"
 import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
+import type { ScheduleProjectData } from "@/lib/schedule/project-scope"
+import { projectScheduleLabel } from "@/lib/schedule/project-scope"
 import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
@@ -70,12 +72,13 @@ import {
 } from "@/components/ui/alert-dialog"
 
 interface ScheduleListViewProps {
-  readonly projectId: string
+  readonly projectId: string | null
   readonly tasks: ScheduleTaskData[]
   readonly dependencies: TaskDependencyData[]
   readonly exceptions: readonly WorkdayExceptionData[]
   readonly assigneeOptions: readonly ProjectTaskAssigneeOption[]
   readonly focusTaskId?: string | null
+  readonly projects?: readonly ScheduleProjectData[]
 }
 
 function StatusDot({
@@ -142,9 +145,10 @@ export function ScheduleListView({
   exceptions,
   assigneeOptions,
   focusTaskId = null,
+  projects = [],
 }: ScheduleListViewProps) {
   const router = useRouter()
-  const displayColorPalette = useScheduleDisplayPalette(projectId)
+  const displayColorPalette = useScheduleDisplayPalette(projectId ?? "unified")
   const [taskFormOpen, setTaskFormOpen] = useState(false)
   const [editingTask, setEditingTask] = useState<ScheduleTaskData | null>(null)
   const [depDialogOpen, setDepDialogOpen] = useState(false)
@@ -154,6 +158,11 @@ export function ScheduleListView({
     readonly ScheduleTaskData[]
   >([])
   const [isWorking, setIsWorking] = useState(false)
+  const projectById = useMemo(
+    () => new Map(projects.map((project) => [project.id, project])),
+    [projects]
+  )
+  const multipleProjects = projectById.size > 1
 
   useEffect(() => {
     setLocalTasks(tasks)
@@ -216,6 +225,30 @@ export function ScheduleListView({
             </button>
           </div>
         ),
+      },
+      {
+        id: "project",
+        header: "Project",
+        cell: ({ row }) => {
+          const project = projectById.get(row.original.projectId)
+          return project ? (
+            <div
+              className="flex max-w-[180px] items-center gap-1.5 text-xs"
+              title={projectScheduleLabel(project)}
+            >
+              <span
+                className="size-2.5 shrink-0 rounded-full"
+                style={{ backgroundColor: project.color }}
+              />
+              <span className="truncate">
+                {project.projectNumber ?? project.name}
+              </span>
+            </div>
+          ) : (
+            <span className="text-xs text-muted-foreground">—</span>
+          )
+        },
+        meta: { className: multipleProjects ? "" : "hidden" },
       },
       {
         id: "complete",
@@ -286,11 +319,11 @@ export function ScheduleListView({
           <div className="flex items-center gap-1">
             <ProjectTaskCreateButton
               compact
-              projectId={projectId}
+              projectId={row.original.projectId}
               sourceLabel="Schedule item"
               sourceRecordId={row.original.id}
               sourceRecordNumber={null}
-              sourceHref={`/dashboard/projects/${projectId}/schedule`}
+              sourceHref={`/dashboard/projects/${row.original.projectId}/schedule`}
               defaultTitle={`Follow up: ${row.original.title}`}
               defaultDescription={`${row.original.phase} schedule item.`}
               defaultAssigneeName={row.original.assignedTo}
@@ -327,7 +360,13 @@ export function ScheduleListView({
         size: 110,
       },
     ],
-    [assigneeOptions, displayColorPalette, handleEdit, projectId]
+    [
+      assigneeOptions,
+      displayColorPalette,
+      handleEdit,
+      multipleProjects,
+      projectById,
+    ]
   )
 
   const table = useReactTable({
@@ -344,16 +383,31 @@ export function ScheduleListView({
     .getSelectedRowModel()
     .rows.map((row) => row.original)
 
+  function selectedByProject(): ReadonlyMap<string, readonly string[]> {
+    const grouped = new Map<string, string[]>()
+    for (const task of selectedTasks) {
+      const current = grouped.get(task.projectId) ?? []
+      current.push(task.id)
+      grouped.set(task.projectId, current)
+    }
+    return grouped
+  }
+
   const handleCompleteSelected = async (): Promise<void> => {
     const selectedIds = selectedTasks.map((task) => task.id)
     if (selectedIds.length === 0) return
 
     setIsWorking(true)
-    const result = await completeScheduleTasks(projectId, selectedIds)
+    const results = await Promise.all(
+      [...selectedByProject()].map(([selectedProjectId, ids]) =>
+        completeScheduleTasks(selectedProjectId, ids)
+      )
+    )
     setIsWorking(false)
 
-    if (!result.success) {
-      toast.error(result.error)
+    const failedResult = results.find((result) => !result.success)
+    if (failedResult && !failedResult.success) {
+      toast.error(failedResult.error)
       return
     }
 
@@ -382,27 +436,34 @@ export function ScheduleListView({
     setIsWorking(true)
     let assignedName = value.trim()
     if (option?.source === "directory" && option.directoryContactId) {
-      const contactResult = await addDirectoryContactToProjectForTask(
-        projectId,
-        option.directoryContactId
-      )
-      if (!contactResult.success) {
-        setIsWorking(false)
-        toast.error(contactResult.error)
-        return
+      for (const selectedProjectId of selectedByProject().keys()) {
+        const contactResult = await addDirectoryContactToProjectForTask(
+          selectedProjectId,
+          option.directoryContactId
+        )
+        if (!contactResult.success) {
+          setIsWorking(false)
+          toast.error(contactResult.error)
+          return
+        }
+        assignedName = contactResult.contact.name
       }
-      assignedName = contactResult.contact.name
     }
 
-    const result = await assignScheduleTasks(
-      projectId,
-      selectedIds,
-      assignedName || null
+    const results = await Promise.all(
+      [...selectedByProject()].map(([selectedProjectId, ids]) =>
+        assignScheduleTasks(
+          selectedProjectId,
+          ids,
+          assignedName || null
+        )
+      )
     )
     setIsWorking(false)
 
-    if (!result.success) {
-      toast.error(result.error)
+    const failedResult = results.find((result) => !result.success)
+    if (failedResult && !failedResult.success) {
+      toast.error(failedResult.error)
       return
     }
 
@@ -429,11 +490,22 @@ export function ScheduleListView({
     if (selectedIds.length === 0) return
 
     setIsWorking(true)
-    const result = await deleteScheduleTasks(projectId, selectedIds)
+    const grouped = new Map<string, string[]>()
+    for (const task of deletingTasks) {
+      const current = grouped.get(task.projectId) ?? []
+      current.push(task.id)
+      grouped.set(task.projectId, current)
+    }
+    const results = await Promise.all(
+      [...grouped].map(([selectedProjectId, ids]) =>
+        deleteScheduleTasks(selectedProjectId, ids)
+      )
+    )
     setIsWorking(false)
 
-    if (!result.success) {
-      toast.error(result.error)
+    const failedResult = results.find((result) => !result.success)
+    if (failedResult && !failedResult.success) {
+      toast.error(failedResult.error)
       return
     }
 
@@ -469,7 +541,12 @@ export function ScheduleListView({
           size="sm"
           variant="outline"
           onClick={() => setDepDialogOpen(true)}
-          disabled={localTasks.length < 2}
+          disabled={!projectId || localTasks.length < 2}
+          title={
+            projectId
+              ? "Add a dependency"
+              : "Choose one project to manage dependencies"
+          }
         >
           <IconLink className="size-4 mr-1" />
           Add Dependency
@@ -654,24 +731,34 @@ export function ScheduleListView({
         </div>
       </div>
 
-      <ScheduleItemFormDialog
-        open={taskFormOpen}
-        onOpenChange={setTaskFormOpen}
-        projectId={projectId}
-        editingTask={editingTask}
-        allTasks={localTasks}
-        dependencies={dependencies}
-        exceptions={exceptions}
-        assigneeOptions={assigneeOptions}
-      />
+      {(editingTask || projectId) && (
+        <ScheduleItemFormDialog
+          open={taskFormOpen}
+          onOpenChange={setTaskFormOpen}
+          projectId={editingTask?.projectId ?? projectId ?? ""}
+          editingTask={editingTask}
+          allTasks={localTasks.filter(
+            (task) =>
+              task.projectId === (editingTask?.projectId ?? projectId)
+          )}
+          dependencies={dependencies}
+          exceptions={exceptions.filter(
+            (exception) =>
+              exception.projectId === (editingTask?.projectId ?? projectId)
+          )}
+          assigneeOptions={assigneeOptions}
+        />
+      )}
 
-      <DependencyDialog
-        open={depDialogOpen}
-        onOpenChange={setDepDialogOpen}
-        projectId={projectId}
-        tasks={localTasks}
-        dependencies={dependencies}
-      />
+      {projectId && (
+        <DependencyDialog
+          open={depDialogOpen}
+          onOpenChange={setDepDialogOpen}
+          projectId={projectId}
+          tasks={localTasks}
+          dependencies={dependencies}
+        />
+      )}
 
       <AlertDialog
         open={pendingDeleteTasks.length > 0}

--- a/src/components/schedule/schedule-scope-switcher.tsx
+++ b/src/components/schedule/schedule-scope-switcher.tsx
@@ -1,0 +1,215 @@
+"use client"
+
+import * as React from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import { Check, ChevronsUpDown, Layers3 } from "lucide-react"
+
+import type { ProjectListItem } from "@/app/actions/projects"
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { Separator } from "@/components/ui/separator"
+import { cn } from "@/lib/utils"
+import {
+  projectScheduleLabel,
+  scheduleScopeLabel,
+  type ScheduleProjectData,
+  type ScheduleScope,
+} from "@/lib/schedule/project-scope"
+import { projectDepartment } from "@/lib/project-branding"
+
+type ScheduleScopeSwitcherProps = {
+  readonly projects: readonly ProjectListItem[]
+  readonly scheduleProjects: readonly ScheduleProjectData[]
+  readonly scope: ScheduleScope
+}
+
+function scopeHref(
+  searchParams: URLSearchParams,
+  next:
+    | { readonly scope: "all" }
+    | { readonly scope: "department"; readonly department: string }
+    | { readonly scope: "selected"; readonly projectIds: readonly string[] }
+    | { readonly scope: "project"; readonly projectId: string }
+): string {
+  const params = new URLSearchParams(searchParams.toString())
+  params.set("mode", "projects")
+  params.set("scope", next.scope)
+  params.delete("department")
+  params.delete("project")
+  params.delete("projects")
+
+  if (next.scope === "department") {
+    params.set("department", next.department)
+  } else if (next.scope === "selected") {
+    params.set("projects", next.projectIds.join(","))
+  } else if (next.scope === "project") {
+    params.set("project", next.projectId)
+  }
+
+  return `/dashboard/schedule?${params.toString()}`
+}
+
+export function ScheduleScopeSwitcher({
+  projects,
+  scheduleProjects,
+  scope,
+}: ScheduleScopeSwitcherProps): React.ReactElement {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [open, setOpen] = React.useState(false)
+  const selectedIds = new Set(
+    scope.kind === "project" || scope.kind === "selected"
+      ? scope.projectIds
+      : []
+  )
+
+  function navigate(href: string): void {
+    setOpen(false)
+    router.push(href)
+  }
+
+  function toggleProject(projectId: string): void {
+    const customProjectIds =
+      scope.kind === "project" || scope.kind === "selected"
+        ? scope.projectIds
+        : []
+    const nextIds = selectedIds.has(projectId)
+      ? customProjectIds.filter((id) => id !== projectId)
+      : [...customProjectIds, projectId]
+    if (nextIds.length === 0) return
+    if (nextIds.length === 1) {
+      navigate(
+        scopeHref(searchParams, {
+          scope: "project",
+          projectId: nextIds[0],
+        })
+      )
+      return
+    }
+    navigate(
+      scopeHref(searchParams, {
+        scope: "selected",
+        projectIds: nextIds,
+      })
+    )
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-label="Choose schedule scope"
+          className="h-8 min-w-[220px] max-w-full justify-between px-3 font-normal"
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            <Layers3 className="size-4 shrink-0 text-muted-foreground" />
+            <span className="truncate">
+              {scheduleScopeLabel(scope, scheduleProjects)}
+            </span>
+          </span>
+          <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[360px] max-w-[90vw] p-0">
+        <div className="grid grid-cols-5 gap-1 p-2">
+          <Button
+            type="button"
+            size="sm"
+            variant={scope.kind === "all" ? "default" : "ghost"}
+            className="col-span-1"
+            onClick={() =>
+              navigate(scopeHref(searchParams, { scope: "all" }))
+            }
+          >
+            All
+          </Button>
+          {(["O", "H", "N", "D"] as const).map((department) => (
+            <Button
+              key={department}
+              type="button"
+              size="sm"
+              variant={
+                scope.kind === "department" &&
+                scope.department === department
+                  ? "default"
+                  : "ghost"
+              }
+              onClick={() =>
+                navigate(
+                  scopeHref(searchParams, {
+                    scope: "department",
+                    department,
+                  })
+                )
+              }
+            >
+              {department}
+            </Button>
+          ))}
+        </div>
+        <Separator />
+        <Command>
+          <CommandInput placeholder="Search projects to select..." />
+          <CommandList className="max-h-72">
+            <CommandEmpty>No matching projects.</CommandEmpty>
+            <CommandGroup heading="Projects">
+              {projects.map((project) => {
+                const department = projectDepartment({
+                  projectId: project.id,
+                  projectNumber: project.projectNumber,
+                })
+                const selected = selectedIds.has(project.id)
+                return (
+                  <CommandItem
+                    key={project.id}
+                    value={[
+                      project.projectNumber,
+                      project.name,
+                      project.clientName,
+                      department,
+                    ]
+                      .filter(Boolean)
+                      .join(" ")}
+                    onSelect={() => toggleProject(project.id)}
+                  >
+                    <Check
+                      className={cn(
+                        "size-4",
+                        selected ? "opacity-100" : "opacity-0"
+                      )}
+                    />
+                    <span className="min-w-0 flex-1 truncate">
+                      {projectScheduleLabel({
+                        name: project.name,
+                        projectNumber: project.projectNumber,
+                      })}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {department}
+                    </span>
+                  </CommandItem>
+                )
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -68,8 +68,13 @@ import { WorkdayExceptionsView } from "./workday-exceptions-view"
 import { ScheduleBaselineView } from "./schedule-baseline-view"
 import { ScheduleItemFormDialog } from "./schedule-item-form-dialog"
 import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
+import { ScheduleScopeSwitcher } from "./schedule-scope-switcher"
 import type { ProjectListItem } from "@/app/actions/projects"
 import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
+import type {
+  ScheduleProjectData,
+  ScheduleScope,
+} from "@/lib/schedule/project-scope"
 import type {
   ScheduleData,
   ScheduleBaselineData,
@@ -96,14 +101,17 @@ const VIEW_OPTIONS = [
 ]
 
 interface ScheduleViewProps {
-  readonly projectId: string
+  readonly projectId: string | null
   readonly projectName: string
   readonly initialData: ScheduleData
   readonly baselines: ScheduleBaselineData[]
   readonly allProjects?: readonly ProjectListItem[]
+  readonly scheduleProjects?: readonly ScheduleProjectData[]
+  readonly scope?: ScheduleScope
   readonly assigneeOptions?: readonly ProjectTaskAssigneeOption[]
   readonly initialView?: View
   readonly focusTaskId?: string | null
+  readonly globalMode?: boolean
 }
 
 export function ScheduleView({
@@ -112,9 +120,12 @@ export function ScheduleView({
   initialData,
   baselines,
   allProjects = [],
+  scheduleProjects = [],
+  scope,
   assigneeOptions = [],
   initialView = "gantt",
   focusTaskId = null,
+  globalMode = false,
 }: ScheduleViewProps) {
   const isMobile = useIsMobile()
   const [view, setView] = useState<View>(initialView)
@@ -127,20 +138,24 @@ export function ScheduleView({
   const [importDialogOpen, setImportDialogOpen] = useState(false)
   const [isImporting, setIsImporting] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const preferenceScopeKey = projectId ?? "unified"
 
   useEffect(() => {
     const storedMode = window.localStorage.getItem(
-      scheduleOrderStorageKey(projectId)
+      scheduleOrderStorageKey(preferenceScopeKey)
     )
     setOrderMode(
       isScheduleOrderMode(storedMode) ? storedMode : "chronological"
     )
-  }, [projectId])
+  }, [preferenceScopeKey])
 
   const handleOrderModeChange = (value: string): void => {
     if (!isScheduleOrderMode(value)) return
     setOrderMode(value)
-    window.localStorage.setItem(scheduleOrderStorageKey(projectId), value)
+    window.localStorage.setItem(
+      scheduleOrderStorageKey(preferenceScopeKey),
+      value
+    )
   }
 
   const phaseOptions = useMemo(() => {
@@ -218,12 +233,25 @@ export function ScheduleView({
 
   // CSV export
   const handleExportCSV = () => {
+    const includeProject = scheduleProjects.length > 1
     const headers = [
+      ...(includeProject ? ["Project"] : []),
       "Title", "Phase", "Status", "Start Date", "End Date",
       "Duration (days)", "% Complete", "Assigned To",
       "Critical Path", "Milestone",
     ]
     const rows = filteredTasks.map((task) => [
+      ...(includeProject
+        ? [
+            scheduleProjects.find(
+              (project) => project.id === task.projectId
+            )?.projectNumber ??
+              scheduleProjects.find(
+                (project) => project.id === task.projectId
+              )?.name ??
+              task.projectId,
+          ]
+        : []),
       task.title, task.phase, task.status, task.startDate,
       task.endDateCalculated, task.workdays.toString(),
       task.percentComplete.toString(), task.assignedTo ?? "",
@@ -336,23 +364,49 @@ export function ScheduleView({
       <div className="mb-3 flex flex-col gap-2 lg:flex-row lg:items-center">
         <nav className="flex min-w-0 items-center gap-1.5 text-sm">
           <Link
-            href={`/dashboard/projects/${projectId}`}
+            href={
+              globalMode || !projectId
+                ? "/dashboard/schedule"
+                : `/dashboard/projects/${projectId}`
+            }
             className="text-muted-foreground hover:text-foreground truncate transition-colors"
           >
-            {projectName}
+            {globalMode ? "Scheduling" : projectName}
           </Link>
           <IconChevronRight className="size-3.5 text-muted-foreground/60 shrink-0" />
-          <span className="font-medium">Schedule</span>
+          <span className="font-medium">
+            {globalMode ? "Project schedules" : "Schedule"}
+          </span>
         </nav>
 
         <div className="flex flex-wrap items-center gap-2 lg:ml-auto lg:justify-end">
-          <ProjectQuickSwitcher
-            projects={allProjects}
-            currentProjectId={projectId}
-            targetSection="schedule"
-            placeholder="Switch schedule project..."
-            className="w-full sm:w-[300px]"
-          />
+          {globalMode && scope ? (
+            <>
+              <Button asChild variant="outline" size="sm" className="h-8">
+                <Link href="/dashboard/schedule">Work calendar</Link>
+              </Button>
+              <ScheduleScopeSwitcher
+                projects={allProjects}
+                scheduleProjects={scheduleProjects}
+                scope={scope}
+              />
+            </>
+          ) : (
+            <>
+              <ProjectQuickSwitcher
+                projects={allProjects}
+                currentProjectId={projectId}
+                targetSection="schedule"
+                placeholder="Switch schedule project..."
+                className="w-full sm:w-[300px]"
+              />
+              <Button asChild variant="outline" size="sm" className="h-8">
+                <Link href="/dashboard/schedule?mode=projects&scope=all&view=gantt">
+                  All project schedules
+                </Link>
+              </Button>
+            </>
+          )}
 
           {/* View switcher */}
           <div className={cn(
@@ -376,7 +430,17 @@ export function ScheduleView({
             ))}
           </div>
 
-          <Button size="sm" onClick={() => setTaskFormOpen(true)} className="h-8">
+          <Button
+            size="sm"
+            onClick={() => setTaskFormOpen(true)}
+            className="h-8"
+            disabled={!projectId}
+            title={
+              projectId
+                ? "Create a schedule item"
+                : "Choose one project before creating a schedule item"
+            }
+          >
             <IconPlus className="size-3.5" />
             <span className="hidden sm:inline ml-1.5">New Schedule Item</span>
           </Button>
@@ -572,17 +636,18 @@ export function ScheduleView({
       {/* View content */}
       <div className="flex flex-col flex-1 min-h-0">
         {view === "calendar" && (
-          isMobile ? (
+          isMobile && !globalMode ? (
             <ScheduleMobileView
-              projectId={projectId}
+              projectId={projectId ?? preferenceScopeKey}
               tasks={filteredTasks}
               exceptions={initialData.exceptions}
             />
           ) : (
             <ScheduleCalendarView
-              projectId={projectId}
+              projectId={projectId ?? preferenceScopeKey}
               tasks={filteredTasks}
               exceptions={initialData.exceptions}
+              projects={scheduleProjects}
             />
           )
         )}
@@ -594,6 +659,7 @@ export function ScheduleView({
             exceptions={initialData.exceptions}
             assigneeOptions={assigneeOptions}
             focusTaskId={focusTaskId}
+            projects={scheduleProjects}
           />
         )}
         {view === "gantt" && (
@@ -603,21 +669,28 @@ export function ScheduleView({
             dependencies={initialData.dependencies}
             exceptions={initialData.exceptions}
             assigneeOptions={assigneeOptions}
+            projects={scheduleProjects}
           />
         )}
       </div>
 
       {/* New schedule item dialog */}
-      <ScheduleItemFormDialog
-        open={taskFormOpen}
-        onOpenChange={setTaskFormOpen}
-        projectId={projectId}
-        editingTask={null}
-        allTasks={initialData.tasks}
-        dependencies={initialData.dependencies}
-        exceptions={initialData.exceptions}
-        assigneeOptions={assigneeOptions}
-      />
+      {projectId && (
+        <ScheduleItemFormDialog
+          open={taskFormOpen}
+          onOpenChange={setTaskFormOpen}
+          projectId={projectId}
+          editingTask={null}
+          allTasks={initialData.tasks.filter(
+            (task) => task.projectId === projectId
+          )}
+          dependencies={initialData.dependencies}
+          exceptions={initialData.exceptions.filter(
+            (exception) => exception.projectId === projectId
+          )}
+          assigneeOptions={assigneeOptions}
+        />
+      )}
 
       {/* Import dialog */}
       <Dialog open={importDialogOpen} onOpenChange={setImportDialogOpen}>
@@ -671,11 +744,17 @@ export function ScheduleView({
             </SheetDescription>
           </SheetHeader>
           <div className="mt-4">
-            <ScheduleBaselineView
-              projectId={projectId}
-              baselines={baselines}
-              currentTasks={initialData.tasks}
-            />
+            {projectId ? (
+              <ScheduleBaselineView
+                projectId={projectId}
+                baselines={baselines}
+                currentTasks={initialData.tasks}
+              />
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Choose one project to manage its baselines.
+              </p>
+            )}
           </div>
         </SheetContent>
       </Sheet>
@@ -690,10 +769,16 @@ export function ScheduleView({
             </SheetDescription>
           </SheetHeader>
           <div className="mt-4">
-            <WorkdayExceptionsView
-              projectId={projectId}
-              exceptions={initialData.exceptions}
-            />
+            {projectId ? (
+              <WorkdayExceptionsView
+                projectId={projectId}
+                exceptions={initialData.exceptions}
+              />
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Choose one project to manage its workday exceptions.
+              </p>
+            )}
           </div>
         </SheetContent>
       </Sheet>

--- a/src/components/schedule/work-calendar.tsx
+++ b/src/components/schedule/work-calendar.tsx
@@ -504,6 +504,11 @@ export function WorkCalendar({
             />
           </div>
           <div className="flex flex-wrap gap-2">
+            <Button asChild size="sm" variant="outline">
+              <Link href="/dashboard/schedule?mode=projects&scope=all&view=gantt">
+                Project schedules
+              </Link>
+            </Button>
             {data.canCreateEvents && (
               <WorkCalendarEventDialog
                 variant="create"

--- a/src/lib/schedule/__tests__/project-scope.test.ts
+++ b/src/lib/schedule/__tests__/project-scope.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  projectScheduleColor,
+  projectScheduleLabel,
+  scheduleScopeLabel,
+  type ScheduleProjectData,
+} from "@/lib/schedule/project-scope"
+
+const projects: readonly ScheduleProjectData[] = [
+  {
+    id: "proj-o-202-loeffler",
+    name: "Twinkle Rd Loeffler Residence",
+    projectNumber: "O-202-595",
+    department: "O",
+    color: projectScheduleColor("proj-o-202-loeffler"),
+  },
+  {
+    id: "proj-o-170-loomis",
+    name: "County Ln 7 Loomis",
+    projectNumber: "O-170-2684",
+    department: "O",
+    color: projectScheduleColor("proj-o-170-loomis"),
+  },
+]
+
+describe("unified schedule project scope", () => {
+  it("assigns a stable project color", () => {
+    expect(projectScheduleColor(projects[0].id)).toBe(
+      projectScheduleColor(projects[0].id)
+    )
+    expect(projectScheduleColor(projects[0].id)).toMatch(/^#[0-9a-f]{6}$/)
+  })
+
+  it("uses project numbers in compact schedule labels", () => {
+    expect(projectScheduleLabel(projects[0])).toBe(
+      "O-202-595 — Twinkle Rd Loeffler Residence"
+    )
+  })
+
+  it("describes every supported scope", () => {
+    expect(
+      scheduleScopeLabel(
+        {
+          kind: "project",
+          projectIds: [projects[0].id],
+          department: null,
+        },
+        projects
+      )
+    ).toContain("O-202-595")
+    expect(
+      scheduleScopeLabel(
+        {
+          kind: "selected",
+          projectIds: projects.map((project) => project.id),
+          department: null,
+        },
+        projects
+      )
+    ).toBe("2 selected projects")
+    expect(
+      scheduleScopeLabel(
+        {
+          kind: "department",
+          projectIds: projects.map((project) => project.id),
+          department: "O",
+        },
+        projects
+      )
+    ).toBe("O department")
+    expect(
+      scheduleScopeLabel(
+        {
+          kind: "all",
+          projectIds: projects.map((project) => project.id),
+          department: null,
+        },
+        projects
+      )
+    ).toBe("All projects")
+  })
+})

--- a/src/lib/schedule/gantt-transform.ts
+++ b/src/lib/schedule/gantt-transform.ts
@@ -16,6 +16,7 @@ export interface FrappeTask {
   dependencies: string
   custom_class: string
   displayColor: string | null
+  projectColor?: string
   isCriticalPath: boolean
   isMilestone: boolean
 }

--- a/src/lib/schedule/project-scope.ts
+++ b/src/lib/schedule/project-scope.ts
@@ -1,0 +1,91 @@
+import type { ProjectDepartment } from "@/lib/project-branding"
+
+const PROJECT_COLORS = [
+  "#2563eb",
+  "#16a34a",
+  "#d97706",
+  "#7c3aed",
+  "#dc2626",
+  "#0891b2",
+  "#c2410c",
+  "#4f46e5",
+  "#0f766e",
+  "#be185d",
+  "#65a30d",
+  "#475569",
+] as const
+
+export type ScheduleScopeKind =
+  | "project"
+  | "selected"
+  | "department"
+  | "all"
+
+export type ScheduleProjectData = {
+  readonly id: string
+  readonly name: string
+  readonly projectNumber: string | null
+  readonly department: ProjectDepartment
+  readonly color: string
+}
+export type ScheduleScope =
+  | {
+      readonly kind: "project"
+      readonly projectIds: readonly [string]
+      readonly department: null
+    }
+  | {
+      readonly kind: "selected"
+      readonly projectIds: readonly string[]
+      readonly department: null
+    }
+  | {
+      readonly kind: "department"
+      readonly projectIds: readonly string[]
+      readonly department: ProjectDepartment
+    }
+  | {
+      readonly kind: "all"
+      readonly projectIds: readonly string[]
+      readonly department: null
+    }
+
+function stableHash(value: string): number {
+  let hash = 0
+  for (const character of value) {
+    hash = (hash * 31 + character.charCodeAt(0)) >>> 0
+  }
+  return hash
+}
+
+export function projectScheduleColor(projectId: string): string {
+  return PROJECT_COLORS[stableHash(projectId) % PROJECT_COLORS.length]
+}
+
+export function projectScheduleLabel(
+  project: Pick<ScheduleProjectData, "name" | "projectNumber">
+): string {
+  return project.projectNumber
+    ? `${project.projectNumber} — ${project.name}`
+    : project.name
+}
+
+export function scheduleScopeLabel(
+  scope: ScheduleScope,
+  projects: readonly ScheduleProjectData[]
+): string {
+  switch (scope.kind) {
+    case "project": {
+      const project = projects.find(
+        (candidate) => candidate.id === scope.projectIds[0]
+      )
+      return project ? projectScheduleLabel(project) : "Project schedule"
+    }
+    case "selected":
+      return `${scope.projectIds.length} selected projects`
+    case "department":
+      return `${scope.department} department`
+    case "all":
+      return "All projects"
+  }
+}

--- a/src/lib/schedule/types.ts
+++ b/src/lib/schedule/types.ts
@@ -84,6 +84,10 @@ export interface ScheduleData {
   exceptions: WorkdayExceptionData[]
 }
 
+export interface ScopedScheduleData extends ScheduleData {
+  projects: import("@/lib/schedule/project-scope").ScheduleProjectData[]
+}
+
 export interface TaskFilters {
   readonly status: readonly TaskStatus[]
   readonly phase: readonly string[]


### PR DESCRIPTION
## What
- adds one-project, selected-project, department, and all-project schedule scopes
- provides Calendar, List, and Gantt views at every scope
- adds Month, Week, Day, and Agenda calendar modes plus a Year Gantt scale
- shows stable project badges, project columns, and project colors across unified views
- preserves exact project navigation and project-safe editing/bulk actions

## Why
Compass scheduling was fragmented between individual project schedules and the Work Calendar. Staff could not review or compare project schedules at department or company level without opening projects one at a time.

## Safety
- all schedule reads are permission-checked and restricted to accessible organization projects
- multi-project dependency queries are limited to the selected task set
- creation, dependencies, baselines, and workday exceptions require a single selected project

## Validation
- `bunx tsc --noEmit`
- focused ESLint on all changed scheduling files
- `bun run test` — 57 files, 402 passed, 3 skipped
- `bun run build`
- pre-push production build
