### PR TITLE
fix(buildertrend): require reviewed owner message ids

### DIFF
--- a/scripts/build-buildertrend-owner-history-promotion.mjs
+++ b/scripts/build-buildertrend-owner-history-promotion.mjs
@@ -1,36 +1,158 @@
-import { writeFile } from "node:fs/promises"
+import { readFile, writeFile } from "node:fs/promises"
+import { pathToFileURL } from "node:url"
+
+const MANIFEST_SCHEMA_VERSION = 1
+const OWNER_VISIBLE_DECISION = "owner_visible"
+const SAFE_IDENTIFIER_PATTERN = /^[A-Za-z0-9._:-]+$/
 
 function sql(value) {
   return `'${String(value).replaceAll("'", "''")}'`
 }
 
-const [outputPath, projectId, buildertrendJobId, ...participantTerms] =
-  process.argv.slice(2)
-
-if (
-  !outputPath ||
-  !projectId ||
-  !buildertrendJobId ||
-  participantTerms.length === 0
-) {
-  throw new Error(
-    "Usage: node scripts/build-buildertrend-owner-history-promotion.mjs " +
-      "<output.sql> <project-id> <buildertrend-job-id> <participant> [participant...]"
-  )
+function requireNonEmptyString(value, fieldName) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${fieldName} must be a non-empty string`)
+  }
+  return value.trim()
 }
 
-const archiveChannelId = `bt-message-archive-${buildertrendJobId}`
-const ownerChannelId = `project-owner-${projectId}`
-const participantFilter = participantTerms
-  .map(
-    (term) =>
-      `lower(source.content) LIKE ${sql(`%${term.trim().toLowerCase()}%`)}`
-  )
-  .join(" OR ")
+function requireSafeIdentifier(value, fieldName) {
+  const identifier = requireNonEmptyString(value, fieldName)
+  if (!SAFE_IDENTIFIER_PATTERN.test(identifier)) {
+    throw new Error(
+      `${fieldName} may contain only letters, numbers, periods, colons, underscores, and hyphens`
+    )
+  }
+  return identifier
+}
 
-const statement = `
--- Promote only Buildertrend messages that identify an approved owner
--- participant. The staff archive remains unchanged.
+function requireReviewTimestamp(value) {
+  const reviewedAt = requireNonEmptyString(value, "reviewedAt")
+  if (!Number.isFinite(Date.parse(reviewedAt))) {
+    throw new Error("reviewedAt must be an ISO-8601 timestamp")
+  }
+  return reviewedAt
+}
+
+export function parseReviewManifest(value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("review manifest must be a JSON object")
+  }
+
+  if (value.schemaVersion !== MANIFEST_SCHEMA_VERSION) {
+    throw new Error(
+      `schemaVersion must be ${MANIFEST_SCHEMA_VERSION}; refusing an unknown review contract`
+    )
+  }
+  if (value.reviewDecision !== OWNER_VISIBLE_DECISION) {
+    throw new Error(
+      `reviewDecision must be ${OWNER_VISIBLE_DECISION}; ambiguous rows remain quarantined`
+    )
+  }
+
+  const projectId = requireSafeIdentifier(value.projectId, "projectId")
+  const buildertrendJobId = requireSafeIdentifier(
+    value.buildertrendJobId,
+    "buildertrendJobId"
+  )
+  const reviewedAt = requireReviewTimestamp(value.reviewedAt)
+  const reviewedBy = requireNonEmptyString(value.reviewedBy, "reviewedBy")
+
+  if (!Array.isArray(value.sourceMessageIds)) {
+    throw new Error("sourceMessageIds must be an array")
+  }
+
+  const expectedPrefix = `bt-message-${buildertrendJobId}-`
+  const sourceMessageIds = value.sourceMessageIds.map((candidate, index) => {
+    const sourceMessageId = requireSafeIdentifier(
+      candidate,
+      `sourceMessageIds[${index}]`
+    )
+    if (
+      !sourceMessageId.startsWith(expectedPrefix) ||
+      sourceMessageId.length === expectedPrefix.length
+    ) {
+      throw new Error(
+        `sourceMessageIds[${index}] must identify a message from Buildertrend job ${buildertrendJobId}`
+      )
+    }
+    return sourceMessageId
+  })
+
+  if (new Set(sourceMessageIds).size !== sourceMessageIds.length) {
+    throw new Error("sourceMessageIds must not contain duplicates")
+  }
+
+  return {
+    schemaVersion: MANIFEST_SCHEMA_VERSION,
+    reviewDecision: OWNER_VISIBLE_DECISION,
+    projectId,
+    buildertrendJobId,
+    reviewedAt,
+    reviewedBy,
+    sourceMessageIds,
+  }
+}
+
+function promotedMessageId(buildertrendJobId, sourceMessageId) {
+  return `bt-owner-history-${buildertrendJobId}-${sourceMessageId.slice(
+    `bt-message-${buildertrendJobId}-`.length
+  )}`
+}
+
+function sqlCommentValue(value) {
+  return value.replace(/[\u0000-\u001f\u007f]+/g, " ")
+}
+
+export function buildPromotionStatement(manifest) {
+  const archiveChannelId = `bt-message-archive-${manifest.buildertrendJobId}`
+  const ownerChannelId = `project-owner-${manifest.projectId}`
+  const sourcePrefix = `bt-message-${manifest.buildertrendJobId}-`
+  const promotedPrefix = `bt-owner-history-${manifest.buildertrendJobId}-`
+  const sourceMessageIdList =
+    manifest.sourceMessageIds.length > 0
+      ? manifest.sourceMessageIds.map(sql).join(",\n    ")
+      : null
+  const promotedMessageIds = manifest.sourceMessageIds.map((sourceMessageId) =>
+    promotedMessageId(manifest.buildertrendJobId, sourceMessageId)
+  )
+  const retainedPromotionClause =
+    promotedMessageIds.length > 0
+      ? `\n  AND id NOT IN (\n    ${promotedMessageIds.map(sql).join(",\n    ")}\n  )`
+      : ""
+  const reviewedSourceClause =
+    sourceMessageIdList === null
+      ? "  AND 0 = 1"
+      : `  AND source.id IN (\n    ${sourceMessageIdList}\n  )`
+
+  return `
+-- Buildertrend owner-history promotion review
+-- project: ${manifest.projectId}
+-- Buildertrend job: ${manifest.buildertrendJobId}
+-- reviewed by: ${sqlCommentValue(manifest.reviewedBy)}
+-- reviewed at: ${manifest.reviewedAt}
+-- reviewed source records: ${manifest.sourceMessageIds.length}
+--
+-- This reconciliation is intentionally silent. It writes no notification,
+-- mention, email, SMS, or unread-state records. Unreviewed source messages
+-- remain quarantined in the staff-only Buildertrend archive. Apply this whole
+-- file as one D1 batch; the source archive remains the recovery authority.
+
+-- Remove any earlier owner-channel promotion that is not in this exact,
+-- explicitly reviewed set. The source archive rows are never deleted.
+DELETE FROM messages
+WHERE channel_id = ${sql(ownerChannelId)}
+  AND substr(id, 1, ${promotedPrefix.length}) = ${sql(promotedPrefix)}${retainedPromotionClause}
+  AND EXISTS (
+    SELECT 1
+    FROM channels AS target_channel
+    WHERE target_channel.id = ${sql(ownerChannelId)}
+      AND target_channel.project_id = ${sql(manifest.projectId)}
+      AND target_channel.audience = 'clients'
+  );
+
+-- Copy only reviewed source record IDs. Channel/project/organization checks
+-- prevent a valid-looking ID from crossing project or organization boundaries.
 INSERT INTO messages (
   id,
   channel_id,
@@ -47,8 +169,8 @@ INSERT INTO messages (
   created_at
 )
 SELECT
-  'bt-owner-history-${buildertrendJobId}-' ||
-    replace(source.id, 'bt-message-${buildertrendJobId}-', ''),
+  ${sql(promotedPrefix)} ||
+    substr(source.id, ${sourcePrefix.length + 1}),
   ${sql(ownerChannelId)},
   NULL,
   source.user_id,
@@ -62,22 +184,58 @@ SELECT
   NULL,
   source.created_at
 FROM messages AS source
+INNER JOIN channels AS archive_channel
+  ON archive_channel.id = source.channel_id
+INNER JOIN channels AS target_channel
+  ON target_channel.id = ${sql(ownerChannelId)}
 WHERE source.channel_id = ${sql(archiveChannelId)}
-  AND (${participantFilter})
+${reviewedSourceClause}
+  AND archive_channel.project_id = ${sql(manifest.projectId)}
+  AND archive_channel.audience = 'organization'
+  AND target_channel.project_id = ${sql(manifest.projectId)}
+  AND target_channel.audience = 'clients'
+  AND target_channel.organization_id = archive_channel.organization_id
 ON CONFLICT(id) DO UPDATE SET
   content = excluded.content,
   content_html = excluded.content_html,
-  created_at = excluded.created_at;
+  created_at = excluded.created_at
+WHERE messages.channel_id = excluded.channel_id;
 `.trimStart()
+}
 
-await writeFile(outputPath, statement, "utf8")
+async function main() {
+  const [outputPath, manifestPath, ...unexpectedArguments] =
+    process.argv.slice(2)
 
-console.log(
-  JSON.stringify({
-    outputPath,
-    projectId,
-    archiveChannelId,
-    ownerChannelId,
-    participantTerms,
-  })
-)
+  if (!outputPath || !manifestPath || unexpectedArguments.length > 0) {
+    throw new Error(
+      "Usage: node scripts/build-buildertrend-owner-history-promotion.mjs " +
+        "<output.sql> <review-manifest.json>"
+    )
+  }
+
+  const manifest = parseReviewManifest(
+    JSON.parse(await readFile(manifestPath, "utf8"))
+  )
+  const statement = buildPromotionStatement(manifest)
+  await writeFile(outputPath, statement, "utf8")
+
+  console.log(
+    JSON.stringify({
+      outputPath,
+      projectId: manifest.projectId,
+      archiveChannelId: `bt-message-archive-${manifest.buildertrendJobId}`,
+      ownerChannelId: `project-owner-${manifest.projectId}`,
+      reviewedSourceMessageCount: manifest.sourceMessageIds.length,
+      quarantinePolicy: "unreviewed_archive_only",
+      notificationPolicy: "silent_reconciliation",
+    })
+  )
+}
+
+if (
+  typeof process.argv[1] === "string" &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main()
+}

--- a/src/lib/__tests__/buildertrend-owner-history-promotion.test.ts
+++ b/src/lib/__tests__/buildertrend-owner-history-promotion.test.ts
@@ -1,0 +1,318 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { spawnSync } from "node:child_process"
+import { DatabaseSync } from "node:sqlite"
+import { describe, expect, it } from "vitest"
+
+type Manifest = {
+  readonly schemaVersion: 1
+  readonly reviewDecision: "owner_visible"
+  readonly projectId: string
+  readonly buildertrendJobId: string
+  readonly reviewedAt: string
+  readonly reviewedBy: string
+  readonly sourceMessageIds: readonly string[]
+}
+
+const scriptPath = resolve(
+  process.cwd(),
+  "scripts/build-buildertrend-owner-history-promotion.mjs"
+)
+
+function reviewManifest(
+  overrides: Partial<Manifest> = {}
+): Manifest {
+  return {
+    schemaVersion: 1,
+    reviewDecision: "owner_visible",
+    projectId: "project-a",
+    buildertrendJobId: "job-a",
+    reviewedAt: "2026-07-30T18:00:00.000Z",
+    reviewedBy: "privacy-reviewer@example.com",
+    sourceMessageIds: ["bt-message-job-a-reviewed-1"],
+    ...overrides,
+  }
+}
+
+async function generateSql(manifest: Manifest): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "compass-bt-promotion-"))
+  const manifestPath = join(directory, "review.json")
+  const outputPath = join(directory, "promotion.sql")
+  await writeFile(manifestPath, JSON.stringify(manifest), "utf8")
+
+  const result = spawnSync(
+    process.execPath,
+    [scriptPath, outputPath, manifestPath],
+    { encoding: "utf8" }
+  )
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout)
+  }
+  return readFile(outputPath, "utf8")
+}
+
+function createPromotionDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:")
+  db.exec(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE channels (
+      id TEXT PRIMARY KEY,
+      organization_id TEXT NOT NULL,
+      project_id TEXT,
+      audience TEXT NOT NULL
+    );
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      channel_id TEXT NOT NULL,
+      thread_id TEXT,
+      user_id TEXT NOT NULL,
+      content TEXT NOT NULL,
+      content_html TEXT,
+      edited_at TEXT,
+      deleted_at TEXT,
+      deleted_by TEXT,
+      is_pinned INTEGER NOT NULL DEFAULT 0,
+      reply_count INTEGER NOT NULL DEFAULT 0,
+      last_reply_at TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE notifications (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL
+    );
+    CREATE TABLE channel_read_state (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      channel_id TEXT NOT NULL,
+      unread_count INTEGER NOT NULL
+    );
+  `)
+  return db
+}
+
+function insertMessage(
+  db: DatabaseSync,
+  input: {
+    readonly id: string
+    readonly channelId: string
+    readonly content: string
+  }
+): void {
+  db.prepare(
+    `INSERT INTO messages (
+      id, channel_id, user_id, content, content_html, created_at
+    ) VALUES (?, ?, 'archive-user', ?, NULL, '2026-07-01T00:00:00.000Z')`
+  ).run(input.id, input.channelId, input.content)
+}
+
+describe("Buildertrend owner-history promotion", () => {
+  it("promotes reviewed IDs only and removes earlier ambiguous promotions", async () => {
+    const db = createPromotionDb()
+    db.exec(`
+      INSERT INTO channels VALUES
+        ('bt-message-archive-job-a', 'org-a', 'project-a', 'organization'),
+        ('project-owner-project-a', 'org-a', 'project-a', 'clients');
+      INSERT INTO notifications VALUES ('existing-notice', 'owner-a');
+      INSERT INTO channel_read_state VALUES
+        ('existing-read', 'owner-a', 'project-owner-project-a', 2);
+    `)
+    insertMessage(db, {
+      id: "bt-message-job-a-reviewed-1",
+      channelId: "bt-message-archive-job-a",
+      content: "Reviewed owner history",
+    })
+    insertMessage(db, {
+      id: "bt-message-job-a-ambiguous-2",
+      channelId: "bt-message-archive-job-a",
+      content: "An owner name appearing here is not authorization",
+    })
+    insertMessage(db, {
+      id: "bt-owner-history-job-a-ambiguous-2",
+      channelId: "project-owner-project-a",
+      content: "Previously promoted by unsafe text matching",
+    })
+
+    db.exec(await generateSql(reviewManifest()))
+
+    const ownerMessages = db
+      .prepare(
+        "SELECT id, content FROM messages WHERE channel_id = ? ORDER BY id"
+      )
+      .all("project-owner-project-a")
+    expect(ownerMessages).toEqual([
+      {
+        id: "bt-owner-history-job-a-reviewed-1",
+        content: "Reviewed owner history",
+      },
+    ])
+    expect(
+      db.prepare("SELECT COUNT(*) AS count FROM notifications").get()
+    ).toEqual({ count: 1 })
+    expect(
+      db.prepare("SELECT unread_count FROM channel_read_state").get()
+    ).toEqual({ unread_count: 2 })
+  })
+
+  it("fails closed when either channel is outside the reviewed project", async () => {
+    const scenarios = [
+      {
+        archiveProjectId: "project-b",
+        ownerProjectId: "project-a",
+        archiveAudience: "organization",
+      },
+      {
+        archiveProjectId: "project-a",
+        ownerProjectId: "project-b",
+        archiveAudience: "organization",
+      },
+      {
+        archiveProjectId: "project-a",
+        ownerProjectId: "project-a",
+        archiveAudience: "clients",
+      },
+    ]
+
+    for (const scenario of scenarios) {
+      const db = createPromotionDb()
+      db.prepare("INSERT INTO channels VALUES (?, ?, ?, ?)").run(
+        "bt-message-archive-job-a",
+        "org-a",
+        scenario.archiveProjectId,
+        scenario.archiveAudience
+      )
+      db.prepare("INSERT INTO channels VALUES (?, ?, ?, ?)").run(
+        "project-owner-project-a",
+        "org-a",
+        scenario.ownerProjectId,
+        "clients"
+      )
+      insertMessage(db, {
+        id: "bt-message-job-a-reviewed-1",
+        channelId: "bt-message-archive-job-a",
+        content: "Must stay quarantined",
+      })
+
+      db.exec(await generateSql(reviewManifest()))
+
+      expect(
+        db
+          .prepare(
+            "SELECT COUNT(*) AS count FROM messages WHERE channel_id = ?"
+          )
+          .get("project-owner-project-a")
+      ).toEqual({ count: 0 })
+      db.close()
+    }
+  })
+
+  it("does not overwrite an ID collision in another channel", async () => {
+    const db = createPromotionDb()
+    db.exec(`
+      INSERT INTO channels VALUES
+        ('bt-message-archive-job-a', 'org-a', 'project-a', 'organization'),
+        ('project-owner-project-a', 'org-a', 'project-a', 'clients'),
+        ('unrelated-channel', 'org-b', 'project-b', 'organization');
+    `)
+    insertMessage(db, {
+      id: "bt-message-job-a-reviewed-1",
+      channelId: "bt-message-archive-job-a",
+      content: "Reviewed source",
+    })
+    insertMessage(db, {
+      id: "bt-owner-history-job-a-reviewed-1",
+      channelId: "unrelated-channel",
+      content: "Unrelated content",
+    })
+
+    db.exec(await generateSql(reviewManifest()))
+
+    expect(
+      db
+        .prepare("SELECT channel_id, content FROM messages WHERE id = ?")
+        .get("bt-owner-history-job-a-reviewed-1")
+    ).toEqual({
+      channel_id: "unrelated-channel",
+      content: "Unrelated content",
+    })
+  })
+
+  it("accepts an empty reviewed set to quarantine every historical row", async () => {
+    const db = createPromotionDb()
+    db.exec(`
+      INSERT INTO channels VALUES
+        ('bt-message-archive-job-a', 'org-a', 'project-a', 'organization'),
+        ('project-owner-project-a', 'org-a', 'project-a', 'clients');
+    `)
+    insertMessage(db, {
+      id: "bt-message-job-a-ambiguous-1",
+      channelId: "bt-message-archive-job-a",
+      content: "Archive only",
+    })
+    insertMessage(db, {
+      id: "bt-owner-history-job-a-ambiguous-1",
+      channelId: "project-owner-project-a",
+      content: "Previously promoted",
+    })
+
+    db.exec(
+      await generateSql(reviewManifest({ sourceMessageIds: [] }))
+    )
+
+    expect(
+      db
+        .prepare(
+          "SELECT COUNT(*) AS count FROM messages WHERE channel_id = ?"
+        )
+        .get("project-owner-project-a")
+    ).toEqual({ count: 0 })
+    expect(
+      db
+        .prepare(
+          "SELECT COUNT(*) AS count FROM messages WHERE channel_id = ?"
+        )
+        .get("bt-message-archive-job-a")
+    ).toEqual({ count: 1 })
+  })
+
+  it("rejects source IDs that do not belong to the reviewed Buildertrend job", async () => {
+    await expect(
+      generateSql(
+        reviewManifest({
+          sourceMessageIds: ["bt-message-job-b-message-1"],
+        })
+      )
+    ).rejects.toThrow("must identify a message from Buildertrend job job-a")
+  })
+
+  it("rejects the retired free-text participant invocation", async () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        "promotion.sql",
+        "project-a",
+        "job-a",
+        "owner-name",
+      ],
+      { encoding: "utf8" }
+    )
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain("<review-manifest.json>")
+  })
+
+  it("generates no text matching or notification/unread mutations", async () => {
+    const sql = await generateSql(reviewManifest())
+
+    expect(sql).not.toMatch(/source\.content\).*LIKE/i)
+    expect(sql).not.toMatch(/INSERT INTO (?:notifications|message_mentions)/i)
+    expect(sql).not.toMatch(/UPDATE channel_read_state/i)
+    expect(sql).toContain("'bt-message-job-a-reviewed-1'")
+    expect(sql).toContain("archive_channel.audience = 'organization'")
+    expect(sql).toContain("target_channel.project_id = 'project-a'")
+    expect(sql).toContain(
+      "target_channel.organization_id = archive_channel.organization_id"
+    )
+  })
+})


### PR DESCRIPTION
## Outcome

- removes free-text participant/name matching from Buildertrend owner-history promotion
- promotes only exact source message IDs in a versioned, explicitly reviewed manifest
- enforces Buildertrend job, project, organization, and audience isolation
- removes stale unreviewed owner-channel copies while preserving the staff archive
- keeps historical reconciliation silent: no bell, unread, email, mention, or SMS writes

## Operational gate

Issue #273 remains open until production source rows are manually reviewed, exact IDs are recorded, and archive channel project/audience metadata is audited. Ambiguous rows remain quarantined.

## Validation

- 9 focused promotion/import tests
- TypeScript
- targeted ESLint
- git diff --check

Related: #273