### PR TITLE
test(e2e): restore deterministic project fixtures

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,9 @@ const isElectron = () => {
 
 const externalBaseUrl = process.env.PLAYWRIGHT_BASE_URL
 const baseURL = externalBaseUrl ?? "http://127.0.0.1:3000"
+const localServerCommand = process.env.CI && !isElectron()
+  ? "COMPASS_E2E=true node node_modules/next/dist/bin/next start"
+  : "node node_modules/next/dist/bin/next dev --webpack"
 
 // Web-specific projects
 const webProjects = [
@@ -68,7 +71,12 @@ export default defineConfig({
   webServer: externalBaseUrl
     ? undefined
     : {
-        command: "bun dev",
+        // The deterministic D1 adapter uses better-sqlite3. Run the Next test
+        // server under Node so the prepared fixture database remains available.
+        // CI builds before Playwright runs, so use the bounded production
+        // server there. The dev server can restart under the full route sweep's
+        // memory pressure, interrupting Firefox/WebKit navigations mid-test.
+        command: localServerCommand,
         url: baseURL,
         timeout: 120000,
         reuseExistingServer: !process.env.CI,

--- a/scripts/seed-e2e-local.mjs
+++ b/scripts/seed-e2e-local.mjs
@@ -66,6 +66,16 @@ const upsert = db.transaction(() => {
   `).run(now, now)
 
   db.prepare(`
+    INSERT INTO project_members (
+      id, project_id, user_id, role, assigned_at
+    ) VALUES (
+      'e2e-project-member-001', 'e2e-project-001', 'demo-user-001',
+      'project_manager', ?
+    )
+    ON CONFLICT(id) DO UPDATE SET role = excluded.role
+  `).run(now)
+
+  db.prepare(`
     INSERT INTO schedule_tasks (
       id, project_id, title, start_date, workdays, end_date_calculated, phase,
       display_color, status, is_critical_path, is_milestone, percent_complete,

--- a/src/app/demo/route.ts
+++ b/src/app/demo/route.ts
@@ -1,11 +1,12 @@
 import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
+import { isE2ETest } from "@/lib/auth-config"
 
 export async function GET() {
   const cookieStore = await cookies()
   cookieStore.set("compass-demo", "true", {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
+    secure: process.env.NODE_ENV === "production" && !isE2ETest(),
     sameSite: "strict",
     path: "/",
     maxAge: 60 * 60 * 24, // 24 hours

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Sora, IBM_Plex_Mono, Playfair_Display } from "next/font/google";
 import { AuthKitProvider } from "@workos-inc/authkit-nextjs/components";
 import { ThemeProvider } from "@/components/theme-provider";
+import { isWorkOSConfigured } from "@/lib/auth-config";
 import "./globals.css";
 
 const sora = Sora({
@@ -42,15 +43,17 @@ export default function RootLayout({
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
+	const content = <ThemeProvider>{children}</ThemeProvider>;
+
 	return (
 		<html lang="en" suppressHydrationWarning>
 		<body className={`${sora.variable} ${ibmPlexMono.variable} ${playfair.variable} font-sans antialiased`}>
-			<AuthKitProvider>
-				<ThemeProvider>
-					{children}
-				</ThemeProvider>
-			</AuthKitProvider>
+			{isWorkOSConfigured() ? (
+				<AuthKitProvider>{content}</AuthKitProvider>
+			) : (
+				content
+			)}
 		</body>
-		</html>
+	</html>
 	);
 }

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -14,6 +14,13 @@ export function isLocalDevelopment(): boolean {
   return process.env.NODE_ENV === "development"
 }
 
+export function isE2ETest(): boolean {
+  return process.env.COMPASS_E2E === "true"
+}
+
 export function isDevAuthFallbackAllowed(): boolean {
-  return isLocalDevelopment() && !isWorkOSConfigured()
+  return (
+    (isLocalDevelopment() || isE2ETest()) &&
+    !isWorkOSConfigured()
+  )
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,3 +1,5 @@
+import { isE2ETest } from "@/lib/auth-config"
+
 type CompassCloudflareContext = {
     env: CloudflareEnv
     ctx: {
@@ -10,7 +12,8 @@ export async function getCloudflareContext(): Promise<CompassCloudflareContext> 
     const useCloudflareDevProxy =
         process.env.COMPASS_USE_CLOUDFLARE_DEV_PROXY === "true"
     const isLocalDev =
-        process.env.NODE_ENV === "development" && !useCloudflareDevProxy
+        (process.env.NODE_ENV === "development" || isE2ETest()) &&
+        !useCloudflareDevProxy
 
     if (isLocalDev) {
         return getLocalCloudflareContext()
@@ -23,7 +26,7 @@ export async function getCloudflareContext(): Promise<CompassCloudflareContext> 
         return getCfContext()
     } catch (error) {
         if (
-            process.env.NODE_ENV === "development" &&
+            (process.env.NODE_ENV === "development" || isE2ETest()) &&
             error instanceof Error &&
             error.message.includes("initOpenNextCloudflareForDev")
         ) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,13 +1,16 @@
 import { NextRequest, NextResponse } from "next/server"
 import { authkit, handleAuthkitHeaders } from "@workos-inc/authkit-nextjs"
-import { isLocalDevelopment, isWorkOSConfigured } from "@/lib/auth-config"
+import {
+  isDevAuthFallbackAllowed,
+  isWorkOSConfigured,
+} from "@/lib/auth-config"
 import { isPublicPath } from "@/lib/public-paths"
 
 export default async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
   if (!isWorkOSConfigured()) {
-    if (isLocalDevelopment()) {
+    if (isDevAuthFallbackAllowed()) {
       return NextResponse.next()
     }
 


### PR DESCRIPTION
## Summary
- run the local Next E2E server under Node/Webpack so the prepared better-sqlite3 D1 fixture remains available
- seed the demo user's project membership so project-scoped actions authorize the deterministic fixture
- mount AuthKitProvider only when WorkOS is configured, avoiding invalid AuthKit server actions in the deliberately unconfigured local/demo harness

## Root cause
The workflow created and seeded `.e2e/compass.db`, then launched Next under Bun. The local D1 adapter uses better-sqlite3, which was unavailable in that runtime. Once Node restored D1, the fixture still lacked the project membership required by project-scoped actions. AuthKitProvider also invoked WorkOS server actions even though E2E intentionally leaves WorkOS unconfigured.

## Validation
- six formerly failing Chromium checks: 6 passed
- complete Chromium usable-area suite: 13 passed
- TypeScript passed
- focused ESLint passed
- production Next webpack build passed
- `git diff --check` passed
- autoreview attempted; blocked by read-only `~/.codex/state_5.sqlite`, followed by manual complete-diff review

Fixes #243
