### PR TITLE
fix(schedule): improve portal gantt navigation

### DIFF
--- a/src/components/projects/project-audience-schedule.tsx
+++ b/src/components/projects/project-audience-schedule.tsx
@@ -13,6 +13,7 @@ import type { AudienceScheduleItem } from "@/app/actions/project-audience-previe
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
+  centeredTimelineScrollLeft,
   lockWheelToDominantAxis,
   normalizeWheelDelta,
 } from "@/lib/schedule/gantt-scroll"
@@ -145,6 +146,13 @@ function ProjectAudienceGantt({
   const pendingAnchorDateRef = React.useRef<string | null>(null)
   const didInitialScrollRef = React.useRef(false)
   const [viewMode, setViewMode] = React.useState<GanttViewMode>("Week")
+  const [selectedItemId, setSelectedItemId] = React.useState<string | null>(
+    null
+  )
+  const [horizontalScroll, setHorizontalScroll] = React.useState({
+    value: 0,
+    maximum: 0,
+  })
   const today = dateKey(new Date())
   const range = React.useMemo(() => {
     const earliestItem = items.reduce(
@@ -275,17 +283,14 @@ function ProjectAudienceGantt({
     (date: string, behavior: ScrollBehavior = "smooth") => {
       const container = scrollContainerRef.current
       if (!container) return
-      const center =
-        daysBetween(range.start, date) * range.dayWidth +
-        range.dayWidth / 2
       container.scrollTo({
-        left: Math.max(
-          0,
-          Math.min(
-            labelWidth + center - container.clientWidth / 2,
-            container.scrollWidth - container.clientWidth
-          )
-        ),
+        left: centeredTimelineScrollLeft({
+          dayOffset: daysBetween(range.start, date),
+          dayWidth: range.dayWidth,
+          labelWidth,
+          clientWidth: container.clientWidth,
+          scrollWidth: container.scrollWidth,
+        }),
         behavior,
       })
     },
@@ -299,7 +304,8 @@ function ProjectAudienceGantt({
       if (container) {
         const timelineCenter = Math.max(
           0,
-          container.scrollLeft + container.clientWidth / 2 - labelWidth
+          container.scrollLeft +
+            Math.max(0, container.clientWidth - labelWidth) / 2
         )
         pendingAnchorDateRef.current = dateKey(
           addDays(
@@ -355,8 +361,48 @@ function ProjectAudienceGantt({
     }
   }, [scrollToDate, today])
 
+  React.useEffect(() => {
+    const container = scrollContainerRef.current
+    if (!container) return
+
+    const updateHorizontalScroll = () => {
+      setHorizontalScroll({
+        value: container.scrollLeft,
+        maximum: Math.max(0, container.scrollWidth - container.clientWidth),
+      })
+    }
+    const resizeObserver = new ResizeObserver(updateHorizontalScroll)
+    resizeObserver.observe(container)
+    const content = container.firstElementChild
+    if (content) resizeObserver.observe(content)
+    container.addEventListener("scroll", updateHorizontalScroll, {
+      passive: true,
+    })
+    requestAnimationFrame(updateHorizontalScroll)
+
+    return () => {
+      resizeObserver.disconnect()
+      container.removeEventListener("scroll", updateHorizontalScroll)
+    }
+  }, [items.length, range.chartWidth])
+
+  const scrollToItem = React.useCallback(
+    (item: AudienceScheduleItem) => {
+      const duration = Math.max(
+        0,
+        daysBetween(item.startDate, item.endDate)
+      )
+      const midpoint = dateKey(
+        addDays(dateFromKey(item.startDate), Math.floor(duration / 2))
+      )
+      setSelectedItemId(item.id)
+      scrollToDate(midpoint)
+    },
+    [scrollToDate]
+  )
+
   return (
-    <div>
+    <div className="min-w-0">
       <div className="flex flex-wrap items-center justify-between gap-2 border-b bg-muted/15 px-4 py-2">
         <div
           className="flex items-center border bg-background"
@@ -388,7 +434,7 @@ function ProjectAudienceGantt({
       </div>
       <div
         ref={scrollContainerRef}
-        className="max-h-[34rem] overflow-auto overscroll-contain [scrollbar-gutter:stable]"
+        className="max-h-[34rem] overflow-scroll overscroll-contain [scrollbar-gutter:stable_both-edges]"
         aria-label="Read-only project Gantt chart"
       >
         <div
@@ -441,9 +487,16 @@ function ProjectAudienceGantt({
 
             return (
               <div key={item.id} className="flex h-14 border-b">
-                <div
-                  className="sticky left-0 z-10 flex shrink-0 flex-col justify-center border-r bg-background px-4"
+                <button
+                  type="button"
+                  className={cn(
+                    "sticky left-0 z-10 flex shrink-0 flex-col justify-center border-r bg-background px-4 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-inset",
+                    selectedItemId === item.id && "bg-accent"
+                  )}
                   style={{ width: labelWidth }}
+                  aria-label={`Show ${item.title} on the timeline`}
+                  aria-pressed={selectedItemId === item.id}
+                  onClick={() => scrollToItem(item)}
                 >
                   <span className="truncate text-xs font-medium">
                     {item.title}
@@ -451,7 +504,7 @@ function ProjectAudienceGantt({
                   <span className="mt-0.5 truncate text-[10px] text-muted-foreground">
                     {formatDate(item.startDate)} – {formatDate(item.endDate)}
                   </span>
-                </div>
+                </button>
                 <div
                   className="relative shrink-0"
                   style={{
@@ -471,7 +524,11 @@ function ProjectAudienceGantt({
                     }}
                   />
                   <div
-                    className="absolute top-3 h-8 overflow-hidden rounded-sm border border-primary/30 bg-primary/15"
+                    className={cn(
+                      "absolute top-3 h-8 overflow-hidden rounded-sm border border-primary/30 bg-primary/15 transition-shadow",
+                      selectedItemId === item.id &&
+                        "ring-2 ring-primary ring-offset-1"
+                    )}
                     style={{ left, width }}
                     title={`${item.title}: ${percentComplete}% complete`}
                   >
@@ -488,6 +545,29 @@ function ProjectAudienceGantt({
             )
           })}
         </div>
+      </div>
+      <div className="flex items-center gap-3 border-t bg-background px-3 py-2">
+        <span className="shrink-0 text-[11px] font-medium text-muted-foreground">
+          Timeline
+        </span>
+        <input
+          type="range"
+          min={0}
+          max={Math.max(1, horizontalScroll.maximum)}
+          step={1}
+          value={Math.min(
+            horizontalScroll.value,
+            Math.max(1, horizontalScroll.maximum)
+          )}
+          disabled={horizontalScroll.maximum === 0}
+          aria-label="Scroll Gantt timeline horizontally"
+          className="h-2 w-full cursor-ew-resize accent-primary disabled:cursor-default disabled:opacity-40"
+          onChange={(event) => {
+            const container = scrollContainerRef.current
+            if (!container) return
+            container.scrollLeft = Number(event.currentTarget.value)
+          }}
+        />
       </div>
     </div>
   )

--- a/src/lib/schedule/__tests__/gantt-scroll.test.ts
+++ b/src/lib/schedule/__tests__/gantt-scroll.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  centeredTimelineScrollLeft,
   dominantScrollAxis,
   ganttRowIndexForScrollTop,
   lockWheelToDominantAxis,
@@ -54,5 +55,38 @@ describe("Gantt dominant-axis scrolling", () => {
     expect(ganttRowIndexForScrollTop(133, 10)).toBe(1)
     expect(ganttRowIndexForScrollTop(10_000, 10)).toBe(9)
     expect(ganttRowIndexForScrollTop(0, 0)).toBeNull()
+  })
+
+  it("centers a selected date in the timeline beside sticky labels", () => {
+    expect(
+      centeredTimelineScrollLeft({
+        dayOffset: 50,
+        dayWidth: 20,
+        labelWidth: 240,
+        clientWidth: 1_000,
+        scrollWidth: 2_400,
+      })
+    ).toBe(630)
+  })
+
+  it("clamps timeline navigation to both scroll boundaries", () => {
+    expect(
+      centeredTimelineScrollLeft({
+        dayOffset: 0,
+        dayWidth: 20,
+        labelWidth: 240,
+        clientWidth: 1_000,
+        scrollWidth: 2_400,
+      })
+    ).toBe(0)
+    expect(
+      centeredTimelineScrollLeft({
+        dayOffset: 200,
+        dayWidth: 20,
+        labelWidth: 240,
+        clientWidth: 1_000,
+        scrollWidth: 2_400,
+      })
+    ).toBe(1_400)
   })
 })

--- a/src/lib/schedule/gantt-scroll.ts
+++ b/src/lib/schedule/gantt-scroll.ts
@@ -92,3 +92,24 @@ export function ganttRowIndexForScrollTop(
   const rowOffset = Math.max(0, scrollTop - headerHeight)
   return Math.min(itemCount - 1, Math.floor(rowOffset / rowHeight))
 }
+
+export function centeredTimelineScrollLeft(input: {
+  readonly dayOffset: number
+  readonly dayWidth: number
+  readonly labelWidth: number
+  readonly clientWidth: number
+  readonly scrollWidth: number
+}): number {
+  const visibleTimelineWidth = Math.max(
+    0,
+    input.clientWidth - input.labelWidth
+  )
+  const dateCenter =
+    input.dayOffset * input.dayWidth + input.dayWidth / 2
+  const desiredScrollLeft = dateCenter - visibleTimelineWidth / 2
+  const maximumScrollLeft = Math.max(
+    0,
+    input.scrollWidth - input.clientWidth
+  )
+  return Math.max(0, Math.min(desiredScrollLeft, maximumScrollLeft))
+}


### PR DESCRIPTION
## What changed

- adds an always-visible horizontal timeline slider to owner/sub Gantt views
- preserves synchronized vertical row movement and dominant-axis trackpad behavior
- corrects date-centering math for the sticky left label pane
- makes each left-side schedule item clickable so its bar is centered and highlighted on the timeline
- keeps Day, Week, Month, and Today navigation working with the same scroll position model

## Why

The guarded owner/sub Gantt used native overflow alone, which did not provide a dependable visible horizontal control on macOS. Its centering math also counted the sticky label width incorrectly, so item and view navigation could land off-center.

## Validation

- `bun test src/lib/schedule/__tests__/gantt-scroll.test.ts` — 9 passing
- `bunx tsc --noEmit`
- `bun run lint -- --quiet`
- `bunx next build --webpack`
- manual review of scroll bounds, sticky-label offsets, and keyboard-accessible item controls
