### PR TITLE
fix(owner-updates): serve audience-scoped photos

### DIFF
--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -32,6 +32,7 @@ import {
   type OwnerScheduleView,
   type OwnerScheduleVisibleItem,
 } from "@/lib/schedule/owner-visibility"
+import { projectAudiencePhotoUrl } from "@/lib/photo-sources"
 
 export type { ProjectAudience } from "@/lib/project-audience-access"
 
@@ -597,8 +598,8 @@ export async function getProjectAudiencePreview(
       return {
         id: photo.id,
         fileName: photo.fileName,
-        driveFileId: photo.driveFileId,
-        thumbnailUrl: photo.thumbnailUrl,
+        driveFileId: null,
+        thumbnailUrl: projectAudiencePhotoUrl(projectId, photo.id, audience),
         caption: photo.caption,
         capturedAt: photo.capturedAt,
         photoDate: resolvedPhotoDate,

--- a/src/app/actions/project-field.ts
+++ b/src/app/actions/project-field.ts
@@ -2332,10 +2332,13 @@ export async function getOwnerProjectUpdateDocument(
       row.thumbnailUrl === null && row.mimeType?.startsWith("image/") !== true
   )
 
-  const photosForUpdate = selectRowsByIdOrder(
-    imageRows,
-    selectedPhotoIds
-  )
+  const selectedImageRows = selectRowsByIdOrder(imageRows, selectedPhotoIds)
+  const photosForUpdate = selectedImageRows
+    .filter(
+      (row) =>
+        update.status !== "published" ||
+        (row.reviewStatus === "approved" && row.ownerVisible)
+    )
     .map((row) => ({
       id: row.id,
       sourceSystem: row.sourceSystem,

--- a/src/app/api/projects/[id]/photos/[photoId]/route.ts
+++ b/src/app/api/projects/[id]/photos/[photoId]/route.ts
@@ -1,0 +1,177 @@
+import { and, eq, or } from "drizzle-orm"
+import { NextRequest } from "next/server"
+
+import { getDb } from "@/db"
+import {
+  dailyLogPhotos,
+  projectMembers,
+} from "@/db/schema"
+import { googleAuth } from "@/db/schema-google"
+import { requireAuth } from "@/lib/auth"
+import { decrypt } from "@/lib/crypto"
+import { getCloudflareContext } from "@/lib/db"
+import { DriveClient } from "@/lib/google/client/drive-client"
+import {
+  getGoogleCryptoSalt,
+  parseServiceAccountKey,
+} from "@/lib/google/config"
+import {
+  canUseProjectAudience,
+  type ProjectAudience,
+} from "@/lib/project-audience-access"
+import { assertProjectAccess } from "@/lib/project-access"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+const DEFAULT_COMPASS_GOOGLE_DOWNLOAD_USER = "compass@hps-colorado.com"
+
+function audienceValue(value: string | null): ProjectAudience | null {
+  if (value === "owner" || value === "sub_vendor") return value
+  return null
+}
+
+function environmentString(
+  env: object,
+  key: string
+): string | null {
+  const rawValue: unknown = Reflect.get(env, key)
+  if (typeof rawValue !== "string") return null
+  const value = rawValue.trim()
+  return value.length > 0 ? value : null
+}
+
+function downloadUserEmail(env: object): string {
+  return (
+    environmentString(env, "COMPASS_GOOGLE_UPLOAD_USER") ??
+    environmentString(env, "COMPASS_GOOGLE_DOWNLOAD_USER") ??
+    DEFAULT_COMPASS_GOOGLE_DOWNLOAD_USER
+  )
+}
+
+function safeFileName(value: string): string {
+  return value.replace(/["\r\n]/g, "_")
+}
+
+export async function GET(
+  request: NextRequest,
+  {
+    params,
+  }: {
+    readonly params: Promise<{
+      readonly id: string
+      readonly photoId: string
+    }>
+  }
+): Promise<Response> {
+  try {
+    const user = await requireAuth()
+    const { id: projectId, photoId } = await params
+    const audience = audienceValue(request.nextUrl.searchParams.get("audience"))
+    if (audience === null) {
+      return new Response("Photo audience is required", { status: 400 })
+    }
+
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const project = await assertProjectAccess(db, user, projectId)
+    if (!project.organizationId) {
+      return new Response("Photo not found", { status: 404 })
+    }
+
+    const viewerIsInternal = isInternalStaffRole(user.role)
+    if (!viewerIsInternal) {
+      const [membership] = await db
+        .select({ role: projectMembers.role })
+        .from(projectMembers)
+        .where(
+          and(
+            eq(projectMembers.projectId, projectId),
+            eq(projectMembers.userId, user.id)
+          )
+        )
+        .limit(1)
+      if (!canUseProjectAudience(membership?.role ?? null, audience)) {
+        return new Response("Photo not found", { status: 404 })
+      }
+    }
+
+    const visibility =
+      audience === "owner"
+        ? or(
+            eq(dailyLogPhotos.ownerVisible, true),
+            eq(dailyLogPhotos.publicShareable, true)
+          )
+        : or(
+            eq(dailyLogPhotos.subVendorVisible, true),
+            eq(dailyLogPhotos.publicShareable, true)
+          )
+    const [photo] = await db
+      .select({
+        driveFileId: dailyLogPhotos.driveFileId,
+        fileName: dailyLogPhotos.fileName,
+        mimeType: dailyLogPhotos.mimeType,
+      })
+      .from(dailyLogPhotos)
+      .where(
+        and(
+          eq(dailyLogPhotos.id, photoId),
+          eq(dailyLogPhotos.projectId, projectId),
+          eq(dailyLogPhotos.reviewStatus, "approved"),
+          visibility
+        )
+      )
+      .limit(1)
+    if (
+      !photo?.driveFileId ||
+      photo.mimeType?.startsWith("image/") !== true
+    ) {
+      return new Response("Photo not found", { status: 404 })
+    }
+
+    const [auth] = await db
+      .select()
+      .from(googleAuth)
+      .where(eq(googleAuth.organizationId, project.organizationId))
+      .limit(1)
+    if (!auth) {
+      return new Response("Photo storage is unavailable", { status: 503 })
+    }
+
+    const encryptionKey =
+      environmentString(env, "GOOGLE_SERVICE_ACCOUNT_ENCRYPTION_KEY") ??
+      process.env.GOOGLE_SERVICE_ACCOUNT_ENCRYPTION_KEY
+    if (!encryptionKey) {
+      return new Response("Photo storage is unavailable", { status: 503 })
+    }
+    const keyJson = await decrypt(
+      auth.serviceAccountKeyEncrypted,
+      encryptionKey,
+      getGoogleCryptoSalt()
+    )
+    const serviceAccountKey = parseServiceAccountKey(keyJson)
+    const client = new DriveClient({ serviceAccountKey })
+    const googleEmail = downloadUserEmail(env)
+    const response = await client.downloadFile(googleEmail, photo.driveFileId)
+    if (!response.ok) {
+      console.error("Audience photo download failed", {
+        projectId,
+        photoId,
+        status: response.status,
+      })
+      return new Response("Photo could not be loaded", {
+        status: response.status,
+      })
+    }
+
+    return new Response(response.body, {
+      headers: {
+        "Content-Type": photo.mimeType,
+        "Content-Disposition": `inline; filename="${safeFileName(photo.fileName)}"`,
+        "Cache-Control": "private, max-age=300",
+        "X-Content-Type-Options": "nosniff",
+      },
+    })
+  } catch (error) {
+    console.error("Audience photo download error", error)
+    return new Response("Photo could not be loaded", { status: 500 })
+  }
+}

--- a/src/components/projects/owner-update-document.tsx
+++ b/src/components/projects/owner-update-document.tsx
@@ -19,6 +19,7 @@ import { OwnerUpdateDraftEditor } from "@/components/projects/owner-update-draft
 import { OwnerUpdatePhotoTile } from "@/components/projects/owner-update-photo-tile"
 import { projectBrandFor } from "@/lib/project-branding"
 import { projectAudienceSectionHref } from "@/lib/project-audience-preview-routes"
+import { projectAudiencePhotoUrl } from "@/lib/photo-sources"
 
 function formatDate(value: string): string {
   return new Date(`${value}T00:00:00`).toLocaleDateString("en-US", {
@@ -314,9 +315,21 @@ export function OwnerUpdateDocument({
                   <OwnerUpdatePhotoTile
                     key={photo.id}
                     fileName={photo.fileName}
-                    driveFileId={photo.driveFileId}
+                    driveFileId={
+                      document.update.status === "published"
+                        ? null
+                        : photo.driveFileId
+                    }
                     driveUrl={photo.driveUrl}
-                    thumbnailUrl={photo.thumbnailUrl}
+                    thumbnailUrl={
+                      document.update.status === "published"
+                        ? projectAudiencePhotoUrl(
+                            document.project.id,
+                            photo.id,
+                            "owner"
+                          )
+                        : photo.thumbnailUrl
+                    }
                     caption={photo.caption}
                   />
                 ))}

--- a/src/lib/photo-sources.ts
+++ b/src/lib/photo-sources.ts
@@ -27,6 +27,7 @@ function isHttpUrl(value: string): boolean {
 function isLocalRenderablePhotoUrl(value: string): boolean {
   return (
     value.startsWith("/api/google/download/") ||
+    (value.startsWith("/api/projects/") && value.includes("/photos/")) ||
     value.startsWith("/owner-update-photos/") ||
     value.startsWith("/project-photo-previews/")
   )
@@ -34,6 +35,14 @@ function isLocalRenderablePhotoUrl(value: string): boolean {
 
 export function googleDriveDownloadUrl(fileId: string): string {
   return `/api/google/download/${encodeURIComponent(fileId)}`
+}
+
+export function projectAudiencePhotoUrl(
+  projectId: string,
+  photoId: string,
+  audience: "owner" | "sub_vendor"
+): string {
+  return `/api/projects/${encodeURIComponent(projectId)}/photos/${encodeURIComponent(photoId)}?audience=${audience}`
 }
 
 export function isLegacyExternalPhotoUrl(value: string): boolean {

--- a/src/lib/photos/__tests__/audience-source.test.ts
+++ b/src/lib/photos/__tests__/audience-source.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  projectAudiencePhotoUrl,
+  resolvePhotoImageSource,
+} from "@/lib/photo-sources"
+
+describe("project audience photo sources", () => {
+  it("builds an audience-scoped URL without exposing the Drive file ID", () => {
+    const url = projectAudiencePhotoUrl(
+      "proj/o-170",
+      "photo 123",
+      "owner"
+    )
+
+    expect(url).toBe(
+      "/api/projects/proj%2Fo-170/photos/photo%20123?audience=owner"
+    )
+    expect(url).not.toContain("drive")
+  })
+
+  it("renders the scoped URL as a local photo source", () => {
+    const scopedUrl = projectAudiencePhotoUrl(
+      "proj-1",
+      "photo-1",
+      "sub_vendor"
+    )
+
+    expect(
+      resolvePhotoImageSource({
+        thumbnailUrl: scopedUrl,
+        driveFileId: null,
+        driveUrl: null,
+      })
+    ).toEqual({
+      src: scopedUrl,
+      reason: "ready",
+      label: "Photo preview",
+    })
+  })
+})


### PR DESCRIPTION
## What changed

- adds a project- and audience-scoped image endpoint for approved owner/sub photos
- serves Drive-backed images through the configured Compass Workspace identity
- routes published owner updates, owner/sub galleries, cover photos, and carousel previews through the scoped endpoint
- removes raw Drive IDs from external photo view models
- re-checks approval and owner/sub visibility at image-request time

## Root cause

Published updates rendered `/api/google/download/:fileId`, an internal Drive endpoint that impersonated the signed-in user's email. External owners such as Tanis are not HPS Workspace users, so the image request failed even though the Compass photo records had valid Drive IDs and correct approval/visibility flags.

## Impact

Loomis and Loeffler owners can load approved photos without direct Drive access. Hidden, unapproved, cross-project, and wrong-audience photos return not found.

## Validation

- production metadata audit: all 19 Loomis July 27 photos have valid Drive IDs and are approved/owner-visible
- TypeScript: passed
- focused ESLint: passed
- Vitest: 2 passed
- Next.js production build (webpack): passed
