### PR TITLE
fix(owner-updates): stabilize large photo selections

### DIFF
--- a/src/app/actions/project-field.ts
+++ b/src/app/actions/project-field.ts
@@ -41,6 +41,7 @@ import {
   ownerUpdateTodoTiming,
 } from "@/lib/owner-updates/composer"
 import { isOwnerUpdateVisibleToRole } from "@/lib/owner-updates/history"
+import { retainSelectedAndScopedRows } from "@/lib/owner-updates/photo-selection"
 import { ownerUpdateIdBatches } from "@/lib/owner-updates/query-batches"
 import { can } from "@/lib/permissions"
 import { requireFeaturePermission } from "@/lib/permission-enforcement"
@@ -2267,7 +2268,6 @@ export async function getOwnerProjectUpdateDocument(
       )
       .map((row) => row.id)
   )
-  const photoIds = new Set(selectedPhotoIds)
   const mapDailyLog = (
     row: (typeof allLogRows)[number]
   ): OwnerUpdateDailyLog => ({
@@ -2354,13 +2354,10 @@ export async function getOwnerProjectUpdateDocument(
       ownerVisible: row.ownerVisible,
     }))
 
-  const selectedEligiblePhotoRows = selectRowsByIdOrder(
+  const selectablePhotoRows = retainSelectedAndScopedRows(
     imageRows,
-    selectedPhotoIds
-  )
-  const scopedUnselectedPhotoRows = imageRows.filter(
+    selectedPhotoIds,
     (row) =>
-      !photoIds.has(row.id) &&
       update.periodStart !== null &&
       update.periodEnd !== null &&
       isPhotoInOwnerUpdateScope(
@@ -2371,9 +2368,7 @@ export async function getOwnerProjectUpdateDocument(
       )
   )
   const availablePhotos = canManage
-    ? [...selectedEligiblePhotoRows, ...scopedUnselectedPhotoRows]
-        .slice(0, 120)
-        .map((row) => ({
+    ? selectablePhotoRows.map((row) => ({
           id: row.id,
           sourceSystem: row.sourceSystem,
           fileName: row.fileName,

--- a/src/components/projects/owner-update-draft-editor.tsx
+++ b/src/components/projects/owner-update-draft-editor.tsx
@@ -733,10 +733,37 @@ export function OwnerUpdateDraftEditor({
                 Project photo library
               </h3>
             </div>
-            <SelectionCount
-              selected={selectedPhotoIds.length}
-              total={document.availablePhotos.length}
-            />
+            <div className="flex flex-wrap items-center gap-2">
+              <SelectionCount
+                selected={selectedPhotoIds.length}
+                total={document.availablePhotos.length}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  setSelectedPhotoIds(
+                    document.availablePhotos.map((photo) => photo.id)
+                  )
+                }
+                disabled={
+                  document.availablePhotos.length === 0 ||
+                  selectedPhotoIds.length === document.availablePhotos.length
+                }
+              >
+                Select all
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setSelectedPhotoIds([])}
+                disabled={selectedPhotoIds.length === 0}
+              >
+                Clear
+              </Button>
+            </div>
           </div>
           <p className="mt-1 text-xs text-muted-foreground">
             Choose Compass or Buildertrend photos for this update. Selecting a
@@ -756,12 +783,13 @@ export function OwnerUpdateDraftEditor({
                   ? null
                   : resolvedImage.src
                 return (
-                  <label
+                  <article
                     key={photo.id}
-                    className="group relative cursor-pointer overflow-hidden border bg-muted/20"
+                    className="group relative overflow-hidden border bg-muted/20"
                   >
                     <div className="absolute left-2 top-2 z-10 bg-background/90 p-1 shadow-sm">
                       <Checkbox
+                        id={`owner-update-photo-${photo.id}`}
                         checked={checked}
                         onCheckedChange={(value) =>
                           toggleId(
@@ -778,6 +806,8 @@ export function OwnerUpdateDraftEditor({
                         src={src}
                         alt={photo.caption ?? photo.fileName}
                         className="aspect-[4/3] w-full object-cover"
+                        loading="lazy"
+                        decoding="async"
                         onError={() =>
                           setFailedImageIds((current) =>
                             uniqueIds([...current, photo.id])
@@ -797,7 +827,7 @@ export function OwnerUpdateDraftEditor({
                         {sourceLabel(photo.sourceSystem)}
                       </p>
                     </div>
-                  </label>
+                  </article>
                 )
               })}
             </div>

--- a/src/lib/owner-updates/__tests__/photo-selection.test.ts
+++ b/src/lib/owner-updates/__tests__/photo-selection.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import { retainSelectedAndScopedRows } from "@/lib/owner-updates/photo-selection"
+
+describe("owner update photo selection", () => {
+  it("keeps the project photo order stable after photos are selected", () => {
+    const rows = [
+      { id: "photo-1", inPeriod: true },
+      { id: "photo-2", inPeriod: false },
+      { id: "photo-3", inPeriod: true },
+    ]
+
+    expect(
+      retainSelectedAndScopedRows(
+        rows,
+        ["photo-2", "photo-3"],
+        (row) => row.inPeriod,
+      ).map((row) => row.id),
+    ).toEqual(["photo-1", "photo-2", "photo-3"])
+  })
+
+  it("does not truncate large photo selections", () => {
+    const rows = Array.from({ length: 150 }, (_, index) => ({
+      id: `photo-${index + 1}`,
+      inPeriod: true,
+    }))
+
+    expect(
+      retainSelectedAndScopedRows(rows, [], (row) => row.inPeriod),
+    ).toHaveLength(150)
+  })
+})

--- a/src/lib/owner-updates/photo-selection.ts
+++ b/src/lib/owner-updates/photo-selection.ts
@@ -1,0 +1,12 @@
+export function retainSelectedAndScopedRows<
+  Row extends { readonly id: string },
+>(
+  rows: readonly Row[],
+  selectedIds: readonly string[],
+  isInScope: (row: Row) => boolean,
+): readonly Row[] {
+  const selectedIdSet = new Set(selectedIds)
+  return rows.filter(
+    (row) => selectedIdSet.has(row.id) || isInScope(row),
+  )
+}


### PR DESCRIPTION
## Summary
- add Select all and Clear controls to the Owner Update project photo library
- keep photo cards in the project's stable canonical order after saving instead of moving selected photos to the top
- remove the hidden 120-photo library cutoff so large reporting periods remain fully selectable
- lazy-load thumbnails to keep large libraries responsive

## Validation
- 11 focused Owner Update tests passed, including new stable-order and 150-photo regressions
- TypeScript passed
- focused ESLint passed
- production Next webpack build passed
- `git diff --check` passed
- autoreview attempted; blocked by read-only `~/.codex/state_5.sqlite`, followed by manual complete-diff review

Fixes #250
Fixes #251
