### PR TITLE
fix(owner): isolate iPad G703 print output

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -431,6 +431,11 @@ em-emoji-picker {
   color: var(--primary);
 }
 
+/* Print clones stay hidden on-screen while iPad Safari builds its preview. */
+.owner-budget-print-root {
+  display: none;
+}
+
 @media print {
   @page {
     margin: 0.5in;

--- a/src/app/preview/projects/[id]/owner/budget/page.tsx
+++ b/src/app/preview/projects/[id]/owner/budget/page.tsx
@@ -258,6 +258,7 @@ export default async function OwnerBudgetPage({
                   alt={brand.logoAlt}
                   width={64}
                   height={64}
+                  priority
                   className="size-14 object-contain"
                 />
                 <div>

--- a/src/components/projects/project-budget-print-button.tsx
+++ b/src/components/projects/project-budget-print-button.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { requiresSynchronousPrint } from "@/lib/print/ios-print"
 
 const PRINT_IMAGE_TIMEOUT_MS = 3_000
+const IOS_PRINT_STATE_TIMEOUT_MS = 120_000
 
 async function waitForImage(image: HTMLImageElement): Promise<void> {
   if (image.complete) return
@@ -54,15 +55,17 @@ export function ProjectBudgetPrintButton(): React.ReactElement {
       window.removeEventListener("afterprint", resetPrintState)
     }
 
-    window.addEventListener("afterprint", resetPrintState)
     if (requiresSynchronousPrint(window.navigator)) {
       // iPad Safari drops the tap's user activation after the first await,
-      // causing window.print() to be ignored entirely.
+      // causing window.print() to be ignored entirely. Its print sheet also
+      // renders asynchronously, so keep the isolated document alive while the
+      // preview is generated instead of relying on afterprint or a short timer.
       window.print()
-      window.setTimeout(resetPrintState, 5_000)
+      window.setTimeout(resetPrintState, IOS_PRINT_STATE_TIMEOUT_MS)
       return
     }
 
+    window.addEventListener("afterprint", resetPrintState)
     await Promise.all(
       Array.from(printRoot.querySelectorAll("img")).map(waitForImage)
     )


### PR DESCRIPTION
## Summary
- keep the iPad-only G703 print clone alive while Safari asynchronously builds its print preview
- hide the retained clone during normal screen rendering
- preserve the existing desktop/Mac print behavior and cleanup path

## Cause
The first iPad fix restored the native print sheet, but the five-second cleanup could remove the isolated G703 document before Safari finished generating the preview for the 83-line table. Safari then printed the underlying owner workspace page.

## Verification
- focused iPad/iPadOS detection tests
- TypeScript
- targeted ESLint
- production build
- pre-commit and pre-push checks
- desktop behavior confirmed unchanged by the reporter
