### PR TITLE
fix(dashboard): include active staff in office roster

### DIFF
--- a/src/app/actions/presence.ts
+++ b/src/app/actions/presence.ts
@@ -209,7 +209,7 @@ export async function getOrganizationTeamAvailability(): Promise<
         lastName: users.lastName,
         displayName: users.displayName,
         avatarUrl: users.avatarUrl,
-        role: users.role,
+        role: organizationMembers.role,
         statusMessage: userPresence.statusMessage,
         lastActiveAt: userPresence.lastActiveAt,
         updatedAt: userPresence.updatedAt,

--- a/src/lib/dashboard/__tests__/office-status.test.ts
+++ b/src/lib/dashboard/__tests__/office-status.test.ts
@@ -109,7 +109,41 @@ describe("teamAvailabilityFromRows", () => {
     ])
   })
 
-  it("omits staff who have not set dashboard availability", () => {
+  it("uses the visible in-office default when an active staff member has no saved label", () => {
+    expect(
+      teamAvailabilityFromRows(
+        [
+          {
+            userId: "cassandra",
+            email: "cassandra@example.com",
+            firstName: "Cassandra",
+            lastName: "Example",
+            displayName: "Cassandra Example",
+            avatarUrl: null,
+            role: "office",
+            statusMessage: null,
+            lastActiveAt: "2026-07-27T15:45:00.000Z",
+            updatedAt: "2026-07-27T16:00:00.000Z",
+          },
+        ],
+        "martine",
+        new Date("2026-07-27T16:00:00.000Z")
+      )
+    ).toEqual([
+      {
+        userId: "cassandra",
+        name: "Cassandra Example",
+        avatarUrl: null,
+        status: "in-office",
+        activity: "active",
+        lastActiveAt: "2026-07-27T15:45:00.000Z",
+        updatedAt: "2026-07-27T16:00:00.000Z",
+        isCurrentUser: false,
+      },
+    ])
+  })
+
+  it("omits staff who have never established presence", () => {
     expect(
       teamAvailabilityFromRows(
         [

--- a/src/lib/dashboard/office-status.ts
+++ b/src/lib/dashboard/office-status.ts
@@ -91,7 +91,12 @@ export function teamAvailabilityFromRows(
   for (const row of rows) {
     if (!isInternalStaffRole(row.role)) continue
 
-    const status = deskStatusFromPresenceMessage(row.statusMessage)
+    // The dashboard presents "In Office" as the initial designation. A staff
+    // member who already has a presence record must therefore remain visible
+    // to coworkers even when that initial label has not yet been persisted.
+    const status =
+      deskStatusFromPresenceMessage(row.statusMessage) ??
+      (row.updatedAt ? "in-office" : null)
     if (!status) continue
     const lastActiveTimestamp = row.lastActiveAt
       ? new Date(row.lastActiveAt).getTime()


### PR DESCRIPTION
## What changed

- keeps active internal HPS staff visible in Who's in today when they have a current presence record but have not explicitly saved the dashboard's default In Office label
- uses the organization membership role, rather than the legacy global user role, when determining internal roster eligibility
- continues excluding inactive/external users and users who have never established presence

## Root cause

The dashboard locally displayed In Office as the initial designation, but the shared roster discarded staff whose persisted `status_message` was still null. Cassandra therefore saw the default locally while coworkers could not see her.

## Production evidence

A read-only D1 check confirmed Cassandra is an active HPS office member with a current online presence and recent activity. Her only missing field was the optional saved location label.

## Validation

- `bun test src/lib/dashboard/__tests__/office-status.test.ts` — 9 passing
- `bun run lint -- --quiet`
- `bunx tsc --noEmit`
- `bunx next build --webpack`
- manual eligibility/privacy review

The structured autoreview helper could not start because the sandbox made its local Codex state database read-only; no source bundle was transmitted outside the approved environment.
