### PR TITLE
feat(schedule): add controlled external publishing

### DIFF
--- a/docs/modules/scheduling.md
+++ b/docs/modules/scheduling.md
@@ -15,7 +15,9 @@ The scheduling data lives in four tables defined in the core schema (`src/db/sch
 
 **`workday_exceptions`** -- non-working days per project. Holidays, vacation days, weather days. These are excluded from business-day calculations. Exceptions can be one-time or yearly recurring, and are categorized (national holiday, state holiday, vacation, company holiday, weather day).
 
-**`schedule_baselines`** -- named snapshots of the schedule at a point in time. Stores a JSON blob of all tasks and dependencies, used for tracking schedule drift.
+**`schedule_baselines`** -- named snapshots of the schedule at a point in time. Stores a JSON blob of all tasks and dependencies, used for tracking schedule drift. Comparisons report start and finish movement per item plus the overall project-finish slippage.
+
+**`schedule_publications`** -- immutable, versioned snapshots released to owner and subcontractor workspaces. Internal schedule mutations remain draft changes until staff publishes a new snapshot with a reason. Existing projects receive an initial snapshot during migration so the rollout does not expose later internal edits by accident.
 
 The type system (`src/lib/schedule/types.ts`) models construction phases explicitly:
 
@@ -135,6 +137,15 @@ server actions
 - `createWorkdayException(projectId, data)` -- create an exception
 - `updateWorkdayException(exceptionId, data)` -- update an exception
 - `deleteWorkdayException(exceptionId)` -- delete an exception
+
+Each exception mutation calculates the resulting schedule first, then commits
+the exception and every affected schedule date in one D1 batch. The activity
+history records how many schedule items moved.
+
+`src/app/actions/schedule-publications.ts` provides:
+
+- `getSchedulePublicationStatus(projectId)` -- report the latest external release and whether internal draft changes exist
+- `publishSchedule(projectId, reason)` -- save the current schedule, dependencies, and workday calendar as the next external snapshot
 
 
 UI components

--- a/drizzle/0076_schedule_publications.sql
+++ b/drizzle/0076_schedule_publications.sql
@@ -1,0 +1,100 @@
+CREATE TABLE `schedule_publications` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_id` text NOT NULL,
+  `snapshot_data` text NOT NULL,
+  `change_reason` text NOT NULL,
+  `published_by` text,
+  `published_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`published_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `idx_schedule_publications_project_published`
+  ON `schedule_publications` (`project_id`, `published_at`);
+--> statement-breakpoint
+INSERT INTO `schedule_publications` (
+  `id`,
+  `project_id`,
+  `snapshot_data`,
+  `change_reason`,
+  `published_by`,
+  `published_at`
+)
+SELECT
+  'initial-schedule-publication-' || p.`id`,
+  p.`id`,
+  json_object(
+    'version', 1,
+    'tasks', json(COALESCE((
+      SELECT json_group_array(json_object(
+        'id', t.`id`,
+        'projectId', t.`project_id`,
+        'title', t.`title`,
+        'startDate', t.`start_date`,
+        'workdays', t.`workdays`,
+        'endDateCalculated', t.`end_date_calculated`,
+        'phase', t.`phase`,
+        'displayColor', t.`display_color`,
+        'status', t.`status`,
+        'isCriticalPath', json(CASE WHEN t.`is_critical_path` = 1 THEN 'true' ELSE 'false' END),
+        'isMilestone', json(CASE WHEN t.`is_milestone` = 1 THEN 'true' ELSE 'false' END),
+        'percentComplete', t.`percent_complete`,
+        'assignedTo', t.`assigned_to`,
+        'sortOrder', t.`sort_order`,
+        'createdAt', t.`created_at`,
+        'updatedAt', t.`updated_at`
+      ))
+      FROM `schedule_tasks` t
+      WHERE t.`project_id` = p.`id`
+      ORDER BY t.`sort_order`
+    ), '[]')),
+    'dependencies', json(COALESCE((
+      SELECT json_group_array(json_object(
+        'id', d.`id`,
+        'predecessorId', d.`predecessor_id`,
+        'successorId', d.`successor_id`,
+        'type', d.`type`,
+        'lagDays', d.`lag_days`
+      ))
+      FROM `task_dependencies` d
+      JOIN `schedule_tasks` successor
+        ON successor.`id` = d.`successor_id`
+      WHERE successor.`project_id` = p.`id`
+    ), '[]')),
+    'exceptions', json(COALESCE((
+      SELECT json_group_array(json_object(
+        'id', e.`id`,
+        'projectId', e.`project_id`,
+        'title', e.`title`,
+        'startDate', e.`start_date`,
+        'endDate', e.`end_date`,
+        'type', e.`type`,
+        'category', e.`category`,
+        'recurrence', e.`recurrence`,
+        'notes', e.`notes`,
+        'createdAt', e.`created_at`,
+        'updatedAt', e.`updated_at`
+      ))
+      FROM `workday_exceptions` e
+      WHERE e.`project_id` = p.`id`
+      ORDER BY e.`start_date`
+    ), '[]'))
+  ),
+  'Initial controlled schedule snapshot.',
+  (
+    SELECT om.`user_id`
+    FROM `organization_members` om
+    WHERE om.`organization_id` = p.`organization_id`
+    ORDER BY
+      CASE WHEN om.`role` IN ('admin', 'super_admin') THEN 0 ELSE 1 END,
+      om.`joined_at`
+    LIMIT 1
+  ),
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+FROM `projects` p
+WHERE p.`organization_id` IS NOT NULL
+  AND EXISTS (
+    SELECT 1
+    FROM `organization_members` om
+    WHERE om.`organization_id` = p.`organization_id`
+  );

--- a/src/app/actions/baselines.ts
+++ b/src/app/actions/baselines.ts
@@ -13,12 +13,15 @@ import { revalidatePath } from "next/cache"
 import { requireAuth } from "@/lib/auth"
 import { requireOrg } from "@/lib/org-scope"
 import { isDemoUser } from "@/lib/demo"
+import { requirePermission } from "@/lib/permissions"
+import { recordActivityEvent } from "@/lib/activity-log"
 import type { ScheduleBaselineData } from "@/lib/schedule/types"
 
 export async function getBaselines(
   projectId: string
 ): Promise<ScheduleBaselineData[]> {
   const user = await requireAuth()
+  requirePermission(user, "schedule", "read")
   const orgId = requireOrg(user)
 
   const { env } = await getCloudflareContext()
@@ -50,6 +53,7 @@ export async function createBaseline(
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
+    requirePermission(user, "schedule", "update")
     const orgId = requireOrg(user)
 
     const { env } = await getCloudflareContext()
@@ -80,14 +84,27 @@ export async function createBaseline(
 
     const snapshot = JSON.stringify({ tasks, dependencies: projectDeps })
 
+    const baselineId = crypto.randomUUID()
     await db.insert(scheduleBaselines).values({
-      id: crypto.randomUUID(),
+      id: baselineId,
       projectId,
       name,
       snapshotData: snapshot,
       createdAt: new Date().toISOString(),
     })
 
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.baseline_created",
+      entityType: "schedule_baseline",
+      entityId: baselineId,
+      summary: `Saved schedule baseline “${name}”.`,
+      metadata: { itemCount: tasks.length },
+    })
     revalidatePath(`/dashboard/projects/${projectId}/schedule`)
     return { success: true }
   } catch (error) {
@@ -104,6 +121,7 @@ export async function deleteBaseline(
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
+    requirePermission(user, "schedule", "update")
     const orgId = requireOrg(user)
 
     const { env } = await getCloudflareContext()
@@ -132,6 +150,17 @@ export async function deleteBaseline(
       .delete(scheduleBaselines)
       .where(eq(scheduleBaselines.id, baselineId))
 
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId: existing.projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.baseline_deleted",
+      entityType: "schedule_baseline",
+      entityId: baselineId,
+      summary: "Deleted a schedule baseline.",
+    })
     revalidatePath(
       `/dashboard/projects/${existing.projectId}/schedule`
     )

--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -13,6 +13,7 @@ import {
   projectOperations,
   projectRfis,
   projects,
+  schedulePublications,
   scheduleTasks,
   users,
 } from "@/db/schema"
@@ -34,6 +35,7 @@ import {
   type OwnerScheduleView,
   type OwnerScheduleVisibleItem,
 } from "@/lib/schedule/owner-visibility"
+import { parsePublishedScheduleSnapshot } from "@/lib/schedule/publications"
 import { projectAudiencePhotoUrl } from "@/lib/photo-sources"
 
 export type { ProjectAudience } from "@/lib/project-audience-access"
@@ -350,7 +352,7 @@ export async function getProjectAudiencePreview(
     )
     .orderBy(desc(dailyLogPhotos.capturedAt), desc(dailyLogPhotos.createdAt))
 
-  const scheduleRows = await db
+  const currentScheduleRows = await db
     .select({
       id: scheduleTasks.id,
       title: scheduleTasks.title,
@@ -366,6 +368,40 @@ export async function getProjectAudiencePreview(
     .from(scheduleTasks)
     .where(eq(scheduleTasks.projectId, projectId))
     .orderBy(asc(scheduleTasks.startDate), asc(scheduleTasks.sortOrder))
+  const publishedSchedule = await db
+    .select({ snapshotData: schedulePublications.snapshotData })
+    .from(schedulePublications)
+    .where(eq(schedulePublications.projectId, projectId))
+    .orderBy(desc(schedulePublications.publishedAt))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  const publishedSnapshot = publishedSchedule
+    ? parsePublishedScheduleSnapshot(publishedSchedule.snapshotData)
+    : null
+  // Once a publication exists, fail closed if its immutable snapshot cannot
+  // be parsed. Falling back to live rows could expose unpublished changes.
+  const scheduleRowsUnsorted = publishedSchedule
+    ? publishedSnapshot
+      ? publishedSnapshot.tasks.map((task) => ({
+          id: task.id,
+          title: task.title,
+          startDate: task.startDate,
+          endDate: task.endDateCalculated,
+          status: task.status,
+          phase: task.phase,
+          assignedTo: task.assignedTo,
+          percentComplete: task.percentComplete,
+          isMilestone: task.isMilestone,
+          workdays: task.workdays,
+        }))
+      : []
+    : currentScheduleRows
+  const scheduleRows = [...scheduleRowsUnsorted].sort(
+    (left, right) =>
+      left.startDate.localeCompare(right.startDate) ||
+      left.title.localeCompare(right.title) ||
+      left.id.localeCompare(right.id)
+  )
 
   const contactRows = await db
     .select({

--- a/src/app/actions/schedule-publications.ts
+++ b/src/app/actions/schedule-publications.ts
@@ -1,0 +1,209 @@
+"use server"
+
+import { and, asc, desc, eq, gt, inArray } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import {
+  activityEvents,
+  projects,
+  schedulePublications,
+  scheduleTasks,
+  taskDependencies,
+  workdayExceptions,
+} from "@/db/schema"
+import { recordActivityEvent } from "@/lib/activity-log"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import { requireOrg } from "@/lib/org-scope"
+import { requirePermission } from "@/lib/permissions"
+import {
+  DRAFT_SCHEDULE_ACTIONS,
+  publishedScheduleSnapshotSchema,
+} from "@/lib/schedule/publications"
+
+export type SchedulePublicationStatus = {
+  readonly hasPublishedSchedule: boolean
+  readonly hasUnpublishedChanges: boolean
+  readonly publishedAt: string | null
+  readonly publishedBy: string | null
+  readonly changeReason: string | null
+}
+
+async function requireProject(
+  db: ReturnType<typeof getDb>,
+  projectId: string,
+  organizationId: string
+): Promise<{ readonly id: string }> {
+  const project = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.id, projectId),
+        eq(projects.organizationId, organizationId)
+      )
+    )
+    .get()
+
+  if (!project) throw new Error("Project not found or access denied")
+  return project
+}
+
+export async function getSchedulePublicationStatus(
+  projectId: string
+): Promise<SchedulePublicationStatus> {
+  const user = await requireAuth()
+  requirePermission(user, "schedule", "read")
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  await requireProject(db, projectId, organizationId)
+
+  const latest = await db
+    .select({
+      publishedAt: schedulePublications.publishedAt,
+      publishedBy: schedulePublications.publishedBy,
+      changeReason: schedulePublications.changeReason,
+    })
+    .from(schedulePublications)
+    .where(eq(schedulePublications.projectId, projectId))
+    .orderBy(desc(schedulePublications.publishedAt))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+
+  if (!latest) {
+    const firstTask = await db
+      .select({ id: scheduleTasks.id })
+      .from(scheduleTasks)
+      .where(eq(scheduleTasks.projectId, projectId))
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    return {
+      hasPublishedSchedule: false,
+      hasUnpublishedChanges: firstTask !== null,
+      publishedAt: null,
+      publishedBy: null,
+      changeReason: null,
+    }
+  }
+
+  const laterDraftEvent = await db
+    .select({ id: activityEvents.id })
+    .from(activityEvents)
+    .where(
+      and(
+        eq(activityEvents.organizationId, organizationId),
+        eq(activityEvents.projectId, projectId),
+        eq(activityEvents.category, "schedule"),
+        gt(activityEvents.createdAt, latest.publishedAt),
+        inArray(activityEvents.action, DRAFT_SCHEDULE_ACTIONS)
+      )
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+
+  return {
+    hasPublishedSchedule: true,
+    hasUnpublishedChanges: laterDraftEvent !== null,
+    publishedAt: latest.publishedAt,
+    publishedBy: latest.publishedBy,
+    changeReason: latest.changeReason,
+  }
+}
+
+export async function publishSchedule(
+  projectId: string,
+  rawReason: string
+): Promise<
+  | { readonly success: true; readonly publishedAt: string }
+  | { readonly success: false; readonly error: string }
+> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    requirePermission(user, "schedule", "update")
+    const organizationId = requireOrg(user)
+    const changeReason = rawReason.trim()
+    if (changeReason.length < 3 || changeReason.length > 500) {
+      return {
+        success: false,
+        error: "Enter a publish reason between 3 and 500 characters.",
+      }
+    }
+
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    await requireProject(db, projectId, organizationId)
+
+    const tasks = await db
+      .select()
+      .from(scheduleTasks)
+      .where(eq(scheduleTasks.projectId, projectId))
+      .orderBy(asc(scheduleTasks.sortOrder))
+    const taskIds = new Set(tasks.map((task) => task.id))
+    const dependencies = (await db.select().from(taskDependencies)).filter(
+      (dependency) =>
+        taskIds.has(dependency.predecessorId) &&
+        taskIds.has(dependency.successorId)
+    )
+    const exceptions = await db
+      .select()
+      .from(workdayExceptions)
+      .where(eq(workdayExceptions.projectId, projectId))
+      .orderBy(asc(workdayExceptions.startDate))
+    const snapshot = publishedScheduleSnapshotSchema.parse({
+      version: 1,
+      tasks,
+      dependencies,
+      exceptions,
+    })
+    const publishedAt = new Date().toISOString()
+
+    await db.insert(schedulePublications).values({
+      id: crypto.randomUUID(),
+      projectId,
+      snapshotData: JSON.stringify(snapshot),
+      changeReason,
+      publishedBy: user.id,
+      publishedAt,
+    })
+    await recordActivityEvent({
+      db,
+      organizationId,
+      projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.published",
+      entityType: "project_schedule",
+      entityId: projectId,
+      summary: `Published the project schedule: ${changeReason}`,
+      metadata: {
+        itemCount: tasks.length,
+        dependencyCount: dependencies.length,
+        exceptionCount: exceptions.length,
+      },
+      createdAt: publishedAt,
+    })
+
+    revalidatePath(`/dashboard/projects/${projectId}/schedule`)
+    revalidatePath("/dashboard/schedule")
+    revalidatePath(`/preview/projects/${projectId}/owner`)
+    revalidatePath(`/preview/projects/${projectId}/owner/schedule`)
+    revalidatePath(`/preview/projects/${projectId}/sub-vendor`)
+    revalidatePath(`/preview/projects/${projectId}/sub-vendor/schedule`)
+    return { success: true, publishedAt }
+  } catch (error) {
+    console.error("Unable to publish schedule", error)
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to publish the schedule.",
+    }
+  }
+}

--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -411,6 +411,7 @@ export async function createTask(
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
+    requirePermission(user, "schedule", "update")
     const orgId = requireOrg(user)
 
     const { env } = await getCloudflareContext()
@@ -524,6 +525,7 @@ export async function updateTask(
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
+    requirePermission(user, "schedule", "update")
     const orgId = requireOrg(user)
 
     const { env } = await getCloudflareContext()
@@ -658,6 +660,7 @@ export async function deleteTask(
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
+    requirePermission(user, "schedule", "update")
     const orgId = requireOrg(user)
 
     const { env } = await getCloudflareContext()
@@ -712,6 +715,7 @@ export async function completeScheduleTasks(
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
+    requirePermission(user, "schedule", "update")
     const orgId = requireOrg(user)
     const ids = [...new Set(taskIds.map((id) => id.trim()).filter(Boolean))]
 
@@ -801,6 +805,7 @@ export async function assignScheduleTasks(
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
+    requirePermission(user, "schedule", "update")
     const orgId = requireOrg(user)
     const ids = [...new Set(taskIds.map((id) => id.trim()).filter(Boolean))]
 
@@ -886,6 +891,7 @@ export async function deleteScheduleTasks(
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
+    requirePermission(user, "schedule", "update")
     const orgId = requireOrg(user)
     const ids = [...new Set(taskIds.map((id) => id.trim()).filter(Boolean))]
 
@@ -966,6 +972,7 @@ export async function reorderTasks(
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
+    requirePermission(user, "schedule", "update")
     const orgId = requireOrg(user)
 
     const { env } = await getCloudflareContext()
@@ -982,13 +989,63 @@ export async function reorderTasks(
       return { success: false, error: "Project not found or access denied" }
     }
 
-    for (const item of items) {
+    const uniqueItems = [...new Map(
+      items
+        .filter((item) => item.id.trim().length > 0)
+        .map((item) => [item.id, item])
+    ).values()]
+    if (uniqueItems.length === 0) {
+      return { success: false, error: "Select schedule items to reorder" }
+    }
+    if (uniqueItems.length > 500) {
+      return {
+        success: false,
+        error: "Reorder no more than 500 schedule items at a time",
+      }
+    }
+    const matchingTasks = await db
+      .select({ id: scheduleTasks.id })
+      .from(scheduleTasks)
+      .where(
+        and(
+          eq(scheduleTasks.projectId, projectId),
+          inArray(
+            scheduleTasks.id,
+            uniqueItems.map((item) => item.id)
+          )
+        )
+      )
+    if (matchingTasks.length !== uniqueItems.length) {
+      return {
+        success: false,
+        error: "One or more schedule items do not belong to this project",
+      }
+    }
+
+    for (const item of uniqueItems) {
       await db
         .update(scheduleTasks)
         .set({ sortOrder: item.sortOrder })
-        .where(eq(scheduleTasks.id, item.id))
+        .where(
+          and(
+            eq(scheduleTasks.id, item.id),
+            eq(scheduleTasks.projectId, projectId)
+          )
+        )
     }
 
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.items_reordered",
+      entityType: "project_schedule",
+      entityId: projectId,
+      summary: `Reordered ${uniqueItems.length} schedule ${uniqueItems.length === 1 ? "item" : "items"}.`,
+      metadata: { itemCount: uniqueItems.length },
+    })
     revalidateSchedulePaths(projectId)
     return { success: true }
   } catch (error) {
@@ -1012,6 +1069,7 @@ export async function createDependency(data: {
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
+    requirePermission(user, "schedule", "update")
     const orgId = requireOrg(user)
 
     const { env } = await getCloudflareContext()
@@ -1111,6 +1169,21 @@ export async function createDependency(data: {
         .where(eq(scheduleTasks.id, id))
     }
 
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId: data.projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.dependency_created",
+      entityType: "schedule_dependency",
+      summary: "Added a schedule dependency.",
+      metadata: {
+        affectedItemCount: updatedTasks.size,
+        relationship: data.type,
+        lagDays: data.lagDays,
+      },
+    })
     await recalcCriticalPath(db, data.projectId)
     revalidateSchedulePaths(data.projectId)
     return { success: true }
@@ -1136,6 +1209,7 @@ export async function updateDependency(data: {
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
+    requirePermission(user, "schedule", "update")
     const orgId = requireOrg(user)
 
     const { env } = await getCloudflareContext()
@@ -1252,6 +1326,22 @@ export async function updateDependency(data: {
       throw new Error("Dependency update batch failed")
     }
 
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId: data.projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.dependency_updated",
+      entityType: "schedule_dependency",
+      entityId: data.dependencyId,
+      summary: "Updated a schedule dependency.",
+      metadata: {
+        affectedItemCount: recalculated.updatedTasks.size,
+        relationship: data.type,
+        lagDays: data.lagDays,
+      },
+    })
     await recalcCriticalPath(db, data.projectId)
     revalidateSchedulePaths(data.projectId)
     return { success: true }
@@ -1270,6 +1360,7 @@ export async function deleteDependency(
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
+    requirePermission(user, "schedule", "update")
     const orgId = requireOrg(user)
 
     const { env } = await getCloudflareContext()
@@ -1315,6 +1406,17 @@ export async function deleteDependency(
     }
 
     await db.delete(taskDependencies).where(eq(taskDependencies.id, depId))
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.dependency_deleted",
+      entityType: "schedule_dependency",
+      entityId: depId,
+      summary: "Removed a schedule dependency.",
+    })
     await recalcCriticalPath(db, projectId)
     revalidateSchedulePaths(projectId)
     return { success: true }
@@ -1333,6 +1435,7 @@ export async function updateTaskStatus(
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
+    requirePermission(user, "schedule", "update")
     const orgId = requireOrg(user)
 
     const { env } = await getCloudflareContext()
@@ -1366,6 +1469,18 @@ export async function updateTaskStatus(
       })
       .where(eq(scheduleTasks.id, taskId))
 
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId: task.projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.item_status_changed",
+      entityType: "schedule_item",
+      entityId: taskId,
+      summary: `Changed “${task.title}” to ${status.toLowerCase().replace("_", " ")}.`,
+      metadata: { status },
+    })
     revalidateSchedulePaths(task.projectId)
     return { success: true }
   } catch (error) {

--- a/src/app/actions/workday-exceptions.ts
+++ b/src/app/actions/workday-exceptions.ts
@@ -13,6 +13,8 @@ import { revalidatePath } from "next/cache"
 import { requireAuth } from "@/lib/auth"
 import { requireOrg } from "@/lib/org-scope"
 import { isDemoUser } from "@/lib/demo"
+import { requirePermission } from "@/lib/permissions"
+import { recordActivityEvent } from "@/lib/activity-log"
 import { recalculateScheduleDates } from "@/lib/schedule/propagate-dates"
 import type {
   DependencyType,
@@ -25,8 +27,12 @@ import type {
 
 async function recalculateProjectDates(
   db: ReturnType<typeof getDb>,
-  projectId: string
-): Promise<void> {
+  projectId: string,
+  exceptions: readonly WorkdayExceptionData[]
+): Promise<ReadonlyMap<string, {
+  readonly startDate: string
+  readonly endDateCalculated: string
+}>> {
   const tasks = await db
     .select()
     .from(scheduleTasks)
@@ -37,11 +43,6 @@ async function recalculateProjectDates(
       taskIds.has(dependency.predecessorId) &&
       taskIds.has(dependency.successorId)
   )
-  const exceptions = await db
-    .select()
-    .from(workdayExceptions)
-    .where(eq(workdayExceptions.projectId, projectId))
-
   const { updatedTasks } = recalculateScheduleDates(
     tasks.map((task) => ({
       ...task,
@@ -51,20 +52,77 @@ async function recalculateProjectDates(
       ...dependency,
       type: dependency.type as DependencyType,
     })),
-    exceptions.map((exception) => ({
-      ...exception,
-      type: exception.type as WorkdayExceptionType,
-      category: exception.category as ExceptionCategory,
-      recurrence: exception.recurrence as ExceptionRecurrence,
-    }))
+    exceptions
   )
 
-  const updatedAt = new Date().toISOString()
+  return updatedTasks
+}
+
+function exceptionType(value: string): WorkdayExceptionType {
+  return value === "working" ? "working" : "non_working"
+}
+
+function exceptionCategory(value: string): ExceptionCategory {
+  switch (value) {
+    case "national_holiday":
+    case "state_holiday":
+    case "vacation_day":
+    case "company_holiday":
+    case "weather_day":
+    case "extra_workday":
+      return value
+    default:
+      return "company_holiday"
+  }
+}
+
+function exceptionRecurrence(value: string): ExceptionRecurrence {
+  return value === "yearly" ? "yearly" : "one_time"
+}
+
+function exceptionData(
+  row: typeof workdayExceptions.$inferSelect
+): WorkdayExceptionData {
+  return {
+    ...row,
+    type: exceptionType(row.type),
+    category: exceptionCategory(row.category),
+    recurrence: exceptionRecurrence(row.recurrence),
+  }
+}
+
+async function runExceptionScheduleBatch(
+  database: D1Database,
+  mutation: D1PreparedStatement,
+  projectId: string,
+  updatedAt: string,
+  updatedTasks: ReadonlyMap<string, {
+    readonly startDate: string
+    readonly endDateCalculated: string
+  }>
+): Promise<void> {
+  const statements: D1PreparedStatement[] = [mutation]
   for (const [taskId, dates] of updatedTasks) {
-    await db
-      .update(scheduleTasks)
-      .set({ ...dates, updatedAt })
-      .where(eq(scheduleTasks.id, taskId))
+    statements.push(
+      database
+        .prepare(
+          `UPDATE schedule_tasks
+           SET start_date = ?, end_date_calculated = ?, updated_at = ?
+           WHERE id = ? AND project_id = ?`
+        )
+        .bind(
+          dates.startDate,
+          dates.endDateCalculated,
+          updatedAt,
+          taskId,
+          projectId
+        )
+    )
+  }
+
+  const results = await database.batch(statements)
+  if (results.some((result) => !result.success)) {
+    throw new Error("Workday exception schedule batch failed")
   }
 }
 
@@ -72,6 +130,7 @@ export async function getWorkdayExceptions(
   projectId: string
 ): Promise<WorkdayExceptionData[]> {
   const user = await requireAuth()
+  requirePermission(user, "schedule", "read")
   const orgId = requireOrg(user)
 
   const { env } = await getCloudflareContext()
@@ -93,12 +152,7 @@ export async function getWorkdayExceptions(
     .from(workdayExceptions)
     .where(eq(workdayExceptions.projectId, projectId))
 
-  return rows.map((r) => ({
-    ...r,
-    type: r.type as WorkdayExceptionType,
-    category: r.category as ExceptionCategory,
-    recurrence: r.recurrence as ExceptionRecurrence,
-  }))
+  return rows.map(exceptionData)
 }
 
 export async function createWorkdayException(
@@ -118,6 +172,7 @@ export async function createWorkdayException(
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
+    requirePermission(user, "schedule", "update")
     const orgId = requireOrg(user)
 
     const { env } = await getCloudflareContext()
@@ -135,9 +190,14 @@ export async function createWorkdayException(
     }
 
     const now = new Date().toISOString()
-
-    await db.insert(workdayExceptions).values({
-      id: crypto.randomUUID(),
+    const exceptionId = crypto.randomUUID()
+    const existingExceptions = await db
+      .select()
+      .from(workdayExceptions)
+      .where(eq(workdayExceptions.projectId, projectId))
+      .then((rows) => rows.map(exceptionData))
+    const newException: WorkdayExceptionData = {
+      id: exceptionId,
       projectId,
       title: data.title,
       startDate: data.startDate,
@@ -148,10 +208,51 @@ export async function createWorkdayException(
       notes: data.notes ?? null,
       createdAt: now,
       updatedAt: now,
+    }
+    const updatedTasks = await recalculateProjectDates(db, projectId, [
+      ...existingExceptions,
+      newException,
+    ])
+    await runExceptionScheduleBatch(
+      env.DB,
+      env.DB
+        .prepare(
+          `INSERT INTO workday_exceptions (
+             id, project_id, title, start_date, end_date, type, category,
+             recurrence, notes, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          newException.id,
+          newException.projectId,
+          newException.title,
+          newException.startDate,
+          newException.endDate,
+          newException.type,
+          newException.category,
+          newException.recurrence,
+          newException.notes,
+          newException.createdAt,
+          newException.updatedAt
+        ),
+      projectId,
+      now,
+      updatedTasks
+    )
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.workday_exception_created",
+      entityType: "workday_exception",
+      entityId: exceptionId,
+      summary: `Added workday exception “${data.title}”.`,
+      metadata: { affectedItemCount: updatedTasks.size },
     })
-
-    await recalculateProjectDates(db, projectId)
     revalidatePath(`/dashboard/projects/${projectId}/schedule`)
+    revalidatePath("/dashboard/schedule")
     return { success: true }
   } catch (error) {
     console.error("Failed to create workday exception:", error)
@@ -176,6 +277,7 @@ export async function updateWorkdayException(
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
+    requirePermission(user, "schedule", "update")
     const orgId = requireOrg(user)
 
     const { env } = await getCloudflareContext()
@@ -200,24 +302,72 @@ export async function updateWorkdayException(
       return { success: false, error: "Access denied" }
     }
 
-    await db
-      .update(workdayExceptions)
-      .set({
-        ...(data.title && { title: data.title }),
-        ...(data.startDate && { startDate: data.startDate }),
-        ...(data.endDate && { endDate: data.endDate }),
-        ...(data.type && { type: data.type }),
-        ...(data.category && { category: data.category }),
-        ...(data.recurrence && { recurrence: data.recurrence }),
-        ...(data.notes !== undefined && { notes: data.notes }),
-        updatedAt: new Date().toISOString(),
-      })
-      .where(eq(workdayExceptions.id, exceptionId))
-
-    await recalculateProjectDates(db, existing.projectId)
+    const updatedAt = new Date().toISOString()
+    const updatedException: WorkdayExceptionData = {
+      ...exceptionData(existing),
+      title: data.title ?? existing.title,
+      startDate: data.startDate ?? existing.startDate,
+      endDate: data.endDate ?? existing.endDate,
+      type: data.type ?? exceptionType(existing.type),
+      category: data.category ?? exceptionCategory(existing.category),
+      recurrence:
+        data.recurrence ?? exceptionRecurrence(existing.recurrence),
+      notes: data.notes === undefined ? existing.notes : data.notes,
+      updatedAt,
+    }
+    const currentExceptions = await db
+      .select()
+      .from(workdayExceptions)
+      .where(eq(workdayExceptions.projectId, existing.projectId))
+      .then((rows) => rows.map(exceptionData))
+    const updatedTasks = await recalculateProjectDates(
+      db,
+      existing.projectId,
+      currentExceptions.map((exception) =>
+        exception.id === exceptionId ? updatedException : exception
+      )
+    )
+    await runExceptionScheduleBatch(
+      env.DB,
+      env.DB
+        .prepare(
+          `UPDATE workday_exceptions
+           SET title = ?, start_date = ?, end_date = ?, type = ?, category = ?,
+               recurrence = ?, notes = ?, updated_at = ?
+           WHERE id = ? AND project_id = ?`
+        )
+        .bind(
+          updatedException.title,
+          updatedException.startDate,
+          updatedException.endDate,
+          updatedException.type,
+          updatedException.category,
+          updatedException.recurrence,
+          updatedException.notes,
+          updatedAt,
+          exceptionId,
+          existing.projectId
+        ),
+      existing.projectId,
+      updatedAt,
+      updatedTasks
+    )
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId: existing.projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.workday_exception_updated",
+      entityType: "workday_exception",
+      entityId: exceptionId,
+      summary: `Updated workday exception “${updatedException.title}”.`,
+      metadata: { affectedItemCount: updatedTasks.size },
+    })
     revalidatePath(
       `/dashboard/projects/${existing.projectId}/schedule`
     )
+    revalidatePath("/dashboard/schedule")
     return { success: true }
   } catch (error) {
     console.error("Failed to update workday exception:", error)
@@ -233,6 +383,7 @@ export async function deleteWorkdayException(
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
+    requirePermission(user, "schedule", "update")
     const orgId = requireOrg(user)
 
     const { env } = await getCloudflareContext()
@@ -257,14 +408,48 @@ export async function deleteWorkdayException(
       return { success: false, error: "Access denied" }
     }
 
-    await db
-      .delete(workdayExceptions)
-      .where(eq(workdayExceptions.id, exceptionId))
-
-    await recalculateProjectDates(db, existing.projectId)
+    const updatedAt = new Date().toISOString()
+    const remainingExceptions = await db
+      .select()
+      .from(workdayExceptions)
+      .where(eq(workdayExceptions.projectId, existing.projectId))
+      .then((rows) =>
+        rows
+          .filter((exception) => exception.id !== exceptionId)
+          .map(exceptionData)
+      )
+    const updatedTasks = await recalculateProjectDates(
+      db,
+      existing.projectId,
+      remainingExceptions
+    )
+    await runExceptionScheduleBatch(
+      env.DB,
+      env.DB
+        .prepare(
+          "DELETE FROM workday_exceptions WHERE id = ? AND project_id = ?"
+        )
+        .bind(exceptionId, existing.projectId),
+      existing.projectId,
+      updatedAt,
+      updatedTasks
+    )
+    await recordActivityEvent({
+      db,
+      organizationId: orgId,
+      projectId: existing.projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.workday_exception_deleted",
+      entityType: "workday_exception",
+      entityId: exceptionId,
+      summary: `Deleted workday exception “${existing.title}”.`,
+      metadata: { affectedItemCount: updatedTasks.size },
+    })
     revalidatePath(
       `/dashboard/projects/${existing.projectId}/schedule`
     )
+    revalidatePath("/dashboard/schedule")
     return { success: true }
   } catch (error) {
     console.error("Failed to delete workday exception:", error)

--- a/src/app/dashboard/projects/[id]/schedule/page.tsx
+++ b/src/app/dashboard/projects/[id]/schedule/page.tsx
@@ -16,6 +16,10 @@ import { ScheduleView } from "@/components/schedule/schedule-view"
 import type { ScheduleData, ScheduleBaselineData } from "@/lib/schedule/types"
 import type { OwnerScheduleView } from "@/lib/schedule/owner-visibility"
 import { getScheduleSavedViews } from "@/app/actions/schedule-saved-views"
+import {
+  getSchedulePublicationStatus,
+  type SchedulePublicationStatus,
+} from "@/app/actions/schedule-publications"
 import { getCurrentUser } from "@/lib/auth"
 import { scheduleAssigneeTerms } from "@/lib/schedule/saved-views"
 
@@ -53,6 +57,7 @@ export default async function SchedulePage({
   let allProjects: ProjectListItem[] = []
   let assigneeOptions: ProjectTaskAssigneeOption[] = []
   let ownerScheduleView: OwnerScheduleView = "items"
+  let publicationStatus: SchedulePublicationStatus | null = null
   const [savedViews, currentUser] = await Promise.all([
     getScheduleSavedViews(),
     getCurrentUser(),
@@ -74,10 +79,11 @@ export default async function SchedulePage({
     projectName = project.projectNumber ?? project.name
     ownerScheduleView =
       project.ownerScheduleView === "phases" ? "phases" : "items"
-    ;[schedule, baselines, allProjects] = await Promise.all([
+    ;[schedule, baselines, allProjects, publicationStatus] = await Promise.all([
       getSchedule(id),
       getBaselines(id),
       getProjects(),
+      getSchedulePublicationStatus(id),
     ])
   } catch (e: unknown) {
     if (e && typeof e === "object" && "digest" in e && e.digest === "NEXT_NOT_FOUND") throw e
@@ -108,6 +114,7 @@ export default async function SchedulePage({
         ownerScheduleView={ownerScheduleView}
         savedViews={savedViews}
         currentUserAssigneeTerms={scheduleAssigneeTerms(currentUser)}
+        publicationStatus={publicationStatus}
       />
     </div>
   )

--- a/src/app/dashboard/schedule/page.tsx
+++ b/src/app/dashboard/schedule/page.tsx
@@ -20,6 +20,7 @@ import type {
 } from "@/lib/schedule/project-scope"
 import type { ProjectDepartment } from "@/lib/project-branding"
 import { getScheduleSavedViews } from "@/app/actions/schedule-saved-views"
+import { getSchedulePublicationStatus } from "@/app/actions/schedule-publications"
 import { getCurrentUser } from "@/lib/auth"
 import { scheduleAssigneeTerms } from "@/lib/schedule/saved-views"
 
@@ -176,6 +177,10 @@ export default async function SchedulePage({
       scope.kind === "project" && primaryProject
         ? await getOwnerScheduleView(primaryProject.id)
         : "items"
+    const publicationStatus =
+      scope.kind === "project" && primaryProject
+        ? await getSchedulePublicationStatus(primaryProject.id)
+        : null
 
     return (
       <div className="flex min-h-0 flex-1 flex-col px-4 py-2">
@@ -196,6 +201,7 @@ export default async function SchedulePage({
           ownerScheduleView={ownerScheduleView}
           savedViews={savedViews}
           currentUserAssigneeTerms={scheduleAssigneeTerms(currentUser)}
+          publicationStatus={publicationStatus}
         />
       </div>
     )

--- a/src/components/schedule/schedule-baseline-view.tsx
+++ b/src/components/schedule/schedule-baseline-view.tsx
@@ -20,6 +20,10 @@ import type {
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { format, parseISO } from "date-fns"
+import {
+  parseBaselineTasks,
+  scheduleBaselineVariance,
+} from "@/lib/schedule/baseline-variance"
 
 interface ScheduleBaselineViewProps {
   projectId: string
@@ -35,12 +39,10 @@ function formatDate(dateStr: string): string {
   }
 }
 
-interface SnapshotTask {
-  id: string
-  title: string
-  startDate: string
-  endDateCalculated: string
-  workdays: number
+function varianceLabel(value: number | null): string {
+  if (value === null) return "—"
+  if (value === 0) return "On plan"
+  return `${value > 0 ? "+" : ""}${value} days`
 }
 
 export function ScheduleBaselineView({
@@ -87,49 +89,9 @@ export function ScheduleBaselineView({
     const baseline = baselines.find((b) => b.id === selectedId)
     if (!baseline) return null
 
-    let snapshotTasks: SnapshotTask[] = []
-    try {
-      const parsed = JSON.parse(baseline.snapshotData)
-      snapshotTasks = parsed.tasks || []
-    } catch {
-      return null
-    }
-
-    const snapshotMap = new Map(
-      snapshotTasks.map((t) => [t.id, t])
-    )
-
-    return currentTasks.map((current) => {
-      const original = snapshotMap.get(current.id)
-      if (!original) {
-        return {
-          title: current.title,
-          originalStart: "-",
-          originalEnd: "-",
-          currentStart: current.startDate,
-          currentEnd: current.endDateCalculated,
-          variance: "New",
-        }
-      }
-
-      const origDays = original.workdays
-      const currDays = current.workdays
-      const diff = currDays - origDays
-
-      return {
-        title: current.title,
-        originalStart: original.startDate,
-        originalEnd: original.endDateCalculated,
-        currentStart: current.startDate,
-        currentEnd: current.endDateCalculated,
-        variance:
-          diff === 0
-            ? "On track"
-            : diff > 0
-              ? `+${diff} days`
-              : `${diff} days`,
-      }
-    })
+    const snapshotTasks = parseBaselineTasks(baseline.snapshotData)
+    if (!snapshotTasks) return null
+    return scheduleBaselineVariance(currentTasks, snapshotTasks)
   }, [selectedId, baselines, currentTasks])
 
   return (
@@ -214,6 +176,46 @@ export function ScheduleBaselineView({
           <h3 className="text-sm font-medium mb-2">
             Comparison: Current vs Baseline
           </h3>
+          <div className="mb-4 grid grid-cols-2 gap-x-6 gap-y-2 border-y py-3 text-sm md:grid-cols-4">
+            <div>
+              <span className="block text-xs text-muted-foreground">
+                Baseline finish
+              </span>
+              {comparison.baselineFinish
+                ? formatDate(comparison.baselineFinish)
+                : "—"}
+            </div>
+            <div>
+              <span className="block text-xs text-muted-foreground">
+                Current finish
+              </span>
+              {comparison.currentFinish
+                ? formatDate(comparison.currentFinish)
+                : "—"}
+            </div>
+            <div>
+              <span className="block text-xs text-muted-foreground">
+                Project slippage
+              </span>
+              <span
+                className={
+                  comparison.finishVarianceDays !== null &&
+                  comparison.finishVarianceDays > 0
+                    ? "font-medium text-red-600"
+                    : "font-medium text-green-700"
+                }
+              >
+                {varianceLabel(comparison.finishVarianceDays)}
+              </span>
+            </div>
+            <div>
+              <span className="block text-xs text-muted-foreground">
+                Item movement
+              </span>
+              {comparison.delayedItemCount} delayed ·{" "}
+              {comparison.aheadItemCount} ahead
+            </div>
+          </div>
           <div className="rounded-md border">
             <Table>
               <TableHeader>
@@ -223,44 +225,69 @@ export function ScheduleBaselineView({
                   <TableHead>Baseline End</TableHead>
                   <TableHead>Current Start</TableHead>
                   <TableHead>Current End</TableHead>
-                  <TableHead>Variance</TableHead>
+                  <TableHead>Start Variance</TableHead>
+                  <TableHead>Finish Variance</TableHead>
+                  <TableHead>Duration</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {comparison.map((row, i) => (
-                  <TableRow key={i}>
+                {comparison.rows.map((row) => (
+                  <TableRow key={row.id}>
                     <TableCell className="font-medium text-sm">
                       {row.title}
+                      {row.state !== "existing" && (
+                        <span className="ml-2 text-xs font-normal text-muted-foreground">
+                          {row.state === "new" ? "New" : "Removed"}
+                        </span>
+                      )}
                     </TableCell>
                     <TableCell className="text-xs text-muted-foreground">
-                      {row.originalStart === "-"
-                        ? "-"
-                        : formatDate(row.originalStart)}
+                      {row.baselineStart
+                        ? formatDate(row.baselineStart)
+                        : "—"}
                     </TableCell>
                     <TableCell className="text-xs text-muted-foreground">
-                      {row.originalEnd === "-"
-                        ? "-"
-                        : formatDate(row.originalEnd)}
+                      {row.baselineFinish
+                        ? formatDate(row.baselineFinish)
+                        : "—"}
                     </TableCell>
                     <TableCell className="text-xs text-muted-foreground">
-                      {formatDate(row.currentStart)}
+                      {row.currentStart
+                        ? formatDate(row.currentStart)
+                        : "—"}
                     </TableCell>
                     <TableCell className="text-xs text-muted-foreground">
-                      {formatDate(row.currentEnd)}
+                      {row.currentFinish
+                        ? formatDate(row.currentFinish)
+                        : "—"}
                     </TableCell>
                     <TableCell>
                       <span
-                        className={`text-xs font-medium ${
-                          row.variance === "On track"
-                            ? "text-green-600"
-                            : row.variance === "New"
-                              ? "text-blue-600"
-                              : row.variance.startsWith("+")
-                                ? "text-red-600"
-                                : "text-green-600"
-                        }`}
+                        className={
+                          row.startVarianceDays !== null &&
+                          row.startVarianceDays > 0
+                            ? "text-xs font-medium text-red-600"
+                            : "text-xs font-medium text-green-700"
+                        }
                       >
-                        {row.variance}
+                        {varianceLabel(row.startVarianceDays)}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      <span
+                        className={
+                          row.finishVarianceDays !== null &&
+                          row.finishVarianceDays > 0
+                            ? "text-xs font-medium text-red-600"
+                            : "text-xs font-medium text-green-700"
+                        }
+                      >
+                        {varianceLabel(row.finishVarianceDays)}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      <span className="text-xs font-medium">
+                        {varianceLabel(row.durationVarianceDays)}
                       </span>
                     </TableCell>
                   </TableRow>

--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -12,6 +12,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Label } from "@/components/ui/label"
@@ -68,6 +69,7 @@ import {
   IconDeviceFloppy,
   IconBookmark,
   IconTrash,
+  IconSend,
 } from "@tabler/icons-react"
 import { toast } from "sonner"
 import { ScheduleListView } from "./schedule-list-view"
@@ -108,6 +110,10 @@ import {
   saveScheduleView,
 } from "@/app/actions/schedule-saved-views"
 import {
+  publishSchedule,
+  type SchedulePublicationStatus,
+} from "@/app/actions/schedule-publications"
+import {
   SCHEDULE_GROUP_MODES,
   SCHEDULE_LIST_COLUMNS,
   SCHEDULE_VIEW_PRESETS,
@@ -141,6 +147,7 @@ interface ScheduleViewProps {
   readonly ownerScheduleView?: OwnerScheduleView
   readonly savedViews?: readonly SavedScheduleViewData[]
   readonly currentUserAssigneeTerms?: readonly string[]
+  readonly publicationStatus?: SchedulePublicationStatus | null
 }
 
 export function ScheduleView({
@@ -158,6 +165,7 @@ export function ScheduleView({
   ownerScheduleView = "items",
   savedViews: initialSavedViews = [],
   currentUserAssigneeTerms = [],
+  publicationStatus: initialPublicationStatus = null,
 }: ScheduleViewProps) {
   const router = useRouter()
   const pathname = usePathname()
@@ -214,8 +222,35 @@ export function ScheduleView({
   const [exceptionsOpen, setExceptionsOpen] = useState(false)
   const [importDialogOpen, setImportDialogOpen] = useState(false)
   const [isImporting, setIsImporting] = useState(false)
+  const [publicationStatus, setPublicationStatus] =
+    useState<SchedulePublicationStatus | null>(initialPublicationStatus)
+  const [publishOpen, setPublishOpen] = useState(false)
+  const [publishReason, setPublishReason] = useState("")
+  const [isPublishing, startPublishTransition] = useTransition()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const preferenceScopeKey = projectId ?? "unified"
+
+  function handlePublish(): void {
+    if (!projectId) return
+    startPublishTransition(async () => {
+      const result = await publishSchedule(projectId, publishReason)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      setPublicationStatus({
+        hasPublishedSchedule: true,
+        hasUnpublishedChanges: false,
+        publishedAt: result.publishedAt,
+        publishedBy: null,
+        changeReason: publishReason.trim(),
+      })
+      setPublishReason("")
+      setPublishOpen(false)
+      toast.success("Schedule published to owner and subcontractor views.")
+      router.refresh()
+    })
+  }
 
   useEffect(() => {
     const requestedOrder = searchParams.get("order")
@@ -702,6 +737,38 @@ export function ScheduleView({
         </div>
       </div>
 
+      {projectId && publicationStatus && (
+        <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1 border-y py-2 text-xs">
+          <span className="font-medium">
+            External schedule:
+            {" "}
+            {publicationStatus.hasPublishedSchedule
+              ? `Published ${new Date(
+                  publicationStatus.publishedAt ?? ""
+                ).toLocaleString()}`
+              : "Not yet published"}
+          </span>
+          {publicationStatus.hasUnpublishedChanges && (
+            <span className="text-amber-700 dark:text-amber-300">
+              Unpublished changes
+            </span>
+          )}
+          <Button
+            className="ml-auto h-7"
+            size="sm"
+            variant={
+              publicationStatus.hasUnpublishedChanges
+                ? "default"
+                : "outline"
+            }
+            onClick={() => setPublishOpen(true)}
+          >
+            <IconSend className="mr-1.5 size-3.5" />
+            Publish schedule
+          </Button>
+        </div>
+      )}
+
       {/* Action bar: search, filters, overflow */}
       <div className="mb-3 flex flex-wrap items-center gap-2 print:hidden">
         {/* Search */}
@@ -1138,6 +1205,51 @@ export function ScheduleView({
         </DialogContent>
       </Dialog>
 
+      <Dialog open={publishOpen} onOpenChange={setPublishOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Publish schedule</DialogTitle>
+            <DialogDescription>
+              Owner and subcontractor workspaces will receive this schedule
+              snapshot. Internal edits made afterward remain unpublished until
+              the next release.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="schedule-publish-reason">Change reason</Label>
+            <Textarea
+              id="schedule-publish-reason"
+              value={publishReason}
+              onChange={(event) => setPublishReason(event.currentTarget.value)}
+              placeholder="Summarize what changed and why..."
+              rows={4}
+              maxLength={500}
+            />
+            <p className="text-xs text-muted-foreground">
+              This reason appears in the internal activity history.
+            </p>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setPublishOpen(false)}
+              disabled={isPublishing}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handlePublish}
+              disabled={isPublishing || publishReason.trim().length < 3}
+            >
+              {isPublishing && (
+                <IconLoader2 className="mr-1.5 size-4 animate-spin" />
+              )}
+              Publish
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
       <Dialog open={saveViewOpen} onOpenChange={setSaveViewOpen}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
@@ -1196,7 +1308,10 @@ export function ScheduleView({
 
       {/* Baselines sheet */}
       <Sheet open={baselinesOpen} onOpenChange={setBaselinesOpen}>
-        <SheetContent side="right" className="w-full sm:max-w-lg overflow-y-auto">
+        <SheetContent
+          side="right"
+          className="w-full overflow-y-auto sm:max-w-3xl xl:max-w-5xl"
+        >
           <SheetHeader>
             <SheetTitle>Baselines</SheetTitle>
             <SheetDescription>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1231,6 +1231,28 @@ export const scheduleBaselines = sqliteTable("schedule_baselines", {
   createdAt: text("created_at").notNull(),
 })
 
+export const schedulePublications = sqliteTable(
+  "schedule_publications",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    snapshotData: text("snapshot_data").notNull(),
+    changeReason: text("change_reason").notNull(),
+    publishedBy: text("published_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    publishedAt: text("published_at").notNull(),
+  },
+  (table) => [
+    index("idx_schedule_publications_project_published").on(
+      table.projectId,
+      table.publishedAt
+    ),
+  ]
+)
+
 export const customers = sqliteTable("customers", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
@@ -1354,6 +1376,8 @@ export type WorkdayException = typeof workdayExceptions.$inferSelect
 export type NewWorkdayException = typeof workdayExceptions.$inferInsert
 export type ScheduleBaseline = typeof scheduleBaselines.$inferSelect
 export type NewScheduleBaseline = typeof scheduleBaselines.$inferInsert
+export type SchedulePublication = typeof schedulePublications.$inferSelect
+export type NewSchedulePublication = typeof schedulePublications.$inferInsert
 export type Customer = typeof customers.$inferSelect
 export type NewCustomer = typeof customers.$inferInsert
 export type SageCostCode = typeof sageCostCodes.$inferSelect

--- a/src/lib/schedule/__tests__/baseline-variance.test.ts
+++ b/src/lib/schedule/__tests__/baseline-variance.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  scheduleBaselineVariance,
+  type BaselineTaskLike,
+} from "@/lib/schedule/baseline-variance"
+
+function task(
+  id: string,
+  startDate: string,
+  endDateCalculated: string,
+  workdays = 5
+): BaselineTaskLike {
+  return {
+    id,
+    title: `Item ${id}`,
+    startDate,
+    endDateCalculated,
+    workdays,
+  }
+}
+
+describe("scheduleBaselineVariance", () => {
+  it("reports project finish slippage from dates rather than duration", () => {
+    const baseline = [task("a", "2026-07-01", "2026-07-10", 5)]
+    const current = [task("a", "2026-07-08", "2026-07-17", 5)]
+
+    const report = scheduleBaselineVariance(current, baseline)
+
+    expect(report.finishVarianceDays).toBe(7)
+    expect(report.rows[0]?.durationVarianceDays).toBe(0)
+    expect(report.rows[0]?.startVarianceDays).toBe(7)
+    expect(report.rows[0]?.finishVarianceDays).toBe(7)
+    expect(report.delayedItemCount).toBe(1)
+  })
+
+  it("reports early finishes and added or removed items", () => {
+    const baseline = [
+      task("a", "2026-07-01", "2026-07-20"),
+      task("removed", "2026-07-21", "2026-07-25"),
+    ]
+    const current = [
+      task("a", "2026-07-01", "2026-07-15"),
+      task("new", "2026-07-16", "2026-07-18"),
+    ]
+
+    const report = scheduleBaselineVariance(current, baseline)
+
+    expect(report.finishVarianceDays).toBe(-7)
+    expect(report.aheadItemCount).toBe(1)
+    expect(report.rows.map((row) => row.state)).toEqual([
+      "existing",
+      "new",
+      "removed",
+    ])
+  })
+})

--- a/src/lib/schedule/__tests__/publications.test.ts
+++ b/src/lib/schedule/__tests__/publications.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isDraftScheduleAction,
+  parsePublishedScheduleSnapshot,
+} from "@/lib/schedule/publications"
+
+describe("schedule publications", () => {
+  it("parses a versioned external schedule snapshot", () => {
+    const snapshot = parsePublishedScheduleSnapshot(JSON.stringify({
+      version: 1,
+      tasks: [{
+        id: "task-1",
+        projectId: "project-1",
+        title: "Framing",
+        startDate: "2026-07-01",
+        workdays: 5,
+        endDateCalculated: "2026-07-07",
+        phase: "framing",
+        displayColor: "blue",
+        status: "IN_PROGRESS",
+        isCriticalPath: true,
+        isMilestone: false,
+        percentComplete: 50,
+        assignedTo: "Crew",
+        sortOrder: 1,
+        createdAt: "2026-07-01T00:00:00.000Z",
+        updatedAt: "2026-07-02T00:00:00.000Z",
+      }],
+      dependencies: [],
+      exceptions: [],
+    }))
+
+    expect(snapshot?.tasks[0]?.title).toBe("Framing")
+  })
+
+  it("rejects malformed publication data", () => {
+    expect(parsePublishedScheduleSnapshot('{"version":2}')).toBeNull()
+    expect(parsePublishedScheduleSnapshot("not-json")).toBeNull()
+  })
+
+  it("distinguishes draft-changing schedule activity", () => {
+    expect(isDraftScheduleAction("schedule.item_updated")).toBe(true)
+    expect(isDraftScheduleAction("schedule.dependency_updated")).toBe(true)
+    expect(isDraftScheduleAction("schedule.baseline_created")).toBe(false)
+    expect(isDraftScheduleAction("schedule.published")).toBe(false)
+  })
+})

--- a/src/lib/schedule/baseline-variance.ts
+++ b/src/lib/schedule/baseline-variance.ts
@@ -1,0 +1,168 @@
+import { z } from "zod/v4"
+
+export type BaselineTaskLike = {
+  readonly id: string
+  readonly title: string
+  readonly startDate: string
+  readonly endDateCalculated: string
+  readonly workdays: number
+}
+
+export type BaselineVarianceRow = {
+  readonly id: string
+  readonly title: string
+  readonly baselineStart: string | null
+  readonly baselineFinish: string | null
+  readonly currentStart: string | null
+  readonly currentFinish: string | null
+  readonly startVarianceDays: number | null
+  readonly finishVarianceDays: number | null
+  readonly durationVarianceDays: number | null
+  readonly state: "existing" | "new" | "removed"
+}
+
+export type BaselineVarianceReport = {
+  readonly baselineFinish: string | null
+  readonly currentFinish: string | null
+  readonly finishVarianceDays: number | null
+  readonly delayedItemCount: number
+  readonly aheadItemCount: number
+  readonly rows: readonly BaselineVarianceRow[]
+}
+
+const baselineTaskSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  startDate: z.string(),
+  endDateCalculated: z.string(),
+  workdays: z.number(),
+})
+
+const baselineSnapshotSchema = z.object({
+  tasks: z.array(baselineTaskSchema),
+})
+
+export function parseBaselineTasks(
+  snapshotData: string
+): readonly BaselineTaskLike[] | null {
+  try {
+    const result = baselineSnapshotSchema.safeParse(JSON.parse(snapshotData))
+    return result.success ? result.data.tasks : null
+  } catch {
+    return null
+  }
+}
+
+function dateOrdinal(value: string): number | null {
+  const parsed = Date.parse(`${value}T00:00:00.000Z`)
+  return Number.isFinite(parsed) ? Math.floor(parsed / 86_400_000) : null
+}
+
+function dateVariance(
+  current: string,
+  baseline: string
+): number | null {
+  const currentDay = dateOrdinal(current)
+  const baselineDay = dateOrdinal(baseline)
+  return currentDay === null || baselineDay === null
+    ? null
+    : currentDay - baselineDay
+}
+
+function latestDate(
+  tasks: readonly BaselineTaskLike[]
+): string | null {
+  return tasks.reduce<string | null>(
+    (latest, task) =>
+      latest === null || task.endDateCalculated > latest
+        ? task.endDateCalculated
+        : latest,
+    null
+  )
+}
+
+export function scheduleBaselineVariance(
+  currentTasks: readonly BaselineTaskLike[],
+  baselineTasks: readonly BaselineTaskLike[]
+): BaselineVarianceReport {
+  const currentById = new Map(currentTasks.map((task) => [task.id, task]))
+  const baselineById = new Map(baselineTasks.map((task) => [task.id, task]))
+  const orderedIds = [
+    ...currentTasks.map((task) => task.id),
+    ...baselineTasks
+      .map((task) => task.id)
+      .filter((taskId) => !currentById.has(taskId)),
+  ]
+
+  const rows = orderedIds.flatMap((taskId): BaselineVarianceRow[] => {
+    const current = currentById.get(taskId)
+    const baseline = baselineById.get(taskId)
+    if (current && baseline) {
+      return [{
+        id: taskId,
+        title: current.title,
+        baselineStart: baseline.startDate,
+        baselineFinish: baseline.endDateCalculated,
+        currentStart: current.startDate,
+        currentFinish: current.endDateCalculated,
+        startVarianceDays: dateVariance(
+          current.startDate,
+          baseline.startDate
+        ),
+        finishVarianceDays: dateVariance(
+          current.endDateCalculated,
+          baseline.endDateCalculated
+        ),
+        durationVarianceDays: current.workdays - baseline.workdays,
+        state: "existing",
+      }]
+    }
+    if (current) {
+      return [{
+        id: taskId,
+        title: current.title,
+        baselineStart: null,
+        baselineFinish: null,
+        currentStart: current.startDate,
+        currentFinish: current.endDateCalculated,
+        startVarianceDays: null,
+        finishVarianceDays: null,
+        durationVarianceDays: null,
+        state: "new",
+      }]
+    }
+    if (!baseline) return []
+    return [{
+      id: taskId,
+      title: baseline.title,
+      baselineStart: baseline.startDate,
+      baselineFinish: baseline.endDateCalculated,
+      currentStart: null,
+      currentFinish: null,
+      startVarianceDays: null,
+      finishVarianceDays: null,
+      durationVarianceDays: null,
+      state: "removed",
+    }]
+  })
+  const baselineFinish = latestDate(baselineTasks)
+  const currentFinish = latestDate(currentTasks)
+
+  return {
+    baselineFinish,
+    currentFinish,
+    finishVarianceDays:
+      baselineFinish && currentFinish
+        ? dateVariance(currentFinish, baselineFinish)
+        : null,
+    delayedItemCount: rows.filter(
+      (row) =>
+        row.finishVarianceDays !== null && row.finishVarianceDays > 0
+    ).length,
+    aheadItemCount: rows.filter(
+      (row) =>
+        row.finishVarianceDays !== null && row.finishVarianceDays < 0
+    ).length,
+    rows,
+  }
+}

--- a/src/lib/schedule/publications.ts
+++ b/src/lib/schedule/publications.ts
@@ -1,0 +1,92 @@
+import { z } from "zod/v4"
+
+const publishedTaskSchema = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  title: z.string(),
+  startDate: z.string(),
+  workdays: z.number(),
+  endDateCalculated: z.string(),
+  phase: z.string(),
+  displayColor: z.string().nullable(),
+  status: z.enum(["PENDING", "IN_PROGRESS", "COMPLETE", "BLOCKED"]),
+  isCriticalPath: z.boolean(),
+  isMilestone: z.boolean(),
+  percentComplete: z.number(),
+  assignedTo: z.string().nullable(),
+  sortOrder: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+const publishedDependencySchema = z.object({
+  id: z.string(),
+  predecessorId: z.string(),
+  successorId: z.string(),
+  type: z.enum(["FS", "SS", "FF", "SF"]),
+  lagDays: z.number(),
+})
+
+const publishedExceptionSchema = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  title: z.string(),
+  startDate: z.string(),
+  endDate: z.string(),
+  type: z.enum(["non_working", "working"]),
+  category: z.enum([
+    "national_holiday",
+    "state_holiday",
+    "vacation_day",
+    "company_holiday",
+    "weather_day",
+    "extra_workday",
+  ]),
+  recurrence: z.enum(["one_time", "yearly"]),
+  notes: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+export const publishedScheduleSnapshotSchema = z.object({
+  version: z.literal(1),
+  tasks: z.array(publishedTaskSchema),
+  dependencies: z.array(publishedDependencySchema),
+  exceptions: z.array(publishedExceptionSchema),
+})
+
+export type PublishedScheduleSnapshot = z.infer<
+  typeof publishedScheduleSnapshotSchema
+>
+
+export function parsePublishedScheduleSnapshot(
+  value: string
+): PublishedScheduleSnapshot | null {
+  try {
+    const result = publishedScheduleSnapshotSchema.safeParse(JSON.parse(value))
+    return result.success ? result.data : null
+  } catch {
+    return null
+  }
+}
+
+export const DRAFT_SCHEDULE_ACTIONS = [
+  "schedule.item_created",
+  "schedule.item_updated",
+  "schedule.item_deleted",
+  "schedule.items_completed",
+  "schedule.items_assigned",
+  "schedule.items_deleted",
+  "schedule.items_reordered",
+  "schedule.item_status_changed",
+  "schedule.dependency_created",
+  "schedule.dependency_updated",
+  "schedule.dependency_deleted",
+  "schedule.workday_exception_created",
+  "schedule.workday_exception_updated",
+  "schedule.workday_exception_deleted",
+] as const
+
+export function isDraftScheduleAction(action: string): boolean {
+  return DRAFT_SCHEDULE_ACTIONS.some((draftAction) => draftAction === action)
+}


### PR DESCRIPTION
## Summary

- add explicit draft/publish control for the schedule shown to owners and subcontractors
- preserve the currently visible external schedule during migration and fail closed on malformed snapshots
- require a publish reason and record schedule publication/mutation activity
- recalculate all affected task dates transactionally when workday exceptions change
- add actual-date baseline variance and project finish slippage reporting
- complete schedule permission enforcement and harden bulk reordering to the selected project

## Validation

- `bunx tsc --noEmit`
- focused ESLint
- `bun test src/lib/schedule` (53 passing)
- production webpack build
- migration tested on a fresh D1-compatible SQLite database
- migration tested against the seeded E2E database with valid JSON and clean foreign keys
- `git diff --check`

## Deployment note

Apply migration `0076_schedule_publications.sql` before deploying the application code. The migration creates an initial immutable publication for each existing project so current owner/sub schedule visibility is preserved.

Refs #258
