### PR TITLE
fix(audience): scope project team memberships

### DIFF
--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -27,7 +27,7 @@ import {
   type ProjectAudience,
 } from "@/lib/project-audience-access"
 import { ensureProjectAudienceConversation } from "@/lib/project-audience-conversations"
-import { isVisibleAudienceTeamMember } from "@/lib/project-audience-team"
+import { isAssignedVisibleAudienceTeamMember } from "@/lib/project-audience-team"
 import { isInternalStaffRole } from "@/lib/user-roles"
 import {
   isOwnerScheduleView,
@@ -612,18 +612,18 @@ export async function getProjectAudiencePreview(
       projectRole: projectMembers.role,
       projectAssignedAt: projectMembers.assignedAt,
     })
-    .from(organizationMembers)
-    .innerJoin(users, eq(users.id, organizationMembers.userId))
-    .leftJoin(
-      projectMembers,
+    .from(projectMembers)
+    .innerJoin(users, eq(users.id, projectMembers.userId))
+    .innerJoin(
+      organizationMembers,
       and(
-        eq(projectMembers.userId, users.id),
-        eq(projectMembers.projectId, projectId)
+        eq(organizationMembers.userId, projectMembers.userId),
+        eq(organizationMembers.organizationId, organizationId)
       )
     )
     .where(
       and(
-        eq(organizationMembers.organizationId, organizationId),
+        eq(projectMembers.projectId, projectId),
         eq(users.isActive, true)
       )
     )
@@ -635,10 +635,11 @@ export async function getProjectAudiencePreview(
     new Map(
       internalTeamRows
         .filter((member) =>
-          isVisibleAudienceTeamMember({
+          isAssignedVisibleAudienceTeamMember({
             userId: member.userId,
             email: member.email,
-            role: member.organizationRole,
+            organizationRole: member.organizationRole,
+            projectRole: member.projectRole,
           })
         )
         .map((member) => [member.userId, member])
@@ -649,7 +650,7 @@ export async function getProjectAudiencePreview(
     contactType: "internal",
     displayName: member.displayName ?? member.email,
     companyName: null,
-    role: member.projectRole ?? member.organizationRole,
+    role: member.projectRole,
     trade: null,
     csiDivision: null,
     csiDivisionName: null,

--- a/src/lib/__tests__/project-audience-conversations.test.ts
+++ b/src/lib/__tests__/project-audience-conversations.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  planProjectAudienceMemberReconciliation,
   projectAudienceChannelAudience,
   projectAudienceConversationId,
 } from "@/lib/project-audience-conversations"
@@ -32,5 +33,61 @@ describe("project audience conversations", () => {
       })
     )
     expect(projectAudienceChannelAudience("sub_vendor")).toBe("sub_vendors")
+  })
+
+  it("removes stale cross-project members and their unread state", () => {
+    expect(
+      planProjectAudienceMemberReconciliation({
+        existingMembers: [
+          { userId: "staff-project-a", role: "moderator" },
+          { userId: "staff-project-b", role: "moderator" },
+          { userId: "owner-project-a", role: "member" },
+        ],
+        existingReadStateUserIds: [
+          "staff-project-a",
+          "staff-project-b",
+          "owner-project-a",
+          "orphan-read-state",
+        ],
+        desiredMembers: [
+          { userId: "staff-project-a", role: "moderator" },
+          { userId: "owner-project-a", role: "member" },
+        ],
+      })
+    ).toEqual({
+      addMembers: [],
+      updateMembers: [],
+      removeMemberUserIds: ["staff-project-b"],
+      addReadStateUserIds: [],
+      removeReadStateUserIds: ["staff-project-b", "orphan-read-state"],
+    })
+  })
+
+  it("repairs roles and preserves valid staff and external participants", () => {
+    expect(
+      planProjectAudienceMemberReconciliation({
+        existingMembers: [
+          { userId: "assigned-staff", role: "member" },
+          { userId: "invited-owner", role: "member" },
+          { userId: "wrong-audience-user", role: "member" },
+        ],
+        existingReadStateUserIds: [
+          "assigned-staff",
+          "wrong-audience-user",
+        ],
+        desiredMembers: [
+          { userId: "assigned-staff", role: "moderator" },
+          { userId: "invited-owner", role: "member" },
+        ],
+      })
+    ).toEqual({
+      addMembers: [],
+      updateMembers: [
+        { userId: "assigned-staff", role: "moderator" },
+      ],
+      removeMemberUserIds: ["wrong-audience-user"],
+      addReadStateUserIds: ["invited-owner"],
+      removeReadStateUserIds: ["wrong-audience-user"],
+    })
   })
 })

--- a/src/lib/__tests__/project-audience-team.test.ts
+++ b/src/lib/__tests__/project-audience-team.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { isVisibleAudienceTeamMember } from "@/lib/project-audience-team"
+import {
+  isAssignedVisibleAudienceTeamMember,
+  isVisibleAudienceTeamMember,
+} from "@/lib/project-audience-team"
 
 describe("project audience team", () => {
   it.each([
@@ -19,5 +22,35 @@ describe("project audience team", () => {
     ["external developer", "user-developer", "nicholai@biohazardvfx.com", "admin"],
   ])("hides %s", (_label, userId, email, role) => {
     expect(isVisibleAudienceTeamMember({ userId, email, role })).toBe(false)
+  })
+
+  it("requires an internal project assignment before exposing staff", () => {
+    expect(
+      isAssignedVisibleAudienceTeamMember({
+        userId: "user-project-a",
+        email: "pm@example.com",
+        organizationRole: "project_manager",
+        projectRole: "project_manager",
+      })
+    ).toBe(true)
+    expect(
+      isAssignedVisibleAudienceTeamMember({
+        userId: "user-project-b",
+        email: "office@example.com",
+        organizationRole: "office",
+        projectRole: null,
+      })
+    ).toBe(false)
+  })
+
+  it("rejects an external project role even when the organization role is internal", () => {
+    expect(
+      isAssignedVisibleAudienceTeamMember({
+        userId: "user-cross-role",
+        email: "owner@example.com",
+        organizationRole: "office",
+        projectRole: "owner",
+      })
+    ).toBe(false)
   })
 })

--- a/src/lib/project-audience-conversations.ts
+++ b/src/lib/project-audience-conversations.ts
@@ -1,8 +1,10 @@
-import { and, eq } from "drizzle-orm"
+import { and, eq, inArray, isNull } from "drizzle-orm"
 
 import type { getDb } from "@/db"
 import {
   organizationMembers,
+  projectAccessInvitations,
+  projectMembers,
   projects,
   users,
 } from "@/db/schema"
@@ -11,10 +13,60 @@ import {
   channelReadState,
   channels,
 } from "@/db/schema-conversations"
-import type { ProjectAudience } from "@/lib/project-audience-access"
-import { isVisibleAudienceTeamMember } from "@/lib/project-audience-team"
+import {
+  canUseProjectAudience,
+  type ProjectAudience,
+} from "@/lib/project-audience-access"
+import { isAssignedVisibleAudienceTeamMember } from "@/lib/project-audience-team"
 
 type Db = ReturnType<typeof getDb>
+type ConversationMemberRole = "owner" | "moderator" | "member"
+type DesiredMember = {
+  readonly userId: string
+  readonly role: ConversationMemberRole
+}
+type ExistingMember = DesiredMember
+
+export type ProjectAudienceMemberReconciliation = {
+  readonly addMembers: readonly DesiredMember[]
+  readonly updateMembers: readonly DesiredMember[]
+  readonly removeMemberUserIds: readonly string[]
+  readonly addReadStateUserIds: readonly string[]
+  readonly removeReadStateUserIds: readonly string[]
+}
+
+export function planProjectAudienceMemberReconciliation(input: {
+  readonly existingMembers: readonly ExistingMember[]
+  readonly existingReadStateUserIds: readonly string[]
+  readonly desiredMembers: readonly DesiredMember[]
+}): ProjectAudienceMemberReconciliation {
+  const desiredByUserId = new Map(
+    input.desiredMembers.map((member) => [member.userId, member])
+  )
+  const existingByUserId = new Map(
+    input.existingMembers.map((member) => [member.userId, member])
+  )
+  const existingReadStateUserIds = new Set(input.existingReadStateUserIds)
+
+  return {
+    addMembers: Array.from(desiredByUserId.values()).filter(
+      (member) => !existingByUserId.has(member.userId)
+    ),
+    updateMembers: Array.from(desiredByUserId.values()).filter((member) => {
+      const existing = existingByUserId.get(member.userId)
+      return existing !== undefined && existing.role !== member.role
+    }),
+    removeMemberUserIds: Array.from(existingByUserId.keys()).filter(
+      (userId) => !desiredByUserId.has(userId)
+    ),
+    addReadStateUserIds: Array.from(desiredByUserId.keys()).filter(
+      (userId) => !existingReadStateUserIds.has(userId)
+    ),
+    removeReadStateUserIds: Array.from(existingReadStateUserIds).filter(
+      (userId) => !desiredByUserId.has(userId)
+    ),
+  }
+}
 
 export function projectAudienceChannelAudience(
   audience: ProjectAudience
@@ -47,27 +99,78 @@ function channelName(input: {
 async function ensureMembers(
   db: Db,
   channelId: string,
-  desiredMembers: readonly {
-    readonly userId: string
-    readonly role: "owner" | "moderator" | "member"
-  }[],
+  desiredMembers: readonly DesiredMember[],
   now: string
 ): Promise<void> {
   const existingMembers = await db
-    .select({ userId: channelMembers.userId })
+    .select({
+      userId: channelMembers.userId,
+      role: channelMembers.role,
+    })
     .from(channelMembers)
     .where(eq(channelMembers.channelId, channelId))
 
-  const existingMemberIds = new Set(
-    existingMembers.map((member) => member.userId)
-  )
-  const missingMembers = desiredMembers.filter(
-    (member) => !existingMemberIds.has(member.userId)
-  )
-  if (missingMembers.length > 0) {
+  const existingReadStates = await db
+    .select({ userId: channelReadState.userId })
+    .from(channelReadState)
+    .where(eq(channelReadState.channelId, channelId))
+
+  const reconciliation = planProjectAudienceMemberReconciliation({
+    existingMembers: existingMembers.map((member) => ({
+      userId: member.userId,
+      role:
+        member.role === "owner" || member.role === "moderator"
+          ? member.role
+          : "member",
+    })),
+    existingReadStateUserIds: existingReadStates.map((state) => state.userId),
+    desiredMembers,
+  })
+
+  // Revoke stale access first so a partial reconciliation fails closed.
+  if (reconciliation.removeReadStateUserIds.length > 0) {
+    await db
+      .delete(channelReadState)
+      .where(
+        and(
+          eq(channelReadState.channelId, channelId),
+          inArray(
+            channelReadState.userId,
+            reconciliation.removeReadStateUserIds
+          )
+        )
+      )
+      .run()
+  }
+  if (reconciliation.removeMemberUserIds.length > 0) {
+    await db
+      .delete(channelMembers)
+      .where(
+        and(
+          eq(channelMembers.channelId, channelId),
+          inArray(channelMembers.userId, reconciliation.removeMemberUserIds)
+        )
+      )
+      .run()
+  }
+
+  for (const member of reconciliation.updateMembers) {
+    await db
+      .update(channelMembers)
+      .set({ role: member.role })
+      .where(
+        and(
+          eq(channelMembers.channelId, channelId),
+          eq(channelMembers.userId, member.userId)
+        )
+      )
+      .run()
+  }
+
+  if (reconciliation.addMembers.length > 0) {
     await db
       .insert(channelMembers)
-      .values(missingMembers.map((member) => ({
+      .values(reconciliation.addMembers.map((member) => ({
         id: crypto.randomUUID(),
         channelId,
         userId: member.userId,
@@ -78,23 +181,12 @@ async function ensureMembers(
       .run()
   }
 
-  const existingReadStates = await db
-    .select({ userId: channelReadState.userId })
-    .from(channelReadState)
-    .where(eq(channelReadState.channelId, channelId))
-
-  const existingReadStateUserIds = new Set(
-    existingReadStates.map((state) => state.userId)
-  )
-  const missingReadStates = desiredMembers.filter(
-    (member) => !existingReadStateUserIds.has(member.userId)
-  )
-  if (missingReadStates.length > 0) {
+  if (reconciliation.addReadStateUserIds.length > 0) {
     await db
       .insert(channelReadState)
-      .values(missingReadStates.map((member) => ({
+      .values(reconciliation.addReadStateUserIds.map((userId) => ({
         id: crypto.randomUUID(),
-        userId: member.userId,
+        userId,
         channelId,
         lastReadMessageId: null,
         lastReadAt: now,
@@ -106,19 +198,28 @@ async function ensureMembers(
 
 async function organizationStaffUserIds(
   db: Db,
-  organizationId: string
+  organizationId: string,
+  projectId: string
 ): Promise<readonly string[]> {
   const memberRows = await db
     .select({
       userId: organizationMembers.userId,
       email: users.email,
-      role: organizationMembers.role,
+      organizationRole: organizationMembers.role,
+      projectRole: projectMembers.role,
     })
-    .from(organizationMembers)
-    .innerJoin(users, eq(users.id, organizationMembers.userId))
+    .from(projectMembers)
+    .innerJoin(users, eq(users.id, projectMembers.userId))
+    .innerJoin(
+      organizationMembers,
+      and(
+        eq(organizationMembers.userId, projectMembers.userId),
+        eq(organizationMembers.organizationId, organizationId)
+      )
+    )
     .where(
       and(
-        eq(organizationMembers.organizationId, organizationId),
+        eq(projectMembers.projectId, projectId),
         eq(users.isActive, true)
       )
     )
@@ -127,15 +228,77 @@ async function organizationStaffUserIds(
     new Set(
       memberRows
         .filter((row) =>
-          isVisibleAudienceTeamMember({
+          isAssignedVisibleAudienceTeamMember({
             userId: row.userId,
             email: row.email,
-            role: row.role,
+            organizationRole: row.organizationRole,
+            projectRole: row.projectRole,
           })
         )
         .map((row) => row.userId)
     )
   )
+}
+
+async function externalParticipantUserIds(input: {
+  readonly db: Db
+  readonly projectId: string
+  readonly audience: ProjectAudience
+  readonly contactId: string | null
+  readonly requestedUserId: string | null
+}): Promise<readonly string[]> {
+  const projectMemberRows = await input.db
+    .select({
+      userId: projectMembers.userId,
+      projectRole: projectMembers.role,
+    })
+    .from(projectMembers)
+    .innerJoin(users, eq(users.id, projectMembers.userId))
+    .where(
+      and(
+        eq(projectMembers.projectId, input.projectId),
+        eq(users.isActive, true)
+      )
+    )
+  const eligibleUserIds = new Set(
+    projectMemberRows
+      .filter((member) =>
+        canUseProjectAudience(member.projectRole, input.audience)
+      )
+      .map((member) => member.userId)
+  )
+
+  if (input.audience === "owner") {
+    return Array.from(eligibleUserIds)
+  }
+
+  const acceptedInvitationRows = await input.db
+    .select({ userId: projectAccessInvitations.acceptedBy })
+    .from(projectAccessInvitations)
+    .where(
+      and(
+        eq(projectAccessInvitations.projectId, input.projectId),
+        input.contactId === null
+          ? isNull(projectAccessInvitations.projectContactId)
+          : eq(projectAccessInvitations.projectContactId, input.contactId),
+        eq(projectAccessInvitations.status, "accepted")
+      )
+    )
+  const acceptedUserIds = acceptedInvitationRows.flatMap((invitation) =>
+    invitation.userId === null ? [] : [invitation.userId]
+  )
+  const participantUserIds = new Set(
+    acceptedUserIds.filter((userId) => eligibleUserIds.has(userId))
+  )
+  // Invitation acceptance provisions the channel before the invitation row is
+  // marked accepted. The requested user is still constrained by project role.
+  if (
+    input.requestedUserId !== null &&
+    eligibleUserIds.has(input.requestedUserId)
+  ) {
+    participantUserIds.add(input.requestedUserId)
+  }
+  return Array.from(participantUserIds)
 }
 
 export async function ensureProjectAudienceConversation(input: {
@@ -166,8 +329,16 @@ export async function ensureProjectAudienceConversation(input: {
 
   const staffIds = await organizationStaffUserIds(
     input.db,
-    input.organizationId
+    input.organizationId,
+    input.projectId
   )
+  const externalParticipantIds = await externalParticipantUserIds({
+    db: input.db,
+    projectId: input.projectId,
+    audience: input.audience,
+    contactId: input.contactId,
+    requestedUserId: input.externalUserId,
+  })
   const createdBy = staffIds.includes(input.createdBy)
     ? input.createdBy
     : staffIds[0] ?? input.createdBy
@@ -215,9 +386,10 @@ export async function ensureProjectAudienceConversation(input: {
     userId,
     role: "moderator",
   }))
-  if (input.externalUserId && !staffIds.includes(input.externalUserId)) {
+  for (const externalUserId of externalParticipantIds) {
+    if (staffIds.includes(externalUserId)) continue
     desiredMembers.push({
-      userId: input.externalUserId,
+      userId: externalUserId,
       role: "member",
     })
   }

--- a/src/lib/project-audience-team.ts
+++ b/src/lib/project-audience-team.ts
@@ -19,3 +19,20 @@ export function isVisibleAudienceTeamMember(input: {
     !HIDDEN_AUDIENCE_TEAM_EMAILS.has(normalizedEmail)
   )
 }
+
+export function isAssignedVisibleAudienceTeamMember(input: {
+  readonly userId: string
+  readonly email: string
+  readonly organizationRole: string
+  readonly projectRole: string | null
+}): boolean {
+  return (
+    input.projectRole !== null &&
+    isInternalStaffRole(input.projectRole) &&
+    isVisibleAudienceTeamMember({
+      userId: input.userId,
+      email: input.email,
+      role: input.organizationRole,
+    })
+  )
+}


### PR DESCRIPTION
## What
- require active internal project assignment before staff appear in owner/sub project-team views
- reconcile private audience-channel membership to remove stale cross-project and wrong-role members and read state before restoring valid membership
- keep owners project-scoped and sub/vendor participants contact-scoped through accepted invitations

## Why
Organization-wide staff and append-only channel membership could expose unrelated internal users or leave stale access in external project workspaces.

## Verification
- 14 focused audience/privacy tests passed
- TypeScript passed
- targeted ESLint passed
- git diff --check passed
- source-level security review completed; no actionable findings

Closes #273