### PR TITLE
feat(schedule): link operational records

### DIFF
--- a/docs/modules/scheduling.md
+++ b/docs/modules/scheduling.md
@@ -26,6 +26,11 @@ user to confirm or decline a schedule commitment. The request is delivered
 after publication; manual-name assignees remain supported but cannot confirm
 until linked to an active Compass account.
 
+Staff can attach operational links to a schedule item for the file, RFI,
+conversation, or to-do that carries the work forward. Links are project-scoped,
+permission checked, and remain internal; they are not included in owner or
+subcontractor publication snapshots.
+
 The type system (`src/lib/schedule/types.ts`) models construction phases explicitly:
 
 ```typescript

--- a/drizzle/0078_schedule_operational_links.sql
+++ b/drizzle/0078_schedule_operational_links.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `schedule_task_links` (
+  `id` text PRIMARY KEY NOT NULL,
+  `schedule_task_id` text NOT NULL,
+  `project_id` text NOT NULL,
+  `resource_type` text NOT NULL,
+  `resource_id` text,
+  `label` text NOT NULL,
+  `href` text NOT NULL,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  FOREIGN KEY (`schedule_task_id`) REFERENCES `schedule_tasks`(`id`) ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON DELETE cascade,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `idx_schedule_task_links_task`
+  ON `schedule_task_links` (`schedule_task_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_schedule_task_links_project_type`
+  ON `schedule_task_links` (`project_id`, `resource_type`);

--- a/src/app/actions/schedule-links.ts
+++ b/src/app/actions/schedule-links.ts
@@ -1,0 +1,225 @@
+"use server"
+
+import { and, asc, eq } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import {
+  projects,
+  scheduleTaskLinks,
+  scheduleTasks,
+} from "@/db/schema"
+import { recordActivityEvent } from "@/lib/activity-log"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import { requireOrg } from "@/lib/org-scope"
+import { requirePermission } from "@/lib/permissions"
+import { assertProjectAccess } from "@/lib/project-access"
+import {
+  isScheduleLinkType,
+  safeScheduleLinkHref,
+  type ScheduleLinkType,
+} from "@/lib/schedule/links"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+export type ScheduleTaskLink = {
+  readonly id: string
+  readonly scheduleTaskId: string
+  readonly resourceType: ScheduleLinkType
+  readonly label: string
+  readonly href: string
+  readonly createdAt: string
+}
+
+type ScheduleLinkResult =
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string }
+
+function revalidateSchedule(projectId: string): void {
+  revalidatePath(`/dashboard/projects/${projectId}/schedule`)
+  revalidatePath("/dashboard/schedule")
+}
+
+export async function getScheduleTaskLinks(
+  taskId: string
+): Promise<readonly ScheduleTaskLink[]> {
+  const user = await requireAuth()
+  requirePermission(user, "schedule", "read")
+  if (!isInternalStaffRole(user.role)) return []
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const task = await db
+    .select({ projectId: scheduleTasks.projectId })
+    .from(scheduleTasks)
+    .where(eq(scheduleTasks.id, taskId))
+    .get()
+  if (!task) return []
+  await assertProjectAccess(db, user, task.projectId)
+
+  const rows = await db
+    .select({
+      id: scheduleTaskLinks.id,
+      scheduleTaskId: scheduleTaskLinks.scheduleTaskId,
+      resourceType: scheduleTaskLinks.resourceType,
+      label: scheduleTaskLinks.label,
+      href: scheduleTaskLinks.href,
+      createdAt: scheduleTaskLinks.createdAt,
+    })
+    .from(scheduleTaskLinks)
+    .where(eq(scheduleTaskLinks.scheduleTaskId, taskId))
+    .orderBy(asc(scheduleTaskLinks.resourceType), asc(scheduleTaskLinks.label))
+
+  const links: ScheduleTaskLink[] = []
+  for (const row of rows) {
+    if (!isScheduleLinkType(row.resourceType)) continue
+    links.push({
+      ...row,
+      resourceType: row.resourceType,
+    })
+  }
+  return links
+}
+
+export async function createScheduleTaskLink(input: {
+  readonly taskId: string
+  readonly resourceType: string
+  readonly label: string
+  readonly href: string
+}): Promise<ScheduleLinkResult> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    requirePermission(user, "schedule", "update")
+    if (!isInternalStaffRole(user.role)) {
+      return { success: false, error: "Only internal staff can manage links." }
+    }
+    const organizationId = requireOrg(user)
+    if (!isScheduleLinkType(input.resourceType)) {
+      return { success: false, error: "Choose a supported link type." }
+    }
+    const label = input.label.trim()
+    if (label.length < 2 || label.length > 160) {
+      return { success: false, error: "Enter a label between 2 and 160 characters." }
+    }
+    const href = safeScheduleLinkHref(input.href)
+    if (!href) {
+      return {
+        success: false,
+        error: "Use a Compass dashboard link or a secure https:// link.",
+      }
+    }
+
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const task = await db
+      .select({
+        id: scheduleTasks.id,
+        projectId: scheduleTasks.projectId,
+        title: scheduleTasks.title,
+      })
+      .from(scheduleTasks)
+      .innerJoin(projects, eq(projects.id, scheduleTasks.projectId))
+      .where(
+        and(
+          eq(scheduleTasks.id, input.taskId),
+          eq(projects.organizationId, organizationId)
+        )
+      )
+      .get()
+    if (!task) {
+      return { success: false, error: "Schedule item not found." }
+    }
+
+    const now = new Date().toISOString()
+    const linkId = crypto.randomUUID()
+    await db.insert(scheduleTaskLinks).values({
+      id: linkId,
+      scheduleTaskId: task.id,
+      projectId: task.projectId,
+      resourceType: input.resourceType,
+      resourceId: null,
+      label,
+      href,
+      createdBy: user.id,
+      createdAt: now,
+    })
+    await recordActivityEvent({
+      db,
+      organizationId,
+      projectId: task.projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.link_created",
+      entityType: "schedule_item_link",
+      entityId: linkId,
+      summary: `Linked ${input.resourceType} “${label}” to “${task.title}”.`,
+    })
+    revalidateSchedule(task.projectId)
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to create schedule link", error)
+    return { success: false, error: "Unable to add the link." }
+  }
+}
+
+export async function deleteScheduleTaskLink(
+  linkId: string
+): Promise<ScheduleLinkResult> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    requirePermission(user, "schedule", "update")
+    if (!isInternalStaffRole(user.role)) {
+      return { success: false, error: "Only internal staff can manage links." }
+    }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const link = await db
+      .select({
+        id: scheduleTaskLinks.id,
+        projectId: scheduleTaskLinks.projectId,
+        label: scheduleTaskLinks.label,
+      })
+      .from(scheduleTaskLinks)
+      .innerJoin(projects, eq(projects.id, scheduleTaskLinks.projectId))
+      .where(
+        and(
+          eq(scheduleTaskLinks.id, linkId),
+          eq(projects.organizationId, organizationId)
+        )
+      )
+      .get()
+    if (!link) return { success: false, error: "Link not found." }
+
+    await db
+      .delete(scheduleTaskLinks)
+      .where(
+        and(
+          eq(scheduleTaskLinks.id, link.id),
+          eq(scheduleTaskLinks.projectId, link.projectId)
+        )
+      )
+    await recordActivityEvent({
+      db,
+      organizationId,
+      projectId: link.projectId,
+      actor: user,
+      category: "schedule",
+      action: "schedule.link_deleted",
+      entityType: "schedule_item_link",
+      entityId: link.id,
+      summary: `Removed schedule link “${link.label}”.`,
+    })
+    revalidateSchedule(link.projectId)
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to delete schedule link", error)
+    return { success: false, error: "Unable to remove the link." }
+  }
+}

--- a/src/components/schedule/schedule-item-form-dialog.tsx
+++ b/src/components/schedule/schedule-item-form-dialog.tsx
@@ -76,6 +76,7 @@ import { toast } from "sonner"
 import { cn } from "@/lib/utils"
 import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
 import { ProjectAssigneePicker } from "@/components/projects/project-assignee-picker"
+import { ScheduleItemLinks } from "@/components/schedule/schedule-item-links"
 
 const phases = PHASE_ORDER.map((value) => ({
   value,
@@ -817,6 +818,8 @@ export function ScheduleItemFormDialog({
                       </div>
                     )}
                   </div>
+
+                  {isEditing && <ScheduleItemLinks taskId={editingTask.id} />}
 
                   {/* Predecessors */}
                   <div className="space-y-2">

--- a/src/components/schedule/schedule-item-links.tsx
+++ b/src/components/schedule/schedule-item-links.tsx
@@ -1,0 +1,203 @@
+"use client"
+
+import * as React from "react"
+import {
+  IconExternalLink,
+  IconLink,
+  IconPlus,
+  IconTrash,
+} from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import {
+  createScheduleTaskLink,
+  deleteScheduleTaskLink,
+  getScheduleTaskLinks,
+  type ScheduleTaskLink,
+} from "@/app/actions/schedule-links"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import type { ScheduleLinkType } from "@/lib/schedule/links"
+
+const LINK_TYPES: readonly {
+  readonly value: ScheduleLinkType
+  readonly label: string
+}[] = [
+  { value: "file", label: "File" },
+  { value: "rfi", label: "RFI" },
+  { value: "conversation", label: "Conversation" },
+  { value: "todo", label: "To-do" },
+]
+
+function typeLabel(value: ScheduleLinkType): string {
+  return LINK_TYPES.find((option) => option.value === value)?.label ?? value
+}
+
+export function ScheduleItemLinks({
+  taskId,
+}: {
+  readonly taskId: string
+}): React.ReactElement {
+  const [links, setLinks] = React.useState<readonly ScheduleTaskLink[]>([])
+  const [resourceType, setResourceType] =
+    React.useState<ScheduleLinkType>("file")
+  const [label, setLabel] = React.useState("")
+  const [href, setHref] = React.useState("")
+  const [loading, setLoading] = React.useState(true)
+  const [saving, setSaving] = React.useState(false)
+
+  const loadLinks = React.useCallback(async (): Promise<void> => {
+    setLoading(true)
+    try {
+      setLinks(await getScheduleTaskLinks(taskId))
+    } catch {
+      toast.error("Unable to load linked records.")
+    } finally {
+      setLoading(false)
+    }
+  }, [taskId])
+
+  React.useEffect(() => {
+    void loadLinks()
+  }, [loadLinks])
+
+  async function addLink(): Promise<void> {
+    setSaving(true)
+    const result = await createScheduleTaskLink({
+      taskId,
+      resourceType,
+      label,
+      href,
+    })
+    setSaving(false)
+    if (!result.success) {
+      toast.error(result.error)
+      return
+    }
+    setLabel("")
+    setHref("")
+    toast.success("Operational link added.")
+    await loadLinks()
+  }
+
+  async function removeLink(linkId: string): Promise<void> {
+    const result = await deleteScheduleTaskLink(linkId)
+    if (!result.success) {
+      toast.error(result.error)
+      return
+    }
+    setLinks((current) => current.filter((link) => link.id !== linkId))
+    toast.success("Link removed.")
+  }
+
+  return (
+    <div className="border-t pt-4">
+      <div className="flex items-center gap-2">
+        <IconLink className="size-4 text-muted-foreground" />
+        <p className="text-xs font-medium">Operational links</p>
+      </div>
+      <p className="mt-1 text-[11px] text-muted-foreground">
+        Keep the file, RFI, conversation, or to-do used to complete this work
+        beside the schedule item.
+      </p>
+
+      <div className="mt-3 space-y-2">
+        {loading ? (
+          <p className="text-xs text-muted-foreground">Loading links…</p>
+        ) : links.length === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            No operational records linked yet.
+          </p>
+        ) : (
+          links.map((link) => (
+            <div
+              key={link.id}
+              className="grid grid-cols-[5rem_minmax(0,1fr)_auto_auto] items-center gap-2 border-b py-2 last:border-b-0"
+            >
+              <span className="text-[11px] font-medium uppercase text-muted-foreground">
+                {typeLabel(link.resourceType)}
+              </span>
+              <span className="truncate text-xs">{link.label}</span>
+              <Button variant="ghost" size="icon" asChild>
+                <a
+                  href={link.href}
+                  target={link.href.startsWith("https://") ? "_blank" : undefined}
+                  rel={link.href.startsWith("https://") ? "noreferrer" : undefined}
+                  aria-label={`Open ${link.label}`}
+                >
+                  <IconExternalLink className="size-4" />
+                </a>
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={`Remove ${link.label}`}
+                onClick={() => void removeLink(link.id)}
+              >
+                <IconTrash className="size-4" />
+              </Button>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-[8rem_minmax(0,1fr)]">
+        <Select
+          value={resourceType}
+          onValueChange={(value) => {
+            if (
+              value === "file" ||
+              value === "rfi" ||
+              value === "conversation" ||
+              value === "todo"
+            ) {
+              setResourceType(value)
+            }
+          }}
+        >
+          <SelectTrigger className="h-9">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {LINK_TYPES.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Input
+          className="h-9"
+          value={label}
+          onChange={(event) => setLabel(event.target.value)}
+          placeholder="Link label"
+        />
+        <Input
+          className="h-9 sm:col-span-2"
+          value={href}
+          onChange={(event) => setHref(event.target.value)}
+          placeholder="Paste a Compass dashboard or secure https:// link"
+        />
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="mt-2"
+        disabled={saving || !label.trim() || !href.trim()}
+        onClick={() => void addLink()}
+      >
+        <IconPlus className="size-4" />
+        {saving ? "Adding…" : "Add link"}
+      </Button>
+    </div>
+  )
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1199,6 +1199,34 @@ export const scheduleTasks = sqliteTable("schedule_tasks", {
   updatedAt: text("updated_at").notNull(),
 })
 
+export const scheduleTaskLinks = sqliteTable(
+  "schedule_task_links",
+  {
+    id: text("id").primaryKey(),
+    scheduleTaskId: text("schedule_task_id")
+      .notNull()
+      .references(() => scheduleTasks.id, { onDelete: "cascade" }),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    resourceType: text("resource_type").notNull(),
+    resourceId: text("resource_id"),
+    label: text("label").notNull(),
+    href: text("href").notNull(),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    index("idx_schedule_task_links_task").on(table.scheduleTaskId),
+    index("idx_schedule_task_links_project_type").on(
+      table.projectId,
+      table.resourceType
+    ),
+  ]
+)
+
 export const dailyLogTaskLinks = sqliteTable("daily_log_task_links", {
   id: text("id").primaryKey(),
   dailyLogId: text("daily_log_id")

--- a/src/lib/schedule/__tests__/links.test.ts
+++ b/src/lib/schedule/__tests__/links.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isScheduleLinkType,
+  safeScheduleLinkHref,
+} from "@/lib/schedule/links"
+
+describe("schedule operational links", () => {
+  it("accepts supported record types", () => {
+    expect(isScheduleLinkType("file")).toBe(true)
+    expect(isScheduleLinkType("rfi")).toBe(true)
+    expect(isScheduleLinkType("invoice")).toBe(false)
+  })
+
+  it("accepts Compass dashboard and secure external links", () => {
+    expect(
+      safeScheduleLinkHref("/dashboard/projects/project-1/rfis")
+    ).toBe("/dashboard/projects/project-1/rfis")
+    expect(safeScheduleLinkHref("https://drive.google.com/file/1")).toBe(
+      "https://drive.google.com/file/1"
+    )
+  })
+
+  it("rejects unsafe and unrelated relative links", () => {
+    expect(safeScheduleLinkHref("javascript:alert(1)")).toBeNull()
+    expect(safeScheduleLinkHref("http://example.com/file")).toBeNull()
+    expect(safeScheduleLinkHref("/preview/projects/project-1")).toBeNull()
+  })
+})

--- a/src/lib/schedule/links.ts
+++ b/src/lib/schedule/links.ts
@@ -1,0 +1,23 @@
+export const SCHEDULE_LINK_TYPES = [
+  "file",
+  "rfi",
+  "conversation",
+  "todo",
+] as const
+
+export type ScheduleLinkType = (typeof SCHEDULE_LINK_TYPES)[number]
+
+export function isScheduleLinkType(value: string): value is ScheduleLinkType {
+  return SCHEDULE_LINK_TYPES.some((linkType) => linkType === value)
+}
+
+export function safeScheduleLinkHref(value: string): string | null {
+  const href = value.trim()
+  if (href.startsWith("/dashboard/")) return href
+  try {
+    const url = new URL(href)
+    return url.protocol === "https:" ? url.toString() : null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary

- add internal operational links to existing schedule items
- categorize linked records as File, RFI, Conversation, or To-do
- accept only Compass dashboard paths or secure HTTPS targets
- enforce project access, organization scope, internal-staff role, and schedule permissions
- record link creation/removal in the activity log
- keep operational links out of owner/sub publication snapshots

## Validation

- `bunx tsc --noEmit`
- focused ESLint
- 59 schedule tests passing
- production webpack build
- migration tested against the seeded pre-0076 database with clean foreign keys
- `git diff --check`

## Deployment note

Apply migration `0078_schedule_operational_links.sql` before deploying the application code.

Refs #258
