### PR TITLE
feat(contacts): show Compass access status

### DIFF
--- a/src/app/actions/project-contacts.ts
+++ b/src/app/actions/project-contacts.ts
@@ -1,13 +1,15 @@
 "use server"
 
-import { and, asc, eq, inArray, or } from "drizzle-orm"
+import { and, asc, desc, eq, inArray, or } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
 import {
   organizationMembers,
+  projectAccessInvitations,
   projectContacts,
   projectContactSourceLinks,
+  projectMembers,
   projects,
   users,
   vendors,
@@ -17,6 +19,11 @@ import { getCloudflareContext } from "@/lib/db"
 import { isDemoUser } from "@/lib/demo"
 import { requireOrg } from "@/lib/org-scope"
 import { requirePermission } from "@/lib/permissions"
+import {
+  projectContactAccessStatus,
+  type ProjectContactAccessStatus,
+  type ProjectContactInvitationSnapshot,
+} from "@/lib/project-contact-access-status"
 
 export type ProjectContactType =
   | "owner"
@@ -50,6 +57,7 @@ export type ProjectContactItem = {
   readonly active: boolean
   readonly syncStatus: string
   readonly lastSyncedAt: string | null
+  readonly accessStatus: ProjectContactAccessStatus
 }
 
 export type ProjectContactGroup = {
@@ -250,7 +258,8 @@ function requireLinkIds(formData: FormData): readonly string[] {
 }
 
 function toContactItem(
-  row: typeof projectContacts.$inferSelect
+  row: typeof projectContacts.$inferSelect,
+  accessStatus: ProjectContactAccessStatus = "not_invited"
 ): ProjectContactItem {
   return {
     id: row.id,
@@ -276,6 +285,7 @@ function toContactItem(
     active: row.active,
     syncStatus: row.syncStatus,
     lastSyncedAt: row.lastSyncedAt,
+    accessStatus,
   }
 }
 
@@ -480,7 +490,83 @@ export async function getProjectContactsSummary(
       asc(projectContacts.displayName)
     )
 
-  const allContacts = rows.map(toContactItem)
+  const invitationRows = await db
+    .select({
+      projectContactId: projectAccessInvitations.projectContactId,
+      email: projectAccessInvitations.email,
+      status: projectAccessInvitations.status,
+      workosExpiresAt: projectAccessInvitations.workosExpiresAt,
+      acceptedUserActive: users.isActive,
+      invitedAt: projectAccessInvitations.invitedAt,
+    })
+    .from(projectAccessInvitations)
+    .leftJoin(users, eq(users.id, projectAccessInvitations.acceptedBy))
+    .where(eq(projectAccessInvitations.projectId, projectId))
+    .orderBy(desc(projectAccessInvitations.invitedAt))
+  const activeProjectMemberRows = await db
+    .select({
+      userId: users.id,
+      email: users.email,
+    })
+    .from(projectMembers)
+    .innerJoin(users, eq(users.id, projectMembers.userId))
+    .where(
+      and(
+        eq(projectMembers.projectId, projectId),
+        eq(users.isActive, true)
+      )
+    )
+  const latestInvitationByContactId = new Map<
+    string,
+    ProjectContactInvitationSnapshot
+  >()
+  const latestInvitationByEmail = new Map<
+    string,
+    ProjectContactInvitationSnapshot
+  >()
+  for (const invitation of invitationRows) {
+    const snapshot: ProjectContactInvitationSnapshot = {
+      status: invitation.status,
+      workosExpiresAt: invitation.workosExpiresAt,
+      acceptedUserActive: invitation.acceptedUserActive,
+    }
+    if (
+      invitation.projectContactId &&
+      !latestInvitationByContactId.has(invitation.projectContactId)
+    ) {
+      latestInvitationByContactId.set(invitation.projectContactId, snapshot)
+    }
+    const email = invitation.email.trim().toLowerCase()
+    if (email && !latestInvitationByEmail.has(email)) {
+      latestInvitationByEmail.set(email, snapshot)
+    }
+  }
+  const activeProjectUserIds = new Set(
+    activeProjectMemberRows.map((member) => member.userId)
+  )
+  const activeProjectEmails = new Set(
+    activeProjectMemberRows.map((member) => member.email.trim().toLowerCase())
+  )
+  const allContacts = rows.map((row) => {
+    const email = row.email?.trim().toLowerCase() ?? ""
+    const latestInvitation =
+      latestInvitationByContactId.get(row.id) ??
+      (email ? latestInvitationByEmail.get(email) : undefined) ??
+      null
+    const activeProjectMember =
+      (row.sourceEntityType === "user" &&
+        row.sourceEntityId !== null &&
+        activeProjectUserIds.has(row.sourceEntityId)) ||
+      (email.length > 0 && activeProjectEmails.has(email))
+
+    return toContactItem(
+      row,
+      projectContactAccessStatus({
+        activeProjectMember,
+        latestInvitation,
+      })
+    )
+  })
   const sourceLinks = await db
     .select({
       matchStatus: projectContactSourceLinks.matchStatus,
@@ -547,7 +633,9 @@ export async function getProjectTaskAssigneeOptions(
       asc(projectContacts.displayName)
     )
 
-  const projectContactItems = projectContactRows.map(toContactItem)
+  const projectContactItems = projectContactRows.map((row) =>
+    toContactItem(row)
+  )
   const projectSourceVendorIds = new Set(
     projectContactItems
       .map((contact) =>
@@ -642,7 +730,7 @@ export async function getProjectContactMatchReview(
       asc(projectContacts.displayName)
     )
 
-  const contacts = contactRows.map(toContactItem)
+  const contacts = contactRows.map((row) => toContactItem(row))
   const contactsById = new Map(contacts.map((contact) => [contact.id, contact]))
 
   const user = await requireAuth()

--- a/src/components/projects/project-contacts-panel.tsx
+++ b/src/components/projects/project-contacts-panel.tsx
@@ -86,6 +86,37 @@ function csiLabel(contact: ProjectContactItem): string | null {
   return `${contact.csiDivision} ${contact.csiDivisionName}`
 }
 
+function accessStatusLabel(contact: ProjectContactItem): string {
+  switch (contact.accessStatus) {
+    case "active":
+      return "Active"
+    case "pending":
+      return "Pending"
+    case "expired":
+      return "Expired"
+    case "inactive":
+      return "Inactive"
+    case "not_invited":
+      return "Not invited"
+  }
+}
+
+function accessStatusBadgeVariant(
+  contact: ProjectContactItem
+): "default" | "secondary" | "destructive" | "outline" {
+  switch (contact.accessStatus) {
+    case "active":
+      return "default"
+    case "pending":
+      return "secondary"
+    case "expired":
+    case "inactive":
+      return "destructive"
+    case "not_invited":
+      return "outline"
+  }
+}
+
 function ContactCard({
   contact,
   projectId,
@@ -105,6 +136,9 @@ function ContactCard({
             <p className="line-clamp-1 text-sm font-medium">
               {contact.displayName}
             </p>
+            <Badge variant={accessStatusBadgeVariant(contact)}>
+              {accessStatusLabel(contact)}
+            </Badge>
             {contact.primaryContact && <Badge variant="secondary">Primary</Badge>}
             {csiLabel(contact) && (
               <Badge variant="outline">{csiLabel(contact)}</Badge>

--- a/src/lib/__tests__/project-contact-access-status.test.ts
+++ b/src/lib/__tests__/project-contact-access-status.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+
+import { projectContactAccessStatus } from "@/lib/project-contact-access-status"
+
+const NOW = new Date("2026-07-29T20:00:00.000Z")
+
+describe("projectContactAccessStatus", () => {
+  it("marks an active project member active without requiring an invitation", () => {
+    expect(
+      projectContactAccessStatus({
+        activeProjectMember: true,
+        latestInvitation: null,
+        now: NOW,
+      })
+    ).toBe("active")
+  })
+
+  it("distinguishes contacts who have not been invited from pending invitations", () => {
+    expect(
+      projectContactAccessStatus({
+        activeProjectMember: false,
+        latestInvitation: null,
+        now: NOW,
+      })
+    ).toBe("not_invited")
+
+    expect(
+      projectContactAccessStatus({
+        activeProjectMember: false,
+        latestInvitation: {
+          status: "sent",
+          workosExpiresAt: "2026-08-12T20:00:00.000Z",
+          acceptedUserActive: null,
+        },
+        now: NOW,
+      })
+    ).toBe("pending")
+  })
+
+  it("infers expiry even before the stored invitation status is refreshed", () => {
+    expect(
+      projectContactAccessStatus({
+        activeProjectMember: false,
+        latestInvitation: {
+          status: "sent",
+          workosExpiresAt: "2026-07-28T20:00:00.000Z",
+          acceptedUserActive: null,
+        },
+        now: NOW,
+      })
+    ).toBe("expired")
+  })
+
+  it("shows accepted deactivated accounts as inactive", () => {
+    expect(
+      projectContactAccessStatus({
+        activeProjectMember: false,
+        latestInvitation: {
+          status: "accepted",
+          workosExpiresAt: null,
+          acceptedUserActive: false,
+        },
+        now: NOW,
+      })
+    ).toBe("inactive")
+  })
+})

--- a/src/lib/project-contact-access-status.ts
+++ b/src/lib/project-contact-access-status.ts
@@ -1,0 +1,39 @@
+export type ProjectContactAccessStatus =
+  | "not_invited"
+  | "pending"
+  | "active"
+  | "expired"
+  | "inactive"
+
+export type ProjectContactInvitationSnapshot = {
+  readonly status: string
+  readonly workosExpiresAt: string | null
+  readonly acceptedUserActive: boolean | null
+}
+
+export function projectContactAccessStatus(input: {
+  readonly activeProjectMember: boolean
+  readonly latestInvitation: ProjectContactInvitationSnapshot | null
+  readonly now?: Date
+}): ProjectContactAccessStatus {
+  if (input.activeProjectMember) return "active"
+
+  const invitation = input.latestInvitation
+  if (!invitation) return "not_invited"
+
+  if (invitation.status === "accepted") {
+    return invitation.acceptedUserActive ? "active" : "inactive"
+  }
+  if (invitation.status === "expired") return "expired"
+  if (invitation.status !== "sent") return "not_invited"
+
+  const expiresAt = invitation.workosExpiresAt
+    ? new Date(invitation.workosExpiresAt).getTime()
+    : Number.NaN
+  const now = input.now ?? new Date()
+  if (Number.isFinite(expiresAt) && expiresAt <= now.getTime()) {
+    return "expired"
+  }
+
+  return "pending"
+}


### PR DESCRIPTION
## What changed

- adds a Compass access badge beside every project contact name in both the project preview and full contact directory
- distinguishes Active, Pending, Expired, Inactive, and Not invited states
- treats actual active project membership as authoritative, including existing Compass users who did not need a new invitation
- uses the newest invitation for each contact/email so resends supersede stale attempts
- infers expiration from the WorkOS deadline even before the invitation row is refreshed

## Why

Staff need to see at a glance who has activated Compass, who still has a pending invitation, and who has not yet been invited without opening the invitation workflow or checking the database.

## Privacy boundary

The badges are rendered only on internal dashboard contact surfaces. Owner/sub workspaces do not receive this account-access metadata.

## Validation

- `bun test src/lib/__tests__/project-contact-access-status.test.ts` — 4 passing
- `bun run lint -- --quiet`
- `bunx tsc --noEmit`
- `bunx next build --webpack`
- manual review of duplicate invites, expiry, deactivation, membership, and external-workspace boundaries

The structured autoreview helper could not start because the sandbox made its local Codex state database read-only; no source bundle was transmitted outside the approved environment.
