### PR TITLE
feat(schedule): add saved views and activity history

### DIFF
--- a/drizzle/0073_presence_last_activity.sql
+++ b/drizzle/0073_presence_last_activity.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `user_presence`
+ADD COLUMN `last_active_at` text;
+
+UPDATE `user_presence`
+SET `last_active_at` = `updated_at`
+WHERE `last_active_at` IS NULL;

--- a/drizzle/0074_activity_events.sql
+++ b/drizzle/0074_activity_events.sql
@@ -1,0 +1,27 @@
+CREATE TABLE `activity_events` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `project_id` text,
+  `actor_user_id` text,
+  `actor_name` text NOT NULL,
+  `actor_role` text NOT NULL,
+  `category` text NOT NULL,
+  `action` text NOT NULL,
+  `entity_type` text NOT NULL,
+  `entity_id` text,
+  `summary` text NOT NULL,
+  `metadata` text,
+  `created_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`actor_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+
+CREATE INDEX `activity_events_org_created_idx`
+ON `activity_events` (`organization_id`, `created_at`);
+
+CREATE INDEX `activity_events_project_created_idx`
+ON `activity_events` (`project_id`, `created_at`);
+
+CREATE INDEX `activity_events_actor_created_idx`
+ON `activity_events` (`actor_user_id`, `created_at`);

--- a/drizzle/0075_schedule_saved_views.sql
+++ b/drizzle/0075_schedule_saved_views.sql
@@ -1,0 +1,21 @@
+CREATE TABLE `schedule_saved_views` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `owner_user_id` text NOT NULL,
+  `name` text NOT NULL,
+  `visibility` text DEFAULT 'personal' NOT NULL,
+  `definition` text NOT NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`owner_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+
+CREATE INDEX `schedule_saved_views_org_idx`
+ON `schedule_saved_views` (`organization_id`);
+
+CREATE INDEX `schedule_saved_views_owner_idx`
+ON `schedule_saved_views` (`owner_user_id`);
+
+CREATE UNIQUE INDEX `schedule_saved_views_owner_name_unique`
+ON `schedule_saved_views` (`owner_user_id`, `name`);

--- a/src/app/actions/activity.ts
+++ b/src/app/actions/activity.ts
@@ -1,0 +1,83 @@
+"use server"
+
+import { and, desc, eq } from "drizzle-orm"
+
+import { getDb } from "@/db"
+import { activityEvents, projects } from "@/db/schema"
+import { requireAuth } from "@/lib/auth"
+import {
+  ACTIVITY_CATEGORIES,
+  type ActivityCategory,
+} from "@/lib/activity-log"
+import { getCloudflareContext } from "@/lib/db"
+import { requireOrg } from "@/lib/org-scope"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+export type ActivityEventView = {
+  readonly id: string
+  readonly projectId: string | null
+  readonly projectName: string | null
+  readonly actorUserId: string | null
+  readonly actorName: string
+  readonly actorRole: string
+  readonly category: ActivityCategory
+  readonly action: string
+  readonly entityType: string
+  readonly entityId: string | null
+  readonly summary: string
+  readonly createdAt: string
+}
+
+export type ActivityFilters = {
+  readonly category?: string
+  readonly projectId?: string
+}
+
+export async function getActivityEvents(
+  filters: ActivityFilters = {}
+): Promise<readonly ActivityEventView[]> {
+  const user = await requireAuth()
+  if (!isInternalStaffRole(user.role)) {
+    throw new Error("Only internal staff can view organization activity.")
+  }
+
+  const organizationId = requireOrg(user)
+  const category = ACTIVITY_CATEGORIES.find(
+    (candidate) => candidate === filters.category
+  )
+  const projectId = filters.projectId?.trim()
+  const conditions = [eq(activityEvents.organizationId, organizationId)]
+  if (category) conditions.push(eq(activityEvents.category, category))
+  if (projectId) conditions.push(eq(activityEvents.projectId, projectId))
+
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const rows = await db
+    .select({
+      id: activityEvents.id,
+      projectId: activityEvents.projectId,
+      projectName: projects.name,
+      actorUserId: activityEvents.actorUserId,
+      actorName: activityEvents.actorName,
+      actorRole: activityEvents.actorRole,
+      category: activityEvents.category,
+      action: activityEvents.action,
+      entityType: activityEvents.entityType,
+      entityId: activityEvents.entityId,
+      summary: activityEvents.summary,
+      createdAt: activityEvents.createdAt,
+    })
+    .from(activityEvents)
+    .leftJoin(projects, eq(activityEvents.projectId, projects.id))
+    .where(and(...conditions))
+    .orderBy(desc(activityEvents.createdAt))
+    .limit(250)
+
+  return rows.flatMap((row) => {
+    const validCategory = ACTIVITY_CATEGORIES.find(
+      (candidate) => candidate === row.category
+    )
+    if (!validCategory) return []
+    return [{ ...row, category: validCategory }]
+  })
+}

--- a/src/app/actions/chat-messages.ts
+++ b/src/app/actions/chat-messages.ts
@@ -43,6 +43,7 @@ import {
   createNotificationEvent,
   notifyChannelMessage,
 } from "@/lib/notifications/events"
+import { recordActivityEvent } from "@/lib/activity-log"
 
 const MAX_MESSAGE_LENGTH = 4000
 const EMOJI_REGEX = /^[\p{Emoji}\u200d\uFE0F]+$/u
@@ -419,6 +420,18 @@ export async function sendMessage(data: {
     if (!membership) {
       return { success: false, error: "Not a member of this channel" }
     }
+    const activityChannel = await db
+      .select({
+        name: channels.name,
+        organizationId: channels.organizationId,
+        projectId: channels.projectId,
+      })
+      .from(channels)
+      .where(eq(channels.id, data.channelId))
+      .get()
+    if (!activityChannel) {
+      return { success: false, error: "Channel not found" }
+    }
 
     const now = new Date().toISOString()
     const messageId = crypto.randomUUID()
@@ -445,6 +458,21 @@ export async function sendMessage(data: {
     }
 
     await db.insert(messages).values(newMessage)
+    await recordActivityEvent({
+      db,
+      organizationId: activityChannel.organizationId,
+      projectId: activityChannel.projectId,
+      actor: user,
+      category: "conversation",
+      action: data.threadId
+        ? "conversation.reply_sent"
+        : "conversation.message_sent",
+      entityType: "message",
+      entityId: messageId,
+      summary: data.threadId
+        ? `Replied in ${activityChannel.name}.`
+        : `Sent a message in ${activityChannel.name}.`,
+    })
 
     // insert mentions if provided
     if (data.mentions && data.mentions.length > 0) {

--- a/src/app/actions/presence.ts
+++ b/src/app/actions/presence.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/dashboard/office-status"
 import { requireOrg } from "@/lib/org-scope"
 import { isInternalStaffRole } from "@/lib/user-roles"
+import { recordActivityEvent } from "@/lib/activity-log"
 
 export type PresenceStatus = "online" | "idle" | "dnd" | "offline"
 
@@ -46,7 +47,8 @@ type GroupedMembers = {
  */
 export async function updatePresence(
   status?: PresenceStatus,
-  statusMessage?: string
+  statusMessage?: string,
+  observedActivity = false
 ): Promise<{ success: true } | { success: false; error: string }> {
   try {
     const user = await getCurrentUser()
@@ -84,6 +86,7 @@ export async function updatePresence(
           status: effectiveStatus,
           statusMessage: statusMessage ?? existing.statusMessage,
           lastSeenAt: now,
+          ...(observedActivity ? { lastActiveAt: now } : {}),
           updatedAt: now,
         })
         .where(eq(userPresence.userId, user.id))
@@ -95,7 +98,25 @@ export async function updatePresence(
         status: effectiveStatus,
         statusMessage: statusMessage ?? null,
         lastSeenAt: now,
+        lastActiveAt: observedActivity ? now : null,
         updatedAt: now,
+      })
+    }
+
+    if (
+      user.organizationId &&
+      statusMessage !== undefined &&
+      statusMessage !== existing?.statusMessage
+    ) {
+      await recordActivityEvent({
+        db,
+        organizationId: user.organizationId,
+        actor: user,
+        category: "presence",
+        action: "presence.designation_changed",
+        entityType: "user_presence",
+        entityId: user.id,
+        summary: `Changed work status to ${statusMessage}.`,
       })
     }
 
@@ -190,6 +211,7 @@ export async function getOrganizationTeamAvailability(): Promise<
         avatarUrl: users.avatarUrl,
         role: users.role,
         statusMessage: userPresence.statusMessage,
+        lastActiveAt: userPresence.lastActiveAt,
         updatedAt: userPresence.updatedAt,
       })
       .from(organizationMembers)

--- a/src/app/actions/project-access-invitations.ts
+++ b/src/app/actions/project-access-invitations.ts
@@ -25,6 +25,7 @@ import {
   isExternalProjectRole,
   isInternalStaffRole,
 } from "@/lib/user-roles"
+import { recordActivityEvent } from "@/lib/activity-log"
 
 const invitationSchema = z.object({
   projectId: z.string().trim().min(1),
@@ -411,6 +412,24 @@ export async function sendProjectAccessInvitation(
         updatedAt: now,
       })
       .run()
+
+    await recordActivityEvent({
+      db,
+      organizationId: row.organizationId,
+      projectId: parsed.data.projectId,
+      actor: currentUser,
+      category: "access",
+      action:
+        accessStatus === "access_granted"
+          ? "project.access_granted"
+          : "project.invitation_sent",
+      entityType: "project_access_invitation",
+      entityId: row.contact.id,
+      summary:
+        accessStatus === "access_granted"
+          ? `Granted ${row.contact.displayName} access to ${projectLabel}.`
+          : `Invited ${row.contact.displayName} to ${projectLabel}.`,
+    })
 
     revalidatePath(`/dashboard/projects/${parsed.data.projectId}/contacts`)
     revalidatePath("/dashboard/people")

--- a/src/app/actions/schedule-saved-views.ts
+++ b/src/app/actions/schedule-saved-views.ts
@@ -31,51 +31,56 @@ type SaveScheduleViewInput = {
 export async function getScheduleSavedViews(): Promise<
   readonly SavedScheduleViewData[]
 > {
-  const user = await requireAuth()
-  if (!isInternalStaffRole(user.role)) return []
-  const organizationId = requireOrg(user)
-  const { env } = await getCloudflareContext()
-  const db = getDb(env.DB)
-  const rows = await db
-    .select()
-    .from(scheduleSavedViews)
-    .where(
-      and(
-        eq(scheduleSavedViews.organizationId, organizationId),
-        or(
-          eq(scheduleSavedViews.ownerUserId, user.id),
-          eq(scheduleSavedViews.visibility, "shared")
+  try {
+    const user = await requireAuth()
+    if (!isInternalStaffRole(user.role)) return []
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const rows = await db
+      .select()
+      .from(scheduleSavedViews)
+      .where(
+        and(
+          eq(scheduleSavedViews.organizationId, organizationId),
+          or(
+            eq(scheduleSavedViews.ownerUserId, user.id),
+            eq(scheduleSavedViews.visibility, "shared")
+          )
         )
       )
-    )
-    .orderBy(asc(scheduleSavedViews.name))
+      .orderBy(asc(scheduleSavedViews.name))
 
-  return rows.flatMap((row) => {
-    let rawDefinition: unknown
-    try {
-      rawDefinition = JSON.parse(row.definition)
-    } catch {
-      return []
-    }
-    const parsedDefinition =
-      scheduleViewDefinitionSchema.safeParse(rawDefinition)
-    if (
-      !parsedDefinition.success ||
-      (row.visibility !== "personal" && row.visibility !== "shared")
-    ) {
-      return []
-    }
-    return [
-      {
-        id: row.id,
-        name: row.name,
-        visibility: row.visibility,
-        ownerUserId: row.ownerUserId,
-        isOwner: row.ownerUserId === user.id,
-        definition: parsedDefinition.data,
-      },
-    ]
-  })
+    return rows.flatMap((row) => {
+      let rawDefinition: unknown
+      try {
+        rawDefinition = JSON.parse(row.definition)
+      } catch {
+        return []
+      }
+      const parsedDefinition =
+        scheduleViewDefinitionSchema.safeParse(rawDefinition)
+      if (
+        !parsedDefinition.success ||
+        (row.visibility !== "personal" && row.visibility !== "shared")
+      ) {
+        return []
+      }
+      return [
+        {
+          id: row.id,
+          name: row.name,
+          visibility: row.visibility,
+          ownerUserId: row.ownerUserId,
+          isOwner: row.ownerUserId === user.id,
+          definition: parsedDefinition.data,
+        },
+      ]
+    })
+  } catch (error) {
+    console.warn("Unable to load schedule saved views", error)
+    return []
+  }
 }
 
 export async function saveScheduleView(

--- a/src/app/actions/schedule-saved-views.ts
+++ b/src/app/actions/schedule-saved-views.ts
@@ -1,0 +1,192 @@
+"use server"
+
+import { and, asc, eq, or } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+import { z } from "zod/v4"
+
+import { getDb } from "@/db"
+import { scheduleSavedViews } from "@/db/schema"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { requireOrg } from "@/lib/org-scope"
+import {
+  scheduleViewDefinitionSchema,
+  type SavedScheduleViewData,
+  type ScheduleViewDefinition,
+} from "@/lib/schedule/saved-views"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+const saveViewSchema = z.object({
+  name: z.string().trim().min(1).max(80),
+  visibility: z.enum(["personal", "shared"]),
+  definition: scheduleViewDefinitionSchema,
+})
+
+type SaveScheduleViewInput = {
+  readonly name: string
+  readonly visibility: "personal" | "shared"
+  readonly definition: ScheduleViewDefinition
+}
+
+export async function getScheduleSavedViews(): Promise<
+  readonly SavedScheduleViewData[]
+> {
+  const user = await requireAuth()
+  if (!isInternalStaffRole(user.role)) return []
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const rows = await db
+    .select()
+    .from(scheduleSavedViews)
+    .where(
+      and(
+        eq(scheduleSavedViews.organizationId, organizationId),
+        or(
+          eq(scheduleSavedViews.ownerUserId, user.id),
+          eq(scheduleSavedViews.visibility, "shared")
+        )
+      )
+    )
+    .orderBy(asc(scheduleSavedViews.name))
+
+  return rows.flatMap((row) => {
+    let rawDefinition: unknown
+    try {
+      rawDefinition = JSON.parse(row.definition)
+    } catch {
+      return []
+    }
+    const parsedDefinition =
+      scheduleViewDefinitionSchema.safeParse(rawDefinition)
+    if (
+      !parsedDefinition.success ||
+      (row.visibility !== "personal" && row.visibility !== "shared")
+    ) {
+      return []
+    }
+    return [
+      {
+        id: row.id,
+        name: row.name,
+        visibility: row.visibility,
+        ownerUserId: row.ownerUserId,
+        isOwner: row.ownerUserId === user.id,
+        definition: parsedDefinition.data,
+      },
+    ]
+  })
+}
+
+export async function saveScheduleView(
+  input: SaveScheduleViewInput
+): Promise<
+  | { readonly success: true; readonly view: SavedScheduleViewData }
+  | { readonly success: false; readonly error: string }
+> {
+  const parsed = saveViewSchema.safeParse(input)
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: parsed.error.issues[0]?.message ?? "Review the saved view.",
+    }
+  }
+
+  try {
+    const user = await requireAuth()
+    if (!isInternalStaffRole(user.role)) {
+      return { success: false, error: "Only internal staff can save views." }
+    }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const now = new Date().toISOString()
+    const existing = await db
+      .select({ id: scheduleSavedViews.id })
+      .from(scheduleSavedViews)
+      .where(
+        and(
+          eq(scheduleSavedViews.ownerUserId, user.id),
+          eq(scheduleSavedViews.name, parsed.data.name)
+        )
+      )
+      .get()
+    const id = existing?.id ?? crypto.randomUUID()
+
+    if (existing) {
+      await db
+        .update(scheduleSavedViews)
+        .set({
+          visibility: parsed.data.visibility,
+          definition: JSON.stringify(parsed.data.definition),
+          updatedAt: now,
+        })
+        .where(eq(scheduleSavedViews.id, id))
+        .run()
+    } else {
+      await db
+        .insert(scheduleSavedViews)
+        .values({
+          id,
+          organizationId,
+          ownerUserId: user.id,
+          name: parsed.data.name,
+          visibility: parsed.data.visibility,
+          definition: JSON.stringify(parsed.data.definition),
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run()
+    }
+
+    revalidatePath("/dashboard/schedule")
+    return {
+      success: true,
+      view: {
+        id,
+        name: parsed.data.name,
+        visibility: parsed.data.visibility,
+        ownerUserId: user.id,
+        isOwner: true,
+        definition: parsed.data.definition,
+      },
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to save this view.",
+    }
+  }
+}
+
+export async function deleteScheduleView(
+  id: string
+): Promise<
+  { readonly success: true } | { readonly success: false; readonly error: string }
+> {
+  try {
+    const user = await requireAuth()
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    await db
+      .delete(scheduleSavedViews)
+      .where(
+        and(
+          eq(scheduleSavedViews.id, id),
+          eq(scheduleSavedViews.organizationId, organizationId),
+          eq(scheduleSavedViews.ownerUserId, user.id)
+        )
+      )
+      .run()
+    revalidatePath("/dashboard/schedule")
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to delete this view.",
+    }
+  }
+}

--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -30,6 +30,7 @@ import { projectDepartment } from "@/lib/project-branding"
 import { projectScheduleColor } from "@/lib/schedule/project-scope"
 import { requirePermission } from "@/lib/permissions"
 import { isInternalStaffRole } from "@/lib/user-roles"
+import { recordActivityEvent } from "@/lib/activity-log"
 import {
   isOwnerScheduleView,
   type OwnerScheduleView,
@@ -211,6 +212,20 @@ export async function updateOwnerScheduleView(
       })
       .where(eq(projects.id, projectId))
 
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.owner_visibility_changed",
+      entityType: "project_schedule",
+      entityId: projectId,
+      summary:
+        ownerScheduleView === "phases"
+          ? "Changed the owner schedule to phase-only visibility."
+          : "Changed the owner schedule to item-level visibility.",
+    })
     revalidateOwnerSchedulePaths(projectId)
     return { success: true }
   } catch (error) {
@@ -452,6 +467,18 @@ export async function createTask(
       updatedAt: now,
     })
 
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.item_created",
+      entityType: "schedule_item",
+      entityId: id,
+      summary: `Created schedule item “${data.title}”.`,
+    })
+
     try {
       await notifyProjectAssignment({
         organizationId: orgId,
@@ -551,6 +578,18 @@ export async function updateTask(
       })
       .where(eq(scheduleTasks.id, taskId))
 
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId: task.projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.item_updated",
+      entityType: "schedule_item",
+      entityId: taskId,
+      summary: `Updated schedule item “${data.title ?? task.title}”.`,
+    })
+
     if (
       data.assignedTo !== undefined &&
       data.assignedTo !== null &&
@@ -644,6 +683,17 @@ export async function deleteTask(
     }
 
     await db.delete(scheduleTasks).where(eq(scheduleTasks.id, taskId))
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId: task.projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.item_deleted",
+      entityType: "schedule_item",
+      entityId: taskId,
+      summary: `Deleted schedule item “${task.title}”.`,
+    })
     await recalcCriticalPath(db, task.projectId)
     revalidateSchedulePaths(task.projectId)
     return { success: true }
@@ -678,7 +728,7 @@ export async function completeScheduleTasks(
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
     const [project] = await db
-      .select({ id: projects.id })
+      .select({ id: projects.id, name: projects.name })
       .from(projects)
       .where(and(eq(projects.id, projectId), eq(projects.organizationId, orgId)))
       .limit(1)
@@ -718,6 +768,17 @@ export async function completeScheduleTasks(
         )
       )
 
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.items_completed",
+      entityType: "schedule_item_batch",
+      summary: `Marked ${ids.length} schedule ${ids.length === 1 ? "item" : "items"} complete.`,
+      metadata: { itemCount: ids.length },
+    })
     await recalcCriticalPath(db, projectId)
     revalidateSchedulePaths(projectId)
     return { success: true }
@@ -756,7 +817,7 @@ export async function assignScheduleTasks(
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
     const [project] = await db
-      .select({ id: projects.id })
+      .select({ id: projects.id, name: projects.name })
       .from(projects)
       .where(and(eq(projects.id, projectId), eq(projects.organizationId, orgId)))
       .limit(1)
@@ -795,6 +856,19 @@ export async function assignScheduleTasks(
         )
       )
 
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.items_assigned",
+      entityType: "schedule_item_batch",
+      summary: assignedTo?.trim()
+        ? `Assigned ${ids.length} schedule ${ids.length === 1 ? "item" : "items"} to ${assignedTo.trim()}.`
+        : `Cleared the assignee from ${ids.length} schedule ${ids.length === 1 ? "item" : "items"}.`,
+      metadata: { itemCount: ids.length },
+    })
     revalidateSchedulePaths(projectId)
     return { success: true }
   } catch (error) {
@@ -828,7 +902,7 @@ export async function deleteScheduleTasks(
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
     const [project] = await db
-      .select({ id: projects.id })
+      .select({ id: projects.id, name: projects.name })
       .from(projects)
       .where(and(eq(projects.id, projectId), eq(projects.organizationId, orgId)))
       .limit(1)
@@ -863,6 +937,17 @@ export async function deleteScheduleTasks(
         )
       )
 
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.items_deleted",
+      entityType: "schedule_item_batch",
+      summary: `Deleted ${ids.length} schedule ${ids.length === 1 ? "item" : "items"}.`,
+      metadata: { itemCount: ids.length },
+    })
     await recalcCriticalPath(db, projectId)
     revalidateSchedulePaths(projectId)
     return { success: true }

--- a/src/app/api/projects/[id]/photos/upload/route.ts
+++ b/src/app/api/projects/[id]/photos/upload/route.ts
@@ -27,6 +27,7 @@ import {
   PHOTO_UPLOAD_LIMIT_LABEL,
 } from "@/lib/photos/upload-limits"
 import { photoUploadVisibility } from "@/lib/photos/upload-visibility"
+import { recordActivityEvent } from "@/lib/activity-log"
 
 const GOOGLE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
 const DEFAULT_PHOTO_FOLDER_NAME = "Pictures"
@@ -456,6 +457,20 @@ export async function POST(
         mimeType: driveFile.mimeType,
       })
     }
+
+    await recordActivityEvent({
+      db,
+      organizationId,
+      projectId,
+      actor: user,
+      category: "file",
+      action: "project.files_uploaded",
+      entityType: "project_file_batch",
+      summary: `Uploaded ${files.length} ${files.length === 1 ? "file" : "files"}: ${uploadedFiles
+        .map((file) => file.fileName)
+        .join(", ")}.`,
+      metadata: { fileCount: files.length },
+    })
 
     revalidatePath(`/dashboard/projects/${projectId}`)
     revalidatePath(`/dashboard/projects/${projectId}/photos`)

--- a/src/app/dashboard/activity/page.tsx
+++ b/src/app/dashboard/activity/page.tsx
@@ -1,0 +1,163 @@
+import Link from "next/link"
+import { redirect } from "next/navigation"
+import { IconActivity, IconChevronRight } from "@tabler/icons-react"
+
+import { getActivityEvents } from "@/app/actions/activity"
+import { getProjects } from "@/app/actions/projects"
+import { Badge } from "@/components/ui/badge"
+import { getCurrentUser } from "@/lib/auth"
+import {
+  ACTIVITY_CATEGORIES,
+  type ActivityCategory,
+} from "@/lib/activity-log"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+const CATEGORY_LABELS: Readonly<Record<ActivityCategory, string>> = {
+  access: "Access",
+  account: "Accounts",
+  conversation: "Conversations",
+  file: "Files",
+  presence: "Availability",
+  schedule: "Schedule",
+}
+
+type ActivityPageProps = {
+  readonly searchParams: Promise<{
+    readonly category?: string
+    readonly project?: string
+  }>
+}
+
+function activityTimestamp(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/Denver",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  }).format(date)
+}
+
+export default async function ActivityPage({
+  searchParams,
+}: ActivityPageProps): Promise<React.ReactElement> {
+  const user = await getCurrentUser()
+  if (!user || !isInternalStaffRole(user.role)) {
+    redirect("/dashboard/access-restricted")
+  }
+
+  const params = await searchParams
+  const [events, projects] = await Promise.all([
+    getActivityEvents({
+      category: params.category,
+      projectId: params.project,
+    }),
+    getProjects(),
+  ])
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col overflow-y-auto px-4 py-6 sm:px-6">
+      <header className="flex flex-wrap items-end justify-between gap-4 border-b pb-5">
+        <div>
+          <div className="flex items-center gap-2">
+            <IconActivity className="size-5 text-muted-foreground" />
+            <h1 className="text-2xl font-semibold tracking-tight">
+              Activity
+            </h1>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Recent staff, owner, subcontractor, and supplier actions in Compass.
+          </p>
+        </div>
+        <form className="flex flex-wrap items-center gap-2">
+          <select
+            name="category"
+            defaultValue={params.category ?? ""}
+            aria-label="Filter activity by category"
+            className="h-9 border bg-background px-3 text-sm"
+          >
+            <option value="">All activity</option>
+            {ACTIVITY_CATEGORIES.map((category) => (
+              <option key={category} value={category}>
+                {CATEGORY_LABELS[category]}
+              </option>
+            ))}
+          </select>
+          <select
+            name="project"
+            defaultValue={params.project ?? ""}
+            aria-label="Filter activity by project"
+            className="h-9 min-w-56 border bg-background px-3 text-sm"
+          >
+            <option value="">All projects</option>
+            {projects.map((project) => (
+              <option key={project.id} value={project.id}>
+                {project.projectNumber
+                  ? `${project.projectNumber} · ${project.name}`
+                  : project.name}
+              </option>
+            ))}
+          </select>
+          <button
+            type="submit"
+            className="h-9 border bg-background px-4 text-sm font-medium hover:bg-muted"
+          >
+            Apply
+          </button>
+        </form>
+      </header>
+
+      <section className="divide-y border-b" aria-label="Compass activity">
+        {events.map((event) => (
+          <article
+            key={event.id}
+            className="grid gap-2 py-4 sm:grid-cols-[10rem_minmax(0,1fr)_auto] sm:items-start"
+          >
+            <time
+              dateTime={event.createdAt}
+              className="text-xs text-muted-foreground"
+            >
+              {activityTimestamp(event.createdAt)}
+            </time>
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="font-medium">{event.actorName}</p>
+                <Badge variant="outline" className="rounded-sm font-normal">
+                  {CATEGORY_LABELS[event.category]}
+                </Badge>
+              </div>
+              <p className="mt-1 text-sm text-foreground/85">
+                {event.summary}
+              </p>
+              <p className="mt-1 text-xs capitalize text-muted-foreground">
+                {event.actorRole.replaceAll("_", " ")}
+              </p>
+            </div>
+            {event.projectId && event.projectName ? (
+              <Link
+                href={`/dashboard/projects/${encodeURIComponent(event.projectId)}`}
+                className="flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground"
+              >
+                {event.projectName}
+                <IconChevronRight className="size-3.5" />
+              </Link>
+            ) : null}
+          </article>
+        ))}
+        {events.length === 0 ? (
+          <div className="py-16 text-center">
+            <IconActivity className="mx-auto size-6 text-muted-foreground" />
+            <p className="mt-3 text-sm font-medium">No matching activity yet</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              New activity will appear here as people work in Compass.
+            </p>
+          </div>
+        ) : null}
+      </section>
+    </main>
+  )
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -27,6 +27,7 @@ import { PushNotificationRegistrar } from "@/hooks/use-native-push"
 import { DesktopShell } from "@/components/desktop/desktop-shell"
 import { DesktopOfflineBanner } from "@/components/desktop/offline-banner"
 import { VoiceProvider } from "@/components/voice/voice-provider"
+import { PresenceProvider } from "@/contexts/presence-context"
 import { DemoBanner } from "@/components/demo/demo-banner"
 import { isDemoUser } from "@/lib/demo"
 import {
@@ -34,6 +35,7 @@ import {
   canUseFieldDesk,
   canUseOfficeTalk,
 } from "@/lib/permissions"
+import { isInternalStaffRole } from "@/lib/user-roles"
 
 export default async function DashboardLayout({
   children,
@@ -54,6 +56,9 @@ export default async function DashboardLayout({
   const canUseCompassAgent = canUseAskCompass(authUser)
   const canUseCompassFieldDesk = canUseFieldDesk(authUser)
   const canUseCompassOfficeTalk = canUseOfficeTalk(authUser)
+  const canViewActivity = authUser
+    ? isInternalStaffRole(authUser.role)
+    : false
   const offlineScopeKey =
     authUser?.organizationId && authUser.id
       ? `${authUser.organizationId}:${authUser.id}`
@@ -65,6 +70,7 @@ export default async function DashboardLayout({
       offlineScopeKey={offlineScopeKey}
       canSubmitCherish={canUseCompassFieldDesk}
     >
+    <PresenceProvider>
     <VoiceProvider>
     <SettingsProvider>
     <ProjectListProvider projects={projectList}>
@@ -90,6 +96,7 @@ export default async function DashboardLayout({
           activeOrgId={activeOrgId}
           activeOrgName={activeOrgName}
           canUseFieldDesk={canUseCompassFieldDesk}
+          canViewActivity={canViewActivity}
         />
         <SidebarInset className="overflow-hidden">
           <DesktopOfflineBanner />
@@ -124,6 +131,7 @@ export default async function DashboardLayout({
     </ProjectListProvider>
     </SettingsProvider>
     </VoiceProvider>
+    </PresenceProvider>
     </ChatProvider>
   )
 }

--- a/src/app/dashboard/projects/[id]/schedule/page.tsx
+++ b/src/app/dashboard/projects/[id]/schedule/page.tsx
@@ -15,6 +15,9 @@ import {
 import { ScheduleView } from "@/components/schedule/schedule-view"
 import type { ScheduleData, ScheduleBaselineData } from "@/lib/schedule/types"
 import type { OwnerScheduleView } from "@/lib/schedule/owner-visibility"
+import { getScheduleSavedViews } from "@/app/actions/schedule-saved-views"
+import { getCurrentUser } from "@/lib/auth"
+import { scheduleAssigneeTerms } from "@/lib/schedule/saved-views"
 
 const emptySchedule: ScheduleData = {
   tasks: [],
@@ -50,6 +53,10 @@ export default async function SchedulePage({
   let allProjects: ProjectListItem[] = []
   let assigneeOptions: ProjectTaskAssigneeOption[] = []
   let ownerScheduleView: OwnerScheduleView = "items"
+  const [savedViews, currentUser] = await Promise.all([
+    getScheduleSavedViews(),
+    getCurrentUser(),
+  ])
 
   try {
     const { env } = await getCloudflareContext()
@@ -99,6 +106,8 @@ export default async function SchedulePage({
         initialView={focusTaskId ? "list" : initialView}
         focusTaskId={focusTaskId}
         ownerScheduleView={ownerScheduleView}
+        savedViews={savedViews}
+        currentUserAssigneeTerms={scheduleAssigneeTerms(currentUser)}
       />
     </div>
   )

--- a/src/app/dashboard/schedule/page.tsx
+++ b/src/app/dashboard/schedule/page.tsx
@@ -19,6 +19,9 @@ import type {
   ScheduleScopeKind,
 } from "@/lib/schedule/project-scope"
 import type { ProjectDepartment } from "@/lib/project-branding"
+import { getScheduleSavedViews } from "@/app/actions/schedule-saved-views"
+import { getCurrentUser } from "@/lib/auth"
+import { scheduleAssigneeTerms } from "@/lib/schedule/saved-views"
 
 function kindFilter(
   value: string | readonly string[] | undefined
@@ -91,7 +94,11 @@ export default async function SchedulePage({
 }): Promise<React.ReactElement> {
   const query = await searchParams
   if (firstValue(query.mode) === "projects") {
-    const allProjects = await getProjects()
+    const [allProjects, savedViews, currentUser] = await Promise.all([
+      getProjects(),
+      getScheduleSavedViews(),
+      getCurrentUser(),
+    ])
     const requestedScope = firstValue(query.scope)
     const scopeKind = isScopeKind(requestedScope) ? requestedScope : "all"
     const requestedProjectId = firstValue(query.project)
@@ -187,6 +194,8 @@ export default async function SchedulePage({
           initialView={initialView}
           globalMode
           ownerScheduleView={ownerScheduleView}
+          savedViews={savedViews}
+          currentUserAssigneeTerms={scheduleAssigneeTerms(currentUser)}
         />
       </div>
     )

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import {
   IconAddressBook,
+  IconActivity,
   IconCalendarStats,
   IconClipboardCheck,
   IconClipboardText,
@@ -61,6 +62,12 @@ const PERSISTENT_NAV = [
 ]
 
 const NAV_MAIN = [
+  {
+    title: "Activity",
+    url: "/dashboard/activity",
+    icon: IconActivity,
+    internalOnly: true,
+  },
   {
     title: "Projects",
     url: "/dashboard/projects",
@@ -153,9 +160,11 @@ const NAV_MAIN = [
 function SidebarNav({
   projects,
   canUseFieldDesk,
+  canViewActivity,
 }: {
   projects: ReadonlyArray<ProjectListItem>
   readonly canUseFieldDesk: boolean
+  readonly canViewActivity: boolean
 }) {
   const pathname = usePathname()
   const { state } = useSidebar()
@@ -187,7 +196,9 @@ function SidebarNav({
         }
       : item
   )
-  const navMain = NAV_MAIN.map((item) =>
+  const navMain = NAV_MAIN.filter(
+    (item) => !item.internalOnly || canViewActivity
+  ).map((item) =>
     typeof item.projectPath === "string"
       ? {
           ...item,
@@ -238,6 +249,7 @@ export function AppSidebar({
   activeOrgId = null,
   activeOrgName = null,
   canUseFieldDesk = false,
+  canViewActivity = false,
   ...props
 }: React.ComponentProps<typeof Sidebar> & {
   readonly projects?: ReadonlyArray<ProjectListItem>
@@ -245,6 +257,7 @@ export function AppSidebar({
   readonly activeOrgId?: string | null
   readonly activeOrgName?: string | null
   readonly canUseFieldDesk?: boolean
+  readonly canViewActivity?: boolean
 }) {
   const { isMobile } = useSidebar()
   const { channelId } = useVoiceState()
@@ -258,6 +271,7 @@ export function AppSidebar({
         <SidebarNav
           projects={projects}
           canUseFieldDesk={canUseFieldDesk}
+          canViewActivity={canViewActivity}
         />
       </SidebarContent>
       <SidebarFooter className="border-t border-sidebar-border/60">

--- a/src/components/dashboard/dashboard-launchpad.tsx
+++ b/src/components/dashboard/dashboard-launchpad.tsx
@@ -77,6 +77,7 @@ import {
 } from "@/lib/dashboard/office-status"
 import { dashboardDeskPhotoStorageKey } from "@/lib/user-photo-storage"
 import { cn } from "@/lib/utils"
+import { usePresence } from "@/contexts/presence-context"
 
 type DashboardMode = "office" | "project"
 
@@ -178,7 +179,8 @@ function deskStatusDotClass(status: DeskStatus): string {
 function includeCurrentAvailability(
   members: readonly TeamAvailabilityMember[],
   user: SidebarUser | null,
-  status: DeskStatus
+  status: DeskStatus,
+  activity: "active" | "idle"
 ): readonly TeamAvailabilityMember[] {
   if (!user) return members
 
@@ -188,6 +190,11 @@ function includeCurrentAvailability(
     name: user.name,
     avatarUrl: user.avatar,
     status,
+    activity,
+    lastActiveAt:
+      activity === "active"
+        ? new Date().toISOString()
+        : existing?.lastActiveAt ?? null,
     updatedAt: existing?.updatedAt ?? new Date().toISOString(),
     isCurrentUser: true,
   }
@@ -395,7 +402,8 @@ function DeskHero({
     startStatusTransition(async () => {
       const result = await updatePresence(
         presenceStatusForDeskStatus(nextStatus),
-        DESK_STATUS_LABELS[nextStatus]
+        DESK_STATUS_LABELS[nextStatus],
+        true
       )
       if (!result.success) {
         onStatusChange(previousStatus)
@@ -736,8 +744,16 @@ function OfficePresence({
   readonly user: SidebarUser | null
   readonly status: DeskStatus
 }): React.ReactElement {
+  const { isIdle } = usePresence()
+  const currentActivity = isIdle ? "idle" : "active"
   const [members, setMembers] = useState<readonly TeamAvailabilityMember[]>(
-    () => includeCurrentAvailability(initialAvailability, user, status)
+    () =>
+      includeCurrentAvailability(
+        initialAvailability,
+        user,
+        status,
+        currentActivity
+      )
   )
   const [isRefreshing, startRefreshTransition] = useTransition()
 
@@ -745,13 +761,22 @@ function OfficePresence({
     startRefreshTransition(async () => {
       const result = await getOrganizationTeamAvailability()
       if (!result.success) return
-      setMembers(includeCurrentAvailability(result.data, user, status))
+      setMembers(
+        includeCurrentAvailability(
+          result.data,
+          user,
+          status,
+          currentActivity
+        )
+      )
     })
-  }, [status, user])
+  }, [currentActivity, status, user])
 
   useEffect(() => {
-    setMembers((current) => includeCurrentAvailability(current, user, status))
-  }, [status, user])
+    setMembers((current) =>
+      includeCurrentAvailability(current, user, status, currentActivity)
+    )
+  }, [currentActivity, status, user])
 
   useEffect(() => {
     refreshAvailability()
@@ -818,7 +843,9 @@ function OfficePresence({
                 ) : null}
               </p>
               <p className="text-xs text-muted-foreground">
-                {DESK_STATUS_LABELS[member.status]}
+                {member.activity === "idle"
+                  ? `${DESK_STATUS_LABELS[member.status]} · Idle`
+                  : DESK_STATUS_LABELS[member.status]}
               </p>
             </div>
           </div>

--- a/src/components/schedule/schedule-gantt-view.tsx
+++ b/src/components/schedule/schedule-gantt-view.tsx
@@ -107,6 +107,8 @@ interface ScheduleGanttViewProps {
   readonly exceptions: readonly WorkdayExceptionData[]
   readonly assigneeOptions: readonly ProjectTaskAssigneeOption[]
   readonly projects?: readonly ScheduleProjectData[]
+  readonly groupByPhase?: boolean
+  readonly onGroupByPhaseChange?: (grouped: boolean) => void
 }
 
 export function ScheduleGanttView({
@@ -116,6 +118,8 @@ export function ScheduleGanttView({
   exceptions,
   assigneeOptions,
   projects = [],
+  groupByPhase = false,
+  onGroupByPhaseChange,
 }: ScheduleGanttViewProps) {
   const router = useRouter()
   const isMobile = useIsMobile()
@@ -157,6 +161,10 @@ export function ScheduleGanttView({
     [projects]
   )
   const multipleProjects = projectById.size > 1
+
+  useEffect(() => {
+    setPhaseGrouping(groupByPhase)
+  }, [groupByPhase])
 
   const [hasLoadedPalette, setHasLoadedPalette] = useState(false)
 
@@ -950,7 +958,10 @@ export function ScheduleGanttView({
                   <span className="text-xs">Group by Phase</span>
                   <Switch
                     checked={phaseGrouping}
-                    onCheckedChange={setPhaseGrouping}
+                    onCheckedChange={(checked) => {
+                      setPhaseGrouping(checked)
+                      onGroupByPhaseChange?.(checked)
+                    }}
                     className="scale-75"
                   />
                 </div>

--- a/src/components/schedule/schedule-list-view.tsx
+++ b/src/components/schedule/schedule-list-view.tsx
@@ -59,6 +59,10 @@ import {
   getScheduleItemDisplayColor,
   type DisplayColorPalette,
 } from "@/lib/schedule/appearance"
+import {
+  SCHEDULE_LIST_COLUMNS,
+  type ScheduleListColumn,
+} from "@/lib/schedule/saved-views"
 import { ProjectAssigneePicker } from "@/components/projects/project-assignee-picker"
 import {
   AlertDialog,
@@ -79,6 +83,7 @@ interface ScheduleListViewProps {
   readonly assigneeOptions: readonly ProjectTaskAssigneeOption[]
   readonly focusTaskId?: string | null
   readonly projects?: readonly ScheduleProjectData[]
+  readonly visibleColumns?: readonly ScheduleListColumn[]
 }
 
 function StatusDot({
@@ -146,6 +151,7 @@ export function ScheduleListView({
   assigneeOptions,
   focusTaskId = null,
   projects = [],
+  visibleColumns = SCHEDULE_LIST_COLUMNS,
 }: ScheduleListViewProps) {
   const router = useRouter()
   const displayColorPalette = useScheduleDisplayPalette(projectId ?? "unified")
@@ -369,6 +375,17 @@ export function ScheduleListView({
     ]
   )
 
+  const columnVisibility = useMemo(
+    () =>
+      Object.fromEntries(
+        SCHEDULE_LIST_COLUMNS.map((column) => [
+          column,
+          visibleColumns.includes(column),
+        ])
+      ),
+    [visibleColumns]
+  )
+
   const table = useReactTable({
     data: localTasks,
     columns,
@@ -376,7 +393,7 @@ export function ScheduleListView({
     getPaginationRowModel: getPaginationRowModel(),
     getRowId: (row) => row.id,
     onRowSelectionChange: setRowSelection,
-    state: { rowSelection },
+    state: { rowSelection, columnVisibility },
     initialState: { pagination: { pageSize: 25 } },
   })
   const selectedTasks = table

--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -1,7 +1,14 @@
 "use client"
 
-import { useState, useMemo, useRef, useEffect } from "react"
+import {
+  useState,
+  useMemo,
+  useRef,
+  useEffect,
+  useTransition,
+} from "react"
 import Link from "next/link"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { Input } from "@/components/ui/input"
@@ -58,6 +65,9 @@ import {
   IconHistory,
   IconCalendarOff,
   IconLoader2,
+  IconDeviceFloppy,
+  IconBookmark,
+  IconTrash,
 } from "@tabler/icons-react"
 import { toast } from "sonner"
 import { ScheduleListView } from "./schedule-list-view"
@@ -93,6 +103,20 @@ import {
   type ScheduleOrderMode,
 } from "@/lib/schedule/task-ordering"
 import type { OwnerScheduleView } from "@/lib/schedule/owner-visibility"
+import {
+  deleteScheduleView,
+  saveScheduleView,
+} from "@/app/actions/schedule-saved-views"
+import {
+  SCHEDULE_GROUP_MODES,
+  SCHEDULE_LIST_COLUMNS,
+  SCHEDULE_VIEW_PRESETS,
+  type SavedScheduleViewData,
+  type ScheduleGroupMode,
+  type ScheduleListColumn,
+  type ScheduleViewDefinition,
+  type ScheduleViewPreset,
+} from "@/lib/schedule/saved-views"
 
 type View = "calendar" | "list" | "gantt"
 
@@ -115,6 +139,8 @@ interface ScheduleViewProps {
   readonly focusTaskId?: string | null
   readonly globalMode?: boolean
   readonly ownerScheduleView?: OwnerScheduleView
+  readonly savedViews?: readonly SavedScheduleViewData[]
+  readonly currentUserAssigneeTerms?: readonly string[]
 }
 
 export function ScheduleView({
@@ -130,13 +156,60 @@ export function ScheduleView({
   focusTaskId = null,
   globalMode = false,
   ownerScheduleView = "items",
+  savedViews: initialSavedViews = [],
+  currentUserAssigneeTerms = [],
 }: ScheduleViewProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
   const isMobile = useIsMobile()
+  const requestedPreset = searchParams.get("preset")
+  const initialPreset =
+    SCHEDULE_VIEW_PRESETS.find((value) => value === requestedPreset) ?? "all"
+  const requestedGroup = searchParams.get("group")
+  const initialGroup =
+    SCHEDULE_GROUP_MODES.find((value) => value === requestedGroup) ?? "none"
+  const requestedColumns = (searchParams.get("columns") ?? "")
+    .split(",")
+    .filter((value): value is ScheduleListColumn =>
+      SCHEDULE_LIST_COLUMNS.some((column) => column === value)
+    )
+  const initialColumns =
+    requestedColumns.length > 0
+      ? requestedColumns
+      : [...SCHEDULE_LIST_COLUMNS]
+  const requestedStatuses = (searchParams.get("status") ?? "")
+    .split(",")
+    .flatMap((value) => {
+      const option = STATUS_OPTIONS.find((candidate) => candidate.value === value)
+      return option ? [option.value] : []
+    })
   const [view, setView] = useState<View>(initialView)
   const [orderMode, setOrderMode] =
-    useState<ScheduleOrderMode>("chronological")
+    useState<ScheduleOrderMode>(() => {
+      const requestedOrder = searchParams.get("order")
+      return isScheduleOrderMode(requestedOrder)
+        ? requestedOrder
+        : "chronological"
+    })
   const [taskFormOpen, setTaskFormOpen] = useState(false)
-  const [filters, setFilters] = useState<TaskFilters>(EMPTY_FILTERS)
+  const [filters, setFilters] = useState<TaskFilters>(() => ({
+    status: requestedStatuses,
+    phase: (searchParams.get("phase") ?? "").split(",").filter(Boolean),
+    assignedTo: searchParams.get("assignee") ?? "",
+    search: searchParams.get("q") ?? "",
+  }))
+  const [preset, setPreset] = useState<ScheduleViewPreset>(initialPreset)
+  const [groupMode, setGroupMode] =
+    useState<ScheduleGroupMode>(initialGroup)
+  const [visibleColumns, setVisibleColumns] =
+    useState<readonly ScheduleListColumn[]>(initialColumns)
+  const [savedViews, setSavedViews] =
+    useState<readonly SavedScheduleViewData[]>(initialSavedViews)
+  const [saveViewOpen, setSaveViewOpen] = useState(false)
+  const [saveViewName, setSaveViewName] = useState("")
+  const [saveViewShared, setSaveViewShared] = useState(false)
+  const [isSavingView, startSaveViewTransition] = useTransition()
   const [baselinesOpen, setBaselinesOpen] = useState(false)
   const [exceptionsOpen, setExceptionsOpen] = useState(false)
   const [importDialogOpen, setImportDialogOpen] = useState(false)
@@ -145,13 +218,59 @@ export function ScheduleView({
   const preferenceScopeKey = projectId ?? "unified"
 
   useEffect(() => {
+    const requestedOrder = searchParams.get("order")
+    if (isScheduleOrderMode(requestedOrder)) {
+      setOrderMode(requestedOrder)
+      return
+    }
     const storedMode = window.localStorage.getItem(
       scheduleOrderStorageKey(preferenceScopeKey)
     )
     setOrderMode(
       isScheduleOrderMode(storedMode) ? storedMode : "chronological"
     )
-  }, [preferenceScopeKey])
+  }, [preferenceScopeKey, searchParams])
+
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString())
+    params.set("view", view)
+    params.set("order", orderMode)
+
+    const setOrDelete = (key: string, value: string): void => {
+      if (value) params.set(key, value)
+      else params.delete(key)
+    }
+    setOrDelete("status", filters.status.join(","))
+    setOrDelete("phase", filters.phase.join(","))
+    setOrDelete("assignee", filters.assignedTo)
+    setOrDelete("q", filters.search)
+    setOrDelete("preset", preset === "all" ? "" : preset)
+    setOrDelete("group", groupMode === "none" ? "" : groupMode)
+    setOrDelete(
+      "columns",
+      visibleColumns.length === SCHEDULE_LIST_COLUMNS.length
+        ? ""
+        : visibleColumns.join(",")
+    )
+
+    const nextQuery = params.toString()
+    const currentQuery = searchParams.toString()
+    if (nextQuery !== currentQuery) {
+      router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, {
+        scroll: false,
+      })
+    }
+  }, [
+    filters,
+    groupMode,
+    orderMode,
+    pathname,
+    preset,
+    router,
+    searchParams,
+    view,
+    visibleColumns,
+  ])
 
   const handleOrderModeChange = (value: string): void => {
     if (!isScheduleOrderMode(value)) return
@@ -195,8 +314,67 @@ export function ScheduleView({
         t.title.toLowerCase().includes(search)
       )
     }
-    return orderScheduleTasks(tasks, orderMode)
-  }, [initialData.tasks, filters, orderMode])
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    if (preset === "my-items") {
+      const terms = currentUserAssigneeTerms
+        .map((term) => term.trim().toLowerCase())
+        .filter(Boolean)
+      tasks = tasks.filter((task) => {
+        const assignee = task.assignedTo?.trim().toLowerCase() ?? ""
+        return terms.some(
+          (term) => assignee === term || assignee.includes(term)
+        )
+      })
+    } else if (preset === "past-due") {
+      tasks = tasks.filter(
+        (task) =>
+          task.status !== "COMPLETE" &&
+          new Date(`${task.endDateCalculated}T00:00:00`).getTime() <
+            today.getTime()
+      )
+    } else if (
+      preset === "next-7" ||
+      preset === "next-30" ||
+      preset === "next-90"
+    ) {
+      const dayCount =
+        preset === "next-7" ? 7 : preset === "next-30" ? 30 : 90
+      const horizon = new Date(today)
+      horizon.setDate(horizon.getDate() + dayCount)
+      tasks = tasks.filter(
+        (task) =>
+          new Date(`${task.startDate}T00:00:00`).getTime() <=
+            horizon.getTime() &&
+          new Date(`${task.endDateCalculated}T00:00:00`).getTime() >=
+            today.getTime()
+      )
+    }
+
+    const ordered = orderScheduleTasks(tasks, orderMode)
+    if (groupMode === "none") return ordered
+
+    const projectById = new Map(
+      scheduleProjects.map((project) => [project.id, project])
+    )
+    const groupKey = (task: (typeof ordered)[number]): string => {
+      if (groupMode === "phase") return task.phase
+      if (groupMode === "status") return task.status
+      const project = projectById.get(task.projectId)
+      return project?.projectNumber ?? project?.name ?? task.projectId
+    }
+    return [...ordered].sort((left, right) =>
+      groupKey(left).localeCompare(groupKey(right))
+    )
+  }, [
+    currentUserAssigneeTerms,
+    filters,
+    groupMode,
+    initialData.tasks,
+    orderMode,
+    preset,
+    scheduleProjects,
+  ])
 
   const activeFilterCount =
     filters.status.length +
@@ -234,6 +412,72 @@ export function ScheduleView({
   }
 
   const clearFilters = () => setFilters(EMPTY_FILTERS)
+
+  const currentViewDefinition = (): ScheduleViewDefinition => ({
+    view,
+    orderMode,
+    groupMode,
+    preset,
+    status: [...filters.status],
+    phase: [...filters.phase],
+    assignedTo: filters.assignedTo,
+    search: filters.search,
+    columns: [...visibleColumns],
+  })
+
+  const applySavedView = (savedView: SavedScheduleViewData): void => {
+    const definition = savedView.definition
+    setView(definition.view)
+    setOrderMode(definition.orderMode)
+    setGroupMode(definition.groupMode)
+    setPreset(definition.preset)
+    setFilters({
+      status: definition.status,
+      phase: definition.phase,
+      assignedTo: definition.assignedTo,
+      search: definition.search,
+    })
+    setVisibleColumns(definition.columns)
+    toast.success(`Applied “${savedView.name}”.`)
+  }
+
+  const handleSaveView = (): void => {
+    const name = saveViewName.trim()
+    if (!name) return
+    startSaveViewTransition(async () => {
+      const result = await saveScheduleView({
+        name,
+        visibility: saveViewShared ? "shared" : "personal",
+        definition: currentViewDefinition(),
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      setSavedViews((current) => [
+        ...current.filter((savedView) => savedView.id !== result.view.id),
+        result.view,
+      ])
+      setSaveViewOpen(false)
+      setSaveViewName("")
+      setSaveViewShared(false)
+      toast.success(`Saved “${result.view.name}”.`)
+    })
+  }
+
+  const handleDeleteView = (savedView: SavedScheduleViewData): void => {
+    startSaveViewTransition(async () => {
+      const result = await deleteScheduleView(savedView.id)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      setSavedViews((current) =>
+        current.filter((candidate) => candidate.id !== savedView.id)
+      )
+      toast.success(`Deleted “${savedView.name}”.`)
+    })
+  }
 
   // CSV export
   const handleExportCSV = () => {
@@ -459,7 +703,7 @@ export function ScheduleView({
       </div>
 
       {/* Action bar: search, filters, overflow */}
-      <div className="flex items-center gap-2 mb-3 print:hidden">
+      <div className="mb-3 flex flex-wrap items-center gap-2 print:hidden">
         {/* Search */}
         <div className="relative min-w-0 flex-1 sm:flex-none sm:w-52">
           <IconSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground pointer-events-none" />
@@ -568,6 +812,150 @@ export function ScheduleView({
           </SelectContent>
         </Select>
 
+        <Select
+          value={preset}
+          onValueChange={(value) => {
+            const nextPreset = SCHEDULE_VIEW_PRESETS.find(
+              (candidate) => candidate === value
+            )
+            if (nextPreset) setPreset(nextPreset)
+          }}
+        >
+          <SelectTrigger className="h-8 w-[126px] shrink-0 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All dates</SelectItem>
+            <SelectItem value="my-items">My items</SelectItem>
+            <SelectItem value="past-due">Past due</SelectItem>
+            <SelectItem value="next-7">Next 7 days</SelectItem>
+            <SelectItem value="next-30">Next 30 days</SelectItem>
+            <SelectItem value="next-90">Next 90 days</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={groupMode}
+          onValueChange={(value) => {
+            const nextGroup = SCHEDULE_GROUP_MODES.find(
+              (candidate) => candidate === value
+            )
+            if (nextGroup) setGroupMode(nextGroup)
+          }}
+        >
+          <SelectTrigger className="h-8 w-[118px] shrink-0 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">No grouping</SelectItem>
+            <SelectItem value="phase">By phase</SelectItem>
+            <SelectItem value="project">By project</SelectItem>
+            <SelectItem value="status">By status</SelectItem>
+          </SelectContent>
+        </Select>
+
+        {view === "list" ? (
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline" size="sm" className="h-8 text-xs">
+                Columns
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="w-52 p-3">
+              <p className="mb-2 text-xs font-medium text-muted-foreground">
+                Visible columns
+              </p>
+              <div className="space-y-1.5">
+                {SCHEDULE_LIST_COLUMNS.map((column) => (
+                  <label
+                    key={column}
+                    className="flex cursor-pointer items-center gap-2 text-sm"
+                  >
+                    <Checkbox
+                      checked={visibleColumns.includes(column)}
+                      onCheckedChange={() =>
+                        setVisibleColumns((current) =>
+                          current.includes(column)
+                            ? current.filter((value) => value !== column)
+                            : [...current, column]
+                        )
+                      }
+                    />
+                    <span className="capitalize">
+                      {column
+                        .replace("endDateCalculated", "End date")
+                        .replace("startDate", "Start date")
+                        .replace("assignedTo", "Responsible")}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </PopoverContent>
+          </Popover>
+        ) : null}
+
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="outline" size="sm" className="h-8 text-xs">
+              <IconBookmark className="size-3.5" />
+              Views
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-72 p-2">
+            <div className="flex items-center justify-between px-2 py-1">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Saved views
+              </p>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 px-2 text-xs"
+                onClick={() => setSaveViewOpen(true)}
+              >
+                <IconDeviceFloppy className="size-3.5" />
+                Save current
+              </Button>
+            </div>
+            <div className="mt-1 max-h-64 overflow-y-auto">
+              {savedViews.map((savedView) => (
+                <div
+                  key={savedView.id}
+                  className="flex items-center gap-1 hover:bg-muted"
+                >
+                  <button
+                    type="button"
+                    className="min-w-0 flex-1 px-2 py-2 text-left text-sm"
+                    onClick={() => applySavedView(savedView)}
+                  >
+                    <span className="block truncate">{savedView.name}</span>
+                    <span className="text-[11px] capitalize text-muted-foreground">
+                      {savedView.visibility}
+                    </span>
+                  </button>
+                  {savedView.isOwner ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="size-7"
+                      disabled={isSavingView}
+                      onClick={() => handleDeleteView(savedView)}
+                      aria-label={`Delete ${savedView.name}`}
+                    >
+                      <IconTrash className="size-3.5" />
+                    </Button>
+                  ) : null}
+                </div>
+              ))}
+              {savedViews.length === 0 ? (
+                <p className="px-2 py-4 text-xs text-muted-foreground">
+                  Save a personal view or share one with the team.
+                </p>
+              ) : null}
+            </div>
+          </PopoverContent>
+        </Popover>
+
         {/* Active filter chips */}
         <div className="hidden sm:flex items-center gap-1 overflow-x-auto min-w-0">
           {filters.status.map((s) => (
@@ -671,6 +1059,7 @@ export function ScheduleView({
             assigneeOptions={assigneeOptions}
             focusTaskId={focusTaskId}
             projects={scheduleProjects}
+            visibleColumns={visibleColumns}
           />
         )}
         {view === "gantt" && (
@@ -681,6 +1070,10 @@ export function ScheduleView({
             exceptions={initialData.exceptions}
             assigneeOptions={assigneeOptions}
             projects={scheduleProjects}
+            groupByPhase={groupMode === "phase"}
+            onGroupByPhaseChange={(grouped) =>
+              setGroupMode(grouped ? "phase" : "none")
+            }
           />
         )}
       </div>
@@ -741,6 +1134,62 @@ export function ScheduleView({
             <p className="text-xs text-muted-foreground mt-2">
               Supported format: CSV with headers
             </p>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={saveViewOpen} onOpenChange={setSaveViewOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Save schedule view</DialogTitle>
+            <DialogDescription>
+              Save the current scope, filters, grouping, ordering, and columns.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="schedule-view-name">View name</Label>
+              <Input
+                id="schedule-view-name"
+                value={saveViewName}
+                onChange={(event) => setSaveViewName(event.target.value)}
+                placeholder="Example: Wes · next 30 days"
+                className="mt-1.5"
+              />
+            </div>
+            <label className="flex items-start gap-2 text-sm">
+              <Checkbox
+                checked={saveViewShared}
+                onCheckedChange={(checked) =>
+                  setSaveViewShared(checked === true)
+                }
+              />
+              <span>
+                Share with internal staff
+                <span className="block text-xs text-muted-foreground">
+                  Personal views are visible only to you.
+                </span>
+              </span>
+            </label>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setSaveViewOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleSaveView}
+                disabled={!saveViewName.trim() || isSavingView}
+              >
+                {isSavingView ? (
+                  <IconLoader2 className="size-4 animate-spin" />
+                ) : (
+                  <IconDeviceFloppy className="size-4" />
+                )}
+                Save view
+              </Button>
+            </div>
           </div>
         </DialogContent>
       </Dialog>

--- a/src/contexts/presence-context.tsx
+++ b/src/contexts/presence-context.tsx
@@ -23,20 +23,21 @@ type PresenceContextValue = {
 const PresenceContext = createContext<PresenceContextValue | null>(null)
 
 const HEARTBEAT_INTERVAL_MS = 30_000 // 30 seconds
-const IDLE_TIMEOUT_MS = 300_000 // 5 minutes
+const ACTIVITY_SYNC_INTERVAL_MS = 60_000
+const IDLE_TIMEOUT_MS = 60 * 60 * 1000
 
 export function PresenceProvider({ children }: { children: React.ReactNode }) {
   const [status, setStatus] = useState<PresenceStatus>("online")
   const [statusMessage, setStatusMessage] = useState<string | null>(null)
-  const [lastActivity, setLastActivity] = useState<Date | null>(null)
+  const [lastActivity, setLastActivity] = useState<Date | null>(() => new Date())
   const [isIdle, setIsIdle] = useState(false)
-  const [isVisible, setIsVisible] = useState(true)
 
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const heartbeatTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const statusRef = useRef<PresenceStatus>(status)
   const statusMessageRef = useRef<string | null>(statusMessage)
-  const lastActivityCallRef = useRef<number>(0)
+  const lastActivityAtRef = useRef<number>(Date.now())
+  const lastActivitySyncRef = useRef<number>(0)
+  const lastActivityHandledRef = useRef<number>(0)
 
   // keep refs in sync with state
   useEffect(() => {
@@ -63,7 +64,11 @@ export function PresenceProvider({ children }: { children: React.ReactNode }) {
       }
 
       try {
-        await updatePresence(newStatus, effectiveMessage ?? undefined)
+        await updatePresence(
+          newStatus,
+          effectiveMessage ?? undefined,
+          newStatus !== "offline"
+        )
       } catch {
         // silently fail - presence updates are non-critical
       }
@@ -71,40 +76,33 @@ export function PresenceProvider({ children }: { children: React.ReactNode }) {
     []
   )
 
-  const resetIdleTimer = useCallback(() => {
-    // clear existing timer
+  const clearIdleTimer = useCallback((): void => {
     if (idleTimerRef.current) {
       clearTimeout(idleTimerRef.current)
       idleTimerRef.current = null
     }
+  }, [])
 
-    // if we were idle, mark as active again
-    if (statusRef.current === "idle" || isIdle) {
-      setIsIdle(false)
-      setStatus("online")
-      updatePresence("online", statusMessageRef.current ?? undefined).catch(
-        () => {}
-      )
-    }
-
-    setLastActivity(new Date())
-
-    // set new idle timer
+  const scheduleIdleTimer = useCallback((): void => {
+    clearIdleTimer()
+    const elapsed = Date.now() - lastActivityAtRef.current
+    const remaining = Math.max(0, IDLE_TIMEOUT_MS - elapsed)
     idleTimerRef.current = setTimeout(() => {
-      if (statusRef.current === "online" && isVisible) {
+      if (!document.hidden && statusRef.current !== "dnd") {
         setIsIdle(true)
         setStatus("idle")
+        statusRef.current = "idle"
         updatePresence("idle", statusMessageRef.current ?? undefined).catch(
           () => {}
         )
       }
-    }, IDLE_TIMEOUT_MS)
-  }, [isIdle, isVisible])
+    }, remaining)
+  }, [clearIdleTimer])
 
   // heartbeat function
   const sendHeartbeat = useCallback(async () => {
-    // only send heartbeat if page is visible and user is online or idle
-    if (!isVisible) return
+    // Heartbeats prove the connection is alive but must not reset inactivity.
+    if (document.hidden) return
     if (statusRef.current === "offline" || statusRef.current === "dnd") return
 
     try {
@@ -112,70 +110,87 @@ export function PresenceProvider({ children }: { children: React.ReactNode }) {
     } catch {
       // silently fail - presence updates are non-critical
     }
-  }, [isVisible])
+  }, [])
 
   // set up heartbeat interval
   useEffect(() => {
-    heartbeatTimerRef.current = setInterval(sendHeartbeat, HEARTBEAT_INTERVAL_MS)
+    const heartbeatTimer = window.setInterval(
+      sendHeartbeat,
+      HEARTBEAT_INTERVAL_MS
+    )
 
     return () => {
-      if (heartbeatTimerRef.current) {
-        clearInterval(heartbeatTimerRef.current)
-        heartbeatTimerRef.current = null
-      }
+      window.clearInterval(heartbeatTimer)
     }
   }, [sendHeartbeat])
 
-  // throttled activity handler (1 second max rate)
-  const throttledHandleActivity = useCallback(() => {
+  const handleActivity = useCallback((): void => {
     const now = Date.now()
-    if (now - lastActivityCallRef.current < 1000) {
-      return // skip if called within last second
+    if (
+      statusRef.current !== "idle" &&
+      now - lastActivityHandledRef.current < 1000
+    ) {
+      return
     }
-    lastActivityCallRef.current = now
+    lastActivityHandledRef.current = now
+    lastActivityAtRef.current = now
+    setLastActivity(new Date(now))
 
-    if (statusRef.current !== "dnd" && statusRef.current !== "offline") {
-      resetIdleTimer()
+    if (statusRef.current === "idle") {
+      statusRef.current = "online"
+      setStatus("online")
+      setIsIdle(false)
     }
-  }, [resetIdleTimer])
+
+    scheduleIdleTimer()
+
+    if (now - lastActivitySyncRef.current >= ACTIVITY_SYNC_INTERVAL_MS) {
+      lastActivitySyncRef.current = now
+      updatePresence(
+        "online",
+        statusMessageRef.current ?? undefined,
+        true
+      ).catch(() => {})
+    }
+  }, [scheduleIdleTimer])
 
   // track user activity
   useEffect(() => {
     const activityEvents = ["mousemove", "keydown", "touchstart", "scroll"]
 
     for (const event of activityEvents) {
-      window.addEventListener(event, throttledHandleActivity, { passive: true })
+      window.addEventListener(event, handleActivity, { passive: true })
     }
 
-    // start initial idle timer
-    resetIdleTimer()
+    scheduleIdleTimer()
 
     return () => {
       for (const event of activityEvents) {
-        window.removeEventListener(event, throttledHandleActivity)
+        window.removeEventListener(event, handleActivity)
       }
-      if (idleTimerRef.current) {
-        clearTimeout(idleTimerRef.current)
-      }
+      clearIdleTimer()
     }
-  }, [throttledHandleActivity, resetIdleTimer])
+  }, [clearIdleTimer, handleActivity, scheduleIdleTimer])
 
   // handle page visibility changes
   useEffect(() => {
     const handleVisibilityChange = () => {
       const nowVisible = !document.hidden
-      setIsVisible(nowVisible)
 
       if (nowVisible) {
-        // page became visible - resume heartbeat and check if we should be idle
-        resetIdleTimer()
+        if (Date.now() - lastActivityAtRef.current >= IDLE_TIMEOUT_MS) {
+          setIsIdle(true)
+          setStatus("idle")
+          statusRef.current = "idle"
+          updatePresence("idle", statusMessageRef.current ?? undefined).catch(
+            () => {}
+          )
+        } else {
+          scheduleIdleTimer()
+        }
         sendHeartbeat()
       } else {
-        // page hidden - clear idle timer to pause idle detection
-        if (idleTimerRef.current) {
-          clearTimeout(idleTimerRef.current)
-          idleTimerRef.current = null
-        }
+        clearIdleTimer()
       }
     }
 
@@ -184,31 +199,12 @@ export function PresenceProvider({ children }: { children: React.ReactNode }) {
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange)
     }
-  }, [resetIdleTimer, sendHeartbeat])
-
-  // set offline on beforeunload
-  useEffect(() => {
-    const handleBeforeUnload = () => {
-      // use navigator.sendBeacon for reliable delivery during page unload
-      // the server action won't work here since the page is unloading
-      // we still call it for browsers that support it, but it may not complete
-      updatePresence("offline", statusMessageRef.current ?? undefined).catch(() => {})
-
-      // as a fallback, try to use sendBeacon with a dedicated endpoint
-      // this would require a separate API route, but we'll rely on the
-      // server-side timeout mechanism to mark users as offline
-    }
-
-    window.addEventListener("beforeunload", handleBeforeUnload)
-
-    return () => {
-      window.removeEventListener("beforeunload", handleBeforeUnload)
-    }
-  }, [])
+  }, [clearIdleTimer, scheduleIdleTimer, sendHeartbeat])
 
   // send initial presence on mount
   useEffect(() => {
-    updatePresence("online").catch(() => {})
+    lastActivitySyncRef.current = Date.now()
+    updatePresence("online", undefined, true).catch(() => {})
   }, [])
 
   const value: PresenceContextValue = {

--- a/src/db/schema-conversations.ts
+++ b/src/db/schema-conversations.ts
@@ -132,6 +132,8 @@ export const userPresence = sqliteTable("user_presence", {
   status: text("status").notNull().default("offline"), // online | idle | dnd | offline
   statusMessage: text("status_message"),
   lastSeenAt: text("last_seen_at").notNull(),
+  // Updated only by real user input, not by connection heartbeats.
+  lastActiveAt: text("last_active_at"),
   updatedAt: text("updated_at").notNull(),
 })
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -378,6 +378,77 @@ export const projects = sqliteTable("projects", {
   updatedAt: text("updated_at"),
 })
 
+export const activityEvents = sqliteTable(
+  "activity_events",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id").references(() => projects.id, {
+      onDelete: "set null",
+    }),
+    actorUserId: text("actor_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    actorName: text("actor_name").notNull(),
+    actorRole: text("actor_role").notNull(),
+    category: text("category").notNull(),
+    action: text("action").notNull(),
+    entityType: text("entity_type").notNull(),
+    entityId: text("entity_id"),
+    summary: text("summary").notNull(),
+    metadata: text("metadata"),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    index("activity_events_org_created_idx").on(
+      table.organizationId,
+      table.createdAt
+    ),
+    index("activity_events_project_created_idx").on(
+      table.projectId,
+      table.createdAt
+    ),
+    index("activity_events_actor_created_idx").on(
+      table.actorUserId,
+      table.createdAt
+    ),
+  ]
+)
+
+export type ActivityEvent = typeof activityEvents.$inferSelect
+export type NewActivityEvent = typeof activityEvents.$inferInsert
+
+export const scheduleSavedViews = sqliteTable(
+  "schedule_saved_views",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    ownerUserId: text("owner_user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    visibility: text("visibility").notNull().default("personal"),
+    definition: text("definition").notNull(),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    index("schedule_saved_views_org_idx").on(table.organizationId),
+    index("schedule_saved_views_owner_idx").on(table.ownerUserId),
+    uniqueIndex("schedule_saved_views_owner_name_unique").on(
+      table.ownerUserId,
+      table.name
+    ),
+  ]
+)
+
+export type ScheduleSavedView = typeof scheduleSavedViews.$inferSelect
+export type NewScheduleSavedView = typeof scheduleSavedViews.$inferInsert
+
 export const projectExternalLinks = sqliteTable("project_external_links", {
   id: text("id").primaryKey(),
   projectId: text("project_id")

--- a/src/lib/activity-log.ts
+++ b/src/lib/activity-log.ts
@@ -1,0 +1,81 @@
+import { activityEvents } from "@/db/schema"
+import type { getDb } from "@/db"
+
+export const ACTIVITY_CATEGORIES = [
+  "access",
+  "account",
+  "conversation",
+  "file",
+  "presence",
+  "schedule",
+] as const
+
+export type ActivityCategory = (typeof ACTIVITY_CATEGORIES)[number]
+
+export type ActivityActor = {
+  readonly id: string
+  readonly email: string
+  readonly displayName: string | null
+  readonly firstName: string | null
+  readonly lastName: string | null
+  readonly role: string
+}
+
+type ActivityDb = ReturnType<typeof getDb>
+
+type RecordActivityInput = {
+  readonly db: ActivityDb
+  readonly organizationId: string
+  readonly projectId?: string | null
+  readonly actor: ActivityActor
+  readonly category: ActivityCategory
+  readonly action: string
+  readonly entityType: string
+  readonly entityId?: string | null
+  readonly summary: string
+  readonly metadata?: Readonly<Record<string, string | number | boolean | null>>
+  readonly createdAt?: string
+}
+
+export function activityActorName(actor: ActivityActor): string {
+  const displayName = actor.displayName?.trim()
+  if (displayName) return displayName
+
+  const fullName = [actor.firstName, actor.lastName]
+    .filter((value) => Boolean(value?.trim()))
+    .join(" ")
+    .trim()
+  return fullName || actor.email
+}
+
+/**
+ * Activity history must never make the underlying user action fail. The
+ * caller awaits this helper so normal writes are ordered before their event,
+ * while logging errors remain isolated and observable in server logs.
+ */
+export async function recordActivityEvent(
+  input: RecordActivityInput
+): Promise<void> {
+  try {
+    await input.db
+      .insert(activityEvents)
+      .values({
+        id: crypto.randomUUID(),
+        organizationId: input.organizationId,
+        projectId: input.projectId ?? null,
+        actorUserId: input.actor.id,
+        actorName: activityActorName(input.actor).slice(0, 200),
+        actorRole: input.actor.role.slice(0, 80),
+        category: input.category,
+        action: input.action.slice(0, 120),
+        entityType: input.entityType.slice(0, 120),
+        entityId: input.entityId ?? null,
+        summary: input.summary.trim().slice(0, 500),
+        metadata: input.metadata ? JSON.stringify(input.metadata) : null,
+        createdAt: input.createdAt ?? new Date().toISOString(),
+      })
+      .run()
+  } catch (error) {
+    console.error("Unable to record Compass activity event", error)
+  }
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -20,6 +20,7 @@ import {
   isExternalProjectRole,
 } from "@/lib/user-roles"
 import { ensureProjectAudienceConversation } from "@/lib/project-audience-conversations"
+import { recordActivityEvent } from "@/lib/activity-log"
 
 export type AuthUser = {
   readonly id: string
@@ -334,6 +335,7 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
     const db = getDb(env.DB)
 
     // check if user exists in our database
+    let activatedPendingAccount = false
     let dbUser = await db
       .select()
       .from(users)
@@ -370,6 +372,7 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
           })
           .where(eq(users.id, emailMatch.id))
           .run()
+        activatedPendingAccount = isPendingPlaceholder
         dbUser = await db
           .select()
           .from(users)
@@ -479,6 +482,26 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
             membership.orgType === "internal" &&
             isExternalProjectRole(membership.memberRole)
         ) ?? activeOrg
+    }
+
+    if (activatedPendingAccount && activeOrg) {
+      await recordActivityEvent({
+        db,
+        organizationId: activeOrg.orgId,
+        actor: {
+          id: dbUser.id,
+          email: dbUser.email,
+          displayName: dbUser.displayName,
+          firstName: dbUser.firstName,
+          lastName: dbUser.lastName,
+          role: effectiveRole,
+        },
+        category: "account",
+        action: "account.activated",
+        entityType: "user",
+        entityId: dbUser.id,
+        summary: "Activated their Compass account.",
+      })
     }
 
     return {

--- a/src/lib/dashboard/__tests__/office-status.test.ts
+++ b/src/lib/dashboard/__tests__/office-status.test.ts
@@ -41,6 +41,7 @@ describe("teamAvailabilityFromRows", () => {
           avatarUrl: "/martine.jpg",
           role: "admin",
           statusMessage: "In Office",
+          lastActiveAt: "2026-07-27T14:30:00.000Z",
           updatedAt: "2026-07-27T15:00:00.000Z",
         },
         {
@@ -52,6 +53,7 @@ describe("teamAvailabilityFromRows", () => {
           avatarUrl: null,
           role: "office",
           statusMessage: "Out",
+          lastActiveAt: "2026-07-27T13:30:00.000Z",
           updatedAt: "2026-07-27T14:00:00.000Z",
         },
         {
@@ -63,6 +65,7 @@ describe("teamAvailabilityFromRows", () => {
           avatarUrl: null,
           role: "office",
           statusMessage: "Remote",
+          lastActiveAt: "2026-07-27T15:45:00.000Z",
           updatedAt: "2026-07-27T16:00:00.000Z",
         },
         {
@@ -74,10 +77,12 @@ describe("teamAvailabilityFromRows", () => {
           avatarUrl: null,
           role: "client",
           statusMessage: "In Office",
+          lastActiveAt: "2026-07-27T15:45:00.000Z",
           updatedAt: "2026-07-27T16:00:00.000Z",
         },
       ],
-      "martine"
+      "martine",
+      new Date("2026-07-27T16:00:00.000Z")
     )
 
     expect(availability).toEqual([
@@ -86,6 +91,8 @@ describe("teamAvailabilityFromRows", () => {
         name: "Martine Vogel",
         avatarUrl: "/martine.jpg",
         status: "in-office",
+        activity: "idle",
+        lastActiveAt: "2026-07-27T14:30:00.000Z",
         updatedAt: "2026-07-27T15:00:00.000Z",
         isCurrentUser: true,
       },
@@ -94,6 +101,8 @@ describe("teamAvailabilityFromRows", () => {
         name: "Sylvi Example",
         avatarUrl: null,
         status: "remote",
+        activity: "active",
+        lastActiveAt: "2026-07-27T15:45:00.000Z",
         updatedAt: "2026-07-27T16:00:00.000Z",
         isCurrentUser: false,
       },
@@ -113,6 +122,7 @@ describe("teamAvailabilityFromRows", () => {
             avatarUrl: null,
             role: "office",
             statusMessage: null,
+            lastActiveAt: null,
             updatedAt: null,
           },
         ],

--- a/src/lib/dashboard/office-status.ts
+++ b/src/lib/dashboard/office-status.ts
@@ -40,6 +40,8 @@ export type TeamAvailabilityMember = {
   readonly name: string
   readonly avatarUrl: string | null
   readonly status: DeskStatus
+  readonly activity: "active" | "idle"
+  readonly lastActiveAt: string | null
   readonly updatedAt: string
   readonly isCurrentUser: boolean
 }
@@ -53,8 +55,11 @@ export type TeamAvailabilityRow = {
   readonly avatarUrl: string | null
   readonly role: string
   readonly statusMessage: string | null
+  readonly lastActiveAt: string | null
   readonly updatedAt: string | null
 }
+
+export const TEAM_IDLE_AFTER_MS = 60 * 60 * 1000
 
 function availabilityName(row: TeamAvailabilityRow): string {
   const displayName = row.displayName?.trim()
@@ -78,7 +83,8 @@ function statusRank(status: DeskStatus): number {
 
 export function teamAvailabilityFromRows(
   rows: readonly TeamAvailabilityRow[],
-  currentUserId: string
+  currentUserId: string,
+  now = new Date()
 ): readonly TeamAvailabilityMember[] {
   const membersById = new Map<string, TeamAvailabilityMember>()
 
@@ -87,12 +93,22 @@ export function teamAvailabilityFromRows(
 
     const status = deskStatusFromPresenceMessage(row.statusMessage)
     if (!status) continue
+    const lastActiveTimestamp = row.lastActiveAt
+      ? new Date(row.lastActiveAt).getTime()
+      : Number.NaN
+    const activity =
+      Number.isFinite(lastActiveTimestamp) &&
+      now.getTime() - lastActiveTimestamp < TEAM_IDLE_AFTER_MS
+        ? "active"
+        : "idle"
 
     const member: TeamAvailabilityMember = {
       userId: row.userId,
       name: availabilityName(row),
       avatarUrl: row.avatarUrl,
       status,
+      activity,
+      lastActiveAt: row.lastActiveAt,
       updatedAt: row.updatedAt ?? "",
       isCurrentUser: row.userId === currentUserId,
     }

--- a/src/lib/schedule/__tests__/saved-views.test.ts
+++ b/src/lib/schedule/__tests__/saved-views.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  scheduleAssigneeTerms,
+  scheduleViewDefinitionSchema,
+} from "@/lib/schedule/saved-views"
+
+describe("scheduleViewDefinitionSchema", () => {
+  it("accepts a shareable schedule customization", () => {
+    const result = scheduleViewDefinitionSchema.safeParse({
+      view: "list",
+      orderMode: "chronological",
+      groupMode: "phase",
+      preset: "next-30",
+      status: ["PENDING", "IN_PROGRESS"],
+      phase: ["Framing"],
+      assignedTo: "Wes",
+      search: "inspection",
+      columns: ["phase", "startDate", "endDateCalculated", "assignedTo"],
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects unsupported presets and columns", () => {
+    const result = scheduleViewDefinitionSchema.safeParse({
+      view: "list",
+      orderMode: "chronological",
+      groupMode: "none",
+      preset: "next-365",
+      status: [],
+      phase: [],
+      assignedTo: "",
+      search: "",
+      columns: ["privateNotes"],
+    })
+
+    expect(result.success).toBe(false)
+  })
+})
+
+describe("scheduleAssigneeTerms", () => {
+  it("builds the labels used by the My Items preset", () => {
+    expect(
+      scheduleAssigneeTerms({
+        email: "wes@example.com",
+        displayName: "Wes Jones",
+        firstName: "Wes",
+        lastName: "Jones",
+      })
+    ).toEqual(["Wes Jones", "wes@example.com"])
+  })
+})

--- a/src/lib/schedule/saved-views.ts
+++ b/src/lib/schedule/saved-views.ts
@@ -1,0 +1,82 @@
+import { z } from "zod/v4"
+
+export const SCHEDULE_VIEW_PRESETS = [
+  "all",
+  "my-items",
+  "past-due",
+  "next-7",
+  "next-30",
+  "next-90",
+] as const
+
+export const SCHEDULE_GROUP_MODES = [
+  "none",
+  "phase",
+  "project",
+  "status",
+] as const
+
+export const SCHEDULE_LIST_COLUMNS = [
+  "project",
+  "complete",
+  "phase",
+  "duration",
+  "startDate",
+  "endDateCalculated",
+  "assignedTo",
+] as const
+
+export type ScheduleViewPreset = (typeof SCHEDULE_VIEW_PRESETS)[number]
+export type ScheduleGroupMode = (typeof SCHEDULE_GROUP_MODES)[number]
+export type ScheduleListColumn = (typeof SCHEDULE_LIST_COLUMNS)[number]
+
+const taskStatusSchema = z.enum([
+  "PENDING",
+  "IN_PROGRESS",
+  "COMPLETE",
+  "BLOCKED",
+])
+
+export const scheduleViewDefinitionSchema = z.object({
+  view: z.enum(["calendar", "list", "gantt"]),
+  orderMode: z.enum(["chronological", "manual"]),
+  groupMode: z.enum(SCHEDULE_GROUP_MODES),
+  preset: z.enum(SCHEDULE_VIEW_PRESETS),
+  status: z.array(taskStatusSchema).max(4),
+  phase: z.array(z.string().trim().min(1).max(100)).max(50),
+  assignedTo: z.string().max(200),
+  search: z.string().max(200),
+  columns: z.array(z.enum(SCHEDULE_LIST_COLUMNS)).max(
+    SCHEDULE_LIST_COLUMNS.length
+  ),
+})
+
+export type ScheduleViewDefinition = z.infer<
+  typeof scheduleViewDefinitionSchema
+>
+
+export type SavedScheduleViewData = {
+  readonly id: string
+  readonly name: string
+  readonly visibility: "personal" | "shared"
+  readonly ownerUserId: string
+  readonly isOwner: boolean
+  readonly definition: ScheduleViewDefinition
+}
+
+export function scheduleAssigneeTerms(user: {
+  readonly email: string
+  readonly displayName: string | null
+  readonly firstName: string | null
+  readonly lastName: string | null
+} | null): readonly string[] {
+  if (!user) return []
+  const fullName = [user.firstName, user.lastName]
+    .filter((value) => Boolean(value?.trim()))
+    .join(" ")
+    .trim()
+  const terms = [user.displayName, fullName, user.email].flatMap((value) =>
+    value ? [value] : []
+  )
+  return [...new Set(terms)]
+}


### PR DESCRIPTION
## What

- adds an organization-scoped Activity page for staff, with privacy-safe events for account activation, access invitations/grants, file uploads, schedule changes, project messages, and manual availability changes
- separates persistent work location (In Office, On Site, Remote, Out) from automatic one-hour Active/Idle presence, restoring the manual designation on the next user interaction
- completes Schedule step 3 with URL-backed filters, search, view, ordering, grouping, rolling date presets, My Items, Past Due, configurable list columns, and personal/shared saved views
- adds D1 migrations for last activity, activity events, and saved schedule views

## Why

Manual work-location selections were persisting indefinitely and implied people were still working after they had left for the day. Compass also lacked a durable, privacy-safe history of important staff/owner/subcontractor actions. Schedule customization did not survive refreshes or support reusable team views.

## How to test

1. Set an office status, verify it remains the selected location, and confirm an inactive user displays as Idle after the threshold; interact with Compass and verify the manual location returns.
2. Open Activity and filter by category/project; perform a schedule edit, send a project message, upload a file, or change availability and verify a concise event appears without message contents.
3. Open a project or unified schedule; change view, filters, order, grouping, preset, and list columns; refresh or copy the URL and verify state persists.
4. Save personal and shared schedule views, apply them, and delete a view owned by the current user.

## Validation

- 11 focused Vitest tests pass
- TypeScript check passes
- targeted ESLint check passes
- production Next.js build passes
- all migrations apply cleanly to a fresh local D1 database

## Notes

The activity feed begins recording after deployment; it does not synthesize historical events. Message events record only the channel and action, never the message body.