### PR TITLE
fix(notifications): deliver opted-in project message texts

### DIFF
--- a/drizzle/0081_project_activity_sms.sql
+++ b/drizzle/0081_project_activity_sms.sql
@@ -1,0 +1,11 @@
+ALTER TABLE `notification_preferences`
+  ADD COLUMN `project_activity_sms_enabled` integer DEFAULT 1 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `notification_preferences`
+  ADD COLUMN `sms_quiet_hours_enabled` integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `notification_preferences`
+  ADD COLUMN `sms_quiet_hours_start` text DEFAULT '21:00' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `notification_preferences`
+  ADD COLUMN `sms_quiet_hours_end` text DEFAULT '07:00' NOT NULL;

--- a/src/app/actions/notifications.ts
+++ b/src/app/actions/notifications.ts
@@ -21,6 +21,7 @@ import {
   SMS_OPT_IN_DISCLOSURE_URL,
   SMS_OPT_IN_DISCLOSURE_VERSION,
 } from "@/lib/notifications/sms-consent"
+import { isValidSmsQuietHoursTime } from "@/lib/notifications/sms-policy"
 import { requireOrg } from "@/lib/org-scope"
 import { isValidTimeZone } from "@/lib/work-calendar"
 
@@ -39,6 +40,10 @@ export type NotificationPreferenceState = {
   readonly mentionSmsEnabled: boolean
   readonly announcementEmailEnabled: boolean
   readonly announcementSmsEnabled: boolean
+  readonly projectActivitySmsEnabled: boolean
+  readonly smsQuietHoursEnabled: boolean
+  readonly smsQuietHoursStart: string
+  readonly smsQuietHoursEnd: string
   readonly weeklyDigestEnabled: boolean
   readonly rfiEnabled: boolean
   readonly ownerUpdateEnabled: boolean
@@ -104,6 +109,10 @@ const DEFAULT_PREFERENCES: NotificationPreferenceState = {
   mentionSmsEnabled: false,
   announcementEmailEnabled: true,
   announcementSmsEnabled: false,
+  projectActivitySmsEnabled: true,
+  smsQuietHoursEnabled: false,
+  smsQuietHoursStart: "21:00",
+  smsQuietHoursEnd: "07:00",
   weeklyDigestEnabled: false,
   rfiEnabled: true,
   ownerUpdateEnabled: true,
@@ -143,6 +152,10 @@ function preferenceFromRow(
     mentionSmsEnabled: row.mentionSmsEnabled,
     announcementEmailEnabled: row.announcementEmailEnabled,
     announcementSmsEnabled: row.announcementSmsEnabled,
+    projectActivitySmsEnabled: row.projectActivitySmsEnabled,
+    smsQuietHoursEnabled: row.smsQuietHoursEnabled,
+    smsQuietHoursStart: row.smsQuietHoursStart,
+    smsQuietHoursEnd: row.smsQuietHoursEnd,
     weeklyDigestEnabled: row.weeklyDigestEnabled,
     rfiEnabled: row.rfiEnabled,
     ownerUpdateEnabled: row.ownerUpdateEnabled,
@@ -195,15 +208,21 @@ export async function updateNotificationPreferences(
     if (!isValidTimeZone(timeZone)) {
       return { success: false, error: "Choose a valid timezone." }
     }
+    if (
+      !isValidSmsQuietHoursTime(input.smsQuietHoursStart) ||
+      !isValidSmsQuietHoursTime(input.smsQuietHoursEnd)
+    ) {
+      return {
+        success: false,
+        error: "Choose valid SMS quiet-hour start and end times.",
+      }
+    }
     const user = await requireAuth()
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
     const now = new Date().toISOString()
     const smsPhoneNumber = input.smsPhoneNumber?.trim() || null
-    const wantsSms =
-      input.smsEnabled ||
-      input.mentionSmsEnabled ||
-      input.announcementSmsEnabled
+    const wantsSms = input.smsEnabled
 
     if (wantsSms && !smsPhoneNumber) {
       return {
@@ -257,6 +276,9 @@ export async function updateNotificationPreferences(
         : false,
       announcementSmsEnabled: input.smsEnabled
         ? input.announcementSmsEnabled
+        : false,
+      projectActivitySmsEnabled: input.smsEnabled
+        ? input.projectActivitySmsEnabled
         : false,
     }
 

--- a/src/components/settings/preferences-tab.tsx
+++ b/src/components/settings/preferences-tab.tsx
@@ -55,6 +55,10 @@ export function PreferencesTab() {
       mentionSmsEnabled: false,
       announcementEmailEnabled: true,
       announcementSmsEnabled: false,
+      projectActivitySmsEnabled: true,
+      smsQuietHoursEnabled: false,
+      smsQuietHoursStart: "21:00",
+      smsQuietHoursEnd: "07:00",
       weeklyDigestEnabled: false,
       rfiEnabled: true,
       ownerUpdateEnabled: true,
@@ -118,6 +122,9 @@ export function PreferencesTab() {
       mentionSmsEnabled: checked ? current.mentionSmsEnabled : false,
       announcementSmsEnabled: checked
         ? current.announcementSmsEnabled
+        : false,
+      projectActivitySmsEnabled: checked
+        ? current.projectActivitySmsEnabled
         : false,
     }))
     setHasUnsavedChanges(true)
@@ -334,7 +341,7 @@ export function PreferencesTab() {
               <div>
                 <Label className="text-xs">Text notifications</Label>
                 <p className="text-muted-foreground text-xs">
-                  Direct mentions and announcements by text.
+                  Project messages, direct mentions, and announcements by text.
                 </p>
               </div>
               <Switch
@@ -428,6 +435,24 @@ export function PreferencesTab() {
           <div className="grid grid-cols-1 gap-3 border-y py-3 sm:grid-cols-2">
             <div className="space-y-3">
               <div>
+                <Label className="text-xs">Project messages</Label>
+                <p className="text-muted-foreground text-xs">
+                  New messages in project channels you follow.
+                </p>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-xs text-muted-foreground">Text</span>
+                <Switch
+                  checked={preferences.projectActivitySmsEnabled}
+                  disabled={!preferences.smsEnabled || !smsConsentReady}
+                  onCheckedChange={(checked) =>
+                    updatePreference("projectActivitySmsEnabled", checked)
+                  }
+                />
+              </div>
+            </div>
+            <div className="space-y-3">
+              <div>
                 <Label className="text-xs">When I am mentioned</Label>
                 <p className="text-muted-foreground text-xs">
                   Applies to @mentions, @channel, and @here.
@@ -484,6 +509,60 @@ export function PreferencesTab() {
                 />
               </div>
             </div>
+          </div>
+
+          <div className="space-y-3 border-b pb-3">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <Label className="text-xs">SMS quiet hours</Label>
+                <p className="text-muted-foreground text-xs">
+                  Pause notification texts in your selected timezone.
+                </p>
+              </div>
+              <Switch
+                checked={preferences.smsQuietHoursEnabled}
+                disabled={!preferences.smsEnabled}
+                onCheckedChange={(checked) =>
+                  updatePreference("smsQuietHoursEnabled", checked)
+                }
+              />
+            </div>
+            {preferences.smsQuietHoursEnabled && (
+              <div className="grid max-w-sm grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="smsQuietHoursStart" className="text-xs">
+                    Starts
+                  </Label>
+                  <Input
+                    id="smsQuietHoursStart"
+                    type="time"
+                    value={preferences.smsQuietHoursStart}
+                    onChange={(event) =>
+                      updatePreference(
+                        "smsQuietHoursStart",
+                        event.currentTarget.value
+                      )
+                    }
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="smsQuietHoursEnd" className="text-xs">
+                    Ends
+                  </Label>
+                  <Input
+                    id="smsQuietHoursEnd"
+                    type="time"
+                    value={preferences.smsQuietHoursEnd}
+                    onChange={(event) =>
+                      updatePreference(
+                        "smsQuietHoursEnd",
+                        event.currentTarget.value
+                      )
+                    }
+                  />
+                </div>
+              </div>
+            )}
           </div>
 
           <div className="grid grid-cols-1 gap-3 rounded-md border p-3 sm:grid-cols-2">

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -114,6 +114,22 @@ export const notificationPreferences = sqliteTable("notification_preferences", {
   })
     .notNull()
     .default(false),
+  projectActivitySmsEnabled: integer("project_activity_sms_enabled", {
+    mode: "boolean",
+  })
+    .notNull()
+    .default(true),
+  smsQuietHoursEnabled: integer("sms_quiet_hours_enabled", {
+    mode: "boolean",
+  })
+    .notNull()
+    .default(false),
+  smsQuietHoursStart: text("sms_quiet_hours_start")
+    .notNull()
+    .default("21:00"),
+  smsQuietHoursEnd: text("sms_quiet_hours_end")
+    .notNull()
+    .default("07:00"),
   weeklyDigestEnabled: integer("weekly_digest_enabled", { mode: "boolean" })
     .notNull()
     .default(false),

--- a/src/lib/notifications/__tests__/sms-policy.test.ts
+++ b/src/lib/notifications/__tests__/sms-policy.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isDuringSmsQuietHours,
+  isValidSmsQuietHoursTime,
+  shouldSendSmsNotification,
+  shouldUseProjectActivitySmsRoute,
+  type SmsPolicyPreferences,
+} from "@/lib/notifications/sms-policy"
+import { SMS_OPT_IN_DISCLOSURE_VERSION } from "@/lib/notifications/sms-consent"
+
+const ENABLED_PREFERENCES: SmsPolicyPreferences = {
+  smsEnabled: true,
+  smsPhoneNumber: "+17195550123",
+  smsConsentAccepted: true,
+  smsConsentDisclosureVersion: SMS_OPT_IN_DISCLOSURE_VERSION,
+  smsConsentPhoneNumber: "+17195550123",
+  mentionSmsEnabled: true,
+  announcementSmsEnabled: true,
+  projectActivitySmsEnabled: true,
+  smsQuietHoursEnabled: false,
+  smsQuietHoursStart: "21:00",
+  smsQuietHoursEnd: "07:00",
+  timeZone: "America/Denver",
+}
+
+describe("SMS notification policy", () => {
+  it("allows opted-in live project messages", () => {
+    expect(
+      shouldSendSmsNotification(ENABLED_PREFERENCES, {
+        eventType: "message.channel",
+        createdBy: "sender",
+        occurredAt: new Date("2026-07-30T18:00:00.000Z"),
+      })
+    ).toBe(true)
+  })
+
+  it("blocks imported or replayed project messages without a live actor", () => {
+    expect(
+      shouldSendSmsNotification(ENABLED_PREFERENCES, {
+        eventType: "message.channel",
+        createdBy: null,
+        occurredAt: new Date("2026-07-30T18:00:00.000Z"),
+      })
+    ).toBe(false)
+  })
+
+  it("requires current consent and the matching category preference", () => {
+    expect(
+      shouldSendSmsNotification(
+        {
+          ...ENABLED_PREFERENCES,
+          smsConsentPhoneNumber: "+17195550999",
+        },
+        {
+          eventType: "message.channel",
+          createdBy: "sender",
+          occurredAt: new Date("2026-07-30T18:00:00.000Z"),
+        }
+      )
+    ).toBe(false)
+    expect(
+      shouldSendSmsNotification(
+        {
+          ...ENABLED_PREFERENCES,
+          projectActivitySmsEnabled: false,
+        },
+        {
+          eventType: "message.thread_reply",
+          createdBy: "sender",
+          occurredAt: new Date("2026-07-30T18:00:00.000Z"),
+        }
+      )
+    ).toBe(false)
+  })
+
+  it("honors overnight quiet hours in the user's timezone", () => {
+    const quietPreferences = {
+      ...ENABLED_PREFERENCES,
+      smsQuietHoursEnabled: true,
+    }
+    expect(
+      isDuringSmsQuietHours(
+        quietPreferences,
+        new Date("2026-07-31T04:30:00.000Z")
+      )
+    ).toBe(true)
+    expect(
+      isDuringSmsQuietHours(
+        quietPreferences,
+        new Date("2026-07-30T18:00:00.000Z")
+      )
+    ).toBe(false)
+  })
+
+  it("validates quiet-hour values and fails closed on invalid data", () => {
+    expect(isValidSmsQuietHoursTime("07:30")).toBe(true)
+    expect(isValidSmsQuietHoursTime("25:00")).toBe(false)
+    expect(
+      isDuringSmsQuietHours(
+        {
+          ...ENABLED_PREFERENCES,
+          smsQuietHoursEnabled: true,
+          smsQuietHoursStart: "invalid",
+        },
+        new Date("2026-07-30T18:00:00.000Z")
+      )
+    ).toBe(true)
+  })
+
+  it("routes mentions and announcements only through their specific SMS preferences", () => {
+    expect(
+      shouldUseProjectActivitySmsRoute({
+        channelType: "announcement",
+        recipientUserId: "recipient",
+        mentions: [],
+      })
+    ).toBe(false)
+    expect(
+      shouldUseProjectActivitySmsRoute({
+        channelType: "text",
+        recipientUserId: "recipient",
+        mentions: [
+          {
+            mentionType: "user",
+            targetId: "recipient",
+          },
+        ],
+      })
+    ).toBe(false)
+    expect(
+      shouldUseProjectActivitySmsRoute({
+        channelType: "text",
+        recipientUserId: "recipient",
+        mentions: [
+          {
+            mentionType: "user",
+            targetId: "someone-else",
+          },
+        ],
+      })
+    ).toBe(true)
+  })
+})

--- a/src/lib/notifications/create-event.ts
+++ b/src/lib/notifications/create-event.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from "drizzle-orm"
+import { and, eq, inArray, isNull } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
@@ -11,6 +11,12 @@ import {
   projects,
   users,
 } from "@/db/schema"
+import {
+  channelMembers,
+  channels,
+  messageMentions,
+  messages,
+} from "@/db/schema-conversations"
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import {
@@ -19,7 +25,11 @@ import {
 } from "@/lib/notifications/delivery"
 import { requireOrg } from "@/lib/org-scope"
 import { sendPushNotification } from "@/lib/push/send"
-import { hasCurrentSmsConsent } from "@/lib/notifications/sms-consent"
+import {
+  isProjectActivitySmsEvent,
+  shouldSendSmsNotification,
+  shouldUseProjectActivitySmsRoute,
+} from "@/lib/notifications/sms-policy"
 
 type NotificationPreferenceState = {
   readonly inAppEnabled: boolean
@@ -34,11 +44,16 @@ type NotificationPreferenceState = {
   readonly mentionSmsEnabled: boolean
   readonly announcementEmailEnabled: boolean
   readonly announcementSmsEnabled: boolean
+  readonly projectActivitySmsEnabled: boolean
+  readonly smsQuietHoursEnabled: boolean
+  readonly smsQuietHoursStart: string
+  readonly smsQuietHoursEnd: string
   readonly weeklyDigestEnabled: boolean
   readonly rfiEnabled: boolean
   readonly ownerUpdateEnabled: boolean
   readonly scheduleEnabled: boolean
   readonly poEnabled: boolean
+  readonly timeZone: string
 }
 
 export type NotificationRecipientInput = {
@@ -75,11 +90,16 @@ const DEFAULT_PREFERENCES: NotificationPreferenceState = {
   mentionSmsEnabled: false,
   announcementEmailEnabled: true,
   announcementSmsEnabled: false,
+  projectActivitySmsEnabled: true,
+  smsQuietHoursEnabled: false,
+  smsQuietHoursStart: "21:00",
+  smsQuietHoursEnd: "07:00",
   weeklyDigestEnabled: false,
   rfiEnabled: true,
   ownerUpdateEnabled: true,
   scheduleEnabled: true,
   poEnabled: true,
+  timeZone: "America/Denver",
 }
 
 type SmsDeliveryResult = {
@@ -138,11 +158,16 @@ function preferenceFromRow(
     mentionSmsEnabled: row.mentionSmsEnabled,
     announcementEmailEnabled: row.announcementEmailEnabled,
     announcementSmsEnabled: row.announcementSmsEnabled,
+    projectActivitySmsEnabled: row.projectActivitySmsEnabled,
+    smsQuietHoursEnabled: row.smsQuietHoursEnabled,
+    smsQuietHoursStart: row.smsQuietHoursStart,
+    smsQuietHoursEnd: row.smsQuietHoursEnd,
     weeklyDigestEnabled: row.weeklyDigestEnabled,
     rfiEnabled: row.rfiEnabled,
     ownerUpdateEnabled: row.ownerUpdateEnabled,
     scheduleEnabled: row.scheduleEnabled,
     poEnabled: row.poEnabled,
+    timeZone: row.timeZone,
   }
 }
 
@@ -194,26 +219,14 @@ function notificationEmailEnabled(
 
 function notificationSmsEnabled(
   preferences: NotificationPreferenceState,
-  eventType: string
+  input: Pick<CreateNotificationInput, "eventType" | "createdBy">,
+  occurredAt: Date
 ): boolean {
-  if (
-    !preferences.smsEnabled ||
-    !hasCurrentSmsConsent({
-      accepted: preferences.smsConsentAccepted,
-      phoneNumber: preferences.smsPhoneNumber,
-      consentPhoneNumber: preferences.smsConsentPhoneNumber,
-      disclosureVersion: preferences.smsConsentDisclosureVersion,
-    })
-  ) {
-    return false
-  }
-  if (eventType === "message.mention") {
-    return preferences.mentionSmsEnabled
-  }
-  if (eventType === "announcement.message") {
-    return preferences.announcementSmsEnabled
-  }
-  return false
+  return shouldSendSmsNotification(preferences, {
+    eventType: input.eventType,
+    createdBy: input.createdBy,
+    occurredAt,
+  })
 }
 
 function notificationEmailBody(
@@ -505,6 +518,99 @@ async function getPreferenceForUser(
   return preferenceFromRow(row)
 }
 
+function isMessageSmsEvent(eventType: string): boolean {
+  return (
+    eventType === "message.mention" ||
+    eventType === "announcement.message" ||
+    isProjectActivitySmsEvent(eventType)
+  )
+}
+
+async function isEligibleLiveMessageSmsRecipient(
+  db: ReturnType<typeof getDb>,
+  input: CreateNotificationInput,
+  userId: string
+): Promise<boolean> {
+  if (!isMessageSmsEvent(input.eventType)) return true
+  if (
+    input.sourceType !== "message" ||
+    input.sourceId === null ||
+    input.createdBy === null
+  ) {
+    return false
+  }
+
+  const source = await db
+    .select({
+      channelType: channels.type,
+    })
+    .from(messages)
+    .innerJoin(channels, eq(channels.id, messages.channelId))
+    .innerJoin(
+      channelMembers,
+      and(
+        eq(channelMembers.channelId, channels.id),
+        eq(channelMembers.userId, userId)
+      )
+    )
+    .where(
+      and(
+        eq(messages.id, input.sourceId),
+        eq(messages.userId, input.createdBy),
+        eq(channels.organizationId, input.organizationId),
+        input.projectId === null
+          ? isNull(channels.projectId)
+          : eq(channels.projectId, input.projectId)
+      )
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  if (!source) return false
+
+  if (!isProjectActivitySmsEvent(input.eventType)) return true
+  // Announcements and mentions have their own explicit SMS switches. Do not
+  // silently route them through the broader project-message preference.
+  const mentions = await db
+    .select({
+      mentionType: messageMentions.mentionType,
+      targetId: messageMentions.targetId,
+    })
+    .from(messageMentions)
+    .where(eq(messageMentions.messageId, input.sourceId))
+  return shouldUseProjectActivitySmsRoute({
+    channelType: source.channelType,
+    recipientUserId: userId,
+    mentions,
+  })
+}
+
+async function hasExistingSmsDeliveryForSource(
+  db: ReturnType<typeof getDb>,
+  input: CreateNotificationInput,
+  userId: string
+): Promise<boolean> {
+  if (input.sourceId === null) return false
+
+  return db
+    .select({ id: notificationDeliveries.id })
+    .from(notificationDeliveries)
+    .innerJoin(
+      notificationEvents,
+      eq(notificationEvents.id, notificationDeliveries.eventId)
+    )
+    .where(
+      and(
+        eq(notificationEvents.organizationId, input.organizationId),
+        eq(notificationEvents.sourceType, input.sourceType),
+        eq(notificationEvents.sourceId, input.sourceId),
+        eq(notificationDeliveries.userId, userId),
+        eq(notificationDeliveries.channel, "sms")
+      )
+    )
+    .limit(1)
+    .then((rows) => rows.length > 0)
+}
+
 async function persistNotificationEvent(
   input: CreateNotificationInput
 ): Promise<void> {
@@ -543,7 +649,8 @@ async function persistNotificationEvent(
         .limit(1)
         .then((rows) => rows[0]?.projectNumber ?? null)
     : null
-  const now = new Date().toISOString()
+  const occurredAt = new Date()
+  const now = occurredAt.toISOString()
   const eventId = crypto.randomUUID()
   try {
     await db.insert(notificationEvents).values({
@@ -582,10 +689,23 @@ async function persistNotificationEvent(
         input.eventType,
         delivery.email
       )
-      const smsEnabled = notificationSmsEnabled(
+      const smsPolicyEnabled = notificationSmsEnabled(
         preferences,
-        input.eventType
+        input,
+        occurredAt
       )
+      const smsEnabled =
+        smsPolicyEnabled &&
+        (await isEligibleLiveMessageSmsRecipient(
+          db,
+          input,
+          recipient.userId
+        )) &&
+        !(await hasExistingSmsDeliveryForSource(
+          db,
+          input,
+          recipient.userId
+        ))
       if (
         !emailEnabled &&
         !delivery.inApp &&

--- a/src/lib/notifications/sms-policy.ts
+++ b/src/lib/notifications/sms-policy.ts
@@ -1,0 +1,140 @@
+import { hasCurrentSmsConsent } from "@/lib/notifications/sms-consent"
+
+export type SmsPolicyPreferences = {
+  readonly smsEnabled: boolean
+  readonly smsPhoneNumber: string | null
+  readonly smsConsentAccepted: boolean
+  readonly smsConsentDisclosureVersion: string | null
+  readonly smsConsentPhoneNumber: string | null
+  readonly mentionSmsEnabled: boolean
+  readonly announcementSmsEnabled: boolean
+  readonly projectActivitySmsEnabled: boolean
+  readonly smsQuietHoursEnabled: boolean
+  readonly smsQuietHoursStart: string
+  readonly smsQuietHoursEnd: string
+  readonly timeZone: string
+}
+
+export type SmsNotificationContext = {
+  readonly eventType: string
+  readonly createdBy: string | null
+  readonly occurredAt: Date
+}
+
+export type SmsMessageMention = {
+  readonly mentionType: string
+  readonly targetId: string | null
+}
+
+const TIME_PATTERN = /^([01]\d|2[0-3]):([0-5]\d)$/
+
+export function isValidSmsQuietHoursTime(value: string): boolean {
+  return TIME_PATTERN.test(value)
+}
+
+function minutesAtTimeZone(date: Date, timeZone: string): number | null {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(date)
+    const hour = Number(parts.find((part) => part.type === "hour")?.value)
+    const minute = Number(
+      parts.find((part) => part.type === "minute")?.value
+    )
+    if (!Number.isInteger(hour) || !Number.isInteger(minute)) return null
+    return hour * 60 + minute
+  } catch {
+    return null
+  }
+}
+
+function timeToMinutes(value: string): number | null {
+  if (!isValidSmsQuietHoursTime(value)) return null
+  const [hourValue, minuteValue] = value.split(":")
+  const hour = Number(hourValue)
+  const minute = Number(minuteValue)
+  return hour * 60 + minute
+}
+
+export function isDuringSmsQuietHours(
+  preferences: Pick<
+    SmsPolicyPreferences,
+    | "smsQuietHoursEnabled"
+    | "smsQuietHoursStart"
+    | "smsQuietHoursEnd"
+    | "timeZone"
+  >,
+  occurredAt: Date
+): boolean {
+  if (!preferences.smsQuietHoursEnabled) return false
+
+  const current = minutesAtTimeZone(occurredAt, preferences.timeZone)
+  const start = timeToMinutes(preferences.smsQuietHoursStart)
+  const end = timeToMinutes(preferences.smsQuietHoursEnd)
+  // Invalid persisted quiet-hour data fails closed rather than sending at an
+  // unexpected time.
+  if (current === null || start === null || end === null) return true
+  if (start === end) return true
+  if (start < end) return current >= start && current < end
+  return current >= start || current < end
+}
+
+export function isProjectActivitySmsEvent(eventType: string): boolean {
+  return (
+    eventType === "message.channel" ||
+    eventType === "message.thread_reply" ||
+    eventType === "message.project"
+  )
+}
+
+export function shouldUseProjectActivitySmsRoute(input: {
+  readonly channelType: string
+  readonly recipientUserId: string
+  readonly mentions: readonly SmsMessageMention[]
+}): boolean {
+  if (input.channelType === "announcement") return false
+  return !input.mentions.some(
+    (mention) =>
+      mention.mentionType === "channel" ||
+      mention.mentionType === "here" ||
+      (mention.mentionType === "user" &&
+        mention.targetId === input.recipientUserId)
+  )
+}
+
+export function shouldSendSmsNotification(
+  preferences: SmsPolicyPreferences,
+  context: SmsNotificationContext
+): boolean {
+  if (
+    !preferences.smsEnabled ||
+    !hasCurrentSmsConsent({
+      accepted: preferences.smsConsentAccepted,
+      phoneNumber: preferences.smsPhoneNumber,
+      consentPhoneNumber: preferences.smsConsentPhoneNumber,
+      disclosureVersion: preferences.smsConsentDisclosureVersion,
+    }) ||
+    isDuringSmsQuietHours(preferences, context.occurredAt)
+  ) {
+    return false
+  }
+
+  if (context.eventType === "message.mention") {
+    return preferences.mentionSmsEnabled
+  }
+  if (context.eventType === "announcement.message") {
+    return preferences.announcementSmsEnabled
+  }
+  if (isProjectActivitySmsEvent(context.eventType)) {
+    // Historical imports and system replays do not have a live actor and must
+    // never produce a burst of project-activity texts.
+    return (
+      context.createdBy !== null &&
+      preferences.projectActivitySmsEnabled
+    )
+  }
+  return false
+}


### PR DESCRIPTION
## Outcome

- sends live project-channel message texts to opted-in exact channel members
- adds an explicit Project messages SMS preference and optional timezone-aware quiet hours
- keeps mention and announcement SMS preferences separate
- deduplicates SMS by source message and recipient

## Safety

Historical imports and system replays fail closed. Consent, active organization membership, exact channel membership, project scope, and user preferences are checked before delivery.

## Migration

Adds `drizzle/0081_project_activity_sms.sql`; migrate production before application deployment.

## Validation

- 12 notification tests
- TypeScript
- targeted ESLint
- git diff --check

Closes #277