### PR TITLE
feat(schedule): add owner visibility modes

### DIFF
--- a/drizzle/0072_owner_schedule_visibility.sql
+++ b/drizzle/0072_owner_schedule_visibility.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `projects`
+ADD COLUMN `owner_schedule_view` text NOT NULL DEFAULT 'items';

--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -24,6 +24,12 @@ import {
   type ProjectAudience,
 } from "@/lib/project-audience-access"
 import { isInternalStaffRole } from "@/lib/user-roles"
+import {
+  isOwnerScheduleView,
+  summarizeOwnerScheduleByPhase,
+  type OwnerScheduleView,
+  type OwnerScheduleVisibleItem,
+} from "@/lib/schedule/owner-visibility"
 
 export type { ProjectAudience } from "@/lib/project-audience-access"
 
@@ -134,6 +140,7 @@ export type ProjectAudiencePreview = {
     readonly address: string | null
     readonly clientName: string | null
     readonly projectManager: string | null
+    readonly ownerScheduleView: OwnerScheduleView
   }
   readonly ownerUpdates: readonly AudienceOwnerUpdate[]
   readonly photos: readonly AudiencePhoto[]
@@ -248,6 +255,7 @@ export async function getProjectAudiencePreview(
       address: projects.address,
       clientName: projects.clientName,
       projectManager: projects.projectManager,
+      ownerScheduleView: projects.ownerScheduleView,
       status: projects.status,
     })
     .from(projects)
@@ -347,6 +355,7 @@ export async function getProjectAudiencePreview(
       assignedTo: scheduleTasks.assignedTo,
       percentComplete: scheduleTasks.percentComplete,
       isMilestone: scheduleTasks.isMilestone,
+      workdays: scheduleTasks.workdays,
     })
     .from(scheduleTasks)
     .where(eq(scheduleTasks.projectId, projectId))
@@ -499,13 +508,41 @@ export async function getProjectAudiencePreview(
       ])
       .filter((value) => value.length > 0)
   )
+  const ownerScheduleView = isOwnerScheduleView(project.ownerScheduleView)
+    ? project.ownerScheduleView
+    : "items"
+  const visibleScheduleItem = (
+    item: (typeof scheduleRows)[number]
+  ): OwnerScheduleVisibleItem => ({
+    id: item.id,
+    title: item.title,
+    startDate: item.startDate,
+    endDate: item.endDate,
+    status: item.status,
+    phase: item.phase,
+    assignedTo: item.assignedTo,
+    percentComplete: item.percentComplete,
+    isMilestone: item.isMilestone,
+  })
+  const ownerScheduleItems =
+    ownerScheduleView === "phases"
+      ? summarizeOwnerScheduleByPhase(scheduleRows)
+      : scheduleRows.map(visibleScheduleItem)
 
   return {
     audience,
     viewerIsInternal,
     viewer,
     projectOptions,
-    project,
+    project: {
+      id: project.id,
+      name: project.name,
+      projectNumber: project.projectNumber,
+      address: project.address,
+      clientName: project.clientName,
+      projectManager: project.projectManager,
+      ownerScheduleView,
+    },
     ownerUpdates: ownerUpdateRows,
     photos: photoRows.filter(isImage).map((photo) => {
       const resolvedPhotoDate = photoDate({
@@ -533,10 +570,10 @@ export async function getProjectAudiencePreview(
     }),
     scheduleItems:
       audience === "owner"
-        ? scheduleRows
+        ? ownerScheduleItems
         : scheduleRows.filter((item) =>
             visibleContactNames.has(normalizeVisibleName(item.assignedTo))
-          ),
+          ).map(visibleScheduleItem),
     operations: operationRows
       .filter(
         (operation) =>

--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -29,6 +29,11 @@ import { getProjects } from "@/app/actions/projects"
 import { projectDepartment } from "@/lib/project-branding"
 import { projectScheduleColor } from "@/lib/schedule/project-scope"
 import { requirePermission } from "@/lib/permissions"
+import { isInternalStaffRole } from "@/lib/user-roles"
+import {
+  isOwnerScheduleView,
+  type OwnerScheduleView,
+} from "@/lib/schedule/owner-visibility"
 import type {
   TaskStatus,
   DependencyType,
@@ -43,6 +48,12 @@ import type {
 function revalidateSchedulePaths(projectId: string): void {
   revalidatePath(`/dashboard/projects/${projectId}/schedule`)
   revalidatePath("/dashboard/schedule")
+}
+
+function revalidateOwnerSchedulePaths(projectId: string): void {
+  revalidateSchedulePaths(projectId)
+  revalidatePath(`/preview/projects/${projectId}/owner`)
+  revalidatePath(`/preview/projects/${projectId}/owner/schedule`)
 }
 
 function chunkValues<T>(values: readonly T[], size: number): T[][] {
@@ -124,6 +135,92 @@ export async function getSchedule(
       type: d.type as DependencyType,
     })),
     exceptions,
+  }
+}
+
+export async function getOwnerScheduleView(
+  projectId: string
+): Promise<OwnerScheduleView> {
+  const user = await requireAuth()
+  requirePermission(user, "schedule", "read")
+  const orgId = requireOrg(user)
+  const accessibleProjects = await getProjects()
+  if (!accessibleProjects.some((project) => project.id === projectId)) {
+    throw new Error("Project not found or access denied")
+  }
+
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const project = await db
+    .select({ ownerScheduleView: projects.ownerScheduleView })
+    .from(projects)
+    .where(
+      and(eq(projects.id, projectId), eq(projects.organizationId, orgId))
+    )
+    .get()
+
+  if (!project) throw new Error("Project not found or access denied")
+  return isOwnerScheduleView(project.ownerScheduleView)
+    ? project.ownerScheduleView
+    : "items"
+}
+
+export async function updateOwnerScheduleView(
+  projectId: string,
+  ownerScheduleView: string
+): Promise<
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string }
+> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    requirePermission(user, "schedule", "update")
+    if (!isInternalStaffRole(user.role)) {
+      return {
+        success: false,
+        error: "Only internal project staff can change owner schedule access.",
+      }
+    }
+    if (!isOwnerScheduleView(ownerScheduleView)) {
+      return { success: false, error: "Unsupported owner schedule view." }
+    }
+
+    const orgId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const existing = await db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(
+        and(eq(projects.id, projectId), eq(projects.organizationId, orgId))
+      )
+      .get()
+
+    if (!existing) {
+      return { success: false, error: "Project not found or access denied" }
+    }
+
+    await db
+      .update(projects)
+      .set({
+        ownerScheduleView,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(projects.id, projectId))
+
+    revalidateOwnerSchedulePaths(projectId)
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to update the owner schedule view.",
+    }
   }
 }
 

--- a/src/app/dashboard/projects/[id]/schedule/page.tsx
+++ b/src/app/dashboard/projects/[id]/schedule/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/app/actions/project-contacts"
 import { ScheduleView } from "@/components/schedule/schedule-view"
 import type { ScheduleData, ScheduleBaselineData } from "@/lib/schedule/types"
+import type { OwnerScheduleView } from "@/lib/schedule/owner-visibility"
 
 const emptySchedule: ScheduleData = {
   tasks: [],
@@ -48,6 +49,7 @@ export default async function SchedulePage({
   let baselines: ScheduleBaselineData[] = []
   let allProjects: ProjectListItem[] = []
   let assigneeOptions: ProjectTaskAssigneeOption[] = []
+  let ownerScheduleView: OwnerScheduleView = "items"
 
   try {
     const { env } = await getCloudflareContext()
@@ -63,6 +65,8 @@ export default async function SchedulePage({
     if (!project) notFound()
 
     projectName = project.projectNumber ?? project.name
+    ownerScheduleView =
+      project.ownerScheduleView === "phases" ? "phases" : "items"
     ;[schedule, baselines, allProjects] = await Promise.all([
       getSchedule(id),
       getBaselines(id),
@@ -94,6 +98,7 @@ export default async function SchedulePage({
         assigneeOptions={assigneeOptions}
         initialView={focusTaskId ? "list" : initialView}
         focusTaskId={focusTaskId}
+        ownerScheduleView={ownerScheduleView}
       />
     </div>
   )

--- a/src/app/dashboard/schedule/page.tsx
+++ b/src/app/dashboard/schedule/page.tsx
@@ -1,7 +1,10 @@
 export const dynamic = "force-dynamic"
 
 import { getWorkCalendar } from "@/app/actions/work-calendar"
-import { getScopedSchedule } from "@/app/actions/schedule"
+import {
+  getOwnerScheduleView,
+  getScopedSchedule,
+} from "@/app/actions/schedule"
 import { getProjects } from "@/app/actions/projects"
 import {
   WorkCalendar,
@@ -162,6 +165,10 @@ export default async function SchedulePage({
         ? requestedView
         : "gantt"
     const primaryProject = data.projects[0] ?? null
+    const ownerScheduleView =
+      scope.kind === "project" && primaryProject
+        ? await getOwnerScheduleView(primaryProject.id)
+        : "items"
 
     return (
       <div className="flex min-h-0 flex-1 flex-col px-4 py-2">
@@ -179,6 +186,7 @@ export default async function SchedulePage({
           scope={scope}
           initialView={initialView}
           globalMode
+          ownerScheduleView={ownerScheduleView}
         />
       </div>
     )

--- a/src/components/projects/project-audience-preview.tsx
+++ b/src/components/projects/project-audience-preview.tsx
@@ -646,7 +646,10 @@ function OwnerProjectPreview({
         )}
 
         {section === "schedule" && (
-        <ProjectAudienceSchedule items={data.scheduleItems} />
+        <ProjectAudienceSchedule
+          items={data.scheduleItems}
+          presentation={data.project.ownerScheduleView}
+        />
         )}
 
         {section === "conversations" && (

--- a/src/components/projects/project-audience-schedule.tsx
+++ b/src/components/projects/project-audience-schedule.tsx
@@ -6,14 +6,16 @@ import {
   IconChevronLeft,
   IconChevronRight,
   IconList,
+  IconTimeline,
 } from "@tabler/icons-react"
 
 import type { AudienceScheduleItem } from "@/app/actions/project-audience-preview"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
+import type { OwnerScheduleView } from "@/lib/schedule/owner-visibility"
 
-type ScheduleView = "list" | "calendar"
+type ScheduleView = "list" | "calendar" | "gantt"
 
 const WEEKDAYS: readonly string[] = [
   "Sun",
@@ -87,10 +89,196 @@ function itemsForDay(
   return items.filter((item) => item.startDate <= key && item.endDate >= key)
 }
 
-export function ProjectAudienceSchedule({
+function addDays(value: Date, amount: number): Date {
+  const next = new Date(value)
+  next.setDate(next.getDate() + amount)
+  return next
+}
+
+function daysBetween(start: string, end: string): number {
+  const [startYear, startMonth, startDay] = start.split("-").map(Number)
+  const [endYear, endMonth, endDay] = end.split("-").map(Number)
+  const milliseconds =
+    Date.UTC(endYear, endMonth - 1, endDay) -
+    Date.UTC(startYear, startMonth - 1, startDay)
+  return Math.round(milliseconds / 86_400_000)
+}
+
+type GanttMonth = {
+  readonly key: string
+  readonly label: string
+  readonly left: number
+  readonly width: number
+}
+
+function ProjectAudienceGantt({
   items,
 }: {
   readonly items: readonly AudienceScheduleItem[]
+}): React.ReactElement {
+  const range = React.useMemo(() => {
+    const earliest = items.reduce(
+      (date, item) => (item.startDate < date ? item.startDate : date),
+      items[0].startDate
+    )
+    const latest = items.reduce(
+      (date, item) => (item.endDate > date ? item.endDate : date),
+      items[0].endDate
+    )
+    const start = dateKey(addDays(dateFromKey(earliest), -3))
+    const end = dateKey(addDays(dateFromKey(latest), 7))
+    const totalDays = daysBetween(start, end) + 1
+    const dayWidth =
+      totalDays > 240 ? 10 : totalDays > 120 ? 14 : totalDays > 60 ? 18 : 24
+    return {
+      start,
+      end,
+      totalDays,
+      dayWidth,
+      chartWidth: Math.max(680, totalDays * dayWidth),
+    }
+  }, [items])
+  const months = React.useMemo(() => {
+    const segments: GanttMonth[] = []
+    let cursor = dateFromKey(range.start)
+    const rangeEnd = dateFromKey(range.end)
+
+    while (cursor <= rangeEnd) {
+      const monthStartDate = new Date(
+        cursor.getFullYear(),
+        cursor.getMonth(),
+        1
+      )
+      const nextMonth = new Date(
+        cursor.getFullYear(),
+        cursor.getMonth() + 1,
+        1
+      )
+      const segmentStart =
+        cursor > monthStartDate ? cursor : monthStartDate
+      const monthEnd = addDays(nextMonth, -1)
+      const segmentEnd = monthEnd < rangeEnd ? monthEnd : rangeEnd
+      const segmentStartKey = dateKey(segmentStart)
+      const segmentEndKey = dateKey(segmentEnd)
+      segments.push({
+        key: segmentStartKey,
+        label: segmentStart.toLocaleDateString("en-US", {
+          month: "short",
+          year: "numeric",
+        }),
+        left: daysBetween(range.start, segmentStartKey) * range.dayWidth,
+        width:
+          (daysBetween(segmentStartKey, segmentEndKey) + 1) * range.dayWidth,
+      })
+      cursor = nextMonth
+    }
+
+    return segments
+  }, [range])
+  const today = dateKey(new Date())
+  const todayVisible = today >= range.start && today <= range.end
+  const labelWidth = 240
+
+  return (
+    <div className="overflow-auto" aria-label="Read-only project Gantt chart">
+      <div
+        className="relative"
+        style={{ minWidth: labelWidth + range.chartWidth }}
+      >
+        <div className="sticky top-0 z-20 flex h-10 border-b bg-background">
+          <div
+            className="sticky left-0 z-30 flex shrink-0 items-center border-r bg-background px-4 text-xs font-medium"
+            style={{ width: labelWidth }}
+          >
+            Schedule
+          </div>
+          <div
+            className="relative shrink-0 overflow-hidden"
+            style={{ width: range.chartWidth }}
+          >
+            {months.map((month) => (
+              <div
+                key={month.key}
+                className="absolute inset-y-0 border-r px-2 py-2 text-xs font-medium text-muted-foreground"
+                style={{ left: month.left, width: month.width }}
+              >
+                {month.label}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {items.map((item) => {
+          const left =
+            daysBetween(range.start, item.startDate) * range.dayWidth
+          const width = Math.max(
+            range.dayWidth,
+            (daysBetween(item.startDate, item.endDate) + 1) * range.dayWidth
+          )
+          const percentComplete = Math.min(
+            100,
+            Math.max(0, item.percentComplete)
+          )
+
+          return (
+            <div key={item.id} className="flex h-14 border-b">
+              <div
+                className="sticky left-0 z-10 flex shrink-0 flex-col justify-center border-r bg-background px-4"
+                style={{ width: labelWidth }}
+              >
+                <span className="truncate text-xs font-medium">{item.title}</span>
+                <span className="mt-0.5 truncate text-[10px] text-muted-foreground">
+                  {formatDate(item.startDate)} – {formatDate(item.endDate)}
+                </span>
+              </div>
+              <div
+                className="relative shrink-0"
+                style={{
+                  width: range.chartWidth,
+                  backgroundImage:
+                    "linear-gradient(to right, transparent calc(100% - 1px), var(--border) calc(100% - 1px))",
+                  backgroundSize: `${range.dayWidth}px 100%`,
+                }}
+              >
+                {todayVisible && (
+                  <span
+                    aria-hidden="true"
+                    className="absolute inset-y-0 z-10 w-px bg-destructive/60"
+                    style={{
+                      left:
+                        daysBetween(range.start, today) * range.dayWidth +
+                        range.dayWidth / 2,
+                    }}
+                  />
+                )}
+                <div
+                  className="absolute top-3 h-8 overflow-hidden rounded-sm border border-primary/30 bg-primary/15"
+                  style={{ left, width }}
+                  title={`${item.title}: ${percentComplete}% complete`}
+                >
+                  <div
+                    className="h-full bg-primary/45"
+                    style={{ width: `${percentComplete}%` }}
+                  />
+                  <span className="absolute inset-0 flex items-center px-2 text-[10px] font-medium">
+                    {percentComplete}%
+                  </span>
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export function ProjectAudienceSchedule({
+  items,
+  presentation = "items",
+}: {
+  readonly items: readonly AudienceScheduleItem[]
+  readonly presentation?: OwnerScheduleView
 }): React.ReactElement {
   const [view, setView] = React.useState<ScheduleView>("list")
   const [visibleMonth, setVisibleMonth] = React.useState(() =>
@@ -114,7 +302,8 @@ export function ProjectAudienceSchedule({
         <div>
           <h2 className="text-sm font-semibold">Project Schedule</h2>
           <p className="mt-1 text-xs text-muted-foreground">
-            {items.length} visible item{items.length === 1 ? "" : "s"}
+            {items.length} visible {presentation === "phases" ? "phase" : "item"}
+            {items.length === 1 ? "" : "s"} · Read only
           </p>
         </div>
         <div className="flex items-center border">
@@ -135,6 +324,15 @@ export function ProjectAudienceSchedule({
           >
             <IconCalendar className="size-4" />
             Calendar
+          </Button>
+          <Button
+            variant={view === "gantt" ? "secondary" : "ghost"}
+            size="sm"
+            className="rounded-none border-l"
+            onClick={() => setView("gantt")}
+          >
+            <IconTimeline className="size-4" />
+            Gantt
           </Button>
         </div>
       </div>
@@ -172,7 +370,7 @@ export function ProjectAudienceSchedule({
             </article>
           ))}
         </div>
-      ) : (
+      ) : view === "calendar" ? (
         <div>
           <div className="flex items-center justify-between border-b px-4 py-3">
             <Button
@@ -270,6 +468,8 @@ export function ProjectAudienceSchedule({
             </div>
           </div>
         </div>
+      ) : (
+        <ProjectAudienceGantt items={sortedItems} />
       )}
     </section>
   )

--- a/src/components/schedule/owner-schedule-visibility-control.tsx
+++ b/src/components/schedule/owner-schedule-visibility-control.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { IconEye } from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import { updateOwnerScheduleView } from "@/app/actions/schedule"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import type { OwnerScheduleView } from "@/lib/schedule/owner-visibility"
+
+const OPTIONS: readonly {
+  readonly value: OwnerScheduleView
+  readonly label: string
+  readonly description: string
+}[] = [
+  {
+    value: "items",
+    label: "Items",
+    description:
+      "Owners can see the title, dates, progress, and phase of each schedule item.",
+  },
+  {
+    value: "phases",
+    label: "Phases",
+    description:
+      "Owners see date ranges and progress summarized by phase; item details stay internal.",
+  },
+]
+
+export function OwnerScheduleVisibilityControl({
+  projectId,
+  initialValue,
+}: {
+  readonly projectId: string
+  readonly initialValue: OwnerScheduleView
+}): React.ReactElement {
+  const router = useRouter()
+  const [value, setValue] = useState(initialValue)
+  const [isPending, startTransition] = useTransition()
+
+  function changeView(nextValue: OwnerScheduleView): void {
+    if (nextValue === value || isPending) return
+    const priorValue = value
+    setValue(nextValue)
+
+    startTransition(async () => {
+      const result = await updateOwnerScheduleView(projectId, nextValue)
+      if (!result.success) {
+        setValue(priorValue)
+        toast.error(result.error)
+        return
+      }
+
+      toast.success(
+        nextValue === "items"
+          ? "Owners can now see individual schedule items."
+          : "Owners will now see phase summaries only."
+      )
+      router.refresh()
+    })
+  }
+
+  return (
+    <div
+      className="flex items-center gap-2"
+      title={OPTIONS.find((option) => option.value === value)?.description}
+    >
+      <span className="hidden items-center gap-1 text-xs font-medium text-muted-foreground xl:flex">
+        <IconEye className="size-3.5" />
+        Owner schedule
+      </span>
+      <div
+        className="flex items-center border bg-background"
+        aria-label="Owner schedule visibility"
+      >
+        {OPTIONS.map((option) => (
+          <Button
+            key={option.value}
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={isPending}
+            aria-pressed={value === option.value}
+            title={option.description}
+            className={cn(
+              "h-8 rounded-none px-2.5 text-xs",
+              option.value === "phases" && "border-l",
+              value === option.value &&
+                "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
+            )}
+            onClick={() => changeView(option.value)}
+          >
+            {option.label}
+          </Button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/schedule/schedule-gantt-view.tsx
+++ b/src/components/schedule/schedule-gantt-view.tsx
@@ -533,19 +533,6 @@ export function ScheduleGanttView({
     })
   }
 
-  const toggleClientView = () => {
-    if (phaseGrouping && collapsedPhases.size > 0) {
-      setPhaseGrouping(false)
-      setCollapsedPhases(new Set())
-    } else {
-      setPhaseGrouping(true)
-      const allPhases = new Set(
-        filteredTasks.map((t) => t.phase || "uncategorized")
-      )
-      setCollapsedPhases(allPhases)
-    }
-  }
-
   const handleDateChange = useCallback(
     async (task: FrappeTask, start: Date, end: Date) => {
       if (task.id.startsWith("phase-")) return
@@ -975,18 +962,6 @@ export function ScheduleGanttView({
                     className="scale-75"
                   />
                 </div>
-                <Button
-                  variant={
-                    phaseGrouping && collapsedPhases.size > 0
-                      ? "default"
-                      : "outline"
-                  }
-                  size="sm"
-                  onClick={toggleClientView}
-                  className="w-full mt-1 text-xs h-7"
-                >
-                  Client View
-                </Button>
               </div>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -69,6 +69,7 @@ import { ScheduleBaselineView } from "./schedule-baseline-view"
 import { ScheduleItemFormDialog } from "./schedule-item-form-dialog"
 import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
 import { ScheduleScopeSwitcher } from "./schedule-scope-switcher"
+import { OwnerScheduleVisibilityControl } from "./owner-schedule-visibility-control"
 import type { ProjectListItem } from "@/app/actions/projects"
 import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
 import type {
@@ -91,6 +92,7 @@ import {
   scheduleOrderStorageKey,
   type ScheduleOrderMode,
 } from "@/lib/schedule/task-ordering"
+import type { OwnerScheduleView } from "@/lib/schedule/owner-visibility"
 
 type View = "calendar" | "list" | "gantt"
 
@@ -112,6 +114,7 @@ interface ScheduleViewProps {
   readonly initialView?: View
   readonly focusTaskId?: string | null
   readonly globalMode?: boolean
+  readonly ownerScheduleView?: OwnerScheduleView
 }
 
 export function ScheduleView({
@@ -126,6 +129,7 @@ export function ScheduleView({
   initialView = "gantt",
   focusTaskId = null,
   globalMode = false,
+  ownerScheduleView = "items",
 }: ScheduleViewProps) {
   const isMobile = useIsMobile()
   const [view, setView] = useState<View>(initialView)
@@ -406,6 +410,13 @@ export function ScheduleView({
                 </Link>
               </Button>
             </>
+          )}
+
+          {projectId && (
+            <OwnerScheduleVisibilityControl
+              projectId={projectId}
+              initialValue={ownerScheduleView}
+            />
           )}
 
           {/* View switcher */}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -373,6 +373,7 @@ export const projects = sqliteTable("projects", {
   }).notNull().default(true),
   ownerUpdateChannel: text("owner_update_channel").notNull().default("compass"),
   ownerUpdateCadence: text("owner_update_cadence").notNull().default("weekly"),
+  ownerScheduleView: text("owner_schedule_view").notNull().default("items"),
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at"),
 })

--- a/src/lib/schedule/__tests__/owner-visibility.test.ts
+++ b/src/lib/schedule/__tests__/owner-visibility.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isOwnerScheduleView,
+  summarizeOwnerScheduleByPhase,
+  type OwnerScheduleSourceItem,
+} from "../owner-visibility"
+
+const ITEMS: readonly OwnerScheduleSourceItem[] = [
+  {
+    id: "task-1",
+    title: "Private foundation detail",
+    startDate: "2026-07-01",
+    endDate: "2026-07-05",
+    status: "COMPLETE",
+    phase: "foundation",
+    assignedTo: "Vendor One",
+    percentComplete: 100,
+    isMilestone: false,
+    workdays: 5,
+  },
+  {
+    id: "task-2",
+    title: "Private foundation follow-up",
+    startDate: "2026-07-06",
+    endDate: "2026-07-15",
+    status: "IN_PROGRESS",
+    phase: "foundation",
+    assignedTo: "Vendor Two",
+    percentComplete: 50,
+    isMilestone: false,
+    workdays: 10,
+  },
+  {
+    id: "task-3",
+    title: "Private framing detail",
+    startDate: "2026-07-16",
+    endDate: "2026-07-20",
+    status: "PENDING",
+    phase: "custom_phase",
+    assignedTo: null,
+    percentComplete: 0,
+    isMilestone: false,
+    workdays: 5,
+  },
+]
+
+describe("owner schedule visibility", () => {
+  it("recognizes the supported persisted values", () => {
+    expect(isOwnerScheduleView("items")).toBe(true)
+    expect(isOwnerScheduleView("phases")).toBe(true)
+    expect(isOwnerScheduleView("client")).toBe(false)
+  })
+
+  it("rolls item details into date-bounded phase summaries", () => {
+    const summaries = summarizeOwnerScheduleByPhase(ITEMS)
+
+    expect(summaries).toEqual([
+      {
+        id: "owner-phase-foundation",
+        title: "Foundation",
+        startDate: "2026-07-01",
+        endDate: "2026-07-15",
+        status: "IN_PROGRESS",
+        phase: "foundation",
+        assignedTo: null,
+        percentComplete: 67,
+        isMilestone: false,
+      },
+      {
+        id: "owner-phase-custom-phase",
+        title: "Custom Phase",
+        startDate: "2026-07-16",
+        endDate: "2026-07-20",
+        status: "PENDING",
+        phase: "custom_phase",
+        assignedTo: null,
+        percentComplete: 0,
+        isMilestone: false,
+      },
+    ])
+  })
+
+  it("does not expose item titles or assignees in phase mode", () => {
+    const serialized = JSON.stringify(summarizeOwnerScheduleByPhase(ITEMS))
+
+    expect(serialized).not.toContain("Private")
+    expect(serialized).not.toContain("Vendor")
+  })
+})

--- a/src/lib/schedule/owner-visibility.ts
+++ b/src/lib/schedule/owner-visibility.ts
@@ -1,0 +1,119 @@
+import { PHASE_LABELS, PHASE_ORDER } from "@/lib/schedule/phase-colors"
+
+export type OwnerScheduleView = "items" | "phases"
+
+export type OwnerScheduleSourceItem = {
+  readonly id: string
+  readonly title: string
+  readonly startDate: string
+  readonly endDate: string
+  readonly status: string
+  readonly phase: string
+  readonly assignedTo: string | null
+  readonly percentComplete: number
+  readonly isMilestone: boolean
+  readonly workdays: number
+}
+
+export type OwnerScheduleVisibleItem = Omit<
+  OwnerScheduleSourceItem,
+  "workdays"
+>
+
+export function isOwnerScheduleView(
+  value: string
+): value is OwnerScheduleView {
+  return value === "items" || value === "phases"
+}
+
+function phaseLabel(phase: string): string {
+  const knownPhase = PHASE_ORDER.find((candidate) => candidate === phase)
+  if (knownPhase) return PHASE_LABELS[knownPhase]
+
+  return phase
+    .split(/[_-]+/)
+    .filter(Boolean)
+    .map(
+      (part) =>
+        `${part.slice(0, 1).toUpperCase()}${part.slice(1).toLowerCase()}`
+    )
+    .join(" ")
+}
+
+function phaseId(phase: string): string {
+  const safePhase = phase
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  return `owner-phase-${safePhase || "uncategorized"}`
+}
+
+export function summarizeOwnerScheduleByPhase(
+  items: readonly OwnerScheduleSourceItem[]
+): readonly OwnerScheduleVisibleItem[] {
+  const grouped = new Map<string, OwnerScheduleSourceItem[]>()
+
+  for (const item of items) {
+    const phase = item.phase.trim() || "uncategorized"
+    const existing = grouped.get(phase) ?? []
+    existing.push(item)
+    grouped.set(phase, existing)
+  }
+
+  return [...grouped].map(([phase, phaseItems]) => {
+    const totalWeight = phaseItems.reduce(
+      (sum, item) => sum + Math.max(1, item.workdays),
+      0
+    )
+    const percentComplete = Math.min(
+      100,
+      Math.max(
+        0,
+        Math.round(
+          phaseItems.reduce(
+            (sum, item) =>
+              sum + item.percentComplete * Math.max(1, item.workdays),
+            0
+          ) / totalWeight
+        )
+      )
+    )
+    const allComplete = phaseItems.every(
+      (item) =>
+        item.status.toUpperCase() === "COMPLETE" ||
+        item.percentComplete >= 100
+    )
+    const hasProgress = phaseItems.some(
+      (item) =>
+        item.status.toUpperCase() === "IN_PROGRESS" ||
+        item.percentComplete > 0
+    )
+
+    return {
+      id: phaseId(phase),
+      title: phaseLabel(phase),
+      startDate: phaseItems.reduce(
+        (earliest, item) =>
+          item.startDate < earliest ? item.startDate : earliest,
+        phaseItems[0].startDate
+      ),
+      endDate: phaseItems.reduce(
+        (latest, item) => (item.endDate > latest ? item.endDate : latest),
+        phaseItems[0].endDate
+      ),
+      status: allComplete
+        ? "COMPLETE"
+        : hasProgress
+          ? "IN_PROGRESS"
+          : "PENDING",
+      phase,
+      assignedTo: null,
+      percentComplete: allComplete ? 100 : percentComplete,
+      isMilestone: false,
+    }
+  }).sort(
+    (left, right) =>
+      left.startDate.localeCompare(right.startDate) ||
+      left.title.localeCompare(right.title)
+  )
+}


### PR DESCRIPTION
## What

- Replaces the temporary Gantt “Client View” button with a persistent project-level owner schedule setting: **Items** or **Phases**.
- Makes the setting available on single-project schedules entered either directly from a project or through unified Project Schedules.
- Adds a read-only Gantt to owner and sub/vendor schedule workspaces alongside list and calendar views.
- Enforces phase-only visibility on the server so individual schedule titles and assignees are not sent to owners.
- Adds the D1 migration for the persisted setting.

## Why

Owner schedule access needs to be a real permission/presentation rule across every owner schedule view, not a temporary internal Gantt grouping toggle.

## How to test

1. Open a single project schedule and switch **Owner schedule** between **Items** and **Phases**.
2. Open the owner preview schedule in a separate window.
3. Verify list, calendar, and Gantt show individual items in Items mode.
4. Switch to Phases and verify all three views show only phase summaries.
5. Verify the Gantt is read-only and the internal schedule remains editable.

## Validation

- TypeScript: passed
- Focused ESLint: passed
- Vitest: 58 files passed; 405 tests passed, 3 skipped
- Production Next.js build: passed
- Privacy regression test confirms phase summaries omit item titles and assignees
