### PR TITLE
feat(sage): add guarded pay application read sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,11 @@ NETSUITE_TOKEN_ENCRYPTION_KEY=your_encryption_key_here
 # Optional: Max concurrent requests to NetSuite API (default: 15)
 NETSUITE_CONCURRENCY_LIMIT=15
 
+# Sage read-only bridge (optional)
+# Cloudflare holds only this HMAC secret; SQL credentials stay on the private
+# tailnet bridge. Generate with: openssl rand -hex 32
+SAGE_BRIDGE_SECRET=your_random_sage_bridge_secret_here
+
 # Optional: For Automatic Github Deployments
 GITHUB_TOKEN=your_github_repo_token_here
 GITHUB_REPO=High-Performance-Structures/compass

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -68,6 +68,7 @@ the repository.
 
 | Variable | Description |
 |----------|-------------|
+| `SAGE_BRIDGE_SECRET` | HMAC secret shared by Compass and the private tailnet Sage poller. Generate at least 32 random bytes. |
 | `SAGE_SQL_SERVER` | Sage SQL Server host or private network name. |
 | `SAGE_SQL_DATABASE` | Sage company database name. |
 | `SAGE_SQL_USER` | Least-privilege Sage/SQL integration user. |

--- a/docs/wip/sage-api-bridge-2026-05-14.md
+++ b/docs/wip/sage-api-bridge-2026-05-14.md
@@ -30,6 +30,9 @@ The prior Sage work established that HPS Sage access is through Sage 100 Contrac
 - `SAGE_SQL_INSTANCE` optional, if a named instance is still used
 - `SAGE_SQL_ENCRYPT` optional, depends on the SQL Server certificate setup
 - `SAGE_READ_ONLY` defaults to read-only unless explicitly set to `false`
+- `SAGE_BRIDGE_SECRET` is a separate HMAC secret shared between Compass and the
+  private poller. SQL credentials remain tailnet-only and are never sent to
+  Compass.
 
 The live connector should start with read-only sync jobs. Writes back to Sage should require a visible user action, idempotency key, diff/conflict review, and audit log entry.
 
@@ -55,4 +58,25 @@ Known workflow/table hints from the migration trail:
 
 The dashboard now exposes the bridge status from `src/lib/sage/config.ts` through `getDashboardOverview()`. It shows whether the Sage bridge has credentials loaded, whether it is read-only, how many projects are mapped to Sage, how many Sage operation records are in Compass, and the latest recorded Sage operation sync time.
 
-This is intentionally not yet a live SQL query from the page. The next implementation step is a dedicated server-only Sage import runner that uses these same config keys, reads Sage, then updates Compass read-model tables.
+Pay-application/G703 reads use an outbound pull queue:
+
+1. Authorized internal staff select **Sync with Sage** in the project budget.
+2. Compass records an idempotent, project-scoped read request.
+3. The private poller claims requests with an HMAC-authenticated `GET` to
+   `/api/integrations/sage/pay-applications/requests`.
+4. The poller reads Sage with least-privilege SQL credentials and posts the
+   captured header and lines to
+   `/api/integrations/sage/pay-applications/results`.
+5. Compass verifies the HMAC, queued job identity, formulas, row identity, and
+   revision/hash before normalizing an internal-only G703 application.
+
+The result body is bounded to 1 MiB. Exact replays are idempotent. Changed data
+without a changed Sage revision, duplicate line IDs, job mismatches, and total
+reconciliation failures cannot replace the current view or become
+owner-visible. Owner publication remains a separate reviewed action.
+
+Each poll carries a unique `x-compass-request-id` UUID. The HMAC covers that
+request ID together with the timestamp, method, target, and raw body. Compass
+consumes poll request IDs once, rejects replayed polls, and only reports the
+bridge online after a recent authenticated poll. Production and
+non-production environments must use distinct `SAGE_BRIDGE_SECRET` values.

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     "./src/db/schema-dashboards.ts",
     "./src/db/schema-mcp.ts",
     "./src/db/schema-conversations.ts",
+    "./src/db/schema-sage.ts",
     "./src/lib/sync/schema.ts",
   ],
   out: "./drizzle",

--- a/drizzle/0082_sage_pay_application_read_sync.sql
+++ b/drizzle/0082_sage_pay_application_read_sync.sql
@@ -1,0 +1,80 @@
+CREATE TABLE `sage_pay_application_sync_runs` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_id` text NOT NULL,
+  `requested_by_user_id` text,
+  `idempotency_key` text NOT NULL,
+  `sage_job_id` text,
+  `sage_job_number` text,
+  `status` text DEFAULT 'queued' NOT NULL,
+  `claim_token` text,
+  `claimed_at` text,
+  `attempt_count` integer DEFAULT 0 NOT NULL,
+  `source_application_id` text,
+  `source_revision` text,
+  `source_hash` text,
+  `snapshot_id` text,
+  `reconciliation_json` text,
+  `error_message` text,
+  `requested_at` text NOT NULL,
+  `captured_at` text,
+  `completed_at` text,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`requested_by_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `sage_pay_app_sync_runs_idempotency_idx`
+  ON `sage_pay_application_sync_runs` (`idempotency_key`);
+--> statement-breakpoint
+CREATE INDEX `sage_pay_app_sync_runs_project_status_idx`
+  ON `sage_pay_application_sync_runs` (`project_id`, `status`, `requested_at`);
+--> statement-breakpoint
+CREATE INDEX `sage_pay_app_sync_runs_claim_idx`
+  ON `sage_pay_application_sync_runs` (`status`, `claimed_at`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `sage_pay_app_sync_runs_active_project_idx`
+  ON `sage_pay_application_sync_runs` (`project_id`)
+  WHERE `status` IN ('queued', 'running', 'processing');
+--> statement-breakpoint
+CREATE TABLE `sage_pay_application_snapshots` (
+  `id` text PRIMARY KEY NOT NULL,
+  `run_id` text NOT NULL,
+  `project_id` text NOT NULL,
+  `source_application_id` text NOT NULL,
+  `source_revision` text NOT NULL,
+  `source_hash` text NOT NULL,
+  `application_number` text NOT NULL,
+  `period_to` text,
+  `row_count` integer NOT NULL,
+  `header_json` text NOT NULL,
+  `lines_json` text NOT NULL,
+  `reconciliation_json` text NOT NULL,
+  `captured_at` text NOT NULL,
+  `created_at` text NOT NULL,
+  FOREIGN KEY (`run_id`) REFERENCES `sage_pay_application_sync_runs`(`id`) ON UPDATE no action ON DELETE restrict,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `sage_pay_app_snapshots_source_revision_idx`
+  ON `sage_pay_application_snapshots` (`project_id`, `source_application_id`, `source_revision`, `source_hash`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `sage_pay_app_snapshots_run_idx`
+  ON `sage_pay_application_snapshots` (`run_id`);
+--> statement-breakpoint
+CREATE INDEX `sage_pay_app_snapshots_project_captured_idx`
+  ON `sage_pay_application_snapshots` (`project_id`, `captured_at`);
+--> statement-breakpoint
+CREATE TABLE `sage_bridge_request_nonces` (
+  `request_id` text PRIMARY KEY NOT NULL,
+  `route` text NOT NULL,
+  `created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `sage_bridge_request_nonces_created_idx`
+  ON `sage_bridge_request_nonces` (`created_at`);
+--> statement-breakpoint
+CREATE TABLE `sage_bridge_status` (
+  `id` text PRIMARY KEY NOT NULL,
+  `last_seen_at` text NOT NULL,
+  `updated_at` text NOT NULL
+);

--- a/src/app/actions/sage-pay-applications.ts
+++ b/src/app/actions/sage-pay-applications.ts
@@ -1,0 +1,287 @@
+"use server"
+
+import { and, desc, eq, inArray } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import { projects } from "@/db/schema"
+import {
+  sageBridgeStatus,
+  sagePayApplicationSyncRuns,
+} from "@/db/schema-sage"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoOrg, isDemoUser } from "@/lib/demo"
+import { requireFeaturePermission } from "@/lib/permission-enforcement"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+const ACTIVE_SYNC_STATUSES = ["queued", "running", "processing"] as const
+const BRIDGE_HEARTBEAT_MAX_AGE_MILLISECONDS = 5 * 60 * 1000
+
+export type SagePayApplicationSyncStatus =
+  | "queued"
+  | "running"
+  | "processing"
+  | "needs_review"
+  | "completed"
+  | "failed"
+
+export type SagePayApplicationSyncItem = {
+  readonly id: string
+  readonly status: SagePayApplicationSyncStatus
+  readonly sageJobId: string | null
+  readonly sageJobNumber: string | null
+  readonly sourceApplicationId: string | null
+  readonly sourceRevision: string | null
+  readonly requestedAt: string
+  readonly capturedAt: string | null
+  readonly completedAt: string | null
+  readonly errorMessage: string | null
+}
+
+export type SagePayApplicationSyncState = {
+  readonly configured: boolean
+  readonly online: boolean
+  readonly canRequest: boolean
+  readonly projectMapped: boolean
+  readonly latest: SagePayApplicationSyncItem | null
+  readonly recent: readonly SagePayApplicationSyncItem[]
+}
+
+type QueueResult =
+  | { readonly success: true; readonly runId: string; readonly reused: boolean }
+  | { readonly success: false; readonly error: string }
+
+function syncStatus(value: string): SagePayApplicationSyncStatus {
+  if (value === "queued") return "queued"
+  if (value === "running") return "running"
+  if (value === "processing") return "processing"
+  if (value === "needs_review") return "needs_review"
+  if (value === "completed") return "completed"
+  return "failed"
+}
+
+function syncItem(
+  row: typeof sagePayApplicationSyncRuns.$inferSelect
+): SagePayApplicationSyncItem {
+  return {
+    id: row.id,
+    status: syncStatus(row.status),
+    sageJobId: row.sageJobId,
+    sageJobNumber: row.sageJobNumber,
+    sourceApplicationId: row.sourceApplicationId,
+    sourceRevision: row.sourceRevision,
+    requestedAt: row.requestedAt,
+    capturedAt: row.capturedAt,
+    completedAt: row.completedAt,
+    errorMessage: row.errorMessage,
+  }
+}
+
+function bridgeConfigured(env: CloudflareEnv): boolean {
+  const secret: unknown = Reflect.get(env, "SAGE_BRIDGE_SECRET")
+  return typeof secret === "string" && secret.trim().length >= 32
+}
+
+async function bridgeOnline(env: CloudflareEnv): Promise<boolean> {
+  const db = getDb(env.DB)
+  const bridge = await db
+    .select({ lastSeenAt: sageBridgeStatus.lastSeenAt })
+    .from(sageBridgeStatus)
+    .where(eq(sageBridgeStatus.id, "pay-application-poller"))
+    .limit(1)
+    .get()
+  const lastSeenAt = bridge ? Date.parse(bridge.lastSeenAt) : Number.NaN
+  return (
+    Number.isFinite(lastSeenAt) &&
+    Date.now() - lastSeenAt <= BRIDGE_HEARTBEAT_MAX_AGE_MILLISECONDS
+  )
+}
+
+export async function getSagePayApplicationSyncState(
+  projectId: string
+): Promise<SagePayApplicationSyncState> {
+  const user = await requireAuth()
+  if (!isInternalStaffRole(user.role)) {
+    throw new Error("Project not found")
+  }
+  await requireFeaturePermission(user, "budget", "read")
+  await requireFeaturePermission(user, "sage-sync", "read")
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+
+  const project = await db
+    .select({
+      id: projects.id,
+      organizationId: projects.organizationId,
+      sageJobId: projects.sageJobId,
+      sageJobNumber: projects.sageJobNumber,
+    })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .limit(1)
+    .get()
+
+  if (
+    !project ||
+    !user.organizationId ||
+    project.organizationId !== user.organizationId
+  ) {
+    throw new Error("Project not found")
+  }
+
+  const rows = await db
+    .select()
+    .from(sagePayApplicationSyncRuns)
+    .where(eq(sagePayApplicationSyncRuns.projectId, projectId))
+    .orderBy(desc(sagePayApplicationSyncRuns.requestedAt))
+    .limit(10)
+  const online = await bridgeOnline(env)
+
+  let canRequest = false
+  if (
+    isInternalStaffRole(user.role) &&
+    !isDemoUser(user.id) &&
+    !isDemoOrg(user.organizationId)
+  ) {
+    try {
+      await requireFeaturePermission(user, "budget", "update")
+      await requireFeaturePermission(user, "sage-sync", "update")
+      canRequest = true
+    } catch {
+      canRequest = false
+    }
+  }
+
+  const recent = rows.map(syncItem)
+  return {
+    configured: bridgeConfigured(env),
+    online,
+    canRequest,
+    projectMapped: Boolean(project.sageJobId || project.sageJobNumber),
+    latest: recent[0] ?? null,
+    recent,
+  }
+}
+
+export async function queueSagePayApplicationSync(
+  projectId: string
+): Promise<QueueResult> {
+  try {
+    const user = await requireAuth()
+    if (
+      !isInternalStaffRole(user.role) ||
+      isDemoUser(user.id) ||
+      !user.organizationId ||
+      isDemoOrg(user.organizationId)
+    ) {
+      return { success: false, error: "Sage sync is unavailable." }
+    }
+
+    await requireFeaturePermission(user, "budget", "update")
+    await requireFeaturePermission(user, "sage-sync", "update")
+
+    const { env } = await getCloudflareContext()
+    if (!bridgeConfigured(env)) {
+      return {
+        success: false,
+        error: "The read-only Sage bridge is not configured.",
+      }
+    }
+
+    const db = getDb(env.DB)
+    if (!(await bridgeOnline(env))) {
+      return {
+        success: false,
+        error: "The private Sage poller is offline.",
+      }
+    }
+    const project = await db
+      .select({
+        id: projects.id,
+        organizationId: projects.organizationId,
+        sageJobId: projects.sageJobId,
+        sageJobNumber: projects.sageJobNumber,
+      })
+      .from(projects)
+      .where(
+        and(
+          eq(projects.id, projectId),
+          eq(projects.organizationId, user.organizationId)
+        )
+      )
+      .limit(1)
+      .get()
+
+    if (!project) return { success: false, error: "Project not found." }
+    if (!project.sageJobId && !project.sageJobNumber) {
+      return {
+        success: false,
+        error: "Map this Compass project to a Sage job before syncing.",
+      }
+    }
+
+    const active = await db
+      .select({ id: sagePayApplicationSyncRuns.id })
+      .from(sagePayApplicationSyncRuns)
+      .where(
+        and(
+          eq(sagePayApplicationSyncRuns.projectId, projectId),
+          inArray(sagePayApplicationSyncRuns.status, ACTIVE_SYNC_STATUSES)
+        )
+      )
+      .orderBy(desc(sagePayApplicationSyncRuns.requestedAt))
+      .limit(1)
+      .get()
+
+    if (active) {
+      return { success: true, runId: active.id, reused: true }
+    }
+
+    const now = new Date().toISOString()
+    const runId = crypto.randomUUID()
+    try {
+      await db.insert(sagePayApplicationSyncRuns).values({
+        id: runId,
+        projectId,
+        requestedByUserId: user.id,
+        idempotencyKey: `sage-pay-application-read:${projectId}:${runId}`,
+        sageJobId: project.sageJobId,
+        sageJobNumber: project.sageJobNumber,
+        status: "queued",
+        requestedAt: now,
+        updatedAt: now,
+      })
+    } catch (error) {
+      // The partial unique index closes the race between the active-run lookup
+      // and insert. A simultaneous request should reuse the winner.
+      const concurrent = await db
+        .select({ id: sagePayApplicationSyncRuns.id })
+        .from(sagePayApplicationSyncRuns)
+        .where(
+          and(
+            eq(sagePayApplicationSyncRuns.projectId, projectId),
+            inArray(sagePayApplicationSyncRuns.status, ACTIVE_SYNC_STATUSES)
+          )
+        )
+        .orderBy(desc(sagePayApplicationSyncRuns.requestedAt))
+        .limit(1)
+        .get()
+      if (concurrent) {
+        return { success: true, runId: concurrent.id, reused: true }
+      }
+      throw error
+    }
+
+    revalidatePath(`/dashboard/projects/${projectId}/budget`)
+    return { success: true, runId, reused: false }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to queue the Sage read sync.",
+    }
+  }
+}

--- a/src/app/api/integrations/sage/pay-applications/requests/route.ts
+++ b/src/app/api/integrations/sage/pay-applications/requests/route.ts
@@ -1,0 +1,163 @@
+import { and, asc, eq, lt, or, sql } from "drizzle-orm"
+
+import { getDb } from "@/db"
+import {
+  sageBridgeRequestNonces,
+  sagePayApplicationSyncRuns,
+} from "@/db/schema-sage"
+import { getCloudflareContext } from "@/lib/db"
+import {
+  getSageBridgeSecret,
+  SAGE_BRIDGE_REQUEST_ID_HEADER,
+  verifySageBridgeRequest,
+} from "@/lib/sage/bridge-auth"
+
+const MAX_BATCH = 20
+const CLAIM_RETRY_MILLISECONDS = 5 * 60 * 1000
+const INGEST_RETRY_MILLISECONDS = 15 * 60 * 1000
+const NONCE_RETENTION_MILLISECONDS = 15 * 60 * 1000
+
+function unauthorized(error: string): Response {
+  return Response.json({ error }, { status: 401 })
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const { env } = await getCloudflareContext()
+  const secret = getSageBridgeSecret(env)
+  if (!secret) {
+    return Response.json(
+      { error: "Sage bridge is not configured" },
+      { status: 503 }
+    )
+  }
+  const verification = await verifySageBridgeRequest(request, secret, "")
+  if (!verification.success) return unauthorized(verification.error)
+
+  const url = new URL(request.url)
+  const requestId = request.headers.get(SAGE_BRIDGE_REQUEST_ID_HEADER)
+  if (!requestId) return unauthorized("Missing bridge signature")
+  const requestedLimit = Number(url.searchParams.get("limit") ?? "10")
+  const limit = Number.isInteger(requestedLimit)
+    ? Math.min(MAX_BATCH, Math.max(1, requestedLimit))
+    : 10
+  const now = new Date()
+  const nowIso = now.toISOString()
+  const staleClaimIso = new Date(
+    now.getTime() - CLAIM_RETRY_MILLISECONDS
+  ).toISOString()
+  const staleIngestIso = new Date(
+    now.getTime() - INGEST_RETRY_MILLISECONDS
+  ).toISOString()
+  const db = getDb(env.DB)
+  await db
+    .delete(sageBridgeRequestNonces)
+    .where(
+      lt(
+        sageBridgeRequestNonces.createdAt,
+        new Date(now.getTime() - NONCE_RETENTION_MILLISECONDS).toISOString()
+      )
+    )
+  try {
+    await db.insert(sageBridgeRequestNonces).values({
+      requestId,
+      route: url.pathname,
+      createdAt: nowIso,
+    })
+  } catch {
+    return Response.json(
+      { error: "Bridge request has already been consumed" },
+      { status: 409 }
+    )
+  }
+
+  await env.DB.prepare(
+    `INSERT INTO sage_bridge_status (id, last_seen_at, updated_at)
+     VALUES ('pay-application-poller', ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       last_seen_at = excluded.last_seen_at,
+       updated_at = excluded.updated_at`
+  )
+    .bind(nowIso, nowIso)
+    .run()
+
+  const candidates = await db
+    .select({ id: sagePayApplicationSyncRuns.id })
+    .from(sagePayApplicationSyncRuns)
+    .where(
+      or(
+        eq(sagePayApplicationSyncRuns.status, "queued"),
+        and(
+          eq(sagePayApplicationSyncRuns.status, "running"),
+          lt(sagePayApplicationSyncRuns.claimedAt, staleClaimIso)
+        ),
+        and(
+          eq(sagePayApplicationSyncRuns.status, "processing"),
+          lt(sagePayApplicationSyncRuns.claimedAt, staleIngestIso)
+        )
+      )
+    )
+    .orderBy(asc(sagePayApplicationSyncRuns.requestedAt))
+    .limit(limit)
+
+  const requests: {
+    id: string
+    projectId: string
+    sageJobId: string | null
+    sageJobNumber: string | null
+    claimToken: string
+    attempt: number
+    requestedAt: string
+  }[] = []
+  for (const candidate of candidates) {
+    const claimToken = crypto.randomUUID()
+    await db
+      .update(sagePayApplicationSyncRuns)
+      .set({
+        status: "running",
+        claimToken,
+        claimedAt: nowIso,
+        attemptCount: sql`${sagePayApplicationSyncRuns.attemptCount} + 1`,
+        updatedAt: nowIso,
+      })
+      .where(
+        and(
+          eq(sagePayApplicationSyncRuns.id, candidate.id),
+          or(
+            eq(sagePayApplicationSyncRuns.status, "queued"),
+            and(
+              eq(sagePayApplicationSyncRuns.status, "running"),
+              lt(sagePayApplicationSyncRuns.claimedAt, staleClaimIso)
+            ),
+            and(
+              eq(sagePayApplicationSyncRuns.status, "processing"),
+              lt(sagePayApplicationSyncRuns.claimedAt, staleIngestIso)
+            )
+          )
+        )
+      )
+    const claimed = await db
+      .select()
+      .from(sagePayApplicationSyncRuns)
+      .where(
+        and(
+          eq(sagePayApplicationSyncRuns.id, candidate.id),
+          eq(sagePayApplicationSyncRuns.claimToken, claimToken),
+          eq(sagePayApplicationSyncRuns.status, "running")
+        )
+      )
+      .limit(1)
+      .get()
+    if (!claimed) continue
+    requests.push({
+      id: claimed.id,
+      projectId: claimed.projectId,
+      sageJobId: claimed.sageJobId,
+      sageJobNumber: claimed.sageJobNumber,
+      claimToken,
+      attempt: claimed.attemptCount,
+      requestedAt: claimed.requestedAt,
+    })
+  }
+
+  return Response.json({ requests })
+}

--- a/src/app/api/integrations/sage/pay-applications/results/route.ts
+++ b/src/app/api/integrations/sage/pay-applications/results/route.ts
@@ -1,0 +1,52 @@
+import { getCloudflareContext } from "@/lib/db"
+import {
+  getSageBridgeSecret,
+  readBoundedSageBridgeBody,
+  verifySageBridgeRequest,
+} from "@/lib/sage/bridge-auth"
+import { ingestSagePayApplicationSnapshot } from "@/lib/sage/pay-application-ingest"
+
+function unauthorized(error: string): Response {
+  return Response.json({ error }, { status: 401 })
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const { env } = await getCloudflareContext()
+  const secret = getSageBridgeSecret(env)
+  if (!secret) {
+    return Response.json(
+      { error: "Sage bridge is not configured" },
+      { status: 503 }
+    )
+  }
+  if (!request.headers.get("content-type")?.startsWith("application/json")) {
+    return Response.json(
+      { error: "Content-Type must be application/json" },
+      { status: 415 }
+    )
+  }
+  const body = await readBoundedSageBridgeBody(request)
+  if (!body.success) {
+    return Response.json({ error: body.error }, { status: 413 })
+  }
+  const verification = await verifySageBridgeRequest(
+    request,
+    secret,
+    body.rawBody
+  )
+  if (!verification.success) return unauthorized(verification.error)
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(body.rawBody)
+  } catch {
+    return Response.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+  const result = await ingestSagePayApplicationSnapshot(env, parsed)
+  if (!result.success) {
+    return Response.json({ error: result.error }, { status: 409 })
+  }
+  return Response.json(result, {
+    status: result.status === "needs_review" ? 202 : 200,
+  })
+}

--- a/src/app/dashboard/projects/[id]/budget/page.tsx
+++ b/src/app/dashboard/projects/[id]/budget/page.tsx
@@ -13,10 +13,15 @@ import {
   type ProjectBudgetSummary,
 } from "@/app/actions/project-budget"
 import {
+  getSagePayApplicationSyncState,
+  type SagePayApplicationSyncState,
+} from "@/app/actions/sage-pay-applications"
+import {
   ProjectBudgetG703Table,
   ProjectBudgetPanel,
 } from "@/components/projects/project-budget-panel"
 import { ProjectContextSwitcher } from "@/components/projects/project-context-switcher"
+import { SagePayApplicationSyncControl } from "@/components/projects/sage-pay-application-sync-control"
 import { Badge } from "@/components/ui/badge"
 
 export default async function ProjectBudgetPage({
@@ -28,12 +33,22 @@ export default async function ProjectBudgetPage({
 
   let internalBudget: ProjectBudgetSummary | null = null
   let ownerBudget: ProjectBudgetSummary | null = null
+  let sageSyncState: SagePayApplicationSyncState | null = null
 
   try {
-    internalBudget = await getProjectBudgetSummary(id, "internal")
-    ownerBudget = await getProjectBudgetSummary(id, "owner")
+    const [internal, owner] = await Promise.all([
+      getProjectBudgetSummary(id, "internal"),
+      getProjectBudgetSummary(id, "owner"),
+    ])
+    internalBudget = internal
+    ownerBudget = owner
   } catch (error) {
     console.warn("Budget unavailable", error)
+  }
+  try {
+    sageSyncState = await getSagePayApplicationSyncState(id)
+  } catch (error) {
+    console.warn("Sage sync unavailable", error)
   }
 
   return (
@@ -77,6 +92,13 @@ export default async function ProjectBudgetPage({
         </div>
       </div>
 
+      {sageSyncState && (
+        <SagePayApplicationSyncControl
+          projectId={id}
+          state={sageSyncState}
+        />
+      )}
+
       <div className="mb-6">
         <ProjectBudgetPanel projectId={id} summary={internalBudget} />
       </div>
@@ -86,7 +108,7 @@ export default async function ProjectBudgetPage({
           <div className="mb-3 flex items-center justify-between gap-3">
             <div>
               <h2 className="text-sm font-semibold">Internal G703</h2>
-            <p className="text-xs text-muted-foreground">
+              <p className="text-xs text-muted-foreground">
                 All mapped lines and internal-only detail.
               </p>
             </div>
@@ -100,7 +122,7 @@ export default async function ProjectBudgetPage({
           <div className="mb-3 flex items-center justify-between gap-3">
             <div>
               <h2 className="text-sm font-semibold">Owner View</h2>
-            <p className="text-xs text-muted-foreground">
+              <p className="text-xs text-muted-foreground">
                 O jobs show approved cost-code detail. H jobs roll up to
                 categories.
               </p>

--- a/src/components/projects/sage-pay-application-sync-control.tsx
+++ b/src/components/projects/sage-pay-application-sync-control.tsx
@@ -1,0 +1,172 @@
+"use client"
+
+import {
+  IconAlertTriangle,
+  IconCheck,
+  IconClock,
+  IconRefresh,
+} from "@tabler/icons-react"
+import { useRouter } from "next/navigation"
+import { useState, useTransition } from "react"
+
+import {
+  queueSagePayApplicationSync,
+  type SagePayApplicationSyncState,
+} from "@/app/actions/sage-pay-applications"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+
+function dateTime(value: string | null): string {
+  if (!value) return "Not yet"
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })
+}
+
+function statusBadge(
+  status: SagePayApplicationSyncState["latest"]
+): React.ReactElement {
+  if (!status) return <Badge variant="outline">Never synced</Badge>
+  if (status.status === "completed") {
+    return (
+      <Badge
+        variant="outline"
+        className="gap-1 border-emerald-300 text-emerald-700"
+      >
+        <IconCheck className="size-3" />
+        Synced
+      </Badge>
+    )
+  }
+  if (
+    status.status === "queued" ||
+    status.status === "running" ||
+    status.status === "processing"
+  ) {
+    return (
+      <Badge
+        variant="outline"
+        className="gap-1 border-blue-300 text-blue-700"
+      >
+        <IconClock className="size-3" />
+        {status.status === "queued"
+          ? "Queued"
+          : status.status === "processing"
+            ? "Importing"
+            : "Reading Sage"}
+      </Badge>
+    )
+  }
+  return (
+    <Badge
+      variant="outline"
+      className="gap-1 border-amber-300 text-amber-700"
+    >
+      <IconAlertTriangle className="size-3" />
+      {status.status === "needs_review" ? "Needs review" : "Failed"}
+    </Badge>
+  )
+}
+
+export function SagePayApplicationSyncControl({
+  projectId,
+  state,
+}: {
+  readonly projectId: string
+  readonly state: SagePayApplicationSyncState
+}): React.ReactElement {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [message, setMessage] = useState<string | null>(null)
+  const active =
+    state.latest?.status === "queued" ||
+    state.latest?.status === "running" ||
+    state.latest?.status === "processing"
+  const disabled =
+    isPending ||
+    active ||
+    !state.configured ||
+    !state.online ||
+    !state.canRequest ||
+    !state.projectMapped
+
+  function queueSync(): void {
+    setMessage(null)
+    startTransition(async () => {
+      const result = await queueSagePayApplicationSync(projectId)
+      setMessage(
+        result.success
+          ? result.reused
+            ? "A read sync is already in progress."
+            : "Sage pay application read queued."
+          : result.error
+      )
+      router.refresh()
+    })
+  }
+
+  return (
+    <section className="mb-6 border-y py-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-sm font-semibold">
+              Sage pay application sync
+            </h2>
+            {statusBadge(state.latest)}
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Read-only import. New Sage data stays internal until separately
+            reviewed and published.
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Latest finished: {dateTime(state.latest?.completedAt ?? null)}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          onClick={queueSync}
+        >
+          <IconRefresh
+            className={`mr-1.5 size-4 ${isPending ? "animate-spin" : ""}`}
+          />
+          {active ? "Sync in progress" : "Sync with Sage"}
+        </Button>
+      </div>
+
+      {!state.projectMapped && (
+        <p className="mt-2 text-xs text-amber-700">
+          Add the Sage job mapping in Project Registry before syncing.
+        </p>
+      )}
+      {!state.configured && (
+        <p className="mt-2 text-xs text-amber-700">
+          The private read-only Sage bridge still needs its shared secret and
+          poller enabled.
+        </p>
+      )}
+      {state.configured && !state.online && (
+        <p className="mt-2 text-xs text-amber-700">
+          The private Sage poller is offline or has not checked in recently.
+        </p>
+      )}
+      {state.latest?.errorMessage && (
+        <p className="mt-2 text-xs text-destructive">
+          {state.latest.errorMessage}
+        </p>
+      )}
+      {message && (
+        <p className="mt-2 text-xs text-muted-foreground">{message}</p>
+      )}
+    </section>
+  )
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -10,6 +10,7 @@ import * as dashboardSchema from "./schema-dashboards"
 import * as mcpSchema from "./schema-mcp"
 import * as conversationsSchema from "./schema-conversations"
 import * as jarvisSchema from "./schema-jarvis"
+import * as sageSchema from "./schema-sage"
 
 const allSchemas = {
   ...schema,
@@ -23,6 +24,7 @@ const allSchemas = {
   ...mcpSchema,
   ...conversationsSchema,
   ...jarvisSchema,
+  ...sageSchema,
 }
 
 // Legacy function - kept for backwards compatibility

--- a/src/db/schema-sage.ts
+++ b/src/db/schema-sage.ts
@@ -1,0 +1,120 @@
+import {
+  index,
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core"
+import { sql } from "drizzle-orm"
+
+import { projects, users } from "./schema"
+
+export const sagePayApplicationSyncRuns = sqliteTable(
+  "sage_pay_application_sync_runs",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    requestedByUserId: text("requested_by_user_id").references(
+      () => users.id,
+      { onDelete: "set null" }
+    ),
+    idempotencyKey: text("idempotency_key").notNull(),
+    sageJobId: text("sage_job_id"),
+    sageJobNumber: text("sage_job_number"),
+    status: text("status").notNull().default("queued"),
+    claimToken: text("claim_token"),
+    claimedAt: text("claimed_at"),
+    attemptCount: integer("attempt_count").notNull().default(0),
+    sourceApplicationId: text("source_application_id"),
+    sourceRevision: text("source_revision"),
+    sourceHash: text("source_hash"),
+    snapshotId: text("snapshot_id"),
+    reconciliationJson: text("reconciliation_json"),
+    errorMessage: text("error_message"),
+    requestedAt: text("requested_at").notNull(),
+    capturedAt: text("captured_at"),
+    completedAt: text("completed_at"),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("sage_pay_app_sync_runs_idempotency_idx").on(
+      table.idempotencyKey
+    ),
+    index("sage_pay_app_sync_runs_project_status_idx").on(
+      table.projectId,
+      table.status,
+      table.requestedAt
+    ),
+    index("sage_pay_app_sync_runs_claim_idx").on(
+      table.status,
+      table.claimedAt
+    ),
+    uniqueIndex("sage_pay_app_sync_runs_active_project_idx")
+      .on(table.projectId)
+      .where(sql`${table.status} IN ('queued', 'running', 'processing')`),
+  ]
+)
+
+export const sagePayApplicationSnapshots = sqliteTable(
+  "sage_pay_application_snapshots",
+  {
+    id: text("id").primaryKey(),
+    runId: text("run_id")
+      .notNull()
+      .references(() => sagePayApplicationSyncRuns.id, {
+        onDelete: "restrict",
+      }),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    sourceApplicationId: text("source_application_id").notNull(),
+    sourceRevision: text("source_revision").notNull(),
+    sourceHash: text("source_hash").notNull(),
+    applicationNumber: text("application_number").notNull(),
+    periodTo: text("period_to"),
+    rowCount: integer("row_count").notNull(),
+    headerJson: text("header_json").notNull(),
+    linesJson: text("lines_json").notNull(),
+    reconciliationJson: text("reconciliation_json").notNull(),
+    capturedAt: text("captured_at").notNull(),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("sage_pay_app_snapshots_source_revision_idx").on(
+      table.projectId,
+      table.sourceApplicationId,
+      table.sourceRevision,
+      table.sourceHash
+    ),
+    uniqueIndex("sage_pay_app_snapshots_run_idx").on(table.runId),
+    index("sage_pay_app_snapshots_project_captured_idx").on(
+      table.projectId,
+      table.capturedAt
+    ),
+  ]
+)
+
+export const sageBridgeRequestNonces = sqliteTable(
+  "sage_bridge_request_nonces",
+  {
+    requestId: text("request_id").primaryKey(),
+    route: text("route").notNull(),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    index("sage_bridge_request_nonces_created_idx").on(table.createdAt),
+  ]
+)
+
+export const sageBridgeStatus = sqliteTable("sage_bridge_status", {
+  id: text("id").primaryKey(),
+  lastSeenAt: text("last_seen_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+})
+
+export type SagePayApplicationSyncRun =
+  typeof sagePayApplicationSyncRuns.$inferSelect
+export type SagePayApplicationSnapshot =
+  typeof sagePayApplicationSnapshots.$inferSelect

--- a/src/lib/__tests__/middleware-routes.test.ts
+++ b/src/lib/__tests__/middleware-routes.test.ts
@@ -20,4 +20,17 @@ describe("middleware public routes", () => {
   it("does not make unrelated integration routes public", () => {
     expect(isPublicPath("/api/integrations/other/events")).toBe(false)
   })
+
+  it("allows only the two HMAC-authenticated Sage bridge endpoints", () => {
+    expect(
+      isPublicPath("/api/integrations/sage/pay-applications/requests")
+    ).toBe(true)
+    expect(
+      isPublicPath("/api/integrations/sage/pay-applications/results")
+    ).toBe(true)
+    expect(isPublicPath("/api/integrations/sage/admin")).toBe(false)
+    expect(
+      isPublicPath("/api/integrations/sage/pay-applications/requests/extra")
+    ).toBe(false)
+  })
 })

--- a/src/lib/public-paths.ts
+++ b/src/lib/public-paths.ts
@@ -16,10 +16,16 @@ const bridgePaths = [
   "/api/bridge/context",
 ]
 
+const sageBridgePaths = [
+  "/api/integrations/sage/pay-applications/requests",
+  "/api/integrations/sage/pay-applications/results",
+]
+
 export function isPublicPath(pathname: string): boolean {
   return (
     publicPaths.includes(pathname) ||
     bridgePaths.includes(pathname) ||
+    sageBridgePaths.includes(pathname) ||
     pathname.startsWith("/api/auth/") ||
     pathname.startsWith("/api/integrations/jarvis/") ||
     pathname.startsWith("/api/netsuite/") ||

--- a/src/lib/sage/__tests__/bridge-auth.test.ts
+++ b/src/lib/sage/__tests__/bridge-auth.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  createSageBridgeSignature,
+  MAX_SAGE_BRIDGE_BODY_BYTES,
+  readBoundedSageBridgeBody,
+  verifySageBridgeRequest,
+} from "@/lib/sage/bridge-auth"
+
+const SECRET = "test-sage-bridge-secret-with-32-characters"
+const REQUEST_ID = "8cae3eb4-757d-419d-9f88-21719ac08e1d"
+
+async function signedRequest(
+  timestamp: string,
+  body: string
+): Promise<Request> {
+  const target = "/api/integrations/sage/pay-applications/results"
+  const signature = await createSageBridgeSignature(
+    SECRET,
+    timestamp,
+    REQUEST_ID,
+    "POST",
+    target,
+    body
+  )
+  return new Request(`https://compass.example${target}`, {
+    method: "POST",
+    headers: {
+      "x-compass-timestamp": timestamp,
+      "x-compass-request-id": REQUEST_ID,
+      "x-compass-signature": signature,
+    },
+    body,
+  })
+}
+
+describe("Sage bridge HMAC authentication", () => {
+  it("accepts a current signature bound to method, target, and body", async () => {
+    const now = Date.parse("2026-07-30T20:00:00.000Z")
+    const timestamp = String(Math.floor(now / 1000))
+    const request = await signedRequest(timestamp, '{"runId":"one"}')
+    await expect(
+      verifySageBridgeRequest(request, SECRET, '{"runId":"one"}', now)
+    ).resolves.toEqual({ success: true })
+  })
+
+  it("rejects tampered and expired requests", async () => {
+    const now = Date.parse("2026-07-30T20:00:00.000Z")
+    const timestamp = String(Math.floor(now / 1000))
+    const request = await signedRequest(timestamp, '{"runId":"one"}')
+    await expect(
+      verifySageBridgeRequest(request, SECRET, '{"runId":"two"}', now)
+    ).resolves.toEqual({
+      success: false,
+      error: "Invalid bridge signature",
+    })
+    await expect(
+      verifySageBridgeRequest(
+        request,
+        SECRET,
+        '{"runId":"one"}',
+        now + 6 * 60 * 1000
+      )
+    ).resolves.toEqual({
+      success: false,
+      error: "Expired bridge signature",
+    })
+  })
+
+  it("rejects a missing or invalid signed request ID", async () => {
+    const now = Date.parse("2026-07-30T20:00:00.000Z")
+    const timestamp = String(Math.floor(now / 1000))
+    const request = await signedRequest(timestamp, "{}")
+    request.headers.delete("x-compass-request-id")
+    await expect(
+      verifySageBridgeRequest(request, SECRET, "{}", now)
+    ).resolves.toEqual({
+      success: false,
+      error: "Missing bridge signature",
+    })
+  })
+
+  it("stops reading a streamed body at the byte limit", async () => {
+    const chunk = new Uint8Array(MAX_SAGE_BRIDGE_BODY_BYTES / 2 + 1)
+    const request = new Request("https://compass.example/results", {
+      method: "POST",
+    })
+    Object.defineProperty(request, "body", {
+      value: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(chunk)
+          controller.enqueue(chunk)
+          controller.close()
+        },
+      }),
+      configurable: true,
+    })
+    await expect(readBoundedSageBridgeBody(request)).resolves.toEqual({
+      success: false,
+      error: "Request body is too large",
+    })
+  })
+})

--- a/src/lib/sage/__tests__/pay-application-snapshot.test.ts
+++ b/src/lib/sage/__tests__/pay-application-snapshot.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  hashSagePayApplicationSnapshot,
+  normalizeSagePayApplicationSnapshot,
+  reconcileSagePayApplicationSnapshot,
+  sagePayApplicationSnapshotSchema,
+  type SagePayApplicationSnapshot,
+} from "@/lib/sage/pay-application-snapshot"
+
+function snapshot(): SagePayApplicationSnapshot {
+  return {
+    runId: "550e8400-e29b-41d4-a716-446655440000",
+    claimToken: "8cae3eb4-757d-419d-9f88-21719ac08e1d",
+    capturedAt: "2026-07-30T20:00:00.000Z",
+    header: {
+      sourceApplicationId: "sage-pay-app-3",
+      sourceRevision: "3",
+      sageJobId: "170",
+      sageJobNumber: "O-170-2684",
+      applicationNumber: "3",
+      periodTo: "2026-07-30",
+      status: "posted",
+      originalContractSum: 1000,
+      netChanges: 100,
+      contractSumToDate: 1100,
+      totalCompletedStoredToDate: 600,
+      retainageHeld: 60,
+      totalEarnedLessRetainage: 540,
+      previousCertificates: 400,
+      currentPaymentDue: 140,
+      balanceToFinish: 560,
+    },
+    lines: [
+      {
+        sourceLineId: "line-2",
+        costCode: "02 00 00",
+        csiDivision: "02",
+        csiDivisionName: "Existing Conditions",
+        description: "Selective demolition",
+        originalEstimate: 400,
+        priorChanges: 0,
+        currentChanges: 100,
+        totalChanges: 100,
+        adjustedEstimate: 500,
+        previousWorkCompleted: 150,
+        currentWorkCompleted: 50,
+        storedMaterials: 0,
+        totalCompletedStoredToDate: 200,
+        retainageHeld: 20,
+        balanceToFinish: 300,
+        sortOrder: 2,
+      },
+      {
+        sourceLineId: "line-1",
+        costCode: "01 00 00",
+        csiDivision: "01",
+        csiDivisionName: "General Requirements",
+        description: "General conditions",
+        originalEstimate: 600,
+        priorChanges: 0,
+        currentChanges: 0,
+        totalChanges: 0,
+        adjustedEstimate: 600,
+        previousWorkCompleted: 300,
+        currentWorkCompleted: 50,
+        storedMaterials: 50,
+        totalCompletedStoredToDate: 400,
+        retainageHeld: 40,
+        balanceToFinish: 200,
+        sortOrder: 1,
+      },
+    ],
+  }
+}
+
+describe("Sage pay application snapshots", () => {
+  it("validates and reconciles a balanced snapshot", () => {
+    const parsed = sagePayApplicationSnapshotSchema.parse(snapshot())
+    const result = reconcileSagePayApplicationSnapshot(parsed)
+
+    expect(result.passed).toBe(true)
+    expect(result.rowCount).toBe(2)
+    expect(result.duplicateSourceLineIds).toEqual([])
+  })
+
+  it("fails closed when header and line formulas do not reconcile", () => {
+    const input = snapshot()
+    const changed: SagePayApplicationSnapshot = {
+      ...input,
+      header: {
+        ...input.header,
+        currentPaymentDue: 200,
+      },
+    }
+
+    const result = reconcileSagePayApplicationSnapshot(changed)
+
+    expect(result.passed).toBe(false)
+    expect(
+      result.checks.find(
+        (item) => item.key === "header.current_payment_due"
+      )?.passed
+    ).toBe(false)
+  })
+
+  it("rejects duplicate source line identifiers", () => {
+    const input = snapshot()
+    const duplicate: SagePayApplicationSnapshot = {
+      ...input,
+      lines: [
+        input.lines[0],
+        {
+          ...input.lines[1],
+          sourceLineId: input.lines[0].sourceLineId,
+        },
+      ],
+    }
+
+    const result = reconcileSagePayApplicationSnapshot(duplicate)
+
+    expect(result.passed).toBe(false)
+    expect(result.duplicateSourceLineIds).toEqual(["line-2"])
+  })
+
+  it("normalizes line order before hashing exact replays", async () => {
+    const input = snapshot()
+    const reversed: SagePayApplicationSnapshot = {
+      ...input,
+      lines: [...input.lines].reverse(),
+    }
+
+    expect(normalizeSagePayApplicationSnapshot(input).lines[0]?.sourceLineId)
+      .toBe("line-1")
+    await expect(hashSagePayApplicationSnapshot(input)).resolves.toBe(
+      await hashSagePayApplicationSnapshot(reversed)
+    )
+  })
+
+  it("does not include run or capture transport metadata in the source hash", async () => {
+    const input = snapshot()
+    const laterCapture: SagePayApplicationSnapshot = {
+      ...input,
+      runId: "19b22780-0fa8-4f5f-8799-2c59c34354b8",
+      claimToken: "6c08be20-900e-4f35-b0cb-3f445da30290",
+      capturedAt: "2026-07-31T20:00:00.000Z",
+    }
+
+    await expect(hashSagePayApplicationSnapshot(input)).resolves.toBe(
+      await hashSagePayApplicationSnapshot(laterCapture)
+    )
+  })
+
+  it("reconciles G702 balance including retained funds", () => {
+    const result = reconcileSagePayApplicationSnapshot(snapshot())
+
+    expect(
+      result.checks.find(
+        (item) => item.key === "header.balance_to_finish"
+      )
+    ).toMatchObject({
+      expected: 560,
+      actual: 560,
+      passed: true,
+    })
+    expect(
+      result.checks.find(
+        (item) => item.key === "lines.balance_plus_retainage"
+      )
+    ).toMatchObject({
+      expected: 560,
+      actual: 560,
+      passed: true,
+    })
+  })
+})

--- a/src/lib/sage/__tests__/sync-claim.test.ts
+++ b/src/lib/sage/__tests__/sync-claim.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  SAGE_SYNC_CLAIM_LEASE_MILLISECONDS,
+  validateSageSyncClaim,
+} from "@/lib/sage/sync-claim"
+
+const NOW = Date.parse("2026-07-30T20:00:00.000Z")
+const CLAIM_TOKEN = "8cae3eb4-757d-419d-9f88-21719ac08e1d"
+
+function run(
+  overrides: Partial<{
+    readonly status: string
+    readonly claimToken: string | null
+    readonly claimedAt: string | null
+    readonly snapshotId: string | null
+  }> = {}
+) {
+  return {
+    status: "running",
+    claimToken: CLAIM_TOKEN,
+    claimedAt: new Date(NOW - 1_000).toISOString(),
+    snapshotId: null,
+    ...overrides,
+  }
+}
+
+describe("Sage bridge sync claims", () => {
+  it("accepts a current running claim", () => {
+    expect(validateSageSyncClaim(run(), CLAIM_TOKEN, NOW)).toEqual({
+      success: true,
+      terminalReplay: false,
+    })
+  })
+
+  it("rejects mismatched, unclaimed, future, and expired claims", () => {
+    expect(
+      validateSageSyncClaim(run(), crypto.randomUUID(), NOW)
+    ).toEqual({
+      success: false,
+      error: "Sage sync claim does not match this run.",
+    })
+    expect(
+      validateSageSyncClaim(
+        run({ status: "queued", claimToken: null, claimedAt: null }),
+        CLAIM_TOKEN,
+        NOW
+      )
+    ).toEqual({
+      success: false,
+      error: "Sage sync claim does not match this run.",
+    })
+    expect(
+      validateSageSyncClaim(
+        run({ claimedAt: new Date(NOW + 1_000).toISOString() }),
+        CLAIM_TOKEN,
+        NOW
+      )
+    ).toEqual({
+      success: false,
+      error: "Sage sync claim is missing or expired.",
+    })
+    expect(
+      validateSageSyncClaim(
+        run({
+          claimedAt: new Date(
+            NOW - SAGE_SYNC_CLAIM_LEASE_MILLISECONDS - 1
+          ).toISOString(),
+        }),
+        CLAIM_TOKEN,
+        NOW
+      )
+    ).toEqual({
+      success: false,
+      error: "Sage sync claim is missing or expired.",
+    })
+  })
+
+  it("permits an idempotent terminal replay only with the same claim", () => {
+    expect(
+      validateSageSyncClaim(
+        run({
+          status: "needs_review",
+          claimedAt: null,
+          snapshotId: "snapshot-1",
+        }),
+        CLAIM_TOKEN,
+        NOW
+      )
+    ).toEqual({ success: true, terminalReplay: true })
+  })
+})

--- a/src/lib/sage/bridge-auth.ts
+++ b/src/lib/sage/bridge-auth.ts
@@ -1,0 +1,144 @@
+const SIGNATURE_HEADER = "x-compass-signature"
+const TIMESTAMP_HEADER = "x-compass-timestamp"
+export const SAGE_BRIDGE_REQUEST_ID_HEADER = "x-compass-request-id"
+const MAX_CLOCK_SKEW_SECONDS = 5 * 60
+export const MAX_SAGE_BRIDGE_BODY_BYTES = 1024 * 1024
+
+type VerificationResult =
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string }
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  if (left.length !== right.length) return false
+  let difference = 0
+  for (let index = 0; index < left.length; index += 1) {
+    difference |= left.charCodeAt(index) ^ right.charCodeAt(index)
+  }
+  return difference === 0
+}
+
+function signingPayload(
+  timestamp: string,
+  requestId: string,
+  method: string,
+  target: string,
+  rawBody: string
+): string {
+  return `${timestamp}.${requestId}.${method.toUpperCase()}.${target}.${rawBody}`
+}
+
+export async function createSageBridgeSignature(
+  secret: string,
+  timestamp: string,
+  requestId: string,
+  method: string,
+  target: string,
+  rawBody: string
+): Promise<string> {
+  const encoder = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  )
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(
+      signingPayload(timestamp, requestId, method, target, rawBody)
+    )
+  )
+  return `sha256=${bytesToHex(new Uint8Array(signature))}`
+}
+
+export async function verifySageBridgeRequest(
+  request: Request,
+  secret: string,
+  rawBody: string,
+  now = Date.now()
+): Promise<VerificationResult> {
+  const timestamp = request.headers.get(TIMESTAMP_HEADER)
+  const requestId = request.headers.get(SAGE_BRIDGE_REQUEST_ID_HEADER)
+  const suppliedSignature = request.headers.get(SIGNATURE_HEADER)
+  if (!timestamp || !requestId || !suppliedSignature) {
+    return { success: false, error: "Missing bridge signature" }
+  }
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      requestId
+    )
+  ) {
+    return { success: false, error: "Invalid bridge request ID" }
+  }
+  const timestampSeconds = Number(timestamp)
+  if (!Number.isInteger(timestampSeconds)) {
+    return { success: false, error: "Invalid bridge timestamp" }
+  }
+  if (
+    Math.abs(Math.floor(now / 1000) - timestampSeconds) >
+    MAX_CLOCK_SKEW_SECONDS
+  ) {
+    return { success: false, error: "Expired bridge signature" }
+  }
+
+  const url = new URL(request.url)
+  const expected = await createSageBridgeSignature(
+    secret,
+    timestamp,
+    requestId,
+    request.method,
+    `${url.pathname}${url.search}`,
+    rawBody
+  )
+  return constantTimeEqual(expected, suppliedSignature)
+    ? { success: true }
+    : { success: false, error: "Invalid bridge signature" }
+}
+
+export async function readBoundedSageBridgeBody(
+  request: Request
+): Promise<
+  | { readonly success: true; readonly rawBody: string }
+  | { readonly success: false; readonly error: string }
+> {
+  const declaredLength = Number(request.headers.get("content-length") ?? "0")
+  if (
+    Number.isFinite(declaredLength) &&
+    declaredLength > MAX_SAGE_BRIDGE_BODY_BYTES
+  ) {
+    return { success: false, error: "Request body is too large" }
+  }
+  if (!request.body) return { success: true, rawBody: "" }
+
+  const reader = request.body.getReader()
+  const decoder = new TextDecoder()
+  const parts: string[] = []
+  let totalBytes = 0
+  while (true) {
+    const next = await reader.read()
+    if (next.done) break
+    totalBytes += next.value.byteLength
+    if (totalBytes > MAX_SAGE_BRIDGE_BODY_BYTES) {
+      await reader.cancel()
+      return { success: false, error: "Request body is too large" }
+    }
+    parts.push(decoder.decode(next.value, { stream: true }))
+  }
+  parts.push(decoder.decode())
+  return { success: true, rawBody: parts.join("") }
+}
+
+export function getSageBridgeSecret(env: CloudflareEnv): string | null {
+  const value: unknown = Reflect.get(env, "SAGE_BRIDGE_SECRET")
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length >= 32 ? trimmed : null
+}

--- a/src/lib/sage/pay-application-ingest.ts
+++ b/src/lib/sage/pay-application-ingest.ts
@@ -1,0 +1,601 @@
+import "server-only"
+
+import { and, eq } from "drizzle-orm"
+
+import { getDb } from "@/db"
+import {
+  sagePayApplicationSnapshots,
+  sagePayApplicationSyncRuns,
+} from "@/db/schema-sage"
+import {
+  hashSagePayApplicationSnapshot,
+  normalizeSagePayApplicationSnapshot,
+  reconcileSagePayApplicationSnapshot,
+  sagePayApplicationSnapshotSchema,
+  type SagePayApplicationSnapshot,
+} from "@/lib/sage/pay-application-snapshot"
+import { validateSageSyncClaim } from "@/lib/sage/sync-claim"
+
+export type SagePayApplicationIngestResult =
+  | {
+      readonly success: true
+      readonly status: "completed" | "needs_review"
+      readonly snapshotId: string
+      readonly replayed: boolean
+    }
+  | { readonly success: false; readonly error: string }
+
+function sameJob(
+  run: {
+    readonly sageJobId: string | null
+    readonly sageJobNumber: string | null
+  },
+  snapshot: SagePayApplicationSnapshot
+): boolean {
+  const header = snapshot.header
+  const comparisons: boolean[] = []
+  if (run.sageJobId && header.sageJobId) {
+    comparisons.push(run.sageJobId.trim() === header.sageJobId.trim())
+  }
+  if (run.sageJobNumber && header.sageJobNumber) {
+    comparisons.push(
+      run.sageJobNumber.trim().toUpperCase() ===
+        header.sageJobNumber.trim().toUpperCase()
+    )
+  }
+  return comparisons.length > 0 && comparisons.every(Boolean)
+}
+
+function percentComplete(total: number, adjusted: number): number {
+  if (adjusted <= 0) return 0
+  return Math.round((total / adjusted) * 1000) / 10
+}
+
+async function markRun(
+  env: CloudflareEnv,
+  runId: string,
+  claimToken: string,
+  input: {
+    readonly status: "completed" | "needs_review" | "failed"
+    readonly snapshotId?: string
+    readonly sourceApplicationId?: string
+    readonly sourceRevision?: string
+    readonly sourceHash?: string
+    readonly reconciliationJson?: string
+    readonly errorMessage?: string
+    readonly capturedAt?: string
+  }
+): Promise<void> {
+  const now = new Date().toISOString()
+  const db = getDb(env.DB)
+  await db
+    .update(sagePayApplicationSyncRuns)
+    .set({
+      status: input.status,
+      snapshotId: input.snapshotId ?? null,
+      sourceApplicationId: input.sourceApplicationId ?? null,
+      sourceRevision: input.sourceRevision ?? null,
+      sourceHash: input.sourceHash ?? null,
+      reconciliationJson: input.reconciliationJson ?? null,
+      errorMessage: input.errorMessage ?? null,
+      capturedAt: input.capturedAt ?? null,
+      completedAt: now,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(sagePayApplicationSyncRuns.id, runId),
+        eq(sagePayApplicationSyncRuns.status, "processing"),
+        eq(sagePayApplicationSyncRuns.claimToken, claimToken)
+      )
+    )
+}
+
+async function acquireRunForIngestion(
+  env: CloudflareEnv,
+  runId: string,
+  claimToken: string,
+  claimedAt: string
+): Promise<boolean> {
+  const now = new Date().toISOString()
+  const result = await env.DB.prepare(
+    `UPDATE sage_pay_application_sync_runs
+     SET status = 'processing', claimed_at = ?, updated_at = ?
+     WHERE id = ? AND status = 'running'
+       AND claim_token = ? AND claimed_at = ?`
+  )
+    .bind(now, now, runId, claimToken, claimedAt)
+    .run()
+  return (result.meta.changes ?? 0) === 1
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function reviewReason(reconciliationJson: string): string | null {
+  try {
+    const parsed: unknown = JSON.parse(reconciliationJson)
+    if (!isRecord(parsed)) return "Sage pay application totals require review."
+    if (parsed.revisionConflict !== null) {
+      return "Sage returned changed data without a new source revision."
+    }
+    return parsed.passed === true
+      ? null
+      : "Sage pay application totals require review."
+  } catch {
+    return "Stored Sage reconciliation data requires review."
+  }
+}
+
+function terminalRunStatement(
+  env: CloudflareEnv,
+  input: {
+    readonly runId: string
+    readonly projectId: string
+    readonly claimToken: string
+    readonly status: "completed" | "needs_review"
+    readonly snapshotId: string
+    readonly sourceApplicationId: string
+    readonly sourceRevision: string
+    readonly sourceHash: string
+    readonly reconciliationJson: string
+    readonly errorMessage: string | null
+    readonly capturedAt: string
+    readonly now: string
+  }
+): D1PreparedStatement {
+  return env.DB.prepare(
+    `UPDATE sage_pay_application_sync_runs
+     SET status = ?, snapshot_id = ?, source_application_id = ?,
+         source_revision = ?, source_hash = ?, reconciliation_json = ?,
+         error_message = ?, captured_at = ?, completed_at = ?,
+         updated_at = ?
+     WHERE id = ? AND project_id = ?
+       AND status = 'processing' AND claim_token = ?`
+  ).bind(
+    input.status,
+    input.snapshotId,
+    input.sourceApplicationId,
+    input.sourceRevision,
+    input.sourceHash,
+    input.reconciliationJson,
+    input.errorMessage,
+    input.capturedAt,
+    input.now,
+    input.now,
+    input.runId,
+    input.projectId,
+    input.claimToken
+  )
+}
+
+function snapshotInsertStatement(
+  env: CloudflareEnv,
+  input: {
+    readonly snapshotId: string
+    readonly projectId: string
+    readonly sourceHash: string
+    readonly snapshot: SagePayApplicationSnapshot
+    readonly reconciliationJson: string
+    readonly now: string
+  }
+): D1PreparedStatement {
+  return env.DB.prepare(
+    `INSERT INTO sage_pay_application_snapshots (
+      id, run_id, project_id, source_application_id, source_revision,
+      source_hash, application_number, period_to, row_count, header_json,
+      lines_json, reconciliation_json, captured_at, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).bind(
+    input.snapshotId,
+    input.snapshot.runId,
+    input.projectId,
+    input.snapshot.header.sourceApplicationId,
+    input.snapshot.header.sourceRevision,
+    input.sourceHash,
+    input.snapshot.header.applicationNumber,
+    input.snapshot.header.periodTo,
+    input.snapshot.lines.length,
+    JSON.stringify(input.snapshot.header),
+    JSON.stringify(input.snapshot.lines),
+    input.reconciliationJson,
+    input.snapshot.capturedAt,
+    input.now
+  )
+}
+
+export async function ingestSagePayApplicationSnapshot(
+  env: CloudflareEnv,
+  input: unknown
+): Promise<SagePayApplicationIngestResult> {
+  const parsed = sagePayApplicationSnapshotSchema.safeParse(input)
+  if (!parsed.success) {
+    return { success: false, error: "Invalid Sage pay application snapshot." }
+  }
+
+  const snapshot = normalizeSagePayApplicationSnapshot(parsed.data)
+  const db = getDb(env.DB)
+  const run = await db
+    .select()
+    .from(sagePayApplicationSyncRuns)
+    .where(eq(sagePayApplicationSyncRuns.id, snapshot.runId))
+    .limit(1)
+    .get()
+
+  if (!run) return { success: false, error: "Sage sync run not found." }
+  const claim = validateSageSyncClaim(run, snapshot.claimToken)
+  if (!claim.success) return claim
+  if (
+    !claim.terminalReplay &&
+    (!run.claimedAt ||
+      !(await acquireRunForIngestion(
+        env,
+        run.id,
+        snapshot.claimToken,
+        run.claimedAt
+      )))
+  ) {
+    return {
+      success: false,
+      error: "Sage sync claim was superseded before ingestion.",
+    }
+  }
+  if (!sameJob(run, snapshot)) {
+    await markRun(env, run.id, snapshot.claimToken, {
+      status: "failed",
+      errorMessage: "Sage job identity did not match the queued project.",
+    })
+    return {
+      success: false,
+      error: "Sage job identity did not match the queued project.",
+    }
+  }
+
+  const sourceHash = await hashSagePayApplicationSnapshot(snapshot)
+  if (run.snapshotId) {
+    const priorRunSnapshot = await db
+      .select({
+        id: sagePayApplicationSnapshots.id,
+        sourceHash: sagePayApplicationSnapshots.sourceHash,
+        reconciliationJson: sagePayApplicationSnapshots.reconciliationJson,
+      })
+      .from(sagePayApplicationSnapshots)
+      .where(
+        and(
+          eq(sagePayApplicationSnapshots.id, run.snapshotId),
+          eq(sagePayApplicationSnapshots.projectId, run.projectId)
+        )
+      )
+      .limit(1)
+      .get()
+    if (!priorRunSnapshot || priorRunSnapshot.sourceHash !== sourceHash) {
+      return {
+        success: false,
+        error: "Sage sync run already captured a different snapshot.",
+      }
+    }
+    const errorMessage = reviewReason(priorRunSnapshot.reconciliationJson)
+    return {
+      success: true,
+      status: errorMessage ? "needs_review" : "completed",
+      snapshotId: priorRunSnapshot.id,
+      replayed: true,
+    }
+  }
+
+  const exact = await db
+    .select({
+      id: sagePayApplicationSnapshots.id,
+      reconciliationJson: sagePayApplicationSnapshots.reconciliationJson,
+    })
+    .from(sagePayApplicationSnapshots)
+    .where(
+      and(
+        eq(sagePayApplicationSnapshots.projectId, run.projectId),
+        eq(
+          sagePayApplicationSnapshots.sourceApplicationId,
+          snapshot.header.sourceApplicationId
+        ),
+        eq(
+          sagePayApplicationSnapshots.sourceRevision,
+          snapshot.header.sourceRevision
+        ),
+        eq(sagePayApplicationSnapshots.sourceHash, sourceHash)
+      )
+    )
+    .limit(1)
+    .get()
+
+  if (exact) {
+    const errorMessage = reviewReason(exact.reconciliationJson)
+    const replayStatus = errorMessage ? "needs_review" : "completed"
+    await markRun(env, run.id, snapshot.claimToken, {
+      status: replayStatus,
+      snapshotId: exact.id,
+      sourceApplicationId: snapshot.header.sourceApplicationId,
+      sourceRevision: snapshot.header.sourceRevision,
+      sourceHash,
+      reconciliationJson: exact.reconciliationJson,
+      errorMessage: errorMessage ?? undefined,
+      capturedAt: snapshot.capturedAt,
+    })
+    return {
+      success: true,
+      status: replayStatus,
+      snapshotId: exact.id,
+      replayed: true,
+    }
+  }
+
+  const priorRevision = await db
+    .select({
+      id: sagePayApplicationSnapshots.id,
+      sourceHash: sagePayApplicationSnapshots.sourceHash,
+    })
+    .from(sagePayApplicationSnapshots)
+    .where(
+      and(
+        eq(sagePayApplicationSnapshots.projectId, run.projectId),
+        eq(
+          sagePayApplicationSnapshots.sourceApplicationId,
+          snapshot.header.sourceApplicationId
+        ),
+        eq(
+          sagePayApplicationSnapshots.sourceRevision,
+          snapshot.header.sourceRevision
+        )
+      )
+    )
+    .limit(1)
+    .get()
+
+  const reconciliation = reconcileSagePayApplicationSnapshot(snapshot)
+  const reconciliationJson = JSON.stringify({
+    ...reconciliation,
+    revisionConflict: priorRevision
+      ? {
+          priorSnapshotId: priorRevision.id,
+          priorHash: priorRevision.sourceHash,
+          receivedHash: sourceHash,
+        }
+      : null,
+  })
+  const snapshotId = `sage-pay-app-snapshot:${run.projectId}:${sourceHash}`
+  const now = new Date().toISOString()
+
+  if (!reconciliation.passed || priorRevision) {
+    const errorMessage = priorRevision
+      ? "Sage returned changed data without a new source revision."
+      : "Sage pay application totals require review."
+    try {
+      await env.DB.batch([
+        snapshotInsertStatement(env, {
+          snapshotId,
+          projectId: run.projectId,
+          sourceHash,
+          snapshot,
+          reconciliationJson,
+          now,
+        }),
+        terminalRunStatement(env, {
+          runId: run.id,
+          projectId: run.projectId,
+          claimToken: snapshot.claimToken,
+          status: "needs_review",
+          snapshotId,
+          sourceApplicationId: snapshot.header.sourceApplicationId,
+          sourceRevision: snapshot.header.sourceRevision,
+          sourceHash,
+          reconciliationJson,
+          errorMessage,
+          capturedAt: snapshot.capturedAt,
+          now,
+        }),
+      ])
+    } catch {
+      const raced = await db
+        .select({ id: sagePayApplicationSnapshots.id })
+        .from(sagePayApplicationSnapshots)
+        .where(
+          and(
+            eq(sagePayApplicationSnapshots.projectId, run.projectId),
+            eq(sagePayApplicationSnapshots.sourceHash, sourceHash)
+          )
+        )
+        .limit(1)
+        .get()
+      if (!raced) {
+        await markRun(env, run.id, snapshot.claimToken, {
+          status: "failed",
+          errorMessage: "Unable to preserve the Sage review snapshot.",
+        })
+        return {
+          success: false,
+          error: "Unable to preserve the Sage review snapshot.",
+        }
+      }
+      await markRun(env, run.id, snapshot.claimToken, {
+        status: "needs_review",
+        snapshotId: raced.id,
+        sourceApplicationId: snapshot.header.sourceApplicationId,
+        sourceRevision: snapshot.header.sourceRevision,
+        sourceHash,
+        reconciliationJson,
+        errorMessage,
+        capturedAt: snapshot.capturedAt,
+      })
+    }
+    return {
+      success: true,
+      status: "needs_review",
+      snapshotId,
+      replayed: false,
+    }
+  }
+
+  const applicationId = `sage-pay-app:${run.projectId}:${sourceHash}`
+  const sourceRecordId = [
+    snapshot.header.sourceApplicationId,
+    snapshot.header.sourceRevision,
+    sourceHash,
+  ].join(":")
+  const statements: D1PreparedStatement[] = [
+    snapshotInsertStatement(env, {
+      snapshotId,
+      projectId: run.projectId,
+      sourceHash,
+      snapshot,
+      reconciliationJson,
+      now,
+    }),
+    env.DB.prepare(
+      `INSERT INTO project_budget_applications (
+        id, project_id, source_system, source_record_id,
+        application_number, period_to, status,
+        original_contract_sum, net_changes, contract_sum_to_date,
+        total_completed_stored_to_date, retainage_held,
+        total_earned_less_retainage, previous_certificates,
+        current_payment_due, balance_to_finish, owner_visible,
+        sync_status, last_synced_at, created_at, updated_at
+      ) VALUES (?, ?, 'sage_read_snapshot', ?, ?, ?, 'imported_draft', ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 'synced', ?, ?, ?)`
+    ).bind(
+      applicationId,
+      run.projectId,
+      sourceRecordId,
+      snapshot.header.applicationNumber,
+      snapshot.header.periodTo,
+      snapshot.header.originalContractSum,
+      snapshot.header.netChanges,
+      snapshot.header.contractSumToDate,
+      snapshot.header.totalCompletedStoredToDate,
+      snapshot.header.retainageHeld,
+      snapshot.header.totalEarnedLessRetainage,
+      snapshot.header.previousCertificates,
+      snapshot.header.currentPaymentDue,
+      snapshot.header.balanceToFinish,
+      snapshot.capturedAt,
+      now,
+      now
+    ),
+  ]
+
+  for (const line of snapshot.lines) {
+    const currentCosts = line.currentWorkCompleted + line.storedMaterials
+    statements.push(
+      env.DB.prepare(
+        `INSERT INTO project_budget_lines (
+          id, project_id, application_id, source_system, source_record_id,
+          source_record_number, cost_code, csi_division, csi_division_name,
+          description, original_estimate, prior_changes, current_changes,
+          total_changes, adjusted_estimate, prior_costs, current_costs,
+          total_costs, percent_complete, balance_to_finish, retainage_held,
+          owner_visible, sort_order, sync_status, last_synced_at,
+          created_at, updated_at
+        ) VALUES (?, ?, ?, 'sage_read_snapshot', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 'synced', ?, ?, ?)`
+      ).bind(
+        `${applicationId}:line:${encodeURIComponent(line.sourceLineId)}`,
+        run.projectId,
+        applicationId,
+        line.sourceLineId,
+        line.sourceLineId,
+        line.costCode,
+        line.csiDivision,
+        line.csiDivisionName,
+        line.description,
+        line.originalEstimate,
+        line.priorChanges,
+        line.currentChanges,
+        line.totalChanges,
+        line.adjustedEstimate,
+        line.previousWorkCompleted,
+        currentCosts,
+        line.totalCompletedStoredToDate,
+        percentComplete(
+          line.totalCompletedStoredToDate,
+          line.adjustedEstimate
+        ),
+        line.balanceToFinish,
+        line.retainageHeld,
+        line.sortOrder,
+        snapshot.capturedAt,
+        now,
+        now
+      )
+    )
+  }
+
+  statements.push(
+    terminalRunStatement(env, {
+      runId: run.id,
+      projectId: run.projectId,
+      claimToken: snapshot.claimToken,
+      status: "completed",
+      snapshotId,
+      sourceApplicationId: snapshot.header.sourceApplicationId,
+      sourceRevision: snapshot.header.sourceRevision,
+      sourceHash,
+      reconciliationJson,
+      errorMessage: null,
+      capturedAt: snapshot.capturedAt,
+      now,
+    })
+  )
+
+  try {
+    const results = await env.DB.batch(statements)
+    if (results.some((result) => !result.success)) {
+      throw new Error("D1 batch reported an unsuccessful statement.")
+    }
+  } catch {
+    const raced = await db
+      .select({ id: sagePayApplicationSnapshots.id })
+      .from(sagePayApplicationSnapshots)
+      .where(
+        and(
+          eq(sagePayApplicationSnapshots.projectId, run.projectId),
+          eq(sagePayApplicationSnapshots.sourceHash, sourceHash)
+        )
+      )
+      .limit(1)
+      .get()
+    if (raced) {
+      await markRun(env, run.id, snapshot.claimToken, {
+        status: "completed",
+        snapshotId: raced.id,
+        sourceApplicationId: snapshot.header.sourceApplicationId,
+        sourceRevision: snapshot.header.sourceRevision,
+        sourceHash,
+        reconciliationJson,
+        capturedAt: snapshot.capturedAt,
+      })
+      return {
+        success: true,
+        status: "completed",
+        snapshotId: raced.id,
+        replayed: true,
+      }
+    }
+    await markRun(env, run.id, snapshot.claimToken, {
+      status: "failed",
+      snapshotId,
+      sourceApplicationId: snapshot.header.sourceApplicationId,
+      sourceRevision: snapshot.header.sourceRevision,
+      sourceHash,
+      reconciliationJson,
+      errorMessage: "Unable to normalize the Sage snapshot.",
+      capturedAt: snapshot.capturedAt,
+    })
+    return {
+      success: false,
+      error: "Unable to normalize the Sage snapshot.",
+    }
+  }
+
+  return {
+    success: true,
+    status: "completed",
+    snapshotId,
+    replayed: false,
+  }
+}

--- a/src/lib/sage/pay-application-snapshot.ts
+++ b/src/lib/sage/pay-application-snapshot.ts
@@ -1,0 +1,258 @@
+import { z } from "zod/v4"
+
+const money = z.number().finite().min(-1_000_000_000_000).max(1_000_000_000_000)
+const MAX_PAY_APPLICATION_LINES = 150
+
+export const sagePayApplicationHeaderSchema = z.object({
+  sourceApplicationId: z.string().min(1).max(256),
+  sourceRevision: z.string().min(1).max(256),
+  sageJobId: z.string().min(1).max(256).nullable(),
+  sageJobNumber: z.string().min(1).max(256).nullable(),
+  applicationNumber: z.string().min(1).max(128),
+  periodTo: z.iso.date().nullable(),
+  status: z.string().min(1).max(64),
+  originalContractSum: money,
+  netChanges: money,
+  contractSumToDate: money,
+  totalCompletedStoredToDate: money,
+  retainageHeld: money,
+  totalEarnedLessRetainage: money,
+  previousCertificates: money,
+  currentPaymentDue: money,
+  balanceToFinish: money,
+})
+
+export const sagePayApplicationLineSchema = z.object({
+  sourceLineId: z.string().min(1).max(256),
+  costCode: z.string().min(1).max(128),
+  csiDivision: z.string().min(1).max(32),
+  csiDivisionName: z.string().min(1).max(256),
+  description: z.string().min(1).max(1000),
+  originalEstimate: money,
+  priorChanges: money,
+  currentChanges: money,
+  totalChanges: money,
+  adjustedEstimate: money,
+  previousWorkCompleted: money,
+  currentWorkCompleted: money,
+  storedMaterials: money,
+  totalCompletedStoredToDate: money,
+  retainageHeld: money,
+  balanceToFinish: money,
+  sortOrder: z.number().int().min(0),
+})
+
+export const sagePayApplicationSnapshotSchema = z.object({
+  runId: z.uuid(),
+  claimToken: z.uuid(),
+  capturedAt: z.iso.datetime({ offset: true }),
+  header: sagePayApplicationHeaderSchema,
+  // The normalized application and all of its lines are committed in one D1
+  // batch. This bound stays below the paid-plan query limit and approximate
+  // per-invocation binding limit while preserving realistic G703 schedules.
+  lines: z
+    .array(sagePayApplicationLineSchema)
+    .min(1)
+    .max(MAX_PAY_APPLICATION_LINES),
+})
+
+export type SagePayApplicationHeader = z.infer<
+  typeof sagePayApplicationHeaderSchema
+>
+export type SagePayApplicationLine = z.infer<
+  typeof sagePayApplicationLineSchema
+>
+export type SagePayApplicationSnapshot = z.infer<
+  typeof sagePayApplicationSnapshotSchema
+>
+
+export type SageReconciliationCheck = {
+  readonly key: string
+  readonly expected: number
+  readonly actual: number
+  readonly difference: number
+  readonly passed: boolean
+}
+
+export type SagePayApplicationReconciliation = {
+  readonly passed: boolean
+  readonly rowCount: number
+  readonly checks: readonly SageReconciliationCheck[]
+  readonly duplicateSourceLineIds: readonly string[]
+}
+
+const CURRENCY_TOLERANCE = 0.02
+
+function cents(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+function total(
+  lines: readonly SagePayApplicationLine[],
+  select: (line: SagePayApplicationLine) => number
+): number {
+  return cents(lines.reduce((sum, line) => sum + select(line), 0))
+}
+
+function check(
+  key: string,
+  expected: number,
+  actual: number
+): SageReconciliationCheck {
+  const normalizedExpected = cents(expected)
+  const normalizedActual = cents(actual)
+  const difference = cents(normalizedActual - normalizedExpected)
+  return {
+    key,
+    expected: normalizedExpected,
+    actual: normalizedActual,
+    difference,
+    passed: Math.abs(difference) <= CURRENCY_TOLERANCE,
+  }
+}
+
+function duplicateLineIds(
+  lines: readonly SagePayApplicationLine[]
+): readonly string[] {
+  const counts = new Map<string, number>()
+  for (const line of lines) {
+    counts.set(line.sourceLineId, (counts.get(line.sourceLineId) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .filter((entry) => entry[1] > 1)
+    .map((entry) => entry[0])
+    .sort()
+}
+
+export function normalizeSagePayApplicationSnapshot(
+  snapshot: SagePayApplicationSnapshot
+): SagePayApplicationSnapshot {
+  return {
+    ...snapshot,
+    lines: [...snapshot.lines].sort((left, right) => {
+      const sortDifference = left.sortOrder - right.sortOrder
+      if (sortDifference !== 0) return sortDifference
+      return left.sourceLineId.localeCompare(right.sourceLineId)
+    }),
+  }
+}
+
+export function reconcileSagePayApplicationSnapshot(
+  snapshot: SagePayApplicationSnapshot
+): SagePayApplicationReconciliation {
+  const lines = snapshot.lines
+  const checks: SageReconciliationCheck[] = [
+    check(
+      "header.contract_sum_to_date",
+      snapshot.header.originalContractSum + snapshot.header.netChanges,
+      snapshot.header.contractSumToDate
+    ),
+    check(
+      "header.earned_less_retainage",
+      snapshot.header.totalCompletedStoredToDate -
+        snapshot.header.retainageHeld,
+      snapshot.header.totalEarnedLessRetainage
+    ),
+    check(
+      "header.current_payment_due",
+      snapshot.header.totalEarnedLessRetainage -
+        snapshot.header.previousCertificates,
+      snapshot.header.currentPaymentDue
+    ),
+    check(
+      "header.balance_to_finish",
+      snapshot.header.contractSumToDate -
+        snapshot.header.totalEarnedLessRetainage,
+      snapshot.header.balanceToFinish
+    ),
+    check(
+      "lines.original_contract_sum",
+      snapshot.header.originalContractSum,
+      total(lines, (line) => line.originalEstimate)
+    ),
+    check(
+      "lines.net_changes",
+      snapshot.header.netChanges,
+      total(lines, (line) => line.totalChanges)
+    ),
+    check(
+      "lines.contract_sum_to_date",
+      snapshot.header.contractSumToDate,
+      total(lines, (line) => line.adjustedEstimate)
+    ),
+    check(
+      "lines.total_completed_stored",
+      snapshot.header.totalCompletedStoredToDate,
+      total(lines, (line) => line.totalCompletedStoredToDate)
+    ),
+    check(
+      "lines.retainage",
+      snapshot.header.retainageHeld,
+      total(lines, (line) => line.retainageHeld)
+    ),
+    check(
+      "lines.balance_plus_retainage",
+      snapshot.header.balanceToFinish,
+      total(
+        lines,
+        (line) => line.balanceToFinish + line.retainageHeld
+      )
+    ),
+  ]
+
+  for (const line of lines) {
+    checks.push(
+      check(
+        `line.${line.sourceLineId}.total_changes`,
+        line.priorChanges + line.currentChanges,
+        line.totalChanges
+      ),
+      check(
+        `line.${line.sourceLineId}.adjusted_estimate`,
+        line.originalEstimate + line.totalChanges,
+        line.adjustedEstimate
+      ),
+      check(
+        `line.${line.sourceLineId}.completed_stored`,
+        line.previousWorkCompleted +
+          line.currentWorkCompleted +
+          line.storedMaterials,
+        line.totalCompletedStoredToDate
+      ),
+      check(
+        `line.${line.sourceLineId}.balance`,
+        line.adjustedEstimate - line.totalCompletedStoredToDate,
+        line.balanceToFinish
+      )
+    )
+  }
+
+  const duplicateSourceLineIds = duplicateLineIds(lines)
+  return {
+    passed:
+      duplicateSourceLineIds.length === 0 &&
+      checks.every((item) => item.passed),
+    rowCount: lines.length,
+    checks,
+    duplicateSourceLineIds,
+  }
+}
+
+export async function hashSagePayApplicationSnapshot(
+  snapshot: SagePayApplicationSnapshot
+): Promise<string> {
+  const normalized = normalizeSagePayApplicationSnapshot(snapshot)
+  // Transport metadata changes every time the bridge captures the same Sage
+  // revision. Hash only source-owned financial content so retries and later
+  // sync runs remain idempotent.
+  const encoded = new TextEncoder().encode(
+    JSON.stringify({
+      header: normalized.header,
+      lines: normalized.lines,
+    })
+  )
+  const digest = await crypto.subtle.digest("SHA-256", encoded)
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+}

--- a/src/lib/sage/sync-claim.ts
+++ b/src/lib/sage/sync-claim.ts
@@ -1,0 +1,50 @@
+export const SAGE_SYNC_CLAIM_LEASE_MILLISECONDS = 5 * 60 * 1000
+
+type SageSyncClaimRun = {
+  readonly status: string
+  readonly claimToken: string | null
+  readonly claimedAt: string | null
+  readonly snapshotId: string | null
+}
+
+export type SageSyncClaimValidation =
+  | { readonly success: true; readonly terminalReplay: boolean }
+  | { readonly success: false; readonly error: string }
+
+export function validateSageSyncClaim(
+  run: SageSyncClaimRun,
+  suppliedClaimToken: string,
+  now = Date.now()
+): SageSyncClaimValidation {
+  if (run.claimToken !== suppliedClaimToken) {
+    return {
+      success: false,
+      error: "Sage sync claim does not match this run.",
+    }
+  }
+  if (run.status === "failed") {
+    return {
+      success: false,
+      error: "Sage sync run is no longer active.",
+    }
+  }
+
+  const terminalReplay =
+    (run.status === "completed" || run.status === "needs_review") &&
+    run.snapshotId !== null
+  if (terminalReplay) return { success: true, terminalReplay: true }
+
+  const claimedAt = run.claimedAt ? Date.parse(run.claimedAt) : Number.NaN
+  if (
+    run.status !== "running" ||
+    !Number.isFinite(claimedAt) ||
+    claimedAt > now ||
+    now - claimedAt > SAGE_SYNC_CLAIM_LEASE_MILLISECONDS
+  ) {
+    return {
+      success: false,
+      error: "Sage sync claim is missing or expired.",
+    }
+  }
+  return { success: true, terminalReplay: false }
+}


### PR DESCRIPTION
## Summary

- add an internal-only **Sync with Sage** control for project pay applications and G703 data
- add exact, HMAC-authenticated pull/result endpoints for the private tailnet poller
- preserve immutable Sage source snapshots and normalize only reconciled data into unpublished internal drafts
- bind each result to a short-lived claimed run, reject poll replays, bound streamed input to 1 MiB, and require a recent authenticated poller heartbeat
- keep all Sage access read-only and server-side; this adds no Sage write path and no automatic owner publication

## Safety boundary

- the WorkOS exemption covers only the two exact HMAC bridge routes
- HMAC covers timestamp, unique request ID, method, target/query, and raw body
- poll request IDs are consumed once
- project and Sage job identity must match
- duplicate lines, revision/hash conflicts, and G702/G703 reconciliation failures remain internal and require review
- successful imports use `imported_draft` with `owner_visible = 0`
- the button remains disabled until the private poller has checked in recently

## Validation

- 16 focused authentication, claim, reconciliation, hashing, and route-scope tests
- TypeScript
- targeted ESLint
- `git diff --check`
- full production `next build`

## Deployment order

1. Apply `0082_sage_pay_application_read_sync.sql`.
2. Merge/deploy this PR.
3. Configure a distinct production `SAGE_BRIDGE_SECRET`.
4. Deploy the private tailnet poller using the documented HMAC contract and verified Sage read queries.

Closes #278 only when the private poller is configured and a real pay application has completed reconciliation.
