### PR TITLE
fix(schedule): align Today with current activity

### DIFF
--- a/src/components/schedule/schedule-gantt-view.tsx
+++ b/src/components/schedule/schedule-gantt-view.tsx
@@ -87,8 +87,10 @@ import { format } from "date-fns"
 import type { ScheduleProjectData } from "@/lib/schedule/project-scope"
 import { projectScheduleLabel } from "@/lib/schedule/project-scope"
 import {
+  centeredGanttRowScrollTop,
   ganttRowIndexForScrollTop,
   lockWheelToDominantAxis,
+  nearestScheduleRowIndexForDate,
   normalizeWheelDelta,
   synchronizedScrollTop,
 } from "@/lib/schedule/gantt-scroll"
@@ -596,8 +598,61 @@ export function ScheduleGanttView({
   )
 
   const scrollToToday = useCallback(() => {
+    const ganttContainer = ganttContainerRef.current
+    if (!ganttContainer) {
+      scrollToTodayRef.current?.()
+      return
+    }
+    const today = format(new Date(), "yyyy-MM-dd")
+    const rowIndex = nearestScheduleRowIndexForDate(
+      displayItems.map((item) =>
+        item.type === "task"
+          ? {
+              startDate: item.task.startDate,
+              endDate: item.task.endDateCalculated,
+            }
+          : {
+              startDate: item.group.startDate,
+              endDate: item.group.endDate,
+            }
+      ),
+      today
+    )
+    if (rowIndex === null) {
+      scrollToTodayRef.current?.()
+      return
+    }
+
+    const ganttTop = centeredGanttRowScrollTop({
+      rowIndex,
+      clientHeight: ganttContainer.clientHeight,
+      scrollHeight: ganttContainer.scrollHeight,
+    })
+    ganttContainer.scrollTop = ganttTop
+
+    const taskList = taskListRef.current
+    if (taskList) {
+      taskList.scrollTop = synchronizedScrollTop(
+        ganttTop,
+        ganttContainer.scrollHeight,
+        ganttContainer.clientHeight,
+        taskList.scrollHeight,
+        taskList.clientHeight
+      )
+    }
+
+    const targetItem = displayItems[rowIndex]
+    if (targetItem?.type === "task") {
+      setFocusedTaskId(targetItem.task.id)
+      followedListItemRef.current = targetItem.task.id
+    } else if (targetItem) {
+      followedListItemRef.current = targetItem.phase
+    }
+
+    // Start the smooth horizontal movement last. Assigning scrollTop after
+    // scrollTo({ behavior: "smooth" }) cancels that animation in browsers.
     scrollToTodayRef.current?.()
-  }, [])
+  }, [displayItems])
 
   const taskTable = (
     <Table className="table-fixed">

--- a/src/lib/schedule/__tests__/gantt-scroll.test.ts
+++ b/src/lib/schedule/__tests__/gantt-scroll.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest"
 import {
+  centeredGanttRowScrollTop,
   centeredTimelineScrollLeft,
   dominantScrollAxis,
   ganttRowIndexForScrollTop,
   lockWheelToDominantAxis,
+  nearestScheduleRowIndexForDate,
   normalizeWheelDelta,
   paddingToIncludeDate,
   synchronizedScrollTop,
@@ -55,6 +57,54 @@ describe("Gantt dominant-axis scrolling", () => {
     expect(ganttRowIndexForScrollTop(133, 10)).toBe(1)
     expect(ganttRowIndexForScrollTop(10_000, 10)).toBe(9)
     expect(ganttRowIndexForScrollTop(0, 0)).toBeNull()
+  })
+
+  it("selects work active today before nearby schedule rows", () => {
+    expect(
+      nearestScheduleRowIndexForDate(
+        [
+          { startDate: "2025-02-01", endDate: "2025-02-10" },
+          { startDate: "2026-07-28", endDate: "2026-08-03" },
+          { startDate: "2026-08-04", endDate: "2026-08-08" },
+        ],
+        "2026-07-29"
+      )
+    ).toBe(1)
+  })
+
+  it("falls forward to upcoming work, then back to the latest past work", () => {
+    const rows = [
+      { startDate: "2025-02-01", endDate: "2025-02-10" },
+      { startDate: "2026-08-04", endDate: "2026-08-08" },
+      { startDate: "2026-08-01", endDate: "2026-08-02" },
+    ]
+    expect(nearestScheduleRowIndexForDate(rows, "2026-07-29")).toBe(2)
+    expect(nearestScheduleRowIndexForDate(rows, "2027-01-01")).toBe(1)
+    expect(nearestScheduleRowIndexForDate([], "2026-07-29")).toBeNull()
+  })
+
+  it("centers the relevant row while respecting scroll boundaries", () => {
+    expect(
+      centeredGanttRowScrollTop({
+        rowIndex: 10,
+        clientHeight: 400,
+        scrollHeight: 1_200,
+      })
+    ).toBe(389)
+    expect(
+      centeredGanttRowScrollTop({
+        rowIndex: 0,
+        clientHeight: 400,
+        scrollHeight: 1_200,
+      })
+    ).toBe(0)
+    expect(
+      centeredGanttRowScrollTop({
+        rowIndex: 40,
+        clientHeight: 400,
+        scrollHeight: 1_200,
+      })
+    ).toBe(800)
   })
 
   it("centers a selected date in the timeline beside sticky labels", () => {

--- a/src/lib/schedule/gantt-scroll.ts
+++ b/src/lib/schedule/gantt-scroll.ts
@@ -5,6 +5,11 @@ interface WheelDelta {
   readonly deltaY: number
 }
 
+interface ScheduleRowDateRange {
+  readonly startDate: string
+  readonly endDate: string
+}
+
 export function dominantScrollAxis(
   deltaX: number,
   deltaY: number
@@ -91,6 +96,54 @@ export function ganttRowIndexForScrollTop(
   if (itemCount === 0) return null
   const rowOffset = Math.max(0, scrollTop - headerHeight)
   return Math.min(itemCount - 1, Math.floor(rowOffset / rowHeight))
+}
+
+export function nearestScheduleRowIndexForDate(
+  rows: readonly ScheduleRowDateRange[],
+  targetDate: string
+): number | null {
+  let nextIndex: number | null = null
+  let nextStart: string | null = null
+  let previousIndex: number | null = null
+  let previousEnd: string | null = null
+
+  for (const [index, row] of rows.entries()) {
+    if (row.startDate <= targetDate && row.endDate >= targetDate) {
+      return index
+    }
+    if (
+      row.startDate > targetDate &&
+      (nextStart === null || row.startDate < nextStart)
+    ) {
+      nextIndex = index
+      nextStart = row.startDate
+    }
+    if (
+      row.endDate < targetDate &&
+      (previousEnd === null || row.endDate > previousEnd)
+    ) {
+      previousIndex = index
+      previousEnd = row.endDate
+    }
+  }
+
+  return nextIndex ?? previousIndex
+}
+
+export function centeredGanttRowScrollTop(input: {
+  readonly rowIndex: number
+  readonly clientHeight: number
+  readonly scrollHeight: number
+  readonly headerHeight?: number
+  readonly rowHeight?: number
+}): number {
+  const headerHeight = input.headerHeight ?? 85
+  const rowHeight = input.rowHeight ?? 48
+  const rowCenter =
+    headerHeight + input.rowIndex * rowHeight + rowHeight / 2
+  const desiredTop = rowCenter - input.clientHeight / 2
+  const maximumTop = Math.max(0, input.scrollHeight - input.clientHeight)
+  return Math.max(0, Math.min(desiredTop, maximumTop))
 }
 
 export function centeredTimelineScrollLeft(input: {


### PR DESCRIPTION
## Summary
- make the shared Gantt Today action select the first row active today
- fall forward to the nearest upcoming item, or back to the most recent completed item when no work is active today
- vertically center and synchronize the schedule list and timeline before horizontally centering today
- highlight the row selected by Today in unified and individual project schedules

## Verification
- 12 focused Gantt scroll tests pass
- TypeScript passes
- focused ESLint passes
- browser-verified with 60 February 2025 rows before current work:
  - unified Gantt: list `scrollTop` 0 → 2784, timeline `scrollTop` 0 → 2803, current row highlighted, horizontal timeline centered on July 2026
  - individual project Gantt: both panes moved from the top to the current row using the shared component
- verified that vertical movement is applied before smooth horizontal centering so the browser does not cancel the horizontal animation
