### PR TITLE
fix(calendar): focus records and prioritize office events

### DIFF
--- a/src/app/actions/work-calendar.ts
+++ b/src/app/actions/work-calendar.ts
@@ -35,6 +35,8 @@ import {
   isWorkCalendarEventVisibility,
   isValidDateKey,
   normalizeWorkCalendarEventTiming,
+  projectPurchaseOrderHref,
+  projectRfiHref,
   projectTodoHref,
   resolveHOfficeProjectId,
   scheduleItemHref,
@@ -222,7 +224,10 @@ function intersectsCalendarWindow(
 }
 
 export async function getWorkCalendar(
-  referenceDate?: string
+  referenceDate?: string,
+  options?: {
+    readonly eventsOnly?: boolean
+  },
 ): Promise<WorkCalendarData> {
   const user = await requireAuth()
   requirePermission(user, "schedule", "read")
@@ -323,7 +328,7 @@ export async function getWorkCalendar(
 
   const entries: WorkCalendarEntry[] = []
 
-  for (const project of projectRows) {
+  for (const project of options?.eventsOnly ? [] : projectRows) {
     const label = projectLabel(project)
 
     const taskRows = await db
@@ -417,7 +422,7 @@ export async function getWorkCalendar(
         assignedTo: rfi.assignedToName,
         companyName: rfi.companyName,
         sourceLabel: `RFI ${rfi.rfiNumber}`,
-        href: `/dashboard/projects/${project.id}/rfis`,
+        href: projectRfiHref(project.id, rfi.id),
         eventDetails: null,
       })
     }
@@ -532,7 +537,7 @@ export async function getWorkCalendar(
         ),
         href:
           operation.sourceRecordType === "purchase_order"
-            ? `/dashboard/projects/${project.id}/purchase-orders`
+            ? projectPurchaseOrderHref(project.id, operation.id)
             : isProjectTodoRecordType(operation.sourceRecordType)
                 ? projectTodoHref(project.id, operation.id)
                 : `/dashboard/projects/${project.id}`,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,7 +7,9 @@ import {
   getCurrentUserPresence,
   getOrganizationTeamAvailability,
 } from "@/app/actions/presence"
+import { getWorkCalendar } from "@/app/actions/work-calendar"
 import { DashboardLaunchpad } from "@/components/dashboard/dashboard-launchpad"
+import type { DashboardOfficeEvent } from "@/components/dashboard/dashboard-launchpad"
 import { getCurrentUser, toSidebarUser } from "@/lib/auth"
 
 export default async function Page(): Promise<React.ReactElement> {
@@ -35,10 +37,12 @@ export default async function Page(): Promise<React.ReactElement> {
     overview,
     presenceResult,
     teamAvailabilityResult,
+    workCalendar,
   ] = await Promise.all([
     getDashboardOverview(),
     getCurrentUserPresence(),
     getOrganizationTeamAvailability(),
+    getWorkCalendar(undefined, { eventsOnly: true }).catch(() => null),
   ])
   const sidebarUser = currentUser ? toSidebarUser(currentUser) : null
   const initialDeskStatusMessage = presenceResult.success
@@ -47,6 +51,22 @@ export default async function Page(): Promise<React.ReactElement> {
   const initialTeamAvailability = teamAvailabilityResult.success
     ? teamAvailabilityResult.data
     : []
+  const officeCalendarEvents: readonly DashboardOfficeEvent[] =
+    workCalendar?.entries.flatMap((entry) =>
+      entry.kind === "event"
+        ? [{
+            id: entry.id,
+            projectId: entry.projectId,
+            projectLabel: entry.projectLabel,
+            title: entry.title,
+            startDate: entry.startDate,
+            endDate: entry.endDate,
+            href: entry.href,
+            allDay: entry.eventDetails.allDay,
+            startTime: entry.eventDetails.startTime,
+          }]
+        : []
+    ) ?? []
 
   return (
     <DashboardLaunchpad
@@ -54,6 +74,8 @@ export default async function Page(): Promise<React.ReactElement> {
       user={sidebarUser}
       initialDeskStatusMessage={initialDeskStatusMessage}
       initialTeamAvailability={initialTeamAvailability}
+      officeCalendarEvents={officeCalendarEvents}
+      officeProjectId={workCalendar?.defaultProjectId ?? null}
     />
   )
 }

--- a/src/app/dashboard/projects/[id]/purchase-orders/page.tsx
+++ b/src/app/dashboard/projects/[id]/purchase-orders/page.tsx
@@ -105,6 +105,7 @@ function PurchaseOrderCard({
   projectId,
   projectLabel,
   isCreated,
+  isFocused,
   taskAssigneeOptions,
 }: {
   readonly brand: ProjectBrand
@@ -112,16 +113,18 @@ function PurchaseOrderCard({
   readonly projectId: string
   readonly projectLabel: string
   readonly isCreated: boolean
+  readonly isFocused: boolean
   readonly taskAssigneeOptions: React.ComponentProps<
     typeof ProjectTaskCreateButton
   >["assigneeOptions"]
 }): React.ReactElement {
   return (
     <article
+      id={`purchase-order-${order.id}`}
       data-po-id={order.id}
       className={cn(
-        "po-printable rounded-lg border bg-background p-4 print:border-0 print:p-0",
-        isCreated && "border-brand-hps-primary bg-card"
+        "po-printable scroll-mt-6 rounded-lg border bg-background p-4 print:border-0 print:p-0",
+        (isCreated || isFocused) && "border-brand-hps-primary bg-card"
       )}
     >
       <div className="print:hidden">
@@ -134,6 +137,9 @@ function PurchaseOrderCard({
           </div>
           <div className="flex flex-wrap gap-1">
             {isCreated && <Badge variant="secondary">Just created</Badge>}
+            {isFocused && !isCreated && (
+              <Badge variant="secondary">Selected from calendar</Badge>
+            )}
             <ProjectOperationStatusSelect
               projectId={projectId}
               operationId={order.id}
@@ -348,6 +354,7 @@ export default async function ProjectPurchaseOrdersPage({
   readonly params: Promise<{ readonly id: string }>
   readonly searchParams: Promise<{
     readonly created?: string | readonly string[]
+    readonly item?: string | readonly string[]
     readonly status?: string | readonly string[]
   }>
 }) {
@@ -356,6 +363,9 @@ export default async function ProjectPurchaseOrdersPage({
   const createdPurchaseOrderId = Array.isArray(query.created)
     ? query.created[0] ?? null
     : query.created ?? null
+  const focusedPurchaseOrderId = Array.isArray(query.item)
+    ? query.item[0] ?? null
+    : query.item ?? null
   const statusFilter = parseProjectOperationStatusFilter(query.status)
   const [
     projects,
@@ -491,6 +501,7 @@ export default async function ProjectPurchaseOrdersPage({
                 }`
               }
               isCreated={order.id === createdPurchaseOrderId}
+              isFocused={order.id === focusedPurchaseOrderId}
               taskAssigneeOptions={taskAssignees}
             />
           ))

--- a/src/app/dashboard/projects/[id]/rfis/page.tsx
+++ b/src/app/dashboard/projects/[id]/rfis/page.tsx
@@ -91,6 +91,7 @@ export default async function ProjectRfisPage({
   readonly params: Promise<{ readonly id: string }>
   readonly searchParams: Promise<{
     readonly created?: string | readonly string[]
+    readonly item?: string | readonly string[]
     readonly status?: string | readonly string[]
   }>
 }) {
@@ -99,6 +100,9 @@ export default async function ProjectRfisPage({
   const createdRfiId = Array.isArray(query.created)
     ? query.created[0] ?? null
     : query.created ?? null
+  const focusedRfiId = Array.isArray(query.item)
+    ? query.item[0] ?? null
+    : query.item ?? null
   const statusFilter = parseRfiStatusFilter(query.status)
   const [projects, rfis, contactsSummary, taskAssigneeOptions] =
     await Promise.all([
@@ -235,6 +239,7 @@ export default async function ProjectRfisPage({
         {visibleRfis.length > 0 ? (
           visibleRfis.map((rfi) => {
             const isCreated = rfi.id === createdRfiId
+            const isFocused = rfi.id === focusedRfiId
             const canonicalStatus = canonicalRfiStatus(rfi.status)
             return (
               <article
@@ -242,7 +247,7 @@ export default async function ProjectRfisPage({
                 id={`rfi-${rfi.id}`}
                 className={cn(
                   "scroll-mt-6 border-l-2 border-y border-r bg-background px-4 py-3",
-                  isCreated
+                  isCreated || isFocused
                     ? "border-l-brand-hps-primary bg-card"
                     : "border-l-brand-nutech-gold"
                 )}
@@ -259,6 +264,9 @@ export default async function ProjectRfisPage({
                   <div className="flex flex-wrap gap-1">
                     {isCreated && (
                       <Badge variant="secondary">Just created</Badge>
+                    )}
+                    {isFocused && !isCreated && (
+                      <Badge variant="secondary">Selected from calendar</Badge>
                     )}
                     <Badge
                       variant={

--- a/src/components/dashboard/dashboard-launchpad.tsx
+++ b/src/components/dashboard/dashboard-launchpad.tsx
@@ -76,6 +76,13 @@ import {
   type TeamAvailabilityMember,
 } from "@/lib/dashboard/office-status"
 import { dashboardDeskPhotoStorageKey } from "@/lib/user-photo-storage"
+import { isProjectTodoRecordType } from "@/lib/project-todos"
+import {
+  compareOfficeCalendarPriority,
+  projectPurchaseOrderHref,
+  projectTodoHref,
+  scheduleItemHref,
+} from "@/lib/work-calendar"
 import { cn } from "@/lib/utils"
 import { usePresence } from "@/contexts/presence-context"
 
@@ -86,7 +93,23 @@ type LaunchpadTask = {
   readonly title: string
   readonly detail: string
   readonly href: string
-  readonly category: "Schedule" | "Invoice" | "Owner update" | "Field review"
+  readonly category:
+    | "Event"
+    | "Invoice"
+    | "Owner update"
+    | "Field review"
+}
+
+export type DashboardOfficeEvent = {
+  readonly id: string
+  readonly projectId: string | null
+  readonly projectLabel: string
+  readonly title: string
+  readonly startDate: string
+  readonly endDate: string
+  readonly href: string
+  readonly allDay: boolean
+  readonly startTime: string
 }
 
 const MARTINE_DEFAULT_DESK_PHOTO = "/user-desk-photos/martine-desk-photo.jpeg"
@@ -243,7 +266,10 @@ function formatLongDate(value: string): string {
 }
 
 function taskFallsOnDay(
-  task: DashboardOverview["upcomingTasks"][number],
+  task: {
+    readonly startDate: string
+    readonly endDate: string
+  },
   day: string
 ): boolean {
   return task.startDate <= day && task.endDate >= day
@@ -277,9 +303,13 @@ function greetingForNow(): string {
 function Horizon({
   overview,
   mode,
+  officeCalendarEvents,
+  officeProjectId,
 }: {
   readonly overview: DashboardOverview
   readonly mode: DashboardMode
+  readonly officeCalendarEvents: readonly DashboardOfficeEvent[]
+  readonly officeProjectId: string | null
 }): React.ReactElement {
   const days = useMemo(
     () =>
@@ -287,6 +317,31 @@ function Horizon({
         dateKey(addDays(parseDateKey(overview.today), index))
       ),
     [overview.today]
+  )
+  const horizonEntries = useMemo(
+    () =>
+      mode === "office"
+        ? officeCalendarEvents
+            .slice()
+            .sort((left, right) =>
+              compareOfficeCalendarPriority(
+                left,
+                right,
+                officeProjectId
+              )
+            )
+        : overview.upcomingTasks.map((task) => ({
+            id: task.id,
+            projectId: task.projectId,
+            projectLabel: task.projectLabel,
+            title: task.title,
+            startDate: task.startDate,
+            endDate: task.endDate,
+            href: scheduleItemHref(task.projectId, task.id),
+            allDay: true,
+            startTime: "",
+          })),
+    [mode, officeCalendarEvents, officeProjectId, overview.upcomingTasks]
   )
 
   return (
@@ -298,13 +353,19 @@ function Horizon({
             <h2 className="text-sm font-semibold">Five-day horizon</h2>
             <p className="text-xs text-muted-foreground">
               {mode === "office"
-                ? "H-Office commitments first, then company-wide work"
+                ? "H-Office events first, then company-wide events"
                 : "The next commitments across active projects"}
             </p>
           </div>
         </div>
         <Button asChild variant="ghost" size="sm" className="shrink-0">
-          <Link href="/dashboard/schedule">
+          <Link
+            href={
+              mode === "office"
+                ? "/dashboard/schedule?kind=event"
+                : "/dashboard/schedule?mode=projects&scope=all&view=gantt"
+            }
+          >
             Full calendar
             <IconArrowRight className="size-4" />
           </Link>
@@ -313,11 +374,9 @@ function Horizon({
 
       <div className="grid grid-cols-2 border-t sm:grid-cols-3 xl:grid-cols-5">
         {days.map((day, index) => {
-          const dayTasks = overview.upcomingTasks
-            .filter((task) => taskFallsOnDay(task, day))
-            .sort((left, right) =>
-              mode === "office" ? compareOfficePriority(left, right) : 0
-            )
+          const dayTasks = horizonEntries.filter((task) =>
+            taskFallsOnDay(task, day)
+          )
 
           return (
             <div
@@ -346,17 +405,21 @@ function Horizon({
                 {dayTasks.slice(0, 2).map((task) => (
                   <Link
                     key={`${day}-${task.id}`}
-                    href={`/dashboard/projects/${task.projectId}/schedule?task=${encodeURIComponent(task.id)}`}
+                    href={task.href}
                     className="block border-l-2 border-[#2f5963] pl-2 text-xs transition-colors hover:text-primary"
                   >
                     <span className="line-clamp-1 font-medium">{task.title}</span>
                     <span className="mt-0.5 block truncate text-[11px] text-muted-foreground">
-                      {task.projectLabel}
+                      {!task.allDay && task.startTime
+                        ? `${task.startTime} · ${task.projectLabel}`
+                        : task.projectLabel}
                     </span>
                   </Link>
                 ))}
                 {dayTasks.length === 0 ? (
-                  <p className="pt-1 text-xs text-muted-foreground/70">Open</p>
+                  <p className="pt-1 text-xs text-muted-foreground/70">
+                    {mode === "office" ? "No office events" : "Open"}
+                  </p>
                 ) : null}
                 {dayTasks.length > 2 ? (
                   <p className="text-[11px] font-medium text-muted-foreground">
@@ -625,24 +688,27 @@ function CherishComposer(): React.ReactElement {
 
 function OfficeTaskList({
   overview,
+  officeCalendarEvents,
+  officeProjectId,
 }: {
   readonly overview: DashboardOverview
+  readonly officeCalendarEvents: readonly DashboardOfficeEvent[]
+  readonly officeProjectId: string | null
 }): React.ReactElement {
   const tasks = useMemo<readonly LaunchpadTask[]>(() => {
-    const scheduleTasks: readonly LaunchpadTask[] = overview.upcomingTasks
+    const eventTasks: readonly LaunchpadTask[] = officeCalendarEvents
       .slice()
-      .sort((left, right) => {
-        const officePriority = compareOfficePriority(left, right)
-        if (officePriority !== 0) return officePriority
-        return left.startDate.localeCompare(right.startDate)
-      })
+      .filter((event) => event.endDate >= overview.today)
+      .sort((left, right) =>
+        compareOfficeCalendarPriority(left, right, officeProjectId)
+      )
       .slice(0, 3)
-      .map((task) => ({
-        id: `schedule-${task.id}`,
-        title: task.title,
-        detail: `${task.projectLabel} · ${formatMonthDay(task.startDate)}`,
-        href: `/dashboard/projects/${task.projectId}/schedule?task=${encodeURIComponent(task.id)}`,
-        category: "Schedule",
+      .map((event) => ({
+        id: `event-${event.id}`,
+        title: event.title,
+        detail: `${event.projectLabel} · ${formatMonthDay(event.startDate)}`,
+        href: event.href,
+        category: "Event",
       }))
     const operationTasks: readonly LaunchpadTask[] = overview.operations
       .slice()
@@ -654,8 +720,10 @@ function OfficeTaskList({
         detail: `${operation.projectLabel}${operation.companyName ? ` · ${operation.companyName}` : ""}`,
         href:
           operation.type === "purchase_order"
-            ? `/dashboard/projects/${operation.projectId}/purchase-orders`
-            : `/dashboard/projects/${operation.projectId}`,
+            ? projectPurchaseOrderHref(operation.projectId, operation.id)
+            : isProjectTodoRecordType(operation.type)
+              ? projectTodoHref(operation.projectId, operation.id)
+              : `/dashboard/projects/${operation.projectId}`,
         category: "Invoice",
       }))
     const ownerUpdateTasks: readonly LaunchpadTask[] =
@@ -680,12 +748,12 @@ function OfficeTaskList({
         : []
 
     return [
-      ...scheduleTasks,
+      ...eventTasks,
       ...ownerUpdateTasks,
       ...operationTasks,
       ...photoTasks,
     ].slice(0, 6)
-  }, [overview])
+  }, [officeCalendarEvents, officeProjectId, overview])
 
   return (
     <section className="min-w-0 border-y border-border/70 bg-background">
@@ -1189,11 +1257,15 @@ export function DashboardLaunchpad({
   user,
   initialDeskStatusMessage,
   initialTeamAvailability,
+  officeCalendarEvents,
+  officeProjectId,
 }: {
   readonly overview: DashboardOverview
   readonly user: SidebarUser | null
   readonly initialDeskStatusMessage: string | null
   readonly initialTeamAvailability: readonly TeamAvailabilityMember[]
+  readonly officeCalendarEvents: readonly DashboardOfficeEvent[]
+  readonly officeProjectId: string | null
 }): React.ReactElement {
   const [mode, setMode] = useState<DashboardMode>("office")
   const [deskStatus, setDeskStatus] = useState<DeskStatus>(() =>
@@ -1251,12 +1323,21 @@ export function DashboardLaunchpad({
           status={deskStatus}
           onStatusChange={setDeskStatus}
         />
-        <Horizon overview={overview} mode={mode} />
+        <Horizon
+          overview={overview}
+          mode={mode}
+          officeCalendarEvents={officeCalendarEvents}
+          officeProjectId={officeProjectId}
+        />
       </div>
 
       {mode === "office" ? (
         <div className="grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(20rem,0.65fr)]">
-          <OfficeTaskList overview={overview} />
+          <OfficeTaskList
+            overview={overview}
+            officeCalendarEvents={officeCalendarEvents}
+            officeProjectId={officeProjectId}
+          />
           <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-1">
             <OfficePresence
               initialAvailability={initialTeamAvailability}

--- a/src/lib/__tests__/work-calendar.test.ts
+++ b/src/lib/__tests__/work-calendar.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  compareOfficeCalendarPriority,
   instantForLocalDateTime,
   isValidDateKey,
   normalizeWorkCalendarEventTiming,
+  projectPurchaseOrderHref,
+  projectRfiHref,
   projectTodoHref,
   resolveHOfficeProjectId,
   scheduleItemHref,
@@ -35,13 +38,48 @@ describe("work calendar navigation and search", () => {
     expect(workCalendarEntryMatches(entry, "Loomis")).toBe(false)
   })
 
-  it("builds focused links for to-dos and schedule items", () => {
+  it("builds focused links for every Work Calendar source record", () => {
     expect(projectTodoHref("proj/o 202", "todo/14")).toBe(
       "/dashboard/projects/proj%2Fo%20202/todos?item=todo%2F14#todo-todo%2F14"
     )
     expect(scheduleItemHref("proj/o 202", "task/8")).toBe(
       "/dashboard/projects/proj%2Fo%20202/schedule?view=list&item=task%2F8#schedule-item-task%2F8"
     )
+    expect(projectRfiHref("proj/o 202", "rfi/3")).toBe(
+      "/dashboard/projects/proj%2Fo%20202/rfis?status=all&item=rfi%2F3#rfi-rfi%2F3"
+    )
+    expect(projectPurchaseOrderHref("proj/o 202", "po/9")).toBe(
+      "/dashboard/projects/proj%2Fo%20202/purchase-orders?status=all&item=po%2F9#purchase-order-po%2F9"
+    )
+  })
+
+  it("places H-Office events before other company events", () => {
+    const events = [
+      {
+        projectId: "loeffler",
+        startDate: "2026-07-30",
+        title: "Site walk",
+      },
+      {
+        projectId: "h-office",
+        startDate: "2026-07-31",
+        title: "Office meeting",
+      },
+      {
+        projectId: null,
+        startDate: "2026-07-29",
+        title: "Company event",
+      },
+    ]
+
+    expect(
+      events
+        .slice()
+        .sort((left, right) =>
+          compareOfficeCalendarPriority(left, right, "h-office")
+        )
+        .map((event) => event.title)
+    ).toEqual(["Office meeting", "Company event", "Site walk"])
   })
 })
 

--- a/src/lib/work-calendar.ts
+++ b/src/lib/work-calendar.ts
@@ -372,3 +372,38 @@ export function scheduleItemHref(projectId: string, itemId: string): string {
 export function projectTodoHref(projectId: string, itemId: string): string {
   return `/dashboard/projects/${encodeURIComponent(projectId)}/todos?item=${encodeURIComponent(itemId)}#todo-${encodeURIComponent(itemId)}`
 }
+
+export function projectRfiHref(projectId: string, itemId: string): string {
+  return `/dashboard/projects/${encodeURIComponent(projectId)}/rfis?status=all&item=${encodeURIComponent(itemId)}#rfi-${encodeURIComponent(itemId)}`
+}
+
+export function projectPurchaseOrderHref(
+  projectId: string,
+  itemId: string,
+): string {
+  return `/dashboard/projects/${encodeURIComponent(projectId)}/purchase-orders?status=all&item=${encodeURIComponent(itemId)}#purchase-order-${encodeURIComponent(itemId)}`
+}
+
+export function compareOfficeCalendarPriority(
+  left: {
+    readonly projectId: string | null
+    readonly startDate: string
+    readonly title: string
+  },
+  right: {
+    readonly projectId: string | null
+    readonly startDate: string
+    readonly title: string
+  },
+  officeProjectId: string | null,
+): number {
+  const leftIsOffice =
+    officeProjectId !== null && left.projectId === officeProjectId
+  const rightIsOffice =
+    officeProjectId !== null && right.projectId === officeProjectId
+  if (leftIsOffice !== rightIsOffice) return leftIsOffice ? -1 : 1
+
+  const byDate = left.startDate.localeCompare(right.startDate)
+  if (byDate !== 0) return byDate
+  return left.title.localeCompare(right.title)
+}


### PR DESCRIPTION
## Summary
- deep-link Work Calendar RFIs and purchase orders to the exact source record, matching existing focused schedule and to-do navigation
- highlight focused RFI and purchase-order records even when their status would normally hide them
- make the Office dashboard five-day horizon and priorities event-based, with H-Office events first and company events next
- keep Project dashboard mode linked to exact schedule items and avoid duplicate dashboard schedule queries

## Validation
- `bun test ./src/lib/__tests__/work-calendar.test.ts` — 11 passed
- TypeScript — passed
- `eslint . --quiet` — passed
- production Next webpack build — passed
- `git diff --check` — passed
- full `bun test` — 394 passed; 45 existing environment failures in better-sqlite3/Bun and WebSocket harness suites
- autoreview attempted; blocked by read-only `~/.codex/state_5.sqlite`, followed by manual complete-diff review
