### PR TITLE
fix(conversations): restore messaging access and delivery

### DIFF
--- a/src/app/actions/chat-messages.ts
+++ b/src/app/actions/chat-messages.ts
@@ -319,10 +319,74 @@ async function resolveMentionNotificationRecipients(
   senderId: string,
   mentions: readonly MentionInput[]
 ): Promise<readonly { readonly userId: string; readonly email: string }[]> {
-  const members = await getChannelNotificationMembers(
-    db,
-    channelId,
-    senderId
+  const [members, allMemberRows, channel] = await Promise.all([
+    getChannelNotificationMembers(db, channelId, senderId),
+    db
+      .select({ userId: channelMembers.userId })
+      .from(channelMembers)
+      .where(eq(channelMembers.channelId, channelId)),
+    db
+      .select({
+        organizationId: channels.organizationId,
+        isPrivate: channels.isPrivate,
+      })
+      .from(channels)
+      .where(eq(channels.id, channelId))
+      .get(),
+  ])
+  const memberById = new Map(members.map((member) => [member.userId, member]))
+  const allMemberIds = new Set(allMemberRows.map((member) => member.userId))
+  const directTargetIds = Array.from(
+    new Set(
+      mentions
+        .filter(
+          (mention) =>
+            mention.mentionType === "user" &&
+            Boolean(mention.targetId) &&
+            mention.targetId !== senderId &&
+            !allMemberIds.has(mention.targetId ?? "")
+        )
+        .map((mention) => mention.targetId)
+        .filter((targetId): targetId is string => Boolean(targetId))
+    )
+  )
+
+  // Public/internal conversations can mention any active coworker in the
+  // organization. Private owner, partner, and direct-message channels remain
+  // strictly membership-scoped so a crafted mention cannot leak their content.
+  const additionalDirectTargets =
+    channel && !channel.isPrivate && directTargetIds.length > 0
+      ? await db
+          .select({
+            userId: users.id,
+            email: users.email,
+            role: organizationMembers.role,
+          })
+          .from(users)
+          .innerJoin(
+            organizationMembers,
+            and(
+              eq(organizationMembers.userId, users.id),
+              eq(organizationMembers.organizationId, channel.organizationId)
+            )
+          )
+          .where(
+            and(
+              inArray(users.id, directTargetIds),
+              eq(users.isActive, true)
+            )
+          )
+          .then((rows) =>
+            rows
+              .filter((row) => isInternalStaffRole(row.role))
+              .map((row) => ({
+                userId: row.userId,
+                email: row.email,
+              }))
+          )
+      : []
+  const directTargetById = new Map(
+    additionalDirectTargets.map((target) => [target.userId, target])
   )
   const onlineRows = mentions.some(
     (mention) => mention.mentionType === "here"
@@ -340,13 +404,13 @@ async function resolveMentionNotificationRecipients(
 
   for (const mention of mentions) {
     if (mention.mentionType === "user" && mention.targetId) {
-      const member = members.find(
-        (row) => row.userId === mention.targetId
-      )
-      if (member) {
-        recipients.set(member.userId, {
-          userId: member.userId,
-          email: member.email,
+      const recipient =
+        memberById.get(mention.targetId) ??
+        directTargetById.get(mention.targetId)
+      if (recipient) {
+        recipients.set(recipient.userId, {
+          userId: recipient.userId,
+          email: recipient.email,
         })
       }
       continue
@@ -379,6 +443,20 @@ function messagePreview(content: string): string {
   return normalized.length <= 180
     ? normalized
     : `${normalized.slice(0, 177)}...`
+}
+
+function conversationHref(channel: {
+  readonly id: string
+  readonly projectId: string | null
+  readonly audience: string
+}): string {
+  if (channel.projectId && channel.audience === "clients") {
+    return `/preview/projects/${channel.projectId}/owner/conversations/${channel.id}`
+  }
+  if (channel.projectId && channel.audience === "sub_vendors") {
+    return `/preview/projects/${channel.projectId}/sub-vendor/conversations/${channel.id}`
+  }
+  return `/dashboard/conversations/${channel.id}`
 }
 
 export async function sendMessage(data: {
@@ -518,10 +596,12 @@ export async function sendMessage(data: {
 
     const channel = await db
       .select({
+        id: channels.id,
         name: channels.name,
         type: channels.type,
         organizationId: channels.organizationId,
         projectId: channels.projectId,
+        audience: channels.audience,
       })
       .from(channels)
       .where(eq(channels.id, data.channelId))
@@ -543,7 +623,7 @@ export async function sendMessage(data: {
           sourceId: messageId,
           title: `${user.displayName ?? user.email} mentioned you`,
           body: messagePreview(data.content),
-          href: `/dashboard/conversations/${data.channelId}`,
+          href: conversationHref(channel),
           priority: "normal",
           audience: "mention",
           createdBy: user.id,
@@ -578,9 +658,9 @@ export async function sendMessage(data: {
           eventType: "announcement.message",
           sourceType: "message",
           sourceId: messageId,
-          title: `Announcement in #${channel.name}`,
+          title: `Announcement in ${channel.name}`,
           body: messagePreview(data.content),
-          href: `/dashboard/conversations/${data.channelId}`,
+          href: conversationHref(channel),
           priority: "high",
           audience: "announcement",
           createdBy: user.id,
@@ -663,6 +743,7 @@ export async function sendMessage(data: {
           projectId: channel.projectId,
           channelId: data.channelId,
           channelName: channel.name,
+          href: conversationHref(channel),
           messageId,
           threadId: data.threadId ?? null,
           content: data.content,

--- a/src/app/actions/conversations.ts
+++ b/src/app/actions/conversations.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import { getCloudflareContext } from "@/lib/db"
-import { eq, and, sql } from "drizzle-orm"
+import { eq, and, sql, ne } from "drizzle-orm"
 import { getDb } from "@/db"
 import {
   channels,
@@ -11,13 +11,211 @@ import {
   type NewChannelMember,
   type NewChannelReadState,
 } from "@/db/schema-conversations"
-import { projects } from "@/db/schema"
+import { organizationMembers, projects, users } from "@/db/schema"
 import { getCurrentUser } from "@/lib/auth"
 import { requirePermission } from "@/lib/permissions"
 import { revalidatePath } from "next/cache"
 import { requireOrg } from "@/lib/org-scope"
 import { isDemoUser } from "@/lib/demo"
 import { isInternalStaffRole } from "@/lib/user-roles"
+
+async function directChannelId(
+  organizationId: string,
+  firstUserId: string,
+  secondUserId: string
+): Promise<string> {
+  const participants = [firstUserId, secondUserId].sort().join(":")
+  const bytes = new TextEncoder().encode(`${organizationId}:${participants}`)
+  const digest = await crypto.subtle.digest("SHA-256", bytes)
+  const hash = Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+  return `direct-${hash.slice(0, 32)}`
+}
+
+async function ensureChannelMember(
+  db: ReturnType<typeof getDb>,
+  channelId: string,
+  userId: string,
+  now: string
+): Promise<void> {
+  const existingMember = await db
+    .select({ id: channelMembers.id })
+    .from(channelMembers)
+    .where(
+      and(
+        eq(channelMembers.channelId, channelId),
+        eq(channelMembers.userId, userId)
+      )
+    )
+    .get()
+
+  if (!existingMember) {
+    await db.insert(channelMembers).values({
+      id: crypto.randomUUID(),
+      channelId,
+      userId,
+      role: "member",
+      notifyLevel: "all",
+      joinedAt: now,
+    })
+  }
+
+  const existingReadState = await db
+    .select({ id: channelReadState.id })
+    .from(channelReadState)
+    .where(
+      and(
+        eq(channelReadState.channelId, channelId),
+        eq(channelReadState.userId, userId)
+      )
+    )
+    .get()
+
+  if (!existingReadState) {
+    await db.insert(channelReadState).values({
+      id: crypto.randomUUID(),
+      channelId,
+      userId,
+      lastReadMessageId: null,
+      lastReadAt: now,
+      unreadCount: 0,
+    })
+  }
+}
+
+export async function listDirectMessageRecipients() {
+  try {
+    const user = await getCurrentUser()
+    if (!user || !isInternalStaffRole(user.role)) {
+      return { success: false, error: "Only staff can start direct messages" }
+    }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const rows = await db
+      .select({
+        id: users.id,
+        name: users.displayName,
+        email: users.email,
+        avatarUrl: users.avatarUrl,
+        role: organizationMembers.role,
+      })
+      .from(users)
+      .innerJoin(
+        organizationMembers,
+        and(
+          eq(organizationMembers.userId, users.id),
+          eq(organizationMembers.organizationId, organizationId)
+        )
+      )
+      .where(and(ne(users.id, user.id), eq(users.isActive, true)))
+      .orderBy(users.displayName, users.email)
+
+    return {
+      success: true,
+      data: rows
+        .filter((row) => isInternalStaffRole(row.role))
+        .map((row) => ({
+          id: row.id,
+          name: row.name ?? row.email,
+          email: row.email,
+          avatarUrl: row.avatarUrl,
+        })),
+    }
+  } catch (err) {
+    return {
+      success: false,
+      error:
+        err instanceof Error
+          ? err.message
+          : "Failed to load direct message recipients",
+    }
+  }
+}
+
+export async function createDirectMessage(targetUserId: string) {
+  try {
+    const user = await getCurrentUser()
+    if (!user || !isInternalStaffRole(user.role)) {
+      return { success: false, error: "Only staff can start direct messages" }
+    }
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    if (targetUserId === user.id) {
+      return { success: false, error: "Choose another team member" }
+    }
+
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const target = await db
+      .select({
+        id: users.id,
+        name: users.displayName,
+        email: users.email,
+        role: organizationMembers.role,
+      })
+      .from(users)
+      .innerJoin(
+        organizationMembers,
+        and(
+          eq(organizationMembers.userId, users.id),
+          eq(organizationMembers.organizationId, organizationId)
+        )
+      )
+      .where(and(eq(users.id, targetUserId), eq(users.isActive, true)))
+      .get()
+
+    if (!target || !isInternalStaffRole(target.role)) {
+      return { success: false, error: "Team member not found" }
+    }
+
+    const channelId = await directChannelId(
+      organizationId,
+      user.id,
+      target.id
+    )
+    const now = new Date().toISOString()
+    const existingChannel = await db
+      .select({ id: channels.id })
+      .from(channels)
+      .where(eq(channels.id, channelId))
+      .get()
+
+    if (!existingChannel) {
+      await db.insert(channels).values({
+        id: channelId,
+        name: `${user.displayName ?? user.email} · ${target.name ?? target.email}`,
+        type: "text",
+        description: "Private direct message",
+        organizationId,
+        projectId: null,
+        categoryId: null,
+        isPrivate: true,
+        audience: "direct",
+        createdBy: user.id,
+        sortOrder: 0,
+        archivedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+    }
+
+    await ensureChannelMember(db, channelId, user.id, now)
+    await ensureChannelMember(db, channelId, target.id, now)
+
+    revalidatePath("/dashboard/conversations")
+    return { success: true, data: { channelId } }
+  } catch (err) {
+    return {
+      success: false,
+      error:
+        err instanceof Error ? err.message : "Failed to start direct message",
+    }
+  }
+}
 
 export async function listChannels() {
   try {

--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -6,6 +6,7 @@ import { getDb } from "@/db"
 import {
   dailyLogPhotos,
   dailyLogs,
+  organizationMembers,
   ownerProjectUpdates,
   projectContacts,
   projectMembers,
@@ -13,6 +14,7 @@ import {
   projectRfis,
   projects,
   scheduleTasks,
+  users,
 } from "@/db/schema"
 import { channelMembers, channels } from "@/db/schema-conversations"
 import { requireAuth } from "@/lib/auth"
@@ -111,6 +113,7 @@ export type AudienceMessageChannel = {
 
 export type AudienceContact = {
   readonly id: string
+  readonly userId: string | null
   readonly contactType: string
   readonly displayName: string
   readonly companyName: string | null
@@ -364,6 +367,7 @@ export async function getProjectAudiencePreview(
   const contactRows = await db
     .select({
       id: projectContacts.id,
+      userId: projectContacts.sourceEntityId,
       contactType: projectContacts.contactType,
       displayName: projectContacts.displayName,
       companyName: projectContacts.companyName,
@@ -491,15 +495,53 @@ export async function getProjectAudiencePreview(
     )
     .orderBy(asc(channels.sortOrder), asc(channels.name))
 
-  const visibleContactRows =
-    !viewerIsInternal && audience === "sub_vendor"
-      ? contactRows.filter(
-          (contact) =>
-            contact.contactType === "internal" ||
-            contact.email?.trim().toLowerCase() ===
-              viewer.email.trim().toLowerCase()
+  const internalTeamRows = viewerIsInternal
+    ? []
+    : await db
+        .select({
+          id: projectMembers.id,
+          userId: users.id,
+          displayName: users.displayName,
+          email: users.email,
+          role: organizationMembers.role,
+        })
+        .from(projectMembers)
+        .innerJoin(users, eq(users.id, projectMembers.userId))
+        .innerJoin(
+          organizationMembers,
+          and(
+            eq(organizationMembers.userId, users.id),
+            eq(organizationMembers.organizationId, organizationId)
+          )
         )
-      : contactRows
+        .where(
+          and(
+            eq(projectMembers.projectId, projectId),
+            eq(users.isActive, true)
+          )
+        )
+
+  // External workspaces expose the authoritative internal project team only.
+  // Owners and partners do not need to see themselves or discover other
+  // external contacts assigned to the project.
+  const visibleContactRows = viewerIsInternal
+    ? contactRows
+    : internalTeamRows
+        .filter((member) => isInternalStaffRole(member.role))
+        .map((member) => ({
+          id: member.id,
+          userId: member.userId,
+          contactType: "internal",
+          displayName: member.displayName ?? member.email,
+          companyName: null,
+          role: member.role,
+          trade: null,
+          csiDivision: null,
+          csiDivisionName: null,
+          email: member.email,
+          phone: null,
+          primaryContact: false,
+        }))
   const visibleContactNames = new Set(
     visibleContactRows
       .flatMap((contact) => [

--- a/src/app/preview/projects/[id]/owner/conversations/[channelId]/page.tsx
+++ b/src/app/preview/projects/[id]/owner/conversations/[channelId]/page.tsx
@@ -6,19 +6,32 @@ import { ProjectAudienceConversation } from "@/components/projects/project-audie
 
 export default async function OwnerConversationPage({
   params,
+  searchParams,
 }: {
   readonly params: Promise<{
     readonly id: string
     readonly channelId: string
   }>
+  readonly searchParams: Promise<{
+    readonly mention?: string | readonly string[]
+    readonly label?: string | readonly string[]
+  }>
 }): Promise<React.ReactElement> {
   const { id, channelId } = await params
+  const query = await searchParams
+  const mention =
+    typeof query.mention === "string" ? query.mention : query.mention?.[0]
+  const label =
+    typeof query.label === "string" ? query.label : query.label?.[0]
 
   return (
     <ProjectAudienceConversation
       projectId={id}
       channelId={channelId}
       audience="owner"
+      initialMention={
+        mention && label ? { userId: mention, label } : undefined
+      }
     />
   )
 }

--- a/src/app/preview/projects/[id]/sub-vendor/conversations/[channelId]/page.tsx
+++ b/src/app/preview/projects/[id]/sub-vendor/conversations/[channelId]/page.tsx
@@ -6,19 +6,32 @@ import { ProjectAudienceConversation } from "@/components/projects/project-audie
 
 export default async function SubVendorConversationPage({
   params,
+  searchParams,
 }: {
   readonly params: Promise<{
     readonly id: string
     readonly channelId: string
   }>
+  readonly searchParams: Promise<{
+    readonly mention?: string | readonly string[]
+    readonly label?: string | readonly string[]
+  }>
 }): Promise<React.ReactElement> {
   const { id, channelId } = await params
+  const query = await searchParams
+  const mention =
+    typeof query.mention === "string" ? query.mention : query.mention?.[0]
+  const label =
+    typeof query.label === "string" ? query.label : query.label?.[0]
 
   return (
     <ProjectAudienceConversation
       projectId={id}
       channelId={channelId}
       audience="sub_vendor"
+      initialMention={
+        mention && label ? { userId: mention, label } : undefined
+      }
     />
   )
 }

--- a/src/components/conversations/channel-header.tsx
+++ b/src/components/conversations/channel-header.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation"
 import Link from "next/link"
 import {
   IconFolder,
-  IconHash,
+  IconMessageCircle,
   IconPin,
   IconSearch,
   IconUsers,
@@ -60,7 +60,7 @@ export function ChannelHeader({
     <>
       <header className="flex h-14 shrink-0 items-center justify-between border-b px-4">
         <div className="flex items-center gap-2 overflow-hidden">
-          <IconHash className="h-5 w-5 shrink-0 text-muted-foreground" />
+          <IconMessageCircle className="h-5 w-5 shrink-0 text-muted-foreground" />
           <div className="min-w-0 flex-1">
             <h1 className="truncate text-base font-semibold">{name}</h1>
             <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">

--- a/src/components/conversations/direct-message-dialog.tsx
+++ b/src/components/conversations/direct-message-dialog.tsx
@@ -1,0 +1,147 @@
+"use client"
+
+import * as React from "react"
+import { IconLoader2, IconMessageCircle, IconSearch } from "@tabler/icons-react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+
+import {
+  createDirectMessage,
+  listDirectMessageRecipients,
+} from "@/app/actions/conversations"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { ScrollArea } from "@/components/ui/scroll-area"
+
+type DirectMessageRecipient = {
+  readonly id: string
+  readonly name: string
+  readonly email: string
+  readonly avatarUrl: string | null
+}
+
+export function DirectMessageDialog({
+  open,
+  onOpenChange,
+}: {
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
+}): React.ReactElement {
+  const router = useRouter()
+  const [recipients, setRecipients] = React.useState<
+    readonly DirectMessageRecipient[]
+  >([])
+  const [query, setQuery] = React.useState("")
+  const [loading, setLoading] = React.useState(false)
+  const [startingId, setStartingId] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    setLoading(true)
+    void listDirectMessageRecipients().then((result) => {
+      if (cancelled) return
+      if (result.success && result.data) {
+        setRecipients(result.data)
+      } else {
+        toast.error(result.error ?? "Could not load team members.")
+      }
+      setLoading(false)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [open])
+
+  const normalizedQuery = query.trim().toLocaleLowerCase()
+  const filteredRecipients = recipients.filter((recipient) =>
+    `${recipient.name} ${recipient.email}`
+      .toLocaleLowerCase()
+      .includes(normalizedQuery)
+  )
+
+  async function startMessage(recipientId: string): Promise<void> {
+    setStartingId(recipientId)
+    const result = await createDirectMessage(recipientId)
+    setStartingId(null)
+    if (!result.success || !result.data) {
+      toast.error(result.error ?? "Could not start the message.")
+      return
+    }
+    onOpenChange(false)
+    setQuery("")
+    router.push(`/dashboard/conversations/${result.data.channelId}`)
+    router.refresh()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>New direct message</DialogTitle>
+          <DialogDescription>
+            Start a private conversation with an internal team member.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="relative">
+          <IconSearch className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.currentTarget.value)}
+            placeholder="Find a team member"
+            className="pl-9"
+            autoFocus
+          />
+        </div>
+        <ScrollArea className="max-h-80">
+          <div className="space-y-1 pr-3">
+            {loading ? (
+              <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+                <IconLoader2 className="size-4 animate-spin" />
+                Loading team members…
+              </div>
+            ) : filteredRecipients.length === 0 ? (
+              <p className="py-10 text-center text-sm text-muted-foreground">
+                No matching team members.
+              </p>
+            ) : (
+              filteredRecipients.map((recipient) => (
+                <Button
+                  key={recipient.id}
+                  type="button"
+                  variant="ghost"
+                  className="h-auto w-full justify-start gap-3 px-3 py-2 text-left"
+                  disabled={startingId !== null}
+                  onClick={() => void startMessage(recipient.id)}
+                >
+                  <span className="grid size-9 shrink-0 place-items-center rounded-full bg-primary/10 text-primary">
+                    {startingId === recipient.id ? (
+                      <IconLoader2 className="size-4 animate-spin" />
+                    ) : (
+                      <IconMessageCircle className="size-4" />
+                    )}
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block truncate text-sm font-medium">
+                      {recipient.name}
+                    </span>
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {recipient.email}
+                    </span>
+                  </span>
+                </Button>
+              ))
+            )}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/conversations/message-composer.tsx
+++ b/src/components/conversations/message-composer.tsx
@@ -106,6 +106,10 @@ type MessageComposerProps = {
   readonly organizationId: string
   readonly isProjectChannel?: boolean
   readonly projectRecipients?: readonly ProjectRecipientContact[]
+  readonly initialMention?: {
+    readonly userId: string
+    readonly label: string
+  }
   readonly threadId?: string
   readonly placeholder?: string
   readonly onSent?: () => void
@@ -316,6 +320,7 @@ export function MessageComposer({
   organizationId,
   isProjectChannel = false,
   projectRecipients = [],
+  initialMention,
   threadId,
   placeholder,
   onSent,
@@ -336,6 +341,7 @@ export function MessageComposer({
   const [hasMessageContent, setHasMessageContent] = React.useState(false)
   const hasProjectDelivery = isProjectChannel && !threadId
   const fileInputRef = React.useRef<HTMLInputElement>(null)
+  const appliedInitialMentionRef = React.useRef<string | null>(null)
 
   const lastTypingSentRef = React.useRef<number>(0)
   const TYPING_DEBOUNCE_MS = 3000
@@ -365,7 +371,7 @@ export function MessageComposer({
         transformCopiedText: true,
       }),
       Placeholder.configure({
-        placeholder: placeholder ?? `Message #${channelName}`,
+        placeholder: placeholder ?? `Message ${channelName}`,
       }),
       Link.configure({
         openOnClick: false,
@@ -398,6 +404,34 @@ export function MessageComposer({
       sendTypingIndicator()
     },
   })
+
+  React.useEffect(() => {
+    if (!editor || !initialMention) return
+    const mentionKey = `${initialMention.userId}:${initialMention.label}`
+    if (appliedInitialMentionRef.current === mentionKey) return
+
+    editor.commands.setContent({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "mention",
+              attrs: {
+                id: initialMention.userId,
+                label: initialMention.label,
+              },
+            },
+            { type: "text", text: " " },
+          ],
+        },
+      ],
+    })
+    editor.commands.focus("end")
+    setHasMessageContent(true)
+    appliedInitialMentionRef.current = mentionKey
+  }, [editor, initialMention])
 
   const recipientOptions = React.useMemo(() => {
     return buildRecipientOptions(projectRecipients)
@@ -700,7 +734,7 @@ export function MessageComposer({
                   </PopoverContent>
                 </Popover>
                 <Badge variant="outline" className="rounded-md">
-                  #{channelName}
+                  {channelName}
                 </Badge>
                 {recipientValue !== "channel" && (
                   <Button

--- a/src/components/conversations/search-dialog.tsx
+++ b/src/components/conversations/search-dialog.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { normalizeConversationMentions } from "@/lib/conversations/message-content"
 import { formatDistanceToNow, format, parseISO } from "date-fns"
-import { IconHash, IconUser, IconCalendar, IconSearch, IconLoader2 } from "@tabler/icons-react"
+import { IconMessageCircle, IconUser, IconCalendar, IconSearch, IconLoader2 } from "@tabler/icons-react"
 import {
   CommandDialog,
   CommandList,
@@ -194,7 +194,7 @@ export function SearchDialog({
       <div className="flex items-center gap-2 border-b px-3 py-2">
         <Select value={selectedChannel} onValueChange={setSelectedChannel}>
           <SelectTrigger size="sm" className="h-7 text-xs">
-            <IconHash className="mr-1 size-3" />
+            <IconMessageCircle className="mr-1 size-3" />
             <SelectValue placeholder="Channel" />
           </SelectTrigger>
           <SelectContent>
@@ -310,7 +310,7 @@ export function SearchDialog({
                     <div className="flex items-center gap-2">
                       <span className="text-sm font-medium">{displayName}</span>
                       <span className="text-xs text-muted-foreground">
-                        in #{message.channelName}
+                        in {message.channelName}
                       </span>
                     </div>
                     <p className="mt-0.5 truncate text-sm text-muted-foreground">

--- a/src/components/nav-conversations.tsx
+++ b/src/components/nav-conversations.tsx
@@ -3,8 +3,11 @@
 import * as React from "react"
 import {
   IconArrowLeft,
-  IconHash,
+  IconBuilding,
+  IconMessageCircle,
+  IconMessages,
   IconPlus,
+  IconUser,
 } from "@tabler/icons-react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
@@ -30,6 +33,7 @@ import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { CreateChannelDialog } from "@/components/conversations/create-channel-dialog"
 import { VoiceChannelStub } from "@/components/conversations/voice-channel-stub"
+import { DirectMessageDialog } from "@/components/conversations/direct-message-dialog"
 import { ChevronRight } from "lucide-react"
 
 type ChannelData = {
@@ -38,6 +42,7 @@ type ChannelData = {
   readonly type: string
   readonly projectId: string | null
   readonly categoryId: string | null
+  readonly audience: string
   readonly unreadCount: number | null
 }
 
@@ -68,6 +73,7 @@ export function NavConversations() {
   const [projects, setProjects] = React.useState<ProjectListItem[]>([])
   const [loading, setLoading] = React.useState(true)
   const [createDialogOpen, setCreateDialogOpen] = React.useState(false)
+  const [directDialogOpen, setDirectDialogOpen] = React.useState(false)
   const [projectsOpen, setProjectsOpen] = React.useState(true)
   const [categoryCollapsedStates, setCategoryCollapsedStates] = React.useState<
     Record<string, boolean>
@@ -98,6 +104,7 @@ export function NavConversations() {
             type: c.type,
             projectId: c.projectId,
             categoryId: c.categoryId,
+            audience: c.audience,
             unreadCount: c.unreadCount,
           }))
         )
@@ -119,10 +126,17 @@ export function NavConversations() {
       setLoading(false)
     }
     loadData()
-  }, [])
+  }, [pathname])
 
   const globalChannels = channels.filter(
-    (c) => !c.projectId && !c.categoryId && c.type === "text"
+    (c) =>
+      !c.projectId &&
+      !c.categoryId &&
+      c.type === "text" &&
+      c.audience !== "direct"
+  )
+  const directChannels = channels.filter(
+    (channel) => channel.type === "text" && channel.audience === "direct"
   )
   const projectChannels = channels.filter((c) => c.projectId && c.type === "text")
   const voiceChannels = channels.filter((c) => c.type === "voice")
@@ -187,7 +201,13 @@ export function NavConversations() {
         )}
       >
         <Link href={`/dashboard/conversations/${channel.id}`}>
-          <IconHash className="shrink-0" />
+          {channel.audience === "direct" ? (
+            <IconUser className="shrink-0" />
+          ) : channel.projectId ? (
+            <IconBuilding className="shrink-0" />
+          ) : (
+            <IconMessageCircle className="shrink-0" />
+          )}
           <span className={cn(channel.unreadCount && channel.unreadCount > 0 && "font-semibold")}>
             {channel.name}
           </span>
@@ -235,7 +255,7 @@ export function NavConversations() {
 
       {/* uncategorized channels */}
       <SidebarGroup>
-        <SidebarGroupLabel>CHANNELS</SidebarGroupLabel>
+        <SidebarGroupLabel>MESSAGES</SidebarGroupLabel>
         <SidebarGroupContent>
           <SidebarMenu>
             {loading ? (
@@ -248,6 +268,39 @@ export function NavConversations() {
               </SidebarMenuItem>
             ) : (
               globalChannels.map(renderChannelItem)
+            )}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+
+      <SidebarGroup>
+        <SidebarGroupLabel className="justify-between">
+          <span>DIRECT MESSAGES</span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6"
+            aria-label="New direct message"
+            onClick={() => setDirectDialogOpen(true)}
+          >
+            <IconPlus className="size-3.5" />
+          </Button>
+        </SidebarGroupLabel>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            {directChannels.length > 0 ? (
+              directChannels.map(renderChannelItem)
+            ) : (
+              <SidebarMenuItem>
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-xs text-muted-foreground hover:text-foreground"
+                  onClick={() => setDirectDialogOpen(true)}
+                >
+                  <IconMessages className="size-4" />
+                  Start a direct message
+                </button>
+              </SidebarMenuItem>
             )}
           </SidebarMenu>
         </SidebarGroupContent>
@@ -294,7 +347,7 @@ export function NavConversations() {
           <SidebarGroup>
             <SidebarGroupLabel asChild>
               <CollapsibleTrigger className="group/collapsible">
-                PROJECT CHANNELS
+                PROJECT MESSAGES
                 <ChevronRight className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-90" />
               </CollapsibleTrigger>
             </SidebarGroupLabel>
@@ -353,6 +406,10 @@ export function NavConversations() {
       </div>
 
       <CreateChannelDialog open={createDialogOpen} onOpenChange={setCreateDialogOpen} />
+      <DirectMessageDialog
+        open={directDialogOpen}
+        onOpenChange={setDirectDialogOpen}
+      />
     </>
   )
 }

--- a/src/components/projects/project-audience-conversation.tsx
+++ b/src/components/projects/project-audience-conversation.tsx
@@ -68,10 +68,15 @@ export async function ProjectAudienceConversation({
   projectId,
   channelId,
   audience,
+  initialMention,
 }: {
   readonly projectId: string
   readonly channelId: string
   readonly audience: ProjectAudience
+  readonly initialMention?: {
+    readonly userId: string
+    readonly label: string
+  }
 }): Promise<React.ReactElement> {
   const { preview, channel, messages } = await loadConversation(
     projectId,
@@ -121,6 +126,7 @@ export async function ProjectAudienceConversation({
                 channelName={channel.name}
                 organizationId={channel.organizationId}
                 isProjectChannel={false}
+                initialMention={initialMention}
               />
             </div>
             <ThreadPanel />

--- a/src/components/projects/project-audience-notification-settings.tsx
+++ b/src/components/projects/project-audience-notification-settings.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import { IconBell } from "@tabler/icons-react"
+
+import { PreferencesTab } from "@/components/settings/preferences-tab"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { cn } from "@/lib/utils"
+
+export function ProjectAudienceNotificationSettings({
+  compact = false,
+  className,
+}: {
+  readonly compact?: boolean
+  readonly className?: string
+}): React.ReactElement {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size={compact ? "icon" : "sm"}
+          className={cn(!compact && "w-full justify-start", className)}
+          aria-label={compact ? "Notification settings" : undefined}
+        >
+          <IconBell className="size-4" />
+          {!compact && "Notifications"}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[90vh] gap-0 overflow-hidden p-0 sm:max-w-2xl">
+        <DialogHeader className="border-b px-6 py-5">
+          <DialogTitle>Notification settings</DialogTitle>
+          <DialogDescription>
+            Choose how Compass should alert you about project activity and
+            direct mentions.
+          </DialogDescription>
+        </DialogHeader>
+        <ScrollArea className="max-h-[calc(90vh-7rem)]">
+          <div className="p-6">
+            <PreferencesTab />
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/projects/project-audience-preview-shell.tsx
+++ b/src/components/projects/project-audience-preview-shell.tsx
@@ -1,7 +1,7 @@
 import type * as React from "react"
+import Image from "next/image"
 import Link from "next/link"
 import {
-  IconBuilding,
   IconCalendar,
   IconChevronDown,
   IconClipboardCheck,
@@ -30,6 +30,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { ProjectAudiencePreviewWindowControls } from "@/components/projects/project-audience-preview-window-controls"
 import { ProjectAudienceSidebarProfile } from "@/components/projects/project-audience-sidebar-profile"
+import { ProjectAudienceNotificationSettings } from "@/components/projects/project-audience-notification-settings"
 import { cn } from "@/lib/utils"
 
 type PreviewNavigationItem = {
@@ -154,12 +155,18 @@ export function ProjectAudiencePreviewShell({
       <aside className="sticky top-0 hidden h-screen flex-col border-r bg-sidebar text-sidebar-foreground md:flex">
         <div className="border-b border-sidebar-border p-4">
           <Link href={homeHref} className="flex items-center gap-3">
-            <span className="grid size-9 shrink-0 place-items-center bg-primary text-primary-foreground">
-              <IconBuilding className="size-5" />
+            <span className="grid size-10 shrink-0 place-items-center bg-white p-1">
+              <Image
+                src="/department-logos/hps-h-green.svg"
+                alt="High Performance Structures"
+                width={34}
+                height={34}
+                className="size-full object-contain"
+              />
             </span>
             <span className="min-w-0">
-              <span className="block truncate text-sm font-semibold">
-                Compass
+              <span className="block text-xs font-semibold leading-tight">
+                High Performance Structures Inc.
               </span>
               <span className="block truncate text-xs text-sidebar-foreground/65">
                 {audience === "owner" ? "Owner workspace" : "Partner workspace"}
@@ -289,7 +296,10 @@ export function ProjectAudiencePreviewShell({
                 {audience === "owner" ? "Owner Compass" : "Partner Compass"}
               </p>
             </Link>
-            <Badge variant="outline">Compass</Badge>
+            <div className="flex items-center gap-1">
+              <ProjectAudienceNotificationSettings compact />
+              <Badge variant="outline">Compass</Badge>
+            </div>
           </div>
           <nav className="mt-3 flex gap-1 overflow-x-auto border-t pt-2">
             {navigation.map((item) => (

--- a/src/components/projects/project-audience-preview.tsx
+++ b/src/components/projects/project-audience-preview.tsx
@@ -195,7 +195,7 @@ function MessageChannelRow({
       className="block rounded-md border bg-background p-3 transition-colors hover:bg-accent"
     >
       <div className="flex items-center justify-between gap-3">
-        <p className="line-clamp-1 text-sm font-medium">#{channel.name}</p>
+        <p className="line-clamp-1 text-sm font-medium">{channel.name}</p>
         <Badge variant={channel.isPrivate ? "secondary" : "outline"}>
           {channel.isPrivate ? "Private" : "Project"}
         </Badge>
@@ -258,8 +258,10 @@ function AudienceConversationSection({
 
 function ContactRow({
   contact,
+  messageHref,
 }: {
   readonly contact: AudienceContact
+  readonly messageHref?: string | null
 }): React.ReactElement {
   const detail = [
     contact.companyName,
@@ -293,8 +295,31 @@ function ContactRow({
         {contact.email && <span>{contact.email}</span>}
         {contact.phone && <span>{contact.phone}</span>}
       </div>
+      {messageHref && (
+        <Button asChild variant="outline" size="sm" className="mt-3">
+          <Link href={messageHref}>
+            <IconMessageCircle className="size-4" />
+            Message {contact.displayName}
+          </Link>
+        </Button>
+      )}
     </article>
   )
+}
+
+function contactMessageHref(
+  data: ProjectAudiencePreviewData,
+  contact: AudienceContact
+): string | null {
+  const channel = data.messageChannels[0]
+  if (data.viewerIsInternal || !channel || !contact.userId) return null
+  const routeAudience = data.audience === "owner" ? "owner" : "sub-vendor"
+  const href = projectAudienceConversationHref(
+    data.project.id,
+    routeAudience,
+    channel.id
+  )
+  return `${href}?mention=${encodeURIComponent(contact.userId)}&label=${encodeURIComponent(contact.displayName)}`
 }
 
 function ownerHeroTitle(data: ProjectAudiencePreviewData): string {
@@ -634,7 +659,11 @@ function OwnerProjectPreview({
             {data.contacts.length > 0 ? (
               <div className="mt-4 grid gap-3 md:grid-cols-2">
                 {data.contacts.map((contact) => (
-                  <ContactRow key={contact.id} contact={contact} />
+                  <ContactRow
+                    key={contact.id}
+                    contact={contact}
+                    messageHref={contactMessageHref(data, contact)}
+                  />
                 ))}
               </div>
             ) : (
@@ -822,7 +851,11 @@ export function ProjectAudiencePreview({
           {data.contacts.length > 0 ? (
             <div className="mt-4 grid gap-3 md:grid-cols-2">
               {data.contacts.map((contact) => (
-                <ContactRow key={contact.id} contact={contact} />
+                <ContactRow
+                  key={contact.id}
+                  contact={contact}
+                  messageHref={contactMessageHref(data, contact)}
+                />
               ))}
             </div>
           ) : (

--- a/src/components/projects/project-audience-sidebar-profile.tsx
+++ b/src/components/projects/project-audience-sidebar-profile.tsx
@@ -21,6 +21,7 @@ import { useCompassTheme, useTheme } from "@/components/theme-provider"
 import { THEME_PRESETS } from "@/lib/theme/presets"
 import { sidebarDeskPhotoStorageKey } from "@/lib/user-photo-storage"
 import { cn } from "@/lib/utils"
+import { ProjectAudienceNotificationSettings } from "@/components/projects/project-audience-notification-settings"
 
 type AudienceViewer = {
   readonly name: string
@@ -151,6 +152,8 @@ export function ProjectAudienceSidebarProfile({
           <IconCamera className="size-3.5" />
         </span>
       </button>
+
+      <ProjectAudienceNotificationSettings />
 
       <Popover>
         <PopoverTrigger asChild>

--- a/src/lib/notifications/events.ts
+++ b/src/lib/notifications/events.ts
@@ -63,6 +63,7 @@ type ChannelMessageNotificationInput = {
   readonly projectId: string | null
   readonly channelId: string
   readonly channelName: string
+  readonly href?: string
   readonly messageId: string
   readonly threadId: string | null
   readonly content: string
@@ -204,10 +205,10 @@ export async function notifyChannelMessage(
     sourceType: "message",
     sourceId: input.messageId,
     title: input.threadId
-      ? `${senderName} replied in #${input.channelName}`
-      : `${senderName} in #${input.channelName}`,
+      ? `${senderName} replied in ${input.channelName}`
+      : `${senderName} in ${input.channelName}`,
     body: notificationPreview(input.content),
-    href: `/dashboard/conversations/${input.channelId}`,
+    href: input.href ?? `/dashboard/conversations/${input.channelId}`,
     priority: "normal",
     audience: "channel",
     createdBy: input.sender.id,


### PR DESCRIPTION
## What changed

- fixes mention text delivery for active internal coworkers who are tagged in public/internal channels, while preserving private owner/sub/direct-message membership boundaries and channel mute preferences
- restores staff direct messages with an internal-only recipient picker and private deterministic conversations
- adds notification, email, push, and SMS opt-in settings to owner/sub workspaces on desktop and mobile
- routes owner/sub conversation notifications back to their guarded portal pages
- refreshes conversation navigation and removes the noisy hash-channel presentation
- limits owner/sub team directories to internal project staff and lets an external user open the guarded project conversation with a chosen staff member pre-mentioned
- restores High Performance Structures Inc. branding in the owner/sub sidebar

## Root cause

The mention picker could select any coworker in the organization, but mention delivery only resolved existing channel members. Those tagged coworkers never reached the SMS delivery selection even when their current consent and mention-text preferences were enabled.

## Validation

- `bun run lint -- --quiet`
- `bunx tsc --noEmit`
- `bunx next build --webpack`
- focused notification and project-audience tests: 8 passing
- manual permission/privacy review; fixed the discovered muted-member delivery edge case

The structured autoreview helper could not run because the execution policy blocked transmitting the source bundle to its external review service.
