### PR TITLE
fix(feedback): activate requester lifecycle delivery

### DIFF
--- a/docs/architecture/jarvis-feedback-bridge.md
+++ b/docs/architecture/jarvis-feedback-bridge.md
@@ -212,6 +212,16 @@ The reference poller is
 `~/.config/systemd/user/`, then enable it only after the filtered production
 endpoint is deployed.
 
+Requester lifecycle delivery uses the separate deterministic notifier at
+`scripts/jarvis-feedback-notifier.py` and the
+`ops/systemd/compass-jarvis-feedback-notifier.service` template. It pulls only
+`feedback.status_changed` events, routes Telegram and Jarvis-mail updates
+through Hermes's existing send adapters, posts Compass-conversation replies
+through the signed reply endpoint, and acknowledges Ask Jarvis/widget events
+after their Compass-native receipt or notification is available. Its local
+delivery ledger prevents a service restart from sending the same external
+update twice before acknowledgement.
+
 ### Acknowledge an event
 
 ```text
@@ -415,6 +425,9 @@ Rollout checklist
     explicit empty `platform_toolsets.api_server` list.
 12. Start the private agent poller, verify one `agent.prompt` round trip, then
     enable `JARVIS_AGENT_BRIDGE_ENABLED` in Compass.
+13. Start the requester lifecycle notifier, submit one test request per
+    enabled source, and confirm each receipt returns only through its original
+    source.
 
 The bundled bridge helper includes a `configure` command for step 5. It
 generates the HMAC key on the private runtime and returns only RSA-encrypted

--- a/ops/systemd/compass-jarvis-feedback-notifier.service
+++ b/ops/systemd/compass-jarvis-feedback-notifier.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Compass requester lifecycle notification relay
+After=network-online.target hermes-gateway.service
+Wants=network-online.target hermes-gateway.service
+
+[Service]
+Type=simple
+EnvironmentFile=%h/.hermes/.env
+Environment=HERMES_AGENT_ROOT=%h/.hermes/hermes-agent
+Environment=COMPASS_FEEDBACK_LEDGER=%h/.local/state/compass/feedback-notifier.json
+ExecStart=/usr/bin/python3 %h/.local/lib/compass/jarvis-feedback-notifier.py
+Restart=always
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=%h/.local/state/compass
+
+[Install]
+WantedBy=default.target

--- a/scripts/jarvis-feedback-notifier.py
+++ b/scripts/jarvis-feedback-notifier.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Deliver Compass Feedback Desk lifecycle updates through their source channel."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import re
+import signal
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+MAX_RESPONSE_BYTES = 64 * 1024
+MAX_LEDGER_EVENTS = 5_000
+PULL_TARGET = (
+    "/api/integrations/jarvis/events"
+    "?limit=20&eventType=feedback.status_changed"
+)
+LOGGER = logging.getLogger("compass-jarvis-feedback-notifier")
+RUNNING = True
+
+
+class RetryableError(RuntimeError):
+    """A temporary delivery or bridge error."""
+
+
+def stop_running(_signum: int, _frame: Any) -> None:
+    global RUNNING
+    RUNNING = False
+
+
+def required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"{name} is required")
+    return value
+
+
+def signature(
+    secret: str,
+    timestamp: str,
+    method: str,
+    target: str,
+    body: bytes,
+) -> str:
+    prefix = f"{timestamp}.{method.upper()}.{target}.".encode("utf-8")
+    digest = hmac.new(
+        secret.encode("utf-8"),
+        prefix + body,
+        hashlib.sha256,
+    ).hexdigest()
+    return f"sha256={digest}"
+
+
+def compass_request(
+    method: str,
+    target: str,
+    payload: dict[str, Any] | None = None,
+) -> Any:
+    base_url = required_env("COMPASS_BASE_URL").rstrip("/")
+    secret = required_env("JARVIS_BRIDGE_SECRET")
+    parsed_url = urllib.parse.urlsplit(base_url)
+    if parsed_url.scheme != "https":
+        raise RuntimeError("COMPASS_BASE_URL must use HTTPS")
+
+    body = (
+        json.dumps(
+            payload,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        if payload is not None
+        else b""
+    )
+    timestamp = str(int(time.time()))
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "Compass-Jarvis-Feedback-Notifier/1.0",
+        "X-Compass-Timestamp": timestamp,
+        "X-Compass-Signature": signature(
+            secret,
+            timestamp,
+            method,
+            target,
+            body,
+        ),
+    }
+    if body:
+        headers["Content-Type"] = "application/json"
+
+    request = urllib.request.Request(
+        f"{base_url}{target}",
+        data=body if body else None,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            raw = response.read(MAX_RESPONSE_BYTES)
+    except urllib.error.HTTPError as error:
+        if error.code == 429 or error.code >= 500:
+            raise RetryableError(
+                f"Compass returned HTTP {error.code}"
+            ) from error
+        message = error.read(2_048).decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"Compass returned HTTP {error.code}: {message}"
+        ) from error
+    except (TimeoutError, urllib.error.URLError) as error:
+        raise RetryableError("Compass request failed") from error
+
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise RuntimeError("Compass returned invalid JSON") from error
+
+
+def acknowledge(
+    event_id: str,
+    payload: dict[str, Any],
+) -> None:
+    escaped_id = urllib.parse.quote(event_id, safe="")
+    compass_request(
+        "POST",
+        f"/api/integrations/jarvis/events/{escaped_id}/ack",
+        payload,
+    )
+
+
+def metadata_object(payload: dict[str, Any]) -> dict[str, Any]:
+    metadata = payload.get("metadata")
+    if isinstance(metadata, dict):
+        return metadata
+    if isinstance(metadata, str):
+        try:
+            parsed = json.loads(metadata)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def reporter_object(payload: dict[str, Any]) -> dict[str, Any]:
+    reporter = payload.get("reporter")
+    return reporter if isinstance(reporter, dict) else {}
+
+
+def external_actor_id(payload: dict[str, Any]) -> str | None:
+    reporter = reporter_object(payload)
+    value = reporter.get("externalActorId")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    metadata = metadata_object(payload)
+    value = metadata.get("externalActorId")
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def reporter_email(payload: dict[str, Any]) -> str | None:
+    value = reporter_object(payload).get("email")
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip().lower()
+    if re.fullmatch(r"[^@\s]+@[^@\s]+\.[^@\s]+", candidate):
+        return candidate
+    return None
+
+
+def message_text(payload: dict[str, Any]) -> str:
+    value = payload.get("message")
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeError("Feedback event has no requester message")
+    return value.strip()[:2_000]
+
+
+def send_via_hermes(target: str, message: str) -> None:
+    root = Path(
+        os.environ.get(
+            "HERMES_AGENT_ROOT",
+            "/home/jarvis/.hermes/hermes-agent",
+        )
+    )
+    root_value = str(root)
+    if root_value not in sys.path:
+        sys.path.insert(0, root_value)
+
+    from tools.send_message_tool import send_message_tool
+
+    result = send_message_tool(
+        {
+            "action": "send",
+            "target": target,
+            "message": message,
+        }
+    )
+    if isinstance(result, str):
+        try:
+            parsed: Any = json.loads(result)
+        except json.JSONDecodeError as error:
+            raise RetryableError(
+                "Hermes returned an invalid delivery result"
+            ) from error
+    else:
+        parsed = result
+    if not isinstance(parsed, dict):
+        raise RetryableError("Hermes returned an invalid delivery result")
+    if parsed.get("error"):
+        raise RetryableError("Hermes could not deliver the requester update")
+
+
+def reply_to_compass(
+    event_id: str,
+    message: str,
+) -> None:
+    compass_request(
+        "POST",
+        "/api/integrations/jarvis/replies",
+        {
+            "eventId": event_id,
+            "idempotencyKey": f"feedback-notify:{event_id}",
+            "content": message,
+        },
+    )
+
+
+def deliver_event(event: dict[str, Any]) -> bool:
+    event_id = event.get("id")
+    source = event.get("source")
+    payload = event.get("payload")
+    if (
+        not isinstance(event_id, str)
+        or event.get("eventType") != "feedback.status_changed"
+        or not isinstance(source, str)
+        or not isinstance(payload, dict)
+    ):
+        raise RuntimeError("Invalid feedback lifecycle event")
+
+    message = message_text(payload)
+    if source == "telegram":
+        target = external_actor_id(payload)
+        if target is None or not re.fullmatch(r"-?\d+", target):
+            raise RuntimeError("Telegram feedback has no valid reply target")
+        send_via_hermes(f"telegram:{target}", message)
+        return True
+    if source == "jarvis-email":
+        target = reporter_email(payload)
+        if target is None:
+            raise RuntimeError("Email feedback has no valid reply target")
+        send_via_hermes(f"email:{target}", message)
+        return True
+    if source == "compass-conversation":
+        reply_to_compass(event_id, message)
+        return False
+    if source in {"ask-jarvis", "feedback-widget"}:
+        # Ask Jarvis confirms receipt in its original response and later
+        # lifecycle changes create requester-scoped Compass notifications.
+        # Widget requests remain visible in the request center.
+        return True
+    raise RuntimeError(f"Unsupported feedback source: {source}")
+
+
+def ledger_path() -> Path:
+    return Path(
+        os.environ.get(
+            "COMPASS_FEEDBACK_LEDGER",
+            "/home/jarvis/.local/state/compass/feedback-notifier.json",
+        )
+    )
+
+
+def load_ledger() -> list[str]:
+    path = ledger_path()
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [value for value in parsed if isinstance(value, str)][
+        -MAX_LEDGER_EVENTS:
+    ]
+
+
+def save_ledger(event_ids: list[str]) -> None:
+    path = ledger_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(
+        json.dumps(event_ids[-MAX_LEDGER_EVENTS:]),
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def handle_event(event: dict[str, Any], delivered: list[str]) -> None:
+    event_id = event.get("id")
+    if not isinstance(event_id, str):
+        raise RuntimeError("Feedback lifecycle event has no ID")
+    if event_id in delivered:
+        acknowledge(event_id, {"status": "completed"})
+        return
+
+    requires_ack = deliver_event(event)
+    if requires_ack:
+        delivered.append(event_id)
+        save_ledger(delivered)
+        acknowledge(event_id, {"status": "completed"})
+
+
+def run() -> None:
+    poll_seconds = max(
+        0.5,
+        float(os.environ.get("COMPASS_FEEDBACK_POLL_SECONDS", "2")),
+    )
+    delivered = load_ledger()
+    while RUNNING:
+        try:
+            response = compass_request("GET", PULL_TARGET)
+            events = (
+                response.get("events")
+                if isinstance(response, dict)
+                else None
+            )
+            if not isinstance(events, list):
+                raise RuntimeError("Compass pull response has no events")
+            if not events:
+                time.sleep(poll_seconds)
+                continue
+
+            for event in events:
+                if not RUNNING:
+                    break
+                if not isinstance(event, dict):
+                    continue
+                event_id = event.get("id")
+                try:
+                    handle_event(event, delivered)
+                    LOGGER.info("Completed feedback event %s", event_id)
+                except RetryableError as error:
+                    if isinstance(event_id, str):
+                        acknowledge(
+                            event_id,
+                            {
+                                "status": "failed",
+                                "error": str(error),
+                                "retryAfterSeconds": 30,
+                            },
+                        )
+                    LOGGER.warning(
+                        "Retryable feedback delivery failure: %s",
+                        event_id,
+                    )
+                except Exception as error:
+                    if isinstance(event_id, str):
+                        acknowledge(
+                            event_id,
+                            {
+                                "status": "failed",
+                                "error": str(error)[:2_000],
+                            },
+                        )
+                    LOGGER.exception(
+                        "Feedback delivery failed: %s",
+                        event_id,
+                    )
+        except RetryableError:
+            LOGGER.warning("Bridge temporarily unavailable")
+            time.sleep(5)
+        except Exception:
+            LOGGER.exception("Feedback poll cycle failed")
+            time.sleep(5)
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    signal.signal(signal.SIGTERM, stop_running)
+    signal.signal(signal.SIGINT, stop_running)
+    required_env("COMPASS_BASE_URL")
+    required_env("JARVIS_BRIDGE_SECRET")
+    run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_jarvis_feedback_notifier.py
+++ b/scripts/test_jarvis_feedback_notifier.py
@@ -1,0 +1,119 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT_PATH = Path(__file__).parent / "jarvis-feedback-notifier.py"
+SPEC = importlib.util.spec_from_file_location(
+    "jarvis_feedback_notifier",
+    SCRIPT_PATH,
+)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("Unable to load Jarvis feedback notifier")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class RoutingTests(unittest.TestCase):
+    def test_reads_external_actor_from_serialized_metadata(self) -> None:
+        payload = {
+            "metadata": json.dumps({"externalActorId": "123456"})
+        }
+
+        self.assertEqual(
+            MODULE.external_actor_id(payload),
+            "123456",
+        )
+
+    def test_telegram_uses_the_existing_hermes_sender(self) -> None:
+        event = {
+            "id": "event-1",
+            "eventType": "feedback.status_changed",
+            "source": "telegram",
+            "payload": {
+                "message": "Your request was received.",
+                "reporter": {"externalActorId": "123456"},
+            },
+        }
+
+        with patch.object(MODULE, "send_via_hermes") as sender:
+            requires_ack = MODULE.deliver_event(event)
+
+        self.assertTrue(requires_ack)
+        sender.assert_called_once_with(
+            "telegram:123456",
+            "Your request was received.",
+        )
+
+    def test_email_uses_the_original_sender_address(self) -> None:
+        event = {
+            "id": "event-2",
+            "eventType": "feedback.status_changed",
+            "source": "jarvis-email",
+            "payload": {
+                "message": "Your request is ready for testing.",
+                "reporter": {"email": "staff@example.com"},
+            },
+        }
+
+        with patch.object(MODULE, "send_via_hermes") as sender:
+            requires_ack = MODULE.deliver_event(event)
+
+        self.assertTrue(requires_ack)
+        sender.assert_called_once_with(
+            "email:staff@example.com",
+            "Your request is ready for testing.",
+        )
+
+    def test_compass_conversation_replies_to_stored_event(self) -> None:
+        event = {
+            "id": "event-3",
+            "eventType": "feedback.status_changed",
+            "source": "compass-conversation",
+            "payload": {"message": "Development has started."},
+        }
+
+        with patch.object(MODULE, "reply_to_compass") as reply:
+            requires_ack = MODULE.deliver_event(event)
+
+        self.assertFalse(requires_ack)
+        reply.assert_called_once_with(
+            "event-3",
+            "Development has started.",
+        )
+
+    def test_delivery_ledger_prevents_a_duplicate_send(self) -> None:
+        event = {
+            "id": "event-4",
+            "eventType": "feedback.status_changed",
+            "source": "telegram",
+            "payload": {
+                "message": "Your request was received.",
+                "reporter": {"externalActorId": "123456"},
+            },
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            ledger = Path(directory) / "ledger.json"
+            with (
+                patch.dict(
+                    MODULE.os.environ,
+                    {"COMPASS_FEEDBACK_LEDGER": str(ledger)},
+                    clear=False,
+                ),
+                patch.object(MODULE, "deliver_event") as delivery,
+                patch.object(MODULE, "acknowledge") as acknowledge,
+            ):
+                MODULE.handle_event(event, ["event-4"])
+
+        delivery.assert_not_called()
+        acknowledge.assert_called_once_with(
+            "event-4",
+            {"status": "completed"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/app/api/integrations/jarvis/events/route.ts
+++ b/src/app/api/integrations/jarvis/events/route.ts
@@ -17,6 +17,17 @@ import { enqueueFeedbackReceipt } from "@/lib/jarvis/feedback-desk"
 const CLAIM_RETRY_MILLISECONDS = 5 * 60 * 1000
 const MAX_EVENT_BATCH = 50
 
+type EventTypeFilter =
+  | "agent.prompt"
+  | "feedback.status_changed"
+
+function isEventTypeFilter(value: string): value is EventTypeFilter {
+  return (
+    value === "agent.prompt" ||
+    value === "feedback.status_changed"
+  )
+}
+
 const inboundEventSchema = z.object({
   source: z.enum(["telegram", "jarvis-email", "ask-jarvis"]),
   sourceEventId: z.string().min(1).max(256),
@@ -78,7 +89,7 @@ export async function GET(request: Request): Promise<Response> {
   const requestedEventType = url.searchParams.get("eventType")
   if (
     requestedEventType !== null &&
-    requestedEventType !== "agent.prompt"
+    !isEventTypeFilter(requestedEventType)
   ) {
     return Response.json(
       { error: "Unsupported event type filter" },
@@ -86,7 +97,7 @@ export async function GET(request: Request): Promise<Response> {
     )
   }
   const eventTypeFilter =
-    requestedEventType === "agent.prompt"
+    requestedEventType !== null
       ? eq(jarvisBridgeEvents.eventType, requestedEventType)
       : undefined
   const now = new Date()

--- a/src/lib/jarvis/feedback-desk.ts
+++ b/src/lib/jarvis/feedback-desk.ts
@@ -8,6 +8,21 @@ import {
 
 type CompassDb = ReturnType<typeof getDb>
 
+function metadataExternalActorId(metadata: string | null): string | null {
+  if (!metadata) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(metadata)
+  } catch {
+    return null
+  }
+  if (typeof parsed !== "object" || parsed === null) return null
+  const externalActorId = Reflect.get(parsed, "externalActorId")
+  return typeof externalActorId === "string" && externalActorId.length > 0
+    ? externalActorId
+    : null
+}
+
 export type FeedbackDeskSource =
   | "compass-conversation"
   | "feedback-widget"
@@ -51,12 +66,18 @@ export async function enqueueFeedbackReceipt(
     status: "new",
     title: item.title,
     message: `Your request “${item.title}” has been received.`,
+    reporter: {
+      name: item.reporterName,
+      email: item.reporterEmail,
+      externalActorId: metadataExternalActorId(item.metadata),
+    },
     compass: {
       organizationId: item.organizationId,
       channelId: item.channelId,
       messageId: item.messageId,
       threadId: item.threadId,
     },
+    metadata: item.metadata,
     createdAt: item.createdAt,
   }
 


### PR DESCRIPTION
## What

Activates requester lifecycle delivery for Compass Feedback Desk events without adding a second Telegram bot or email integration.

- permits a dedicated lifecycle-event poller without racing the Ask Jarvis prompt poller
- routes Telegram and Jarvis email updates through the existing Hermes adapters
- routes Compass conversation replies through the signed Compass endpoint
- keeps Ask Jarvis and feedback-widget updates inside Compass
- adds a durable local delivery ledger to prevent duplicate external sends after restarts

## Why

The Feedback Desk intake and GitHub project automations were active, but lifecycle notifications could remain queued because Signet had no dedicated consumer for feedback.status_changed events.

## How to test

- bun lint -- --quiet
- bun run build
- focused Vitest feedback lifecycle/privacy tests: 6 passed
- notifier plus existing agent poller Python tests: 20 passed
- git diff --check

## Notes

The repository-wide Bun test runner still reports its existing better-sqlite3 and vi.hoisted incompatibilities; the affected focused Vitest suites pass.