### PR TITLE
feat(audience): add project team messaging shortcut

### DIFF
--- a/src/app/preview/projects/[id]/owner/budget/page.tsx
+++ b/src/app/preview/projects/[id]/owner/budget/page.tsx
@@ -26,6 +26,7 @@ import { ProjectBudgetPrintButton } from "@/components/projects/project-budget-p
 import { ProjectAudiencePreviewShell } from "@/components/projects/project-audience-preview-shell"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { projectAudienceMessageShortcut } from "@/lib/project-audience-direct-message"
 import { projectBrandFor } from "@/lib/project-branding"
 
 function hasDigest(error: unknown): error is { readonly digest: string } {
@@ -114,6 +115,13 @@ export default async function OwnerBudgetPage({
     Math.abs(contractDifference) >= 0.02 ||
     Math.abs(priorDifference) >= 0.02 ||
     Math.abs(currentDifference) >= 0.02
+  const messageShortcut = projectAudienceMessageShortcut({
+    projectId: preview.project.id,
+    audience: preview.audience,
+    viewerId: preview.viewer.id,
+    contacts: preview.contacts,
+    messageChannels: preview.messageChannels,
+  })
 
   return (
     <ProjectAudiencePreviewShell
@@ -124,6 +132,7 @@ export default async function OwnerBudgetPage({
       projectOptions={preview.projectOptions}
       viewer={preview.viewer}
       viewerIsInternal={preview.viewerIsInternal}
+      messageShortcut={messageShortcut}
       activeSection="budget"
     >
       <main className="min-h-screen bg-muted/20 px-4 py-5 sm:px-6 lg:px-8">

--- a/src/app/preview/projects/[id]/owner/updates/[updateId]/page.tsx
+++ b/src/app/preview/projects/[id]/owner/updates/[updateId]/page.tsx
@@ -17,6 +17,7 @@ import {
   projectAudiencePreviewHref,
   projectAudienceSectionHref,
 } from "@/lib/project-audience-preview-routes"
+import { projectAudienceMessageShortcut } from "@/lib/project-audience-direct-message"
 
 function hasDigest(error: unknown): error is { readonly digest: string } {
   return typeof error === "object" && error !== null && "digest" in error
@@ -57,6 +58,13 @@ export default async function OwnerUpdatePreviewPage({
   const { id, updateId } = await params
   const { document, preview } = await loadOwnerUpdatePreview(id, updateId)
   const homeHref = projectAudiencePreviewHref(id, "owner")
+  const messageShortcut = projectAudienceMessageShortcut({
+    projectId: preview.project.id,
+    audience: preview.audience,
+    viewerId: preview.viewer.id,
+    contacts: preview.contacts,
+    messageChannels: preview.messageChannels,
+  })
 
   return (
     <ProjectAudiencePreviewShell
@@ -67,6 +75,7 @@ export default async function OwnerUpdatePreviewPage({
       projectOptions={preview.projectOptions}
       viewer={preview.viewer}
       viewerIsInternal={preview.viewerIsInternal}
+      messageShortcut={messageShortcut}
       activeSection="updates"
     >
       <OwnerUpdateDocument

--- a/src/components/projects/project-audience-conversation.tsx
+++ b/src/components/projects/project-audience-conversation.tsx
@@ -15,6 +15,7 @@ import {
   projectAudiencePreviewHref,
   type ProjectAudiencePreviewRoute,
 } from "@/lib/project-audience-preview-routes"
+import { projectAudienceMessageShortcut } from "@/lib/project-audience-direct-message"
 
 function routeAudience(audience: ProjectAudience): ProjectAudiencePreviewRoute {
   return audience === "owner" ? "owner" : "sub-vendor"
@@ -95,6 +96,13 @@ export async function ProjectAudienceConversation({
     projectNumber: preview.project.projectNumber,
     clientName: preview.project.clientName,
   }
+  const messageShortcut = projectAudienceMessageShortcut({
+    projectId: preview.project.id,
+    audience,
+    viewerId: preview.viewer.id,
+    contacts: preview.contacts,
+    messageChannels: preview.messageChannels,
+  })
 
   return (
     <ProjectAudiencePreviewShell
@@ -105,9 +113,11 @@ export async function ProjectAudienceConversation({
       projectOptions={preview.projectOptions}
       viewer={preview.viewer}
       viewerIsInternal={preview.viewerIsInternal}
+      messageShortcut={messageShortcut}
+      contentMode="viewport"
       activeSection="conversations"
     >
-      <main className="h-[calc(100vh-3.5rem)] min-h-[34rem] bg-background md:h-screen">
+      <main className="min-h-0 flex-1 overflow-hidden bg-background">
         <ConversationsProvider>
           <div className="flex h-full w-full min-w-0 overflow-hidden">
             <div

--- a/src/components/projects/project-audience-direct-message-dialog.tsx
+++ b/src/components/projects/project-audience-direct-message-dialog.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import * as React from "react"
+import { IconMessageCircle, IconSearch } from "@tabler/icons-react"
+import { useRouter } from "next/navigation"
+
+import type {
+  ProjectAudienceMessageRecipient,
+  ProjectAudienceMessageShortcut,
+} from "@/lib/project-audience-direct-message"
+import { projectAudienceMessageRecipientHref } from "@/lib/project-audience-direct-message"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { ScrollArea } from "@/components/ui/scroll-area"
+
+function recipientDetail(
+  recipient: ProjectAudienceMessageRecipient
+): string {
+  return recipient.role ?? "Project team"
+}
+
+export function ProjectAudienceDirectMessageDialog({
+  open,
+  onOpenChange,
+  shortcut,
+}: {
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
+  readonly shortcut: ProjectAudienceMessageShortcut
+}): React.ReactElement {
+  const router = useRouter()
+  const [query, setQuery] = React.useState("")
+  const normalizedQuery = query.trim().toLocaleLowerCase()
+  const filteredRecipients = shortcut.recipients.filter((recipient) =>
+    `${recipient.displayName} ${recipient.role ?? ""}`
+      .toLocaleLowerCase()
+      .includes(normalizedQuery)
+  )
+
+  function startMessage(recipient: ProjectAudienceMessageRecipient): void {
+    onOpenChange(false)
+    setQuery("")
+    router.push(
+      projectAudienceMessageRecipientHref(
+        shortcut.conversationHref,
+        recipient
+      )
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Message your project team</DialogTitle>
+          <DialogDescription>
+            Choose an internal team member. Your message stays in this
+            project&apos;s private conversation.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="relative">
+          <IconSearch className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.currentTarget.value)}
+            placeholder="Find a project team member"
+            className="pl-9"
+            autoFocus
+          />
+        </div>
+        <ScrollArea className="max-h-80">
+          <div className="space-y-1 pr-3">
+            {filteredRecipients.length === 0 ? (
+              <p className="py-10 text-center text-sm text-muted-foreground">
+                No matching project team members.
+              </p>
+            ) : (
+              filteredRecipients.map((recipient) => (
+                <Button
+                  key={recipient.userId}
+                  type="button"
+                  variant="ghost"
+                  className="h-auto w-full justify-start gap-3 px-3 py-2 text-left"
+                  onClick={() => startMessage(recipient)}
+                >
+                  <span className="grid size-9 shrink-0 place-items-center rounded-full bg-primary/10 text-primary">
+                    <IconMessageCircle className="size-4" />
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block truncate text-sm font-medium">
+                      {recipient.displayName}
+                    </span>
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {recipientDetail(recipient)}
+                    </span>
+                  </span>
+                </Button>
+              ))
+            )}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/projects/project-audience-header-controls.tsx
+++ b/src/components/projects/project-audience-header-controls.tsx
@@ -1,14 +1,16 @@
 "use client"
 
 import * as React from "react"
-import { IconMoon, IconSun } from "@tabler/icons-react"
+import { IconMessageCircle, IconMoon, IconSun } from "@tabler/icons-react"
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
 import { NotificationsPopover } from "@/components/notifications-popover"
 import { ProjectAudienceNotificationSettings } from "@/components/projects/project-audience-notification-settings"
+import { ProjectAudienceDirectMessageDialog } from "@/components/projects/project-audience-direct-message-dialog"
 import { useTheme } from "@/components/theme-provider"
 import { getInitials } from "@/lib/utils"
+import type { ProjectAudienceMessageShortcut } from "@/lib/project-audience-direct-message"
 
 type AudienceViewer = {
   readonly name: string
@@ -17,13 +19,35 @@ type AudienceViewer = {
 
 export function ProjectAudienceHeaderControls({
   viewer,
+  messageShortcut,
 }: {
   readonly viewer: AudienceViewer
+  readonly messageShortcut: ProjectAudienceMessageShortcut | null
 }): React.ReactElement {
   const { theme, setTheme } = useTheme()
+  const [messageOpen, setMessageOpen] = React.useState(false)
 
   return (
     <div className="flex shrink-0 items-center justify-end gap-0.5">
+      {messageShortcut && (
+        <>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-7 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+            onClick={() => setMessageOpen(true)}
+            aria-label="Message a project team member"
+            title="Direct message"
+          >
+            <IconMessageCircle className="size-4" />
+          </Button>
+          <ProjectAudienceDirectMessageDialog
+            open={messageOpen}
+            onOpenChange={setMessageOpen}
+            shortcut={messageShortcut}
+          />
+        </>
+      )}
       <NotificationsPopover />
       <ProjectAudienceNotificationSettings
         compact

--- a/src/components/projects/project-audience-preview-shell.tsx
+++ b/src/components/projects/project-audience-preview-shell.tsx
@@ -32,6 +32,7 @@ import { ProjectAudiencePreviewWindowControls } from "@/components/projects/proj
 import { ProjectAudienceHeaderControls } from "@/components/projects/project-audience-header-controls"
 import { ProjectAudienceSidebarProfile } from "@/components/projects/project-audience-sidebar-profile"
 import { cn } from "@/lib/utils"
+import type { ProjectAudienceMessageShortcut } from "@/lib/project-audience-direct-message"
 
 type PreviewNavigationItem = {
   readonly label: string
@@ -133,6 +134,8 @@ export function ProjectAudiencePreviewShell({
   projectOptions,
   viewer,
   viewerIsInternal,
+  messageShortcut,
+  contentMode = "document",
   activeSection = "overview",
   children,
 }: {
@@ -148,6 +151,8 @@ export function ProjectAudiencePreviewShell({
     readonly sidebarPhotoUrl: string | null
   }
   readonly viewerIsInternal: boolean
+  readonly messageShortcut: ProjectAudienceMessageShortcut | null
+  readonly contentMode?: "document" | "viewport"
   readonly activeSection?: ProjectAudienceWorkspaceSection
   readonly children: React.ReactNode
 }): React.ReactElement {
@@ -157,8 +162,15 @@ export function ProjectAudiencePreviewShell({
     audience === "owner" ? OWNER_NAVIGATION : SUB_VENDOR_NAVIGATION
 
   return (
-    <div className="min-h-screen bg-muted/20 text-foreground md:grid md:grid-cols-[16rem_minmax(0,1fr)]">
-      <aside className="sticky top-0 hidden h-screen flex-col border-r bg-sidebar text-sidebar-foreground md:flex">
+    <div
+      className={cn(
+        "bg-muted/20 text-foreground md:grid md:grid-cols-[16rem_minmax(0,1fr)]",
+        contentMode === "viewport"
+          ? "h-dvh min-h-0 overflow-hidden"
+          : "min-h-screen"
+      )}
+    >
+      <aside className="sticky top-0 hidden h-dvh flex-col border-r bg-sidebar text-sidebar-foreground md:flex">
         <div className="border-b border-sidebar-border p-4">
           <Link href={homeHref} className="flex items-center gap-3">
             <span className="flex size-9 shrink-0 items-center justify-center">
@@ -259,9 +271,18 @@ export function ProjectAudiencePreviewShell({
         <ProjectAudienceSidebarProfile viewer={viewer} />
       </aside>
 
-      <div className="min-w-0">
+      <div
+        className={cn(
+          "min-w-0",
+          contentMode === "viewport" &&
+            "flex h-dvh min-h-0 flex-col overflow-hidden"
+        )}
+      >
         <header className="sticky top-0 z-40 hidden h-12 items-center justify-end border-b border-border/40 bg-background/80 px-4 backdrop-blur-sm md:flex">
-          <ProjectAudienceHeaderControls viewer={viewer} />
+          <ProjectAudienceHeaderControls
+            viewer={viewer}
+            messageShortcut={messageShortcut}
+          />
         </header>
 
         {viewerIsInternal && (
@@ -308,7 +329,10 @@ export function ProjectAudiencePreviewShell({
                 {audience === "owner" ? "Owner Compass" : "Partner Compass"}
               </p>
             </Link>
-            <ProjectAudienceHeaderControls viewer={viewer} />
+            <ProjectAudienceHeaderControls
+              viewer={viewer}
+              messageShortcut={messageShortcut}
+            />
           </div>
           <nav className="mt-3 flex gap-1 overflow-x-auto border-t pt-2">
             {navigation.map((item) => (

--- a/src/components/projects/project-audience-preview.tsx
+++ b/src/components/projects/project-audience-preview.tsx
@@ -42,6 +42,7 @@ import {
   projectAudienceSectionHref,
   type ProjectAudienceWorkspaceSection,
 } from "@/lib/project-audience-preview-routes"
+import { projectAudienceMessageShortcut } from "@/lib/project-audience-direct-message"
 import { selectUpcomingScheduleItems } from "@/lib/project-audience-schedule-selection"
 
 function formatDate(value: string | null): string {
@@ -719,6 +720,13 @@ export function ProjectAudiencePreview({
     new Date().toISOString().slice(0, 10)
   )
   const partnerNextScheduleItem = partnerUpcomingScheduleItems[0]
+  const messageShortcut = projectAudienceMessageShortcut({
+    projectId: data.project.id,
+    audience: data.audience,
+    viewerId: data.viewer.id,
+    contacts: data.contacts,
+    messageChannels: data.messageChannels,
+  })
 
   if (isOwner) {
     return (
@@ -730,6 +738,7 @@ export function ProjectAudiencePreview({
         projectOptions={data.projectOptions}
         viewer={data.viewer}
         viewerIsInternal={data.viewerIsInternal}
+        messageShortcut={messageShortcut}
         activeSection={section}
       >
         <OwnerProjectPreview data={data} section={section} />
@@ -746,6 +755,7 @@ export function ProjectAudiencePreview({
       projectOptions={data.projectOptions}
       viewer={data.viewer}
       viewerIsInternal={data.viewerIsInternal}
+      messageShortcut={messageShortcut}
       activeSection={section}
     >
       <main className="min-h-screen bg-muted/30">

--- a/src/lib/__tests__/project-audience-direct-message.test.ts
+++ b/src/lib/__tests__/project-audience-direct-message.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest"
+
+import type {
+  AudienceContact,
+  AudienceMessageChannel,
+} from "@/app/actions/project-audience-preview"
+import {
+  projectAudienceMessageRecipientHref,
+  projectAudienceMessageShortcut,
+} from "@/lib/project-audience-direct-message"
+
+function contact(input: {
+  readonly id: string
+  readonly userId: string | null
+  readonly displayName: string
+  readonly role?: string | null
+}): AudienceContact {
+  return {
+    id: input.id,
+    userId: input.userId,
+    contactType: "internal",
+    displayName: input.displayName,
+    companyName: null,
+    role: input.role ?? null,
+    trade: null,
+    csiDivision: null,
+    csiDivisionName: null,
+    email: `${input.id}@example.com`,
+    phone: null,
+    primaryContact: false,
+  }
+}
+
+const CHANNELS: readonly AudienceMessageChannel[] = [
+  {
+    id: "owner/channel",
+    name: "Owner Team",
+    description: null,
+    isPrivate: true,
+  },
+]
+
+describe("projectAudienceMessageShortcut", () => {
+  it("uses only the server-authorized project contacts", () => {
+    const result = projectAudienceMessageShortcut({
+      projectId: "project one",
+      audience: "owner",
+      viewerId: "viewer",
+      contacts: [
+        contact({
+          id: "pm",
+          userId: "staff-pm",
+          displayName: "Project Manager",
+          role: "project_manager",
+        }),
+        contact({
+          id: "viewer",
+          userId: "viewer",
+          displayName: "Previewing Staff",
+        }),
+        contact({
+          id: "unlinked",
+          userId: null,
+          displayName: "Unlinked Contact",
+        }),
+        contact({
+          id: "duplicate",
+          userId: "staff-pm",
+          displayName: "Duplicate Project Manager",
+        }),
+      ],
+      messageChannels: CHANNELS,
+    })
+
+    expect(result).toEqual({
+      conversationHref:
+        "/preview/projects/project%20one/owner/conversations/owner%2Fchannel",
+      recipients: [
+        {
+          userId: "staff-pm",
+          displayName: "Project Manager",
+          role: "project_manager",
+        },
+      ],
+    })
+  })
+
+  it("fails closed without both a private project conversation and recipient", () => {
+    expect(
+      projectAudienceMessageShortcut({
+        projectId: "project",
+        audience: "sub_vendor",
+        viewerId: "partner",
+        contacts: [
+          contact({
+            id: "pm",
+            userId: "staff-pm",
+            displayName: "Project Manager",
+          }),
+        ],
+        messageChannels: [],
+      })
+    ).toBeNull()
+
+    expect(
+      projectAudienceMessageShortcut({
+        projectId: "project",
+        audience: "sub_vendor",
+        viewerId: "partner",
+        contacts: [
+          contact({
+            id: "pm",
+            userId: "staff-pm",
+            displayName: "Project Manager",
+          }),
+        ],
+        messageChannels: [{ ...CHANNELS[0], isPrivate: false }],
+      })
+    ).toBeNull()
+
+    expect(
+      projectAudienceMessageShortcut({
+        projectId: "project",
+        audience: "sub_vendor",
+        viewerId: "staff-pm",
+        contacts: [
+          contact({
+            id: "pm",
+            userId: "staff-pm",
+            displayName: "Project Manager",
+          }),
+        ],
+        messageChannels: CHANNELS,
+      })
+    ).toBeNull()
+  })
+
+  it("opens the guarded conversation with an encoded initial mention", () => {
+    expect(
+      projectAudienceMessageRecipientHref(
+        "/preview/projects/project/sub-vendor/conversations/channel",
+        {
+          userId: "user/one",
+          displayName: "Wes Jones & Team",
+          role: "assistant_project_manager",
+        }
+      )
+    ).toBe(
+      "/preview/projects/project/sub-vendor/conversations/channel" +
+        "?mention=user%2Fone&label=Wes+Jones+%26+Team"
+    )
+  })
+})

--- a/src/lib/project-audience-direct-message.ts
+++ b/src/lib/project-audience-direct-message.ts
@@ -1,0 +1,72 @@
+import type {
+  AudienceContact,
+  AudienceMessageChannel,
+} from "@/app/actions/project-audience-preview"
+import type { ProjectAudience } from "@/lib/project-audience-access"
+import { projectAudienceConversationHref } from "@/lib/project-audience-preview-routes"
+
+export type ProjectAudienceMessageRecipient = {
+  readonly userId: string
+  readonly displayName: string
+  readonly role: string | null
+}
+
+export type ProjectAudienceMessageShortcut = {
+  readonly conversationHref: string
+  readonly recipients: readonly ProjectAudienceMessageRecipient[]
+}
+
+export function projectAudienceMessageShortcut(input: {
+  readonly projectId: string
+  readonly audience: ProjectAudience
+  readonly viewerId: string
+  readonly contacts: readonly AudienceContact[]
+  readonly messageChannels: readonly AudienceMessageChannel[]
+}): ProjectAudienceMessageShortcut | null {
+  const channel = input.messageChannels.find((item) => item.isPrivate)
+  if (!channel) return null
+
+  // getProjectAudiencePreview already limits contacts to active, explicitly
+  // assigned internal project-team members. Keep this helper structural so the
+  // header can never broaden that server-authorized directory.
+  const recipientsByUserId = new Map<
+    string,
+    ProjectAudienceMessageRecipient
+  >()
+  for (const contact of input.contacts) {
+    if (
+      !contact.userId ||
+      contact.userId === input.viewerId ||
+      recipientsByUserId.has(contact.userId)
+    ) {
+      continue
+    }
+    recipientsByUserId.set(contact.userId, {
+      userId: contact.userId,
+      displayName: contact.displayName,
+      role: contact.role,
+    })
+  }
+  const recipients = Array.from(recipientsByUserId.values())
+  if (recipients.length === 0) return null
+
+  return {
+    conversationHref: projectAudienceConversationHref(
+      input.projectId,
+      input.audience === "owner" ? "owner" : "sub-vendor",
+      channel.id
+    ),
+    recipients,
+  }
+}
+
+export function projectAudienceMessageRecipientHref(
+  conversationHref: string,
+  recipient: ProjectAudienceMessageRecipient
+): string {
+  const query = new URLSearchParams({
+    mention: recipient.userId,
+    label: recipient.displayName,
+  })
+  return `${conversationHref}?${query.toString()}`
+}


### PR DESCRIPTION
## Outcome

- adds a Message project team shortcut beside the owner/sub notification bell
- limits recipients to active, explicitly assigned internal project-team members
- opens the existing guarded private project conversation with the selected teammate mentioned
- keeps the owner/sub left navigation fixed while message history scrolls

## Safety

No organization-wide directory is exposed. Unassigned staff, developers, service accounts, and unrelated project users remain excluded.

## Validation

- 17 focused audience/privacy tests
- TypeScript
- targeted ESLint
- git diff --check

Closes #276