### PR TITLE
feat(owner): add secure financial history and printable G703

### DIFF
--- a/docs/wip/owner-collaboration-workspace-plan-2026-07-29.md
+++ b/docs/wip/owner-collaboration-workspace-plan-2026-07-29.md
@@ -1,0 +1,237 @@
+# Owner Collaboration Workspace Plan
+
+Date: 2026-07-29
+
+## Outcome
+
+The owner workspace should be a guarded project collaboration portal for
+people who are financially and personally invested in an ORC or Design
+project. It should not be a read-only preview, and it should not expose the
+internal Compass application by hiding a few menu items.
+
+Owners should be able to understand the project, make decisions, provide
+information, and keep durable copies of the records they are entitled to see.
+Every read and write must remain scoped to the owner's project membership and
+to the audience of the individual record.
+
+## Owner workspace information architecture
+
+1. **Home**
+   - Project photo, current phase, next update, decisions needed, and project
+     team.
+   - Clear alerts for assigned to-dos, RFIs awaiting a response, selections,
+     and new pay applications.
+2. **Updates**
+   - Current and historical published owner updates.
+   - Print and save as PDF.
+3. **Schedule**
+   - Published schedule only, using the project's item or phase publication
+     setting.
+   - List, calendar, and read-only Gantt views.
+   - Print/save a dated published snapshot rather than attempting to print the
+     interactive Gantt canvas.
+4. **Financials**
+   - Current approved budget and G703.
+   - Chronological pay-application history with period, status, amount, and
+     immutable PDF.
+   - Print/save current G703 and every prior published application.
+   - Change orders and owner approvals can be added after their visibility and
+     approval rules are formalized.
+5. **To-Dos and Decisions**
+   - Only owner-visible items or items assigned to the signed-in owner.
+   - Owner can update their own response/status and add an attachment.
+   - Staff retains control of project-wide status, assignment, and internal
+     notes.
+6. **RFIs**
+   - View owner/public RFIs.
+   - Create an owner-originated RFI and respond when assigned.
+   - Attach files and photos.
+   - Internal routing, internal notes, and draft answers remain staff-only.
+7. **Plans and Documents**
+   - Published plans, specifications, selections, contracts, and other
+     approved document versions.
+   - Downloadable current and superseded versions with clear version status.
+   - A controlled owner upload inbox; uploads are reviewed before being moved
+     into the official project record.
+8. **Photos**
+   - Approved project photos and owner-update photos.
+   - Owner uploads enter a review queue unless the destination explicitly
+     permits immediate sharing.
+9. **Conversations**
+   - Project-scoped channels with the internal project team.
+   - Owners do not discover or message unrelated external participants.
+10. **Selections and Approvals**
+    - Particularly important for ORC and Design clients.
+    - Due dates, alternatives, documents, decisions, and immutable approval
+      history.
+11. **Warranty**
+    - Appears when the project enters the warranty stage.
+    - Submit a claim with location, category, description, priority, photos or
+      video.
+    - Track acknowledgment, scheduled visit, work status, resolution, and
+      owner confirmation.
+12. **Project Team**
+    - Approved internal project contacts with direct project messaging.
+
+## Authorization model
+
+Access is the intersection of all of the following:
+
+1. The authenticated user belongs to the requested project.
+2. Their project-member role permits the owner workspace.
+3. The record is published or explicitly marked owner-visible.
+4. A write is permitted for that record and relationship, such as creator,
+   assignee, approver, or warranty claimant.
+5. The action never exposes staff-only fields.
+
+This needs project-specific capabilities rather than granting an external role
+general `project.update` or `document.create` permission.
+
+Examples:
+
+- An owner may create an RFI for their own project. The server forces the
+  audience and initial status; the owner cannot choose an internal audience.
+- An owner may respond to a to-do assigned to their user ID. They cannot query
+  all project operations or reassign the item.
+- An owner may download a published document through a project-specific route.
+  A raw Google Drive file ID is never sufficient authorization.
+- An owner upload enters a controlled project inbox. It does not grant write
+  access to an internal Drive folder.
+
+## Data and security prerequisites
+
+### Project access
+
+All owner-facing actions and routes must use `assertProjectAccess` and, for an
+external viewer, verify the project membership role. Organization membership
+alone is not project access.
+
+The existing RFI and project-operation actions need this audit before their
+features are linked into the owner workspace.
+
+### Record-level participation
+
+The current to-do model stores an assignee name but not an assigned user ID or
+owner audience. Add explicit assignee/audience fields (or a relation) before
+owners can safely view and update to-dos.
+
+RFIs already have an audience field, but owner-specific create/respond actions
+must force safe values and enforce creator/assignee rules.
+
+### Documents
+
+Create a project-document publication index rather than exposing the internal
+Google Drive browser. Suggested fields:
+
+- project ID and category
+- display title and description
+- storage ID kept server-side
+- version and current/superseded status
+- owner-visible, downloadable, and uploadable flags
+- published timestamp and publisher
+- review status for external uploads
+- source document ID and checksum where available
+
+The general Google Drive download endpoint must remain internal-only.
+External downloads need project- and record-specific authorization.
+
+### Financial snapshots
+
+A published pay application is a durable record:
+
+- application header
+- frozen G702/G703 line snapshot
+- generated or imported PDF
+- publication timestamp and publisher
+- owner visibility
+
+Later Sage or source-system synchronization must not rewrite a prior published
+owner document.
+
+Sage 100 Contractor is the financial system of record. The owner workflow
+should use a read-only Sage import for job/contract values, approved change
+orders, progress-billing lines, prior certificates, deposits/credits,
+retainage, current billing, and balance to finish. Compass should normalize
+that data into a draft pay-application package, reconcile the G702 header to
+the G703 Schedule of Values, require staff review when any difference remains,
+then publish an immutable owner snapshot and PDF. A future write back to Sage
+must remain approval-gated, idempotent, and audited.
+
+Loomis currently has archived PDFs for pay applications 1, 2, and 3. Only pay
+application 3 has imported G703 lines, so Compass can safely show the current
+interactive G703 and all three original PDFs. It must not use pay application
+3 lines to fabricate historical G703 detail for applications 1 or 2.
+
+The current Loomis source records do not fully reconcile: the certified G702
+contract total differs from the imported G703 line total, and the G702 includes
+deposit/payment behavior that the current Compass schema does not model.
+Compass must surface that condition to staff and preserve the certified PDF
+while the Sage progress-billing import is completed.
+
+## Delivery sequence
+
+### Stage 0 — Guardrails
+
+- Audit every owner/sub route and server action for project membership.
+- Restrict generic file download paths to internal users.
+- Add regression tests proving one external project member cannot access
+  another project by changing an ID.
+- Record owner actions in the existing activity log.
+
+### Stage 1 — Durable read experience
+
+- Build the read-only Sage progress-billing import and reconciliation gate.
+- Complete Budget/G703 display, project totals, pay-app history, and print/save.
+- Add printable published schedule snapshots.
+- Add the published document index and owner plans/specifications library.
+- Complete project-team and conversation visibility.
+
+### Stage 2 — Assigned participation
+
+- Owner-assigned to-dos and decisions.
+- Owner RFI creation and assigned responses.
+- File/photo attachments and notifications.
+- Selection review and approval history.
+
+### Stage 3 — Owner submissions
+
+- Controlled document upload inbox.
+- Owner photo contributions with review.
+- Warranty claim workflow, stage-gated by project status.
+
+### Stage 4 — Operational polish
+
+- Mobile and offline submission queues where appropriate.
+- Notification preferences and delivery receipts.
+- Activity history visible to staff and a limited “your activity” history for
+  owners.
+- Accessibility, print, tablet, and phone regression coverage.
+
+## Immediate Budget/G703 acceptance criteria
+
+- The dedicated owner financial page shows every approved budget category; it
+  does not silently stop after six.
+- The G703 has a project-total row for original contract, changes, adjusted
+  contract, prior, current, completed/stored, percentage, and balance.
+- Prior costs appear on category rows.
+- Every owner-visible archived pay application is listed.
+- Archived PDFs open and download only after project and owner-role checks.
+- Current G703 can be printed or saved as a landscape PDF with project
+  department branding.
+- A G702/G703 mismatch is visible to staff and cannot be silently represented
+  as reconciled Sage data.
+- Internal notes, vendor identity, raw storage URLs, and staff-only lines
+  remain absent.
+- Tablet layout supports horizontal table navigation without constraining the
+  category list to a hidden fixed-height area.
+
+## Regression coverage
+
+- Owner, sub/vendor, unrelated external user, and internal preview role tests.
+- Direct-ID access tests for pay applications, documents, RFIs, to-dos,
+  photos, and conversations.
+- Current vs historical financial snapshot tests.
+- Printed G703 visual test in Chromium at Letter landscape.
+- Schedule print visual test at list and published-phase levels.
+- Tablet and phone owner navigation, table scrolling, downloads, and uploads.
+- Activity-log assertions for every external write.

--- a/src/app/actions/project-budget.ts
+++ b/src/app/actions/project-budget.ts
@@ -35,6 +35,7 @@ export type ProjectBudgetApplicationItem = {
   readonly currentPaymentDue: number
   readonly balanceToFinish: number
   readonly ownerVisible: boolean
+  readonly documentAvailable: boolean
   readonly sourceUrl: string | null
   readonly lastSyncedAt: string | null
 }
@@ -70,8 +71,10 @@ export type ProjectBudgetDivision = {
   readonly originalEstimate: number
   readonly totalChanges: number
   readonly adjustedEstimate: number
+  readonly priorCosts: number
   readonly totalCosts: number
   readonly currentCosts: number
+  readonly retainageHeld: number
   readonly balanceToFinish: number
   readonly percentComplete: number
   readonly lineCount: number
@@ -79,9 +82,13 @@ export type ProjectBudgetDivision = {
 }
 
 export type ProjectBudgetTotals = {
+  readonly originalEstimate: number
+  readonly totalChanges: number
   readonly adjustedEstimate: number
+  readonly priorCosts: number
   readonly totalCosts: number
   readonly currentCosts: number
+  readonly retainageHeld: number
   readonly balanceToFinish: number
   readonly percentComplete: number
   readonly overBudgetAmount: number
@@ -91,6 +98,7 @@ export type ProjectBudgetTotals = {
 export type ProjectBudgetSummary = {
   readonly audience: ProjectBudgetAudience
   readonly detailMode: ProjectBudgetDetailMode
+  readonly applications: readonly ProjectBudgetApplicationItem[]
   readonly currentApplication: ProjectBudgetApplicationItem | null
   readonly totals: ProjectBudgetTotals
   readonly divisions: readonly ProjectBudgetDivision[]
@@ -123,6 +131,9 @@ function toApplicationItem(
   audience: ProjectBudgetAudience
 ): ProjectBudgetApplicationItem {
   const ownerSafe = audience === "owner"
+  const documentAvailable =
+    row.sourceSystem === "google_drive_g702_g703" &&
+    Boolean(row.sourceRecordId)
   return {
     id: row.id,
     sourceSystem: row.sourceSystem,
@@ -139,6 +150,7 @@ function toApplicationItem(
     currentPaymentDue: row.currentPaymentDue,
     balanceToFinish: row.balanceToFinish,
     ownerVisible: row.ownerVisible,
+    documentAvailable,
     sourceUrl: ownerSafe ? null : row.sourceUrl,
     lastSyncedAt: ownerSafe ? null : row.lastSyncedAt,
   }
@@ -215,7 +227,12 @@ function buildDivisions(
       0
     )
     const totalCosts = items.reduce((sum, item) => sum + item.totalCosts, 0)
+    const priorCosts = items.reduce((sum, item) => sum + item.priorCosts, 0)
     const currentCosts = items.reduce((sum, item) => sum + item.currentCosts, 0)
+    const retainageHeld = items.reduce(
+      (sum, item) => sum + item.retainageHeld,
+      0
+    )
     const balanceToFinish = items.reduce(
       (sum, item) => sum + item.balanceToFinish,
       0
@@ -227,8 +244,10 @@ function buildDivisions(
       originalEstimate,
       totalChanges,
       adjustedEstimate,
+      priorCosts,
       totalCosts,
       currentCosts,
+      retainageHeld,
       balanceToFinish,
       percentComplete: percent(totalCosts, adjustedEstimate),
       lineCount: items.length,
@@ -313,12 +332,15 @@ export async function getProjectBudgetSummary(
           )
         : eq(projectBudgetApplications.projectId, projectId)
     )
-    .orderBy(desc(projectBudgetApplications.periodTo))
-    .limit(1)
+    .orderBy(
+      desc(projectBudgetApplications.periodTo),
+      desc(projectBudgetApplications.createdAt)
+    )
 
-  const currentApplication = applicationRows[0]
-    ? toApplicationItem(applicationRows[0], effectiveAudience)
-    : null
+  const applications = applicationRows.map((row) =>
+    toApplicationItem(row, effectiveAudience)
+  )
+  const currentApplication = applications[0] ?? null
 
   const lineRows = await access.db
     .select()
@@ -339,12 +361,25 @@ export async function getProjectBudgetSummary(
   const allLines =
     detailMode === "category" ? buildOwnerCategoryLines(sourceLines) : sourceLines
   const divisions = buildDivisions(allLines)
+  const originalEstimate = allLines.reduce(
+    (sum, line) => sum + line.originalEstimate,
+    0
+  )
+  const totalChanges = allLines.reduce(
+    (sum, line) => sum + line.totalChanges,
+    0
+  )
   const adjustedEstimate = allLines.reduce(
     (sum, line) => sum + line.adjustedEstimate,
     0
   )
+  const priorCosts = allLines.reduce((sum, line) => sum + line.priorCosts, 0)
   const totalCosts = allLines.reduce((sum, line) => sum + line.totalCosts, 0)
   const currentCosts = allLines.reduce((sum, line) => sum + line.currentCosts, 0)
+  const retainageHeld = allLines.reduce(
+    (sum, line) => sum + line.retainageHeld,
+    0
+  )
   const balanceToFinish = allLines.reduce(
     (sum, line) => sum + line.balanceToFinish,
     0
@@ -353,11 +388,16 @@ export async function getProjectBudgetSummary(
   return {
     audience: effectiveAudience,
     detailMode,
+    applications,
     currentApplication,
     totals: {
+      originalEstimate,
+      totalChanges,
       adjustedEstimate,
+      priorCosts,
       totalCosts,
       currentCosts,
+      retainageHeld,
       balanceToFinish,
       percentComplete: percent(totalCosts, adjustedEstimate),
       overBudgetAmount: Math.max(0, totalCosts - adjustedEstimate),

--- a/src/app/api/google/download/[fileId]/route.ts
+++ b/src/app/api/google/download/[fileId]/route.ts
@@ -16,6 +16,7 @@ import {
   getExportMimeType,
   getExportExtension,
 } from "@/lib/google/mapper"
+import { isInternalStaffRole } from "@/lib/user-roles"
 
 export async function GET(
   _request: NextRequest,
@@ -24,6 +25,11 @@ export async function GET(
   try {
     const user = await requireAuth()
     requirePermission(user, "document", "read")
+    // External users must use project-specific download routes that verify
+    // membership and record visibility before resolving a storage ID.
+    if (!isInternalStaffRole(user.role)) {
+      return new Response("File not found", { status: 404 })
+    }
 
     const googleEmail = user.googleEmail ?? user.email
 

--- a/src/app/api/projects/[id]/pay-applications/[applicationId]/download/route.ts
+++ b/src/app/api/projects/[id]/pay-applications/[applicationId]/download/route.ts
@@ -1,0 +1,169 @@
+import { and, eq } from "drizzle-orm"
+import { NextRequest } from "next/server"
+
+import { getDb } from "@/db"
+import {
+  projectBudgetApplications,
+  projectMembers,
+} from "@/db/schema"
+import { googleAuth } from "@/db/schema-google"
+import { requireAuth } from "@/lib/auth"
+import { decrypt } from "@/lib/crypto"
+import { getCloudflareContext } from "@/lib/db"
+import { DriveClient } from "@/lib/google/client/drive-client"
+import {
+  getGoogleCryptoSalt,
+  parseServiceAccountKey,
+} from "@/lib/google/config"
+import { canUseProjectAudience } from "@/lib/project-audience-access"
+import { assertProjectAccess } from "@/lib/project-access"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+const DEFAULT_COMPASS_GOOGLE_DOWNLOAD_USER = "compass@hps-colorado.com"
+const GOOGLE_NATIVE_MIME_PREFIX = "application/vnd.google-apps."
+
+function environmentString(env: object, key: string): string | null {
+  const rawValue: unknown = Reflect.get(env, key)
+  if (typeof rawValue !== "string") return null
+  const value = rawValue.trim()
+  return value.length > 0 ? value : null
+}
+
+function downloadUserEmail(env: object): string {
+  return (
+    environmentString(env, "COMPASS_GOOGLE_UPLOAD_USER") ??
+    environmentString(env, "COMPASS_GOOGLE_DOWNLOAD_USER") ??
+    DEFAULT_COMPASS_GOOGLE_DOWNLOAD_USER
+  )
+}
+
+function safeFileName(value: string): string {
+  return value.replace(/["\r\n]/g, "_")
+}
+
+export async function GET(
+  request: NextRequest,
+  {
+    params,
+  }: {
+    readonly params: Promise<{
+      readonly id: string
+      readonly applicationId: string
+    }>
+  }
+): Promise<Response> {
+  try {
+    const user = await requireAuth()
+    const { id: projectId, applicationId } = await params
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const project = await assertProjectAccess(db, user, projectId)
+    if (!project.organizationId) {
+      return new Response("Pay application not found", { status: 404 })
+    }
+
+    if (!isInternalStaffRole(user.role)) {
+      const [membership] = await db
+        .select({ role: projectMembers.role })
+        .from(projectMembers)
+        .where(
+          and(
+            eq(projectMembers.projectId, projectId),
+            eq(projectMembers.userId, user.id)
+          )
+        )
+        .limit(1)
+      if (!canUseProjectAudience(membership?.role ?? null, "owner")) {
+        return new Response("Pay application not found", { status: 404 })
+      }
+    }
+
+    const [application] = await db
+      .select({
+        sourceRecordId: projectBudgetApplications.sourceRecordId,
+        sourceSystem: projectBudgetApplications.sourceSystem,
+        applicationNumber: projectBudgetApplications.applicationNumber,
+      })
+      .from(projectBudgetApplications)
+      .where(
+        and(
+          eq(projectBudgetApplications.id, applicationId),
+          eq(projectBudgetApplications.projectId, projectId),
+          eq(projectBudgetApplications.ownerVisible, true)
+        )
+      )
+      .limit(1)
+    if (
+      !application?.sourceRecordId ||
+      application.sourceSystem !== "google_drive_g702_g703"
+    ) {
+      return new Response("Pay application document is unavailable", {
+        status: 404,
+      })
+    }
+
+    const [auth] = await db
+      .select()
+      .from(googleAuth)
+      .where(eq(googleAuth.organizationId, project.organizationId))
+      .limit(1)
+    if (!auth) {
+      return new Response("Document storage is unavailable", { status: 503 })
+    }
+
+    const encryptionKey =
+      environmentString(env, "GOOGLE_SERVICE_ACCOUNT_ENCRYPTION_KEY") ??
+      process.env.GOOGLE_SERVICE_ACCOUNT_ENCRYPTION_KEY
+    if (!encryptionKey) {
+      return new Response("Document storage is unavailable", { status: 503 })
+    }
+
+    const keyJson = await decrypt(
+      auth.serviceAccountKeyEncrypted,
+      encryptionKey,
+      getGoogleCryptoSalt()
+    )
+    const client = new DriveClient({
+      serviceAccountKey: parseServiceAccountKey(keyJson),
+    })
+    const googleEmail = downloadUserEmail(env)
+    const file = await client.getFile(googleEmail, application.sourceRecordId)
+    const isGoogleNative = file.mimeType.startsWith(GOOGLE_NATIVE_MIME_PREFIX)
+    const response = isGoogleNative
+      ? await client.exportFile(
+          googleEmail,
+          application.sourceRecordId,
+          "application/pdf"
+        )
+      : await client.downloadFile(googleEmail, application.sourceRecordId)
+    if (!response.ok) {
+      console.error("Owner pay application download failed", {
+        projectId,
+        applicationId,
+        status: response.status,
+      })
+      return new Response("Pay application could not be loaded", {
+        status: response.status,
+      })
+    }
+
+    const fallbackName = `Pay Application ${application.applicationNumber}.pdf`
+    const sourceName = file.name.trim() || fallbackName
+    const fileName = isGoogleNative ? `${sourceName}.pdf` : sourceName
+    const download = request.nextUrl.searchParams.get("download") === "1"
+
+    return new Response(response.body, {
+      headers: {
+        "Content-Type": isGoogleNative ? "application/pdf" : file.mimeType,
+        "Content-Disposition":
+          `${download ? "attachment" : "inline"}; ` +
+          `filename="${safeFileName(fileName)}"`,
+        "Cache-Control": "private, max-age=300",
+        "X-Content-Type-Options": "nosniff",
+      },
+    })
+  } catch (error) {
+    console.error("Owner pay application download error", error)
+    return new Response("Pay application could not be loaded", { status: 500 })
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -436,6 +436,11 @@ em-emoji-picker {
     margin: 0.5in;
   }
 
+  @page owner-budget {
+    size: landscape;
+    margin: 0.35in;
+  }
+
   body.po-printing-selected > * {
     visibility: hidden;
   }
@@ -480,6 +485,58 @@ em-emoji-picker {
     min-height: 0 !important;
     max-height: none !important;
     overflow: visible !important;
+  }
+
+  body.owner-budget-printing > :not([data-owner-budget-print-root="true"]) {
+    display: none !important;
+  }
+
+  body.owner-budget-printing [data-owner-budget-print-root="true"] {
+    display: block !important;
+    position: static !important;
+    width: 100%;
+    max-width: none !important;
+    height: auto !important;
+    max-height: none !important;
+    overflow: visible !important;
+    page: owner-budget;
+  }
+
+  body.owner-budget-printing,
+  body.owner-budget-printing .owner-budget-print-root {
+    background: #ffffff !important;
+    height: auto !important;
+    min-height: 0 !important;
+    max-height: none !important;
+    overflow: visible !important;
+  }
+
+  .owner-budget-print-root table {
+    min-width: 0 !important;
+    width: 100% !important;
+    font-size: 8pt !important;
+  }
+
+  .owner-budget-print-root .overflow-x-auto {
+    overflow: visible !important;
+  }
+
+  .owner-budget-print-root th,
+  .owner-budget-print-root td {
+    padding: 0.08in 0.05in !important;
+  }
+
+  .owner-budget-print-root thead {
+    display: table-header-group;
+  }
+
+  .owner-budget-print-root tfoot {
+    display: table-row-group;
+  }
+
+  .owner-budget-print-root tr {
+    break-inside: avoid;
+    page-break-inside: avoid;
   }
 
   body.daily-log-printing * {

--- a/src/app/preview/projects/[id]/owner/budget/page.tsx
+++ b/src/app/preview/projects/[id]/owner/budget/page.tsx
@@ -1,8 +1,14 @@
 export const dynamic = "force-dynamic"
 
 import type * as React from "react"
+import Image from "next/image"
 import { notFound } from "next/navigation"
-import { IconFileDollar, IconLock } from "@tabler/icons-react"
+import {
+  IconDownload,
+  IconExternalLink,
+  IconFileDollar,
+  IconLock,
+} from "@tabler/icons-react"
 
 import {
   getProjectBudgetSummary,
@@ -16,10 +22,53 @@ import {
   ProjectBudgetG703Table,
   ProjectBudgetPanel,
 } from "@/components/projects/project-budget-panel"
+import { ProjectBudgetPrintButton } from "@/components/projects/project-budget-print-button"
 import { ProjectAudiencePreviewShell } from "@/components/projects/project-audience-preview-shell"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { projectBrandFor } from "@/lib/project-branding"
 
 function hasDigest(error: unknown): error is { readonly digest: string } {
   return typeof error === "object" && error !== null && "digest" in error
+}
+
+function money(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "Period not dated"
+  return new Date(`${value}T00:00:00`).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+function statusLabel(value: string): string {
+  return value
+    .split("_")
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ")
+}
+
+function applicationDownloadHref(
+  projectId: string,
+  applicationId: string,
+  download = false
+): string {
+  const href =
+    `/api/projects/${encodeURIComponent(projectId)}` +
+    `/pay-applications/${encodeURIComponent(applicationId)}/download`
+  return download ? `${href}?download=1` : href
+}
+
+function centsDifference(left: number, right: number): number {
+  return Math.round((left - right) * 100) / 100
 }
 
 export default async function OwnerBudgetPage({
@@ -38,6 +87,33 @@ export default async function OwnerBudgetPage({
     if (hasDigest(error) && error.digest === "NEXT_NOT_FOUND") throw error
     notFound()
   }
+
+  const brand = projectBrandFor({
+    projectId: preview.project.id,
+    projectNumber: preview.project.projectNumber,
+  })
+  const contractDifference = budget.currentApplication
+    ? centsDifference(
+        budget.totals.adjustedEstimate,
+        budget.currentApplication.contractSumToDate
+      )
+    : 0
+  const priorDifference = budget.currentApplication
+    ? centsDifference(
+        budget.totals.priorCosts,
+        budget.currentApplication.previousCertificates
+      )
+    : 0
+  const currentDifference = budget.currentApplication
+    ? centsDifference(
+        budget.totals.currentCosts,
+        budget.currentApplication.currentPaymentDue
+      )
+    : 0
+  const reconciliationRequired =
+    Math.abs(contractDifference) >= 0.02 ||
+    Math.abs(priorDifference) >= 0.02 ||
+    Math.abs(currentDifference) >= 0.02
 
   return (
     <ProjectAudiencePreviewShell
@@ -66,34 +142,173 @@ export default async function OwnerBudgetPage({
             </div>
             <p className="flex items-center gap-2 text-xs text-muted-foreground">
               <IconLock className="size-4" />
-              Read-only owner view
+              Approved owner financials
             </p>
           </div>
 
-          <div className="mt-5">
-            <ProjectBudgetPanel
-              projectId={id}
-              summary={budget}
-              detailHref={null}
-            />
-          </div>
-
-          {budget.allLines.length > 0 && (
-            <section className="mt-6">
-              <div className="mb-3">
-                <h2 className="text-sm font-semibold">
-                  G703 Schedule of Values
-                </h2>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Only lines approved for owner visibility are included.
-                </p>
+          {budget.applications.length > 0 && (
+            <section className="mt-5 border bg-background p-4">
+              <div className="flex flex-wrap items-end justify-between gap-3">
+                <div>
+                  <h2 className="text-sm font-semibold">Pay applications</h2>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Review, print, or save every published application.
+                  </p>
+                </div>
+                <Badge variant="outline">
+                  {budget.applications.length} published
+                </Badge>
               </div>
-              <ProjectBudgetG703Table
-                summary={budget}
-                showVisibility={false}
-              />
+              <div className="mt-4 divide-y border">
+                {budget.applications.map((application, index) => (
+                  <article
+                    key={application.id}
+                    className="grid gap-3 p-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="font-medium">
+                          Pay application {application.applicationNumber}
+                        </p>
+                        {index === 0 && <Badge>Current</Badge>}
+                        <Badge variant="outline">
+                          {statusLabel(application.status)}
+                        </Badge>
+                      </div>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Through {formatDate(application.periodTo)}
+                        {" · "}
+                        {money(application.currentPaymentDue)} current payment
+                        {" · "}
+                        {money(application.contractSumToDate)} contract to date
+                      </p>
+                    </div>
+                    {application.documentAvailable ? (
+                      <div className="flex flex-wrap gap-2">
+                        <Button asChild size="sm" variant="outline">
+                          <a
+                            href={applicationDownloadHref(
+                              id,
+                              application.id
+                            )}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            <IconExternalLink className="size-4" />
+                            Open PDF
+                          </a>
+                        </Button>
+                        <Button asChild size="sm" variant="outline">
+                          <a
+                            href={applicationDownloadHref(
+                              id,
+                              application.id,
+                              true
+                            )}
+                          >
+                            <IconDownload className="size-4" />
+                            Save
+                          </a>
+                        </Button>
+                      </div>
+                    ) : (
+                      <Badge variant="secondary">Document unavailable</Badge>
+                    )}
+                  </article>
+                ))}
+              </div>
             </section>
           )}
+
+          {reconciliationRequired && (
+            <div
+              className="mt-5 border-l-4 border-l-amber-500 bg-amber-50 px-4 py-3 text-amber-950 print:hidden dark:bg-amber-950 dark:text-amber-50"
+              role="status"
+            >
+              <p className="text-sm font-semibold">
+                {preview.viewerIsInternal
+                  ? "Sage reconciliation required"
+                  : "Current detail is being reconciled"}
+              </p>
+              <p className="mt-1 text-xs leading-5">
+                {preview.viewerIsInternal
+                  ? "The certified pay-application header and imported G703 lines do not currently reconcile. Review the Sage progress-billing, deposit, retainage, and Schedule of Values data before publishing a regenerated package."
+                  : "The detailed G703 is being checked against the certified pay application. The published application PDFs above remain available."}
+              </p>
+              {preview.viewerIsInternal && (
+                <p className="mt-2 text-xs tabular-nums">
+                  Contract difference: {money(contractDifference)}
+                  {" · "}
+                  Prior difference: {money(priorDifference)}
+                  {" · "}
+                  Current difference: {money(currentDifference)}
+                </p>
+              )}
+            </div>
+          )}
+
+          <div
+            className="mt-5"
+            data-owner-budget-print-source="true"
+          >
+            <header className="hidden border-b pb-3 print:flex print:items-start print:justify-between print:gap-4">
+              <div className="flex items-center gap-3">
+                <Image
+                  src={brand.logoSrc}
+                  alt={brand.logoAlt}
+                  width={64}
+                  height={64}
+                  className="size-14 object-contain"
+                />
+                <div>
+                  <p className="text-lg font-semibold">{brand.companyName}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {preview.project.projectNumber ?? preview.project.name}
+                  </p>
+                </div>
+              </div>
+              <div className="text-right text-xs">
+                <p className="font-semibold">G703 Schedule of Values</p>
+                <p className="mt-1 text-muted-foreground">
+                  {budget.currentApplication
+                    ? `Pay application ${budget.currentApplication.applicationNumber} · ` +
+                      formatDate(budget.currentApplication.periodTo)
+                    : "Current approved budget"}
+                </p>
+              </div>
+            </header>
+
+            <div className="print:hidden">
+              <ProjectBudgetPanel
+                projectId={id}
+                summary={budget}
+                detailHref={null}
+                divisionLimit={null}
+              />
+            </div>
+
+            {budget.allLines.length > 0 && (
+              <section className="mt-6">
+                <div className="mb-3 flex flex-wrap items-end justify-between gap-3">
+                  <div>
+                    <h2 className="text-sm font-semibold">
+                      G703 Schedule of Values
+                    </h2>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Only lines approved for owner visibility are included.
+                    </p>
+                  </div>
+                  <div className="print:hidden">
+                    <ProjectBudgetPrintButton />
+                  </div>
+                </div>
+                <ProjectBudgetG703Table
+                  summary={budget}
+                  showVisibility={false}
+                />
+              </section>
+            )}
+          </div>
         </div>
       </main>
     </ProjectAudiencePreviewShell>

--- a/src/components/projects/__tests__/project-budget-panel.test.tsx
+++ b/src/components/projects/__tests__/project-budget-panel.test.tsx
@@ -1,0 +1,115 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import type {
+  ProjectBudgetDivision,
+  ProjectBudgetLineItem,
+  ProjectBudgetSummary,
+} from "@/app/actions/project-budget"
+import {
+  ProjectBudgetG703Table,
+  ProjectBudgetPanel,
+} from "@/components/projects/project-budget-panel"
+
+function budgetLine(index: number): ProjectBudgetLineItem {
+  const code = String(index).padStart(2, "0")
+  return {
+    id: `line-${index}`,
+    sourceSystem: "test",
+    costCode: `${code} 00 00`,
+    csiDivision: code,
+    csiDivisionName: `Division ${index + 1}`,
+    description: `Division ${index + 1}`,
+    notes: null,
+    originalEstimate: 1_000,
+    priorChanges: 50,
+    currentChanges: 50,
+    totalChanges: 100,
+    adjustedEstimate: 1_100,
+    priorCosts: 400,
+    currentCosts: 100,
+    totalCosts: 500,
+    percentComplete: 45.5,
+    balanceToFinish: 600,
+    retainageHeld: 50,
+    vendorName: null,
+    ownerLabel: null,
+    ownerVisible: true,
+    internalNotes: null,
+  }
+}
+
+function budgetDivision(
+  line: ProjectBudgetLineItem
+): ProjectBudgetDivision {
+  return {
+    csiDivision: line.csiDivision,
+    csiDivisionName: line.csiDivisionName,
+    originalEstimate: line.originalEstimate,
+    totalChanges: line.totalChanges,
+    adjustedEstimate: line.adjustedEstimate,
+    priorCosts: line.priorCosts,
+    totalCosts: line.totalCosts,
+    currentCosts: line.currentCosts,
+    retainageHeld: line.retainageHeld,
+    balanceToFinish: line.balanceToFinish,
+    percentComplete: line.percentComplete,
+    lineCount: 1,
+    lines: [line],
+  }
+}
+
+function budgetSummary(): ProjectBudgetSummary {
+  const lines = Array.from({ length: 7 }, (_, index) => budgetLine(index))
+  return {
+    audience: "owner",
+    detailMode: "cost_code",
+    applications: [],
+    currentApplication: null,
+    totals: {
+      originalEstimate: 7_000,
+      totalChanges: 700,
+      adjustedEstimate: 7_700,
+      priorCosts: 2_800,
+      totalCosts: 3_500,
+      currentCosts: 700,
+      retainageHeld: 350,
+      balanceToFinish: 4_200,
+      percentComplete: 45.5,
+      overBudgetAmount: 0,
+      ownerVisibleLineCount: 7,
+    },
+    divisions: lines.map(budgetDivision),
+    allLines: lines,
+  }
+}
+
+describe("owner project budget", () => {
+  it("shows every approved category when the dedicated view has no limit", () => {
+    const html = renderToStaticMarkup(
+      <ProjectBudgetPanel
+        projectId="project-1"
+        summary={budgetSummary()}
+        detailHref={null}
+        divisionLimit={null}
+      />
+    )
+
+    expect(html).toContain("00 - Division 1")
+    expect(html).toContain("06 - Division 7")
+  })
+
+  it("includes prior amounts and project totals in the G703", () => {
+    const html = renderToStaticMarkup(
+      <ProjectBudgetG703Table
+        summary={budgetSummary()}
+        showVisibility={false}
+      />
+    )
+
+    expect(html).toContain("G703 project totals")
+    expect(html).toContain("$2,800")
+    expect(html).toContain("$7,700")
+    expect(html).toContain("$4,200")
+  })
+})

--- a/src/components/projects/project-budget-panel.tsx
+++ b/src/components/projects/project-budget-panel.tsx
@@ -39,10 +39,12 @@ export function ProjectBudgetPanel({
   projectId,
   summary,
   detailHref,
+  divisionLimit = 6,
 }: {
   readonly projectId: string
   readonly summary: ProjectBudgetSummary | null
   readonly detailHref?: string | null
+  readonly divisionLimit?: number | null
 }): React.ReactElement {
   if (!summary || summary.allLines.length === 0) {
     return (
@@ -58,9 +60,13 @@ export function ProjectBudgetPanel({
     )
   }
 
-  const topDivisions = summary.divisions
-    .filter((division) => division.adjustedEstimate > 0)
-    .slice(0, 6)
+  const visibleDivisions = summary.divisions.filter(
+    (division) => division.adjustedEstimate > 0
+  )
+  const displayedDivisions =
+    divisionLimit === null
+      ? visibleDivisions
+      : visibleDivisions.slice(0, divisionLimit)
   const resolvedDetailHref =
     detailHref === undefined
       ? `/dashboard/projects/${projectId}/budget`
@@ -145,8 +151,8 @@ export function ProjectBudgetPanel({
         </div>
       </div>
 
-      <div className="mt-4 space-y-3">
-        {topDivisions.map((division) => (
+      <div className="mt-4 space-y-3 print:hidden">
+        {displayedDivisions.map((division) => (
           <div key={division.csiDivision} className="border-l-2 border-l-teal-500 border-y border-r px-3 py-2">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div className="min-w-0">
@@ -171,7 +177,7 @@ export function ProjectBudgetPanel({
         ))}
       </div>
 
-      <div className="mt-4 flex items-start gap-2 border-t pt-3 text-xs text-muted-foreground">
+      <div className="mt-4 flex items-start gap-2 border-t pt-3 text-xs text-muted-foreground print:hidden">
         <IconLock className="mt-0.5 size-4 shrink-0" />
         <p>
           Internal view shows all budget detail. Owner view uses approved
@@ -229,7 +235,9 @@ export function ProjectBudgetG703Table({
                 <td className="px-3 py-2 text-right font-semibold">
                   {money(division.adjustedEstimate)}
                 </td>
-                <td className="px-3 py-2 text-right" />
+                <td className="px-3 py-2 text-right font-semibold">
+                  {money(division.priorCosts)}
+                </td>
                 <td className="px-3 py-2 text-right font-semibold">
                   {money(division.currentCosts)}
                 </td>
@@ -303,6 +311,38 @@ export function ProjectBudgetG703Table({
             </Fragment>
           ))}
         </tbody>
+        <tfoot className="border-t-2 bg-muted/50">
+          <tr>
+            <td className="px-3 py-3 text-left font-semibold" colSpan={2}>
+              G703 project totals
+            </td>
+            <td className="px-3 py-3 text-right font-semibold">
+              {money(summary.totals.originalEstimate)}
+            </td>
+            <td className="px-3 py-3 text-right font-semibold">
+              {money(summary.totals.totalChanges)}
+            </td>
+            <td className="px-3 py-3 text-right font-semibold">
+              {money(summary.totals.adjustedEstimate)}
+            </td>
+            <td className="px-3 py-3 text-right font-semibold">
+              {money(summary.totals.priorCosts)}
+            </td>
+            <td className="px-3 py-3 text-right font-semibold">
+              {money(summary.totals.currentCosts)}
+            </td>
+            <td className="px-3 py-3 text-right font-semibold">
+              {money(summary.totals.totalCosts)}
+            </td>
+            <td className="px-3 py-3 text-right font-semibold">
+              {pct(summary.totals.percentComplete)}
+            </td>
+            <td className="px-3 py-3 text-right font-semibold">
+              {money(summary.totals.balanceToFinish)}
+            </td>
+            {showVisibility && <td className="px-3 py-3" />}
+          </tr>
+        </tfoot>
       </table>
     </div>
   )

--- a/src/components/projects/project-budget-print-button.tsx
+++ b/src/components/projects/project-budget-print-button.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import type * as React from "react"
+import { IconPrinter } from "@tabler/icons-react"
+
+import { Button } from "@/components/ui/button"
+
+const PRINT_IMAGE_TIMEOUT_MS = 3_000
+
+async function waitForImage(image: HTMLImageElement): Promise<void> {
+  if (image.complete) return
+
+  await new Promise<void>((resolve) => {
+    let settled = false
+    const finish = (): void => {
+      if (settled) return
+      settled = true
+      window.clearTimeout(timeoutId)
+      image.removeEventListener("load", finish)
+      image.removeEventListener("error", finish)
+      resolve()
+    }
+    const timeoutId = window.setTimeout(finish, PRINT_IMAGE_TIMEOUT_MS)
+    image.addEventListener("load", finish, { once: true })
+    image.addEventListener("error", finish, { once: true })
+  })
+}
+
+export function ProjectBudgetPrintButton(): React.ReactElement {
+  async function printBudget(): Promise<void> {
+    const selected = document.querySelector(
+      '[data-owner-budget-print-source="true"]'
+    )
+    if (!(selected instanceof HTMLElement)) {
+      window.print()
+      return
+    }
+
+    const printRoot = selected.cloneNode(true)
+    if (!(printRoot instanceof HTMLElement)) {
+      window.print()
+      return
+    }
+
+    printRoot.setAttribute("data-owner-budget-print-root", "true")
+    printRoot.classList.add("owner-budget-print-root")
+    document.body.classList.add("owner-budget-printing")
+    document.body.appendChild(printRoot)
+
+    const resetPrintState = (): void => {
+      printRoot.remove()
+      document.body.classList.remove("owner-budget-printing")
+      window.removeEventListener("afterprint", resetPrintState)
+    }
+
+    window.addEventListener("afterprint", resetPrintState)
+    await Promise.all(
+      Array.from(printRoot.querySelectorAll("img")).map(waitForImage)
+    )
+    await document.fonts.ready
+    window.print()
+    window.setTimeout(resetPrintState, 5_000)
+  }
+
+  return (
+    <Button type="button" size="sm" onClick={printBudget}>
+      <IconPrinter className="size-4" />
+      Print / Save G703
+    </Button>
+  )
+}


### PR DESCRIPTION
## What changed

- show every approved owner budget category instead of silently stopping at six
- add prior amounts and a G703 project-total row
- list all published owner pay applications with open/save actions
- serve archived pay-application files through a project- and owner-scoped route
- restrict the generic Google Drive download route to internal staff
- add a branded landscape print/save layout for the current G703
- surface G702/G703 reconciliation differences to staff and a neutral
  reconciliation notice to owners
- document the staged owner collaboration workspace and Sage-backed financial
  architecture

## Why

The owner Budget/G703 view was incomplete and not printable. Loomis also has
three archived pay applications, but only the current application has imported
G703 line detail. The implementation preserves the certified archived PDFs,
does not fabricate historical line detail, and makes the current source-data
mismatch visible while the Sage progress-billing component is built.

## Security

External downloads require:

1. authenticated project access;
2. an owner/client project-member role;
3. a pay application belonging to that project;
4. `owner_visible = true`;
5. a recognized Google Drive pay-application source.

Raw Google Drive file IDs are not sufficient authorization.

## Validation

- `bun test src/components/projects/__tests__/project-budget-panel.test.tsx src/lib/__tests__/project-audience-access.test.ts src/lib/__tests__/project-budget-audience.test.ts`
- `bunx tsc --noEmit`
- `bun lint` (0 errors; existing repository warnings only)
- `bun run build`
- read-only production reconciliation against Loomis G702/G703 records
- inspected archived Loomis pay application 3 in authenticated Google Drive

Tracks #263.
