### PR TITLE
test(schedule): cover published audience boundaries

### DIFF
--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -338,6 +338,75 @@ test.describe("usable Compass areas", () => {
     ).toHaveCount(2)
   })
 
+  test("published audience schedules stay isolated from drafts and internal links", async ({
+    page,
+  }) => {
+    const internalPath =
+      "/dashboard/projects/e2e-project-001/schedule?view=list"
+    let response = await page.goto(internalPath)
+    await expectHealthyNavigation(
+      page,
+      response,
+      "/dashboard/projects/e2e-project-001/schedule"
+    )
+
+    await expect(
+      page.getByText("Regression Schedule Item", { exact: true }).first()
+    ).toBeVisible()
+    await expect(
+      page.getByText("Published schedule commitment", { exact: true })
+    ).toHaveCount(0)
+
+    const scheduleRow = page.locator("#schedule-item-e2e-schedule-001")
+    await scheduleRow.locator('button[title="Edit schedule item"]').click()
+    const editDialog = page.getByRole("dialog", {
+      name: "Edit Schedule Item",
+    })
+    await expect(editDialog.getByText("Operational links")).toBeVisible()
+    await expect(
+      editDialog.getByRole("link", { name: "Internal regression RFI link" })
+    ).toBeVisible()
+
+    await page.keyboard.press("Escape")
+    const ownerPath =
+      "/preview/projects/e2e-project-001/owner/schedule"
+    response = await page.goto(ownerPath)
+    await expectHealthyNavigation(page, response, ownerPath)
+    await expect(
+      page.getByText("Published schedule commitment", { exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByText("Owner-visible published milestone", { exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByText("Partner-visible published delivery", { exact: true })
+    ).toHaveCount(0)
+    await expect(
+      page.getByText("Regression Schedule Item", { exact: true })
+    ).toHaveCount(0)
+    await expect(page.getByText("Internal regression RFI link")).toHaveCount(0)
+    await expect(page.getByText("Awaiting confirmation")).toBeVisible()
+    await expect(page.getByRole("button", { name: "Confirm" })).toHaveCount(0)
+
+    const partnerPath =
+      "/preview/projects/e2e-project-001/sub-vendor/schedule"
+    response = await page.goto(partnerPath)
+    await expectHealthyNavigation(page, response, partnerPath)
+    await expect(
+      page.getByText("Published schedule commitment", { exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByText("Partner-visible published delivery", { exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByText("Owner-visible published milestone", { exact: true })
+    ).toHaveCount(0)
+    await expect(
+      page.getByText("Regression Schedule Item", { exact: true })
+    ).toHaveCount(0)
+    await expect(page.getByText("Internal regression RFI link")).toHaveCount(0)
+  })
+
   test("work calendar list shows the actual item title", async ({
     page,
   }) => {

--- a/scripts/seed-e2e-local.mjs
+++ b/scripts/seed-e2e-local.mjs
@@ -5,6 +5,91 @@ import { dirname, resolve } from "node:path"
 const databasePath = resolve(process.env.LOCAL_DB_PATH || "local.db")
 const now = new Date().toISOString()
 const today = now.slice(0, 10)
+const publishedScheduleSnapshot = JSON.stringify({
+  version: 1,
+  tasks: [
+    {
+      id: "e2e-schedule-001",
+      projectId: "e2e-project-001",
+      title: "Published schedule commitment",
+      startDate: today,
+      workdays: 3,
+      endDateCalculated: today,
+      phase: "Preconstruction",
+      displayColor: "blue",
+      status: "IN_PROGRESS",
+      isCriticalPath: true,
+      isMilestone: false,
+      percentComplete: 25,
+      assignedTo: "Demo User",
+      assignedUserId: "demo-user-001",
+      ownerVisible: true,
+      subVendorVisible: true,
+      confirmationRequired: true,
+      confirmationStatus: "pending",
+      confirmationRequestedAt: now,
+      confirmationRespondedAt: null,
+      reminderSentAt: null,
+      sortOrder: 1,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: "e2e-published-owner-only",
+      projectId: "e2e-project-001",
+      title: "Owner-visible published milestone",
+      startDate: today,
+      workdays: 1,
+      endDateCalculated: today,
+      phase: "Closeout",
+      displayColor: "green",
+      status: "PENDING",
+      isCriticalPath: false,
+      isMilestone: true,
+      percentComplete: 0,
+      assignedTo: null,
+      assignedUserId: null,
+      ownerVisible: true,
+      subVendorVisible: false,
+      confirmationRequired: false,
+      confirmationStatus: "not_requested",
+      confirmationRequestedAt: null,
+      confirmationRespondedAt: null,
+      reminderSentAt: null,
+      sortOrder: 2,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: "e2e-published-sub-only",
+      projectId: "e2e-project-001",
+      title: "Partner-visible published delivery",
+      startDate: today,
+      workdays: 1,
+      endDateCalculated: today,
+      phase: "Procurement",
+      displayColor: "orange",
+      status: "PENDING",
+      isCriticalPath: false,
+      isMilestone: true,
+      percentComplete: 0,
+      assignedTo: "Demo Trade Partner",
+      assignedUserId: null,
+      ownerVisible: false,
+      subVendorVisible: true,
+      confirmationRequired: false,
+      confirmationStatus: "not_requested",
+      confirmationRequestedAt: null,
+      confirmationRespondedAt: null,
+      reminderSentAt: null,
+      sortOrder: 3,
+      createdAt: now,
+      updatedAt: now,
+    },
+  ],
+  dependencies: [],
+  exceptions: [],
+})
 
 mkdirSync(dirname(databasePath), { recursive: true })
 
@@ -199,6 +284,36 @@ const upsert = db.transaction(() => {
       due_date = excluded.due_date,
       updated_at = excluded.updated_at
   `).run(today, now, now)
+
+  db.prepare(`
+    INSERT INTO schedule_task_links (
+      id, schedule_task_id, project_id, resource_type, resource_id, label,
+      href, created_by, created_at
+    ) VALUES (
+      'e2e-schedule-link-001', 'e2e-schedule-001', 'e2e-project-001',
+      'rfi', 'e2e-rfi-private', 'Internal regression RFI link',
+      '/dashboard/projects/e2e-project-001/rfis?item=e2e-rfi-private',
+      'demo-user-001', ?
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      label = excluded.label,
+      href = excluded.href
+  `).run(now)
+
+  db.prepare(`
+    INSERT INTO schedule_publications (
+      id, project_id, snapshot_data, change_reason, published_by, published_at
+    ) VALUES (
+      'e2e-schedule-publication-001', 'e2e-project-001', ?,
+      'Deterministic published schedule regression fixture.',
+      'demo-user-001', ?
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      snapshot_data = excluded.snapshot_data,
+      change_reason = excluded.change_reason,
+      published_by = excluded.published_by,
+      published_at = excluded.published_at
+  `).run(publishedScheduleSnapshot, now)
 })
 
 try {

--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -36,6 +36,7 @@ import {
 } from "@/lib/schedule/owner-visibility"
 import { parsePublishedScheduleSnapshot } from "@/lib/schedule/publications"
 import { projectAudiencePhotoUrl } from "@/lib/photo-sources"
+import { canViewerConfirmScheduleTask } from "@/lib/schedule/confirmation"
 
 export type { ProjectAudience } from "@/lib/project-audience-access"
 
@@ -685,10 +686,12 @@ export async function getProjectAudiencePreview(
     isMilestone: item.isMilestone,
     confirmationRequired: item.confirmationRequired,
     confirmationStatus: item.confirmationStatus,
-    viewerCanConfirm:
-      !viewerIsInternal &&
-      item.confirmationRequired &&
-      item.assignedUserId === viewer.id,
+    viewerCanConfirm: canViewerConfirmScheduleTask({
+      viewerIsInternal,
+      viewerId: viewer.id,
+      assignedUserId: item.assignedUserId,
+      confirmationRequired: item.confirmationRequired,
+    }),
   })
   const audienceScheduleItems: readonly AudienceScheduleItem[] =
     ownerScheduleView === "phases"

--- a/src/app/actions/schedule-confirmations.ts
+++ b/src/app/actions/schedule-confirmations.ts
@@ -19,6 +19,7 @@ import { createNotificationEvent } from "@/lib/notifications/events"
 import { requireOrg } from "@/lib/org-scope"
 import { requirePermission } from "@/lib/permissions"
 import { assertProjectAccess } from "@/lib/project-access"
+import { isPublishedScheduleAssignmentVisible } from "@/lib/schedule/confirmation"
 import { parsePublishedScheduleSnapshot } from "@/lib/schedule/publications"
 
 type ConfirmationResponse = "confirmed" | "declined"
@@ -119,13 +120,13 @@ export async function sendPublishedScheduleAssignment(
         )
       )
       .get()
-    if (
-      ((membership?.role === "client" || membership?.role === "owner") &&
-        publishedTask.ownerVisible === false) ||
-      ((membership?.role === "subcontractor" ||
-        membership?.role === "supplier") &&
-        publishedTask.subVendorVisible !== true)
-    ) {
+    if (!isPublishedScheduleAssignmentVisible({
+      currentAssignedUserId: task.assignedUserId,
+      publishedAssignedUserId: publishedTask.assignedUserId,
+      projectRole: membership?.role ?? null,
+      ownerVisible: publishedTask.ownerVisible,
+      subVendorVisible: publishedTask.subVendorVisible,
+    })) {
       return {
         success: false,
         error: "The published item is not visible to the assigned user.",
@@ -265,13 +266,15 @@ export async function sendScheduleTaskReminder(
         )
       )
       .get()
-    if (
-      ((membership?.role === "client" || membership?.role === "owner") &&
-        publishedTask.ownerVisible === false) ||
-      ((membership?.role === "subcontractor" ||
-        membership?.role === "supplier") &&
-        publishedTask.subVendorVisible !== true)
-    ) {
+    if (!isPublishedScheduleAssignmentVisible({
+      currentAssignedUserId: task.assignedUserId,
+      publishedAssignedUserId: publishedTask.assignedUserId,
+      projectRole: membership?.role ?? null,
+      ownerVisible: publishedTask.ownerVisible,
+      subVendorVisible: publishedTask.subVendorVisible,
+      confirmationRequired: true,
+      publishedConfirmationRequired: publishedTask.confirmationRequired,
+    })) {
       return {
         success: false,
         error:

--- a/src/lib/schedule/__tests__/confirmation.test.ts
+++ b/src/lib/schedule/__tests__/confirmation.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
 
-import { newScheduleConfirmationState } from "@/lib/schedule/confirmation"
+import {
+  canViewerConfirmScheduleTask,
+  isPublishedScheduleAssignmentVisible,
+  newScheduleConfirmationState,
+} from "@/lib/schedule/confirmation"
 
 describe("schedule assignment confirmation", () => {
   const now = "2026-07-29T12:00:00.000Z"
@@ -33,5 +37,63 @@ describe("schedule assignment confirmation", () => {
         now,
       })
     ).toEqual({ status: "not_requested", requestedAt: null })
+  })
+
+  it("only lets the assigned external user respond", () => {
+    expect(
+      canViewerConfirmScheduleTask({
+        viewerIsInternal: false,
+        viewerId: "assigned-user",
+        assignedUserId: "assigned-user",
+        confirmationRequired: true,
+      })
+    ).toBe(true)
+    expect(
+      canViewerConfirmScheduleTask({
+        viewerIsInternal: true,
+        viewerId: "assigned-user",
+        assignedUserId: "assigned-user",
+        confirmationRequired: true,
+      })
+    ).toBe(false)
+    expect(
+      canViewerConfirmScheduleTask({
+        viewerIsInternal: false,
+        viewerId: "different-user",
+        assignedUserId: "assigned-user",
+        confirmationRequired: true,
+      })
+    ).toBe(false)
+  })
+
+  it("gates assignment notifications on the published audience snapshot", () => {
+    const shared = {
+      currentAssignedUserId: "assigned-user",
+      publishedAssignedUserId: "assigned-user",
+      projectRole: "subcontractor",
+      ownerVisible: true,
+      subVendorVisible: true,
+    } satisfies Parameters<typeof isPublishedScheduleAssignmentVisible>[0]
+
+    expect(isPublishedScheduleAssignmentVisible(shared)).toBe(true)
+    expect(
+      isPublishedScheduleAssignmentVisible({
+        ...shared,
+        publishedAssignedUserId: "previous-user",
+      })
+    ).toBe(false)
+    expect(
+      isPublishedScheduleAssignmentVisible({
+        ...shared,
+        subVendorVisible: false,
+      })
+    ).toBe(false)
+    expect(
+      isPublishedScheduleAssignmentVisible({
+        ...shared,
+        confirmationRequired: true,
+        publishedConfirmationRequired: false,
+      })
+    ).toBe(false)
   })
 })

--- a/src/lib/schedule/confirmation.ts
+++ b/src/lib/schedule/confirmation.ts
@@ -6,6 +6,56 @@ export type ScheduleConfirmationState = {
   readonly requestedAt: string | null
 }
 
+export function canViewerConfirmScheduleTask(input: {
+  readonly viewerIsInternal: boolean
+  readonly viewerId: string
+  readonly assignedUserId: string | null
+  readonly confirmationRequired: boolean
+}): boolean {
+  return (
+    !input.viewerIsInternal &&
+    input.confirmationRequired &&
+    input.assignedUserId === input.viewerId
+  )
+}
+
+export function isPublishedScheduleAssignmentVisible(input: {
+  readonly currentAssignedUserId: string | null
+  readonly publishedAssignedUserId: string | null
+  readonly projectRole: string | null
+  readonly ownerVisible: boolean | undefined
+  readonly subVendorVisible: boolean | undefined
+  readonly confirmationRequired?: boolean
+  readonly publishedConfirmationRequired?: boolean
+}): boolean {
+  if (
+    input.currentAssignedUserId === null ||
+    input.currentAssignedUserId !== input.publishedAssignedUserId
+  ) {
+    return false
+  }
+  if (
+    input.confirmationRequired === true &&
+    input.publishedConfirmationRequired !== true
+  ) {
+    return false
+  }
+  if (
+    (input.projectRole === "client" || input.projectRole === "owner") &&
+    input.ownerVisible === false
+  ) {
+    return false
+  }
+  if (
+    (input.projectRole === "subcontractor" ||
+      input.projectRole === "supplier") &&
+    input.subVendorVisible !== true
+  ) {
+    return false
+  }
+  return true
+}
+
 export function newScheduleConfirmationState(input: {
   readonly required: boolean
   readonly assignedUserId: string | null


### PR DESCRIPTION
## Summary

- add deterministic published-schedule fixtures for internal, owner, and trade-partner views
- verify unpublished schedule edits never appear in audience workspaces
- verify owner/sub item visibility and confirmation eligibility boundaries
- verify internal operational links never appear in owner/sub schedule pages
- centralize and test publication-gated assignment notification rules

## Verification

- `bunx tsc --noEmit`
- focused ESLint
- `bun test src/lib/schedule/__tests__` (61 passing)
- production webpack build
- Chromium published-audience Playwright regression

Refs #258.
