### PR TITLE
feat(buildertrend): add guarded staging foundation

### DIFF
--- a/docs/wip/buildertrend-cutover-recovery-baseline-2026-07-30.md
+++ b/docs/wip/buildertrend-cutover-recovery-baseline-2026-07-30.md
@@ -1,0 +1,121 @@
+# Buildertrend Cutover Recovery Baseline
+
+## Purpose
+
+This baseline defines how to recover the Buildertrend and Sage cutover work
+without merging a long-lived, divergent development branch into current
+`main`. It complements the cutover epic in GitHub issue #144 and the extraction
+work tracked in #147.
+
+The primary rule is simple: treat the divergent branch and local working files
+as an inventory source, then forward-port reviewed capabilities through small
+branches based on current `main`.
+
+## Current baseline
+
+- Current production migrations end at `0080_work_calendar_recurrence.sql`.
+- The historical staging migration number must not be reused.
+- The first recovered migration is
+  `0084_buildertrend_staging_foundation.sql`.
+- Existing production activity, scheduling, audience, owner-update, and
+  financial-read models remain authoritative.
+- Buildertrend imports are archive and review operations by default.
+- Sage remains server-side and read-only by default.
+
+## Recovery classification
+
+### Foundation
+
+Recover first:
+
+- organization-scoped import runs;
+- replay-safe source records;
+- immutable run-to-record observation history;
+- Drive-backed archive-file pointers;
+- review-only access candidates;
+- explicit source keys and deterministic replay behavior;
+- explicit unresolved-reference and changed-reference quarantine states;
+- dry-run and manifest validation.
+
+The staging foundation does not create projects, grant access, notify users,
+promote operational records, or write to Sage.
+
+Replays may backfill a previously unresolved project or source reference, but
+they do not move an already-resolved record. Changed references, identities, or
+evidence pointers are quarantined for review and retained in immutable
+run-observation payloads. Source capture fields, verified evidence, and human
+review fields are stored separately so an incomplete replay cannot erase
+preserved evidence or reviewer decisions. A manifest fingerprint prevents a
+run key from being reused with different membership.
+
+### Generic generators
+
+Recover after the foundation:
+
+- job inventory;
+- lead and proposal inventory;
+- generic report snapshots;
+- shared manifest normalization;
+- Drive archive and reconciliation helpers.
+
+Every generator must require explicit organization context, validate project
+ownership, produce a reconciliation summary, and support dry-run operation.
+
+### Operational history
+
+Recover in independent, reviewable branches:
+
+1. daily logs, owner updates, and approved photo history;
+2. conversations and RFI history;
+3. schedules, tasks, and dependencies;
+4. purchase orders, selections, and financial archive history;
+5. cutover readiness and exception reporting.
+
+Historical imports must not overwrite newer Compass-authored work or trigger
+the normal notification lifecycle.
+
+### Restricted preservation evidence
+
+Client-, dispute-, claim-, and project-specific preservation material belongs
+in the private evidence archive. Production code may retain reusable parsing or
+reconciliation behavior only after it is generalized, tested, and stripped of
+local paths, operator identities, source IDs, Drive IDs, and client data.
+
+The guarded canonical warranty register is tracked separately in issue #271.
+
+### Do not recover as written
+
+- migrations with obsolete sequence numbers;
+- complete schema snapshots from the divergent branch;
+- project-number-only identity matching;
+- hard-coded organization, project, user, or filesystem values;
+- automatic portal access decisions;
+- scripts that treat captured financial evidence as authorization for a Sage
+  or Compass financial write.
+
+## Issue map
+
+- #144 — Buildertrend cutover and Sage integration epic
+- #145 — fail-closed Sage queue
+- #147 — extract and baseline divergent cutover work
+- #148 — restricted preservation archive
+- #149 — reproducible staging and importer framework
+- #150–#158 — Buildertrend exit, archive, identity, and reconciliation
+- #159–#164 — Sage read models, audit, approvals, and controlled automation
+- #165 — cutover certification and rollback package
+- #263 — guarded owner collaboration workspace
+- #271 — historical warranty and claim import
+
+## Release gates
+
+Each recovered slice must demonstrate:
+
+- clean branch ancestry from current `main`;
+- additive migrations generated after the current migration tip;
+- organization and project isolation;
+- deterministic, idempotent replay;
+- dry-run and validation output;
+- no implicit access grant, notification, promotion, or Sage write;
+- clean-database migration reproduction;
+- tests and a reconciliation summary;
+- a linked GitHub issue and production verification before closure.

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     "./src/db/schema-mcp.ts",
     "./src/db/schema-conversations.ts",
     "./src/db/schema-sage.ts",
+    "./src/db/schema-buildertrend.ts",
     "./src/lib/sync/schema.ts",
   ],
   out: "./drizzle",

--- a/drizzle/0084_buildertrend_staging_foundation.sql
+++ b/drizzle/0084_buildertrend_staging_foundation.sql
@@ -1,0 +1,269 @@
+CREATE TABLE `buildertrend_staging_runs` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `run_key` text NOT NULL,
+  `manifest_fingerprint` text NOT NULL,
+  `source_method` text NOT NULL,
+  `source_label` text NOT NULL,
+  `status` text DEFAULT 'draft' NOT NULL,
+  `started_by` text,
+  `started_at` text NOT NULL,
+  `completed_at` text,
+  `raw_artifact_drive_file_id` text,
+  `raw_artifact_drive_url` text,
+  `source_notes` text,
+  `summary_json` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`started_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `buildertrend_staging_runs_org_key_unique` ON `buildertrend_staging_runs` (`organization_id`, `run_key`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_staging_runs_org_status_idx` ON `buildertrend_staging_runs` (`organization_id`, `status`);
+--> statement-breakpoint
+CREATE TABLE `buildertrend_staging_records` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `source_key` text NOT NULL,
+  `requested_project_id` text,
+  `project_id` text,
+  `source_scope` text DEFAULT 'job' NOT NULL,
+  `source_record_type` text NOT NULL,
+  `buildertrend_job_id` text,
+  `buildertrend_lead_id` text,
+  `buildertrend_record_id` text,
+  `buildertrend_record_number` text,
+  `buildertrend_url` text,
+  `title` text NOT NULL,
+  `record_date` text,
+  `record_status` text,
+  `source_status` text,
+  `department_code` text,
+  `client_name` text,
+  `contact_name` text,
+  `contact_email` text,
+  `amount` real,
+  `searchable_text` text,
+  `normalized_summary` text,
+  `raw_payload_json` text,
+  `source_archive_drive_folder_id` text,
+  `source_archive_drive_file_id` text,
+  `source_archive_drive_url` text,
+  `verified_archive_drive_folder_id` text,
+  `verified_archive_drive_file_id` text,
+  `verified_archive_drive_url` text,
+  `review_status` text DEFAULT 'needs_review' NOT NULL,
+  `promotion_status` text DEFAULT 'archive_only' NOT NULL,
+  `promoted_record_type` text,
+  `promoted_record_id` text,
+  `sage_reconciliation_status` text DEFAULT 'not_reviewed' NOT NULL,
+  `source_notes` text,
+  `review_notes` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `buildertrend_staging_records_org_key_unique` ON `buildertrend_staging_records` (`organization_id`, `source_key`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_staging_records_project_type_idx` ON `buildertrend_staging_records` (`project_id`, `source_record_type`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_staging_records_job_idx` ON `buildertrend_staging_records` (`buildertrend_job_id`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_staging_records_lead_idx` ON `buildertrend_staging_records` (`buildertrend_lead_id`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_staging_records_review_idx` ON `buildertrend_staging_records` (`organization_id`, `review_status`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_staging_records_promotion_idx` ON `buildertrend_staging_records` (`organization_id`, `promotion_status`);
+--> statement-breakpoint
+CREATE TABLE `buildertrend_staging_files` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `source_key` text NOT NULL,
+  `requested_source_record_key` text,
+  `source_record_id` text,
+  `requested_project_id` text,
+  `project_id` text,
+  `source_scope` text DEFAULT 'job' NOT NULL,
+  `source_record_type` text NOT NULL,
+  `buildertrend_job_id` text,
+  `buildertrend_lead_id` text,
+  `buildertrend_file_id` text,
+  `buildertrend_url` text,
+  `file_name` text NOT NULL,
+  `mime_type` text,
+  `file_size` integer,
+  `source_drive_folder_id` text,
+  `source_drive_file_id` text,
+  `source_drive_url` text,
+  `source_thumbnail_drive_file_id` text,
+  `source_thumbnail_url` text,
+  `verified_drive_folder_id` text,
+  `verified_drive_file_id` text,
+  `verified_drive_url` text,
+  `verified_thumbnail_drive_file_id` text,
+  `verified_thumbnail_url` text,
+  `source_checksum` text,
+  `verified_checksum` text,
+  `captured_at` text,
+  `visibility` text DEFAULT 'internal' NOT NULL,
+  `review_status` text DEFAULT 'needs_review' NOT NULL,
+  `source_metadata_json` text,
+  `review_metadata_json` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`source_record_id`) REFERENCES `buildertrend_staging_records`(`id`) ON UPDATE no action ON DELETE restrict,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `buildertrend_staging_files_org_key_unique` ON `buildertrend_staging_files` (`organization_id`, `source_key`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_staging_files_source_idx` ON `buildertrend_staging_files` (`source_record_id`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_staging_files_project_idx` ON `buildertrend_staging_files` (`project_id`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_staging_files_job_idx` ON `buildertrend_staging_files` (`buildertrend_job_id`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_staging_files_review_idx` ON `buildertrend_staging_files` (`organization_id`, `review_status`);
+--> statement-breakpoint
+CREATE TABLE `buildertrend_staging_access_candidates` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `source_key` text NOT NULL,
+  `requested_source_record_key` text,
+  `source_record_id` text,
+  `requested_project_id` text,
+  `project_id` text,
+  `buildertrend_job_id` text,
+  `buildertrend_lead_id` text,
+  `buildertrend_contact_id` text,
+  `buildertrend_access_role` text,
+  `contact_name` text NOT NULL,
+  `company_name` text,
+  `email` text,
+  `phone` text,
+  `proposed_contact_type` text DEFAULT 'vendor' NOT NULL,
+  `proposed_project_role` text,
+  `matched_user_id` text,
+  `matched_customer_id` text,
+  `matched_vendor_id` text,
+  `match_status` text DEFAULT 'unmatched' NOT NULL,
+  `match_confidence` real DEFAULT 0 NOT NULL,
+  `portal_access_status` text DEFAULT 'not_granted' NOT NULL,
+  `review_status` text DEFAULT 'needs_review' NOT NULL,
+  `source_notes` text,
+  `review_notes` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`source_record_id`) REFERENCES `buildertrend_staging_records`(`id`) ON UPDATE no action ON DELETE restrict,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`matched_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`matched_customer_id`) REFERENCES `customers`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`matched_vendor_id`) REFERENCES `vendors`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `buildertrend_staging_access_org_key_unique` ON `buildertrend_staging_access_candidates` (`organization_id`, `source_key`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_staging_access_source_idx` ON `buildertrend_staging_access_candidates` (`source_record_id`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_staging_access_project_idx` ON `buildertrend_staging_access_candidates` (`project_id`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_staging_access_contact_idx` ON `buildertrend_staging_access_candidates` (`buildertrend_contact_id`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_staging_access_review_idx` ON `buildertrend_staging_access_candidates` (`organization_id`, `review_status`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_staging_access_portal_idx` ON `buildertrend_staging_access_candidates` (`organization_id`, `portal_access_status`);
+--> statement-breakpoint
+CREATE TABLE `buildertrend_staging_observations` (
+  `id` text PRIMARY KEY NOT NULL,
+  `import_run_id` text NOT NULL,
+  `organization_id` text NOT NULL,
+  `entity_kind` text NOT NULL,
+  `entity_key` text NOT NULL,
+  `entity_id` text NOT NULL,
+  `observed_payload_json` text NOT NULL,
+  `observed_at` text NOT NULL,
+  FOREIGN KEY (`import_run_id`) REFERENCES `buildertrend_staging_runs`(`id`) ON UPDATE no action ON DELETE restrict,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `buildertrend_staging_observations_run_entity_unique` ON `buildertrend_staging_observations` (`import_run_id`, `entity_kind`, `entity_key`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_staging_observations_entity_idx` ON `buildertrend_staging_observations` (`organization_id`, `entity_kind`, `entity_id`);
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_staging_observations_update_guard`
+BEFORE UPDATE ON `buildertrend_staging_observations`
+BEGIN
+  SELECT RAISE(ABORT, 'Buildertrend staging observations are immutable');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_staging_observations_delete_guard`
+BEFORE DELETE ON `buildertrend_staging_observations`
+BEGIN
+  SELECT RAISE(ABORT, 'Buildertrend staging observations cannot be deleted');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_staging_records_delete_guard`
+BEFORE DELETE ON `buildertrend_staging_records`
+WHEN EXISTS (
+  SELECT 1 FROM `buildertrend_staging_observations`
+  WHERE `entity_kind` = 'record' AND `entity_id` = OLD.`id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'observed Buildertrend staging records cannot be deleted');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_staging_records_id_guard`
+BEFORE UPDATE OF `id` ON `buildertrend_staging_records`
+WHEN EXISTS (
+  SELECT 1 FROM `buildertrend_staging_observations`
+  WHERE `entity_kind` = 'record' AND `entity_id` = OLD.`id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'observed Buildertrend staging record IDs are immutable');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_staging_files_delete_guard`
+BEFORE DELETE ON `buildertrend_staging_files`
+WHEN EXISTS (
+  SELECT 1 FROM `buildertrend_staging_observations`
+  WHERE `entity_kind` = 'file' AND `entity_id` = OLD.`id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'observed Buildertrend staging files cannot be deleted');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_staging_files_id_guard`
+BEFORE UPDATE OF `id` ON `buildertrend_staging_files`
+WHEN EXISTS (
+  SELECT 1 FROM `buildertrend_staging_observations`
+  WHERE `entity_kind` = 'file' AND `entity_id` = OLD.`id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'observed Buildertrend staging file IDs are immutable');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_staging_access_delete_guard`
+BEFORE DELETE ON `buildertrend_staging_access_candidates`
+WHEN EXISTS (
+  SELECT 1 FROM `buildertrend_staging_observations`
+  WHERE `entity_kind` = 'access_candidate' AND `entity_id` = OLD.`id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'observed Buildertrend access candidates cannot be deleted');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_staging_access_id_guard`
+BEFORE UPDATE OF `id` ON `buildertrend_staging_access_candidates`
+WHEN EXISTS (
+  SELECT 1 FROM `buildertrend_staging_observations`
+  WHERE `entity_kind` = 'access_candidate' AND `entity_id` = OLD.`id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'observed Buildertrend access candidate IDs are immutable');
+END;

--- a/scripts/build-buildertrend-staging-sql.mjs
+++ b/scripts/build-buildertrend-staging-sql.mjs
@@ -1,0 +1,157 @@
+import {
+  readFile,
+  realpath,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises"
+import { basename, dirname, join, resolve } from "node:path"
+
+import {
+  buildBuildertrendStagingSql,
+  parseBuildertrendStagingManifest,
+} from "../src/lib/buildertrend/staging-manifest"
+
+function usage() {
+  console.error(
+    "Usage: bun scripts/build-buildertrend-staging-sql.mjs " +
+      "--input <manifest.json> --organization-id <org-id> " +
+      "[--output <import.sql>] [--dry-run]"
+  )
+}
+
+function parseArgs(argv) {
+  const valueOptions = new Set(["input", "organization-id", "output"])
+  const values = new Map()
+  let dryRun = false
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]
+    if (argument === "--dry-run") {
+      if (dryRun) throw new Error("--dry-run may only be provided once")
+      dryRun = true
+      continue
+    }
+    if (!argument?.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${argument ?? ""}`)
+    }
+    const option = argument.slice(2)
+    if (!valueOptions.has(option)) {
+      throw new Error(`Unknown option: ${argument}`)
+    }
+    if (values.has(option)) {
+      throw new Error(`${argument} may only be provided once`)
+    }
+
+    const value = argv[index + 1]
+    if (!value || value.startsWith("--")) {
+      throw new Error(`${argument} requires a value`)
+    }
+    values.set(option, value)
+    index += 1
+  }
+
+  const input = values.get("input")
+  const organizationId = values.get("organization-id")
+  const output = values.get("output")
+  if (!input || !organizationId || (!dryRun && !output)) {
+    throw new Error("Missing a required option")
+  }
+  if (output && resolve(input) === resolve(output)) {
+    throw new Error("--output must not overwrite --input")
+  }
+
+  return { dryRun, input, organizationId, output }
+}
+
+async function existingFileIdentity(path) {
+  try {
+    const canonicalPath = await realpath(path)
+    const metadata = await stat(canonicalPath)
+    return {
+      canonicalPath,
+      device: metadata.dev,
+      inode: metadata.ino,
+    }
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") {
+      return null
+    }
+    throw error
+  }
+}
+
+async function assertDistinctFiles(input, output) {
+  const inputIdentity = await existingFileIdentity(input)
+  if (!inputIdentity) throw new Error("--input does not exist")
+
+  const outputIdentity = await existingFileIdentity(output)
+  if (
+    outputIdentity &&
+    (outputIdentity.canonicalPath === inputIdentity.canonicalPath ||
+      (outputIdentity.device === inputIdentity.device &&
+        outputIdentity.inode === inputIdentity.inode))
+  ) {
+    throw new Error("--output must not overwrite --input")
+  }
+}
+
+async function writeFileAtomically(output, contents) {
+  const resolvedOutput = resolve(output)
+  const temporaryOutput = join(
+    dirname(resolvedOutput),
+    `.${basename(resolvedOutput)}.${process.pid}.${Date.now()}.tmp`
+  )
+
+  try {
+    await writeFile(temporaryOutput, contents, { flag: "wx" })
+    await rename(temporaryOutput, resolvedOutput)
+  } catch (error) {
+    try {
+      await unlink(temporaryOutput)
+    } catch {
+      // The temporary file may not have been created.
+    }
+    throw error
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  if (!options.dryRun && options.output) {
+    await assertDistinctFiles(options.input, options.output)
+  }
+  const input = JSON.parse(await readFile(options.input, "utf8"))
+  const parsed = parseBuildertrendStagingManifest(input)
+  if (!parsed.success) {
+    throw new Error(`Invalid staging manifest:\n${parsed.errors.join("\n")}`)
+  }
+
+  const build = await buildBuildertrendStagingSql(
+    options.organizationId,
+    parsed.data
+  )
+  if (!options.dryRun && options.output) {
+    await writeFileAtomically(options.output, build.sql)
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        dryRun: options.dryRun,
+        input: options.input,
+        output: options.dryRun ? null : options.output,
+        ...build.summary,
+      },
+      null,
+      2
+    )
+  )
+}
+
+main().catch((error) => {
+  usage()
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+})

--- a/scripts/fixtures/buildertrend-staging-example.json
+++ b/scripts/fixtures/buildertrend-staging-example.json
@@ -1,0 +1,46 @@
+{
+  "runKey": "example-job-inventory-2026-07-30",
+  "sourceMethod": "authenticated_export",
+  "sourceLabel": "Buildertrend example job inventory",
+  "capturedAt": "2026-07-30T12:00:00.000Z",
+  "notes": "Generic fixture for dry-run and replay validation.",
+  "records": [
+    {
+      "sourceKey": "job:example-123",
+      "projectId": "project-example-123",
+      "sourceRecordType": "job",
+      "buildertrendJobId": "example-123",
+      "buildertrendRecordId": "example-123",
+      "title": "Example project",
+      "recordStatus": "Open",
+      "rawPayload": {
+        "status": "Open"
+      }
+    }
+  ],
+  "files": [
+    {
+      "sourceKey": "file:example-123:photo-1",
+      "sourceRecordKey": "job:example-123",
+      "projectId": "project-example-123",
+      "sourceRecordType": "job_photo",
+      "buildertrendJobId": "example-123",
+      "buildertrendFileId": "photo-1",
+      "fileName": "photo-1.jpg",
+      "mimeType": "image/jpeg",
+      "checksum": "fixture-checksum"
+    }
+  ],
+  "accessCandidates": [
+    {
+      "sourceKey": "access:example-123:contact-1",
+      "sourceRecordKey": "job:example-123",
+      "projectId": "project-example-123",
+      "buildertrendJobId": "example-123",
+      "buildertrendContactId": "contact-1",
+      "buildertrendAccessRole": "client",
+      "contactName": "Example Owner",
+      "proposedContactType": "customer"
+    }
+  ]
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -11,6 +11,7 @@ import * as mcpSchema from "./schema-mcp"
 import * as conversationsSchema from "./schema-conversations"
 import * as jarvisSchema from "./schema-jarvis"
 import * as sageSchema from "./schema-sage"
+import * as buildertrendSchema from "./schema-buildertrend"
 
 const allSchemas = {
   ...schema,
@@ -25,6 +26,7 @@ const allSchemas = {
   ...conversationsSchema,
   ...jarvisSchema,
   ...sageSchema,
+  ...buildertrendSchema,
 }
 
 // Legacy function - kept for backwards compatibility

--- a/src/db/provider/d1-provider.ts
+++ b/src/db/provider/d1-provider.ts
@@ -9,6 +9,7 @@ import * as googleSchema from "../schema-google"
 import * as dashboardSchema from "../schema-dashboards"
 import * as mcpSchema from "../schema-mcp"
 import * as conversationsSchema from "../schema-conversations"
+import * as buildertrendSchema from "../schema-buildertrend"
 import type { DatabaseProvider, DrizzleDB } from "./interface"
 
 const allSchemas = {
@@ -22,6 +23,7 @@ const allSchemas = {
   ...dashboardSchema,
   ...mcpSchema,
   ...conversationsSchema,
+  ...buildertrendSchema,
 }
 
 type D1DrizzleDB = ReturnType<typeof createD1Drizzle>

--- a/src/db/provider/memory-provider.ts
+++ b/src/db/provider/memory-provider.ts
@@ -51,6 +51,7 @@ export function createMemoryProvider(config?: MemoryProviderConfig): DatabasePro
       const dashboardSchema = await import("../schema-dashboards")
       const mcpSchema = await import("../schema-mcp")
       const conversationsSchema = await import("../schema-conversations")
+      const buildertrendSchema = await import("../schema-buildertrend")
 
       const allSchemas = {
         ...schemaModule,
@@ -63,6 +64,7 @@ export function createMemoryProvider(config?: MemoryProviderConfig): DatabasePro
         ...dashboardSchema,
         ...mcpSchema,
         ...conversationsSchema,
+        ...buildertrendSchema,
       }
 
       sqlite = new Database(":memory:") as BetterSqlite3Database

--- a/src/db/schema-buildertrend.ts
+++ b/src/db/schema-buildertrend.ts
@@ -1,0 +1,308 @@
+import {
+  index,
+  integer,
+  real,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core"
+
+import {
+  customers,
+  organizations,
+  projects,
+  users,
+  vendors,
+} from "./schema"
+
+// These names intentionally differ from the abandoned 0062 staging tables.
+// That keeps this foundation upgrade-safe if the old migration was applied
+// manually in an environment that never recorded it in the migration journal.
+export const buildertrendImportRuns = sqliteTable(
+  "buildertrend_staging_runs",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    runKey: text("run_key").notNull(),
+    manifestFingerprint: text("manifest_fingerprint").notNull(),
+    sourceMethod: text("source_method").notNull(),
+    sourceLabel: text("source_label").notNull(),
+    status: text("status").notNull().default("draft"),
+    startedBy: text("started_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    startedAt: text("started_at").notNull(),
+    completedAt: text("completed_at"),
+    rawArtifactDriveFileId: text("raw_artifact_drive_file_id"),
+    rawArtifactDriveUrl: text("raw_artifact_drive_url"),
+    sourceNotes: text("source_notes"),
+    summaryJson: text("summary_json"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("buildertrend_staging_runs_org_key_unique").on(
+      table.organizationId,
+      table.runKey
+    ),
+    index("buildertrend_staging_runs_org_status_idx").on(
+      table.organizationId,
+      table.status
+    ),
+  ]
+)
+
+export const buildertrendSourceRecords = sqliteTable(
+  "buildertrend_staging_records",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    sourceKey: text("source_key").notNull(),
+    requestedProjectId: text("requested_project_id"),
+    projectId: text("project_id").references(() => projects.id, {
+      onDelete: "set null",
+    }),
+    sourceScope: text("source_scope").notNull().default("job"),
+    sourceRecordType: text("source_record_type").notNull(),
+    buildertrendJobId: text("buildertrend_job_id"),
+    buildertrendLeadId: text("buildertrend_lead_id"),
+    buildertrendRecordId: text("buildertrend_record_id"),
+    buildertrendRecordNumber: text("buildertrend_record_number"),
+    buildertrendUrl: text("buildertrend_url"),
+    title: text("title").notNull(),
+    recordDate: text("record_date"),
+    recordStatus: text("record_status"),
+    sourceStatus: text("source_status"),
+    departmentCode: text("department_code"),
+    clientName: text("client_name"),
+    contactName: text("contact_name"),
+    contactEmail: text("contact_email"),
+    amount: real("amount"),
+    searchableText: text("searchable_text"),
+    normalizedSummary: text("normalized_summary"),
+    rawPayloadJson: text("raw_payload_json"),
+    sourceArchiveDriveFolderId: text("source_archive_drive_folder_id"),
+    sourceArchiveDriveFileId: text("source_archive_drive_file_id"),
+    sourceArchiveDriveUrl: text("source_archive_drive_url"),
+    verifiedArchiveDriveFolderId: text("verified_archive_drive_folder_id"),
+    verifiedArchiveDriveFileId: text("verified_archive_drive_file_id"),
+    verifiedArchiveDriveUrl: text("verified_archive_drive_url"),
+    reviewStatus: text("review_status").notNull().default("needs_review"),
+    promotionStatus: text("promotion_status").notNull().default("archive_only"),
+    promotedRecordType: text("promoted_record_type"),
+    promotedRecordId: text("promoted_record_id"),
+    sageReconciliationStatus: text("sage_reconciliation_status")
+      .notNull()
+      .default("not_reviewed"),
+    sourceNotes: text("source_notes"),
+    reviewNotes: text("review_notes"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("buildertrend_staging_records_org_key_unique").on(
+      table.organizationId,
+      table.sourceKey
+    ),
+    index("buildertrend_staging_records_project_type_idx").on(
+      table.projectId,
+      table.sourceRecordType
+    ),
+    index("buildertrend_staging_records_job_idx").on(table.buildertrendJobId),
+    index("buildertrend_staging_records_lead_idx").on(table.buildertrendLeadId),
+    index("buildertrend_staging_records_review_idx").on(
+      table.organizationId,
+      table.reviewStatus
+    ),
+    index("buildertrend_staging_records_promotion_idx").on(
+      table.organizationId,
+      table.promotionStatus
+    ),
+  ]
+)
+
+export const buildertrendArchiveFiles = sqliteTable(
+  "buildertrend_staging_files",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    sourceKey: text("source_key").notNull(),
+    requestedSourceRecordKey: text("requested_source_record_key"),
+    sourceRecordId: text("source_record_id").references(
+      () => buildertrendSourceRecords.id,
+      { onDelete: "restrict" }
+    ),
+    requestedProjectId: text("requested_project_id"),
+    projectId: text("project_id").references(() => projects.id, {
+      onDelete: "set null",
+    }),
+    sourceScope: text("source_scope").notNull().default("job"),
+    sourceRecordType: text("source_record_type").notNull(),
+    buildertrendJobId: text("buildertrend_job_id"),
+    buildertrendLeadId: text("buildertrend_lead_id"),
+    buildertrendFileId: text("buildertrend_file_id"),
+    buildertrendUrl: text("buildertrend_url"),
+    fileName: text("file_name").notNull(),
+    mimeType: text("mime_type"),
+    fileSize: integer("file_size"),
+    sourceDriveFolderId: text("source_drive_folder_id"),
+    sourceDriveFileId: text("source_drive_file_id"),
+    sourceDriveUrl: text("source_drive_url"),
+    sourceThumbnailDriveFileId: text("source_thumbnail_drive_file_id"),
+    sourceThumbnailUrl: text("source_thumbnail_url"),
+    verifiedDriveFolderId: text("verified_drive_folder_id"),
+    verifiedDriveFileId: text("verified_drive_file_id"),
+    verifiedDriveUrl: text("verified_drive_url"),
+    verifiedThumbnailDriveFileId: text("verified_thumbnail_drive_file_id"),
+    verifiedThumbnailUrl: text("verified_thumbnail_url"),
+    sourceChecksum: text("source_checksum"),
+    verifiedChecksum: text("verified_checksum"),
+    capturedAt: text("captured_at"),
+    visibility: text("visibility").notNull().default("internal"),
+    reviewStatus: text("review_status").notNull().default("needs_review"),
+    sourceMetadataJson: text("source_metadata_json"),
+    reviewMetadataJson: text("review_metadata_json"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("buildertrend_staging_files_org_key_unique").on(
+      table.organizationId,
+      table.sourceKey
+    ),
+    index("buildertrend_staging_files_source_idx").on(table.sourceRecordId),
+    index("buildertrend_staging_files_project_idx").on(table.projectId),
+    index("buildertrend_staging_files_job_idx").on(table.buildertrendJobId),
+    index("buildertrend_staging_files_review_idx").on(
+      table.organizationId,
+      table.reviewStatus
+    ),
+  ]
+)
+
+export const buildertrendAccessCandidates = sqliteTable(
+  "buildertrend_staging_access_candidates",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    sourceKey: text("source_key").notNull(),
+    requestedSourceRecordKey: text("requested_source_record_key"),
+    sourceRecordId: text("source_record_id").references(
+      () => buildertrendSourceRecords.id,
+      { onDelete: "restrict" }
+    ),
+    requestedProjectId: text("requested_project_id"),
+    projectId: text("project_id").references(() => projects.id, {
+      onDelete: "set null",
+    }),
+    buildertrendJobId: text("buildertrend_job_id"),
+    buildertrendLeadId: text("buildertrend_lead_id"),
+    buildertrendContactId: text("buildertrend_contact_id"),
+    buildertrendAccessRole: text("buildertrend_access_role"),
+    contactName: text("contact_name").notNull(),
+    companyName: text("company_name"),
+    email: text("email"),
+    phone: text("phone"),
+    proposedContactType: text("proposed_contact_type")
+      .notNull()
+      .default("vendor"),
+    proposedProjectRole: text("proposed_project_role"),
+    matchedUserId: text("matched_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    matchedCustomerId: text("matched_customer_id").references(
+      () => customers.id,
+      { onDelete: "set null" }
+    ),
+    matchedVendorId: text("matched_vendor_id").references(() => vendors.id, {
+      onDelete: "set null",
+    }),
+    matchStatus: text("match_status").notNull().default("unmatched"),
+    matchConfidence: real("match_confidence").notNull().default(0),
+    portalAccessStatus: text("portal_access_status")
+      .notNull()
+      .default("not_granted"),
+    reviewStatus: text("review_status").notNull().default("needs_review"),
+    sourceNotes: text("source_notes"),
+    reviewNotes: text("review_notes"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("buildertrend_staging_access_org_key_unique").on(
+      table.organizationId,
+      table.sourceKey
+    ),
+    index("buildertrend_staging_access_source_idx").on(table.sourceRecordId),
+    index("buildertrend_staging_access_project_idx").on(table.projectId),
+    index("buildertrend_staging_access_contact_idx").on(
+      table.buildertrendContactId
+    ),
+    index("buildertrend_staging_access_review_idx").on(
+      table.organizationId,
+      table.reviewStatus
+    ),
+    index("buildertrend_staging_access_portal_idx").on(
+      table.organizationId,
+      table.portalAccessStatus
+    ),
+  ]
+)
+
+export const buildertrendImportObservations = sqliteTable(
+  "buildertrend_staging_observations",
+  {
+    id: text("id").primaryKey(),
+    importRunId: text("import_run_id")
+      .notNull()
+      .references(() => buildertrendImportRuns.id, { onDelete: "restrict" }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    entityKind: text("entity_kind").notNull(),
+    entityKey: text("entity_key").notNull(),
+    entityId: text("entity_id").notNull(),
+    observedPayloadJson: text("observed_payload_json").notNull(),
+    observedAt: text("observed_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("buildertrend_staging_observations_run_entity_unique").on(
+      table.importRunId,
+      table.entityKind,
+      table.entityKey
+    ),
+    index("buildertrend_staging_observations_entity_idx").on(
+      table.organizationId,
+      table.entityKind,
+      table.entityId
+    ),
+  ]
+)
+
+export type BuildertrendImportRun = typeof buildertrendImportRuns.$inferSelect
+export type NewBuildertrendImportRun =
+  typeof buildertrendImportRuns.$inferInsert
+export type BuildertrendSourceRecord =
+  typeof buildertrendSourceRecords.$inferSelect
+export type NewBuildertrendSourceRecord =
+  typeof buildertrendSourceRecords.$inferInsert
+export type BuildertrendArchiveFile =
+  typeof buildertrendArchiveFiles.$inferSelect
+export type NewBuildertrendArchiveFile =
+  typeof buildertrendArchiveFiles.$inferInsert
+export type BuildertrendAccessCandidate =
+  typeof buildertrendAccessCandidates.$inferSelect
+export type NewBuildertrendAccessCandidate =
+  typeof buildertrendAccessCandidates.$inferInsert
+export type BuildertrendImportObservation =
+  typeof buildertrendImportObservations.$inferSelect
+export type NewBuildertrendImportObservation =
+  typeof buildertrendImportObservations.$inferInsert

--- a/src/lib/buildertrend/__tests__/staging-manifest.test.ts
+++ b/src/lib/buildertrend/__tests__/staging-manifest.test.ts
@@ -204,6 +204,84 @@ describe("Buildertrend staging manifest", () => {
     })
   })
 
+  it("treats reordered manifest members as the same captured run", async () => {
+    const firstRecord = {
+      ...manifestInput.records[0],
+      rawPayload: {
+        z: 1,
+        nested: { b: 2, a: 1 },
+        a: 0,
+      },
+    }
+    const reorderedFirstRecord = {
+      ...manifestInput.records[0],
+      rawPayload: {
+        a: 0,
+        nested: { a: 1, b: 2 },
+        z: 1,
+      },
+    }
+    const secondRecord = {
+      ...manifestInput.records[0],
+      sourceKey: "job:456",
+      projectId: "project-other",
+      buildertrendJobId: "456",
+      buildertrendRecordId: "456",
+      title: "Second example project",
+    }
+    const secondFile = {
+      ...manifestInput.files[0],
+      sourceKey: "file:123:photo-2",
+      buildertrendFileId: "photo-2",
+      fileName: "photo-2.jpg",
+    }
+    const secondAccessCandidate = {
+      ...manifestInput.accessCandidates[0],
+      sourceKey: "access:123:contact-2",
+      buildertrendContactId: "contact-2",
+      contactName: "Second Example Owner",
+    }
+    const original = parsedManifest({
+      ...manifestInput,
+      records: [firstRecord, secondRecord],
+      files: [manifestInput.files[0], secondFile],
+      accessCandidates: [
+        manifestInput.accessCandidates[0],
+        secondAccessCandidate,
+      ],
+    })
+    const reordered = parsedManifest({
+      ...manifestInput,
+      records: [secondRecord, reorderedFirstRecord],
+      files: [secondFile, manifestInput.files[0]],
+      accessCandidates: [
+        secondAccessCandidate,
+        manifestInput.accessCandidates[0],
+      ],
+    })
+    const firstBuild = await buildBuildertrendStagingSql(
+      "org-example",
+      original
+    )
+    const secondBuild = await buildBuildertrendStagingSql(
+      "org-example",
+      reordered
+    )
+
+    database.exec(firstBuild.sql)
+    database.exec(secondBuild.sql)
+
+    expect(
+      scalar(database, "SELECT status FROM buildertrend_staging_runs")
+    ).toBe("completed")
+    expect(
+      scalar(
+        database,
+        "SELECT COUNT(*) FROM buildertrend_staging_observations"
+      )
+    ).toBe(6)
+  })
+
   it("leaves an interrupted import visibly in progress", async () => {
     const build = await buildBuildertrendStagingSql(
       "org-example",

--- a/src/lib/buildertrend/__tests__/staging-manifest.test.ts
+++ b/src/lib/buildertrend/__tests__/staging-manifest.test.ts
@@ -1,0 +1,773 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  buildBuildertrendStagingSql,
+  parseBuildertrendStagingManifest,
+} from "../staging-manifest"
+
+const migrationSql = readFileSync(
+  resolve(process.cwd(), "drizzle/0084_buildertrend_staging_foundation.sql"),
+  "utf8"
+).replaceAll("--> statement-breakpoint", "")
+
+const manifestInput = {
+  runKey: "jobs-2026-07-30",
+  sourceMethod: "authenticated_export",
+  sourceLabel: "Buildertrend job inventory",
+  capturedAt: "2026-07-30T12:00:00.000Z",
+  records: [
+    {
+      sourceKey: "job:123",
+      projectId: "project-123",
+      sourceRecordType: "job",
+      buildertrendJobId: "123",
+      buildertrendRecordId: "123",
+      title: "Example project",
+      rawPayload: { status: "Open" },
+      archiveDriveFolderId: "source-record-folder",
+      archiveDriveFileId: "source-record-drive",
+      archiveDriveUrl: "https://source.example/record",
+    },
+  ],
+  files: [
+    {
+      sourceKey: "file:123:photo-1",
+      sourceRecordKey: "job:123",
+      projectId: "project-123",
+      sourceRecordType: "job_photo",
+      buildertrendJobId: "123",
+      buildertrendFileId: "photo-1",
+      fileName: "photo-1.jpg",
+      checksum: "abc123",
+      driveFolderId: "source-file-folder",
+      driveFileId: "source-file-drive",
+      driveUrl: "https://source.example/file",
+      thumbnailDriveFileId: "source-thumbnail-drive",
+      thumbnailUrl: "https://source.example/thumbnail",
+    },
+  ],
+  accessCandidates: [
+    {
+      sourceKey: "access:123:contact-1",
+      sourceRecordKey: "job:123",
+      projectId: "project-123",
+      buildertrendJobId: "123",
+      buildertrendContactId: "contact-1",
+      buildertrendAccessRole: "client",
+      contactName: "Example Owner",
+      email: "approved@example.test",
+      proposedContactType: "customer",
+    },
+  ],
+}
+
+type TestStatement = {
+  readonly get: () => unknown
+  readonly run: () => unknown
+}
+
+type TestDatabase = {
+  readonly exec: (sql: string) => unknown
+  readonly prepare: (sql: string) => TestStatement
+  readonly close: () => void
+}
+
+type TestDatabaseModule = {
+  readonly Database: new (filename: string) => TestDatabase
+}
+
+function isTestDatabaseModule(value: unknown): value is TestDatabaseModule {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "Database" in value &&
+    typeof value.Database === "function"
+  )
+}
+
+async function createDatabase(): Promise<TestDatabase> {
+  if ("Bun" in globalThis) {
+    const bunSqliteSpecifier = "bun:sqlite"
+    const sqliteModule: unknown = await import(bunSqliteSpecifier)
+    if (!isTestDatabaseModule(sqliteModule)) {
+      throw new Error("bun:sqlite did not provide a Database constructor")
+    }
+    return new sqliteModule.Database(":memory:")
+  }
+
+  const { default: Database } = await import("better-sqlite3")
+  const database = new Database(":memory:")
+  return {
+    exec: (sql) => database.exec(sql),
+    prepare: (sql) => {
+      const statement = database.prepare(sql)
+      return {
+        get: () => statement.get(),
+        run: () => statement.run(),
+      }
+    },
+    close: () => database.close(),
+  }
+}
+
+async function createTestDb(): Promise<TestDatabase> {
+  const database = await createDatabase()
+  database.exec(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE organizations (id TEXT PRIMARY KEY);
+    CREATE TABLE users (id TEXT PRIMARY KEY);
+    CREATE TABLE customers (id TEXT PRIMARY KEY);
+    CREATE TABLE vendors (id TEXT PRIMARY KEY);
+    CREATE TABLE projects (
+      id TEXT PRIMARY KEY,
+      organization_id TEXT NOT NULL REFERENCES organizations(id)
+    );
+  `)
+  database.exec(migrationSql)
+  database.exec(`
+    INSERT INTO organizations (id) VALUES ('org-example'), ('org-other');
+    INSERT INTO projects (id, organization_id)
+      VALUES
+        ('project-123', 'org-example'),
+        ('project-other', 'org-example'),
+        ('project-cross-org', 'org-other');
+  `)
+  return database
+}
+
+function parsedManifest(value: unknown) {
+  const result = parseBuildertrendStagingManifest(value)
+  if (!result.success) throw new Error(result.errors.join("\n"))
+  return result.data
+}
+
+function scalar(
+  database: TestDatabase,
+  sql: string
+): unknown {
+  const row: unknown = database.prepare(sql).get()
+  if (row === null || typeof row !== "object") return row
+  return Object.values(row)[0]
+}
+
+describe("Buildertrend staging manifest", () => {
+  let database: TestDatabase
+
+  beforeEach(async () => {
+    database = await createTestDb()
+  })
+
+  afterEach(() => {
+    if (database) database.close()
+  })
+
+  it("parses normalized manifests and rejects duplicate or inconsistent keys", () => {
+    expect(parseBuildertrendStagingManifest(manifestInput).success).toBe(true)
+
+    const duplicate = parseBuildertrendStagingManifest({
+      ...manifestInput,
+      records: [manifestInput.records[0], manifestInput.records[0]],
+    })
+    expect(duplicate).toEqual({
+      success: false,
+      errors: ['records contains duplicate sourceKey "job:123"'],
+    })
+
+    const mismatch = parseBuildertrendStagingManifest({
+      ...manifestInput,
+      files: [{ ...manifestInput.files[0], projectId: "project-other" }],
+    })
+    expect(mismatch).toEqual({
+      success: false,
+      errors: [
+        'files.file:123:photo-1 projectId does not match source record "job:123"',
+      ],
+    })
+  })
+
+  it("generates deterministic SQL with explicit run finalization", async () => {
+    const manifest = parsedManifest(manifestInput)
+    const first = await buildBuildertrendStagingSql("org-example", manifest)
+    const second = await buildBuildertrendStagingSql("org-example", manifest)
+
+    expect(first.sql).toBe(second.sql)
+    expect(first.statements[0]).toContain("'in_progress'")
+    expect(first.statements.at(-1)).toContain("status = 'completed'")
+    expect(first.summary).toEqual({
+      runKey: "jobs-2026-07-30",
+      sourceLabel: "Buildertrend job inventory",
+      recordCount: 1,
+      fileCount: 1,
+      accessCandidateCount: 1,
+    })
+  })
+
+  it("leaves an interrupted import visibly in progress", async () => {
+    const build = await buildBuildertrendStagingSql(
+      "org-example",
+      parsedManifest(manifestInput)
+    )
+    const firstStatement = build.statements[0]
+    if (!firstStatement) throw new Error("Import start statement is missing")
+    database.exec(firstStatement)
+
+    expect(
+      scalar(database, "SELECT status FROM buildertrend_staging_runs")
+    ).toBe("in_progress")
+    expect(
+      scalar(database, "SELECT summary_json FROM buildertrend_staging_runs")
+    ).toBeNull()
+  })
+
+  it("executes and replays without erasing reviewer decisions or evidence", async () => {
+    const build = await buildBuildertrendStagingSql(
+      "org-example",
+      parsedManifest(manifestInput)
+    )
+    database.exec(build.sql)
+    database.exec(`
+      UPDATE buildertrend_staging_records
+      SET review_status = 'approved',
+          promotion_status = 'promoted',
+          promoted_record_id = 'manual-promoted',
+          verified_archive_drive_file_id = 'manual-source-drive',
+          review_notes = 'manual source note'
+      WHERE source_key = 'job:123';
+      UPDATE buildertrend_staging_files
+      SET review_status = 'approved',
+          visibility = 'owner',
+          verified_drive_file_id = 'manual-file-drive',
+          verified_drive_url = 'https://drive.example/file',
+          verified_checksum = 'verified-checksum',
+          review_metadata_json = '{"reviewer":"staff"}'
+      WHERE source_key = 'file:123:photo-1';
+      UPDATE buildertrend_staging_access_candidates
+      SET review_status = 'approved',
+          portal_access_status = 'granted',
+          match_status = 'matched',
+          review_notes = 'manual access note'
+      WHERE source_key = 'access:123:contact-1';
+    `)
+
+    database.exec(build.sql)
+
+    expect(
+      scalar(
+        database,
+        "SELECT promotion_status FROM buildertrend_staging_records"
+      )
+    ).toBe("promoted")
+    expect(
+      scalar(
+        database,
+        "SELECT verified_archive_drive_file_id FROM buildertrend_staging_records"
+      )
+    ).toBe("manual-source-drive")
+    expect(
+      scalar(database, "SELECT review_notes FROM buildertrend_staging_records")
+    ).toBe("manual source note")
+    expect(
+      scalar(
+        database,
+        "SELECT verified_drive_file_id FROM buildertrend_staging_files"
+      )
+    ).toBe("manual-file-drive")
+    expect(
+      scalar(
+        database,
+        "SELECT verified_checksum FROM buildertrend_staging_files"
+      )
+    ).toBe("verified-checksum")
+    expect(
+      scalar(
+        database,
+        "SELECT portal_access_status FROM buildertrend_staging_access_candidates"
+      )
+    ).toBe("granted")
+    expect(
+      scalar(
+        database,
+        "SELECT review_notes FROM buildertrend_staging_access_candidates"
+      )
+    ).toBe("manual access note")
+    expect(
+      scalar(database, "SELECT COUNT(*) FROM buildertrend_staging_observations")
+    ).toBe(3)
+  })
+
+  it("preserves project identity and quarantines changed references", async () => {
+    const first = await buildBuildertrendStagingSql(
+      "org-example",
+      parsedManifest(manifestInput)
+    )
+    database.exec(first.sql)
+    database.exec(`
+      UPDATE buildertrend_staging_records
+        SET promotion_status = 'promoted', promoted_record_id = 'record-1';
+      UPDATE buildertrend_staging_access_candidates
+        SET portal_access_status = 'granted';
+    `)
+
+    const changed = {
+      ...manifestInput,
+      runKey: "changed-project-run",
+      records: manifestInput.records.map((record) => ({
+        ...record,
+        projectId: "project-other",
+      })),
+      files: manifestInput.files.map((file) => ({
+        ...file,
+        projectId: "project-other",
+      })),
+      accessCandidates: manifestInput.accessCandidates.map((candidate) => ({
+        ...candidate,
+        projectId: "project-other",
+      })),
+    }
+    const changedBuild = await buildBuildertrendStagingSql(
+      "org-example",
+      parsedManifest(changed)
+    )
+    database.exec(changedBuild.sql)
+
+    expect(
+      scalar(database, "SELECT project_id FROM buildertrend_staging_records")
+    ).toBe("project-123")
+    expect(
+      scalar(
+        database,
+        "SELECT review_status FROM buildertrend_staging_records"
+      )
+    ).toBe("reference_conflict")
+    expect(
+      scalar(
+        database,
+        "SELECT project_id FROM buildertrend_staging_access_candidates"
+      )
+    ).toBe("project-123")
+    expect(
+      scalar(
+        database,
+        "SELECT portal_access_status FROM buildertrend_staging_access_candidates"
+      )
+    ).toBe("granted")
+  })
+
+  it("rejects changed manifest membership for an existing run key", async () => {
+    const first = await buildBuildertrendStagingSql(
+      "org-example",
+      parsedManifest(manifestInput)
+    )
+    database.exec(first.sql)
+
+    const changedMembership = {
+      ...manifestInput,
+      files: [],
+      accessCandidates: [],
+    }
+    const replay = await buildBuildertrendStagingSql(
+      "org-example",
+      parsedManifest(changedMembership)
+    )
+    database.exec(replay.sql)
+
+    expect(
+      scalar(database, "SELECT status FROM buildertrend_staging_runs")
+    ).toBe("manifest_conflict")
+    expect(
+      scalar(database, "SELECT COUNT(*) FROM buildertrend_staging_observations")
+    ).toBe(3)
+    expect(
+      scalar(
+        database,
+        "SELECT json_extract(observed_payload_json, '$.sourceKey') FROM buildertrend_staging_observations WHERE entity_kind = 'file'"
+      )
+    ).toBe("file:123:photo-1")
+  })
+
+  it("preserves reviewed evidence pointers and quarantines source changes", async () => {
+    const first = await buildBuildertrendStagingSql(
+      "org-example",
+      parsedManifest(manifestInput)
+    )
+    database.exec(first.sql)
+    database.exec(`
+      UPDATE buildertrend_staging_records
+      SET review_status = 'approved',
+          verified_archive_drive_file_id = 'verified-record-drive';
+      UPDATE buildertrend_staging_files
+      SET review_status = 'approved',
+          visibility = 'owner',
+          verified_drive_file_id = 'verified-file-drive';
+    `)
+
+    const changedEvidence = {
+      ...manifestInput,
+      runKey: "changed-evidence-run",
+      records: manifestInput.records.map((record) => ({
+        ...record,
+        archiveDriveFolderId: "different-source-record-folder",
+      })),
+      files: manifestInput.files.map((file) => ({
+        ...file,
+        driveFolderId: "different-source-file-folder",
+        thumbnailUrl: "https://source.example/different-thumbnail",
+      })),
+    }
+    const replay = await buildBuildertrendStagingSql(
+      "org-example",
+      parsedManifest(changedEvidence)
+    )
+    database.exec(replay.sql)
+
+    expect(
+      scalar(
+        database,
+        "SELECT source_archive_drive_folder_id FROM buildertrend_staging_records"
+      )
+    ).toBe("source-record-folder")
+    expect(
+      scalar(
+        database,
+        "SELECT source_archive_drive_file_id FROM buildertrend_staging_records"
+      )
+    ).toBe("source-record-drive")
+    expect(
+      scalar(
+        database,
+        "SELECT verified_archive_drive_file_id FROM buildertrend_staging_records"
+      )
+    ).toBe("verified-record-drive")
+    expect(
+      scalar(
+        database,
+        "SELECT source_drive_folder_id FROM buildertrend_staging_files"
+      )
+    ).toBe("source-file-folder")
+    expect(
+      scalar(
+        database,
+        "SELECT source_drive_file_id FROM buildertrend_staging_files"
+      )
+    ).toBe("source-file-drive")
+    expect(
+      scalar(
+        database,
+        "SELECT source_thumbnail_url FROM buildertrend_staging_files"
+      )
+    ).toBe("https://source.example/thumbnail")
+    expect(
+      scalar(
+        database,
+        "SELECT verified_drive_file_id FROM buildertrend_staging_files"
+      )
+    ).toBe("verified-file-drive")
+    expect(
+      scalar(
+        database,
+        "SELECT review_status FROM buildertrend_staging_files"
+      )
+    ).toBe("evidence_conflict")
+    expect(
+      scalar(
+        database,
+        "SELECT json_extract(summary_json, '$.unresolvedOrConflicted') FROM buildertrend_staging_runs WHERE run_key = 'changed-evidence-run'"
+      )
+    ).toBe(2)
+  })
+
+  it("preserves a granted identity and quarantines identity changes", async () => {
+    const first = await buildBuildertrendStagingSql(
+      "org-example",
+      parsedManifest(manifestInput)
+    )
+    database.exec(first.sql)
+    database.exec(`
+      UPDATE buildertrend_staging_access_candidates
+      SET review_status = 'approved',
+          portal_access_status = 'granted',
+          match_status = 'matched';
+    `)
+
+    const changedIdentity = {
+      ...manifestInput,
+      runKey: "changed-identity-run",
+      accessCandidates: manifestInput.accessCandidates.map((candidate) => ({
+        ...candidate,
+        buildertrendContactId: "contact-2",
+        contactName: "Different Person",
+        email: "different@example.test",
+      })),
+    }
+    const replay = await buildBuildertrendStagingSql(
+      "org-example",
+      parsedManifest(changedIdentity)
+    )
+    database.exec(replay.sql)
+
+    expect(
+      scalar(
+        database,
+        "SELECT buildertrend_contact_id FROM buildertrend_staging_access_candidates"
+      )
+    ).toBe("contact-1")
+    expect(
+      scalar(
+        database,
+        "SELECT email FROM buildertrend_staging_access_candidates"
+      )
+    ).toBe("approved@example.test")
+    expect(
+      scalar(
+        database,
+        "SELECT portal_access_status FROM buildertrend_staging_access_candidates"
+      )
+    ).toBe("granted")
+    expect(
+      scalar(
+        database,
+        "SELECT review_status FROM buildertrend_staging_access_candidates"
+      )
+    ).toBe("identity_conflict")
+  })
+
+  it("quarantines children that conflict when an unresolved parent resolves", async () => {
+    const unresolvedParent = {
+      runKey: "unresolved-parent-run",
+      sourceMethod: "authenticated_export",
+      sourceLabel: "Unresolved parent",
+      capturedAt: "2026-07-30T13:00:00.000Z",
+      records: [
+        {
+          sourceKey: "job:late-parent",
+          projectId: "project-cross-org",
+          sourceRecordType: "job",
+          title: "Late parent",
+        },
+      ],
+      files: [],
+      accessCandidates: [],
+    }
+    const first = await buildBuildertrendStagingSql(
+      "org-example",
+      parsedManifest(unresolvedParent)
+    )
+    database.exec(first.sql)
+
+    const child = {
+      ...unresolvedParent,
+      runKey: "child-run",
+      sourceLabel: "Child before parent resolution",
+      records: [],
+      files: [
+        {
+          sourceKey: "file:late-parent",
+          sourceRecordKey: "job:late-parent",
+          projectId: "project-other",
+          sourceRecordType: "job_photo",
+          fileName: "late-parent.jpg",
+        },
+      ],
+    }
+    const second = await buildBuildertrendStagingSql(
+      "org-example",
+      parsedManifest(child)
+    )
+    database.exec(second.sql)
+
+    const resolvedParent = {
+      ...unresolvedParent,
+      runKey: "resolved-parent-run",
+      sourceLabel: "Resolved parent",
+      records: unresolvedParent.records.map((record) => ({
+        ...record,
+        projectId: "project-123",
+      })),
+    }
+    const third = await buildBuildertrendStagingSql(
+      "org-example",
+      parsedManifest(resolvedParent)
+    )
+    database.exec(third.sql)
+
+    expect(
+      scalar(
+        database,
+        "SELECT project_id FROM buildertrend_staging_records WHERE source_key = 'job:late-parent'"
+      )
+    ).toBe("project-123")
+    expect(
+      scalar(
+        database,
+        "SELECT review_status FROM buildertrend_staging_files WHERE source_key = 'file:late-parent'"
+      )
+    ).toBe("reference_conflict")
+    expect(
+      scalar(
+        database,
+        "SELECT json_extract(summary_json, '$.relationshipConflicts') FROM buildertrend_staging_runs WHERE run_key = 'resolved-parent-run'"
+      )
+    ).toBe(1)
+  })
+
+  it("quarantines unresolved cross-organization and missing references", async () => {
+    const unresolved = {
+      ...manifestInput,
+      runKey: "unresolved-run",
+      records: [
+        {
+          ...manifestInput.records[0],
+          sourceKey: "job:cross-org",
+          projectId: "project-cross-org",
+        },
+      ],
+      files: [
+        {
+          ...manifestInput.files[0],
+          sourceKey: "file:missing-parent",
+          sourceRecordKey: "job:missing",
+          projectId: "project-123",
+        },
+      ],
+      accessCandidates: [],
+    }
+    const unresolvedBuild = await buildBuildertrendStagingSql(
+      "org-example",
+      parsedManifest(unresolved)
+    )
+    database.exec(unresolvedBuild.sql)
+
+    expect(
+      scalar(
+        database,
+        "SELECT project_id FROM buildertrend_staging_records WHERE source_key = 'job:cross-org'"
+      )
+    ).toBeNull()
+    expect(
+      scalar(
+        database,
+        "SELECT review_status FROM buildertrend_staging_records WHERE source_key = 'job:cross-org'"
+      )
+    ).toBe("unresolved_reference")
+    expect(
+      scalar(
+        database,
+        "SELECT source_record_id FROM buildertrend_staging_files WHERE source_key = 'file:missing-parent'"
+      )
+    ).toBeNull()
+    expect(
+      scalar(
+        database,
+        "SELECT review_status FROM buildertrend_staging_files WHERE source_key = 'file:missing-parent'"
+      )
+    ).toBe("unresolved_reference")
+    expect(
+      scalar(
+        database,
+        "SELECT json_extract(summary_json, '$.unresolvedOrConflicted') FROM buildertrend_staging_runs WHERE run_key = 'unresolved-run'"
+      )
+    ).toBe(2)
+  })
+
+  it("retains immutable run observations and blocks destructive run deletion", async () => {
+    const build = await buildBuildertrendStagingSql(
+      "org-example",
+      parsedManifest(manifestInput)
+    )
+    database.exec(build.sql)
+
+    expect(() =>
+      database
+        .prepare(
+          "DELETE FROM buildertrend_staging_runs WHERE run_key = 'jobs-2026-07-30'"
+        )
+        .run()
+    ).toThrow()
+    expect(() =>
+      database
+        .prepare(
+          "UPDATE buildertrend_staging_observations SET observed_payload_json = '{}'"
+        )
+        .run()
+    ).toThrow()
+    expect(() =>
+      database.prepare("DELETE FROM buildertrend_staging_observations").run()
+    ).toThrow()
+    expect(() =>
+      database
+        .prepare(
+          "UPDATE buildertrend_staging_files SET id = 'changed-file-id'"
+        )
+        .run()
+    ).toThrow()
+    expect(() =>
+      database
+        .prepare(
+          "UPDATE buildertrend_staging_records SET id = 'changed-record-id'"
+        )
+        .run()
+    ).toThrow()
+    expect(() =>
+      database
+        .prepare(
+          "UPDATE buildertrend_staging_access_candidates SET id = 'changed-access-id'"
+        )
+        .run()
+    ).toThrow()
+    expect(() =>
+      database.prepare("DELETE FROM buildertrend_staging_files").run()
+    ).toThrow()
+    expect(() =>
+      database
+        .prepare("DELETE FROM buildertrend_staging_access_candidates")
+        .run()
+    ).toThrow()
+    expect(
+      scalar(database, "SELECT COUNT(*) FROM buildertrend_staging_records")
+    ).toBe(1)
+    expect(
+      scalar(database, "SELECT COUNT(*) FROM buildertrend_staging_files")
+    ).toBe(1)
+    expect(
+      scalar(
+        database,
+        "SELECT COUNT(*) FROM buildertrend_staging_access_candidates"
+      )
+    ).toBe(1)
+  })
+
+  it("uses a table namespace that does not collide with abandoned staging", async () => {
+    const collisionDatabase = await createDatabase()
+    try {
+      collisionDatabase.exec(`
+        CREATE TABLE organizations (id TEXT PRIMARY KEY);
+        CREATE TABLE users (id TEXT PRIMARY KEY);
+        CREATE TABLE customers (id TEXT PRIMARY KEY);
+        CREATE TABLE vendors (id TEXT PRIMARY KEY);
+        CREATE TABLE projects (
+          id TEXT PRIMARY KEY,
+          organization_id TEXT NOT NULL
+        );
+        CREATE TABLE buildertrend_import_runs (id TEXT PRIMARY KEY);
+      `)
+      expect(() => collisionDatabase.exec(migrationSql)).not.toThrow()
+    } finally {
+      collisionDatabase.close()
+    }
+  })
+
+  it("keeps operational side effects out of generated SQL", async () => {
+    const build = await buildBuildertrendStagingSql(
+      "org-example",
+      parsedManifest(manifestInput)
+    )
+    const sql = build.sql
+
+    expect(sql).not.toContain("INSERT INTO project_members")
+    expect(sql).not.toContain("INSERT INTO notification_events")
+    expect(sql).not.toContain("INSERT INTO project_budget_applications")
+    expect(sql).not.toContain("INSERT INTO sage")
+  })
+})

--- a/src/lib/buildertrend/staging-manifest.ts
+++ b/src/lib/buildertrend/staging-manifest.ts
@@ -146,11 +146,42 @@ function jsonText(value: unknown): string {
 async function manifestFingerprint(
   manifest: BuildertrendStagingManifest
 ): Promise<string> {
-  const bytes = new TextEncoder().encode(JSON.stringify(manifest))
+  const canonicalManifest = {
+    ...manifest,
+    records: [...manifest.records].sort((left, right) =>
+      stableTextCompare(left.sourceKey, right.sourceKey)
+    ),
+    files: [...manifest.files].sort((left, right) =>
+      stableTextCompare(left.sourceKey, right.sourceKey)
+    ),
+    accessCandidates: [...manifest.accessCandidates].sort((left, right) =>
+      stableTextCompare(left.sourceKey, right.sourceKey)
+    ),
+  }
+  const bytes = new TextEncoder().encode(
+    JSON.stringify(canonicalJsonValue(canonicalManifest))
+  )
   const digest = await crypto.subtle.digest("SHA-256", bytes)
   return [...new Uint8Array(digest)]
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("")
+}
+
+function canonicalJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalJsonValue)
+  if (value === null || typeof value !== "object") return value
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => stableTextCompare(left, right))
+      .map(([key, nestedValue]) => [key, canonicalJsonValue(nestedValue)])
+  )
+}
+
+function stableTextCompare(left: string, right: string): number {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
 }
 
 function stableId(

--- a/src/lib/buildertrend/staging-manifest.ts
+++ b/src/lib/buildertrend/staging-manifest.ts
@@ -1,0 +1,1130 @@
+import { z } from "zod/v4"
+
+const optionalText = z.string().trim().min(1).optional()
+const nullableText = z.string().trim().min(1).nullable().optional()
+
+const sourceRecordSchema = z
+  .object({
+    sourceKey: z.string().trim().min(1),
+    projectId: optionalText,
+    sourceScope: z.string().trim().min(1).default("job"),
+    sourceRecordType: z.string().trim().min(1),
+    buildertrendJobId: optionalText,
+    buildertrendLeadId: optionalText,
+    buildertrendRecordId: optionalText,
+    buildertrendRecordNumber: optionalText,
+    buildertrendUrl: optionalText,
+    title: z.string().trim().min(1),
+    recordDate: optionalText,
+    recordStatus: optionalText,
+    sourceStatus: optionalText,
+    departmentCode: optionalText,
+    clientName: optionalText,
+    contactName: optionalText,
+    contactEmail: optionalText,
+    amount: z.number().finite().optional(),
+    searchableText: optionalText,
+    normalizedSummary: optionalText,
+    rawPayload: z.unknown().optional(),
+    archiveDriveFolderId: optionalText,
+    archiveDriveFileId: optionalText,
+    archiveDriveUrl: optionalText,
+    notes: optionalText,
+  })
+  .strict()
+
+const archiveFileSchema = z
+  .object({
+    sourceKey: z.string().trim().min(1),
+    sourceRecordKey: optionalText,
+    projectId: optionalText,
+    sourceScope: z.string().trim().min(1).default("job"),
+    sourceRecordType: z.string().trim().min(1),
+    buildertrendJobId: optionalText,
+    buildertrendLeadId: optionalText,
+    buildertrendFileId: optionalText,
+    buildertrendUrl: optionalText,
+    fileName: z.string().trim().min(1),
+    mimeType: optionalText,
+    fileSize: z.number().int().nonnegative().optional(),
+    driveFolderId: optionalText,
+    driveFileId: optionalText,
+    driveUrl: optionalText,
+    thumbnailDriveFileId: optionalText,
+    thumbnailUrl: optionalText,
+    checksum: optionalText,
+    capturedAt: optionalText,
+    metadata: z.unknown().optional(),
+  })
+  .strict()
+
+const accessCandidateSchema = z
+  .object({
+    sourceKey: z.string().trim().min(1),
+    sourceRecordKey: optionalText,
+    projectId: optionalText,
+    buildertrendJobId: optionalText,
+    buildertrendLeadId: optionalText,
+    buildertrendContactId: optionalText,
+    buildertrendAccessRole: optionalText,
+    contactName: z.string().trim().min(1),
+    companyName: nullableText,
+    email: nullableText,
+    phone: nullableText,
+    proposedContactType: z.string().trim().min(1).default("vendor"),
+    proposedProjectRole: nullableText,
+    notes: nullableText,
+  })
+  .strict()
+
+export const buildertrendStagingManifestSchema = z
+  .object({
+    runKey: z.string().trim().min(1),
+    sourceMethod: z.string().trim().min(1),
+    sourceLabel: z.string().trim().min(1),
+    capturedAt: z.iso.datetime({ offset: true }),
+    rawArtifactDriveFileId: optionalText,
+    rawArtifactDriveUrl: optionalText,
+    notes: optionalText,
+    records: z.array(sourceRecordSchema).readonly().default([]),
+    files: z.array(archiveFileSchema).readonly().default([]),
+    accessCandidates: z
+      .array(accessCandidateSchema)
+      .readonly()
+      .default([]),
+  })
+  .strict()
+
+export type BuildertrendStagingManifest = z.infer<
+  typeof buildertrendStagingManifestSchema
+>
+
+export type BuildertrendStagingSummary = {
+  readonly runKey: string
+  readonly sourceLabel: string
+  readonly recordCount: number
+  readonly fileCount: number
+  readonly accessCandidateCount: number
+}
+
+export type BuildertrendStagingBuild = {
+  readonly sql: string
+  readonly statements: readonly string[]
+  readonly summary: BuildertrendStagingSummary
+}
+
+export type BuildertrendStagingParseResult =
+  | {
+      readonly success: true
+      readonly data: BuildertrendStagingManifest
+    }
+  | {
+      readonly success: false
+      readonly errors: readonly string[]
+    }
+
+type ChildReference = {
+  readonly projectId?: string
+  readonly sourceRecordKey?: string
+}
+
+function sqlText(value: string | null | undefined): string {
+  if (value === null || value === undefined || value === "") return "NULL"
+  return `'${value.replaceAll("'", "''")}'`
+}
+
+function sqlNumber(value: number | undefined): string {
+  return value === undefined ? "NULL" : String(value)
+}
+
+function jsonText(value: unknown): string {
+  if (value === undefined) return "NULL"
+  const encoded = JSON.stringify(value)
+  return encoded === undefined ? "NULL" : sqlText(encoded)
+}
+
+async function manifestFingerprint(
+  manifest: BuildertrendStagingManifest
+): Promise<string> {
+  const bytes = new TextEncoder().encode(JSON.stringify(manifest))
+  const digest = await crypto.subtle.digest("SHA-256", bytes)
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+function stableId(
+  kind: "run" | "source" | "file" | "access" | "observation",
+  organizationId: string,
+  key: string
+): string {
+  return `buildertrend:${kind}:${organizationId}:${key}`
+}
+
+function scopedProjectId(
+  organizationId: string,
+  projectId: string | undefined
+): string {
+  if (!projectId) return "NULL"
+  return `(SELECT id FROM projects WHERE id = ${sqlText(projectId)} AND organization_id = ${sqlText(organizationId)} LIMIT 1)`
+}
+
+function scopedSourceRecordId(
+  organizationId: string,
+  reference: ChildReference
+): string {
+  if (!reference.sourceRecordKey) return "NULL"
+
+  const projectCompatibility = reference.projectId
+    ? ` AND (project_id IS NULL OR project_id = ${scopedProjectId(
+        organizationId,
+        reference.projectId
+      )})`
+    : ""
+
+  return `(SELECT id FROM buildertrend_staging_records WHERE organization_id = ${sqlText(organizationId)} AND source_key = ${sqlText(reference.sourceRecordKey)}${projectCompatibility} LIMIT 1)`
+}
+
+function activeRunGuardSql(
+  organizationId: string,
+  manifest: BuildertrendStagingManifest,
+  fingerprint: string
+): string {
+  const runId = stableId("run", organizationId, manifest.runKey)
+  return `EXISTS (
+    SELECT 1 FROM buildertrend_staging_runs
+    WHERE id = ${sqlText(runId)}
+      AND organization_id = ${sqlText(organizationId)}
+      AND manifest_fingerprint = ${sqlText(fingerprint)}
+      AND status = 'in_progress'
+  )`
+}
+
+function initialReviewStatusSql(
+  organizationId: string,
+  reference: ChildReference
+): string {
+  const invalidChecks: string[] = []
+  if (reference.projectId) {
+    invalidChecks.push(
+      `NOT EXISTS (SELECT 1 FROM projects WHERE id = ${sqlText(
+        reference.projectId
+      )} AND organization_id = ${sqlText(organizationId)})`
+    )
+  }
+  if (reference.sourceRecordKey) {
+    invalidChecks.push(
+      `${scopedSourceRecordId(organizationId, reference)} IS NULL`
+    )
+  }
+
+  if (invalidChecks.length === 0) return "'needs_review'"
+  return `CASE WHEN ${invalidChecks.join(
+    " OR "
+  )} THEN 'unresolved_reference' ELSE 'needs_review' END`
+}
+
+function ensureUniqueKeys(
+  label: string,
+  values: readonly { readonly sourceKey: string }[]
+): readonly string[] {
+  const seen = new Set<string>()
+  const duplicates = new Set<string>()
+
+  for (const value of values) {
+    if (seen.has(value.sourceKey)) duplicates.add(value.sourceKey)
+    seen.add(value.sourceKey)
+  }
+
+  return [...duplicates].map(
+    (sourceKey) => `${label} contains duplicate sourceKey "${sourceKey}"`
+  )
+}
+
+function validateManifestLinks(
+  manifest: BuildertrendStagingManifest
+): readonly string[] {
+  const recordProjects = new Map(
+    manifest.records.map((record) => [record.sourceKey, record.projectId])
+  )
+  const errors: string[] = []
+
+  function validateChildren(
+    label: string,
+    children: readonly {
+      readonly sourceKey: string
+      readonly sourceRecordKey?: string
+      readonly projectId?: string
+    }[]
+  ): void {
+    for (const child of children) {
+      if (!child.sourceRecordKey) continue
+      const parentProjectId = recordProjects.get(child.sourceRecordKey)
+      if (!recordProjects.has(child.sourceRecordKey)) continue
+      if (
+        parentProjectId &&
+        child.projectId &&
+        parentProjectId !== child.projectId
+      ) {
+        errors.push(
+          `${label}.${child.sourceKey} projectId does not match source record "${child.sourceRecordKey}"`
+        )
+      }
+    }
+  }
+
+  validateChildren("files", manifest.files)
+  validateChildren("accessCandidates", manifest.accessCandidates)
+
+  return errors
+}
+
+export function parseBuildertrendStagingManifest(
+  value: unknown
+): BuildertrendStagingParseResult {
+  const result = buildertrendStagingManifestSchema.safeParse(value)
+  if (!result.success) {
+    return {
+      success: false,
+      errors: result.error.issues.map(
+        (issue) =>
+          `${issue.path.length > 0 ? issue.path.join(".") : "manifest"}: ${issue.message}`
+      ),
+    }
+  }
+
+  const errors = [
+    ...ensureUniqueKeys("records", result.data.records),
+    ...ensureUniqueKeys("files", result.data.files),
+    ...ensureUniqueKeys("accessCandidates", result.data.accessCandidates),
+    ...validateManifestLinks(result.data),
+  ]
+
+  return errors.length > 0
+    ? { success: false, errors }
+    : { success: true, data: result.data }
+}
+
+function importRunStartSql(
+  organizationId: string,
+  manifest: BuildertrendStagingManifest,
+  fingerprint: string
+): string {
+  const id = stableId("run", organizationId, manifest.runKey)
+
+  return `INSERT INTO buildertrend_staging_runs (
+  id, organization_id, run_key, manifest_fingerprint, source_method,
+  source_label, status,
+  started_at, completed_at, raw_artifact_drive_file_id,
+  raw_artifact_drive_url, source_notes, summary_json, created_at, updated_at
+) VALUES (
+  ${sqlText(id)}, ${sqlText(organizationId)}, ${sqlText(manifest.runKey)},
+  ${sqlText(fingerprint)}, ${sqlText(manifest.sourceMethod)},
+  ${sqlText(manifest.sourceLabel)},
+  'in_progress', ${sqlText(manifest.capturedAt)}, NULL,
+  ${sqlText(manifest.rawArtifactDriveFileId)},
+  ${sqlText(manifest.rawArtifactDriveUrl)}, ${sqlText(manifest.notes)}, NULL,
+  ${sqlText(manifest.capturedAt)}, ${sqlText(manifest.capturedAt)}
+)
+ON CONFLICT(organization_id, run_key) DO UPDATE SET
+  source_method = CASE
+    WHEN buildertrend_staging_runs.manifest_fingerprint
+      = excluded.manifest_fingerprint THEN excluded.source_method
+    ELSE buildertrend_staging_runs.source_method
+  END,
+  source_label = CASE
+    WHEN buildertrend_staging_runs.manifest_fingerprint
+      = excluded.manifest_fingerprint THEN excluded.source_label
+    ELSE buildertrend_staging_runs.source_label
+  END,
+  status = CASE
+    WHEN buildertrend_staging_runs.manifest_fingerprint
+      = excluded.manifest_fingerprint THEN 'in_progress'
+    ELSE 'manifest_conflict'
+  END,
+  completed_at = CASE
+    WHEN buildertrend_staging_runs.manifest_fingerprint
+      = excluded.manifest_fingerprint THEN NULL
+    ELSE buildertrend_staging_runs.completed_at
+  END,
+  raw_artifact_drive_file_id = CASE
+    WHEN buildertrend_staging_runs.manifest_fingerprint
+      = excluded.manifest_fingerprint THEN COALESCE(
+        buildertrend_staging_runs.raw_artifact_drive_file_id,
+        excluded.raw_artifact_drive_file_id
+      )
+    ELSE buildertrend_staging_runs.raw_artifact_drive_file_id
+  END,
+  raw_artifact_drive_url = CASE
+    WHEN buildertrend_staging_runs.manifest_fingerprint
+      = excluded.manifest_fingerprint THEN COALESCE(
+        buildertrend_staging_runs.raw_artifact_drive_url,
+        excluded.raw_artifact_drive_url
+      )
+    ELSE buildertrend_staging_runs.raw_artifact_drive_url
+  END,
+  source_notes = CASE
+    WHEN buildertrend_staging_runs.manifest_fingerprint
+      = excluded.manifest_fingerprint THEN COALESCE(
+        buildertrend_staging_runs.source_notes,
+        excluded.source_notes
+      )
+    ELSE buildertrend_staging_runs.source_notes
+  END,
+  summary_json = CASE
+    WHEN buildertrend_staging_runs.manifest_fingerprint
+      = excluded.manifest_fingerprint THEN NULL
+    ELSE buildertrend_staging_runs.summary_json
+  END,
+  updated_at = excluded.updated_at;`
+}
+
+function sourceRecordSql(
+  organizationId: string,
+  manifest: BuildertrendStagingManifest,
+  fingerprint: string,
+  record: BuildertrendStagingManifest["records"][number]
+): string {
+  const id = stableId("source", organizationId, record.sourceKey)
+  const projectId = scopedProjectId(organizationId, record.projectId)
+  const reviewStatus = initialReviewStatusSql(organizationId, {
+    projectId: record.projectId,
+  })
+
+  return `INSERT INTO buildertrend_staging_records (
+  id, organization_id, source_key, requested_project_id, project_id,
+  source_scope, source_record_type, buildertrend_job_id, buildertrend_lead_id,
+  buildertrend_record_id, buildertrend_record_number, buildertrend_url,
+  title, record_date, record_status, source_status, department_code,
+  client_name, contact_name, contact_email, amount, searchable_text,
+  normalized_summary, raw_payload_json, source_archive_drive_folder_id,
+  source_archive_drive_file_id, source_archive_drive_url, review_status,
+  promotion_status,
+  sage_reconciliation_status, source_notes, created_at, updated_at
+) SELECT
+  ${sqlText(id)}, ${sqlText(organizationId)}, ${sqlText(record.sourceKey)},
+  ${sqlText(record.projectId)}, ${projectId}, ${sqlText(record.sourceScope)},
+  ${sqlText(record.sourceRecordType)}, ${sqlText(record.buildertrendJobId)},
+  ${sqlText(record.buildertrendLeadId)},
+  ${sqlText(record.buildertrendRecordId)},
+  ${sqlText(record.buildertrendRecordNumber)},
+  ${sqlText(record.buildertrendUrl)}, ${sqlText(record.title)},
+  ${sqlText(record.recordDate)}, ${sqlText(record.recordStatus)},
+  ${sqlText(record.sourceStatus)}, ${sqlText(record.departmentCode)},
+  ${sqlText(record.clientName)}, ${sqlText(record.contactName)},
+  ${sqlText(record.contactEmail)}, ${sqlNumber(record.amount)},
+  ${sqlText(record.searchableText)}, ${sqlText(record.normalizedSummary)},
+  ${jsonText(record.rawPayload)}, ${sqlText(record.archiveDriveFolderId)},
+  ${sqlText(record.archiveDriveFileId)}, ${sqlText(record.archiveDriveUrl)},
+  ${reviewStatus}, 'archive_only', 'not_reviewed',
+  ${sqlText(record.notes)}, ${sqlText(manifest.capturedAt)},
+  ${sqlText(manifest.capturedAt)}
+WHERE ${activeRunGuardSql(organizationId, manifest, fingerprint)}
+ON CONFLICT(organization_id, source_key) DO UPDATE SET
+  requested_project_id = CASE
+    WHEN buildertrend_staging_records.project_id IS NULL
+      THEN COALESCE(
+        excluded.requested_project_id,
+        buildertrend_staging_records.requested_project_id
+      )
+    ELSE buildertrend_staging_records.requested_project_id
+  END,
+  project_id = COALESCE(
+    buildertrend_staging_records.project_id,
+    excluded.project_id
+  ),
+  source_scope = excluded.source_scope,
+  source_record_type = excluded.source_record_type,
+  buildertrend_job_id = COALESCE(
+    excluded.buildertrend_job_id,
+    buildertrend_staging_records.buildertrend_job_id
+  ),
+  buildertrend_lead_id = COALESCE(
+    excluded.buildertrend_lead_id,
+    buildertrend_staging_records.buildertrend_lead_id
+  ),
+  buildertrend_record_id = COALESCE(
+    excluded.buildertrend_record_id,
+    buildertrend_staging_records.buildertrend_record_id
+  ),
+  buildertrend_record_number = COALESCE(
+    excluded.buildertrend_record_number,
+    buildertrend_staging_records.buildertrend_record_number
+  ),
+  buildertrend_url = COALESCE(
+    excluded.buildertrend_url,
+    buildertrend_staging_records.buildertrend_url
+  ),
+  title = excluded.title,
+  record_date = COALESCE(
+    excluded.record_date,
+    buildertrend_staging_records.record_date
+  ),
+  record_status = COALESCE(
+    excluded.record_status,
+    buildertrend_staging_records.record_status
+  ),
+  source_status = COALESCE(
+    excluded.source_status,
+    buildertrend_staging_records.source_status
+  ),
+  department_code = COALESCE(
+    excluded.department_code,
+    buildertrend_staging_records.department_code
+  ),
+  client_name = COALESCE(
+    excluded.client_name,
+    buildertrend_staging_records.client_name
+  ),
+  contact_name = COALESCE(
+    excluded.contact_name,
+    buildertrend_staging_records.contact_name
+  ),
+  contact_email = COALESCE(
+    excluded.contact_email,
+    buildertrend_staging_records.contact_email
+  ),
+  amount = COALESCE(excluded.amount, buildertrend_staging_records.amount),
+  searchable_text = COALESCE(
+    excluded.searchable_text,
+    buildertrend_staging_records.searchable_text
+  ),
+  normalized_summary = COALESCE(
+    excluded.normalized_summary,
+    buildertrend_staging_records.normalized_summary
+  ),
+  raw_payload_json = COALESCE(
+    excluded.raw_payload_json,
+    buildertrend_staging_records.raw_payload_json
+  ),
+  source_archive_drive_folder_id = COALESCE(
+    buildertrend_staging_records.source_archive_drive_folder_id,
+    excluded.source_archive_drive_folder_id
+  ),
+  source_archive_drive_file_id = COALESCE(
+    buildertrend_staging_records.source_archive_drive_file_id,
+    excluded.source_archive_drive_file_id
+  ),
+  source_archive_drive_url = COALESCE(
+    buildertrend_staging_records.source_archive_drive_url,
+    excluded.source_archive_drive_url
+  ),
+  review_status = CASE
+    WHEN excluded.project_id IS NOT NULL
+      AND buildertrend_staging_records.project_id IS NOT NULL
+      AND excluded.project_id <> buildertrend_staging_records.project_id
+      THEN 'reference_conflict'
+    WHEN excluded.source_archive_drive_file_id IS NOT NULL
+      AND buildertrend_staging_records.source_archive_drive_file_id IS NOT NULL
+      AND excluded.source_archive_drive_file_id
+        <> buildertrend_staging_records.source_archive_drive_file_id
+      THEN 'evidence_conflict'
+    WHEN excluded.source_archive_drive_url IS NOT NULL
+      AND buildertrend_staging_records.source_archive_drive_url IS NOT NULL
+      AND excluded.source_archive_drive_url
+        <> buildertrend_staging_records.source_archive_drive_url
+      THEN 'evidence_conflict'
+    WHEN excluded.source_archive_drive_folder_id IS NOT NULL
+      AND buildertrend_staging_records.source_archive_drive_folder_id
+        IS NOT NULL
+      AND excluded.source_archive_drive_folder_id
+        <> buildertrend_staging_records.source_archive_drive_folder_id
+      THEN 'evidence_conflict'
+    WHEN buildertrend_staging_records.review_status = 'unresolved_reference'
+      AND excluded.review_status = 'needs_review'
+      THEN 'needs_review'
+    ELSE buildertrend_staging_records.review_status
+  END,
+  source_notes = COALESCE(
+    excluded.source_notes,
+    buildertrend_staging_records.source_notes
+  ),
+  updated_at = excluded.updated_at;`
+}
+
+function archiveFileSql(
+  organizationId: string,
+  manifest: BuildertrendStagingManifest,
+  fingerprint: string,
+  file: BuildertrendStagingManifest["files"][number]
+): string {
+  const id = stableId("file", organizationId, file.sourceKey)
+  const reference = {
+    projectId: file.projectId,
+    sourceRecordKey: file.sourceRecordKey,
+  }
+  const projectId = scopedProjectId(organizationId, file.projectId)
+  const sourceRecordId = scopedSourceRecordId(organizationId, reference)
+  const reviewStatus = initialReviewStatusSql(organizationId, reference)
+
+  return `INSERT INTO buildertrend_staging_files (
+  id, organization_id, source_key, requested_source_record_key,
+  source_record_id, requested_project_id, project_id, source_scope,
+  source_record_type, buildertrend_job_id, buildertrend_lead_id,
+  buildertrend_file_id, buildertrend_url, file_name, mime_type, file_size,
+  source_drive_folder_id, source_drive_file_id, source_drive_url,
+  source_thumbnail_drive_file_id, source_thumbnail_url, source_checksum,
+  captured_at, visibility, review_status, source_metadata_json, created_at,
+  updated_at
+) SELECT
+  ${sqlText(id)}, ${sqlText(organizationId)}, ${sqlText(file.sourceKey)},
+  ${sqlText(file.sourceRecordKey)}, ${sourceRecordId},
+  ${sqlText(file.projectId)}, ${projectId}, ${sqlText(file.sourceScope)},
+  ${sqlText(file.sourceRecordType)}, ${sqlText(file.buildertrendJobId)},
+  ${sqlText(file.buildertrendLeadId)}, ${sqlText(file.buildertrendFileId)},
+  ${sqlText(file.buildertrendUrl)}, ${sqlText(file.fileName)},
+  ${sqlText(file.mimeType)}, ${sqlNumber(file.fileSize)},
+  ${sqlText(file.driveFolderId)}, ${sqlText(file.driveFileId)},
+  ${sqlText(file.driveUrl)}, ${sqlText(file.thumbnailDriveFileId)},
+  ${sqlText(file.thumbnailUrl)}, ${sqlText(file.checksum)},
+  ${sqlText(file.capturedAt ?? manifest.capturedAt)}, 'internal',
+  ${reviewStatus}, ${jsonText(file.metadata)},
+  ${sqlText(manifest.capturedAt)}, ${sqlText(manifest.capturedAt)}
+WHERE ${activeRunGuardSql(organizationId, manifest, fingerprint)}
+ON CONFLICT(organization_id, source_key) DO UPDATE SET
+  requested_source_record_key = CASE
+    WHEN buildertrend_staging_files.source_record_id IS NULL
+      THEN COALESCE(
+        excluded.requested_source_record_key,
+        buildertrend_staging_files.requested_source_record_key
+      )
+    ELSE buildertrend_staging_files.requested_source_record_key
+  END,
+  source_record_id = COALESCE(
+    buildertrend_staging_files.source_record_id,
+    excluded.source_record_id
+  ),
+  requested_project_id = CASE
+    WHEN buildertrend_staging_files.project_id IS NULL
+      THEN COALESCE(
+        excluded.requested_project_id,
+        buildertrend_staging_files.requested_project_id
+      )
+    ELSE buildertrend_staging_files.requested_project_id
+  END,
+  project_id = COALESCE(buildertrend_staging_files.project_id, excluded.project_id),
+  source_scope = excluded.source_scope,
+  source_record_type = excluded.source_record_type,
+  buildertrend_job_id = COALESCE(
+    excluded.buildertrend_job_id,
+    buildertrend_staging_files.buildertrend_job_id
+  ),
+  buildertrend_lead_id = COALESCE(
+    excluded.buildertrend_lead_id,
+    buildertrend_staging_files.buildertrend_lead_id
+  ),
+  buildertrend_file_id = COALESCE(
+    excluded.buildertrend_file_id,
+    buildertrend_staging_files.buildertrend_file_id
+  ),
+  buildertrend_url = COALESCE(
+    excluded.buildertrend_url,
+    buildertrend_staging_files.buildertrend_url
+  ),
+  file_name = excluded.file_name,
+  mime_type = COALESCE(excluded.mime_type, buildertrend_staging_files.mime_type),
+  file_size = COALESCE(excluded.file_size, buildertrend_staging_files.file_size),
+  source_drive_folder_id = COALESCE(
+    buildertrend_staging_files.source_drive_folder_id,
+    excluded.source_drive_folder_id
+  ),
+  source_drive_file_id = COALESCE(
+    buildertrend_staging_files.source_drive_file_id,
+    excluded.source_drive_file_id
+  ),
+  source_drive_url = COALESCE(
+    buildertrend_staging_files.source_drive_url,
+    excluded.source_drive_url
+  ),
+  source_thumbnail_drive_file_id = COALESCE(
+    buildertrend_staging_files.source_thumbnail_drive_file_id,
+    excluded.source_thumbnail_drive_file_id
+  ),
+  source_thumbnail_url = COALESCE(
+    buildertrend_staging_files.source_thumbnail_url,
+    excluded.source_thumbnail_url
+  ),
+  source_checksum = COALESCE(
+    buildertrend_staging_files.source_checksum,
+    excluded.source_checksum
+  ),
+  captured_at = COALESCE(
+    excluded.captured_at,
+    buildertrend_staging_files.captured_at
+  ),
+  source_metadata_json = COALESCE(
+    excluded.source_metadata_json,
+    buildertrend_staging_files.source_metadata_json
+  ),
+  review_status = CASE
+    WHEN excluded.project_id IS NOT NULL
+      AND buildertrend_staging_files.project_id IS NOT NULL
+      AND excluded.project_id <> buildertrend_staging_files.project_id
+      THEN 'reference_conflict'
+    WHEN excluded.source_record_id IS NOT NULL
+      AND buildertrend_staging_files.source_record_id IS NOT NULL
+      AND excluded.source_record_id <> buildertrend_staging_files.source_record_id
+      THEN 'reference_conflict'
+    WHEN excluded.source_checksum IS NOT NULL
+      AND buildertrend_staging_files.source_checksum IS NOT NULL
+      AND excluded.source_checksum <> buildertrend_staging_files.source_checksum
+      THEN 'evidence_conflict'
+    WHEN excluded.source_drive_file_id IS NOT NULL
+      AND buildertrend_staging_files.source_drive_file_id IS NOT NULL
+      AND excluded.source_drive_file_id
+        <> buildertrend_staging_files.source_drive_file_id
+      THEN 'evidence_conflict'
+    WHEN excluded.source_drive_url IS NOT NULL
+      AND buildertrend_staging_files.source_drive_url IS NOT NULL
+      AND excluded.source_drive_url <> buildertrend_staging_files.source_drive_url
+      THEN 'evidence_conflict'
+    WHEN excluded.source_drive_folder_id IS NOT NULL
+      AND buildertrend_staging_files.source_drive_folder_id IS NOT NULL
+      AND excluded.source_drive_folder_id
+        <> buildertrend_staging_files.source_drive_folder_id
+      THEN 'evidence_conflict'
+    WHEN excluded.source_thumbnail_drive_file_id IS NOT NULL
+      AND buildertrend_staging_files.source_thumbnail_drive_file_id IS NOT NULL
+      AND excluded.source_thumbnail_drive_file_id
+        <> buildertrend_staging_files.source_thumbnail_drive_file_id
+      THEN 'evidence_conflict'
+    WHEN excluded.source_thumbnail_url IS NOT NULL
+      AND buildertrend_staging_files.source_thumbnail_url IS NOT NULL
+      AND excluded.source_thumbnail_url
+        <> buildertrend_staging_files.source_thumbnail_url
+      THEN 'evidence_conflict'
+    WHEN buildertrend_staging_files.review_status = 'unresolved_reference'
+      AND excluded.review_status = 'needs_review'
+      THEN 'needs_review'
+    ELSE buildertrend_staging_files.review_status
+  END,
+  updated_at = excluded.updated_at;`
+}
+
+function accessCandidateSql(
+  organizationId: string,
+  manifest: BuildertrendStagingManifest,
+  fingerprint: string,
+  candidate: BuildertrendStagingManifest["accessCandidates"][number]
+): string {
+  const id = stableId("access", organizationId, candidate.sourceKey)
+  const reference = {
+    projectId: candidate.projectId,
+    sourceRecordKey: candidate.sourceRecordKey,
+  }
+  const projectId = scopedProjectId(organizationId, candidate.projectId)
+  const sourceRecordId = scopedSourceRecordId(organizationId, reference)
+  const reviewStatus = initialReviewStatusSql(organizationId, reference)
+
+  return `INSERT INTO buildertrend_staging_access_candidates (
+  id, organization_id, source_key, requested_source_record_key,
+  source_record_id, requested_project_id, project_id, buildertrend_job_id,
+  buildertrend_lead_id, buildertrend_contact_id, buildertrend_access_role,
+  contact_name, company_name, email, phone, proposed_contact_type,
+  proposed_project_role, match_status, match_confidence, portal_access_status,
+  review_status, source_notes, created_at, updated_at
+) SELECT
+  ${sqlText(id)}, ${sqlText(organizationId)}, ${sqlText(candidate.sourceKey)},
+  ${sqlText(candidate.sourceRecordKey)}, ${sourceRecordId},
+  ${sqlText(candidate.projectId)}, ${projectId},
+  ${sqlText(candidate.buildertrendJobId)},
+  ${sqlText(candidate.buildertrendLeadId)},
+  ${sqlText(candidate.buildertrendContactId)},
+  ${sqlText(candidate.buildertrendAccessRole)},
+  ${sqlText(candidate.contactName)}, ${sqlText(candidate.companyName)},
+  ${sqlText(candidate.email)}, ${sqlText(candidate.phone)},
+  ${sqlText(candidate.proposedContactType)},
+  ${sqlText(candidate.proposedProjectRole)}, 'unmatched', 0, 'not_granted',
+  ${reviewStatus}, ${sqlText(candidate.notes)},
+  ${sqlText(manifest.capturedAt)}, ${sqlText(manifest.capturedAt)}
+WHERE ${activeRunGuardSql(organizationId, manifest, fingerprint)}
+ON CONFLICT(organization_id, source_key) DO UPDATE SET
+  requested_source_record_key = CASE
+    WHEN buildertrend_staging_access_candidates.source_record_id IS NULL
+      THEN COALESCE(
+        excluded.requested_source_record_key,
+        buildertrend_staging_access_candidates.requested_source_record_key
+      )
+    ELSE buildertrend_staging_access_candidates.requested_source_record_key
+  END,
+  source_record_id = COALESCE(
+    buildertrend_staging_access_candidates.source_record_id,
+    excluded.source_record_id
+  ),
+  requested_project_id = CASE
+    WHEN buildertrend_staging_access_candidates.project_id IS NULL
+      THEN COALESCE(
+        excluded.requested_project_id,
+        buildertrend_staging_access_candidates.requested_project_id
+      )
+    ELSE buildertrend_staging_access_candidates.requested_project_id
+  END,
+  project_id = COALESCE(
+    buildertrend_staging_access_candidates.project_id,
+    excluded.project_id
+  ),
+  buildertrend_job_id = COALESCE(
+    buildertrend_staging_access_candidates.buildertrend_job_id,
+    excluded.buildertrend_job_id
+  ),
+  buildertrend_lead_id = COALESCE(
+    buildertrend_staging_access_candidates.buildertrend_lead_id,
+    excluded.buildertrend_lead_id
+  ),
+  buildertrend_contact_id = COALESCE(
+    buildertrend_staging_access_candidates.buildertrend_contact_id,
+    excluded.buildertrend_contact_id
+  ),
+  buildertrend_access_role = COALESCE(
+    buildertrend_staging_access_candidates.buildertrend_access_role,
+    excluded.buildertrend_access_role
+  ),
+  contact_name = buildertrend_staging_access_candidates.contact_name,
+  company_name = COALESCE(
+    buildertrend_staging_access_candidates.company_name,
+    excluded.company_name
+  ),
+  email = COALESCE(
+    buildertrend_staging_access_candidates.email,
+    excluded.email
+  ),
+  phone = COALESCE(
+    buildertrend_staging_access_candidates.phone,
+    excluded.phone
+  ),
+  proposed_contact_type =
+    buildertrend_staging_access_candidates.proposed_contact_type,
+  proposed_project_role = COALESCE(
+    buildertrend_staging_access_candidates.proposed_project_role,
+    excluded.proposed_project_role
+  ),
+  review_status = CASE
+    WHEN excluded.project_id IS NOT NULL
+      AND buildertrend_staging_access_candidates.project_id IS NOT NULL
+      AND excluded.project_id
+        <> buildertrend_staging_access_candidates.project_id
+      THEN 'reference_conflict'
+    WHEN excluded.source_record_id IS NOT NULL
+      AND buildertrend_staging_access_candidates.source_record_id IS NOT NULL
+      AND excluded.source_record_id
+        <> buildertrend_staging_access_candidates.source_record_id
+      THEN 'reference_conflict'
+    WHEN excluded.buildertrend_contact_id IS NOT NULL
+      AND buildertrend_staging_access_candidates.buildertrend_contact_id
+        IS NOT NULL
+      AND excluded.buildertrend_contact_id
+        <> buildertrend_staging_access_candidates.buildertrend_contact_id
+      THEN 'identity_conflict'
+    WHEN excluded.buildertrend_job_id IS NOT NULL
+      AND buildertrend_staging_access_candidates.buildertrend_job_id IS NOT NULL
+      AND excluded.buildertrend_job_id
+        <> buildertrend_staging_access_candidates.buildertrend_job_id
+      THEN 'identity_conflict'
+    WHEN excluded.buildertrend_lead_id IS NOT NULL
+      AND buildertrend_staging_access_candidates.buildertrend_lead_id
+        IS NOT NULL
+      AND excluded.buildertrend_lead_id
+        <> buildertrend_staging_access_candidates.buildertrend_lead_id
+      THEN 'identity_conflict'
+    WHEN excluded.buildertrend_access_role IS NOT NULL
+      AND buildertrend_staging_access_candidates.buildertrend_access_role
+        IS NOT NULL
+      AND excluded.buildertrend_access_role
+        <> buildertrend_staging_access_candidates.buildertrend_access_role
+      THEN 'identity_conflict'
+    WHEN excluded.contact_name
+        <> buildertrend_staging_access_candidates.contact_name
+      THEN 'identity_conflict'
+    WHEN excluded.email IS NOT NULL
+      AND buildertrend_staging_access_candidates.email IS NOT NULL
+      AND excluded.email <> buildertrend_staging_access_candidates.email
+      THEN 'identity_conflict'
+    WHEN excluded.company_name IS NOT NULL
+      AND buildertrend_staging_access_candidates.company_name IS NOT NULL
+      AND excluded.company_name
+        <> buildertrend_staging_access_candidates.company_name
+      THEN 'identity_conflict'
+    WHEN excluded.phone IS NOT NULL
+      AND buildertrend_staging_access_candidates.phone IS NOT NULL
+      AND excluded.phone <> buildertrend_staging_access_candidates.phone
+      THEN 'identity_conflict'
+    WHEN excluded.proposed_contact_type
+        <> buildertrend_staging_access_candidates.proposed_contact_type
+      THEN 'identity_conflict'
+    WHEN excluded.proposed_project_role IS NOT NULL
+      AND buildertrend_staging_access_candidates.proposed_project_role
+        IS NOT NULL
+      AND excluded.proposed_project_role
+        <> buildertrend_staging_access_candidates.proposed_project_role
+      THEN 'identity_conflict'
+    WHEN buildertrend_staging_access_candidates.review_status
+        = 'unresolved_reference'
+      AND excluded.review_status = 'needs_review'
+      THEN 'needs_review'
+    ELSE buildertrend_staging_access_candidates.review_status
+  END,
+  source_notes = COALESCE(
+    excluded.source_notes,
+    buildertrend_staging_access_candidates.source_notes
+  ),
+  updated_at = excluded.updated_at;`
+}
+
+function observationSql(
+  organizationId: string,
+  manifest: BuildertrendStagingManifest,
+  fingerprint: string,
+  entityKind: "record" | "file" | "access_candidate",
+  entityKey: string,
+  entityId: string,
+  observedPayload: unknown
+): string {
+  const runId = stableId("run", organizationId, manifest.runKey)
+  const observationKey = `${manifest.runKey}:${entityKind}:${entityKey}`
+  const id = stableId("observation", organizationId, observationKey)
+
+  return `INSERT INTO buildertrend_staging_observations (
+  id, import_run_id, organization_id, entity_kind, entity_key, entity_id,
+  observed_payload_json, observed_at
+) SELECT
+  ${sqlText(id)}, ${sqlText(runId)}, ${sqlText(organizationId)},
+  ${sqlText(entityKind)}, ${sqlText(entityKey)}, ${sqlText(entityId)},
+  ${jsonText(observedPayload)},
+  ${sqlText(manifest.capturedAt)}
+WHERE ${activeRunGuardSql(organizationId, manifest, fingerprint)}
+ON CONFLICT(import_run_id, entity_kind, entity_key) DO NOTHING;`
+}
+
+function parentChildInvariantSql(
+  organizationId: string,
+  manifest: BuildertrendStagingManifest,
+  fingerprint: string
+): readonly string[] {
+  const guard = activeRunGuardSql(organizationId, manifest, fingerprint)
+  return [
+    `UPDATE buildertrend_staging_files
+SET review_status = 'reference_conflict'
+WHERE organization_id = ${sqlText(organizationId)}
+  AND project_id IS NOT NULL
+  AND source_record_id IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM buildertrend_staging_records parent
+    WHERE parent.id = buildertrend_staging_files.source_record_id
+      AND parent.project_id IS NOT NULL
+      AND parent.project_id <> buildertrend_staging_files.project_id
+  )
+  AND ${guard};`,
+    `UPDATE buildertrend_staging_access_candidates
+SET review_status = 'reference_conflict'
+WHERE organization_id = ${sqlText(organizationId)}
+  AND project_id IS NOT NULL
+  AND source_record_id IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM buildertrend_staging_records parent
+    WHERE parent.id = buildertrend_staging_access_candidates.source_record_id
+      AND parent.project_id IS NOT NULL
+      AND parent.project_id
+        <> buildertrend_staging_access_candidates.project_id
+  )
+  AND ${guard};`,
+  ]
+}
+
+function importRunFinalizeSql(
+  organizationId: string,
+  manifest: BuildertrendStagingManifest,
+  fingerprint: string
+): string {
+  const runId = stableId("run", organizationId, manifest.runKey)
+
+  return `UPDATE buildertrend_staging_runs
+SET
+  status = 'completed',
+  completed_at = ${sqlText(manifest.capturedAt)},
+  summary_json = json_object(
+    'records',
+    (SELECT COUNT(*) FROM buildertrend_staging_observations
+      WHERE import_run_id = ${sqlText(runId)} AND entity_kind = 'record'),
+    'files',
+    (SELECT COUNT(*) FROM buildertrend_staging_observations
+      WHERE import_run_id = ${sqlText(runId)} AND entity_kind = 'file'),
+    'accessCandidates',
+    (SELECT COUNT(*) FROM buildertrend_staging_observations
+      WHERE import_run_id = ${sqlText(
+        runId
+      )} AND entity_kind = 'access_candidate'),
+    'unresolvedOrConflicted',
+    (
+      SELECT
+        (SELECT COUNT(*) FROM buildertrend_staging_records r
+          JOIN buildertrend_staging_observations o ON o.entity_id = r.id
+          WHERE o.import_run_id = ${sqlText(runId)}
+            AND o.entity_kind = 'record'
+            AND r.review_status IN (
+              'unresolved_reference',
+              'reference_conflict',
+              'evidence_conflict'
+            ))
+        +
+        (SELECT COUNT(*) FROM buildertrend_staging_files f
+          JOIN buildertrend_staging_observations o ON o.entity_id = f.id
+          WHERE o.import_run_id = ${sqlText(runId)}
+            AND o.entity_kind = 'file'
+            AND f.review_status IN (
+              'unresolved_reference',
+              'reference_conflict',
+              'evidence_conflict'
+            ))
+        +
+        (SELECT COUNT(*) FROM buildertrend_staging_access_candidates a
+          JOIN buildertrend_staging_observations o ON o.entity_id = a.id
+          WHERE o.import_run_id = ${sqlText(runId)}
+            AND o.entity_kind = 'access_candidate'
+            AND a.review_status IN (
+              'unresolved_reference',
+              'reference_conflict',
+              'identity_conflict'
+            ))
+    ),
+    'relationshipConflicts',
+    (
+      (SELECT COUNT(*) FROM buildertrend_staging_files f
+        JOIN buildertrend_staging_records parent
+          ON parent.id = f.source_record_id
+        JOIN buildertrend_staging_observations o
+          ON o.entity_id = parent.id AND o.entity_kind = 'record'
+        WHERE o.import_run_id = ${sqlText(runId)}
+          AND f.project_id IS NOT NULL
+          AND parent.project_id IS NOT NULL
+          AND f.project_id <> parent.project_id)
+      +
+      (SELECT COUNT(*) FROM buildertrend_staging_access_candidates a
+        JOIN buildertrend_staging_records parent
+          ON parent.id = a.source_record_id
+        JOIN buildertrend_staging_observations o
+          ON o.entity_id = parent.id AND o.entity_kind = 'record'
+        WHERE o.import_run_id = ${sqlText(runId)}
+          AND a.project_id IS NOT NULL
+          AND parent.project_id IS NOT NULL
+          AND a.project_id <> parent.project_id)
+    )
+  ),
+  updated_at = ${sqlText(manifest.capturedAt)}
+WHERE id = ${sqlText(runId)}
+  AND organization_id = ${sqlText(organizationId)}
+  AND manifest_fingerprint = ${sqlText(fingerprint)}
+  AND status = 'in_progress';`
+}
+
+export async function buildBuildertrendStagingSql(
+  organizationId: string,
+  manifest: BuildertrendStagingManifest
+): Promise<BuildertrendStagingBuild> {
+  const normalizedOrganizationId = organizationId.trim()
+  if (!normalizedOrganizationId) {
+    throw new Error("organizationId is required")
+  }
+
+  const summary: BuildertrendStagingSummary = {
+    runKey: manifest.runKey,
+    sourceLabel: manifest.sourceLabel,
+    recordCount: manifest.records.length,
+    fileCount: manifest.files.length,
+    accessCandidateCount: manifest.accessCandidates.length,
+  }
+  const fingerprint = await manifestFingerprint(manifest)
+
+  const statements = [
+    importRunStartSql(normalizedOrganizationId, manifest, fingerprint),
+    ...manifest.records.flatMap((record) => {
+      const entityId = stableId(
+        "source",
+        normalizedOrganizationId,
+        record.sourceKey
+      )
+      return [
+        sourceRecordSql(
+          normalizedOrganizationId,
+          manifest,
+          fingerprint,
+          record
+        ),
+        observationSql(
+          normalizedOrganizationId,
+          manifest,
+          fingerprint,
+          "record",
+          record.sourceKey,
+          entityId,
+          record
+        ),
+      ]
+    }),
+    ...manifest.files.flatMap((file) => {
+      const entityId = stableId(
+        "file",
+        normalizedOrganizationId,
+        file.sourceKey
+      )
+      return [
+        archiveFileSql(
+          normalizedOrganizationId,
+          manifest,
+          fingerprint,
+          file
+        ),
+        observationSql(
+          normalizedOrganizationId,
+          manifest,
+          fingerprint,
+          "file",
+          file.sourceKey,
+          entityId,
+          file
+        ),
+      ]
+    }),
+    ...manifest.accessCandidates.flatMap((candidate) => {
+      const entityId = stableId(
+        "access",
+        normalizedOrganizationId,
+        candidate.sourceKey
+      )
+      return [
+        accessCandidateSql(
+          normalizedOrganizationId,
+          manifest,
+          fingerprint,
+          candidate
+        ),
+        observationSql(
+          normalizedOrganizationId,
+          manifest,
+          fingerprint,
+          "access_candidate",
+          candidate.sourceKey,
+          entityId,
+          candidate
+        ),
+      ]
+    }),
+    ...parentChildInvariantSql(
+      normalizedOrganizationId,
+      manifest,
+      fingerprint
+    ),
+    importRunFinalizeSql(normalizedOrganizationId, manifest, fingerprint),
+  ]
+
+  const sql = [
+    "-- Buildertrend staging import generated by Compass.",
+    "-- Execute statements as one D1 batch when applying outside Wrangler.",
+    "-- A partial execution remains in_progress and is safe to replay.",
+    "-- Archive/review only: no access grants, notifications, operational finance, or Sage writes.",
+    `-- Input summary: ${JSON.stringify(summary)}`,
+    ...statements,
+    "",
+  ].join("\n")
+
+  return { sql, statements, summary }
+}


### PR DESCRIPTION
## What changed

- adds organization-scoped Buildertrend staging runs, records, files, access candidates, and immutable run observations
- adds migration `0084_buildertrend_staging_foundation.sql` under a non-colliding table namespace
- adds a normalized manifest parser and SQL generator with deterministic IDs, manifest fingerprints, dry-run support, and atomic CLI output
- separates source-captured evidence from verified evidence and human review fields
- quarantines unresolved, cross-project, evidence, identity, and manifest conflicts without granting access or changing operational records
- adds database guards that prevent observed evidence and audit history from being mutated or deleted
- documents the clean extraction sequence from the divergent cutover work

## Why

The existing cutover work lives in a long-diverged branch mixed with unrelated application changes and obsolete migration numbers. This PR forward-ports only the reusable staging foundation onto current `main`, so later Buildertrend archive and operational-history importers can be recovered in small, reviewable slices.

This is intentionally archive/review-only. It does not create projects, grant portal access, notify users, promote records, write operational financial data, or write to Sage.

## Safety properties

- organization-scoped project and source lookups
- deterministic replay with changed-manifest rejection
- reviewed project, identity, evidence, access, and promotion decisions preserved
- changed references and evidence retained in immutable observation payloads for review
- partial runs remain `in_progress`
- old abandoned staging table names cannot collide with this migration
- direct observation mutation/deletion and observed entity deletion/ID changes are blocked

## Validation

- rebased onto current `main`; migration reconciled after SMS, Sage, and change-order migrations
- 28 focused Buildertrend staging and inventory tests passed
- TypeScript passed
- targeted ESLint passed
- production build passed (existing Turbopack trace warnings remain)
- full clean local D1 migration chain through the staging migration passed before rebase
- CLI dry-run, unknown/duplicate option, same-path, symlink/hardlink, and atomic-output checks passed
- the rebase range-diff matches the previously reviewed implementation except for the required migration renumbering and preservation of the Sage schema registration

Closes the foundation portion of #147 and advances #149.

Follow-up historical warranty/claim landing work is tracked in #271. Parent cutover epic: #144.
