### PR TITLE
fix(financials): isolate owner G703 applications

### DIFF
--- a/src/app/actions/project-budget.ts
+++ b/src/app/actions/project-budget.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { and, asc, desc, eq } from "drizzle-orm"
+import { and, asc, desc, eq, sql } from "drizzle-orm"
 
 import { getDb } from "@/db"
 import {
@@ -15,6 +15,13 @@ import {
   effectiveProjectBudgetAudience,
   type ProjectBudgetAudience,
 } from "@/lib/project-budget-audience"
+import {
+  sanitizeBudgetApplicationForOwner,
+  sanitizeBudgetLineForOwner,
+  scopeBudgetLinesToApplication,
+  selectBudgetApplication,
+  type BudgetLineSnapshotRow,
+} from "@/lib/project-budget-snapshot"
 
 export type { ProjectBudgetAudience } from "@/lib/project-budget-audience"
 export type ProjectBudgetDetailMode = "cost_code" | "category"
@@ -130,11 +137,10 @@ function toApplicationItem(
   row: typeof projectBudgetApplications.$inferSelect,
   audience: ProjectBudgetAudience
 ): ProjectBudgetApplicationItem {
-  const ownerSafe = audience === "owner"
   const documentAvailable =
     row.sourceSystem === "google_drive_g702_g703" &&
     Boolean(row.sourceRecordId)
-  return {
+  const application = {
     id: row.id,
     sourceSystem: row.sourceSystem,
     applicationNumber: row.applicationNumber,
@@ -151,24 +157,26 @@ function toApplicationItem(
     balanceToFinish: row.balanceToFinish,
     ownerVisible: row.ownerVisible,
     documentAvailable,
-    sourceUrl: ownerSafe ? null : row.sourceUrl,
-    lastSyncedAt: ownerSafe ? null : row.lastSyncedAt,
+    sourceUrl: row.sourceUrl,
+    lastSyncedAt: row.lastSyncedAt,
   }
+  return audience === "owner"
+    ? sanitizeBudgetApplicationForOwner(application)
+    : application
 }
 
 function toLineItem(
   row: typeof projectBudgetLines.$inferSelect,
   audience: ProjectBudgetAudience
 ): ProjectBudgetLineItem {
-  const ownerSafe = audience === "owner"
-  return {
+  const line = {
     id: row.id,
     sourceSystem: row.sourceSystem,
     costCode: row.costCode,
     csiDivision: row.csiDivision,
     csiDivisionName: row.csiDivisionName,
     description: row.description,
-    notes: ownerSafe ? null : row.notes,
+    notes: row.notes,
     originalEstimate: row.originalEstimate,
     priorChanges: row.priorChanges,
     currentChanges: row.currentChanges,
@@ -180,11 +188,12 @@ function toLineItem(
     percentComplete: row.percentComplete,
     balanceToFinish: row.balanceToFinish,
     retainageHeld: row.retainageHeld,
-    vendorName: ownerSafe ? null : row.vendorName,
+    vendorName: row.vendorName,
     ownerLabel: row.ownerLabel,
     ownerVisible: row.ownerVisible,
-    internalNotes: ownerSafe ? null : row.internalNotes,
+    internalNotes: row.internalNotes,
   }
+  return audience === "owner" ? sanitizeBudgetLineForOwner(line) : line
 }
 
 function percent(numerator: number, denominator: number): number {
@@ -309,7 +318,8 @@ function buildOwnerCategoryLines(
 
 export async function getProjectBudgetSummary(
   projectId: string,
-  audience: ProjectBudgetAudience = "internal"
+  audience: ProjectBudgetAudience = "internal",
+  applicationId?: string
 ): Promise<ProjectBudgetSummary> {
   const access = await verifyProjectAccess(projectId)
   const effectiveAudience = effectiveProjectBudgetAudience(
@@ -321,43 +331,145 @@ export async function getProjectBudgetSummary(
       ? ownerDetailMode(access.projectNumber)
       : "cost_code"
 
-  const applicationRows = await access.db
-    .select()
-    .from(projectBudgetApplications)
-    .where(
-      effectiveAudience === "owner"
-        ? and(
-            eq(projectBudgetApplications.projectId, projectId),
-            eq(projectBudgetApplications.ownerVisible, true)
-          )
-        : eq(projectBudgetApplications.projectId, projectId)
-    )
-    .orderBy(
-      desc(projectBudgetApplications.periodTo),
-      desc(projectBudgetApplications.createdAt)
-    )
+  const applications =
+    effectiveAudience === "owner"
+      ? (
+          await access.db
+            .select({
+              id: projectBudgetApplications.id,
+              sourceSystem: projectBudgetApplications.sourceSystem,
+              applicationNumber: projectBudgetApplications.applicationNumber,
+              periodTo: projectBudgetApplications.periodTo,
+              status: projectBudgetApplications.status,
+              originalContractSum:
+                projectBudgetApplications.originalContractSum,
+              netChanges: projectBudgetApplications.netChanges,
+              contractSumToDate: projectBudgetApplications.contractSumToDate,
+              totalCompletedStoredToDate:
+                projectBudgetApplications.totalCompletedStoredToDate,
+              retainageHeld: projectBudgetApplications.retainageHeld,
+              totalEarnedLessRetainage:
+                projectBudgetApplications.totalEarnedLessRetainage,
+              previousCertificates:
+                projectBudgetApplications.previousCertificates,
+              currentPaymentDue: projectBudgetApplications.currentPaymentDue,
+              balanceToFinish: projectBudgetApplications.balanceToFinish,
+              ownerVisible: projectBudgetApplications.ownerVisible,
+              documentAvailable: sql<number>`
+                case
+                  when ${projectBudgetApplications.sourceSystem} = 'google_drive_g702_g703'
+                    and ${projectBudgetApplications.sourceRecordId} is not null
+                  then 1
+                  else 0
+                end
+              `,
+            })
+            .from(projectBudgetApplications)
+            .where(
+              and(
+                eq(projectBudgetApplications.projectId, projectId),
+                eq(projectBudgetApplications.ownerVisible, true)
+              )
+            )
+            .orderBy(
+              desc(projectBudgetApplications.periodTo),
+              desc(projectBudgetApplications.createdAt)
+            )
+        ).map((row) =>
+          sanitizeBudgetApplicationForOwner({
+            ...row,
+            documentAvailable: Boolean(row.documentAvailable),
+            sourceUrl: null,
+            lastSyncedAt: null,
+          })
+        )
+      : (
+          await access.db
+            .select()
+            .from(projectBudgetApplications)
+            .where(eq(projectBudgetApplications.projectId, projectId))
+            .orderBy(
+              desc(projectBudgetApplications.periodTo),
+              desc(projectBudgetApplications.createdAt)
+            )
+        ).map((row) => toApplicationItem(row, effectiveAudience))
 
-  const applications = applicationRows.map((row) =>
-    toApplicationItem(row, effectiveAudience)
+  const currentApplication = selectBudgetApplication(
+    applications,
+    applicationId
   )
-  const currentApplication = applications[0] ?? null
 
-  const lineRows = await access.db
-    .select()
-    .from(projectBudgetLines)
-    .where(
-      effectiveAudience === "owner"
-        ? and(
-            eq(projectBudgetLines.projectId, projectId),
-            eq(projectBudgetLines.ownerVisible, true)
-          )
-        : eq(projectBudgetLines.projectId, projectId)
-    )
-    .orderBy(asc(projectBudgetLines.sortOrder), asc(projectBudgetLines.costCode))
-
-  const sourceLines = lineRows.map((row) =>
-    toLineItem(row, effectiveAudience)
-  )
+  const sourceLines: readonly ProjectBudgetLineItem[] = currentApplication
+    ? effectiveAudience === "owner"
+      ? scopeBudgetLinesToApplication(
+          (
+            await access.db
+              .select({
+                applicationId: projectBudgetLines.applicationId,
+                id: projectBudgetLines.id,
+                sourceSystem: projectBudgetLines.sourceSystem,
+                costCode: projectBudgetLines.costCode,
+                csiDivision: projectBudgetLines.csiDivision,
+                csiDivisionName: projectBudgetLines.csiDivisionName,
+                description: projectBudgetLines.description,
+                originalEstimate: projectBudgetLines.originalEstimate,
+                priorChanges: projectBudgetLines.priorChanges,
+                currentChanges: projectBudgetLines.currentChanges,
+                totalChanges: projectBudgetLines.totalChanges,
+                adjustedEstimate: projectBudgetLines.adjustedEstimate,
+                priorCosts: projectBudgetLines.priorCosts,
+                currentCosts: projectBudgetLines.currentCosts,
+                totalCosts: projectBudgetLines.totalCosts,
+                percentComplete: projectBudgetLines.percentComplete,
+                balanceToFinish: projectBudgetLines.balanceToFinish,
+                retainageHeld: projectBudgetLines.retainageHeld,
+                ownerLabel: projectBudgetLines.ownerLabel,
+                ownerVisible: projectBudgetLines.ownerVisible,
+              })
+              .from(projectBudgetLines)
+              .where(
+                and(
+                  eq(projectBudgetLines.projectId, projectId),
+                  eq(projectBudgetLines.applicationId, currentApplication.id),
+                  eq(projectBudgetLines.ownerVisible, true)
+                )
+              )
+              .orderBy(
+                asc(projectBudgetLines.sortOrder),
+                asc(projectBudgetLines.costCode)
+              )
+          ).map(
+            (row): BudgetLineSnapshotRow => ({
+              ...row,
+              notes: null,
+              vendorName: null,
+              internalNotes: null,
+            })
+          ),
+          currentApplication.id
+        ).map((row) => sanitizeBudgetLineForOwner(row))
+      : scopeBudgetLinesToApplication(
+          (
+            await access.db
+              .select()
+              .from(projectBudgetLines)
+              .where(
+                and(
+                  eq(projectBudgetLines.projectId, projectId),
+                  eq(projectBudgetLines.applicationId, currentApplication.id)
+                )
+              )
+              .orderBy(
+                asc(projectBudgetLines.sortOrder),
+                asc(projectBudgetLines.costCode)
+              )
+          ).map((row) => ({
+            ...toLineItem(row, effectiveAudience),
+            applicationId: row.applicationId,
+          })),
+          currentApplication.id
+        )
+    : []
   const allLines =
     detailMode === "category" ? buildOwnerCategoryLines(sourceLines) : sourceLines
   const divisions = buildDivisions(allLines)

--- a/src/lib/__tests__/project-budget-snapshot.test.ts
+++ b/src/lib/__tests__/project-budget-snapshot.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  sanitizeBudgetApplicationForOwner,
+  sanitizeBudgetLineForOwner,
+  scopeBudgetLinesToApplication,
+  selectBudgetApplication,
+  type BudgetApplicationView,
+  type BudgetLineSnapshotRow,
+} from "@/lib/project-budget-snapshot"
+
+function application(
+  id: string,
+  ownerVisible = true
+): BudgetApplicationView {
+  return {
+    id,
+    sourceSystem: "sage",
+    applicationNumber: id,
+    periodTo: "2026-07-30",
+    status: "current",
+    originalContractSum: 1_000,
+    netChanges: 0,
+    contractSumToDate: 1_000,
+    totalCompletedStoredToDate: 400,
+    retainageHeld: 40,
+    totalEarnedLessRetainage: 360,
+    previousCertificates: 200,
+    currentPaymentDue: 160,
+    balanceToFinish: 600,
+    ownerVisible,
+    documentAvailable: true,
+    sourceUrl: "https://internal.example/source",
+    lastSyncedAt: "2026-07-30T12:00:00.000Z",
+  }
+}
+
+function line(
+  id: string,
+  applicationId: string | null
+): BudgetLineSnapshotRow {
+  return {
+    applicationId,
+    id,
+    sourceSystem: "sage",
+    costCode: "01 00 00",
+    csiDivision: "01",
+    csiDivisionName: "General Requirements",
+    description: id,
+    notes: "Internal source note",
+    originalEstimate: 1_000,
+    priorChanges: 0,
+    currentChanges: 0,
+    totalChanges: 0,
+    adjustedEstimate: 1_000,
+    priorCosts: 200,
+    currentCosts: 100,
+    totalCosts: 300,
+    percentComplete: 30,
+    balanceToFinish: 700,
+    retainageHeld: 30,
+    vendorName: "Internal vendor",
+    ownerLabel: "General Requirements",
+    ownerVisible: true,
+    internalNotes: "Internal reconciliation note",
+  }
+}
+
+describe("project budget snapshot boundary", () => {
+  it("never mixes lines from two pay applications", () => {
+    const applications = [application("pay-app-2"), application("pay-app-1")]
+    const selected = selectBudgetApplication(applications, "pay-app-1")
+    const lines = [
+      line("line-current", "pay-app-2"),
+      line("line-selected", "pay-app-1"),
+      line("line-unassigned", null),
+    ]
+
+    expect(selected?.id).toBe("pay-app-1")
+    expect(
+      scopeBudgetLinesToApplication(lines, selected?.id ?? null).map(
+        (item) => item.id
+      )
+    ).toEqual(["line-selected"])
+  })
+
+  it("does not fall back when a requested application is unavailable", () => {
+    const selected = selectBudgetApplication(
+      [application("published")],
+      "internal-draft"
+    )
+
+    expect(selected).toBeNull()
+    expect(scopeBudgetLinesToApplication([line("line", "published")], null)).toEqual(
+      []
+    )
+  })
+
+  it("removes internal source and reconciliation detail from owner data", () => {
+    const safeApplication = sanitizeBudgetApplicationForOwner(
+      application("pay-app-1")
+    )
+    const safeLine = sanitizeBudgetLineForOwner(line("line-1", "pay-app-1"))
+
+    expect(safeApplication.sourceUrl).toBeNull()
+    expect(safeApplication.lastSyncedAt).toBeNull()
+    expect(safeLine.notes).toBeNull()
+    expect(safeLine.vendorName).toBeNull()
+    expect(safeLine.internalNotes).toBeNull()
+  })
+})

--- a/src/lib/project-budget-snapshot.ts
+++ b/src/lib/project-budget-snapshot.ts
@@ -1,0 +1,94 @@
+export type BudgetApplicationView = {
+  readonly id: string
+  readonly sourceSystem: string
+  readonly applicationNumber: string
+  readonly periodTo: string | null
+  readonly status: string
+  readonly originalContractSum: number
+  readonly netChanges: number
+  readonly contractSumToDate: number
+  readonly totalCompletedStoredToDate: number
+  readonly retainageHeld: number
+  readonly totalEarnedLessRetainage: number
+  readonly previousCertificates: number
+  readonly currentPaymentDue: number
+  readonly balanceToFinish: number
+  readonly ownerVisible: boolean
+  readonly documentAvailable: boolean
+  readonly sourceUrl: string | null
+  readonly lastSyncedAt: string | null
+}
+
+export type BudgetLineView = {
+  readonly id: string
+  readonly sourceSystem: string
+  readonly costCode: string
+  readonly csiDivision: string
+  readonly csiDivisionName: string
+  readonly description: string
+  readonly notes: string | null
+  readonly originalEstimate: number
+  readonly priorChanges: number
+  readonly currentChanges: number
+  readonly totalChanges: number
+  readonly adjustedEstimate: number
+  readonly priorCosts: number
+  readonly currentCosts: number
+  readonly totalCosts: number
+  readonly percentComplete: number
+  readonly balanceToFinish: number
+  readonly retainageHeld: number
+  readonly vendorName: string | null
+  readonly ownerLabel: string | null
+  readonly ownerVisible: boolean
+  readonly internalNotes: string | null
+}
+
+export type BudgetLineSnapshotRow = BudgetLineView & {
+  readonly applicationId: string | null
+}
+
+export function selectBudgetApplication<
+  TApplication extends { readonly id: string },
+>(
+  applications: readonly TApplication[],
+  requestedApplicationId?: string
+): TApplication | null {
+  if (!requestedApplicationId) return applications[0] ?? null
+  return (
+    applications.find(
+      (application) => application.id === requestedApplicationId
+    ) ?? null
+  )
+}
+
+export function scopeBudgetLinesToApplication<
+  TLine extends { readonly applicationId: string | null },
+>(
+  lines: readonly TLine[],
+  applicationId: string | null
+): readonly TLine[] {
+  if (!applicationId) return []
+  return lines.filter((line) => line.applicationId === applicationId)
+}
+
+export function sanitizeBudgetApplicationForOwner(
+  application: BudgetApplicationView
+): BudgetApplicationView {
+  return {
+    ...application,
+    sourceUrl: null,
+    lastSyncedAt: null,
+  }
+}
+
+export function sanitizeBudgetLineForOwner(
+  line: BudgetLineView
+): BudgetLineView {
+  return {
+    ...line,
+    notes: null,
+    vendorName: null,
+    internalNotes: null,
+  }
+}


### PR DESCRIPTION
## What
- scope every G703 line read to both the selected pay application and project
- fail closed when a requested application is not visible to the viewer
- use owner-safe SQL projections that omit raw source identifiers, source URLs, sync metadata, notes, vendors, and internal reconciliation detail
- add a second application-level guard against mixed pay-app lines

## Why
The prior query selected one application but could load lines from every application on the project, creating incorrect G703 totals and an external-data disclosure risk.

## Verification
- 10 focused budget/audience/component tests passed
- TypeScript passed
- targeted ESLint passed
- git diff --check passed
- source-level security review completed; no actionable findings

## Follow-up
A separate additive migration will create physically immutable/versioned owner publications. This PR intentionally strengthens the current owner-visible boundary without widening into that financial schema change.

Closes #274