### PR TITLE
fix(owner): align workspace shell controls

### DIFF
--- a/src/components/projects/project-audience-header-controls.tsx
+++ b/src/components/projects/project-audience-header-controls.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import * as React from "react"
+import { IconMoon, IconSun } from "@tabler/icons-react"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import { NotificationsPopover } from "@/components/notifications-popover"
+import { ProjectAudienceNotificationSettings } from "@/components/projects/project-audience-notification-settings"
+import { useTheme } from "@/components/theme-provider"
+import { getInitials } from "@/lib/utils"
+
+type AudienceViewer = {
+  readonly name: string
+  readonly avatarUrl: string | null
+}
+
+export function ProjectAudienceHeaderControls({
+  viewer,
+}: {
+  readonly viewer: AudienceViewer
+}): React.ReactElement {
+  const { theme, setTheme } = useTheme()
+
+  return (
+    <div className="flex shrink-0 items-center justify-end gap-0.5">
+      <NotificationsPopover />
+      <ProjectAudienceNotificationSettings
+        compact
+        triggerIcon="settings"
+        className="size-7 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+      />
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-7 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+        onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+        aria-label="Toggle theme"
+        title="Toggle theme"
+      >
+        <IconSun className="hidden size-4 dark:block" />
+        <IconMoon className="block size-4 dark:hidden" />
+      </Button>
+      <Avatar className="ml-0.5 size-6 grayscale">
+        {viewer.avatarUrl && (
+          <AvatarImage src={viewer.avatarUrl} alt={viewer.name} />
+        )}
+        <AvatarFallback className="text-[10px]">
+          {getInitials(viewer.name)}
+        </AvatarFallback>
+      </Avatar>
+    </div>
+  )
+}

--- a/src/components/projects/project-audience-notification-settings.tsx
+++ b/src/components/projects/project-audience-notification-settings.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { IconBell } from "@tabler/icons-react"
+import { IconBell, IconSettings } from "@tabler/icons-react"
 
 import { PreferencesTab } from "@/components/settings/preferences-tab"
 import { Button } from "@/components/ui/button"
@@ -18,11 +18,15 @@ import { cn } from "@/lib/utils"
 
 export function ProjectAudienceNotificationSettings({
   compact = false,
+  triggerIcon = "bell",
   className,
 }: {
   readonly compact?: boolean
+  readonly triggerIcon?: "bell" | "settings"
   readonly className?: string
 }): React.ReactElement {
+  const TriggerIcon = triggerIcon === "settings" ? IconSettings : IconBell
+
   return (
     <Dialog>
       <DialogTrigger asChild>
@@ -31,9 +35,10 @@ export function ProjectAudienceNotificationSettings({
           size={compact ? "icon" : "sm"}
           className={cn(!compact && "w-full justify-start", className)}
           aria-label={compact ? "Notification settings" : undefined}
+          title={compact ? "Notification settings" : undefined}
         >
-          <IconBell className="size-4" />
-          {!compact && "Notifications"}
+          <TriggerIcon className="size-4" />
+          {!compact && "Notification settings"}
         </Button>
       </DialogTrigger>
       <DialogContent className="max-h-[90vh] gap-0 overflow-hidden p-0 sm:max-w-2xl">

--- a/src/components/projects/project-audience-preview-shell.tsx
+++ b/src/components/projects/project-audience-preview-shell.tsx
@@ -21,7 +21,6 @@ import {
   projectAudienceSectionHref,
   type ProjectAudienceWorkspaceSection,
 } from "@/lib/project-audience-preview-routes"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -30,8 +29,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { ProjectAudiencePreviewWindowControls } from "@/components/projects/project-audience-preview-window-controls"
+import { ProjectAudienceHeaderControls } from "@/components/projects/project-audience-header-controls"
 import { ProjectAudienceSidebarProfile } from "@/components/projects/project-audience-sidebar-profile"
-import { ProjectAudienceNotificationSettings } from "@/components/projects/project-audience-notification-settings"
 import { cn } from "@/lib/utils"
 
 type PreviewNavigationItem = {
@@ -161,13 +160,15 @@ export function ProjectAudiencePreviewShell({
       <aside className="sticky top-0 hidden h-screen flex-col border-r bg-sidebar text-sidebar-foreground md:flex">
         <div className="border-b border-sidebar-border p-4">
           <Link href={homeHref} className="flex items-center gap-3">
-            <span className="grid size-10 shrink-0 place-items-center bg-white p-1">
+            <span className="flex size-9 shrink-0 items-center justify-center">
               <Image
                 src="/department-logos/hps-h-green.svg"
-                alt="High Performance Structures"
-                width={34}
-                height={34}
-                className="size-full object-contain"
+                alt="High Performance Structures Inc."
+                width={36}
+                height={36}
+                className="size-9 rounded-[5px] object-contain"
+                priority
+                unoptimized
               />
             </span>
             <span className="min-w-0">
@@ -258,6 +259,10 @@ export function ProjectAudiencePreviewShell({
       </aside>
 
       <div className="min-w-0">
+        <header className="sticky top-0 z-40 hidden h-12 items-center justify-end border-b border-border/40 bg-background/80 px-4 backdrop-blur-sm md:flex">
+          <ProjectAudienceHeaderControls viewer={viewer} />
+        </header>
+
         {viewerIsInternal && (
           <div className="border-b bg-amber-50 px-4 py-2 text-amber-950 dark:bg-amber-950 dark:text-amber-50">
             <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-2">
@@ -292,7 +297,7 @@ export function ProjectAudiencePreviewShell({
           </div>
         )}
 
-        <header className="sticky top-0 z-30 border-b bg-background/95 px-4 py-3 backdrop-blur md:hidden">
+        <header className="sticky top-0 z-40 border-b bg-background/95 px-3 py-2 backdrop-blur md:hidden">
           <div className="flex items-center justify-between gap-3">
             <Link href={homeHref} className="min-w-0">
               <p className="truncate text-sm font-semibold">
@@ -302,10 +307,7 @@ export function ProjectAudiencePreviewShell({
                 {audience === "owner" ? "Owner Compass" : "Partner Compass"}
               </p>
             </Link>
-            <div className="flex items-center gap-1">
-              <ProjectAudienceNotificationSettings compact />
-              <Badge variant="outline">Compass</Badge>
-            </div>
+            <ProjectAudienceHeaderControls viewer={viewer} />
           </div>
           <nav className="mt-3 flex gap-1 overflow-x-auto border-t pt-2">
             {navigation.map((item) => (


### PR DESCRIPTION
## What changed

- adds the real notification center to the top-right of owner and subcontractor workspaces
- keeps notification preferences separate under a settings control
- aligns theme and profile controls with the internal Compass header on desktop and mobile
- removes the white tile around the HPS sidebar logo and uses the same logo treatment as the internal sidebar
- clarifies the sidebar preference label as “Notification settings”

## Why

The external workspace shell had drifted from the internal Compass layout. Its bell opened preferences instead of actual notifications, shared controls appeared in different locations, and the company logo used a separate white background treatment.

## Validation

- `bunx tsc --noEmit`
- focused ESLint on all changed components
- `bun run build`
- focused Vitest suite: 21 passing
- pre-commit and pre-push repository checks
