### PR TITLE
fix(portal): complete owner workspace access

### DIFF
--- a/scripts/build-buildertrend-owner-history-promotion.mjs
+++ b/scripts/build-buildertrend-owner-history-promotion.mjs
@@ -1,0 +1,83 @@
+import { writeFile } from "node:fs/promises"
+
+function sql(value) {
+  return `'${String(value).replaceAll("'", "''")}'`
+}
+
+const [outputPath, projectId, buildertrendJobId, ...participantTerms] =
+  process.argv.slice(2)
+
+if (
+  !outputPath ||
+  !projectId ||
+  !buildertrendJobId ||
+  participantTerms.length === 0
+) {
+  throw new Error(
+    "Usage: node scripts/build-buildertrend-owner-history-promotion.mjs " +
+      "<output.sql> <project-id> <buildertrend-job-id> <participant> [participant...]"
+  )
+}
+
+const archiveChannelId = `bt-message-archive-${buildertrendJobId}`
+const ownerChannelId = `project-owner-${projectId}`
+const participantFilter = participantTerms
+  .map(
+    (term) =>
+      `lower(source.content) LIKE ${sql(`%${term.trim().toLowerCase()}%`)}`
+  )
+  .join(" OR ")
+
+const statement = `
+-- Promote only Buildertrend messages that identify an approved owner
+-- participant. The staff archive remains unchanged.
+INSERT INTO messages (
+  id,
+  channel_id,
+  thread_id,
+  user_id,
+  content,
+  content_html,
+  edited_at,
+  deleted_at,
+  deleted_by,
+  is_pinned,
+  reply_count,
+  last_reply_at,
+  created_at
+)
+SELECT
+  'bt-owner-history-${buildertrendJobId}-' ||
+    replace(source.id, 'bt-message-${buildertrendJobId}-', ''),
+  ${sql(ownerChannelId)},
+  NULL,
+  source.user_id,
+  source.content,
+  source.content_html,
+  NULL,
+  NULL,
+  NULL,
+  0,
+  0,
+  NULL,
+  source.created_at
+FROM messages AS source
+WHERE source.channel_id = ${sql(archiveChannelId)}
+  AND (${participantFilter})
+ON CONFLICT(id) DO UPDATE SET
+  content = excluded.content,
+  content_html = excluded.content_html,
+  created_at = excluded.created_at;
+`.trimStart()
+
+await writeFile(outputPath, statement, "utf8")
+
+console.log(
+  JSON.stringify({
+    outputPath,
+    projectId,
+    archiveChannelId,
+    ownerChannelId,
+    participantTerms,
+  })
+)

--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -25,6 +25,8 @@ import {
   canUseProjectAudience,
   type ProjectAudience,
 } from "@/lib/project-audience-access"
+import { ensureProjectAudienceConversation } from "@/lib/project-audience-conversations"
+import { isVisibleAudienceTeamMember } from "@/lib/project-audience-team"
 import { isInternalStaffRole } from "@/lib/user-roles"
 import {
   isOwnerScheduleView,
@@ -467,6 +469,26 @@ export async function getProjectAudiencePreview(
     .where(and(eq(projectRfis.projectId, projectId), rfiVisibility))
     .orderBy(asc(projectRfis.dueDate), desc(projectRfis.submittedAt))
 
+  const audienceContactId =
+    viewerIsInternal
+      ? null
+      : contactRows.find((contact) => contact.userId === viewer.id)?.id ?? null
+  if (
+    audience === "owner" ||
+    (!viewerIsInternal && audienceContactId !== null)
+  ) {
+    await ensureProjectAudienceConversation({
+      db,
+      projectId,
+      organizationId,
+      audience,
+      contactId: audience === "owner" ? null : audienceContactId,
+      externalUserId: viewerIsInternal ? null : viewer.id,
+      createdBy: viewer.id,
+      now: new Date().toISOString(),
+    })
+  }
+
   const channelAudience =
     audience === "owner" ? "clients" : "sub_vendors"
   const messageChannelRows = await db
@@ -495,53 +517,61 @@ export async function getProjectAudiencePreview(
     )
     .orderBy(asc(channels.sortOrder), asc(channels.name))
 
-  const internalTeamRows = viewerIsInternal
-    ? []
-    : await db
-        .select({
-          id: projectMembers.id,
-          userId: users.id,
-          displayName: users.displayName,
-          email: users.email,
-          role: organizationMembers.role,
-        })
-        .from(projectMembers)
-        .innerJoin(users, eq(users.id, projectMembers.userId))
-        .innerJoin(
-          organizationMembers,
-          and(
-            eq(organizationMembers.userId, users.id),
-            eq(organizationMembers.organizationId, organizationId)
-          )
-        )
-        .where(
-          and(
-            eq(projectMembers.projectId, projectId),
-            eq(users.isActive, true)
-          )
-        )
+  const internalTeamRows = await db
+    .select({
+      id: users.id,
+      userId: users.id,
+      displayName: users.displayName,
+      email: users.email,
+      organizationRole: organizationMembers.role,
+      projectRole: projectMembers.role,
+      projectAssignedAt: projectMembers.assignedAt,
+    })
+    .from(organizationMembers)
+    .innerJoin(users, eq(users.id, organizationMembers.userId))
+    .leftJoin(
+      projectMembers,
+      and(
+        eq(projectMembers.userId, users.id),
+        eq(projectMembers.projectId, projectId)
+      )
+    )
+    .where(
+      and(
+        eq(organizationMembers.organizationId, organizationId),
+        eq(users.isActive, true)
+      )
+    )
+    .orderBy(desc(projectMembers.assignedAt), asc(users.displayName))
 
-  // External workspaces expose the authoritative internal project team only.
-  // Owners and partners do not need to see themselves or discover other
-  // external contacts assigned to the project.
-  const visibleContactRows = viewerIsInternal
-    ? contactRows
-    : internalTeamRows
-        .filter((member) => isInternalStaffRole(member.role))
-        .map((member) => ({
-          id: member.id,
-          userId: member.userId,
-          contactType: "internal",
-          displayName: member.displayName ?? member.email,
-          companyName: null,
-          role: member.role,
-          trade: null,
-          csiDivision: null,
-          csiDivisionName: null,
-          email: member.email,
-          phone: null,
-          primaryContact: false,
-        }))
+  // Audience workspaces expose the authoritative internal team only. Internal
+  // previewers receive the same directory that an owner or partner will see.
+  const visibleContactRows = Array.from(
+    new Map(
+      internalTeamRows
+        .filter((member) =>
+          isVisibleAudienceTeamMember({
+            userId: member.userId,
+            email: member.email,
+            role: member.organizationRole,
+          })
+        )
+        .map((member) => [member.userId, member])
+    ).values()
+  ).map((member) => ({
+    id: member.id,
+    userId: member.userId,
+    contactType: "internal",
+    displayName: member.displayName ?? member.email,
+    companyName: null,
+    role: member.projectRole ?? member.organizationRole,
+    trade: null,
+    csiDivision: null,
+    csiDivisionName: null,
+    email: member.email,
+    phone: null,
+    primaryContact: false,
+  }))
   const visibleContactNames = new Set(
     visibleContactRows
       .flatMap((contact) => [

--- a/src/app/actions/project-budget.ts
+++ b/src/app/actions/project-budget.ts
@@ -6,14 +6,17 @@ import { getDb } from "@/db"
 import {
   projectBudgetApplications,
   projectBudgetLines,
-  projects,
 } from "@/db/schema"
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
-import { requireOrg } from "@/lib/org-scope"
 import { requirePermission } from "@/lib/permissions"
+import { assertProjectAccess } from "@/lib/project-access"
+import {
+  effectiveProjectBudgetAudience,
+  type ProjectBudgetAudience,
+} from "@/lib/project-budget-audience"
 
-export type ProjectBudgetAudience = "internal" | "owner"
+export type { ProjectBudgetAudience } from "@/lib/project-budget-audience"
 export type ProjectBudgetDetailMode = "cost_code" | "category"
 
 export type ProjectBudgetApplicationItem = {
@@ -97,33 +100,29 @@ export type ProjectBudgetSummary = {
 type ProjectAccess = {
   readonly db: ReturnType<typeof getDb>
   readonly projectNumber: string | null
+  readonly viewerRole: string
 }
 
 async function verifyProjectAccess(projectId: string): Promise<ProjectAccess> {
   const user = await requireAuth()
   requirePermission(user, "budget", "read")
-  const orgId = requireOrg(user)
 
   const { env } = await getCloudflareContext()
   const db = getDb(env.DB)
+  const project = await assertProjectAccess(db, user, projectId)
 
-  const existing = await db
-    .select({ id: projects.id, projectNumber: projects.projectNumber })
-    .from(projects)
-    .where(and(eq(projects.id, projectId), eq(projects.organizationId, orgId)))
-    .limit(1)
-
-  const project = existing[0]
-  if (!project) {
-    throw new Error("Project not found")
+  return {
+    db,
+    projectNumber: project.projectNumber,
+    viewerRole: user.role,
   }
-
-  return { db, projectNumber: project.projectNumber }
 }
 
 function toApplicationItem(
-  row: typeof projectBudgetApplications.$inferSelect
+  row: typeof projectBudgetApplications.$inferSelect,
+  audience: ProjectBudgetAudience
 ): ProjectBudgetApplicationItem {
+  const ownerSafe = audience === "owner"
   return {
     id: row.id,
     sourceSystem: row.sourceSystem,
@@ -140,14 +139,16 @@ function toApplicationItem(
     currentPaymentDue: row.currentPaymentDue,
     balanceToFinish: row.balanceToFinish,
     ownerVisible: row.ownerVisible,
-    sourceUrl: row.sourceUrl,
-    lastSyncedAt: row.lastSyncedAt,
+    sourceUrl: ownerSafe ? null : row.sourceUrl,
+    lastSyncedAt: ownerSafe ? null : row.lastSyncedAt,
   }
 }
 
 function toLineItem(
-  row: typeof projectBudgetLines.$inferSelect
+  row: typeof projectBudgetLines.$inferSelect,
+  audience: ProjectBudgetAudience
 ): ProjectBudgetLineItem {
+  const ownerSafe = audience === "owner"
   return {
     id: row.id,
     sourceSystem: row.sourceSystem,
@@ -155,7 +156,7 @@ function toLineItem(
     csiDivision: row.csiDivision,
     csiDivisionName: row.csiDivisionName,
     description: row.description,
-    notes: row.notes,
+    notes: ownerSafe ? null : row.notes,
     originalEstimate: row.originalEstimate,
     priorChanges: row.priorChanges,
     currentChanges: row.currentChanges,
@@ -167,10 +168,10 @@ function toLineItem(
     percentComplete: row.percentComplete,
     balanceToFinish: row.balanceToFinish,
     retainageHeld: row.retainageHeld,
-    vendorName: row.vendorName,
+    vendorName: ownerSafe ? null : row.vendorName,
     ownerLabel: row.ownerLabel,
     ownerVisible: row.ownerVisible,
-    internalNotes: row.internalNotes,
+    internalNotes: ownerSafe ? null : row.internalNotes,
   }
 }
 
@@ -292,14 +293,20 @@ export async function getProjectBudgetSummary(
   audience: ProjectBudgetAudience = "internal"
 ): Promise<ProjectBudgetSummary> {
   const access = await verifyProjectAccess(projectId)
+  const effectiveAudience = effectiveProjectBudgetAudience(
+    audience,
+    access.viewerRole
+  )
   const detailMode =
-    audience === "owner" ? ownerDetailMode(access.projectNumber) : "cost_code"
+    effectiveAudience === "owner"
+      ? ownerDetailMode(access.projectNumber)
+      : "cost_code"
 
   const applicationRows = await access.db
     .select()
     .from(projectBudgetApplications)
     .where(
-      audience === "owner"
+      effectiveAudience === "owner"
         ? and(
             eq(projectBudgetApplications.projectId, projectId),
             eq(projectBudgetApplications.ownerVisible, true)
@@ -310,14 +317,14 @@ export async function getProjectBudgetSummary(
     .limit(1)
 
   const currentApplication = applicationRows[0]
-    ? toApplicationItem(applicationRows[0])
+    ? toApplicationItem(applicationRows[0], effectiveAudience)
     : null
 
   const lineRows = await access.db
     .select()
     .from(projectBudgetLines)
     .where(
-      audience === "owner"
+      effectiveAudience === "owner"
         ? and(
             eq(projectBudgetLines.projectId, projectId),
             eq(projectBudgetLines.ownerVisible, true)
@@ -326,7 +333,9 @@ export async function getProjectBudgetSummary(
     )
     .orderBy(asc(projectBudgetLines.sortOrder), asc(projectBudgetLines.costCode))
 
-  const sourceLines = lineRows.map(toLineItem)
+  const sourceLines = lineRows.map((row) =>
+    toLineItem(row, effectiveAudience)
+  )
   const allLines =
     detailMode === "category" ? buildOwnerCategoryLines(sourceLines) : sourceLines
   const divisions = buildDivisions(allLines)
@@ -342,7 +351,7 @@ export async function getProjectBudgetSummary(
   )
 
   return {
-    audience,
+    audience: effectiveAudience,
     detailMode,
     currentApplication,
     totals: {

--- a/src/app/preview/projects/[id]/owner/budget/page.tsx
+++ b/src/app/preview/projects/[id]/owner/budget/page.tsx
@@ -1,0 +1,101 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+import { notFound } from "next/navigation"
+import { IconFileDollar, IconLock } from "@tabler/icons-react"
+
+import {
+  getProjectBudgetSummary,
+  type ProjectBudgetSummary,
+} from "@/app/actions/project-budget"
+import {
+  getProjectAudiencePreview,
+  type ProjectAudiencePreview as ProjectAudiencePreviewData,
+} from "@/app/actions/project-audience-preview"
+import {
+  ProjectBudgetG703Table,
+  ProjectBudgetPanel,
+} from "@/components/projects/project-budget-panel"
+import { ProjectAudiencePreviewShell } from "@/components/projects/project-audience-preview-shell"
+
+function hasDigest(error: unknown): error is { readonly digest: string } {
+  return typeof error === "object" && error !== null && "digest" in error
+}
+
+export default async function OwnerBudgetPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  let preview: ProjectAudiencePreviewData
+  let budget: ProjectBudgetSummary
+
+  try {
+    preview = await getProjectAudiencePreview(id, "owner")
+    budget = await getProjectBudgetSummary(id, "owner")
+  } catch (error) {
+    if (hasDigest(error) && error.digest === "NEXT_NOT_FOUND") throw error
+    notFound()
+  }
+
+  return (
+    <ProjectAudiencePreviewShell
+      audience="owner"
+      projectId={preview.project.id}
+      projectName={preview.project.name}
+      projectNumber={preview.project.projectNumber}
+      projectOptions={preview.projectOptions}
+      viewer={preview.viewer}
+      viewerIsInternal={preview.viewerIsInternal}
+      activeSection="budget"
+    >
+      <main className="min-h-screen bg-muted/20 px-4 py-5 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-7xl">
+          <div className="flex flex-wrap items-start justify-between gap-4 border-b pb-4">
+            <div>
+              <div className="flex items-center gap-2">
+                <IconFileDollar className="size-5 text-primary" />
+                <h1 className="text-2xl font-semibold tracking-tight">
+                  Budget / G703
+                </h1>
+              </div>
+              <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+                Your approved Schedule of Values and current payment progress.
+              </p>
+            </div>
+            <p className="flex items-center gap-2 text-xs text-muted-foreground">
+              <IconLock className="size-4" />
+              Read-only owner view
+            </p>
+          </div>
+
+          <div className="mt-5">
+            <ProjectBudgetPanel
+              projectId={id}
+              summary={budget}
+              detailHref={null}
+            />
+          </div>
+
+          {budget.allLines.length > 0 && (
+            <section className="mt-6">
+              <div className="mb-3">
+                <h2 className="text-sm font-semibold">
+                  G703 Schedule of Values
+                </h2>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Only lines approved for owner visibility are included.
+                </p>
+              </div>
+              <ProjectBudgetG703Table
+                summary={budget}
+                showVisibility={false}
+              />
+            </section>
+          )}
+        </div>
+      </main>
+    </ProjectAudiencePreviewShell>
+  )
+}

--- a/src/components/projects/project-audience-conversation.tsx
+++ b/src/components/projects/project-audience-conversation.tsx
@@ -36,8 +36,11 @@ async function loadConversation(
   audience: ProjectAudience
 ) {
   try {
-    const [preview, channelResult, messagesResult] = await Promise.all([
-      getProjectAudiencePreview(projectId, audience),
+    // Loading the preview first synchronizes the private audience channel's
+    // current owner/partner and internal-team memberships before message
+    // authorization runs.
+    const preview = await getProjectAudiencePreview(projectId, audience)
+    const [channelResult, messagesResult] = await Promise.all([
       getChannel(channelId),
       getMessages(channelId),
     ])

--- a/src/components/projects/project-audience-preview-shell.tsx
+++ b/src/components/projects/project-audience-preview-shell.tsx
@@ -6,6 +6,7 @@ import {
   IconChevronDown,
   IconClipboardCheck,
   IconEye,
+  IconFileDollar,
   IconHome,
   IconMessageCircle,
   IconPhoto,
@@ -54,6 +55,11 @@ const OWNER_NAVIGATION: readonly PreviewNavigationItem[] = [
     label: "Schedule",
     section: "schedule",
     icon: <IconCalendar className="size-4" />,
+  },
+  {
+    label: "Budget / G703",
+    section: "budget",
+    icon: <IconFileDollar className="size-4" />,
   },
   {
     label: "Conversations",

--- a/src/components/projects/project-budget-panel.tsx
+++ b/src/components/projects/project-budget-panel.tsx
@@ -38,9 +38,11 @@ function barWidth(value: number): string {
 export function ProjectBudgetPanel({
   projectId,
   summary,
+  detailHref,
 }: {
   readonly projectId: string
   readonly summary: ProjectBudgetSummary | null
+  readonly detailHref?: string | null
 }): React.ReactElement {
   if (!summary || summary.allLines.length === 0) {
     return (
@@ -59,6 +61,10 @@ export function ProjectBudgetPanel({
   const topDivisions = summary.divisions
     .filter((division) => division.adjustedEstimate > 0)
     .slice(0, 6)
+  const resolvedDetailHref =
+    detailHref === undefined
+      ? `/dashboard/projects/${projectId}/budget`
+      : detailHref
 
   return (
     <section className="rounded-lg border p-3 sm:p-4">
@@ -83,13 +89,15 @@ export function ProjectBudgetPanel({
               ? `${summary.divisions.length} owner categories`
               : `${summary.totals.ownerVisibleLineCount} owner-visible lines`}
           </Badge>
-          <Link
-            href={`/dashboard/projects/${projectId}/budget`}
-            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-          >
-            <IconChartBar className="size-4" />
-            Open budget
-          </Link>
+          {resolvedDetailHref && (
+            <Link
+              href={resolvedDetailHref}
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+            >
+              <IconChartBar className="size-4" />
+              Open budget
+            </Link>
+          )}
         </div>
       </div>
 
@@ -176,8 +184,10 @@ export function ProjectBudgetPanel({
 
 export function ProjectBudgetG703Table({
   summary,
+  showVisibility = true,
 }: {
   readonly summary: ProjectBudgetSummary
+  readonly showVisibility?: boolean
 }): React.ReactElement {
   const showLineDetail = summary.detailMode === "cost_code"
 
@@ -196,7 +206,9 @@ export function ProjectBudgetG703Table({
             <th className="px-3 py-2 text-right font-medium">Total</th>
             <th className="px-3 py-2 text-right font-medium">%</th>
             <th className="px-3 py-2 text-right font-medium">Balance</th>
-            <th className="px-3 py-2 text-left font-medium">Visibility</th>
+            {showVisibility && (
+              <th className="px-3 py-2 text-left font-medium">Visibility</th>
+            )}
           </tr>
         </thead>
         <tbody>
@@ -230,7 +242,7 @@ export function ProjectBudgetG703Table({
                 <td className="px-3 py-2 text-right font-semibold">
                   {money(division.balanceToFinish)}
                 </td>
-                <td className="px-3 py-2" />
+                {showVisibility && <td className="px-3 py-2" />}
               </tr>
               {showLineDetail &&
                 division.lines.map((line) => (
@@ -274,16 +286,18 @@ export function ProjectBudgetG703Table({
                     <td className="px-3 py-2 text-right">
                       {money(line.balanceToFinish)}
                     </td>
-                    <td className="px-3 py-2">
-                      {line.ownerVisible ? (
-                        <Badge variant="secondary">Owner</Badge>
-                      ) : (
-                        <Badge variant="outline">
-                          <IconReceipt2 className="mr-1 size-3" />
-                          Internal
-                        </Badge>
-                      )}
-                    </td>
+                    {showVisibility && (
+                      <td className="px-3 py-2">
+                        {line.ownerVisible ? (
+                          <Badge variant="secondary">Owner</Badge>
+                        ) : (
+                          <Badge variant="outline">
+                            <IconReceipt2 className="mr-1 size-3" />
+                            Internal
+                          </Badge>
+                        )}
+                      </td>
+                    )}
                   </tr>
                 ))}
             </Fragment>

--- a/src/lib/__tests__/project-audience-preview-routes.test.ts
+++ b/src/lib/__tests__/project-audience-preview-routes.test.ts
@@ -35,6 +35,12 @@ describe("project audience preview routes", () => {
     ).toBe("/preview/projects/project%2Fone/owner")
   })
 
+  it("routes owner budget access through the guarded owner workspace", () => {
+    expect(
+      projectAudienceSectionHref("project/one", "owner", "budget")
+    ).toBe("/preview/projects/project%2Fone/owner/budget")
+  })
+
   it("keeps conversations inside the guarded audience workspace", () => {
     expect(
       projectAudienceConversationHref("project/one", "owner", "channel/two")

--- a/src/lib/__tests__/project-audience-team.test.ts
+++ b/src/lib/__tests__/project-audience-team.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+
+import { isVisibleAudienceTeamMember } from "@/lib/project-audience-team"
+
+describe("project audience team", () => {
+  it.each([
+    ["project administrator", "user-sylvi", "sylvi@example.com", "secondary_admin"],
+    ["assistant PM", "user-wes", "wes@example.com", "assistant_project_manager"],
+    ["office staff", "user-office", "office@example.com", "office"],
+  ])("shows active human %s roles", (_label, userId, email, role) => {
+    expect(isVisibleAudienceTeamMember({ userId, email, role })).toBe(true)
+  })
+
+  it.each([
+    ["external owner", "user-owner", "owner@example.com", "client"],
+    ["service agent", "svc_jarvis", "jarvis@example.com", "office"],
+    ["Compass system account", "user-compass", "compass@hps-colorado.com", "admin"],
+    ["archive account", "system-archive", "archive@compass.local", "office"],
+  ])("hides %s", (_label, userId, email, role) => {
+    expect(isVisibleAudienceTeamMember({ userId, email, role })).toBe(false)
+  })
+})

--- a/src/lib/__tests__/project-budget-audience.test.ts
+++ b/src/lib/__tests__/project-budget-audience.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+
+import { effectiveProjectBudgetAudience } from "@/lib/project-budget-audience"
+
+describe("project budget audience", () => {
+  it("allows internal staff to request internal detail", () => {
+    expect(effectiveProjectBudgetAudience("internal", "office")).toBe(
+      "internal"
+    )
+  })
+
+  it.each(["client", "subcontractor", "supplier", "guest"])(
+    "forces %s users to owner-safe detail",
+    (role) => {
+      expect(effectiveProjectBudgetAudience("internal", role)).toBe("owner")
+    }
+  )
+})

--- a/src/lib/project-audience-conversations.ts
+++ b/src/lib/project-audience-conversations.ts
@@ -3,7 +3,6 @@ import { and, eq } from "drizzle-orm"
 import type { getDb } from "@/db"
 import {
   organizationMembers,
-  projectMembers,
   projects,
   users,
 } from "@/db/schema"
@@ -13,7 +12,7 @@ import {
   channels,
 } from "@/db/schema-conversations"
 import type { ProjectAudience } from "@/lib/project-audience-access"
-import { isInternalStaffRole } from "@/lib/user-roles"
+import { isVisibleAudienceTeamMember } from "@/lib/project-audience-team"
 
 type Db = ReturnType<typeof getDb>
 
@@ -45,91 +44,95 @@ function channelName(input: {
     : `${projectLabel} · Project Team`
 }
 
-async function ensureMember(
+async function ensureMembers(
   db: Db,
   channelId: string,
-  userId: string,
-  role: "owner" | "moderator" | "member",
+  desiredMembers: readonly {
+    readonly userId: string
+    readonly role: "owner" | "moderator" | "member"
+  }[],
   now: string
 ): Promise<void> {
-  const existing = await db
-    .select({ id: channelMembers.id })
+  const existingMembers = await db
+    .select({ userId: channelMembers.userId })
     .from(channelMembers)
-    .where(
-      and(
-        eq(channelMembers.channelId, channelId),
-        eq(channelMembers.userId, userId)
-      )
-    )
-    .get()
+    .where(eq(channelMembers.channelId, channelId))
 
-  if (!existing) {
+  const existingMemberIds = new Set(
+    existingMembers.map((member) => member.userId)
+  )
+  const missingMembers = desiredMembers.filter(
+    (member) => !existingMemberIds.has(member.userId)
+  )
+  if (missingMembers.length > 0) {
     await db
       .insert(channelMembers)
-      .values({
+      .values(missingMembers.map((member) => ({
         id: crypto.randomUUID(),
         channelId,
-        userId,
-        role,
+        userId: member.userId,
+        role: member.role,
         notifyLevel: "all",
         joinedAt: now,
-      })
+      })))
       .run()
   }
 
-  const readState = await db
-    .select({ id: channelReadState.id })
+  const existingReadStates = await db
+    .select({ userId: channelReadState.userId })
     .from(channelReadState)
-    .where(
-      and(
-        eq(channelReadState.channelId, channelId),
-        eq(channelReadState.userId, userId)
-      )
-    )
-    .get()
+    .where(eq(channelReadState.channelId, channelId))
 
-  if (!readState) {
+  const existingReadStateUserIds = new Set(
+    existingReadStates.map((state) => state.userId)
+  )
+  const missingReadStates = desiredMembers.filter(
+    (member) => !existingReadStateUserIds.has(member.userId)
+  )
+  if (missingReadStates.length > 0) {
     await db
       .insert(channelReadState)
-      .values({
+      .values(missingReadStates.map((member) => ({
         id: crypto.randomUUID(),
-        userId,
+        userId: member.userId,
         channelId,
         lastReadMessageId: null,
         lastReadAt: now,
         unreadCount: 0,
-      })
+      })))
       .run()
   }
 }
 
-async function projectStaffUserIds(
+async function organizationStaffUserIds(
   db: Db,
-  projectId: string,
   organizationId: string
 ): Promise<readonly string[]> {
   const memberRows = await db
     .select({
-      userId: projectMembers.userId,
+      userId: organizationMembers.userId,
+      email: users.email,
       role: organizationMembers.role,
     })
-    .from(projectMembers)
-    .innerJoin(users, eq(users.id, projectMembers.userId))
-    .innerJoin(
-      organizationMembers,
-      and(
-        eq(organizationMembers.userId, users.id),
-        eq(organizationMembers.organizationId, organizationId)
-      )
-    )
+    .from(organizationMembers)
+    .innerJoin(users, eq(users.id, organizationMembers.userId))
     .where(
-      and(eq(projectMembers.projectId, projectId), eq(users.isActive, true))
+      and(
+        eq(organizationMembers.organizationId, organizationId),
+        eq(users.isActive, true)
+      )
     )
 
   return Array.from(
     new Set(
       memberRows
-        .filter((row) => isInternalStaffRole(row.role))
+        .filter((row) =>
+          isVisibleAudienceTeamMember({
+            userId: row.userId,
+            email: row.email,
+            role: row.role,
+          })
+        )
         .map((row) => row.userId)
     )
   )
@@ -161,6 +164,13 @@ export async function ensureProjectAudienceConversation(input: {
 
   if (!project) throw new Error("Project not found")
 
+  const staffIds = await organizationStaffUserIds(
+    input.db,
+    input.organizationId
+  )
+  const createdBy = staffIds.includes(input.createdBy)
+    ? input.createdBy
+    : staffIds[0] ?? input.createdBy
   const channelId = projectAudienceConversationId({
     projectId: input.projectId,
     audience: input.audience,
@@ -189,7 +199,7 @@ export async function ensureProjectAudienceConversation(input: {
         categoryId: null,
         isPrivate: true,
         audience: projectAudienceChannelAudience(input.audience),
-        createdBy: input.createdBy,
+        createdBy,
         sortOrder: 0,
         archivedAt: null,
         createdAt: input.now,
@@ -198,24 +208,20 @@ export async function ensureProjectAudienceConversation(input: {
       .run()
   }
 
-  const staffIds = await projectStaffUserIds(
-    input.db,
-    input.projectId,
-    input.organizationId
-  )
-  const internalIds = new Set([input.createdBy, ...staffIds])
-  for (const userId of internalIds) {
-    await ensureMember(input.db, channelId, userId, "moderator", input.now)
+  const desiredMembers: {
+    userId: string
+    role: "moderator" | "member"
+  }[] = staffIds.map((userId) => ({
+    userId,
+    role: "moderator",
+  }))
+  if (input.externalUserId && !staffIds.includes(input.externalUserId)) {
+    desiredMembers.push({
+      userId: input.externalUserId,
+      role: "member",
+    })
   }
-  if (input.externalUserId) {
-    await ensureMember(
-      input.db,
-      channelId,
-      input.externalUserId,
-      "member",
-      input.now
-    )
-  }
+  await ensureMembers(input.db, channelId, desiredMembers, input.now)
 
   return channelId
 }

--- a/src/lib/project-audience-preview-routes.ts
+++ b/src/lib/project-audience-preview-routes.ts
@@ -3,6 +3,7 @@ export type ProjectAudienceWorkspaceSection =
   | "overview"
   | "updates"
   | "schedule"
+  | "budget"
   | "commitments"
   | "rfis"
   | "conversations"

--- a/src/lib/project-audience-team.ts
+++ b/src/lib/project-audience-team.ts
@@ -1,0 +1,20 @@
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+const HIDDEN_AUDIENCE_TEAM_EMAILS = new Set([
+  "compass@hps-colorado.com",
+  "buildertrend-archive@compass.local",
+])
+
+export function isVisibleAudienceTeamMember(input: {
+  readonly userId: string
+  readonly email: string
+  readonly role: string
+}): boolean {
+  const normalizedEmail = input.email.trim().toLowerCase()
+  return (
+    isInternalStaffRole(input.role) &&
+    !input.userId.startsWith("svc_") &&
+    !normalizedEmail.endsWith("@compass.local") &&
+    !HIDDEN_AUDIENCE_TEAM_EMAILS.has(normalizedEmail)
+  )
+}

--- a/src/lib/project-budget-audience.ts
+++ b/src/lib/project-budget-audience.ts
@@ -1,0 +1,10 @@
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+export type ProjectBudgetAudience = "internal" | "owner"
+
+export function effectiveProjectBudgetAudience(
+  requestedAudience: ProjectBudgetAudience,
+  viewerRole: string
+): ProjectBudgetAudience {
+  return isInternalStaffRole(viewerRole) ? requestedAudience : "owner"
+}


### PR DESCRIPTION
## What changed

- show the same human internal team to owners and internal previewers
- synchronize private owner-channel membership before loading messages
- exclude service, archive, and Compass system identities from the owner team
- add a reusable, participant-scoped Buildertrend history promotion script
- add a guarded, read-only Owner Budget / G703 page and navigation item
- force all external budget requests to owner-safe data, regardless of the requested audience
- remove internal notes, vendor names, source links, and sync metadata from owner budget results

## Why

The Loomis owner preview did not match Tanis's actual workspace. Sylvi and Wes were missing from the team, the private message channel was not available to all human office staff, and Tanis could not see her prior Buildertrend correspondence. Owners also need approved Budget / G703 visibility without internal accounting details.

## Production data repair

The original 270-message staff-only Buildertrend archive remains unchanged. Exactly 219 messages whose archived content identifies Tanis were copied into the private Loomis owner channel. Tanis and seven human internal staff members now belong to that channel.

## Validation

- 19 focused Vitest tests passed
- TypeScript passed with `bunx tsc --noEmit`
- ESLint passed with `bun run lint -- --quiet`
- production Next.js webpack build passed
- production D1 verified 83 owner-visible Loomis G703 lines and three owner-visible pay applications
- manual privacy review confirmed external roles are forced to owner-safe budget data

## Separate draw-workflow finding

The newly staged Loomis `PAYAPP-004` is an empty Sage write-intent placeholder, not a completed invoice or G702/G703 packet. It remains unqueued and requires a separate edit/delete, validation, line-selection, preview, approval, packet-generation, and Sage-submission workflow before staff should use it for a real draw.
