### PR TITLE
fix(owner): restore G703 printing on iPad

### DIFF
--- a/src/components/projects/project-budget-print-button.tsx
+++ b/src/components/projects/project-budget-print-button.tsx
@@ -4,6 +4,7 @@ import type * as React from "react"
 import { IconPrinter } from "@tabler/icons-react"
 
 import { Button } from "@/components/ui/button"
+import { requiresSynchronousPrint } from "@/lib/print/ios-print"
 
 const PRINT_IMAGE_TIMEOUT_MS = 3_000
 
@@ -54,6 +55,14 @@ export function ProjectBudgetPrintButton(): React.ReactElement {
     }
 
     window.addEventListener("afterprint", resetPrintState)
+    if (requiresSynchronousPrint(window.navigator)) {
+      // iPad Safari drops the tap's user activation after the first await,
+      // causing window.print() to be ignored entirely.
+      window.print()
+      window.setTimeout(resetPrintState, 5_000)
+      return
+    }
+
     await Promise.all(
       Array.from(printRoot.querySelectorAll("img")).map(waitForImage)
     )

--- a/src/lib/print/__tests__/ios-print.test.ts
+++ b/src/lib/print/__tests__/ios-print.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+
+import { requiresSynchronousPrint } from "@/lib/print/ios-print"
+
+describe("requiresSynchronousPrint", () => {
+  it("detects iPadOS when Safari identifies the device as a Mac", () => {
+    expect(
+      requiresSynchronousPrint({
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15",
+        platform: "MacIntel",
+        maxTouchPoints: 5,
+      })
+    ).toBe(true)
+  })
+
+  it("detects traditional iPad user agents", () => {
+    expect(
+      requiresSynchronousPrint({
+        userAgent:
+          "Mozilla/5.0 (iPad; CPU OS 18_7 like Mac OS X) AppleWebKit/605.1.15",
+        platform: "iPad",
+        maxTouchPoints: 5,
+      })
+    ).toBe(true)
+  })
+
+  it("keeps desktop browsers on the image-aware print path", () => {
+    expect(
+      requiresSynchronousPrint({
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/140",
+        platform: "MacIntel",
+        maxTouchPoints: 0,
+      })
+    ).toBe(false)
+  })
+})

--- a/src/lib/print/ios-print.ts
+++ b/src/lib/print/ios-print.ts
@@ -1,0 +1,21 @@
+type PrintNavigator = Readonly<{
+  userAgent: string
+  platform: string
+  maxTouchPoints: number
+}>
+
+/**
+ * iPadOS may identify itself as macOS. Safari requires window.print() to run
+ * while the original tap still owns user activation, so avoid async waits on
+ * both traditional iOS identifiers and touch-capable MacIntel devices.
+ */
+export function requiresSynchronousPrint(
+  browserNavigator: PrintNavigator
+): boolean {
+  if (/iPad|iPhone|iPod/i.test(browserNavigator.userAgent)) return true
+
+  return (
+    browserNavigator.platform === "MacIntel" &&
+    browserNavigator.maxTouchPoints > 1
+  )
+}


### PR DESCRIPTION
## Summary
- preserve iPad Safari's tap authorization by calling `window.print()` synchronously
- retain the existing image/font-aware print path for desktop browsers
- detect both traditional iPad user agents and modern iPadOS devices that identify as MacIntel

## Cause
The existing handler awaited images and fonts before invoking print. iPad Safari drops the original user activation after that asynchronous boundary and silently ignores `window.print()`.

## Verification
- 3 focused device-detection tests
- TypeScript
- targeted ESLint
- production build
- pre-commit and pre-push checks
