### PR TITLE
feat(buildertrend): normalize job and lead inventories

### DIFF
--- a/docs/wip/buildertrend-cutover-recovery-baseline-2026-07-30.md
+++ b/docs/wip/buildertrend-cutover-recovery-baseline-2026-07-30.md
@@ -61,6 +61,39 @@ Recover after the foundation:
 Every generator must require explicit organization context, validate project
 ownership, produce a reconciliation summary, and support dry-run operation.
 
+The job and lead-opportunity adapter is intentionally separate from proposal
+and payment history. It converts captured inventory rows into the normalized
+staging manifest, but it does not infer a project from a project number or
+name. The normalized manifest then flows through the organization-scoped
+staging SQL generator. Lead proposals remain a later financial-history slice
+so Buildertrend amounts and payment labels cannot be mistaken for Sage
+authority.
+
+Example review-only pipeline:
+
+```bash
+bun scripts/build-buildertrend-inventory-manifest.mjs \
+  --input path/to/captured-jobs.json \
+  --kind jobs \
+  --run-key buildertrend-jobs-YYYY-MM-DD \
+  --source-label "Buildertrend job inventory" \
+  --captured-at 2026-07-30T12:00:00.000Z \
+  --expected-row-count EXPECTED_CAPTURE_COUNT \
+  --output path/to/staging-manifest.json
+
+bun scripts/build-buildertrend-staging-sql.mjs \
+  --input path/to/staging-manifest.json \
+  --organization-id organization-id \
+  --output path/to/review-only-import.sql
+```
+
+Both commands support `--dry-run`. Generated SQL remains confined to
+`buildertrend_staging_*` tables. Empty, failed, count-mismatched, duplicate,
+and identity-inconsistent captures fail closed. The inventory adapter reports
+only whether an explicit project ID was supplied; authoritative organization
+ownership and project resolution occur in the organization-scoped staging
+step.
+
 ### Operational history
 
 Recover in independent, reviewable branches:

--- a/scripts/build-buildertrend-inventory-manifest.mjs
+++ b/scripts/build-buildertrend-inventory-manifest.mjs
@@ -1,0 +1,236 @@
+import {
+  readFile,
+  realpath,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises"
+import { basename, dirname, join, resolve } from "node:path"
+
+import {
+  buildBuildertrendInventoryManifest,
+  buildertrendInventoryKinds,
+} from "../src/lib/buildertrend/inventory-manifest"
+
+function usage() {
+  console.error(
+    "Usage: bun scripts/build-buildertrend-inventory-manifest.mjs " +
+      "--input <snapshot.json> --kind <jobs|lead-opportunities> " +
+      "--run-key <key> --source-label <label> --captured-at <ISO timestamp> " +
+      "[--expected-row-count <count>] [--allow-empty] " +
+      "[--source-method <method>] [--raw-artifact-drive-file-id <id>] " +
+      "[--raw-artifact-drive-url <url>] [--notes <notes>] " +
+      "[--output <manifest.json>] [--dry-run]"
+  )
+}
+
+function parseKind(value) {
+  const normalized = value.replaceAll("-", "_")
+  if (!buildertrendInventoryKinds.includes(normalized)) {
+    throw new Error(`Unsupported --kind: ${value}`)
+  }
+  return normalized
+}
+
+function parseArgs(argv) {
+  const valueOptions = new Set([
+    "input",
+    "kind",
+    "run-key",
+    "source-label",
+    "captured-at",
+    "expected-row-count",
+    "source-method",
+    "raw-artifact-drive-file-id",
+    "raw-artifact-drive-url",
+    "notes",
+    "output",
+  ])
+  const values = new Map()
+  let dryRun = false
+  let allowEmpty = false
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]
+    if (argument === "--dry-run") {
+      if (dryRun) throw new Error("--dry-run may only be provided once")
+      dryRun = true
+      continue
+    }
+    if (argument === "--allow-empty") {
+      if (allowEmpty) {
+        throw new Error("--allow-empty may only be provided once")
+      }
+      allowEmpty = true
+      continue
+    }
+    if (!argument?.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${argument ?? ""}`)
+    }
+    const option = argument.slice(2)
+    if (!valueOptions.has(option)) {
+      throw new Error(`Unknown option: ${argument}`)
+    }
+    if (values.has(option)) {
+      throw new Error(`${argument} may only be provided once`)
+    }
+
+    const value = argv[index + 1]
+    if (!value || value.startsWith("--")) {
+      throw new Error(`${argument} requires a value`)
+    }
+    values.set(option, value)
+    index += 1
+  }
+
+  const input = values.get("input")
+  const kind = values.get("kind")
+  const runKey = values.get("run-key")
+  const sourceLabel = values.get("source-label")
+  const capturedAt = values.get("captured-at")
+  const output = values.get("output")
+  if (
+    !input ||
+    !kind ||
+    !runKey ||
+    !sourceLabel ||
+    !capturedAt ||
+    (!dryRun && !output)
+  ) {
+    throw new Error("Missing a required option")
+  }
+  if (output && resolve(input) === resolve(output)) {
+    throw new Error("--output must not overwrite --input")
+  }
+  const expectedRowCountValue = values.get("expected-row-count")
+  const expectedRowCount =
+    expectedRowCountValue === undefined
+      ? undefined
+      : Number(expectedRowCountValue)
+  if (
+    expectedRowCount !== undefined &&
+    (!Number.isInteger(expectedRowCount) || expectedRowCount < 0)
+  ) {
+    throw new Error("--expected-row-count must be a nonnegative integer")
+  }
+
+  return {
+    dryRun,
+    allowEmpty,
+    input,
+    kind: parseKind(kind),
+    runKey,
+    sourceLabel,
+    capturedAt,
+    sourceMethod: values.get("source-method"),
+    rawArtifactDriveFileId: values.get("raw-artifact-drive-file-id"),
+    rawArtifactDriveUrl: values.get("raw-artifact-drive-url"),
+    notes: values.get("notes"),
+    expectedRowCount,
+    output,
+  }
+}
+
+async function existingFileIdentity(path) {
+  try {
+    const canonicalPath = await realpath(path)
+    const metadata = await stat(canonicalPath)
+    return {
+      canonicalPath,
+      device: metadata.dev,
+      inode: metadata.ino,
+    }
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") {
+      return null
+    }
+    throw error
+  }
+}
+
+async function assertDistinctFiles(input, output) {
+  const inputIdentity = await existingFileIdentity(input)
+  if (!inputIdentity) throw new Error("--input does not exist")
+
+  const outputIdentity = await existingFileIdentity(output)
+  if (
+    outputIdentity &&
+    (outputIdentity.canonicalPath === inputIdentity.canonicalPath ||
+      (outputIdentity.device === inputIdentity.device &&
+        outputIdentity.inode === inputIdentity.inode))
+  ) {
+    throw new Error("--output must not overwrite --input")
+  }
+}
+
+async function writeFileAtomically(output, contents) {
+  const resolvedOutput = resolve(output)
+  const temporaryOutput = join(
+    dirname(resolvedOutput),
+    `.${basename(resolvedOutput)}.${process.pid}.${Date.now()}.tmp`
+  )
+
+  try {
+    await writeFile(temporaryOutput, contents, { flag: "wx" })
+    await rename(temporaryOutput, resolvedOutput)
+  } catch (error) {
+    try {
+      await unlink(temporaryOutput)
+    } catch {
+      // The temporary file may not have been created.
+    }
+    throw error
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  if (!options.dryRun && options.output) {
+    await assertDistinctFiles(options.input, options.output)
+  }
+
+  const snapshot = JSON.parse(await readFile(options.input, "utf8"))
+  const build = buildBuildertrendInventoryManifest(snapshot, {
+    kind: options.kind,
+    runKey: options.runKey,
+    sourceLabel: options.sourceLabel,
+    capturedAt: options.capturedAt,
+    sourceMethod: options.sourceMethod,
+    rawArtifactDriveFileId: options.rawArtifactDriveFileId,
+    rawArtifactDriveUrl: options.rawArtifactDriveUrl,
+    notes: options.notes,
+    allowEmpty: options.allowEmpty,
+    expectedRowCount: options.expectedRowCount,
+  })
+  if (!build.success) {
+    throw new Error(`Invalid Buildertrend inventory:\n${build.errors.join("\n")}`)
+  }
+
+  if (!options.dryRun && options.output) {
+    await writeFileAtomically(
+      options.output,
+      `${JSON.stringify(build.manifest, null, 2)}\n`
+    )
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        dryRun: options.dryRun,
+        input: options.input,
+        output: options.dryRun ? null : options.output,
+        runKey: build.manifest.runKey,
+        ...build.summary,
+      },
+      null,
+      2
+    )
+  )
+}
+
+main().catch((error) => {
+  usage()
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+})

--- a/scripts/fixtures/buildertrend-job-inventory-all-status.json
+++ b/scripts/fixtures/buildertrend-job-inventory-all-status.json
@@ -1,0 +1,32 @@
+{
+  "summary": "All Buildertrend job statuses",
+  "rows": [
+    {
+      "jobHref": "/app/JobPage/1002/1",
+      "cells": [
+        "",
+        "",
+        "N-100-1002 Example Service Project",
+        "100 Example Road",
+        "Example City",
+        "CO",
+        "80000",
+        "Example Manager",
+        "",
+        "555-0100",
+        "owner@example.test",
+        "",
+        "",
+        "",
+        "",
+        "Complete"
+      ],
+      "contactLinks": [
+        {
+          "text": "First Owner & Second Owner",
+          "href": "/app/Contact/502"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/fixtures/buildertrend-job-inventory-visible.json
+++ b/scripts/fixtures/buildertrend-job-inventory-visible.json
@@ -1,0 +1,19 @@
+{
+  "summary": "Visible Buildertrend jobs",
+  "rows": [
+    {
+      "buildertrendJobId": "1001",
+      "name": "O-100-1001 Example Residence",
+      "href": "/app/JobPage/1001/1",
+      "projectId": "project-example",
+      "buildertrendStatus": "Open",
+      "rowText": "O-100-1001 Example Residence | Open",
+      "contacts": [
+        {
+          "text": "Example Owner",
+          "href": "/app/Contact/501"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/fixtures/buildertrend-lead-opportunities.json
+++ b/scripts/fixtures/buildertrend-lead-opportunities.json
@@ -1,0 +1,18 @@
+{
+  "rows": [
+    {
+      "buildertrendLeadId": "2001",
+      "title": "D-100-2001 Example Design Lead",
+      "href": "/app/leads/opportunities/Lead/2001",
+      "status": "Open",
+      "rowText": "D-100-2001 Example Design Lead | Open",
+      "contacts": [
+        {
+          "name": "Example Lead",
+          "buildertrendContactId": "601",
+          "email": "lead@example.test"
+        }
+      ]
+    }
+  ]
+}

--- a/src/lib/buildertrend/__tests__/inventory-manifest-cli.test.ts
+++ b/src/lib/buildertrend/__tests__/inventory-manifest-cli.test.ts
@@ -1,0 +1,153 @@
+import { spawnSync, type SpawnSyncReturns } from "node:child_process"
+import {
+  copyFileSync,
+  existsSync,
+  linkSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { basename, join, resolve } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+const script = resolve(
+  process.cwd(),
+  "scripts/build-buildertrend-inventory-manifest.mjs"
+)
+const fixture = resolve(
+  process.cwd(),
+  "scripts/fixtures/buildertrend-job-inventory-visible.json"
+)
+
+function runCli(args: readonly string[]): SpawnSyncReturns<string> {
+  return spawnSync("bun", [script, ...args], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  })
+}
+
+function requiredArgs(input: string): readonly string[] {
+  return [
+    "--input",
+    input,
+    "--kind",
+    "jobs",
+    "--run-key",
+    "cli-test-jobs",
+    "--source-label",
+    "CLI test jobs",
+    "--captured-at",
+    "2026-07-30T12:00:00.000Z",
+  ]
+}
+
+describe("Buildertrend inventory manifest CLI", () => {
+  let directory: string
+  let input: string
+
+  beforeEach(() => {
+    directory = mkdtempSync(join(tmpdir(), "compass-buildertrend-cli-"))
+    input = join(directory, "input.json")
+    copyFileSync(fixture, input)
+  })
+
+  afterEach(() => {
+    rmSync(directory, { force: true, recursive: true })
+  })
+
+  it("performs a dry run without writing an output file", () => {
+    const output = join(directory, "manifest.json")
+    const result = runCli([
+      ...requiredArgs(input),
+      "--output",
+      output,
+      "--dry-run",
+    ])
+
+    expect(result.status).toBe(0)
+    expect(existsSync(output)).toBe(false)
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      dryRun: true,
+      recordCount: 1,
+      accessCandidateCount: 1,
+    })
+  })
+
+  it("rejects unknown, duplicate, and unsafe output options", () => {
+    const unknown = runCli([...requiredArgs(input), "--unknown"])
+    expect(unknown.status).toBe(1)
+    expect(unknown.stderr).toContain("Unknown option: --unknown")
+
+    const duplicate = runCli([
+      ...requiredArgs(input),
+      "--kind",
+      "jobs",
+      "--dry-run",
+    ])
+    expect(duplicate.status).toBe(1)
+    expect(duplicate.stderr).toContain(
+      "--kind may only be provided once"
+    )
+
+    const samePath = runCli([
+      ...requiredArgs(input),
+      "--output",
+      input,
+    ])
+    expect(samePath.status).toBe(1)
+    expect(samePath.stderr).toContain(
+      "--output must not overwrite --input"
+    )
+  })
+
+  it("rejects hardlink and symlink aliases of the input", () => {
+    const hardlink = join(directory, "hardlink.json")
+    linkSync(input, hardlink)
+    const hardlinkResult = runCli([
+      ...requiredArgs(input),
+      "--output",
+      hardlink,
+    ])
+    expect(hardlinkResult.status).toBe(1)
+    expect(hardlinkResult.stderr).toContain(
+      "--output must not overwrite --input"
+    )
+
+    const symlink = join(directory, "symlink.json")
+    symlinkSync(input, symlink)
+    const symlinkResult = runCli([
+      ...requiredArgs(input),
+      "--output",
+      symlink,
+    ])
+    expect(symlinkResult.status).toBe(1)
+    expect(symlinkResult.stderr).toContain(
+      "--output must not overwrite --input"
+    )
+  })
+
+  it("atomically replaces output without leaving temporary files", () => {
+    const output = join(directory, "manifest.json")
+    writeFileSync(output, "old output")
+    const result = runCli([
+      ...requiredArgs(input),
+      "--output",
+      output,
+    ])
+
+    expect(result.status).toBe(0)
+    expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
+      runKey: "cli-test-jobs",
+      records: [{ sourceKey: "job:1001" }],
+    })
+    expect(
+      readdirSync(directory).filter((name) =>
+        name.startsWith(`.${basename(output)}.`)
+      )
+    ).toEqual([])
+  })
+})

--- a/src/lib/buildertrend/__tests__/inventory-manifest.test.ts
+++ b/src/lib/buildertrend/__tests__/inventory-manifest.test.ts
@@ -320,6 +320,108 @@ describe("Buildertrend inventory manifests", () => {
         "rows.0.contacts.0: Buildertrend contact ID does not match its contact link",
       ],
     })
+
+    const jobAliasMismatch = buildBuildertrendInventoryManifest(
+      {
+        rows: [
+          {
+            buildertrendJobId: "1008",
+            jobId: "9999",
+            name: "Mismatched Job Aliases",
+          },
+        ],
+      },
+      baseOptions
+    )
+    expect(jobAliasMismatch).toEqual({
+      success: false,
+      errors: ["rows.0: Buildertrend job ID aliases disagree"],
+    })
+
+    const jobLinkMismatch = buildBuildertrendInventoryManifest(
+      {
+        rows: [
+          {
+            name: "Mismatched Job Links",
+            href: "/app/JobPage/1008/1",
+            jobHref: "/app/JobPage/9999/1",
+          },
+        ],
+      },
+      baseOptions
+    )
+    expect(jobLinkMismatch).toEqual({
+      success: false,
+      errors: ["rows.0: Buildertrend job links disagree"],
+    })
+
+    const leadAliasMismatch = buildBuildertrendInventoryManifest(
+      {
+        rows: [
+          {
+            buildertrendLeadId: "2002",
+            leadId: "9999",
+            title: "Mismatched Lead Aliases",
+          },
+        ],
+      },
+      { ...baseOptions, kind: "lead_opportunities" }
+    )
+    expect(leadAliasMismatch).toEqual({
+      success: false,
+      errors: ["rows.0: Buildertrend lead ID aliases disagree"],
+    })
+
+    const untrustedContact = buildBuildertrendInventoryManifest(
+      {
+        rows: [
+          {
+            buildertrendJobId: "1008",
+            name: "Untrusted Contact",
+            contacts: [
+              {
+                buildertrendContactId: "700",
+                text: "Example Contact",
+                href: "https://example.test/app/Contact/700",
+              },
+            ],
+          },
+        ],
+      },
+      baseOptions
+    )
+    expect(untrustedContact).toEqual({
+      success: false,
+      errors: [
+        "rows.0.contacts.0: Buildertrend contact link is not trusted",
+      ],
+    })
+
+    const lowercaseContactMismatch =
+      buildBuildertrendInventoryManifest(
+        {
+          rows: [
+            {
+              buildertrendJobId: "1008",
+              name: "Lowercase Contact Link",
+              contacts: [
+                {
+                  buildertrendContactId: "700",
+                  text: "Example Contact",
+                  href: "/app/contact/701",
+                },
+              ],
+            },
+          ],
+        },
+        baseOptions
+      )
+    expect(lowercaseContactMismatch).toEqual({
+      success: false,
+      errors: [
+        "rows.0.contacts.0: Buildertrend contact ID does not match its contact link",
+      ],
+    })
   })
 
   it("produces byte-stable manifests for exact replay", () => {

--- a/src/lib/buildertrend/__tests__/inventory-manifest.test.ts
+++ b/src/lib/buildertrend/__tests__/inventory-manifest.test.ts
@@ -1,0 +1,343 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+import {
+  buildBuildertrendInventoryManifest,
+  type BuildertrendInventoryManifestOptions,
+} from "../inventory-manifest"
+import { buildBuildertrendStagingSql } from "../staging-manifest"
+
+function fixture(name: string): unknown {
+  return JSON.parse(
+    readFileSync(
+      resolve(process.cwd(), "scripts/fixtures", name),
+      "utf8"
+    )
+  )
+}
+
+const baseOptions: BuildertrendInventoryManifestOptions = {
+  kind: "jobs",
+  runKey: "job-inventory-2026-07-30",
+  sourceLabel: "Buildertrend job inventory",
+  capturedAt: "2026-07-30T12:00:00.000Z",
+}
+
+function successfulBuild(
+  input: unknown,
+  options = baseOptions
+) {
+  const build = buildBuildertrendInventoryManifest(input, options)
+  if (!build.success) throw new Error(build.errors.join("\n"))
+  return build
+}
+
+describe("Buildertrend inventory manifests", () => {
+  it("normalizes the visible job capture shape without operational writes", async () => {
+    const build = successfulBuild(
+      fixture("buildertrend-job-inventory-visible.json")
+    )
+
+    expect(build.summary).toEqual({
+      kind: "jobs",
+      recordCount: 1,
+      accessCandidateCount: 1,
+      missingProjectIdCount: 0,
+    })
+    expect(build.manifest.records[0]).toMatchObject({
+      sourceKey: "job:1001",
+      projectId: "project-example",
+      buildertrendJobId: "1001",
+      buildertrendRecordId: "1001",
+      sourceRecordType: "job",
+      title: "O-100-1001 Example Residence",
+    })
+    expect(build.manifest.accessCandidates[0]).toMatchObject({
+      sourceKey: "access:job:1001:501",
+      sourceRecordKey: "job:1001",
+      projectId: "project-example",
+      buildertrendContactId: "501",
+    })
+
+    const sql = await buildBuildertrendStagingSql(
+      "organization-example",
+      build.manifest
+    )
+    expect(sql.sql).toContain("buildertrend_staging_records")
+    const writtenTables = new Set(
+      [
+        ...sql.sql.matchAll(
+          /^\s*(?:INSERT(?:\s+OR\s+\w+)?\s+INTO|UPDATE|DELETE\s+FROM|REPLACE\s+INTO)\s+([a-z_]+)/gim
+        ),
+      ].flatMap((match) => (match[1] ? [match[1].toLowerCase()] : []))
+    )
+    expect(writtenTables).toEqual(
+      new Set([
+        "buildertrend_staging_runs",
+        "buildertrend_staging_records",
+        "buildertrend_staging_files",
+        "buildertrend_staging_access_candidates",
+        "buildertrend_staging_observations",
+      ])
+    )
+    expect(sql.sql).not.toContain("pending_sage")
+    expect(sql.sql).not.toContain("queued_sage")
+    expect(sql.sql).toContain("'not_granted'")
+  })
+
+  it("normalizes the all-status job capture shape without inferring a project", () => {
+    const build = successfulBuild(
+      fixture("buildertrend-job-inventory-all-status.json")
+    )
+
+    expect(build.summary.missingProjectIdCount).toBe(1)
+    expect(build.manifest.records[0]).toMatchObject({
+      sourceKey: "job:1002",
+      projectId: undefined,
+      buildertrendJobId: "1002",
+      title: "N-100-1002 Example Service Project",
+      clientName: "First Owner & Second Owner",
+      contactEmail: "owner@example.test",
+    })
+    expect(build.manifest.accessCandidates[0]).toMatchObject({
+      sourceKey: "access:job:1002:502",
+      contactName: "First Owner & Second Owner",
+    })
+    expect(build.manifest.accessCandidates[0]?.notes).toContain(
+      "split and verify identity"
+    )
+  })
+
+  it("normalizes lead opportunities as archive-only review inputs", () => {
+    const build = successfulBuild(
+      fixture("buildertrend-lead-opportunities.json"),
+      {
+        ...baseOptions,
+        kind: "lead_opportunities",
+        runKey: "lead-inventory-2026-07-30",
+        sourceLabel: "Buildertrend lead opportunity inventory",
+      }
+    )
+
+    expect(build.summary).toEqual({
+      kind: "lead_opportunities",
+      recordCount: 1,
+      accessCandidateCount: 1,
+      missingProjectIdCount: 1,
+    })
+    expect(build.manifest.records[0]).toMatchObject({
+      sourceKey: "lead:2001",
+      buildertrendLeadId: "2001",
+      sourceRecordType: "lead_opportunity",
+      title: "D-100-2001 Example Design Lead",
+    })
+    expect(build.manifest.accessCandidates[0]).toMatchObject({
+      sourceKey: "access:lead:2001:601",
+      sourceRecordKey: "lead:2001",
+      buildertrendAccessRole: "lead_contact",
+      contactName: "Example Lead",
+    })
+  })
+
+  it("keeps reused project numbers distinct by Buildertrend job ID", () => {
+    const build = successfulBuild({
+      rows: [
+        {
+          buildertrendJobId: "1003",
+          name: "O-100 Shared Number",
+        },
+        {
+          buildertrendJobId: "1004",
+          name: "O-100 Shared Number",
+        },
+      ],
+    })
+
+    expect(build.manifest.records.map((record) => record.sourceKey)).toEqual([
+      "job:1003",
+      "job:1004",
+    ])
+    expect(build.summary.missingProjectIdCount).toBe(2)
+  })
+
+  it("rejects duplicate or missing source identities instead of filtering rows", () => {
+    const duplicate = buildBuildertrendInventoryManifest(
+      {
+        rows: [
+          { buildertrendJobId: "1005", name: "Example One" },
+          { buildertrendJobId: "1005", name: "Example Two" },
+        ],
+      },
+      baseOptions
+    )
+    expect(duplicate).toEqual({
+      success: false,
+      errors: ['records contains duplicate sourceKey "job:1005"'],
+    })
+
+    const missing = buildBuildertrendInventoryManifest(
+      { rows: [{ name: "Missing ID" }] },
+      baseOptions
+    )
+    expect(missing).toEqual({
+      success: false,
+      errors: [
+        "rows.0: job inventory rows require a Buildertrend job ID and title",
+      ],
+    })
+  })
+
+  it("rejects untrusted links and invalid capture timestamps", () => {
+    const untrusted = buildBuildertrendInventoryManifest(
+      {
+        rows: [
+          {
+            buildertrendJobId: "1006",
+            name: "Untrusted Link",
+            href: "https://example.test/app/JobPage/1006/1",
+          },
+        ],
+      },
+      baseOptions
+    )
+    expect(untrusted).toEqual({
+      success: false,
+      errors: ["rows.0: Buildertrend job URL is not trusted"],
+    })
+
+    const invalidTime = buildBuildertrendInventoryManifest(
+      {
+        rows: [{ buildertrendJobId: "1006", name: "Invalid Time" }],
+      },
+      { ...baseOptions, capturedAt: "today" }
+    )
+    expect(invalidTime).toMatchObject({ success: false })
+    if (invalidTime.success) throw new Error("Expected an invalid manifest")
+    expect(invalidTime.errors[0]).toContain("capturedAt")
+  })
+
+  it("rejects empty, failed, and incomplete capture envelopes by default", () => {
+    expect(
+      buildBuildertrendInventoryManifest({ rows: [] }, baseOptions)
+    ).toEqual({
+      success: false,
+      errors: [
+        "snapshot.rows: empty captures require an explicit allowEmpty decision",
+      ],
+    })
+    expect(
+      buildBuildertrendInventoryManifest(
+        { rows: [], error: "authentication failed" },
+        { ...baseOptions, allowEmpty: true }
+      )
+    ).toEqual({
+      success: false,
+      errors: ["snapshot: capture reported an error or unsuccessful status"],
+    })
+    expect(
+      buildBuildertrendInventoryManifest(
+        {
+          rows: [{ buildertrendJobId: "1007", name: "Captured Row" }],
+        },
+        { ...baseOptions, expectedRowCount: 2 }
+      )
+    ).toEqual({
+      success: false,
+      errors: ["snapshot.rows: expected 2 rows but captured 1"],
+    })
+
+    const approvedEmpty = buildBuildertrendInventoryManifest(
+      { rows: [], success: true },
+      { ...baseOptions, allowEmpty: true, expectedRowCount: 0 }
+    )
+    expect(approvedEmpty).toMatchObject({
+      success: true,
+      summary: { recordCount: 0 },
+    })
+  })
+
+  it("cross-validates job, lead, and contact identities against links", () => {
+    const jobMismatch = buildBuildertrendInventoryManifest(
+      {
+        rows: [
+          {
+            buildertrendJobId: "1008",
+            name: "Mismatched Job",
+            href: "/app/JobPage/9999/1",
+          },
+        ],
+      },
+      baseOptions
+    )
+    expect(jobMismatch).toEqual({
+      success: false,
+      errors: [
+        "rows.0: Buildertrend job ID does not match its job link",
+      ],
+    })
+
+    const leadMismatch = buildBuildertrendInventoryManifest(
+      {
+        rows: [
+          {
+            buildertrendLeadId: "2002",
+            title: "Mismatched Lead",
+            href: "/app/leads/opportunities/Lead/9999",
+          },
+        ],
+      },
+      { ...baseOptions, kind: "lead_opportunities" }
+    )
+    expect(leadMismatch).toEqual({
+      success: false,
+      errors: [
+        "rows.0: Buildertrend lead ID does not match its lead link",
+      ],
+    })
+
+    const contactMismatch = buildBuildertrendInventoryManifest(
+      {
+        rows: [
+          {
+            buildertrendJobId: "1008",
+            name: "Mismatched Contact",
+            contacts: [
+              {
+                buildertrendContactId: "700",
+                text: "Example Contact",
+                href: "/app/Contact/701",
+              },
+            ],
+          },
+        ],
+      },
+      baseOptions
+    )
+    expect(contactMismatch).toEqual({
+      success: false,
+      errors: [
+        "rows.0.contacts.0: Buildertrend contact ID does not match its contact link",
+      ],
+    })
+  })
+
+  it("produces byte-stable manifests for exact replay", () => {
+    const snapshot = fixture("buildertrend-job-inventory-visible.json")
+    const first = successfulBuild(snapshot)
+    const second = successfulBuild(snapshot)
+
+    expect(JSON.stringify(first.manifest)).toBe(JSON.stringify(second.manifest))
+  })
+
+  it("canonicalizes captured row order before producing a manifest", () => {
+    const rows = [
+      { buildertrendJobId: "1010", name: "Example Alpha" },
+      { buildertrendJobId: "1009", name: "Example Beta" },
+    ]
+    const first = successfulBuild({ rows })
+    const second = successfulBuild({ rows: [...rows].reverse() })
+
+    expect(JSON.stringify(first.manifest)).toBe(JSON.stringify(second.manifest))
+  })
+})

--- a/src/lib/buildertrend/inventory-manifest.ts
+++ b/src/lib/buildertrend/inventory-manifest.ts
@@ -1,0 +1,623 @@
+import { z } from "zod/v4"
+
+import {
+  type BuildertrendStagingManifest,
+  parseBuildertrendStagingManifest,
+} from "./staging-manifest"
+
+const optionalText = z
+  .union([z.string(), z.null()])
+  .transform((value) => value?.trim() || undefined)
+  .optional()
+const nullableText = z
+  .union([z.string(), z.null()])
+  .transform((value) => {
+    if (value === null) return null
+    return value.trim() || null
+  })
+  .optional()
+
+const contactSchema = z
+  .object({
+    buildertrendContactId: optionalText,
+    text: optionalText,
+    name: optionalText,
+    href: optionalText,
+    email: nullableText,
+    phone: nullableText,
+    companyName: nullableText,
+  })
+  .passthrough()
+
+const jobRowSchema = z
+  .object({
+    buildertrendJobId: optionalText,
+    jobId: optionalText,
+    href: optionalText,
+    jobHref: optionalText,
+    name: optionalText,
+    jobName: optionalText,
+    projectId: optionalText,
+    rowText: optionalText,
+    sourceContext: optionalText,
+    pageSummary: optionalText,
+    buildertrendStatus: optionalText,
+    jobStatus: optionalText,
+    address: optionalText,
+    city: optionalText,
+    state: optionalText,
+    zipCode: optionalText,
+    projectManager: optionalText,
+    clientPhone: optionalText,
+    clientEmail: optionalText,
+    scheduleStatus: optionalText,
+    cells: z.array(z.unknown()).optional(),
+    contacts: z.array(contactSchema).optional(),
+    contactLinks: z.array(contactSchema).optional(),
+  })
+  .passthrough()
+
+const leadRowSchema = z
+  .object({
+    buildertrendLeadId: optionalText,
+    leadId: optionalText,
+    href: optionalText,
+    title: optionalText,
+    name: optionalText,
+    projectId: optionalText,
+    rowText: optionalText,
+    sourceStatus: optionalText,
+    status: optionalText,
+    clientName: optionalText,
+    contacts: z.array(contactSchema).optional(),
+  })
+  .passthrough()
+
+const snapshotSchema = z
+  .object({
+    rows: z.array(z.unknown()),
+    error: z.unknown().optional(),
+    success: z.boolean().optional(),
+  })
+  .passthrough()
+
+export const buildertrendInventoryKinds = [
+  "jobs",
+  "lead_opportunities",
+] as const
+
+export type BuildertrendInventoryKind =
+  (typeof buildertrendInventoryKinds)[number]
+
+export type BuildertrendInventoryManifestOptions = {
+  readonly kind: BuildertrendInventoryKind
+  readonly runKey: string
+  readonly sourceLabel: string
+  readonly capturedAt: string
+  readonly sourceMethod?: string
+  readonly rawArtifactDriveFileId?: string
+  readonly rawArtifactDriveUrl?: string
+  readonly notes?: string
+  readonly allowEmpty?: boolean
+  readonly expectedRowCount?: number
+}
+
+export type BuildertrendInventoryManifestSummary = {
+  readonly kind: BuildertrendInventoryKind
+  readonly recordCount: number
+  readonly accessCandidateCount: number
+  readonly missingProjectIdCount: number
+}
+
+export type BuildertrendInventoryManifestBuild =
+  | {
+      readonly success: true
+      readonly manifest: BuildertrendStagingManifest
+      readonly summary: BuildertrendInventoryManifestSummary
+    }
+  | {
+      readonly success: false
+      readonly errors: readonly string[]
+    }
+
+type InventoryRecord = BuildertrendStagingManifest["records"][number]
+type AccessCandidate =
+  BuildertrendStagingManifest["accessCandidates"][number]
+
+function text(value: unknown): string {
+  if (typeof value === "string") return value.trim()
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value).trim()
+  }
+  return ""
+}
+
+function firstText(...values: readonly unknown[]): string | undefined {
+  for (const value of values) {
+    const normalized = text(value)
+    if (normalized) return normalized
+  }
+  return undefined
+}
+
+function cellText(cells: readonly unknown[] | undefined, index: number): string {
+  return text(cells?.[index])
+}
+
+function slug(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 90)
+}
+
+function stableTextCompare(left: string, right: string): number {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}
+
+function departmentCode(value: string): string | undefined {
+  return value.match(/^([OHND])-/)?.[1]
+}
+
+function projectNumber(value: string): string | undefined {
+  return value.match(/^([OHND]-\d+(?:-\d+){0,2})\b/)?.[1]
+}
+
+function buildertrendIdFromHref(
+  href: string | undefined,
+  segment: "JobPage" | "Contact"
+): string | undefined {
+  if (!href) return undefined
+  return href.match(new RegExp(`${segment}/(\\d+)`))?.[1]
+}
+
+function leadIdFromHref(href: string | undefined): string | undefined {
+  if (!href) return undefined
+  return href.match(/\/leads\/opportunities\/Lead\/(\d+)/i)?.[1]
+}
+
+function trustedBuildertrendEntityUrl(
+  href: string | undefined,
+  fallbackPath: string,
+  entityKind: "job" | "lead",
+  entityId: string
+): string | undefined {
+  const candidate = href || fallbackPath
+  try {
+    const url = new URL(candidate, "https://buildertrend.net")
+    const hostname = url.hostname.toLowerCase()
+    const allowed =
+      hostname === "buildertrend.net" ||
+      hostname.endsWith(".buildertrend.net") ||
+      hostname === "buildertrend.com" ||
+      hostname.endsWith(".buildertrend.com")
+    if (
+      !allowed ||
+      url.protocol !== "https:" ||
+      url.username ||
+      url.password ||
+      url.port
+    ) {
+      return undefined
+    }
+    const pathMatches =
+      entityKind === "job"
+        ? new RegExp(`^/app/JobPage/${entityId}(?:/|$)`, "i").test(
+            url.pathname
+          )
+        : new RegExp(
+            `^/app/leads/opportunities/Lead/${entityId}(?:/|$)`,
+            "i"
+          ).test(url.pathname)
+    if (!pathMatches) return undefined
+    return url.toString()
+  } catch {
+    return undefined
+  }
+}
+
+function validBuildertrendId(value: string): boolean {
+  return /^\d+$/.test(value)
+}
+
+function normalizedContacts(
+  contacts: readonly z.infer<typeof contactSchema>[] | undefined
+): readonly z.infer<typeof contactSchema>[] {
+  return contacts ?? []
+}
+
+function contactName(
+  contact: z.infer<typeof contactSchema>
+): string | undefined {
+  return firstText(contact.name, contact.text)
+}
+
+function contactIdentityError(
+  contact: z.infer<typeof contactSchema>
+): string | undefined {
+  const explicitId = contact.buildertrendContactId
+  const hrefId = buildertrendIdFromHref(contact.href, "Contact")
+  if (explicitId && !validBuildertrendId(explicitId)) {
+    return "Buildertrend contact ID must contain only digits"
+  }
+  if (explicitId && hrefId && explicitId !== hrefId) {
+    return "Buildertrend contact ID does not match its contact link"
+  }
+  return undefined
+}
+
+function accessCandidate(
+  scope: "job" | "lead",
+  parentKey: string,
+  projectId: string | undefined,
+  buildertrendId: string,
+  contact: z.infer<typeof contactSchema>
+): AccessCandidate | null {
+  const name = contactName(contact)
+  if (!name) return null
+  const buildertrendContactId =
+    contact.buildertrendContactId ||
+    buildertrendIdFromHref(contact.href, "Contact")
+  const stableContactKey =
+    buildertrendContactId || slug(contact.email || "") || slug(name)
+  if (!stableContactKey) return null
+
+  const combinedName = /\s(?:&|and|\+)\s/i.test(name)
+  return {
+    sourceKey: `access:${scope}:${buildertrendId}:${stableContactKey}`,
+    sourceRecordKey: parentKey,
+    projectId,
+    ...(scope === "job"
+      ? { buildertrendJobId: buildertrendId }
+      : { buildertrendLeadId: buildertrendId }),
+    buildertrendContactId,
+    buildertrendAccessRole:
+      scope === "job" ? "client" : "lead_contact",
+    contactName: name,
+    companyName: contact.companyName,
+    email: contact.email,
+    phone: contact.phone,
+    proposedContactType: "customer",
+    notes: combinedName
+      ? "Combined Buildertrend contact name; split and verify identity before any portal invitation."
+      : "Captured contact candidate only; this import does not grant portal access.",
+  }
+}
+
+function normalizeJob(
+  value: unknown,
+  index: number
+):
+  | {
+      readonly record: InventoryRecord
+      readonly contacts: readonly AccessCandidate[]
+    }
+  | { readonly error: string } {
+  const parsed = jobRowSchema.safeParse(value)
+  if (!parsed.success) {
+    return { error: `rows.${index}: ${parsed.error.issues[0]?.message}` }
+  }
+
+  const row = parsed.data
+  const href = firstText(row.href, row.jobHref)
+  const explicitJobId = firstText(row.buildertrendJobId, row.jobId)
+  const hrefJobId = buildertrendIdFromHref(href, "JobPage")
+  if (explicitJobId && !validBuildertrendId(explicitJobId)) {
+    return {
+      error: `rows.${index}: Buildertrend job ID must contain only digits`,
+    }
+  }
+  if (explicitJobId && hrefJobId && explicitJobId !== hrefJobId) {
+    return {
+      error: `rows.${index}: Buildertrend job ID does not match its job link`,
+    }
+  }
+  const jobId = explicitJobId || hrefJobId
+  const title = firstText(row.name, row.jobName, cellText(row.cells, 2))
+  if (!jobId || !title) {
+    return {
+      error: `rows.${index}: job inventory rows require a Buildertrend job ID and title`,
+    }
+  }
+
+  const sourceUrl = trustedBuildertrendEntityUrl(
+    href,
+    `/app/JobPage/${jobId}/1`,
+    "job",
+    jobId
+  )
+  if (!sourceUrl) {
+    return { error: `rows.${index}: Buildertrend job URL is not trusted` }
+  }
+
+  const sourceKey = `job:${jobId}`
+  const contacts = normalizedContacts(row.contacts ?? row.contactLinks)
+  for (const [contactIndex, contact] of contacts.entries()) {
+    const identityError = contactIdentityError(contact)
+    if (identityError) {
+      return {
+        error: `rows.${index}.contacts.${contactIndex}: ${identityError}`,
+      }
+    }
+  }
+  const names = contacts.map(contactName).filter((name) => Boolean(name))
+  const rowText =
+    firstText(row.rowText) ||
+    (row.cells ?? []).map(text).filter(Boolean).join(" | ")
+  const projectAddress = [
+    firstText(row.address, cellText(row.cells, 3)),
+    firstText(row.city, cellText(row.cells, 4)),
+    firstText(row.state, cellText(row.cells, 5)),
+    firstText(row.zipCode, cellText(row.cells, 6)),
+  ]
+    .filter((part) => Boolean(part))
+    .join(", ")
+  const sourceStatus = firstText(
+    row.buildertrendStatus,
+    row.jobStatus,
+    row.sourceContext,
+    row.pageSummary
+  )
+
+  const record: InventoryRecord = {
+    sourceKey,
+    projectId: row.projectId,
+    sourceScope: "job",
+    sourceRecordType: "job",
+    buildertrendJobId: jobId,
+    buildertrendRecordId: jobId,
+    buildertrendUrl: sourceUrl,
+    title,
+    recordStatus: firstText(row.buildertrendStatus, row.jobStatus),
+    sourceStatus,
+    departmentCode: departmentCode(title),
+    clientName: names.join("; ") || undefined,
+    contactEmail: firstText(row.clientEmail, cellText(row.cells, 10)),
+    searchableText: [
+      title,
+      rowText,
+      projectAddress,
+      firstText(row.projectManager, cellText(row.cells, 7)),
+      names.join(" "),
+    ]
+      .filter((part) => Boolean(part))
+      .join(" | "),
+    normalizedSummary: `Buildertrend job inventory record for ${title}.`,
+    rawPayload: {
+      ...row,
+      extractedProjectNumber: projectNumber(title),
+      projectAddress: projectAddress || null,
+      scheduleStatus: firstText(
+        row.scheduleStatus,
+        cellText(row.cells, 15)
+      ),
+      clientPhone: firstText(row.clientPhone, cellText(row.cells, 9)),
+    },
+    notes:
+      "Archive and reconciliation only. Project linkage must be explicit and reviewed.",
+  }
+
+  return {
+    record,
+    contacts: contacts
+      .map((contact) =>
+        accessCandidate("job", sourceKey, row.projectId, jobId, contact)
+      )
+      .filter((candidate) => candidate !== null),
+  }
+}
+
+function normalizeLead(
+  value: unknown,
+  index: number
+):
+  | {
+      readonly record: InventoryRecord
+      readonly contacts: readonly AccessCandidate[]
+    }
+  | { readonly error: string } {
+  const parsed = leadRowSchema.safeParse(value)
+  if (!parsed.success) {
+    return { error: `rows.${index}: ${parsed.error.issues[0]?.message}` }
+  }
+  const row = parsed.data
+  const explicitLeadId = firstText(row.buildertrendLeadId, row.leadId)
+  const hrefLeadId = leadIdFromHref(row.href)
+  if (explicitLeadId && !validBuildertrendId(explicitLeadId)) {
+    return {
+      error: `rows.${index}: Buildertrend lead ID must contain only digits`,
+    }
+  }
+  if (explicitLeadId && hrefLeadId && explicitLeadId !== hrefLeadId) {
+    return {
+      error: `rows.${index}: Buildertrend lead ID does not match its lead link`,
+    }
+  }
+  const leadId = explicitLeadId || hrefLeadId
+  const title = firstText(row.title, row.name)
+  if (!leadId || !title) {
+    return {
+      error: `rows.${index}: lead opportunity rows require a Buildertrend lead ID and title`,
+    }
+  }
+  const sourceUrl = trustedBuildertrendEntityUrl(
+    row.href,
+    `/app/leads/opportunities/Lead/${leadId}`,
+    "lead",
+    leadId
+  )
+  if (!sourceUrl) {
+    return { error: `rows.${index}: Buildertrend lead URL is not trusted` }
+  }
+
+  const sourceKey = `lead:${leadId}`
+  const contacts = normalizedContacts(row.contacts)
+  for (const [contactIndex, contact] of contacts.entries()) {
+    const identityError = contactIdentityError(contact)
+    if (identityError) {
+      return {
+        error: `rows.${index}.contacts.${contactIndex}: ${identityError}`,
+      }
+    }
+  }
+  const names = contacts.map(contactName).filter((name) => Boolean(name))
+  const record: InventoryRecord = {
+    sourceKey,
+    projectId: row.projectId,
+    sourceScope: "lead",
+    sourceRecordType: "lead_opportunity",
+    buildertrendLeadId: leadId,
+    buildertrendRecordId: leadId,
+    buildertrendUrl: sourceUrl,
+    title,
+    recordStatus: firstText(row.status),
+    sourceStatus: firstText(row.sourceStatus),
+    departmentCode: departmentCode(title),
+    clientName: firstText(row.clientName) || names.join("; ") || undefined,
+    contactName: names.join("; ") || undefined,
+    searchableText: [title, row.rowText, names.join(" ")]
+      .filter((part) => Boolean(part))
+      .join(" | "),
+    normalizedSummary: `Buildertrend lead opportunity for ${title}.`,
+    rawPayload: {
+      ...row,
+      extractedProjectNumber: projectNumber(title),
+    },
+    notes:
+      "Preconstruction archive only. Do not create a project, customer, or invitation from this record.",
+  }
+
+  return {
+    record,
+    contacts: contacts
+      .map((contact) =>
+        accessCandidate("lead", sourceKey, row.projectId, leadId, contact)
+      )
+      .filter((candidate) => candidate !== null),
+  }
+}
+
+function defaultSourceMethod(kind: BuildertrendInventoryKind): string {
+  if (kind === "jobs") return "buildertrend_job_inventory_snapshot"
+  return "buildertrend_lead_opportunity_snapshot"
+}
+
+export function buildBuildertrendInventoryManifest(
+  snapshot: unknown,
+  options: BuildertrendInventoryManifestOptions
+): BuildertrendInventoryManifestBuild {
+  const parsedSnapshot = snapshotSchema.safeParse(snapshot)
+  if (!parsedSnapshot.success) {
+    return {
+      success: false,
+      errors: parsedSnapshot.error.issues.map(
+        (issue) =>
+          `${issue.path.length > 0 ? issue.path.join(".") : "snapshot"}: ${issue.message}`
+      ),
+    }
+  }
+  if (
+    parsedSnapshot.data.success === false ||
+    (parsedSnapshot.data.error !== undefined &&
+      parsedSnapshot.data.error !== null &&
+      parsedSnapshot.data.error !== false &&
+      parsedSnapshot.data.error !== "")
+  ) {
+    return {
+      success: false,
+      errors: ["snapshot: capture reported an error or unsuccessful status"],
+    }
+  }
+  if (
+    options.expectedRowCount !== undefined &&
+    (!Number.isInteger(options.expectedRowCount) ||
+      options.expectedRowCount < 0)
+  ) {
+    return {
+      success: false,
+      errors: ["expectedRowCount: expected a nonnegative integer"],
+    }
+  }
+  if (
+    options.expectedRowCount !== undefined &&
+    parsedSnapshot.data.rows.length !== options.expectedRowCount
+  ) {
+    return {
+      success: false,
+      errors: [
+        `snapshot.rows: expected ${options.expectedRowCount} rows but captured ${parsedSnapshot.data.rows.length}`,
+      ],
+    }
+  }
+  if (parsedSnapshot.data.rows.length === 0 && !options.allowEmpty) {
+    return {
+      success: false,
+      errors: [
+        "snapshot.rows: empty captures require an explicit allowEmpty decision",
+      ],
+    }
+  }
+
+  const records: InventoryRecord[] = []
+  const accessCandidates: AccessCandidate[] = []
+  const errors: string[] = []
+
+  for (const [index, row] of parsedSnapshot.data.rows.entries()) {
+    const normalized =
+      options.kind === "jobs"
+        ? normalizeJob(row, index)
+        : normalizeLead(row, index)
+
+    if ("error" in normalized) {
+      errors.push(normalized.error)
+      continue
+    }
+    records.push(normalized.record)
+    if ("contacts" in normalized) {
+      accessCandidates.push(...normalized.contacts)
+    }
+  }
+
+  if (errors.length > 0) return { success: false, errors }
+
+  records.sort((left, right) =>
+    stableTextCompare(left.sourceKey, right.sourceKey)
+  )
+  accessCandidates.sort((left, right) =>
+    stableTextCompare(left.sourceKey, right.sourceKey)
+  )
+
+  const candidate: unknown = {
+    runKey: options.runKey,
+    sourceMethod: options.sourceMethod || defaultSourceMethod(options.kind),
+    sourceLabel: options.sourceLabel,
+    capturedAt: options.capturedAt,
+    rawArtifactDriveFileId: options.rawArtifactDriveFileId,
+    rawArtifactDriveUrl: options.rawArtifactDriveUrl,
+    notes:
+      options.notes ||
+      "Generated from a captured Buildertrend inventory. Archive and review only.",
+    records,
+    files: [],
+    accessCandidates,
+  }
+  const parsedManifest = parseBuildertrendStagingManifest(candidate)
+  if (!parsedManifest.success) {
+    return { success: false, errors: parsedManifest.errors }
+  }
+
+  return {
+    success: true,
+    manifest: parsedManifest.data,
+    summary: {
+      kind: options.kind,
+      recordCount: records.length,
+      accessCandidateCount: accessCandidates.length,
+      missingProjectIdCount: records.filter((record) => !record.projectId)
+        .length,
+    },
+  }
+}

--- a/src/lib/buildertrend/inventory-manifest.ts
+++ b/src/lib/buildertrend/inventory-manifest.ts
@@ -171,7 +171,7 @@ function buildertrendIdFromHref(
   segment: "JobPage" | "Contact"
 ): string | undefined {
   if (!href) return undefined
-  return href.match(new RegExp(`${segment}/(\\d+)`))?.[1]
+  return href.match(new RegExp(`${segment}/(\\d+)`, "i"))?.[1]
 }
 
 function leadIdFromHref(href: string | undefined): string | undefined {
@@ -179,13 +179,7 @@ function leadIdFromHref(href: string | undefined): string | undefined {
   return href.match(/\/leads\/opportunities\/Lead\/(\d+)/i)?.[1]
 }
 
-function trustedBuildertrendEntityUrl(
-  href: string | undefined,
-  fallbackPath: string,
-  entityKind: "job" | "lead",
-  entityId: string
-): string | undefined {
-  const candidate = href || fallbackPath
+function trustedBuildertrendUrl(candidate: string): URL | undefined {
   try {
     const url = new URL(candidate, "https://buildertrend.net")
     const hostname = url.hostname.toLowerCase()
@@ -203,6 +197,21 @@ function trustedBuildertrendEntityUrl(
     ) {
       return undefined
     }
+    return url
+  } catch {
+    return undefined
+  }
+}
+
+function trustedBuildertrendEntityUrl(
+  href: string | undefined,
+  fallbackPath: string,
+  entityKind: "job" | "lead",
+  entityId: string
+): string | undefined {
+  const url = trustedBuildertrendUrl(href || fallbackPath)
+  if (!url) return undefined
+  try {
     const pathMatches =
       entityKind === "job"
         ? new RegExp(`^/app/JobPage/${entityId}(?:/|$)`, "i").test(
@@ -219,8 +228,21 @@ function trustedBuildertrendEntityUrl(
   }
 }
 
+function trustedBuildertrendContactId(
+  href: string | undefined
+): string | undefined {
+  if (!href) return undefined
+  const url = trustedBuildertrendUrl(href)
+  if (!url) return undefined
+  return url.pathname.match(/\/Contact\/(\d+)(?:\/|$)/i)?.[1]
+}
+
 function validBuildertrendId(value: string): boolean {
   return /^\d+$/.test(value)
+}
+
+function uniqueValues(values: readonly (string | undefined)[]): readonly string[] {
+  return [...new Set(values.filter((value) => value !== undefined))]
 }
 
 function normalizedContacts(
@@ -239,9 +261,12 @@ function contactIdentityError(
   contact: z.infer<typeof contactSchema>
 ): string | undefined {
   const explicitId = contact.buildertrendContactId
-  const hrefId = buildertrendIdFromHref(contact.href, "Contact")
+  const hrefId = trustedBuildertrendContactId(contact.href)
   if (explicitId && !validBuildertrendId(explicitId)) {
     return "Buildertrend contact ID must contain only digits"
+  }
+  if (contact.href && !hrefId) {
+    return "Buildertrend contact link is not trusted"
   }
   if (explicitId && hrefId && explicitId !== hrefId) {
     return "Buildertrend contact ID does not match its contact link"
@@ -260,7 +285,7 @@ function accessCandidate(
   if (!name) return null
   const buildertrendContactId =
     contact.buildertrendContactId ||
-    buildertrendIdFromHref(contact.href, "Contact")
+    trustedBuildertrendContactId(contact.href)
   const stableContactKey =
     buildertrendContactId || slug(contact.email || "") || slug(name)
   if (!stableContactKey) return null
@@ -302,9 +327,26 @@ function normalizeJob(
   }
 
   const row = parsed.data
-  const href = firstText(row.href, row.jobHref)
-  const explicitJobId = firstText(row.buildertrendJobId, row.jobId)
-  const hrefJobId = buildertrendIdFromHref(href, "JobPage")
+  const explicitJobIds = uniqueValues([
+    row.buildertrendJobId,
+    row.jobId,
+  ])
+  if (explicitJobIds.length > 1) {
+    return {
+      error: `rows.${index}: Buildertrend job ID aliases disagree`,
+    }
+  }
+  const hrefs = uniqueValues([row.href, row.jobHref])
+  const hrefJobIds = uniqueValues(
+    hrefs.map((href) => buildertrendIdFromHref(href, "JobPage"))
+  )
+  if (hrefJobIds.length > 1) {
+    return {
+      error: `rows.${index}: Buildertrend job links disagree`,
+    }
+  }
+  const explicitJobId = explicitJobIds[0]
+  const hrefJobId = hrefJobIds[0]
   if (explicitJobId && !validBuildertrendId(explicitJobId)) {
     return {
       error: `rows.${index}: Buildertrend job ID must contain only digits`,
@@ -323,12 +365,20 @@ function normalizeJob(
     }
   }
 
-  const sourceUrl = trustedBuildertrendEntityUrl(
-    href,
-    `/app/JobPage/${jobId}/1`,
-    "job",
-    jobId
+  const normalizedHrefs = (
+    hrefs.length > 0 ? hrefs : [undefined]
+  ).map((href) =>
+    trustedBuildertrendEntityUrl(
+      href,
+      `/app/JobPage/${jobId}/1`,
+      "job",
+      jobId
+    )
   )
+  if (normalizedHrefs.some((href) => !href)) {
+    return { error: `rows.${index}: Buildertrend job URL is not trusted` }
+  }
+  const sourceUrl = normalizedHrefs[0]
   if (!sourceUrl) {
     return { error: `rows.${index}: Buildertrend job URL is not trusted` }
   }
@@ -424,7 +474,16 @@ function normalizeLead(
     return { error: `rows.${index}: ${parsed.error.issues[0]?.message}` }
   }
   const row = parsed.data
-  const explicitLeadId = firstText(row.buildertrendLeadId, row.leadId)
+  const explicitLeadIds = uniqueValues([
+    row.buildertrendLeadId,
+    row.leadId,
+  ])
+  if (explicitLeadIds.length > 1) {
+    return {
+      error: `rows.${index}: Buildertrend lead ID aliases disagree`,
+    }
+  }
+  const explicitLeadId = explicitLeadIds[0]
   const hrefLeadId = leadIdFromHref(row.href)
   if (explicitLeadId && !validBuildertrendId(explicitLeadId)) {
     return {


### PR DESCRIPTION
## What changed

- adds a pure Buildertrend job and lead-opportunity capture-to-manifest adapter
- supports both known visible-job and all-status job capture shapes without creating project shells or guessing project identity
- produces deterministic, source-key-sorted staging manifests that flow through the guarded organization-scoped importer in #272
- captures contact candidates for review only; no customer creation, invitation, portal access, or notifications
- adds a strict CLI with dry-run, expected-row-count, empty/error-envelope rejection, atomic output, and path-alias overwrite protection
- validates trusted Buildertrend URLs and cross-checks every supplied job, lead, and contact identity alias/link
- documents the review-only two-step capture → manifest → staging SQL pipeline

## Safety properties

- no writes outside the five `buildertrend_staging_*` tables
- no project/project-link creation or project-number/name identity inference
- no access grant, directory mutation, notification, financial promotion, or Sage queue/write
- empty, failed, count-mismatched, duplicate, conflicting-alias, untrusted-link, and missing-identity captures fail closed
- explicit project IDs are only reported as supplied; organization ownership is validated later by the staging SQL
- member ordering and nested object-key ordering are canonical and locale-independent for replay fingerprints

## Compatibility evidence

- private dry-run compatibility: 32 captured jobs normalized; no records written
- private dry-run compatibility: 91 captured leads and 90 contact candidates normalized; no records written
- the 129-row all-status capture is intentionally blocked because one source row has neither a Buildertrend job ID nor title; that exception will be reconciled rather than silently dropped or guessed
- no private capture data is included in this branch

## Validation

- focused Vitest/Bun suites: 28 passed
- full suite: 77 files passed; 497 tests passed, 3 skipped
- TypeScript: passed
- targeted ESLint: passed
- production build: passed (existing Turbopack NFT warnings remain)
- CLI dry-run, unknown/duplicate options, same path, hardlink, symlink, atomic replacement, and temp cleanup: passed
- independent read-only review: no P1 findings; all P2 identity findings resolved

This is a stacked draft PR targeting the staging foundation branch. It advances #149 and prepares the identity-review work in #152. Lead proposals/payment history remain a separate Sage-aware financial-history slice rather than being treated as authoritative here.

Parent cutover epic: #144. Foundation: #272.