### PR TITLE
fix(owner-updates): save current edits before publishing

### DIFF
--- a/src/app/api/projects/[id]/owner-updates/[updateId]/draft/route.ts
+++ b/src/app/api/projects/[id]/owner-updates/[updateId]/draft/route.ts
@@ -1,5 +1,9 @@
-import { updateOwnerProjectUpdateDraft } from "@/app/actions/project-field"
+import {
+  publishOwnerProjectUpdate,
+  updateOwnerProjectUpdateDraft,
+} from "@/app/actions/project-field"
 import { ownerUpdateDraftEditSchema } from "@/lib/owner-updates/draft-recovery"
+import { persistOwnerUpdateDraft } from "@/lib/owner-updates/draft-publish"
 
 export async function PUT(
   request: Request,
@@ -31,11 +35,20 @@ export async function PUT(
   }
 
   const { id, updateId } = await params
-  const result = await updateOwnerProjectUpdateDraft(
-    id,
-    updateId,
-    parsed.data
-  )
+  const intent =
+    new URL(request.url).searchParams.get("intent") === "publish"
+      ? "publish"
+      : "save"
+  const result = await persistOwnerUpdateDraft({
+    intent,
+    save: () =>
+      updateOwnerProjectUpdateDraft(
+        id,
+        updateId,
+        parsed.data
+      ),
+    publish: () => publishOwnerProjectUpdate(id, updateId),
+  })
 
   return Response.json(result, { status: result.success ? 200 : 400 })
 }

--- a/src/components/projects/owner-update-actions.tsx
+++ b/src/components/projects/owner-update-actions.tsx
@@ -8,14 +8,10 @@ import {
   IconMail,
   IconPrinter,
   IconSparkles,
-  IconSend,
   IconTrash,
 } from "@tabler/icons-react"
 
-import {
-  deleteOwnerProjectUpdateDraft,
-  publishOwnerProjectUpdate,
-} from "@/app/actions/project-field"
+import { deleteOwnerProjectUpdateDraft } from "@/app/actions/project-field"
 import { Button } from "@/components/ui/button"
 
 const PRINT_IMAGE_TIMEOUT_MS = 3_000
@@ -88,7 +84,6 @@ export function OwnerUpdateActions({
   readonly updateTitle: string
 }): React.ReactElement {
   const router = useRouter()
-  const [isPublishing, setIsPublishing] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [publishError, setPublishError] = useState<string | null>(null)
   const [copied, setCopied] = useState<"link" | "email" | "html" | null>(null)
@@ -188,23 +183,6 @@ export function OwnerUpdateActions({
     window.setTimeout(resetPrintState, 5000)
   }
 
-  async function publish(): Promise<void> {
-    setPublishError(null)
-    setIsPublishing(true)
-    try {
-      const result = await publishOwnerProjectUpdate(projectId, updateId)
-      if (result.success) {
-        window.location.reload()
-        return
-      }
-      setPublishError(result.error)
-    } catch {
-      setPublishError("Unable to publish this update. Please try again.")
-    } finally {
-      setIsPublishing(false)
-    }
-  }
-
   async function deleteDraft(): Promise<void> {
     const confirmed = window.confirm(
       "Delete this owner update draft? This cannot be undone."
@@ -231,12 +209,6 @@ export function OwnerUpdateActions({
 
   return (
     <div className="flex flex-wrap items-center gap-2 print:hidden">
-      {canManage && status !== "published" && (
-        <Button size="sm" onClick={publish} disabled={isPublishing}>
-          <IconSend className="size-4" />
-          {isPublishing ? "Publishing..." : "Publish"}
-        </Button>
-      )}
       {canManage && status === "draft" && (
         <Button
           size="sm"

--- a/src/components/projects/owner-update-draft-editor.tsx
+++ b/src/components/projects/owner-update-draft-editor.tsx
@@ -10,6 +10,7 @@ import {
   IconPhoto,
   IconRefresh,
   IconRobot,
+  IconSend,
   IconUpload,
   IconX,
 } from "@tabler/icons-react"
@@ -413,11 +414,19 @@ export function OwnerUpdateDraftEditor({
     }
   }
 
-  async function saveDraft(): Promise<boolean> {
-    setStatus({ kind: "saving", message: "Saving curated sources..." })
+  async function saveDraft(
+    intent: "save" | "publish" = "save"
+  ): Promise<boolean> {
+    setStatus({
+      kind: "saving",
+      message:
+        intent === "publish"
+          ? "Saving the latest edits before publishing..."
+          : "Saving curated sources...",
+    })
     try {
       const response = await fetch(
-        `/api/projects/${document.project.id}/owner-updates/${document.update.id}/draft`,
+        `/api/projects/${document.project.id}/owner-updates/${document.update.id}/draft?intent=${intent}`,
         {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
@@ -436,6 +445,15 @@ export function OwnerUpdateDraftEditor({
       } catch {
         // The server save succeeded even if browser storage cleanup fails.
       }
+      if (intent === "publish") {
+        setStatus({
+          kind: "saved",
+          message: "Draft saved and published.",
+        })
+        window.location.reload()
+        return true
+      }
+
       initialServerDraftJson.current = JSON.stringify(currentDraft)
       setDraftRecoveryReady(false)
       setStatus({
@@ -448,7 +466,9 @@ export function OwnerUpdateDraftEditor({
       setStatus({
         kind: "error",
         message:
-          "Unable to reach Compass. Your edits are backed up in this browser; do not close this page until the connection returns.",
+          intent === "publish"
+            ? "Unable to save and publish. Your edits are backed up in this browser; do not close this page until the connection returns."
+            : "Unable to reach Compass. Your edits are backed up in this browser; do not close this page until the connection returns.",
       })
       return false
     }
@@ -516,6 +536,17 @@ export function OwnerUpdateDraftEditor({
                 <IconRefresh className="size-4" />
               )}
               Save draft
+            </Button>
+            <Button
+              type="button"
+              onClick={() => void saveDraft("publish")}
+              disabled={status.kind === "saving"}
+            >
+              <IconSend className="size-4" />
+              {status.kind === "saving" &&
+              status.message.includes("publishing")
+                ? "Publishing..."
+                : "Save & publish"}
             </Button>
           </div>
         </div>

--- a/src/lib/owner-updates/__tests__/draft-publish.test.ts
+++ b/src/lib/owner-updates/__tests__/draft-publish.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { persistOwnerUpdateDraft } from "@/lib/owner-updates/draft-publish"
+
+describe("owner update draft publishing", () => {
+  it("saves current edits before publishing", async () => {
+    const sequence: string[] = []
+    const save = vi.fn(async () => {
+      sequence.push("save")
+      return { success: true } as const
+    })
+    const publish = vi.fn(async () => {
+      sequence.push("publish")
+      return { success: true } as const
+    })
+
+    const result = await persistOwnerUpdateDraft({
+      intent: "publish",
+      save,
+      publish,
+    })
+
+    expect(result).toEqual({ success: true })
+    expect(sequence).toEqual(["save", "publish"])
+  })
+
+  it("does not publish when saving fails", async () => {
+    const save = vi.fn(async () => ({
+      success: false,
+      error: "Unable to save the draft.",
+    }) as const)
+    const publish = vi.fn(async () => ({ success: true }) as const)
+
+    const result = await persistOwnerUpdateDraft({
+      intent: "publish",
+      save,
+      publish,
+    })
+
+    expect(result).toEqual({
+      success: false,
+      error: "Unable to save the draft.",
+    })
+    expect(publish).not.toHaveBeenCalled()
+  })
+
+  it("does not publish for an ordinary save", async () => {
+    const save = vi.fn(async () => ({ success: true }) as const)
+    const publish = vi.fn(async () => ({ success: true }) as const)
+
+    const result = await persistOwnerUpdateDraft({
+      intent: "save",
+      save,
+      publish,
+    })
+
+    expect(result).toEqual({ success: true })
+    expect(publish).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/owner-updates/draft-publish.ts
+++ b/src/lib/owner-updates/draft-publish.ts
@@ -1,0 +1,14 @@
+export type OwnerUpdateMutationResult =
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string }
+
+export async function persistOwnerUpdateDraft(input: {
+  readonly intent: "save" | "publish"
+  readonly save: () => Promise<OwnerUpdateMutationResult>
+  readonly publish: () => Promise<OwnerUpdateMutationResult>
+}): Promise<OwnerUpdateMutationResult> {
+  const saved = await input.save()
+  if (!saved.success || input.intent === "save") return saved
+
+  return input.publish()
+}


### PR DESCRIPTION
## What changed

- replaces the unsafe standalone Publish action with **Save & publish** inside the draft editor
- persists the complete current editor payload before publishing
- prevents publishing when the save fails
- retains the browser recovery backup and gives a specific save-and-publish failure message

## Root cause

The previous Publish button invoked the publish action directly. Validation read the last D1 version, so unsaved title, date, summary, selected photos, logs, schedule items, and to-dos were invisible to publication and could produce the misleading required-fields error.

## Impact

Staff can publish the exact draft currently visible in the editor without first performing a separate save. A failed save cannot publish stale content.

## Validation

- `./node_modules/.bin/tsc --noEmit`
- focused ESLint (no errors; one pre-existing `img` warning)
- 11 focused Vitest tests
- `next build --webpack`

