### PR TITLE
feat(tasks): unify assignee and company pickers

### DIFF
--- a/src/app/actions/project-contacts.ts
+++ b/src/app/actions/project-contacts.ts
@@ -18,6 +18,7 @@ import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { isDemoUser } from "@/lib/demo"
 import { requireOrg } from "@/lib/org-scope"
+import { requireFeaturePermission } from "@/lib/permission-enforcement"
 import { requirePermission } from "@/lib/permissions"
 import {
   projectContactAccessStatus,
@@ -618,8 +619,9 @@ export async function getProjectContactsSummary(
 export async function getProjectTaskAssigneeOptions(
   projectId: string
 ): Promise<ProjectTaskAssigneeOptions> {
-  const db = await verifyProjectAccess(projectId)
   const user = await requireAuth()
+  await requireFeaturePermission(user, "tasks", "update")
+  const db = await verifyProjectAccess(projectId)
   const orgId = requireOrg(user)
 
   const projectContactRows = await db
@@ -898,6 +900,7 @@ export async function addDirectoryContactToProjectForTask(
   try {
     const user = await requireAuth()
     if (isDemoUser(user.id)) return { success: false, error: "DEMO_READ_ONLY" }
+    await requireFeaturePermission(user, "tasks", "update")
 
     const orgId = requireOrg(user)
     const db = await verifyProjectAccess(projectId, "update")

--- a/src/app/actions/work-calendar.ts
+++ b/src/app/actions/work-calendar.ts
@@ -23,6 +23,7 @@ import { calendarDetailLevel } from "@/lib/google/calendar/sync-policy"
 import { createNotificationEvent } from "@/lib/notifications/events"
 import { eventAttendeeNotificationRecipients } from "@/lib/notifications/audience"
 import { requireOrg } from "@/lib/org-scope"
+import { canFeature } from "@/lib/permission-enforcement"
 import {
   can,
   canManageWorkCalendarEvents,
@@ -246,7 +247,7 @@ export async function getWorkCalendar(
   const canCreateEvents =
     canManageEvents && can(user, "schedule", "create")
   const canCreateTodos =
-    !isDemoUser(user.id) && isInternalStaffRole(user.role)
+    !isDemoUser(user.id) && (await canFeature(user, "tasks", "update"))
 
   const { env } = await getCloudflareContext()
   const db = getDb(env.DB)

--- a/src/app/dashboard/projects/[id]/todos/page.tsx
+++ b/src/app/dashboard/projects/[id]/todos/page.tsx
@@ -11,7 +11,7 @@ import { getProjects } from "@/app/actions/projects"
 import { ProjectTodosView } from "@/components/projects/project-todos-view"
 import { requireAuth } from "@/lib/auth"
 import { isDemoUser } from "@/lib/demo"
-import { can } from "@/lib/permissions"
+import { canFeature } from "@/lib/permission-enforcement"
 
 export default async function ProjectTodosPage({
   params,
@@ -37,7 +37,7 @@ export default async function ProjectTodosPage({
   const initialItemId =
     typeof query.item === "string" ? query.item : query.item?.[0] ?? null
   const canManage =
-    !isDemoUser(user.id) && can(user, "project", "update")
+    !isDemoUser(user.id) && (await canFeature(user, "tasks", "update"))
   let assigneeOptions: ProjectTaskAssigneeOption[] = []
   if (canManage) {
     const assigneeData = await getProjectTaskAssigneeOptions(id)

--- a/src/components/projects/__tests__/project-company-picker.test.ts
+++ b/src/components/projects/__tests__/project-company-picker.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
+import { projectCompanyOptions } from "@/components/projects/project-company-picker"
+
+function option(
+  id: string,
+  companyName: string | null
+): ProjectTaskAssigneeOption {
+  return {
+    id,
+    label: id,
+    name: id,
+    companyName,
+    email: null,
+    phone: null,
+    contactType: "subcontractor",
+    source: "project",
+    projectContactId: id,
+    directoryContactId: null,
+    projectAccess: true,
+  }
+}
+
+describe("projectCompanyOptions", () => {
+  it("returns trimmed, sorted, case-insensitively unique company names", () => {
+    expect(
+      projectCompanyOptions([
+        option("one", " Zenith Electric "),
+        option("two", "acme framing"),
+        option("three", "ACME Framing"),
+        option("four", null),
+        option("five", " "),
+      ])
+    ).toEqual(["acme framing", "Zenith Electric"])
+  })
+})

--- a/src/components/projects/project-company-picker.tsx
+++ b/src/components/projects/project-company-picker.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import * as React from "react"
+import { IconCheck, IconChevronDown, IconPlus } from "@tabler/icons-react"
+
+import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+
+type ProjectCompanyPickerProps = {
+  readonly value: string
+  readonly options: readonly ProjectTaskAssigneeOption[]
+  readonly onValueChange: (value: string) => void
+  readonly placeholder?: string
+  readonly className?: string
+  readonly disabled?: boolean
+  readonly clearLabel?: string
+}
+
+function normalizeChoice(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+}
+
+export function projectCompanyOptions(
+  options: readonly ProjectTaskAssigneeOption[]
+): readonly string[] {
+  const companyByKey = new Map<string, string>()
+
+  for (const option of options) {
+    const companyName = option.companyName?.trim() ?? ""
+    const key = normalizeChoice(companyName)
+    if (!key || companyByKey.has(key)) continue
+    companyByKey.set(key, companyName)
+  }
+
+  return [...companyByKey.values()].sort((left, right) =>
+    left.localeCompare(right)
+  )
+}
+
+export function ProjectCompanyPicker({
+  value,
+  options,
+  onValueChange,
+  placeholder = "Choose company or type a name...",
+  className,
+  disabled = false,
+  clearLabel = "Clear",
+}: ProjectCompanyPickerProps): React.ReactElement {
+  const [open, setOpen] = React.useState(false)
+  const [query, setQuery] = React.useState("")
+  const normalizedQuery = normalizeChoice(query)
+  const normalizedValue = normalizeChoice(value)
+  const companies = projectCompanyOptions(options).filter((company) =>
+    normalizeChoice(company).includes(normalizedQuery)
+  )
+
+  function selectCompany(company: string): void {
+    onValueChange(company)
+    setQuery("")
+    setOpen(false)
+  }
+
+  function useTypedCompany(): void {
+    const typedCompany = query.trim()
+    if (!typedCompany) return
+
+    onValueChange(typedCompany)
+    setQuery("")
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={disabled}
+          className={cn(
+            "h-9 w-full justify-between bg-background px-3 text-left font-normal",
+            !value && "text-muted-foreground",
+            className
+          )}
+        >
+          <span className="min-w-0 truncate">{value || placeholder}</span>
+          <IconChevronDown className="size-4 shrink-0 opacity-60" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[min(28rem,calc(100vw-3rem))] p-0"
+      >
+        <div className="border-b p-3">
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search companies or type a name..."
+            autoFocus
+          />
+        </div>
+        <div className="max-h-72 overflow-y-auto p-2">
+          {companies.length > 0 ? (
+            companies.map((company) => (
+              <button
+                key={normalizeChoice(company)}
+                type="button"
+                onClick={() => selectCompany(company)}
+                className="flex w-full items-center justify-between gap-3 rounded-md px-2 py-2 text-left text-sm hover:bg-accent"
+              >
+                <span className="min-w-0 truncate font-medium">{company}</span>
+                {normalizeChoice(company) === normalizedValue && (
+                  <IconCheck className="size-4 shrink-0" />
+                )}
+              </button>
+            ))
+          ) : (
+            <p className="px-2 py-3 text-sm text-muted-foreground">
+              No matching companies.
+            </p>
+          )}
+        </div>
+        <div className="flex items-center justify-between gap-2 border-t p-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              onValueChange("")
+              setQuery("")
+              setOpen(false)
+            }}
+          >
+            {clearLabel}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={!query.trim()}
+            onClick={useTypedCompany}
+          >
+            <IconPlus className="size-4" />
+            Use typed company
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/projects/project-task-create-button.tsx
+++ b/src/components/projects/project-task-create-button.tsx
@@ -4,7 +4,6 @@ import * as React from "react"
 import { useRouter } from "next/navigation"
 import {
   IconCheck,
-  IconChevronDown,
   IconListCheck,
   IconPlus,
 } from "@tabler/icons-react"
@@ -17,6 +16,8 @@ import {
   createProjectTask,
   type ProjectTaskRecordType,
 } from "@/app/actions/project-operations"
+import { ProjectAssigneePicker } from "@/components/projects/project-assignee-picker"
+import { ProjectCompanyPicker } from "@/components/projects/project-company-picker"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -29,13 +30,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover"
 import { Textarea } from "@/components/ui/textarea"
-import { cn } from "@/lib/utils"
 
 type TaskStatus =
   | { readonly kind: "idle" }
@@ -90,25 +85,6 @@ function normalizeChoice(value: string): string {
     .trim()
 }
 
-function optionMatches(
-  option: ProjectTaskAssigneeOption,
-  normalizedQuery: string
-): boolean {
-  if (!normalizedQuery) return true
-
-  return normalizeChoice(
-    [
-      option.name,
-      option.label,
-      option.companyName,
-      option.email,
-      option.contactType,
-    ]
-      .filter((value): value is string => Boolean(value))
-      .join(" ")
-  ).includes(normalizedQuery)
-}
-
 export function ProjectTaskCreateButton({
   projectId,
   sourceLabel,
@@ -127,8 +103,6 @@ export function ProjectTaskCreateButton({
 }: ProjectTaskCreateButtonProps): React.ReactElement {
   const router = useRouter()
   const [open, setOpen] = React.useState(false)
-  const [assigneePickerOpen, setAssigneePickerOpen] = React.useState(false)
-  const [assigneeQuery, setAssigneeQuery] = React.useState("")
   const [selectedAssigneeId, setSelectedAssigneeId] = React.useState<
     string | null
   >(null)
@@ -149,17 +123,6 @@ export function ProjectTaskCreateButton({
   const [dueDate, setDueDate] = React.useState(defaultDueDate ?? "")
   const [priority, setPriority] = React.useState(defaultPriority)
   const [status, setStatus] = React.useState<TaskStatus>({ kind: "idle" })
-  const normalizedAssigneeQuery = normalizeChoice(assigneeQuery)
-  const projectAssigneeOptions = assigneeOptions.filter(
-    (option) =>
-      option.source === "project" &&
-      optionMatches(option, normalizedAssigneeQuery)
-  )
-  const directoryAssigneeOptions = assigneeOptions.filter(
-    (option) =>
-      option.source === "directory" &&
-      optionMatches(option, normalizedAssigneeQuery)
-  )
   const selectedAssignee = selectedAssigneeId
     ? assigneeOptions.find((option) => option.id === selectedAssigneeId) ?? null
     : (() => {
@@ -179,29 +142,13 @@ export function ProjectTaskCreateButton({
   const hasAssigneeText = assigneeName.trim().length > 0
   const hasUnmatchedAssignee = hasAssigneeText && !selectedAssignee
 
-  function selectAssignee(option: ProjectTaskAssigneeOption): void {
-    setSelectedAssigneeId(option.id)
-    setAssigneeName(option.name)
-    setCompanyName(option.companyName ?? "")
-    setAssigneeQuery("")
-    setAssigneePickerOpen(false)
-  }
-
-  function useTypedAssignee(): void {
-    const typedName = assigneeQuery.trim()
-    if (!typedName) return
-
-    setSelectedAssigneeId(null)
-    setAssigneeName(typedName)
-    setAssigneeQuery("")
-    setAssigneePickerOpen(false)
-  }
-
-  function clearAssignee(): void {
-    setSelectedAssigneeId(null)
-    setAssigneeName("")
-    setCompanyName("")
-    setAssigneeQuery("")
+  function changeAssignee(
+    value: string,
+    option: ProjectTaskAssigneeOption | null
+  ): void {
+    setSelectedAssigneeId(option?.id ?? null)
+    setAssigneeName(value)
+    setCompanyName(option?.companyName ?? "")
   }
 
   async function saveTask(input?: {
@@ -352,137 +299,21 @@ export function ProjectTaskCreateButton({
 
           <div className="grid gap-4 sm:grid-cols-3">
             <div className="space-y-2">
-              <Label htmlFor={`task-assignee-${sourceRecordId ?? sourceLabel}`}>
-                Assigned to
-              </Label>
-              <Popover
-                open={assigneePickerOpen}
-                onOpenChange={setAssigneePickerOpen}
-              >
-                <PopoverTrigger asChild>
-                  <Button
-                    id={`task-assignee-${sourceRecordId ?? sourceLabel}`}
-                    type="button"
-                    variant="outline"
-                    className={cn(
-                      "h-10 w-full justify-between rounded-md bg-background px-3 text-left font-normal",
-                      !assigneeName && "text-muted-foreground"
-                    )}
-                  >
-                    <span className="min-w-0 truncate">
-                      {assigneeName || "Choose contact..."}
-                    </span>
-                    <IconChevronDown className="size-4 shrink-0 opacity-60" />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent
-                  align="start"
-                  className="w-[min(28rem,calc(100vw-3rem))] p-0"
-                >
-                  <div className="border-b p-3">
-                    <Input
-                      value={assigneeQuery}
-                      onChange={(event) => setAssigneeQuery(event.target.value)}
-                      placeholder="Search contacts or type a name..."
-                      autoFocus
-                    />
-                  </div>
-                  <div className="max-h-72 overflow-y-auto p-2">
-                    {projectAssigneeOptions.length > 0 && (
-                      <div className="space-y-1">
-                        <p className="px-2 py-1 text-xs font-medium text-muted-foreground">
-                          Project &amp; team contacts
-                        </p>
-                        {projectAssigneeOptions.map((option) => (
-                          <button
-                            key={option.id}
-                            type="button"
-                            onClick={() => selectAssignee(option)}
-                            className="flex w-full items-start justify-between gap-3 rounded-md px-2 py-2 text-left text-sm hover:bg-accent"
-                          >
-                            <span className="min-w-0">
-                              <span className="block truncate font-medium">
-                                {option.name}
-                              </span>
-                              <span className="block truncate text-xs text-muted-foreground">
-                                {option.companyName ?? option.contactType}
-                              </span>
-                            </span>
-                            {selectedAssigneeId === option.id && (
-                              <IconCheck className="mt-0.5 size-4 shrink-0" />
-                            )}
-                          </button>
-                        ))}
-                      </div>
-                    )}
-
-                    {directoryAssigneeOptions.length > 0 && (
-                      <div className="mt-2 space-y-1 border-t pt-2">
-                        <p className="px-2 py-1 text-xs font-medium text-muted-foreground">
-                          Directory contacts
-                        </p>
-                        {directoryAssigneeOptions.map((option) => (
-                          <button
-                            key={option.id}
-                            type="button"
-                            onClick={() => selectAssignee(option)}
-                            className="flex w-full items-start justify-between gap-3 rounded-md px-2 py-2 text-left text-sm hover:bg-accent"
-                          >
-                            <span className="min-w-0">
-                              <span className="block truncate font-medium">
-                                {option.name}
-                              </span>
-                              <span className="block truncate text-xs text-muted-foreground">
-                                Not on this project yet
-                              </span>
-                            </span>
-                            {selectedAssigneeId === option.id && (
-                              <IconCheck className="mt-0.5 size-4 shrink-0" />
-                            )}
-                          </button>
-                        ))}
-                      </div>
-                    )}
-
-                    {normalizedAssigneeQuery &&
-                      projectAssigneeOptions.length === 0 &&
-                      directoryAssigneeOptions.length === 0 && (
-                        <p className="px-2 py-3 text-sm text-muted-foreground">
-                          No matching contacts.
-                        </p>
-                      )}
-                  </div>
-                  <div className="flex items-center justify-between gap-2 border-t p-2">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={clearAssignee}
-                    >
-                      Clear
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      disabled={!assigneeQuery.trim()}
-                      onClick={useTypedAssignee}
-                    >
-                      Use typed name
-                    </Button>
-                  </div>
-                </PopoverContent>
-              </Popover>
+              <Label>Assigned to</Label>
+              <ProjectAssigneePicker
+                value={assigneeName}
+                options={assigneeOptions}
+                onValueChange={changeAssignee}
+                className="h-10"
+              />
             </div>
             <div className="space-y-2">
-              <Label htmlFor={`task-company-${sourceRecordId ?? sourceLabel}`}>
-                Company
-              </Label>
-              <Input
-                id={`task-company-${sourceRecordId ?? sourceLabel}`}
+              <Label>Company</Label>
+              <ProjectCompanyPicker
                 value={companyName}
-                onChange={(event) => setCompanyName(event.target.value)}
-                placeholder="Optional"
+                options={assigneeOptions}
+                onValueChange={setCompanyName}
+                className="h-10"
               />
             </div>
             <div className="space-y-2">

--- a/src/components/projects/project-todo-edit-dialog.tsx
+++ b/src/components/projects/project-todo-edit-dialog.tsx
@@ -13,6 +13,7 @@ import {
   type ProjectTaskRecordType,
 } from "@/app/actions/project-operations"
 import { ProjectAssigneePicker } from "@/components/projects/project-assignee-picker"
+import { ProjectCompanyPicker } from "@/components/projects/project-company-picker"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -255,20 +256,20 @@ export function ProjectTodoEditDialog({
                 options={assigneeOptions}
                 onValueChange={(value, option) => {
                   setAssigneeName(value)
-                  if (option?.companyName) setCompanyName(option.companyName)
+                  setCompanyName(option?.companyName ?? "")
                 }}
                 className="h-10"
                 disabled={archived}
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor={`todo-company-${item.id}`}>Company</Label>
-              <Input
-                id={`todo-company-${item.id}`}
+              <Label>Company</Label>
+              <ProjectCompanyPicker
                 value={companyName}
-                onChange={(event) => setCompanyName(event.target.value)}
+                options={assigneeOptions}
+                onValueChange={setCompanyName}
+                className="h-10"
                 disabled={archived}
-                placeholder="Optional"
               />
             </div>
           </div>

--- a/src/components/schedule/work-calendar-todo-dialog.tsx
+++ b/src/components/schedule/work-calendar-todo-dialog.tsx
@@ -5,8 +5,14 @@ import { IconClipboardPlus } from "@tabler/icons-react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 
+import {
+  getProjectTaskAssigneeOptions,
+  type ProjectTaskAssigneeOption,
+} from "@/app/actions/project-contacts"
 import { createProjectTask } from "@/app/actions/project-operations"
 import type { ProjectRow } from "@/app/actions/work-calendar"
+import { ProjectAssigneePicker } from "@/components/projects/project-assignee-picker"
+import { ProjectCompanyPicker } from "@/components/projects/project-company-picker"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -53,6 +59,43 @@ export function WorkCalendarTodoDialog({
   const [companyName, setCompanyName] = React.useState("")
   const [dueDate, setDueDate] = React.useState(today)
   const [priority, setPriority] = React.useState("normal")
+  const [assigneeOptions, setAssigneeOptions] = React.useState<
+    readonly ProjectTaskAssigneeOption[]
+  >([])
+  const [loadingAssignees, setLoadingAssignees] = React.useState(false)
+
+  React.useEffect(() => {
+    if (!open || !projectId) {
+      setAssigneeOptions([])
+      setLoadingAssignees(false)
+      return
+    }
+
+    let cancelled = false
+    setLoadingAssignees(true)
+    setAssigneeOptions([])
+
+    void getProjectTaskAssigneeOptions(projectId)
+      .then((result) => {
+        if (cancelled) return
+        setAssigneeOptions([
+          ...result.projectContacts,
+          ...result.directoryContacts,
+        ])
+      })
+      .catch(() => {
+        if (cancelled) return
+        setAssigneeOptions([])
+        toast.error("Unable to load project contacts.")
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingAssignees(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [open, projectId])
 
   function reset(): void {
     setProjectId(defaultProjectId ?? "")
@@ -120,7 +163,14 @@ export function WorkCalendarTodoDialog({
           <div className="grid gap-4 py-5">
             <div className="grid gap-2">
               <Label htmlFor="calendar-todo-project">Project</Label>
-              <Select value={projectId} onValueChange={setProjectId}>
+              <Select
+                value={projectId}
+                onValueChange={(value) => {
+                  setProjectId(value)
+                  setAssigneeName("")
+                  setCompanyName("")
+                }}
+              >
                 <SelectTrigger id="calendar-todo-project">
                   <SelectValue placeholder="Select a project" />
                 </SelectTrigger>
@@ -146,25 +196,36 @@ export function WorkCalendarTodoDialog({
             </div>
             <div className="grid gap-2 sm:grid-cols-2">
               <div className="grid gap-2">
-                <Label htmlFor="calendar-todo-assignee">Assignee</Label>
-                <Input
-                  id="calendar-todo-assignee"
+                <Label>Assignee</Label>
+                <ProjectAssigneePicker
                   value={assigneeName}
-                  onChange={(event) =>
-                    setAssigneeName(event.currentTarget.value)
+                  options={assigneeOptions}
+                  onValueChange={(value, option) => {
+                    setAssigneeName(value)
+                    setCompanyName(option?.companyName ?? "")
+                  }}
+                  placeholder={
+                    loadingAssignees
+                      ? "Loading project contacts..."
+                      : "Choose contact or type a name..."
                   }
-                  placeholder="Name"
+                  className="h-10"
+                  disabled={loadingAssignees}
                 />
               </div>
               <div className="grid gap-2">
-                <Label htmlFor="calendar-todo-company">Company</Label>
-                <Input
-                  id="calendar-todo-company"
+                <Label>Company</Label>
+                <ProjectCompanyPicker
                   value={companyName}
-                  onChange={(event) =>
-                    setCompanyName(event.currentTarget.value)
+                  options={assigneeOptions}
+                  onValueChange={setCompanyName}
+                  placeholder={
+                    loadingAssignees
+                      ? "Loading project companies..."
+                      : "Choose company or type a name..."
                   }
-                  placeholder="Optional"
+                  className="h-10"
+                  disabled={loadingAssignees}
                 />
               </div>
             </div>


### PR DESCRIPTION
## What
- use shared searchable Assignee and Company pickers in To-Do create, edit, and Work Calendar flows
- preserve explicit manual-entry fallback for both fields
- clear stale company state when assignee or project changes
- lazily load project-specific contact options in Work Calendar
- require tasks:update before returning the organization directory or assigning a directory contact to a project

## Why
The To-Do surfaces were inconsistent, and some still used free-text fields. Directory-backed dropdowns must also remain unavailable to guest/project-reader roles.

## Verification
- 19 focused task/calendar/picker tests passed
- TypeScript passed
- targeted ESLint passed
- git diff --check passed
- source-level permission review completed; no actionable findings

Closes #275