### PR TITLE
feat(schedule): add audience commitments

### DIFF
--- a/docs/modules/scheduling.md
+++ b/docs/modules/scheduling.md
@@ -19,6 +19,13 @@ The scheduling data lives in four tables defined in the core schema (`src/db/sch
 
 **`schedule_publications`** -- immutable, versioned snapshots released to owner and subcontractor workspaces. Internal schedule mutations remain draft changes until staff publishes a new snapshot with a reason. Existing projects receive an initial snapshot during migration so the rollout does not expose later internal edits by accident.
 
+Each schedule item has independent owner and subcontractor visibility. Internal
+staff always retain access, and external visibility changes take effect only
+when the schedule is published. Staff can also require an assigned Compass
+user to confirm or decline a schedule commitment. The request is delivered
+after publication; manual-name assignees remain supported but cannot confirm
+until linked to an active Compass account.
+
 The type system (`src/lib/schedule/types.ts`) models construction phases explicitly:
 
 ```typescript

--- a/drizzle/0077_schedule_audience_confirmations.sql
+++ b/drizzle/0077_schedule_audience_confirmations.sql
@@ -1,0 +1,23 @@
+ALTER TABLE `schedule_tasks`
+  ADD `assigned_user_id` text REFERENCES `users`(`id`) ON DELETE set null;
+--> statement-breakpoint
+ALTER TABLE `schedule_tasks`
+  ADD `owner_visible` integer NOT NULL DEFAULT 1;
+--> statement-breakpoint
+ALTER TABLE `schedule_tasks`
+  ADD `sub_vendor_visible` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `schedule_tasks`
+  ADD `confirmation_required` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE `schedule_tasks`
+  ADD `confirmation_status` text NOT NULL DEFAULT 'not_requested';
+--> statement-breakpoint
+ALTER TABLE `schedule_tasks`
+  ADD `confirmation_requested_at` text;
+--> statement-breakpoint
+ALTER TABLE `schedule_tasks`
+  ADD `confirmation_responded_at` text;
+--> statement-breakpoint
+ALTER TABLE `schedule_tasks`
+  ADD `reminder_sent_at` text;

--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -33,7 +33,6 @@ import {
   isOwnerScheduleView,
   summarizeOwnerScheduleByPhase,
   type OwnerScheduleView,
-  type OwnerScheduleVisibleItem,
 } from "@/lib/schedule/owner-visibility"
 import { parsePublishedScheduleSnapshot } from "@/lib/schedule/publications"
 import { projectAudiencePhotoUrl } from "@/lib/photo-sources"
@@ -63,6 +62,9 @@ export type AudienceScheduleItem = {
   readonly assignedTo: string | null
   readonly percentComplete: number
   readonly isMilestone: boolean
+  readonly confirmationRequired: boolean
+  readonly confirmationStatus: string
+  readonly viewerCanConfirm: boolean
 }
 
 export type AudienceOperationItem = {
@@ -364,6 +366,14 @@ export async function getProjectAudiencePreview(
       percentComplete: scheduleTasks.percentComplete,
       isMilestone: scheduleTasks.isMilestone,
       workdays: scheduleTasks.workdays,
+      assignedUserId: scheduleTasks.assignedUserId,
+      ownerVisible: scheduleTasks.ownerVisible,
+      subVendorVisible: scheduleTasks.subVendorVisible,
+      confirmationRequired: scheduleTasks.confirmationRequired,
+      confirmationStatus: scheduleTasks.confirmationStatus,
+      confirmationRequestedAt: scheduleTasks.confirmationRequestedAt,
+      confirmationRespondedAt: scheduleTasks.confirmationRespondedAt,
+      reminderSentAt: scheduleTasks.reminderSentAt,
     })
     .from(scheduleTasks)
     .where(eq(scheduleTasks.projectId, projectId))
@@ -380,6 +390,9 @@ export async function getProjectAudiencePreview(
     : null
   // Once a publication exists, fail closed if its immutable snapshot cannot
   // be parsed. Falling back to live rows could expose unpublished changes.
+  const currentScheduleById = new Map(
+    currentScheduleRows.map((task) => [task.id, task])
+  )
   const scheduleRowsUnsorted = publishedSchedule
     ? publishedSnapshot
       ? publishedSnapshot.tasks.map((task) => ({
@@ -393,6 +406,37 @@ export async function getProjectAudiencePreview(
           percentComplete: task.percentComplete,
           isMilestone: task.isMilestone,
           workdays: task.workdays,
+          assignedUserId: task.assignedUserId,
+          ownerVisible: task.ownerVisible,
+          subVendorVisible: task.subVendorVisible,
+          confirmationRequired: task.confirmationRequired,
+          // Response state may update after publication, but only overlay it
+          // while the published assignee and requirement still match live.
+          confirmationStatus:
+            currentScheduleById.get(task.id)?.assignedUserId ===
+              task.assignedUserId &&
+            currentScheduleById.get(task.id)?.confirmationRequired ===
+              task.confirmationRequired
+              ? currentScheduleById.get(task.id)?.confirmationStatus ??
+                task.confirmationStatus
+              : task.confirmationStatus,
+          confirmationRequestedAt: task.confirmationRequestedAt,
+          confirmationRespondedAt:
+            currentScheduleById.get(task.id)?.assignedUserId ===
+              task.assignedUserId &&
+            currentScheduleById.get(task.id)?.confirmationRequired ===
+              task.confirmationRequired
+              ? currentScheduleById.get(task.id)?.confirmationRespondedAt ??
+                task.confirmationRespondedAt
+              : task.confirmationRespondedAt,
+          reminderSentAt:
+            currentScheduleById.get(task.id)?.assignedUserId ===
+              task.assignedUserId &&
+            currentScheduleById.get(task.id)?.confirmationRequired ===
+              task.confirmationRequired
+              ? currentScheduleById.get(task.id)?.reminderSentAt ??
+                task.reminderSentAt
+              : task.reminderSentAt,
         }))
       : []
     : currentScheduleRows
@@ -617,12 +661,19 @@ export async function getProjectAudiencePreview(
       ])
       .filter((value) => value.length > 0)
   )
-  const ownerScheduleView = isOwnerScheduleView(project.ownerScheduleView)
-    ? project.ownerScheduleView
-    : "items"
+  const ownerScheduleView =
+    audience === "owner" && isOwnerScheduleView(project.ownerScheduleView)
+      ? project.ownerScheduleView
+      : "items"
+  const audienceScheduleRows = scheduleRows.filter((item) =>
+    audience === "owner"
+      ? item.ownerVisible !== false
+      : item.subVendorVisible ??
+        visibleContactNames.has(normalizeVisibleName(item.assignedTo))
+  )
   const visibleScheduleItem = (
-    item: (typeof scheduleRows)[number]
-  ): OwnerScheduleVisibleItem => ({
+    item: (typeof audienceScheduleRows)[number]
+  ): AudienceScheduleItem => ({
     id: item.id,
     title: item.title,
     startDate: item.startDate,
@@ -632,11 +683,22 @@ export async function getProjectAudiencePreview(
     assignedTo: item.assignedTo,
     percentComplete: item.percentComplete,
     isMilestone: item.isMilestone,
+    confirmationRequired: item.confirmationRequired,
+    confirmationStatus: item.confirmationStatus,
+    viewerCanConfirm:
+      !viewerIsInternal &&
+      item.confirmationRequired &&
+      item.assignedUserId === viewer.id,
   })
-  const ownerScheduleItems =
+  const audienceScheduleItems: readonly AudienceScheduleItem[] =
     ownerScheduleView === "phases"
-      ? summarizeOwnerScheduleByPhase(scheduleRows)
-      : scheduleRows.map(visibleScheduleItem)
+      ? summarizeOwnerScheduleByPhase(audienceScheduleRows).map((item) => ({
+          ...item,
+          confirmationRequired: false,
+          confirmationStatus: "not_requested",
+          viewerCanConfirm: false,
+        }))
+      : audienceScheduleRows.map(visibleScheduleItem)
 
   return {
     audience,
@@ -677,12 +739,7 @@ export async function getProjectAudiencePreview(
             : "No phase assigned.",
       }
     }),
-    scheduleItems:
-      audience === "owner"
-        ? ownerScheduleItems
-        : scheduleRows.filter((item) =>
-            visibleContactNames.has(normalizeVisibleName(item.assignedTo))
-          ).map(visibleScheduleItem),
+    scheduleItems: audienceScheduleItems,
     operations: operationRows
       .filter(
         (operation) =>

--- a/src/app/actions/schedule-confirmations.ts
+++ b/src/app/actions/schedule-confirmations.ts
@@ -1,0 +1,439 @@
+"use server"
+
+import { and, desc, eq } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import {
+  projectMembers,
+  projects,
+  schedulePublications,
+  scheduleTasks,
+  users,
+} from "@/db/schema"
+import { recordActivityEvent } from "@/lib/activity-log"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import { createNotificationEvent } from "@/lib/notifications/events"
+import { requireOrg } from "@/lib/org-scope"
+import { requirePermission } from "@/lib/permissions"
+import { assertProjectAccess } from "@/lib/project-access"
+import { parsePublishedScheduleSnapshot } from "@/lib/schedule/publications"
+
+type ConfirmationResponse = "confirmed" | "declined"
+
+type ScheduleConfirmationResult =
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string }
+
+function confirmationHref(
+  projectId: string,
+  taskId: string,
+  projectRole: string | null
+): string {
+  if (projectRole === "client" || projectRole === "owner") {
+    return `/preview/projects/${projectId}/owner/schedule`
+  }
+  if (projectRole === "subcontractor" || projectRole === "supplier") {
+    return `/preview/projects/${projectId}/sub-vendor/schedule`
+  }
+  return `/dashboard/projects/${projectId}/schedule?view=list&item=${taskId}`
+}
+
+function revalidateConfirmationPaths(projectId: string): void {
+  revalidatePath(`/dashboard/projects/${projectId}/schedule`)
+  revalidatePath(`/preview/projects/${projectId}/owner/schedule`)
+  revalidatePath(`/preview/projects/${projectId}/sub-vendor/schedule`)
+}
+
+export async function sendPublishedScheduleAssignment(
+  taskId: string
+): Promise<ScheduleConfirmationResult> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    requirePermission(user, "schedule", "update")
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const task = await db
+      .select({
+        id: scheduleTasks.id,
+        projectId: scheduleTasks.projectId,
+        title: scheduleTasks.title,
+        assignedUserId: scheduleTasks.assignedUserId,
+      })
+      .from(scheduleTasks)
+      .innerJoin(projects, eq(projects.id, scheduleTasks.projectId))
+      .where(
+        and(
+          eq(scheduleTasks.id, taskId),
+          eq(projects.organizationId, organizationId)
+        )
+      )
+      .get()
+    if (!task?.assignedUserId) {
+      return {
+        success: false,
+        error: "The assignment is not linked to an active Compass user.",
+      }
+    }
+
+    const publication = await db
+      .select({ snapshotData: schedulePublications.snapshotData })
+      .from(schedulePublications)
+      .where(eq(schedulePublications.projectId, task.projectId))
+      .orderBy(desc(schedulePublications.publishedAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    const publishedTask = publication
+      ? parsePublishedScheduleSnapshot(publication.snapshotData)?.tasks.find(
+          (item) => item.id === task.id
+        )
+      : null
+    if (!publishedTask || publishedTask.assignedUserId !== task.assignedUserId) {
+      return {
+        success: false,
+        error: "Publish this assignment before sending its notification.",
+      }
+    }
+
+    const recipient = await db
+      .select({ id: users.id, email: users.email })
+      .from(users)
+      .where(and(eq(users.id, task.assignedUserId), eq(users.isActive, true)))
+      .get()
+    if (!recipient) {
+      return { success: false, error: "The assigned Compass user is inactive." }
+    }
+    const membership = await db
+      .select({ role: projectMembers.role })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.projectId, task.projectId),
+          eq(projectMembers.userId, recipient.id)
+        )
+      )
+      .get()
+    if (
+      ((membership?.role === "client" || membership?.role === "owner") &&
+        publishedTask.ownerVisible === false) ||
+      ((membership?.role === "subcontractor" ||
+        membership?.role === "supplier") &&
+        publishedTask.subVendorVisible !== true)
+    ) {
+      return {
+        success: false,
+        error: "The published item is not visible to the assigned user.",
+      }
+    }
+
+    await createNotificationEvent({
+      organizationId,
+      projectId: task.projectId,
+      eventType: "schedule.assigned",
+      sourceType: "schedule_item",
+      sourceId: task.id,
+      title: `Schedule item assigned: ${task.title}`,
+      body: `${user.displayName ?? user.email} assigned this to you.`,
+      href: confirmationHref(
+        task.projectId,
+        task.id,
+        membership?.role ?? null
+      ),
+      priority: "normal",
+      audience: "assignee",
+      createdBy: user.id,
+      recipients: [{ userId: recipient.id, email: recipient.email }],
+      delivery: {
+        inApp: true,
+        email: true,
+        push: true,
+      },
+    })
+    await recordActivityEvent({
+      db,
+      organizationId,
+      projectId: task.projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.assignment_notified",
+      entityType: "schedule_item",
+      entityId: task.id,
+      summary: `Sent the published assignment for “${task.title}”.`,
+    })
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to send published schedule assignment", error)
+    return { success: false, error: "Unable to send the assignment notification." }
+  }
+}
+
+export async function sendScheduleTaskReminder(
+  taskId: string
+): Promise<ScheduleConfirmationResult> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    requirePermission(user, "schedule", "update")
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const task = await db
+      .select({
+        id: scheduleTasks.id,
+        projectId: scheduleTasks.projectId,
+        title: scheduleTasks.title,
+        assignedUserId: scheduleTasks.assignedUserId,
+        confirmationRequired: scheduleTasks.confirmationRequired,
+        confirmationStatus: scheduleTasks.confirmationStatus,
+      })
+      .from(scheduleTasks)
+      .innerJoin(projects, eq(projects.id, scheduleTasks.projectId))
+      .where(
+        and(
+          eq(scheduleTasks.id, taskId),
+          eq(projects.organizationId, organizationId)
+        )
+      )
+      .get()
+
+    if (!task) {
+      return { success: false, error: "Schedule item not found" }
+    }
+    if (!task.confirmationRequired) {
+      return {
+        success: false,
+        error: "Confirmation is not required for this schedule item.",
+      }
+    }
+    if (!task.assignedUserId) {
+      return {
+        success: false,
+        error:
+          "The responsible contact needs an active Compass account before reminders can be sent.",
+      }
+    }
+    if (task.confirmationStatus === "confirmed") {
+      return { success: false, error: "This assignment is already confirmed." }
+    }
+    const publication = await db
+      .select({ snapshotData: schedulePublications.snapshotData })
+      .from(schedulePublications)
+      .where(eq(schedulePublications.projectId, task.projectId))
+      .orderBy(desc(schedulePublications.publishedAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    const publishedTask = publication
+      ? parsePublishedScheduleSnapshot(publication.snapshotData)?.tasks.find(
+          (item) => item.id === task.id
+        )
+      : null
+    if (
+      !publishedTask ||
+      publishedTask.assignedUserId !== task.assignedUserId ||
+      publishedTask.confirmationRequired !== true
+    ) {
+      return {
+        success: false,
+        error:
+          "Publish this schedule change before sending a confirmation reminder.",
+      }
+    }
+
+    const recipient = await db
+      .select({ id: users.id, email: users.email })
+      .from(users)
+      .where(and(eq(users.id, task.assignedUserId), eq(users.isActive, true)))
+      .get()
+    if (!recipient) {
+      return { success: false, error: "The assigned Compass user is inactive." }
+    }
+    const membership = await db
+      .select({ role: projectMembers.role })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.projectId, task.projectId),
+          eq(projectMembers.userId, recipient.id)
+        )
+      )
+      .get()
+    if (
+      ((membership?.role === "client" || membership?.role === "owner") &&
+        publishedTask.ownerVisible === false) ||
+      ((membership?.role === "subcontractor" ||
+        membership?.role === "supplier") &&
+        publishedTask.subVendorVisible !== true)
+    ) {
+      return {
+        success: false,
+        error:
+          "Make this item visible to the assigned project audience before sending a reminder.",
+      }
+    }
+
+    await createNotificationEvent({
+      organizationId,
+      projectId: task.projectId,
+      eventType: "schedule.confirmation_reminder",
+      sourceType: "schedule_item",
+      sourceId: task.id,
+      title: `Please confirm: ${task.title}`,
+      body: `${user.displayName ?? user.email} is waiting for your schedule commitment response.`,
+      href: confirmationHref(
+        task.projectId,
+        task.id,
+        membership?.role ?? null
+      ),
+      priority: "high",
+      audience: "assignee",
+      createdBy: user.id,
+      recipients: [{ userId: recipient.id, email: recipient.email }],
+      delivery: {
+        inApp: true,
+        email: true,
+        push: true,
+      },
+    })
+
+    const now = new Date().toISOString()
+    await db
+      .update(scheduleTasks)
+      .set({ reminderSentAt: now, updatedAt: now })
+      .where(
+        and(
+          eq(scheduleTasks.id, task.id),
+          eq(scheduleTasks.projectId, task.projectId)
+        )
+      )
+    await recordActivityEvent({
+      db,
+      organizationId,
+      projectId: task.projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.confirmation_reminded",
+      entityType: "schedule_item",
+      entityId: task.id,
+      summary: `Sent a confirmation reminder for “${task.title}”.`,
+    })
+    revalidateConfirmationPaths(task.projectId)
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to send schedule confirmation reminder", error)
+    return { success: false, error: "Unable to send the reminder." }
+  }
+}
+
+export async function respondToScheduleTaskConfirmation(
+  taskId: string,
+  response: ConfirmationResponse
+): Promise<ScheduleConfirmationResult> {
+  try {
+    if (response !== "confirmed" && response !== "declined") {
+      return { success: false, error: "Unsupported confirmation response." }
+    }
+    const user = await requireAuth()
+    requirePermission(user, "schedule", "read")
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const task = await db
+      .select()
+      .from(scheduleTasks)
+      .where(eq(scheduleTasks.id, taskId))
+      .get()
+    if (!task) {
+      return { success: false, error: "Schedule item not found." }
+    }
+
+    const project = await assertProjectAccess(db, user, task.projectId)
+    if (!project.organizationId || task.assignedUserId !== user.id) {
+      return { success: false, error: "This confirmation is not assigned to you." }
+    }
+    if (!task.confirmationRequired) {
+      return { success: false, error: "Confirmation is no longer required." }
+    }
+    const publication = await db
+      .select({ snapshotData: schedulePublications.snapshotData })
+      .from(schedulePublications)
+      .where(eq(schedulePublications.projectId, task.projectId))
+      .orderBy(desc(schedulePublications.publishedAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    const publishedTask = publication
+      ? parsePublishedScheduleSnapshot(publication.snapshotData)?.tasks.find(
+          (item) => item.id === task.id
+        )
+      : null
+    if (
+      !publishedTask ||
+      publishedTask.assignedUserId !== user.id ||
+      !publishedTask.confirmationRequired
+    ) {
+      return {
+        success: false,
+        error: "This confirmation request has not been published.",
+      }
+    }
+    const membership = await db
+      .select({ role: projectMembers.role })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.projectId, task.projectId),
+          eq(projectMembers.userId, user.id)
+        )
+      )
+      .get()
+    if (
+      ((membership?.role === "client" || membership?.role === "owner") &&
+        !publishedTask.ownerVisible) ||
+      ((membership?.role === "subcontractor" ||
+        membership?.role === "supplier") &&
+        !publishedTask.subVendorVisible)
+    ) {
+      return { success: false, error: "This schedule item is not visible to you." }
+    }
+
+    const now = new Date().toISOString()
+    await db
+      .update(scheduleTasks)
+      .set({
+        confirmationStatus: response,
+        confirmationRespondedAt: now,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(scheduleTasks.id, task.id),
+          eq(scheduleTasks.assignedUserId, user.id)
+        )
+      )
+    await recordActivityEvent({
+      db,
+      organizationId: project.organizationId,
+      projectId: task.projectId,
+      actor: user,
+      category: "schedule",
+      action: `schedule.assignment_${response}`,
+      entityType: "schedule_item",
+      entityId: task.id,
+      summary:
+        response === "confirmed"
+          ? `Confirmed the assignment for “${task.title}”.`
+          : `Could not confirm the assignment for “${task.title}”.`,
+    })
+    revalidateConfirmationPaths(task.projectId)
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to respond to schedule confirmation", error)
+    return { success: false, error: "Unable to save your response." }
+  }
+}

--- a/src/app/actions/schedule-publications.ts
+++ b/src/app/actions/schedule-publications.ts
@@ -13,6 +13,10 @@ import {
   workdayExceptions,
 } from "@/db/schema"
 import { recordActivityEvent } from "@/lib/activity-log"
+import {
+  sendPublishedScheduleAssignment,
+  sendScheduleTaskReminder,
+} from "@/app/actions/schedule-confirmations"
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { isDemoUser } from "@/lib/demo"
@@ -20,6 +24,7 @@ import { requireOrg } from "@/lib/org-scope"
 import { requirePermission } from "@/lib/permissions"
 import {
   DRAFT_SCHEDULE_ACTIONS,
+  parsePublishedScheduleSnapshot,
   publishedScheduleSnapshotSchema,
 } from "@/lib/schedule/publications"
 
@@ -139,6 +144,19 @@ export async function publishSchedule(
     const db = getDb(env.DB)
     await requireProject(db, projectId, organizationId)
 
+    const previousPublication = await db
+      .select({ snapshotData: schedulePublications.snapshotData })
+      .from(schedulePublications)
+      .where(eq(schedulePublications.projectId, projectId))
+      .orderBy(desc(schedulePublications.publishedAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    const previousSnapshot = previousPublication
+      ? parsePublishedScheduleSnapshot(previousPublication.snapshotData)
+      : null
+    const previousTasksById = new Map(
+      previousSnapshot?.tasks.map((task) => [task.id, task]) ?? []
+    )
     const tasks = await db
       .select()
       .from(scheduleTasks)
@@ -188,6 +206,41 @@ export async function publishSchedule(
       },
       createdAt: publishedAt,
     })
+    for (const task of tasks) {
+      const previousTask = previousTasksById.get(task.id)
+      const assignmentChanged =
+        task.assignedTo !== null &&
+        (previousTask?.assignedTo !== task.assignedTo ||
+          previousTask.assignedUserId !== task.assignedUserId)
+      if (
+        assignmentChanged &&
+        task.assignedUserId &&
+        !task.confirmationRequired &&
+        (!previousPublication || previousSnapshot)
+      ) {
+        const notification = await sendPublishedScheduleAssignment(task.id)
+        if (!notification.success) {
+          console.error(
+            `Unable to send published schedule assignment for ${task.id}:`,
+            notification.error
+          )
+        }
+      }
+      if (
+        task.confirmationRequired &&
+        task.assignedUserId &&
+        task.confirmationStatus === "pending" &&
+        !task.reminderSentAt
+      ) {
+        const reminder = await sendScheduleTaskReminder(task.id)
+        if (!reminder.success) {
+          console.error(
+            `Unable to send published schedule confirmation for ${task.id}:`,
+            reminder.error
+          )
+        }
+      }
+    }
 
     revalidatePath(`/dashboard/projects/${projectId}/schedule`)
     revalidatePath("/dashboard/schedule")

--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -7,6 +7,9 @@ import {
   taskDependencies,
   workdayExceptions,
   projects,
+  organizationMembers,
+  projectAccessInvitations,
+  users,
 } from "@/db/schema"
 import { eq, asc, and, inArray } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
@@ -21,10 +24,10 @@ import {
   effectivePercentComplete,
   normalizeScheduleProgress,
 } from "@/lib/schedule/progress"
+import { newScheduleConfirmationState } from "@/lib/schedule/confirmation"
 import { requireAuth } from "@/lib/auth"
 import { requireOrg } from "@/lib/org-scope"
 import { isDemoUser } from "@/lib/demo"
-import { notifyProjectAssignment } from "@/lib/notifications/events"
 import { getProjects } from "@/app/actions/projects"
 import { projectDepartment } from "@/lib/project-branding"
 import { projectScheduleColor } from "@/lib/schedule/project-scope"
@@ -80,6 +83,54 @@ async function fetchExceptions(
     category: r.category as ExceptionCategory,
     recurrence: r.recurrence as ExceptionRecurrence,
   }))
+}
+
+async function resolveAssignedUserId(
+  db: ReturnType<typeof getDb>,
+  organizationId: string,
+  projectId: string,
+  assigneeOptionId: string | null | undefined
+): Promise<string | null> {
+  if (!assigneeOptionId) return null
+
+  if (assigneeOptionId.startsWith("team:")) {
+    const userId = assigneeOptionId.slice("team:".length)
+    const member = await db
+      .select({ userId: users.id })
+      .from(users)
+      .innerJoin(
+        organizationMembers,
+        eq(organizationMembers.userId, users.id)
+      )
+      .where(
+        and(
+          eq(users.id, userId),
+          eq(users.isActive, true),
+          eq(organizationMembers.organizationId, organizationId)
+        )
+      )
+      .get()
+    return member?.userId ?? null
+  }
+
+  if (assigneeOptionId.startsWith("project:")) {
+    const projectContactId = assigneeOptionId.slice("project:".length)
+    const invitation = await db
+      .select({ userId: projectAccessInvitations.acceptedBy })
+      .from(projectAccessInvitations)
+      .where(
+        and(
+          eq(projectAccessInvitations.organizationId, organizationId),
+          eq(projectAccessInvitations.projectId, projectId),
+          eq(projectAccessInvitations.projectContactId, projectContactId),
+          eq(projectAccessInvitations.status, "accepted")
+        )
+      )
+      .get()
+    return invitation?.userId ?? null
+  }
+
+  return null
 }
 
 export async function getSchedule(
@@ -401,6 +452,10 @@ export async function createTask(
     isMilestone?: boolean
     percentComplete?: number
     assignedTo?: string
+    assignedOptionId?: string | null
+    ownerVisible?: boolean
+    subVendorVisible?: boolean
+    confirmationRequired?: boolean
   }
 ): Promise<
   | { readonly success: true; readonly taskId: string }
@@ -445,6 +500,18 @@ export async function createTask(
       : 0
 
     const id = crypto.randomUUID()
+    const assignedUserId = await resolveAssignedUserId(
+      db,
+      orgId,
+      projectId,
+      data.assignedOptionId
+    )
+    const confirmationRequired = data.confirmationRequired ?? false
+    const confirmation = newScheduleConfirmationState({
+      required: confirmationRequired,
+      assignedUserId,
+      now,
+    })
     const progress = normalizeScheduleProgress(
       data.status ?? "PENDING",
       data.percentComplete ?? 0
@@ -463,6 +530,12 @@ export async function createTask(
       isMilestone: data.isMilestone ?? false,
       percentComplete: progress.percentComplete,
       assignedTo: data.assignedTo ?? null,
+      assignedUserId,
+      ownerVisible: data.ownerVisible ?? true,
+      subVendorVisible: data.subVendorVisible ?? false,
+      confirmationRequired,
+      confirmationStatus: confirmation.status,
+      confirmationRequestedAt: confirmation.requestedAt,
       sortOrder: nextOrder,
       createdAt: now,
       updatedAt: now,
@@ -479,23 +552,6 @@ export async function createTask(
       entityId: id,
       summary: `Created schedule item “${data.title}”.`,
     })
-
-    try {
-      await notifyProjectAssignment({
-        organizationId: orgId,
-        projectId,
-        itemId: id,
-        title: data.title,
-        assignedToName: data.assignedTo ?? null,
-        createdBy: user,
-        kind: "schedule",
-      })
-    } catch (notificationError) {
-      console.error(
-        "Schedule assignment notification failed:",
-        notificationError
-      )
-    }
 
     await recalcCriticalPath(db, projectId)
     revalidateSchedulePaths(projectId)
@@ -518,6 +574,10 @@ export async function updateTask(
     isMilestone?: boolean
     percentComplete?: number
     assignedTo?: string | null
+    assignedOptionId?: string | null
+    ownerVisible?: boolean
+    subVendorVisible?: boolean
+    confirmationRequired?: boolean
   }
 ): Promise<{ success: boolean; error?: string }> {
   try {
@@ -558,6 +618,34 @@ export async function updateTask(
       (data.status ?? task.status) as TaskStatus,
       data.percentComplete ?? task.percentComplete
     )
+    const assignedUserId =
+      data.assignedOptionId !== undefined
+        ? await resolveAssignedUserId(
+            db,
+            orgId,
+            task.projectId,
+            data.assignedOptionId
+          )
+        : data.assignedTo === null
+          ? null
+          : task.assignedUserId
+    const assignmentChanged =
+      (data.assignedTo !== undefined &&
+        data.assignedTo !== task.assignedTo) ||
+      (data.assignedOptionId !== undefined &&
+        assignedUserId !== task.assignedUserId)
+    const confirmationRequired =
+      data.confirmationRequired ?? task.confirmationRequired
+    const resetConfirmation =
+      assignmentChanged ||
+      (data.confirmationRequired !== undefined &&
+        data.confirmationRequired !== task.confirmationRequired)
+    const now = new Date().toISOString()
+    const confirmation = newScheduleConfirmationState({
+      required: confirmationRequired,
+      assignedUserId,
+      now,
+    })
 
     await db
       .update(scheduleTasks)
@@ -576,7 +664,27 @@ export async function updateTask(
         ...(data.assignedTo !== undefined && {
           assignedTo: data.assignedTo,
         }),
-        updatedAt: new Date().toISOString(),
+        ...(data.assignedOptionId !== undefined || data.assignedTo === null
+          ? { assignedUserId }
+          : {}),
+        ...(data.ownerVisible !== undefined && {
+          ownerVisible: data.ownerVisible,
+        }),
+        ...(data.subVendorVisible !== undefined && {
+          subVendorVisible: data.subVendorVisible,
+        }),
+        ...(data.confirmationRequired !== undefined && {
+          confirmationRequired,
+        }),
+        ...(resetConfirmation
+          ? {
+              confirmationStatus: confirmation.status,
+              confirmationRequestedAt: confirmation.requestedAt,
+              confirmationRespondedAt: null,
+              reminderSentAt: null,
+            }
+          : {}),
+        updatedAt: now,
       })
       .where(eq(scheduleTasks.id, taskId))
 
@@ -591,29 +699,6 @@ export async function updateTask(
       entityId: taskId,
       summary: `Updated schedule item “${data.title ?? task.title}”.`,
     })
-
-    if (
-      data.assignedTo !== undefined &&
-      data.assignedTo !== null &&
-      data.assignedTo !== task.assignedTo
-    ) {
-      try {
-        await notifyProjectAssignment({
-          organizationId: orgId,
-          projectId: task.projectId,
-          itemId: taskId,
-          title: data.title ?? task.title,
-          assignedToName: data.assignedTo,
-          createdBy: user,
-          kind: "schedule",
-        })
-      } catch (notificationError) {
-        console.error(
-          "Schedule reassignment notification failed:",
-          notificationError
-        )
-      }
-    }
 
     // propagate date changes to downstream tasks
     const schedule = await getSchedule(task.projectId)
@@ -832,7 +917,10 @@ export async function assignScheduleTasks(
     }
 
     const matchingTasks = await db
-      .select({ id: scheduleTasks.id })
+      .select({
+        id: scheduleTasks.id,
+        confirmationRequired: scheduleTasks.confirmationRequired,
+      })
       .from(scheduleTasks)
       .where(
         and(
@@ -848,18 +936,28 @@ export async function assignScheduleTasks(
       }
     }
 
-    await db
-      .update(scheduleTasks)
-      .set({
-        assignedTo: assignedTo?.trim() || null,
-        updatedAt: new Date().toISOString(),
-      })
-      .where(
-        and(
-          eq(scheduleTasks.projectId, projectId),
-          inArray(scheduleTasks.id, ids)
+    const now = new Date().toISOString()
+    for (const task of matchingTasks) {
+      await db
+        .update(scheduleTasks)
+        .set({
+          assignedTo: assignedTo?.trim() || null,
+          assignedUserId: null,
+          confirmationStatus: task.confirmationRequired
+            ? "unavailable"
+            : "not_requested",
+          confirmationRequestedAt: task.confirmationRequired ? now : null,
+          confirmationRespondedAt: null,
+          reminderSentAt: null,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(scheduleTasks.id, task.id),
+            eq(scheduleTasks.projectId, projectId)
+          )
         )
-      )
+    }
 
     await recordActivityEvent({
       db,

--- a/src/components/projects/__tests__/project-audience-preview.test.ts
+++ b/src/components/projects/__tests__/project-audience-preview.test.ts
@@ -20,6 +20,9 @@ function scheduleItem(
     assignedTo: null,
     percentComplete,
     isMilestone: false,
+    confirmationRequired: false,
+    confirmationStatus: "not_requested",
+    viewerCanConfirm: false,
   }
 }
 

--- a/src/components/projects/project-audience-schedule.tsx
+++ b/src/components/projects/project-audience-schedule.tsx
@@ -1,14 +1,19 @@
 "use client"
 
 import * as React from "react"
+import { useRouter } from "next/navigation"
 import {
   IconCalendar,
+  IconCheck,
   IconChevronLeft,
   IconChevronRight,
   IconList,
   IconTimeline,
+  IconX,
 } from "@tabler/icons-react"
+import { toast } from "sonner"
 
+import { respondToScheduleTaskConfirmation } from "@/app/actions/schedule-confirmations"
 import type { AudienceScheduleItem } from "@/app/actions/project-audience-preview"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -103,6 +108,74 @@ function statusLabel(value: string): string {
     .split("_")
     .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
     .join(" ")
+}
+
+function confirmationLabel(value: string): string {
+  if (value === "confirmed") return "Confirmed"
+  if (value === "declined") return "Cannot commit"
+  if (value === "pending") return "Awaiting confirmation"
+  if (value === "unavailable") return "Compass account needed"
+  return "Not requested"
+}
+
+function ScheduleConfirmationControl({
+  item,
+}: {
+  readonly item: AudienceScheduleItem
+}): React.ReactElement | null {
+  const router = useRouter()
+  const [pending, startTransition] = React.useTransition()
+  if (!item.confirmationRequired) return null
+
+  const respond = (response: "confirmed" | "declined"): void => {
+    startTransition(async () => {
+      const result = await respondToScheduleTaskConfirmation(item.id, response)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(
+        response === "confirmed"
+          ? "Schedule commitment confirmed."
+          : "The project team has been notified that you cannot commit."
+      )
+      router.refresh()
+    })
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Badge
+        variant={item.confirmationStatus === "confirmed" ? "secondary" : "outline"}
+      >
+        {confirmationLabel(item.confirmationStatus)}
+      </Badge>
+      {item.viewerCanConfirm && item.confirmationStatus !== "confirmed" && (
+        <>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={pending}
+            onClick={() => respond("confirmed")}
+          >
+            <IconCheck className="size-4" />
+            Confirm
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={pending}
+            onClick={() => respond("declined")}
+          >
+            <IconX className="size-4" />
+            Cannot commit
+          </Button>
+        </>
+      )}
+    </div>
+  )
 }
 
 function itemsForDay(
@@ -658,15 +731,18 @@ export function ProjectAudienceSchedule({
               <p className="text-xs tabular-nums text-muted-foreground">
                 {formatDate(item.startDate)} – {formatDate(item.endDate)}
               </p>
-              <Badge
-                variant={item.percentComplete === 100 ? "secondary" : "outline"}
-              >
-                {item.percentComplete === 100
-                  ? "Complete"
-                  : item.isMilestone
-                    ? "Milestone"
-                    : `${item.percentComplete}%`}
-              </Badge>
+              <div className="flex flex-wrap items-center justify-end gap-2">
+                <Badge
+                  variant={item.percentComplete === 100 ? "secondary" : "outline"}
+                >
+                  {item.percentComplete === 100
+                    ? "Complete"
+                    : item.isMilestone
+                      ? "Milestone"
+                      : `${item.percentComplete}%`}
+                </Badge>
+                <ScheduleConfirmationControl item={item} />
+              </div>
             </article>
           ))}
         </div>

--- a/src/components/schedule/schedule-item-form-dialog.tsx
+++ b/src/components/schedule/schedule-item-form-dialog.tsx
@@ -57,6 +57,7 @@ import {
   updateDependency,
   deleteDependency,
 } from "@/app/actions/schedule"
+import { sendScheduleTaskReminder } from "@/app/actions/schedule-confirmations"
 import { calculateEndDate } from "@/lib/schedule/business-days"
 import type {
   ScheduleTaskData,
@@ -98,6 +99,9 @@ const scheduleItemSchema = z.object({
   isMilestone: z.boolean(),
   percentComplete: z.number().min(0).max(100),
   assignedTo: z.string(),
+  ownerVisible: z.boolean(),
+  subVendorVisible: z.boolean(),
+  confirmationRequired: z.boolean(),
   notes: z.string(),
 })
 
@@ -139,6 +143,8 @@ export function ScheduleItemFormDialog({
   const [existingPredecessorEdits, setExistingPredecessorEdits] = useState<
     Record<string, PendingPredecessor>
   >({})
+  const [assignedOptionId, setAssignedOptionId] = useState<string | null>(null)
+  const [sendingReminder, setSendingReminder] = useState(false)
 
   const existingPredecessors = useMemo(() => {
     if (!editingTask) return []
@@ -161,6 +167,9 @@ export function ScheduleItemFormDialog({
       isMilestone: false,
       percentComplete: 0,
       assignedTo: "",
+      ownerVisible: true,
+      subVendorVisible: false,
+      confirmationRequired: false,
       notes: "",
     },
   })
@@ -177,8 +186,18 @@ export function ScheduleItemFormDialog({
         isMilestone: editingTask.isMilestone,
         percentComplete: editingTask.percentComplete,
         assignedTo: editingTask.assignedTo ?? "",
+        ownerVisible: editingTask.ownerVisible ?? true,
+        subVendorVisible: editingTask.subVendorVisible ?? false,
+        confirmationRequired: editingTask.confirmationRequired ?? false,
         notes: "",
       })
+      setAssignedOptionId(
+        assigneeOptions.find(
+          (option) =>
+            option.name.trim().toLowerCase() ===
+            (editingTask.assignedTo ?? "").trim().toLowerCase()
+        )?.id ?? null
+      )
       // expand details when editing since they likely want to see everything
       setDetailsOpen(true)
     } else {
@@ -192,12 +211,16 @@ export function ScheduleItemFormDialog({
         isMilestone: false,
         percentComplete: 0,
         assignedTo: "",
+        ownerVisible: true,
+        subVendorVisible: false,
+        confirmationRequired: false,
         notes: "",
       })
+      setAssignedOptionId(null)
       setDetailsOpen(false)
     }
     setPendingPredecessors([])
-  }, [editingTask, form])
+  }, [assigneeOptions, editingTask, form])
 
   useEffect(() => {
     if (!editingTask) {
@@ -241,6 +264,7 @@ export function ScheduleItemFormDialog({
       const result = await updateTask(editingTask.id, {
         ...taskValues,
         assignedTo: taskValues.assignedTo || null,
+        assignedOptionId,
       })
       if (!result.success) {
         toast.error(result.error)
@@ -251,6 +275,7 @@ export function ScheduleItemFormDialog({
       const result = await createTask(projectId, {
         ...taskValues,
         assignedTo: taskValues.assignedTo || undefined,
+        assignedOptionId,
       })
       if (!result.success) {
         toast.error(result.error)
@@ -358,6 +383,19 @@ export function ScheduleItemFormDialog({
 
   const hasPredecessors =
     existingPredecessors.length > 0 || pendingPredecessors.length > 0
+
+  async function handleSendReminder(): Promise<void> {
+    if (!editingTask) return
+    setSendingReminder(true)
+    const result = await sendScheduleTaskReminder(editingTask.id)
+    setSendingReminder(false)
+    if (!result.success) {
+      toast.error(result.error)
+      return
+    }
+    toast.success("Confirmation reminder sent.")
+    router.refresh()
+  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -610,7 +648,23 @@ export function ScheduleItemFormDialog({
                           <ProjectAssigneePicker
                             value={field.value}
                             options={assigneeOptions}
-                            onValueChange={(value) => field.onChange(value)}
+                            onValueChange={(value, option) => {
+                              field.onChange(value)
+                              setAssignedOptionId(option?.id ?? null)
+                              if (option?.contactType === "owner") {
+                                form.setValue("ownerVisible", true, {
+                                  shouldDirty: true,
+                                })
+                              }
+                              if (
+                                option?.contactType === "subcontractor" ||
+                                option?.contactType === "supplier"
+                              ) {
+                                form.setValue("subVendorVisible", true, {
+                                  shouldDirty: true,
+                                })
+                              }
+                            }}
                             placeholder="Choose contact or type a name..."
                           />
                         </FormItem>
@@ -679,6 +733,90 @@ export function ScheduleItemFormDialog({
                       </FormItem>
                     )}
                   />
+
+                  <div className="border-t pt-4">
+                    <p className="text-xs font-medium">
+                      Audience &amp; commitment
+                    </p>
+                    <p className="mt-1 text-[11px] text-muted-foreground">
+                      Visibility changes reach project workspaces only after the
+                      schedule is published.
+                    </p>
+                    <div className="mt-3 grid gap-3 sm:grid-cols-3">
+                      <FormField
+                        control={form.control}
+                        name="ownerVisible"
+                        render={({ field }) => (
+                          <FormItem className="flex items-center justify-between gap-3 border px-3 py-2">
+                            <FormLabel className="!mt-0 text-xs">
+                              Owner can view
+                            </FormLabel>
+                            <FormControl>
+                              <Switch
+                                checked={field.value}
+                                onCheckedChange={field.onChange}
+                              />
+                            </FormControl>
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={form.control}
+                        name="subVendorVisible"
+                        render={({ field }) => (
+                          <FormItem className="flex items-center justify-between gap-3 border px-3 py-2">
+                            <FormLabel className="!mt-0 text-xs">
+                              Subs can view
+                            </FormLabel>
+                            <FormControl>
+                              <Switch
+                                checked={field.value}
+                                onCheckedChange={field.onChange}
+                              />
+                            </FormControl>
+                          </FormItem>
+                        )}
+                      />
+                      <FormField
+                        control={form.control}
+                        name="confirmationRequired"
+                        render={({ field }) => (
+                          <FormItem className="flex items-center justify-between gap-3 border px-3 py-2">
+                            <FormLabel className="!mt-0 text-xs">
+                              Require confirmation
+                            </FormLabel>
+                            <FormControl>
+                              <Switch
+                                checked={field.value}
+                                onCheckedChange={field.onChange}
+                              />
+                            </FormControl>
+                          </FormItem>
+                        )}
+                      />
+                    </div>
+                    {isEditing && editingTask.confirmationRequired && (
+                      <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs">
+                        <span className="text-muted-foreground">
+                          Status:{" "}
+                          {(editingTask.confirmationStatus ?? "not_requested")
+                            .replace(/_/g, " ")
+                            .replace(/^\w/, (letter) => letter.toUpperCase())}
+                        </span>
+                        {editingTask.confirmationStatus !== "confirmed" && (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            disabled={sendingReminder}
+                            onClick={handleSendReminder}
+                          >
+                            {sendingReminder ? "Sending…" : "Send reminder"}
+                          </Button>
+                        )}
+                      </div>
+                    )}
+                  </div>
 
                   {/* Predecessors */}
                   <div className="space-y-2">

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1176,6 +1176,24 @@ export const scheduleTasks = sqliteTable("schedule_tasks", {
     .default(false),
   percentComplete: integer("percent_complete").notNull().default(0),
   assignedTo: text("assigned_to"),
+  assignedUserId: text("assigned_user_id").references(() => users.id, {
+    onDelete: "set null",
+  }),
+  ownerVisible: integer("owner_visible", { mode: "boolean" })
+    .notNull()
+    .default(true),
+  subVendorVisible: integer("sub_vendor_visible", { mode: "boolean" })
+    .notNull()
+    .default(false),
+  confirmationRequired: integer("confirmation_required", { mode: "boolean" })
+    .notNull()
+    .default(false),
+  confirmationStatus: text("confirmation_status")
+    .notNull()
+    .default("not_requested"),
+  confirmationRequestedAt: text("confirmation_requested_at"),
+  confirmationRespondedAt: text("confirmation_responded_at"),
+  reminderSentAt: text("reminder_sent_at"),
   sortOrder: integer("sort_order").notNull().default(0),
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),

--- a/src/lib/schedule/__tests__/confirmation.test.ts
+++ b/src/lib/schedule/__tests__/confirmation.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import { newScheduleConfirmationState } from "@/lib/schedule/confirmation"
+
+describe("schedule assignment confirmation", () => {
+  const now = "2026-07-29T12:00:00.000Z"
+
+  it("requests confirmation from an assigned Compass user", () => {
+    expect(
+      newScheduleConfirmationState({
+        required: true,
+        assignedUserId: "user-1",
+        now,
+      })
+    ).toEqual({ status: "pending", requestedAt: now })
+  })
+
+  it("marks manual-name assignments as unavailable", () => {
+    expect(
+      newScheduleConfirmationState({
+        required: true,
+        assignedUserId: null,
+        now,
+      })
+    ).toEqual({ status: "unavailable", requestedAt: now })
+  })
+
+  it("clears request state when confirmation is not required", () => {
+    expect(
+      newScheduleConfirmationState({
+        required: false,
+        assignedUserId: "user-1",
+        now,
+      })
+    ).toEqual({ status: "not_requested", requestedAt: null })
+  })
+})

--- a/src/lib/schedule/__tests__/publications.test.ts
+++ b/src/lib/schedule/__tests__/publications.test.ts
@@ -31,7 +31,13 @@ describe("schedule publications", () => {
       exceptions: [],
     }))
 
-    expect(snapshot?.tasks[0]?.title).toBe("Framing")
+    expect(snapshot?.tasks[0]).toMatchObject({
+      title: "Framing",
+      confirmationRequired: false,
+      confirmationStatus: "not_requested",
+    })
+    expect(snapshot?.tasks[0]?.ownerVisible).toBeUndefined()
+    expect(snapshot?.tasks[0]?.subVendorVisible).toBeUndefined()
   })
 
   it("rejects malformed publication data", () => {

--- a/src/lib/schedule/confirmation.ts
+++ b/src/lib/schedule/confirmation.ts
@@ -1,0 +1,21 @@
+export type ScheduleConfirmationState = {
+  readonly status:
+    | "not_requested"
+    | "pending"
+    | "unavailable"
+  readonly requestedAt: string | null
+}
+
+export function newScheduleConfirmationState(input: {
+  readonly required: boolean
+  readonly assignedUserId: string | null
+  readonly now: string
+}): ScheduleConfirmationState {
+  if (!input.required) {
+    return { status: "not_requested", requestedAt: null }
+  }
+  return {
+    status: input.assignedUserId ? "pending" : "unavailable",
+    requestedAt: input.now,
+  }
+}

--- a/src/lib/schedule/publications.ts
+++ b/src/lib/schedule/publications.ts
@@ -14,6 +14,22 @@ const publishedTaskSchema = z.object({
   isMilestone: z.boolean(),
   percentComplete: z.number(),
   assignedTo: z.string().nullable(),
+  assignedUserId: z.string().nullable().default(null),
+  ownerVisible: z.boolean().optional(),
+  subVendorVisible: z.boolean().optional(),
+  confirmationRequired: z.boolean().default(false),
+  confirmationStatus: z
+    .enum([
+      "not_requested",
+      "pending",
+      "confirmed",
+      "declined",
+      "unavailable",
+    ])
+    .default("not_requested"),
+  confirmationRequestedAt: z.string().nullable().default(null),
+  confirmationRespondedAt: z.string().nullable().default(null),
+  reminderSentAt: z.string().nullable().default(null),
   sortOrder: z.number(),
   createdAt: z.string(),
   updatedAt: z.string(),

--- a/src/lib/schedule/types.ts
+++ b/src/lib/schedule/types.ts
@@ -43,6 +43,14 @@ export interface ScheduleTaskData {
   isMilestone: boolean
   percentComplete: number
   assignedTo: string | null
+  assignedUserId?: string | null
+  ownerVisible?: boolean
+  subVendorVisible?: boolean
+  confirmationRequired?: boolean
+  confirmationStatus?: string
+  confirmationRequestedAt?: string | null
+  confirmationRespondedAt?: string | null
+  reminderSentAt?: string | null
   sortOrder: number
   createdAt: string
   updatedAt: string


### PR DESCRIPTION
## Summary

- add independent owner and subcontractor visibility to each schedule item
- preserve legacy subcontractor assignment filtering without widening access
- add assignee confirmation status with confirm/decline controls in project workspaces
- send assignment and confirmation notifications only after the exact change is published
- allow staff to resend confirmation reminders from the schedule item
- bind confirmations to active Compass users while preserving manual assignee names

## Privacy and rollout

- internal schedule edits remain private until published
- legacy owner visibility remains unchanged
- new subcontractor visibility is opt-in; old snapshots retain their prior assignment-based filter
- notification and response actions verify the latest immutable publication, project membership, assignee identity, and audience visibility

## Validation

- `bunx tsc --noEmit`
- focused ESLint
- 58 focused tests passing
- production webpack build
- migration tested from a fresh database
- migration tested against a seeded pre-0076 database (valid snapshot JSON, clean foreign keys, expected defaults)
- `git diff --check`

## Deployment note

Apply migration `0077_schedule_audience_confirmations.sql` before deploying the application code.

Refs #258
