### PR TITLE
fix(feedback): recover confirmed Jarvis submissions

### DIFF
--- a/scripts/jarvis-agent-poller.py
+++ b/scripts/jarvis-agent-poller.py
@@ -255,6 +255,7 @@ def explicitly_requests_compass_feedback(message: str) -> bool:
             r"(?:upload|create|open|save|send|edit|delete|view|see|use|submit)\b"
         ),
         r"\b(?:not working|doesn['’]?t work|isn['’]?t working)\b",
+        r"\b(?:incorrect|incomplete|missing|empty)\b",
         r"\b(?:feature request|enhancement|feedback|suggestion|suggest)\b",
         (
             r"(?:^|[.!?]\s+)(?:please\s+|also\s+)?"
@@ -270,10 +271,10 @@ def explicitly_requests_compass_feedback(message: str) -> bool:
     return any(re.search(pattern, value) for pattern in patterns)
 
 
-def confirms_pending_feedback(payload: dict[str, Any]) -> bool:
+def pending_feedback_report(payload: dict[str, Any]) -> str | None:
     messages = payload.get("messages")
     if not isinstance(messages, list):
-        return False
+        return None
     conversation = [
         message
         for message in messages
@@ -285,7 +286,7 @@ def confirms_pending_feedback(payload: dict[str, Any]) -> bool:
         )
     ]
     if len(conversation) < 3:
-        return False
+        return None
 
     latest = conversation[-1]
     previous = conversation[-2]
@@ -295,10 +296,10 @@ def confirms_pending_feedback(payload: dict[str, Any]) -> bool:
         or previous.get("role") != "assistant"
         or report.get("role") != "user"
     ):
-        return False
+        return None
 
     latest_content = str(latest["content"]).strip().lower()
-    confirmation = re.fullmatch(
+    short_confirmation = re.fullmatch(
         (
             r"(?:yes|yep|yeah)(?:,\s*please)?"
             r"(?:,?\s+(?:file|submit|report)\s+it)?[.!]?"
@@ -307,11 +308,61 @@ def confirms_pending_feedback(payload: dict[str, Any]) -> bool:
         ),
         latest_content,
     )
-    return bool(
-        confirmation
-        and FEEDBACK_CONFIRMATION_QUESTION in str(previous["content"])
-        and explicitly_requests_compass_feedback(str(report["content"]))
+    explicit_confirmation = bool(
+        re.match(
+            r"^(?:yes|yep|yeah|please\s+do|go\s+ahead|"
+            r"file|submit|report|do\s+it)\b",
+            latest_content,
+        )
+        and (
+            re.search(r"\b(?:file|submit|report|record)\b", latest_content)
+            or "feedback desk" in latest_content
+        )
     )
+    if not short_confirmation and not explicit_confirmation:
+        return None
+    if FEEDBACK_CONFIRMATION_QUESTION not in str(previous["content"]):
+        return None
+
+    report_content = str(report["content"]).strip()
+    if not explicitly_requests_compass_feedback(report_content):
+        return None
+    return report_content
+
+
+def confirms_pending_feedback(payload: dict[str, Any]) -> bool:
+    return pending_feedback_report(payload) is not None
+
+
+def fallback_feedback_candidate(report: str) -> dict[str, str]:
+    normalized = " ".join(report.split())
+    lowered = normalized.lower()
+    if re.search(
+        r"\b(?:bug|issue|problem|broken|error|fails?|failed|unable to|"
+        r"not working|doesn['’]?t work|isn['’]?t working|"
+        r"incorrect|incomplete|missing|empty)\b",
+        lowered,
+    ):
+        kind = "bug"
+    elif re.search(
+        r"\b(?:feature request|enhancement|would like|please add|"
+        r"should (?:be|have|show|allow|include|use))\b",
+        lowered,
+    ):
+        kind = "feature"
+    elif normalized.endswith("?"):
+        kind = "question"
+    else:
+        kind = "general"
+
+    title = normalized
+    if len(title) > 160:
+        title = f"{title[:157].rstrip()}..."
+    return {
+        "kind": kind,
+        "title": title,
+        "description": report.strip(),
+    }
 
 
 def _required_payload_string(
@@ -647,8 +698,9 @@ def handle_event(event: dict[str, Any]) -> None:
         assistant_content(completion),
     )
     latest_message = latest_user_message(payload)
+    confirmed_report = pending_feedback_report(payload)
     if feedback is not None:
-        if confirms_pending_feedback(payload):
+        if confirmed_report is not None:
             pass
         elif explicitly_requests_compass_feedback(latest_message):
             feedback = None
@@ -663,11 +715,15 @@ def handle_event(event: dict[str, Any]) -> None:
                 event_id,
             )
             feedback = None
+    elif confirmed_report is not None:
+        # Hermes occasionally acknowledges a confirmation without repeating
+        # the structured candidate. The relay owns the confirmation contract,
+        # so recover the immediately preceding report deterministically.
+        feedback = fallback_feedback_candidate(confirmed_report)
     if feedback is not None:
         submit_feedback(event_id, payload, feedback)
         content = (
-            f"{content}\n\n"
-            "I recorded that with the Compass Feedback Desk."
+            f"I recorded “{feedback['title']}” with the Compass Feedback Desk."
         )
 
     model = completion.get("model")

--- a/scripts/test_jarvis_agent_poller.py
+++ b/scripts/test_jarvis_agent_poller.py
@@ -161,6 +161,117 @@ class CompassSearchContextTests(unittest.TestCase):
         self.assertTrue(MODULE.confirms_pending_feedback(confirmed))
         self.assertFalse(MODULE.confirms_pending_feedback(unrelated))
 
+    def test_feedback_confirmation_accepts_explicit_sentence_with_context(
+        self,
+    ) -> None:
+        report = (
+            "The owner update says required fields are incomplete even "
+            "though I filled them in."
+        )
+        payload = {
+            "messages": [
+                {"role": "user", "content": report},
+                {
+                    "role": "assistant",
+                    "content": MODULE.FEEDBACK_CONFIRMATION_QUESTION,
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        "Yes, please file this with the Compass Feedback "
+                        "Desk. The draft also reopened without my photos."
+                    ),
+                },
+            ]
+        }
+
+        self.assertEqual(
+            MODULE.pending_feedback_report(payload),
+            report,
+        )
+
+    def test_confirmed_report_has_deterministic_fallback_candidate(
+        self,
+    ) -> None:
+        report = (
+            "The owner update fails to publish after I complete the fields."
+        )
+
+        self.assertEqual(
+            MODULE.fallback_feedback_candidate(report),
+            {
+                "kind": "bug",
+                "title": report,
+                "description": report,
+            },
+        )
+
+    def test_confirmation_submits_when_model_omits_feedback_object(
+        self,
+    ) -> None:
+        report = "Please add Select all to the owner-update photo picker."
+        event = {
+            "id": "event-confirmed-feedback",
+            "eventType": "agent.prompt",
+            "payload": {
+                "user": {
+                    "id": "user-1",
+                    "displayName": "Staff Member",
+                    "email": "staff@example.com",
+                },
+                "context": {"organizationId": "org-1"},
+                "messages": [
+                    {"role": "user", "content": report},
+                    {
+                        "role": "assistant",
+                        "content": MODULE.FEEDBACK_CONFIRMATION_QUESTION,
+                    },
+                    {"role": "user", "content": "Yes, please file it."},
+                ],
+            },
+        }
+        completion = {
+            "model": "hermes-agent",
+            "choices": [
+                {
+                    "message": {
+                        "content": MODULE.json.dumps(
+                            {
+                                "response": "I will submit that.",
+                                "feedback": None,
+                            }
+                        )
+                    }
+                }
+            ],
+        }
+
+        with (
+            patch.object(
+                MODULE,
+                "compass_search",
+                return_value=None,
+            ),
+            patch.object(
+                MODULE,
+                "hermes_request",
+                return_value=completion,
+            ),
+            patch.object(MODULE, "submit_feedback") as submit,
+            patch.object(MODULE, "acknowledge") as acknowledge,
+        ):
+            MODULE.handle_event(event)
+
+        submitted = submit.call_args.args[2]
+        self.assertEqual(submitted["kind"], "feature")
+        self.assertEqual(submitted["description"], report)
+        result = acknowledge.call_args.args[1]["result"]
+        self.assertTrue(result["feedbackSubmitted"])
+        self.assertNotIn(
+            MODULE.FEEDBACK_CONFIRMATION_QUESTION,
+            result["content"],
+        )
+
     def test_initial_report_is_not_confirmation(self) -> None:
         payload = {
             "messages": [


### PR DESCRIPTION
## What changed

- recognizes explicit Feedback Desk confirmations that include additional context
- deterministically reconstructs the immediately preceding report when Hermes acknowledges consent but omits the structured feedback object
- preserves the existing requirement that Jarvis ask for consent before filing
- acknowledges successful submission without asking the confirmation question again
- expands bug detection for missing, incomplete, empty, and failed behavior

## Root cause

The relay only submitted a report when Hermes repeated a hidden structured feedback object on the confirmation turn. Hermes could answer in prose with `feedback: null`; the event was then acknowledged as completed with `feedbackSubmitted: false`, silently losing the confirmed report.

## Impact

An explicit confirmation now always creates the requested Feedback Desk item, while unconfirmed comments remain unfiled.

## Validation

- `python3 -m unittest scripts/test_jarvis_agent_poller.py` — 18 tests passed
- `python3 -m py_compile scripts/jarvis-agent-poller.py scripts/test_jarvis_agent_poller.py`

