### PR TITLE
feat(change-orders): add guarded request workflow

### DIFF
--- a/drizzle/0083_project_change_orders.sql
+++ b/drizzle/0083_project_change_orders.sql
@@ -1,0 +1,86 @@
+CREATE TABLE `project_change_orders` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_id` text NOT NULL,
+  `change_order_number` text NOT NULL,
+  `title` text NOT NULL,
+  `scope` text NOT NULL,
+  `reason` text,
+  `amount_cents` integer,
+  `status` text NOT NULL DEFAULT 'draft',
+  `audience` text NOT NULL DEFAULT 'internal',
+  `requester_type` text NOT NULL,
+  `requester_user_id` text,
+  `requester_name` text NOT NULL,
+  `requester_company` text,
+  `source_type` text NOT NULL,
+  `source_record_id` text,
+  `source_href` text,
+  `internal_notes` text,
+  `foxit_status` text NOT NULL DEFAULT 'not_started',
+  `foxit_envelope_id` text,
+  `signature_requested_at` text,
+  `executed_at` text,
+  `sage_status` text NOT NULL DEFAULT 'not_ready',
+  `sage_record_id` text,
+  `last_sage_sync_at` text,
+  `created_by` text,
+  `submitted_at` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`requester_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `project_change_orders_project_number_uq`
+  ON `project_change_orders` (`project_id`, `change_order_number`);
+--> statement-breakpoint
+CREATE INDEX `project_change_orders_project_status_idx`
+  ON `project_change_orders` (`project_id`, `status`);
+--> statement-breakpoint
+CREATE INDEX `project_change_orders_requester_idx`
+  ON `project_change_orders` (`project_id`, `requester_user_id`);
+--> statement-breakpoint
+CREATE TABLE `project_change_order_documents` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_id` text NOT NULL,
+  `change_order_id` text NOT NULL,
+  `label` text NOT NULL,
+  `url` text NOT NULL,
+  `notes` text,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`change_order_id`) REFERENCES `project_change_orders`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `project_change_order_documents_order_idx`
+  ON `project_change_order_documents` (`change_order_id`);
+--> statement-breakpoint
+CREATE INDEX `project_change_order_documents_project_idx`
+  ON `project_change_order_documents` (`project_id`);
+--> statement-breakpoint
+CREATE TABLE `project_change_order_history` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_id` text NOT NULL,
+  `change_order_id` text NOT NULL,
+  `event_type` text NOT NULL,
+  `from_status` text,
+  `to_status` text,
+  `actor_user_id` text,
+  `actor_name` text NOT NULL,
+  `actor_role` text NOT NULL,
+  `note` text,
+  `metadata_json` text,
+  `created_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`change_order_id`) REFERENCES `project_change_orders`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`actor_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `project_change_order_history_order_idx`
+  ON `project_change_order_history` (`change_order_id`, `created_at`);
+--> statement-breakpoint
+CREATE INDEX `project_change_order_history_project_idx`
+  ON `project_change_order_history` (`project_id`);

--- a/src/app/actions/project-change-orders.ts
+++ b/src/app/actions/project-change-orders.ts
@@ -1,0 +1,760 @@
+"use server"
+
+import { and, asc, desc, eq } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import {
+  projectChangeOrderDocuments,
+  projectChangeOrderHistory,
+  projectChangeOrders,
+  projectMembers,
+} from "@/db/schema"
+import { requireAuth, type AuthUser } from "@/lib/auth"
+import {
+  allowedChangeOrderTransitions,
+  canEditChangeOrderContent,
+  canTransitionChangeOrder,
+  isChangeOrderStatus,
+  isExternallyPublishedChangeOrderStatus,
+  type ChangeOrderStatus,
+} from "@/lib/change-orders/status"
+import {
+  canViewChangeOrder,
+  changeOrderRequesterType,
+  type ChangeOrderRequesterType,
+} from "@/lib/change-orders/access"
+import { getCloudflareContext } from "@/lib/db"
+import {
+  canFeature,
+  requireFeaturePermission,
+} from "@/lib/permission-enforcement"
+import { assertProjectAccess } from "@/lib/project-access"
+import type { ProjectAudience } from "@/lib/project-audience-access"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+export type ChangeOrderAudience = "internal" | "owner" | "sub_vendor"
+export type ChangeOrderDocumentInput = {
+  readonly label: string
+  readonly url: string
+  readonly notes: string | null
+}
+
+export type ProjectChangeOrderItem = {
+  readonly id: string
+  readonly projectId: string
+  readonly changeOrderNumber: string
+  readonly title: string
+  readonly scope: string
+  readonly reason: string | null
+  readonly amountCents: number | null
+  readonly status: ChangeOrderStatus
+  readonly audience: ChangeOrderAudience
+  readonly requesterType: ChangeOrderRequesterType
+  readonly requesterUserId: string | null
+  readonly requesterName: string
+  readonly requesterCompany: string | null
+  readonly sourceType: string
+  readonly sourceRecordId: string | null
+  readonly sourceHref: string | null
+  readonly internalNotes: string | null
+  readonly foxitStatus: string
+  readonly sageStatus: string
+  readonly submittedAt: string | null
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly canEdit: boolean
+  readonly canApprove: boolean
+  readonly allowedTransitions: readonly ChangeOrderStatus[]
+  readonly documents: readonly {
+    readonly id: string
+    readonly label: string
+    readonly url: string
+    readonly notes: string | null
+  }[]
+  readonly history: readonly {
+    readonly id: string
+    readonly eventType: string
+    readonly fromStatus: string | null
+    readonly toStatus: string | null
+    readonly actorName: string
+    readonly actorRole: string
+    readonly note: string | null
+    readonly createdAt: string
+  }[]
+}
+
+export type CreateProjectChangeOrderInput = {
+  readonly title: string
+  readonly scope: string
+  readonly reason: string | null
+  readonly amountCents: number | null
+  readonly audience: ChangeOrderAudience
+  readonly requesterCompany: string | null
+  readonly sourceRecordId: string | null
+  readonly sourceHref: string | null
+  readonly initialStatus: "draft" | "submitted"
+  readonly documents: readonly ChangeOrderDocumentInput[]
+}
+
+export type UpdateProjectChangeOrderInput = {
+  readonly title: string
+  readonly scope: string
+  readonly reason: string | null
+  readonly amountCents: number | null
+  readonly audience: ChangeOrderAudience
+  readonly internalNotes: string | null
+  readonly status: ChangeOrderStatus
+  readonly transitionNote: string | null
+  readonly documents: readonly ChangeOrderDocumentInput[]
+}
+
+type ChangeOrderContext = {
+  readonly db: ReturnType<typeof getDb>
+  readonly user: AuthUser
+  readonly projectNumber: string | null
+  readonly projectRole: string | null
+  readonly internal: boolean
+  readonly canUpdate: boolean
+  readonly canApprove: boolean
+  readonly requesterType: ChangeOrderRequesterType | null
+}
+
+type ChangeOrderActionResult =
+  | { readonly success: true; readonly id: string }
+  | { readonly success: false; readonly error: string }
+
+function cleanText(value: string | null): string | null {
+  const trimmed = value?.trim() ?? ""
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function requireText(value: string, label: string, maxLength = 10_000): string {
+  const cleaned = cleanText(value)
+  if (!cleaned) throw new Error(`${label} is required`)
+  if (cleaned.length > maxLength) {
+    throw new Error(`${label} must be ${maxLength} characters or fewer`)
+  }
+  return cleaned
+}
+
+function cleanLimitedText(
+  value: string | null,
+  label: string,
+  maxLength: number
+): string | null {
+  const cleaned = cleanText(value)
+  if (!cleaned) return null
+  if (cleaned.length > maxLength) {
+    throw new Error(`${label} must be ${maxLength} characters or fewer`)
+  }
+  return cleaned
+}
+
+function validAudience(value: string): value is ChangeOrderAudience {
+  return ["internal", "owner", "sub_vendor"].includes(value)
+}
+
+function cleanAmountCents(value: number | null): number | null {
+  if (value === null) return null
+  if (!Number.isFinite(value)) throw new Error("Requested amount is invalid")
+  const cents = Math.round(value)
+  if (!Number.isSafeInteger(cents) || Math.abs(cents) > 1_000_000_000_000) {
+    throw new Error("Requested amount is outside the supported range")
+  }
+  return cents
+}
+
+function safeDocumentUrl(value: string): string {
+  const cleaned = requireText(value, "Document URL", 2_048)
+  const parsed = new URL(cleaned)
+  if (!["https:", "http:"].includes(parsed.protocol)) {
+    throw new Error("Document links must use HTTP or HTTPS")
+  }
+  return parsed.toString()
+}
+
+function cleanDocuments(
+  documents: readonly ChangeOrderDocumentInput[]
+): readonly ChangeOrderDocumentInput[] {
+  if (documents.length > 20) {
+    throw new Error("A change order can have at most 20 document links")
+  }
+  return documents
+    .filter((document) => cleanText(document.url) !== null)
+    .map((document) => ({
+      label: document.label.trim()
+        ? requireText(document.label, "Document label", 200)
+        : "Supporting document",
+      url: safeDocumentUrl(document.url),
+      notes: cleanLimitedText(document.notes, "Document notes", 1_000),
+    }))
+}
+
+async function changeOrderContext(
+  projectId: string,
+  action: "create" | "read" | "update"
+): Promise<ChangeOrderContext> {
+  const user = await requireAuth()
+  await requireFeaturePermission(user, "change-orders", action)
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const project = await assertProjectAccess(db, user, projectId)
+  const membership = await db
+    .select({ role: projectMembers.role })
+    .from(projectMembers)
+    .where(
+      and(
+        eq(projectMembers.projectId, projectId),
+        eq(projectMembers.userId, user.id)
+      )
+    )
+    .get()
+  const internal = isInternalStaffRole(user.role)
+  const projectRole = membership?.role ?? null
+  const canApprove =
+    internal && (await canFeature(user, "change-orders", "approve"))
+  const canUpdate =
+    internal && (await canFeature(user, "change-orders", "update"))
+
+  return {
+    db,
+    user,
+    projectNumber: project.projectNumber,
+    projectRole,
+    internal,
+    canUpdate,
+    canApprove,
+    requesterType: changeOrderRequesterType({ internal, projectRole }),
+  }
+}
+
+function canExternalViewerSee(
+  row: typeof projectChangeOrders.$inferSelect,
+  context: ChangeOrderContext
+): boolean {
+  if (!isChangeOrderStatus(row.status)) return false
+  return canViewChangeOrder({
+    internal: context.internal,
+    viewerId: context.user.id,
+    viewerRequesterType: context.requesterType,
+    requesterUserId: row.requesterUserId,
+    audience: row.audience,
+    status: row.status,
+  })
+}
+
+function audiencePreviewContext(
+  context: ChangeOrderContext,
+  audience: ProjectAudience | undefined
+): ChangeOrderContext {
+  if (!context.internal || !audience) return context
+  return {
+    ...context,
+    internal: false,
+    canUpdate: false,
+    canApprove: false,
+    requesterType: audience === "owner" ? "owner" : "subcontractor",
+  }
+}
+
+function revalidateChangeOrderPaths(projectId: string): void {
+  revalidatePath(`/dashboard/projects/${projectId}`)
+  revalidatePath(`/dashboard/projects/${projectId}/change-orders`)
+  revalidatePath(`/preview/projects/${projectId}/owner/change-orders`)
+  revalidatePath(`/preview/projects/${projectId}/sub-vendor/change-orders`)
+}
+
+function changeOrderNumber(
+  projectNumber: string | null,
+  count: number
+): string {
+  const prefix = cleanText(projectNumber) ?? "PROJECT"
+  return `${prefix}-CO-${String(count + 1).padStart(3, "0")}`
+}
+
+function actorName(user: AuthUser): string {
+  return user.displayName ?? user.email
+}
+
+function viewModel(
+  row: typeof projectChangeOrders.$inferSelect,
+  context: ChangeOrderContext,
+  documents: ProjectChangeOrderItem["documents"],
+  history: ProjectChangeOrderItem["history"]
+): ProjectChangeOrderItem | null {
+  if (
+    !isChangeOrderStatus(row.status) ||
+    !validAudience(row.audience) ||
+    !["internal", "owner", "subcontractor"].includes(row.requesterType)
+  ) {
+    return null
+  }
+  const requesterType =
+    row.requesterType === "owner"
+      ? "owner"
+      : row.requesterType === "subcontractor"
+        ? "subcontractor"
+        : "internal"
+  const status = row.status
+  const isRequester = row.requesterUserId === context.user.id
+  const canApprove = context.canApprove
+  const canEdit =
+    (!context.internal || context.canUpdate) &&
+    canEditChangeOrderContent({
+      status,
+      internal: context.internal,
+      isRequester,
+    })
+  const transitions =
+    context.internal && !context.canUpdate
+      ? []
+      : allowedChangeOrderTransitions(status).filter((to) =>
+          canTransitionChangeOrder({
+            from: status,
+            to,
+            internal: context.internal,
+            canApprove,
+          })
+        )
+
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    changeOrderNumber: row.changeOrderNumber,
+    title: row.title,
+    scope: row.scope,
+    reason: row.reason,
+    amountCents: row.amountCents,
+    status,
+    audience: row.audience,
+    requesterType,
+    requesterUserId: row.requesterUserId,
+    requesterName: row.requesterName,
+    requesterCompany: row.requesterCompany,
+    sourceType: row.sourceType,
+    sourceRecordId: context.internal ? row.sourceRecordId : null,
+    sourceHref: context.internal ? row.sourceHref : null,
+    internalNotes: context.internal ? row.internalNotes : null,
+    foxitStatus: row.foxitStatus,
+    sageStatus: row.sageStatus,
+    submittedAt: row.submittedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    canEdit,
+    canApprove,
+    allowedTransitions: transitions.filter((status) => status !== "synced"),
+    documents,
+    history,
+  }
+}
+
+export async function getProjectChangeOrders(
+  projectId: string,
+  viewAsAudience?: ProjectAudience
+): Promise<readonly ProjectChangeOrderItem[]> {
+  const authorizedContext = await changeOrderContext(projectId, "read")
+  const context = audiencePreviewContext(authorizedContext, viewAsAudience)
+  const rows = await authorizedContext.db
+    .select()
+    .from(projectChangeOrders)
+    .where(eq(projectChangeOrders.projectId, projectId))
+    .orderBy(desc(projectChangeOrders.updatedAt))
+
+  return rows
+    .filter((row) => canExternalViewerSee(row, context))
+    .map((row) => viewModel(row, context, [], []))
+    .filter((row): row is ProjectChangeOrderItem => row !== null)
+}
+
+export async function getProjectChangeOrderCapabilities(
+  projectId: string
+): Promise<{
+  readonly canCreate: boolean
+  readonly requesterType: ChangeOrderRequesterType | null
+}> {
+  const context = await changeOrderContext(projectId, "read")
+  const createAllowed = await canFeature(
+    context.user,
+    "change-orders",
+    "create"
+  )
+  return {
+    canCreate: createAllowed && context.requesterType !== null,
+    requesterType: context.requesterType,
+  }
+}
+
+export async function getProjectChangeOrder(
+  projectId: string,
+  changeOrderId: string,
+  viewAsAudience?: ProjectAudience
+): Promise<ProjectChangeOrderItem | null> {
+  const authorizedContext = await changeOrderContext(projectId, "read")
+  const context = audiencePreviewContext(authorizedContext, viewAsAudience)
+  const row = await authorizedContext.db
+    .select()
+    .from(projectChangeOrders)
+    .where(
+      and(
+        eq(projectChangeOrders.id, changeOrderId),
+        eq(projectChangeOrders.projectId, projectId)
+      )
+    )
+    .get()
+  if (!row || !canExternalViewerSee(row, context)) return null
+
+  const [documentRows, historyRows] = await Promise.all([
+    authorizedContext.db
+      .select({
+        id: projectChangeOrderDocuments.id,
+        label: projectChangeOrderDocuments.label,
+        url: projectChangeOrderDocuments.url,
+        notes: projectChangeOrderDocuments.notes,
+      })
+      .from(projectChangeOrderDocuments)
+      .where(eq(projectChangeOrderDocuments.changeOrderId, changeOrderId))
+      .orderBy(asc(projectChangeOrderDocuments.createdAt)),
+    authorizedContext.db
+      .select({
+        id: projectChangeOrderHistory.id,
+        eventType: projectChangeOrderHistory.eventType,
+        fromStatus: projectChangeOrderHistory.fromStatus,
+        toStatus: projectChangeOrderHistory.toStatus,
+        actorName: projectChangeOrderHistory.actorName,
+        actorRole: projectChangeOrderHistory.actorRole,
+        actorUserId: projectChangeOrderHistory.actorUserId,
+        note: projectChangeOrderHistory.note,
+        createdAt: projectChangeOrderHistory.createdAt,
+      })
+      .from(projectChangeOrderHistory)
+      .where(eq(projectChangeOrderHistory.changeOrderId, changeOrderId))
+      .orderBy(desc(projectChangeOrderHistory.createdAt)),
+  ])
+
+  const visibleHistory = context.internal
+    ? historyRows
+    : historyRows
+        .filter((event) => {
+          if (row.requesterUserId === context.user.id) return true
+          return (
+            event.toStatus !== null &&
+            isChangeOrderStatus(event.toStatus) &&
+            isExternallyPublishedChangeOrderStatus(event.toStatus)
+          )
+        })
+        .map((event) => ({
+          ...event,
+          // Transition notes are internal by default. External requesters see
+          // their own notes plus explicit requests for more information.
+          note:
+            event.actorUserId === context.user.id ||
+            event.toStatus === "needs_information"
+              ? event.note
+              : null,
+        }))
+
+  return viewModel(row, context, documentRows, visibleHistory)
+}
+
+export async function createProjectChangeOrder(
+  projectId: string,
+  input: CreateProjectChangeOrderInput
+): Promise<ChangeOrderActionResult> {
+  try {
+    const context = await changeOrderContext(projectId, "create")
+    if (!context.requesterType) {
+      return {
+        success: false,
+        error: "Only internal staff, owners, and subcontractors can request changes.",
+      }
+    }
+    const existing = await context.db
+      .select({ id: projectChangeOrders.id })
+      .from(projectChangeOrders)
+      .where(eq(projectChangeOrders.projectId, projectId))
+    const now = new Date().toISOString()
+    const id = crypto.randomUUID()
+    const internal = context.internal
+    const requestedInitialStatus =
+      input.initialStatus === "submitted" ? "submitted" : "draft"
+    const status: ChangeOrderStatus = internal
+      ? requestedInitialStatus
+      : "submitted"
+    const audience: ChangeOrderAudience = internal
+      ? input.audience
+      : context.requesterType === "owner"
+        ? "owner"
+        : "sub_vendor"
+    if (!validAudience(audience)) {
+      return { success: false, error: "Choose a valid audience." }
+    }
+    const documents = cleanDocuments(input.documents)
+    const sourceType =
+      context.requesterType === "owner"
+        ? "owner_request"
+        : context.requesterType === "subcontractor"
+          ? "subcontractor_request"
+          : "internal_request"
+    const row: typeof projectChangeOrders.$inferInsert = {
+      id,
+      projectId,
+      changeOrderNumber: changeOrderNumber(
+        context.projectNumber,
+        existing.length
+      ),
+      title: requireText(input.title, "Title", 200),
+      scope: requireText(input.scope, "Scope", 10_000),
+      reason: cleanLimitedText(input.reason, "Reason", 4_000),
+      amountCents: cleanAmountCents(input.amountCents),
+      status,
+      audience,
+      requesterType: context.requesterType,
+      requesterUserId: context.user.id,
+      requesterName: actorName(context.user),
+      requesterCompany: input.requesterCompany
+        ? requireText(input.requesterCompany, "Company", 200)
+        : null,
+      sourceType,
+      sourceRecordId: cleanText(input.sourceRecordId),
+      sourceHref: input.sourceHref ? safeDocumentUrl(input.sourceHref) : null,
+      internalNotes: null,
+      foxitStatus: "not_started",
+      sageStatus: "not_ready",
+      createdBy: context.user.id,
+      submittedAt: status === "submitted" ? now : null,
+      createdAt: now,
+      updatedAt: now,
+    }
+    const documentRows = documents.map((document) => ({
+      id: crypto.randomUUID(),
+      projectId,
+      changeOrderId: id,
+      label: document.label,
+      url: document.url,
+      notes: document.notes,
+      createdBy: context.user.id,
+      createdAt: now,
+    }))
+    const historyRow = {
+      id: crypto.randomUUID(),
+      projectId,
+      changeOrderId: id,
+      eventType: "created",
+      fromStatus: null,
+      toStatus: status,
+      actorUserId: context.user.id,
+      actorName: actorName(context.user),
+      actorRole: context.user.role,
+      note: null,
+      metadataJson: JSON.stringify({ audience, sourceType }),
+      createdAt: now,
+    }
+
+    if (documentRows.length > 0) {
+      await context.db.batch([
+        context.db.insert(projectChangeOrders).values(row),
+        context.db.insert(projectChangeOrderDocuments).values(documentRows),
+        context.db.insert(projectChangeOrderHistory).values(historyRow),
+      ])
+    } else {
+      await context.db.batch([
+        context.db.insert(projectChangeOrders).values(row),
+        context.db.insert(projectChangeOrderHistory).values(historyRow),
+      ])
+    }
+    revalidateChangeOrderPaths(projectId)
+    return { success: true, id }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to create change order request",
+    }
+  }
+}
+
+export async function updateProjectChangeOrder(
+  projectId: string,
+  changeOrderId: string,
+  input: UpdateProjectChangeOrderInput
+): Promise<ChangeOrderActionResult> {
+  try {
+    const context = await changeOrderContext(projectId, "read")
+    if (context.internal) {
+      await requireFeaturePermission(context.user, "change-orders", "update")
+    }
+    const existing = await context.db
+      .select()
+      .from(projectChangeOrders)
+      .where(
+        and(
+          eq(projectChangeOrders.id, changeOrderId),
+          eq(projectChangeOrders.projectId, projectId)
+        )
+      )
+      .get()
+    if (
+      !existing ||
+      !canExternalViewerSee(existing, context) ||
+      !isChangeOrderStatus(existing.status)
+    ) {
+      return { success: false, error: "Change order request not found." }
+    }
+    const isRequester = existing.requesterUserId === context.user.id
+    const contentAllowed = canEditChangeOrderContent({
+      status: existing.status,
+      internal: context.internal,
+      isRequester,
+    })
+    if (!isChangeOrderStatus(input.status)) {
+      return { success: false, error: "Choose a valid status." }
+    }
+    const statusChanged = input.status !== existing.status
+    const canApprove = context.canApprove
+    if (
+      statusChanged &&
+      !canTransitionChangeOrder({
+        from: existing.status,
+        to: input.status,
+        internal: context.internal,
+        canApprove,
+      })
+    ) {
+      return { success: false, error: "That status transition is not allowed." }
+    }
+    if (input.status === "synced") {
+      return {
+        success: false,
+        error: "Sage sync must be completed by the future approved connector.",
+      }
+    }
+    const audience = context.internal ? input.audience : existing.audience
+    if (!validAudience(audience)) {
+      return { success: false, error: "Choose a valid audience." }
+    }
+    const now = new Date().toISOString()
+    const documents = contentAllowed ? cleanDocuments(input.documents) : null
+    const title = contentAllowed
+      ? requireText(input.title, "Title", 200)
+      : existing.title
+    const scope = contentAllowed
+      ? requireText(input.scope, "Scope", 10_000)
+      : existing.scope
+    const reason = contentAllowed
+      ? cleanLimitedText(input.reason, "Reason", 4_000)
+      : existing.reason
+    const amountCents = contentAllowed
+      ? cleanAmountCents(input.amountCents)
+      : existing.amountCents
+    const updateStatement = context.db
+      .update(projectChangeOrders)
+      .set({
+        title,
+        scope,
+        reason,
+        amountCents,
+        audience: contentAllowed ? audience : existing.audience,
+        internalNotes: context.internal
+          ? cleanLimitedText(input.internalNotes, "Internal notes", 4_000)
+          : existing.internalNotes,
+        status: input.status,
+        submittedAt:
+          input.status === "submitted"
+            ? existing.submittedAt ?? now
+            : existing.submittedAt,
+        foxitStatus:
+          input.status === "signature_pending"
+            ? "handoff_ready"
+            : existing.foxitStatus,
+        executedAt:
+          input.status === "executed" ? existing.executedAt ?? now : existing.executedAt,
+        sageStatus:
+          input.status === "sage_pending"
+            ? "pending_manual_sync"
+            : existing.sageStatus,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(projectChangeOrders.id, changeOrderId),
+          eq(projectChangeOrders.projectId, projectId)
+        )
+      )
+    const historyStatement = context.db
+      .insert(projectChangeOrderHistory)
+      .values({
+        id: crypto.randomUUID(),
+        projectId,
+        changeOrderId,
+        eventType: statusChanged ? "status_transition" : "updated",
+        fromStatus: existing.status,
+        toStatus: input.status,
+        actorUserId: context.user.id,
+        actorName: actorName(context.user),
+        actorRole: context.user.role,
+        note: cleanLimitedText(
+          input.transitionNote,
+          "Transition note",
+          2_000
+        ),
+        metadataJson: JSON.stringify({
+          audience: contentAllowed ? audience : existing.audience,
+          documentCount: documents?.length ?? null,
+        }),
+        createdAt: now,
+      })
+    if (documents === null) {
+      await context.db.batch([updateStatement, historyStatement])
+    } else {
+      const deleteDocumentsStatement = context.db
+        .delete(projectChangeOrderDocuments)
+        .where(
+          and(
+            eq(projectChangeOrderDocuments.changeOrderId, changeOrderId),
+            eq(projectChangeOrderDocuments.projectId, projectId)
+          )
+        )
+      if (documents.length === 0) {
+        await context.db.batch([
+          updateStatement,
+          deleteDocumentsStatement,
+          historyStatement,
+        ])
+      } else {
+        const insertDocumentsStatement = context.db
+          .insert(projectChangeOrderDocuments)
+          .values(
+            documents.map((document) => ({
+            id: crypto.randomUUID(),
+            projectId,
+            changeOrderId,
+            label: document.label,
+            url: document.url,
+            notes: document.notes,
+            createdBy: context.user.id,
+            createdAt: now,
+          }))
+          )
+        await context.db.batch([
+          updateStatement,
+          deleteDocumentsStatement,
+          insertDocumentsStatement,
+          historyStatement,
+        ])
+      }
+    }
+    revalidateChangeOrderPaths(projectId)
+    return { success: true, id: changeOrderId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to update change order request",
+    }
+  }
+}

--- a/src/app/dashboard/projects/[id]/change-orders/[changeOrderId]/page.tsx
+++ b/src/app/dashboard/projects/[id]/change-orders/[changeOrderId]/page.tsx
@@ -1,0 +1,36 @@
+import type * as React from "react"
+import { notFound } from "next/navigation"
+
+import { getProjectChangeOrder } from "@/app/actions/project-change-orders"
+import { ProjectChangeOrderDetail } from "@/components/projects/project-change-order-detail"
+import { redirectIfFeaturePermissionDenied } from "@/lib/permission-redirect"
+
+export default async function ProjectChangeOrderDetailPage({
+  params,
+}: {
+  readonly params: Promise<{
+    readonly id: string
+    readonly changeOrderId: string
+  }>
+}): Promise<React.ReactElement> {
+  const { id, changeOrderId } = await params
+  const item = await getProjectChangeOrder(id, changeOrderId).catch(
+    (error: unknown) => {
+      redirectIfFeaturePermissionDenied(error)
+      throw error
+    }
+  )
+  if (!item) notFound()
+
+  const backHref =
+    `/dashboard/projects/${encodeURIComponent(id)}/change-orders`
+  return (
+    <div className="flex-1 p-4 pt-6 sm:p-6 md:p-8">
+      <ProjectChangeOrderDetail
+        item={item}
+        backHref={backHref}
+        internal
+      />
+    </div>
+  )
+}

--- a/src/app/dashboard/projects/[id]/change-orders/page.tsx
+++ b/src/app/dashboard/projects/[id]/change-orders/page.tsx
@@ -1,0 +1,64 @@
+import type * as React from "react"
+import Link from "next/link"
+import { IconArrowLeft } from "@tabler/icons-react"
+
+import {
+  getProjectChangeOrderCapabilities,
+  getProjectChangeOrders,
+} from "@/app/actions/project-change-orders"
+import { getProjects } from "@/app/actions/projects"
+import { ProjectChangeOrderList } from "@/components/projects/project-change-order-list"
+import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
+import { Button } from "@/components/ui/button"
+import { redirectIfFeaturePermissionDenied } from "@/lib/permission-redirect"
+
+export default async function ProjectChangeOrdersPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  const [projects, items, capabilities] = await Promise.all([
+    getProjects(),
+    getProjectChangeOrders(id),
+    getProjectChangeOrderCapabilities(id),
+  ]).catch((error: unknown) => {
+    redirectIfFeaturePermissionDenied(error)
+    throw error
+  })
+  const project = projects.find((item) => item.id === id)
+  const baseHref = `/dashboard/projects/${encodeURIComponent(id)}/change-orders`
+
+  return (
+    <div className="flex-1 space-y-5 p-4 pt-6 sm:p-6 md:p-8">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <Button asChild variant="ghost" size="sm" className="-ml-2 mb-2">
+            <Link href={`/dashboard/projects/${encodeURIComponent(id)}`}>
+              <IconArrowLeft className="size-4" />
+              Project
+            </Link>
+          </Button>
+          <p className="text-sm text-muted-foreground">
+            {project?.projectNumber ? `${project.projectNumber} · ` : ""}
+            {project?.name ?? "Project"}
+          </p>
+        </div>
+        <ProjectQuickSwitcher
+          projects={projects}
+          currentProjectId={id}
+          targetSection="change-orders"
+          placeholder="Switch change-order project..."
+          className="w-full sm:w-[320px]"
+        />
+      </div>
+      <ProjectChangeOrderList
+        projectId={id}
+        items={items}
+        detailBaseHref={baseHref}
+        internal
+        canCreate={capabilities.canCreate}
+      />
+    </div>
+  )
+}

--- a/src/app/dashboard/projects/select/page.tsx
+++ b/src/app/dashboard/projects/select/page.tsx
@@ -3,6 +3,7 @@ import {
   IconAddressBook,
   IconClipboardText,
   IconFileDollar,
+  IconFileInvoice,
   IconFolderSearch,
   IconMailForward,
   IconMessageCircleQuestion,
@@ -91,6 +92,14 @@ const TARGETS: readonly ProjectTarget[] = [
     placeholder: "Search projects for RFQs...",
     badge: "RFQ context",
     icon: <IconShoppingCartQuestion className="size-5 text-muted-foreground" />,
+  },
+  {
+    section: "change-orders",
+    title: "Change Orders",
+    description: "Choose a project before requesting or reviewing scope changes.",
+    placeholder: "Search projects for change orders...",
+    badge: "Change-order context",
+    icon: <IconFileInvoice className="size-5 text-muted-foreground" />,
   },
   {
     section: "schedule",

--- a/src/app/preview/projects/[id]/owner/change-orders/[changeOrderId]/page.tsx
+++ b/src/app/preview/projects/[id]/owner/change-orders/[changeOrderId]/page.tsx
@@ -1,0 +1,23 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+
+import { ProjectAudienceChangeOrders } from "@/components/projects/project-audience-change-orders"
+
+export default async function OwnerChangeOrderDetailPage({
+  params,
+}: {
+  readonly params: Promise<{
+    readonly id: string
+    readonly changeOrderId: string
+  }>
+}): Promise<React.ReactElement> {
+  const { id, changeOrderId } = await params
+  return (
+    <ProjectAudienceChangeOrders
+      projectId={id}
+      audience="owner"
+      changeOrderId={changeOrderId}
+    />
+  )
+}

--- a/src/app/preview/projects/[id]/owner/change-orders/page.tsx
+++ b/src/app/preview/projects/[id]/owner/change-orders/page.tsx
@@ -1,0 +1,14 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+
+import { ProjectAudienceChangeOrders } from "@/components/projects/project-audience-change-orders"
+
+export default async function OwnerChangeOrdersPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  return <ProjectAudienceChangeOrders projectId={id} audience="owner" />
+}

--- a/src/app/preview/projects/[id]/sub-vendor/change-orders/[changeOrderId]/page.tsx
+++ b/src/app/preview/projects/[id]/sub-vendor/change-orders/[changeOrderId]/page.tsx
@@ -1,0 +1,23 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+
+import { ProjectAudienceChangeOrders } from "@/components/projects/project-audience-change-orders"
+
+export default async function PartnerChangeOrderDetailPage({
+  params,
+}: {
+  readonly params: Promise<{
+    readonly id: string
+    readonly changeOrderId: string
+  }>
+}): Promise<React.ReactElement> {
+  const { id, changeOrderId } = await params
+  return (
+    <ProjectAudienceChangeOrders
+      projectId={id}
+      audience="sub_vendor"
+      changeOrderId={changeOrderId}
+    />
+  )
+}

--- a/src/app/preview/projects/[id]/sub-vendor/change-orders/page.tsx
+++ b/src/app/preview/projects/[id]/sub-vendor/change-orders/page.tsx
@@ -1,0 +1,14 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+
+import { ProjectAudienceChangeOrders } from "@/components/projects/project-audience-change-orders"
+
+export default async function PartnerChangeOrdersPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  return <ProjectAudienceChangeOrders projectId={id} audience="sub_vendor" />
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -9,6 +9,7 @@ import {
   IconClipboardText,
   IconFiles,
   IconFileDollar,
+  IconFileInvoice,
   IconHeartHandshake,
   IconFolder,
   IconHome2,
@@ -154,6 +155,11 @@ const NAV_MAIN = [
     title: "Purchase Orders",
     url: "/dashboard/purchase-orders",
     icon: IconShoppingCart,
+  },
+  {
+    title: "Change Orders",
+    url: "/dashboard/projects/select?target=change-orders",
+    icon: IconFileInvoice,
   },
 ]
 

--- a/src/components/nav-projects.tsx
+++ b/src/components/nav-projects.tsx
@@ -9,6 +9,7 @@ import {
   IconClipboardText,
   IconEye,
   IconFileDollar,
+  IconFileInvoice,
   IconFolder,
   IconHome2,
   IconMailForward,
@@ -47,6 +48,7 @@ type ProjectSectionKey =
   | "rfis"
   | "rfqs"
   | "purchase-orders"
+  | "change-orders"
   | "budget"
   | "financials"
   | "contacts"
@@ -126,6 +128,12 @@ const PROJECT_SECTION_ITEMS: readonly ProjectSectionItem[] = [
     hrefSuffix: "purchase-orders",
     icon: IconShoppingCart,
     section: "purchase-orders",
+  },
+  {
+    title: "Change Orders",
+    hrefSuffix: "change-orders",
+    icon: IconFileInvoice,
+    section: "change-orders",
   },
   {
     title: "Budget / G703",

--- a/src/components/projects/project-audience-change-orders.tsx
+++ b/src/components/projects/project-audience-change-orders.tsx
@@ -1,0 +1,107 @@
+import type * as React from "react"
+import { notFound } from "next/navigation"
+
+import {
+  getProjectChangeOrder,
+  getProjectChangeOrderCapabilities,
+  getProjectChangeOrders,
+} from "@/app/actions/project-change-orders"
+import {
+  getProjectAudiencePreview,
+  type ProjectAudiencePreview,
+} from "@/app/actions/project-audience-preview"
+import { ProjectAudiencePreviewShell } from "@/components/projects/project-audience-preview-shell"
+import { ProjectChangeOrderDetail } from "@/components/projects/project-change-order-detail"
+import { ProjectChangeOrderList } from "@/components/projects/project-change-order-list"
+import type { ProjectAudience } from "@/lib/project-audience-access"
+import { projectAudienceMessageShortcut } from "@/lib/project-audience-direct-message"
+import { projectAudienceSectionHref } from "@/lib/project-audience-preview-routes"
+
+function routeAudience(audience: ProjectAudience): "owner" | "sub-vendor" {
+  return audience === "owner" ? "owner" : "sub-vendor"
+}
+
+function hasDigest(error: unknown): error is { readonly digest: string } {
+  return typeof error === "object" && error !== null && "digest" in error
+}
+
+async function loadPreview(
+  projectId: string,
+  audience: ProjectAudience
+): Promise<ProjectAudiencePreview> {
+  try {
+    return await getProjectAudiencePreview(projectId, audience)
+  } catch (error) {
+    if (hasDigest(error) && error.digest === "NEXT_NOT_FOUND") throw error
+    notFound()
+  }
+}
+
+export async function ProjectAudienceChangeOrders({
+  projectId,
+  audience,
+  changeOrderId,
+}: {
+  readonly projectId: string
+  readonly audience: ProjectAudience
+  readonly changeOrderId?: string
+}): Promise<React.ReactElement> {
+  const preview = await loadPreview(projectId, audience)
+  const route = routeAudience(audience)
+  const baseHref = projectAudienceSectionHref(
+    projectId,
+    route,
+    "change-orders"
+  )
+  const item = changeOrderId
+    ? await getProjectChangeOrder(projectId, changeOrderId, audience)
+    : null
+  const items = changeOrderId
+    ? []
+    : await getProjectChangeOrders(projectId, audience)
+  const capabilities = await getProjectChangeOrderCapabilities(projectId)
+  const messageShortcut = projectAudienceMessageShortcut({
+    projectId: preview.project.id,
+    audience,
+    viewerId: preview.viewer.id,
+    contacts: preview.contacts,
+    messageChannels: preview.messageChannels,
+  })
+  if (changeOrderId && !item) notFound()
+
+  return (
+    <ProjectAudiencePreviewShell
+      audience={audience}
+      projectId={preview.project.id}
+      projectName={preview.project.name}
+      projectNumber={preview.project.projectNumber}
+      projectOptions={preview.projectOptions}
+      viewer={preview.viewer}
+      viewerIsInternal={preview.viewerIsInternal}
+      messageShortcut={messageShortcut}
+      activeSection="change-orders"
+    >
+      <main className="min-h-screen bg-muted/20 px-4 py-5 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-6xl">
+          {item ? (
+            <ProjectChangeOrderDetail
+              item={item}
+              backHref={baseHref}
+              internal={false}
+            />
+          ) : (
+            <ProjectChangeOrderList
+              projectId={projectId}
+              items={items}
+              detailBaseHref={baseHref}
+              internal={false}
+              canCreate={
+                !preview.viewerIsInternal && capabilities.canCreate
+              }
+            />
+          )}
+        </div>
+      </main>
+    </ProjectAudiencePreviewShell>
+  )
+}

--- a/src/components/projects/project-audience-preview-shell.tsx
+++ b/src/components/projects/project-audience-preview-shell.tsx
@@ -7,6 +7,7 @@ import {
   IconClipboardCheck,
   IconEye,
   IconFileDollar,
+  IconFileInvoice,
   IconHome,
   IconMessageCircle,
   IconPhoto,
@@ -62,6 +63,11 @@ const OWNER_NAVIGATION: readonly PreviewNavigationItem[] = [
     icon: <IconFileDollar className="size-4" />,
   },
   {
+    label: "Change Orders",
+    section: "change-orders",
+    icon: <IconFileInvoice className="size-4" />,
+  },
+  {
     label: "Conversations",
     section: "conversations",
     icon: <IconMessageCircle className="size-4" />,
@@ -98,6 +104,11 @@ const SUB_VENDOR_NAVIGATION: readonly PreviewNavigationItem[] = [
     label: "RFIs",
     section: "rfis",
     icon: <IconQuestionMark className="size-4" />,
+  },
+  {
+    label: "Change Orders",
+    section: "change-orders",
+    icon: <IconFileInvoice className="size-4" />,
   },
   {
     label: "Conversations",

--- a/src/components/projects/project-change-order-create-form.tsx
+++ b/src/components/projects/project-change-order-create-form.tsx
@@ -1,0 +1,219 @@
+"use client"
+
+import * as React from "react"
+import { IconFilePlus } from "@tabler/icons-react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+
+import { createProjectChangeOrder } from "@/app/actions/project-change-orders"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
+import { Textarea } from "@/components/ui/textarea"
+
+function optionalText(formData: FormData, name: string): string | null {
+  const value = formData.get(name)
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function requiredText(formData: FormData, name: string): string {
+  return optionalText(formData, name) ?? ""
+}
+
+function amountCents(formData: FormData): number | null {
+  const value = optionalText(formData, "amount")
+  if (!value) return null
+  const amount = Number(value.replaceAll(",", ""))
+  return Number.isFinite(amount) ? Math.round(amount * 100) : Number.NaN
+}
+
+export function ProjectChangeOrderCreateForm({
+  projectId,
+  detailBaseHref,
+  internal,
+}: {
+  readonly projectId: string
+  readonly detailBaseHref: string
+  readonly internal: boolean
+}): React.ReactElement {
+  const router = useRouter()
+  const [open, setOpen] = React.useState(false)
+  const [saving, startSaving] = React.useTransition()
+
+  function submit(formData: FormData): void {
+    startSaving(async () => {
+      const documentUrl = optionalText(formData, "documentUrl")
+      const result = await createProjectChangeOrder(projectId, {
+        title: requiredText(formData, "title"),
+        scope: requiredText(formData, "scope"),
+        reason: optionalText(formData, "reason"),
+        amountCents: amountCents(formData),
+        audience:
+          optionalText(formData, "audience") === "owner"
+            ? "owner"
+            : optionalText(formData, "audience") === "sub_vendor"
+              ? "sub_vendor"
+              : "internal",
+        requesterCompany: optionalText(formData, "requesterCompany"),
+        sourceRecordId: null,
+        sourceHref: optionalText(formData, "sourceHref"),
+        initialStatus:
+          optionalText(formData, "initialStatus") === "submitted"
+            ? "submitted"
+            : "draft",
+        documents: documentUrl
+          ? [
+              {
+                label:
+                  optionalText(formData, "documentLabel") ??
+                  "Supporting document",
+                url: documentUrl,
+                notes: null,
+              },
+            ]
+          : [],
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      setOpen(false)
+      toast.success("Change order request created.")
+      router.push(`${detailBaseHref}/${encodeURIComponent(result.id)}`)
+      router.refresh()
+    })
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button>
+          <IconFilePlus className="size-4" />
+          Request change
+        </Button>
+      </SheetTrigger>
+      <SheetContent className="w-full overflow-y-auto sm:max-w-xl">
+        <SheetHeader>
+          <SheetTitle>Request a change order</SheetTitle>
+          <SheetDescription>
+            Describe the requested scope and attach a supporting document link.
+            This does not approve work or send anything to Sage or Foxit.
+          </SheetDescription>
+        </SheetHeader>
+        <form action={submit} className="space-y-5 px-4 pb-6">
+          <div className="space-y-2">
+            <Label htmlFor="change-order-title">Title</Label>
+            <Input id="change-order-title" name="title" required />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="change-order-scope">Requested scope</Label>
+            <Textarea
+              id="change-order-scope"
+              name="scope"
+              rows={6}
+              required
+              placeholder="Describe what should change and the desired result."
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="change-order-reason">Reason</Label>
+            <Textarea id="change-order-reason" name="reason" rows={3} />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="change-order-amount">
+                Requested amount (optional)
+              </Label>
+              <Input
+                id="change-order-amount"
+                name="amount"
+                type="number"
+                step="0.01"
+                inputMode="decimal"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="change-order-company">Company</Label>
+              <Input id="change-order-company" name="requesterCompany" />
+            </div>
+          </div>
+          {internal && (
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="change-order-audience">Audience</Label>
+                <select
+                  id="change-order-audience"
+                  name="audience"
+                  className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                  defaultValue="internal"
+                >
+                  <option value="internal">Internal only</option>
+                  <option value="owner">Owner visible when approved</option>
+                  <option value="sub_vendor">Sub/vendor request</option>
+                </select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="change-order-initial-status">Save as</Label>
+                <select
+                  id="change-order-initial-status"
+                  name="initialStatus"
+                  className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                  defaultValue="draft"
+                >
+                  <option value="draft">Draft</option>
+                  <option value="submitted">Submitted for triage</option>
+                </select>
+              </div>
+            </div>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="change-order-source">Source link (optional)</Label>
+            <Input
+              id="change-order-source"
+              name="sourceHref"
+              type="url"
+              placeholder="https://..."
+            />
+          </div>
+          <div className="border-t pt-4">
+            <p className="text-sm font-medium">Supporting document</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Link a plan, estimate, photo folder, or other project document.
+            </p>
+            <div className="mt-3 grid gap-3">
+              <Input name="documentLabel" placeholder="Document label" />
+              <Input
+                name="documentUrl"
+                type="url"
+                placeholder="https://..."
+              />
+            </div>
+          </div>
+          <SheetFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={saving}>
+              {saving ? "Creating…" : internal ? "Create request" : "Submit request"}
+            </Button>
+          </SheetFooter>
+        </form>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/components/projects/project-change-order-detail.tsx
+++ b/src/components/projects/project-change-order-detail.tsx
@@ -1,0 +1,151 @@
+import type * as React from "react"
+import Link from "next/link"
+import { IconArrowLeft, IconExternalLink } from "@tabler/icons-react"
+
+import type { ProjectChangeOrderItem } from "@/app/actions/project-change-orders"
+import { ProjectChangeOrderEditForm } from "@/components/projects/project-change-order-edit-form"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  changeOrderStatusLabel,
+  isChangeOrderStatus,
+} from "@/lib/change-orders/status"
+
+function formatDate(value: string): string {
+  return new Date(value).toLocaleString("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  })
+}
+
+function money(cents: number | null): string {
+  if (cents === null) return "Not determined"
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(cents / 100)
+}
+
+function historyStatusLabel(value: string | null): string {
+  return value && isChangeOrderStatus(value)
+    ? changeOrderStatusLabel(value)
+    : value ?? "Updated"
+}
+
+export function ProjectChangeOrderDetail({
+  item,
+  backHref,
+  internal,
+}: {
+  readonly item: ProjectChangeOrderItem
+  readonly backHref: string
+  readonly internal: boolean
+}): React.ReactElement {
+  return (
+    <div className="space-y-5">
+      <Button asChild variant="ghost" size="sm" className="-ml-2">
+        <Link href={backHref}>
+          <IconArrowLeft className="size-4" />
+          Change orders
+        </Link>
+      </Button>
+      <header className="border-b pb-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-medium text-muted-foreground">
+              {item.changeOrderNumber}
+            </p>
+            <h1 className="mt-1 text-2xl font-semibold">{item.title}</h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Requested by {item.requesterName}
+              {item.requesterCompany ? ` · ${item.requesterCompany}` : ""}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Badge>{changeOrderStatusLabel(item.status)}</Badge>
+            <Badge variant="outline">{money(item.amountCents)}</Badge>
+            <Badge variant="secondary">{item.audience}</Badge>
+          </div>
+        </div>
+      </header>
+
+      <ProjectChangeOrderEditForm item={item} internal={internal} />
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <div className="border-y bg-background p-4">
+          <h2 className="text-sm font-semibold">Supporting documents</h2>
+          {item.documents.length > 0 ? (
+            <div className="mt-3 space-y-2">
+              {item.documents.map((document) => (
+                <a
+                  key={document.id}
+                  href={document.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center justify-between gap-3 border px-3 py-2 text-sm hover:bg-muted"
+                >
+                  <span>
+                    <span className="font-medium">{document.label}</span>
+                    {document.notes && (
+                      <span className="mt-1 block text-xs text-muted-foreground">
+                        {document.notes}
+                      </span>
+                    )}
+                  </span>
+                  <IconExternalLink className="size-4 shrink-0" />
+                </a>
+              ))}
+            </div>
+          ) : (
+            <p className="mt-3 text-sm text-muted-foreground">
+              No supporting links.
+            </p>
+          )}
+        </div>
+        <div className="border-y bg-background p-4">
+          <h2 className="text-sm font-semibold">Integration boundaries</h2>
+          <dl className="mt-3 grid gap-3 text-sm">
+            <div>
+              <dt className="text-xs text-muted-foreground">Foxit signature</dt>
+              <dd className="font-medium">{item.foxitStatus}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">Sage</dt>
+              <dd className="font-medium">{item.sageStatus}</dd>
+            </div>
+          </dl>
+          <p className="mt-3 text-xs leading-5 text-muted-foreground">
+            Compass records readiness only. No document is sent to Foxit and no
+            accounting record is written to Sage from this workflow.
+          </p>
+        </div>
+      </section>
+
+      <section className="border-y bg-background p-4">
+        <h2 className="text-sm font-semibold">Activity history</h2>
+        <div className="mt-3 divide-y">
+          {item.history.map((event) => (
+            <article key={event.id} className="py-3 text-sm">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="font-medium">
+                  {event.eventType === "status_transition"
+                    ? `${event.fromStatus ? historyStatusLabel(event.fromStatus) : "Created"} → ${historyStatusLabel(event.toStatus)}`
+                    : event.eventType === "created"
+                      ? "Request created"
+                      : "Request updated"}
+                </p>
+                <time className="text-xs text-muted-foreground">
+                  {formatDate(event.createdAt)}
+                </time>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {event.actorName} · {event.actorRole}
+              </p>
+              {event.note && <p className="mt-2">{event.note}</p>}
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/projects/project-change-order-edit-form.tsx
+++ b/src/components/projects/project-change-order-edit-form.tsx
@@ -1,0 +1,284 @@
+"use client"
+
+import * as React from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+
+import {
+  updateProjectChangeOrder,
+  type ProjectChangeOrderItem,
+} from "@/app/actions/project-change-orders"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  changeOrderStatusLabel,
+  isChangeOrderStatus,
+} from "@/lib/change-orders/status"
+
+function optionalText(formData: FormData, name: string): string | null {
+  const value = formData.get(name)
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function requiredText(formData: FormData, name: string): string {
+  return optionalText(formData, name) ?? ""
+}
+
+function amountCents(formData: FormData): number | null {
+  const value = optionalText(formData, "amount")
+  if (!value) return null
+  const amount = Number(value.replaceAll(",", ""))
+  return Number.isFinite(amount) ? Math.round(amount * 100) : Number.NaN
+}
+
+export function ProjectChangeOrderEditForm({
+  item,
+  internal,
+}: {
+  readonly item: ProjectChangeOrderItem
+  readonly internal: boolean
+}): React.ReactElement {
+  const router = useRouter()
+  const [documents, setDocuments] = React.useState(item.documents)
+  const [saving, startSaving] = React.useTransition()
+
+  if (!item.canEdit && item.allowedTransitions.length === 0) {
+    return (
+      <p className="border-y bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
+        This record is read-only at its current workflow stage.
+      </p>
+    )
+  }
+
+  function submit(formData: FormData): void {
+    startSaving(async () => {
+      const requestedStatus = requiredText(formData, "status")
+      const status =
+        isChangeOrderStatus(requestedStatus) &&
+        (requestedStatus === item.status ||
+          item.allowedTransitions.includes(requestedStatus))
+          ? requestedStatus
+          : item.status
+      const result = await updateProjectChangeOrder(item.projectId, item.id, {
+        title: requiredText(formData, "title"),
+        scope: requiredText(formData, "scope"),
+        reason: optionalText(formData, "reason"),
+        amountCents: amountCents(formData),
+        audience:
+          optionalText(formData, "audience") === "owner"
+            ? "owner"
+            : optionalText(formData, "audience") === "sub_vendor"
+              ? "sub_vendor"
+              : "internal",
+        internalNotes: optionalText(formData, "internalNotes"),
+        status,
+        transitionNote: optionalText(formData, "transitionNote"),
+        documents: documents.map((document) => ({
+          label: document.label,
+          url: document.url,
+          notes: document.notes,
+        })),
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success("Change order request updated.")
+      router.refresh()
+    })
+  }
+
+  return (
+    <form action={submit} className="space-y-5 border-y bg-background p-4">
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="change-order-edit-title">Title</Label>
+          <Input
+            id="change-order-edit-title"
+            name="title"
+            defaultValue={item.title}
+            disabled={!item.canEdit}
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="change-order-edit-amount">Requested amount</Label>
+          <Input
+            id="change-order-edit-amount"
+            name="amount"
+            type="number"
+            step="0.01"
+            defaultValue={
+              item.amountCents === null
+                ? ""
+                : (item.amountCents / 100).toFixed(2)
+            }
+            disabled={!item.canEdit}
+          />
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="change-order-edit-scope">Scope</Label>
+        <Textarea
+          id="change-order-edit-scope"
+          name="scope"
+          defaultValue={item.scope}
+          rows={6}
+          disabled={!item.canEdit}
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="change-order-edit-reason">Reason</Label>
+        <Textarea
+          id="change-order-edit-reason"
+          name="reason"
+          defaultValue={item.reason ?? ""}
+          rows={3}
+          disabled={!item.canEdit}
+        />
+      </div>
+      {internal && (
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="change-order-edit-audience">Audience</Label>
+            <select
+              id="change-order-edit-audience"
+              name="audience"
+              defaultValue={item.audience}
+              disabled={!item.canEdit}
+              className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+            >
+              <option value="internal">Internal only</option>
+              <option value="owner">Owner visible when approved</option>
+              <option value="sub_vendor">Sub/vendor request</option>
+            </select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="change-order-internal-notes">Internal notes</Label>
+            <Input
+              id="change-order-internal-notes"
+              name="internalNotes"
+              defaultValue={item.internalNotes ?? ""}
+              disabled={!item.canEdit}
+            />
+          </div>
+        </div>
+      )}
+      {item.canEdit && (
+        <div className="space-y-3 border-t pt-4">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-sm font-medium">Document links</p>
+              <p className="text-xs text-muted-foreground">
+                Links stay in Compass; no document is sent externally.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                setDocuments((current) => [
+                  ...current,
+                  {
+                    id: crypto.randomUUID(),
+                    label: "",
+                    url: "",
+                    notes: null,
+                  },
+                ])
+              }
+            >
+              Add link
+            </Button>
+          </div>
+          {documents.map((document, index) => (
+            <div
+              key={document.id}
+              className="grid gap-2 border-l-2 pl-3 sm:grid-cols-[1fr_2fr_auto]"
+            >
+              <Input
+                value={document.label}
+                aria-label={`Document ${index + 1} label`}
+                placeholder="Label"
+                onChange={(event) =>
+                  setDocuments((current) =>
+                    current.map((item) =>
+                      item.id === document.id
+                        ? { ...item, label: event.currentTarget.value }
+                        : item
+                    )
+                  )
+                }
+              />
+              <Input
+                value={document.url}
+                aria-label={`Document ${index + 1} URL`}
+                type="url"
+                placeholder="https://..."
+                onChange={(event) =>
+                  setDocuments((current) =>
+                    current.map((item) =>
+                      item.id === document.id
+                        ? { ...item, url: event.currentTarget.value }
+                        : item
+                    )
+                  )
+                }
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() =>
+                  setDocuments((current) =>
+                    current.filter((item) => item.id !== document.id)
+                  )
+                }
+              >
+                Remove
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="grid gap-4 border-t pt-4 lg:grid-cols-[1fr_2fr_auto]">
+        <div className="space-y-2">
+          <Label htmlFor="change-order-edit-status">Status</Label>
+          <select
+            id="change-order-edit-status"
+            name="status"
+            defaultValue={item.status}
+            className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+          >
+            <option value={item.status}>
+              {changeOrderStatusLabel(item.status)}
+            </option>
+            {item.allowedTransitions.map((status) => (
+              <option key={status} value={status}>
+                {changeOrderStatusLabel(status)}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="change-order-transition-note">
+            Update / transition note
+          </Label>
+          <Input
+            id="change-order-transition-note"
+            name="transitionNote"
+            placeholder="Explain the decision or information supplied."
+          />
+        </div>
+        <Button type="submit" className="self-end" disabled={saving}>
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/projects/project-change-order-list.tsx
+++ b/src/components/projects/project-change-order-list.tsx
@@ -1,0 +1,109 @@
+import type * as React from "react"
+import Link from "next/link"
+import { IconFileInvoice } from "@tabler/icons-react"
+
+import type { ProjectChangeOrderItem } from "@/app/actions/project-change-orders"
+import { ProjectChangeOrderCreateForm } from "@/components/projects/project-change-order-create-form"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { changeOrderStatusLabel } from "@/lib/change-orders/status"
+
+function money(cents: number | null): string {
+  if (cents === null) return "Amount not determined"
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(cents / 100)
+}
+
+export function ProjectChangeOrderList({
+  projectId,
+  items,
+  detailBaseHref,
+  internal,
+  canCreate = true,
+}: {
+  readonly projectId: string
+  readonly items: readonly ProjectChangeOrderItem[]
+  readonly detailBaseHref: string
+  readonly internal: boolean
+  readonly canCreate?: boolean
+}): React.ReactElement {
+  const openCount = items.filter(
+    (item) => !["closed", "declined", "void"].includes(item.status)
+  ).length
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap items-end justify-between gap-3 border-y py-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <IconFileInvoice className="size-5 text-muted-foreground" />
+            <h1 className="text-xl font-semibold">Change orders</h1>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Request, review, price, approve, and track project scope changes.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge variant={openCount > 0 ? "secondary" : "outline"}>
+            {openCount} active
+          </Badge>
+          {canCreate && (
+            <ProjectChangeOrderCreateForm
+              projectId={projectId}
+              detailBaseHref={detailBaseHref}
+              internal={internal}
+            />
+          )}
+        </div>
+      </div>
+
+      {items.length > 0 ? (
+        <div className="divide-y border-y bg-background">
+          {items.map((item) => (
+            <article
+              key={item.id}
+              className="grid gap-3 px-4 py-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center"
+            >
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    {item.changeOrderNumber}
+                  </p>
+                  <Badge variant="outline">
+                    {changeOrderStatusLabel(item.status)}
+                  </Badge>
+                  <Badge variant="secondary">{item.requesterType}</Badge>
+                </div>
+                <h2 className="mt-2 font-semibold">{item.title}</h2>
+                <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                  {item.scope}
+                </p>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {money(item.amountCents)} · Requested by {item.requesterName}
+                </p>
+              </div>
+              <Button asChild variant="outline" size="sm">
+                <Link
+                  href={`${detailBaseHref}/${encodeURIComponent(item.id)}`}
+                >
+                  Open
+                </Link>
+              </Button>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <div className="border-y bg-background p-8 text-center">
+          <IconFileInvoice className="mx-auto size-7 text-muted-foreground" />
+          <h2 className="mt-3 text-sm font-semibold">No change requests yet</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Use Request change to document the first scope, pricing, or owner
+            request.
+          </p>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1062,6 +1062,115 @@ export const projectRfiAttachments = sqliteTable("project_rfi_attachments", {
   updatedAt: text("updated_at").notNull(),
 })
 
+export const projectChangeOrders = sqliteTable(
+  "project_change_orders",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    changeOrderNumber: text("change_order_number").notNull(),
+    title: text("title").notNull(),
+    scope: text("scope").notNull(),
+    reason: text("reason"),
+    amountCents: integer("amount_cents"),
+    status: text("status").notNull().default("draft"),
+    audience: text("audience").notNull().default("internal"),
+    requesterType: text("requester_type").notNull(),
+    requesterUserId: text("requester_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    requesterName: text("requester_name").notNull(),
+    requesterCompany: text("requester_company"),
+    sourceType: text("source_type").notNull(),
+    sourceRecordId: text("source_record_id"),
+    sourceHref: text("source_href"),
+    internalNotes: text("internal_notes"),
+    foxitStatus: text("foxit_status").notNull().default("not_started"),
+    foxitEnvelopeId: text("foxit_envelope_id"),
+    signatureRequestedAt: text("signature_requested_at"),
+    executedAt: text("executed_at"),
+    sageStatus: text("sage_status").notNull().default("not_ready"),
+    sageRecordId: text("sage_record_id"),
+    lastSageSyncAt: text("last_sage_sync_at"),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    submittedAt: text("submitted_at"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("project_change_orders_project_number_uq").on(
+      table.projectId,
+      table.changeOrderNumber
+    ),
+    index("project_change_orders_project_status_idx").on(
+      table.projectId,
+      table.status
+    ),
+    index("project_change_orders_requester_idx").on(
+      table.projectId,
+      table.requesterUserId
+    ),
+  ]
+)
+
+export const projectChangeOrderDocuments = sqliteTable(
+  "project_change_order_documents",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    changeOrderId: text("change_order_id")
+      .notNull()
+      .references(() => projectChangeOrders.id, { onDelete: "cascade" }),
+    label: text("label").notNull(),
+    url: text("url").notNull(),
+    notes: text("notes"),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    index("project_change_order_documents_order_idx").on(table.changeOrderId),
+    index("project_change_order_documents_project_idx").on(table.projectId),
+  ]
+)
+
+export const projectChangeOrderHistory = sqliteTable(
+  "project_change_order_history",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    changeOrderId: text("change_order_id")
+      .notNull()
+      .references(() => projectChangeOrders.id, { onDelete: "cascade" }),
+    eventType: text("event_type").notNull(),
+    fromStatus: text("from_status"),
+    toStatus: text("to_status"),
+    actorUserId: text("actor_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    actorName: text("actor_name").notNull(),
+    actorRole: text("actor_role").notNull(),
+    note: text("note"),
+    metadataJson: text("metadata_json"),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    index("project_change_order_history_order_idx").on(
+      table.changeOrderId,
+      table.createdAt
+    ),
+    index("project_change_order_history_project_idx").on(table.projectId),
+  ]
+)
+
 export const projectContacts = sqliteTable("project_contacts", {
   id: text("id").primaryKey(),
   projectId: text("project_id")
@@ -1428,6 +1537,16 @@ export type ProjectRfi = typeof projectRfis.$inferSelect
 export type NewProjectRfi = typeof projectRfis.$inferInsert
 export type ProjectRfiAttachment = typeof projectRfiAttachments.$inferSelect
 export type NewProjectRfiAttachment = typeof projectRfiAttachments.$inferInsert
+export type ProjectChangeOrder = typeof projectChangeOrders.$inferSelect
+export type NewProjectChangeOrder = typeof projectChangeOrders.$inferInsert
+export type ProjectChangeOrderDocument =
+  typeof projectChangeOrderDocuments.$inferSelect
+export type NewProjectChangeOrderDocument =
+  typeof projectChangeOrderDocuments.$inferInsert
+export type ProjectChangeOrderHistory =
+  typeof projectChangeOrderHistory.$inferSelect
+export type NewProjectChangeOrderHistory =
+  typeof projectChangeOrderHistory.$inferInsert
 export type ProjectContact = typeof projectContacts.$inferSelect
 export type NewProjectContact = typeof projectContacts.$inferInsert
 export type ProjectContactSourceLink =

--- a/src/lib/__tests__/change-order-access.test.ts
+++ b/src/lib/__tests__/change-order-access.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  canViewChangeOrder,
+  changeOrderRequesterType,
+} from "@/lib/change-orders/access"
+import type { AuthUser } from "@/lib/auth"
+import { can } from "@/lib/permissions"
+
+function user(role: string): AuthUser {
+  return {
+    id: `user-${role}`,
+    email: `${role}@example.com`,
+    firstName: null,
+    lastName: null,
+    displayName: role,
+    avatarUrl: null,
+    role,
+    googleEmail: null,
+    isActive: true,
+    lastLoginAt: null,
+    organizationId: "org",
+    organizationName: "Organization",
+    organizationType: role === "client" ? "client" : "internal",
+    createdAt: "2026-07-30T00:00:00.000Z",
+    updatedAt: "2026-07-30T00:00:00.000Z",
+  }
+}
+
+describe("change order audience access", () => {
+  it("accepts internal, owner, and subcontractor requesters only", () => {
+    expect(
+      changeOrderRequesterType({ internal: true, projectRole: null })
+    ).toBe("internal")
+    expect(
+      changeOrderRequesterType({ internal: false, projectRole: "client" })
+    ).toBe("owner")
+    expect(
+      changeOrderRequesterType({
+        internal: false,
+        projectRole: "subcontractor",
+      })
+    ).toBe("subcontractor")
+    expect(
+      changeOrderRequesterType({ internal: false, projectRole: "supplier" })
+    ).toBeNull()
+    expect(
+      changeOrderRequesterType({ internal: false, projectRole: "guest" })
+    ).toBeNull()
+  })
+
+  it("grants request creation to clients and subcontractors, not generic guests or suppliers", () => {
+    expect(can(user("client"), "changeorder", "create")).toBe(true)
+    expect(can(user("subcontractor"), "changeorder", "create")).toBe(true)
+    expect(can(user("supplier"), "changeorder", "create")).toBe(false)
+    expect(can(user("guest"), "changeorder", "create")).toBe(false)
+  })
+
+  it("keeps owner requests visible to their requester during internal review", () => {
+    expect(
+      canViewChangeOrder({
+        internal: false,
+        viewerId: "owner-one",
+        viewerRequesterType: "owner",
+        requesterUserId: "owner-one",
+        audience: "owner",
+        status: "triage",
+      })
+    ).toBe(true)
+  })
+
+  it("shows other owner requests only after explicit owner approval", () => {
+    expect(
+      canViewChangeOrder({
+        internal: false,
+        viewerId: "owner-two",
+        viewerRequesterType: "owner",
+        requesterUserId: "owner-one",
+        audience: "owner",
+        status: "internal_review",
+      })
+    ).toBe(false)
+    expect(
+      canViewChangeOrder({
+        internal: false,
+        viewerId: "owner-two",
+        viewerRequesterType: "owner",
+        requesterUserId: "owner-one",
+        audience: "owner",
+        status: "approved_for_owner",
+      })
+    ).toBe(true)
+  })
+
+  it("never broadens one subcontractor's request to another subcontractor", () => {
+    expect(
+      canViewChangeOrder({
+        internal: false,
+        viewerId: "sub-two",
+        viewerRequesterType: "subcontractor",
+        requesterUserId: "sub-one",
+        audience: "sub_vendor",
+        status: "closed",
+      })
+    ).toBe(false)
+  })
+})

--- a/src/lib/__tests__/change-order-status.test.ts
+++ b/src/lib/__tests__/change-order-status.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  allowedChangeOrderTransitions,
+  canEditChangeOrderContent,
+  canTransitionChangeOrder,
+  isExternallyPublishedChangeOrderStatus,
+} from "@/lib/change-orders/status"
+
+describe("change order workflow", () => {
+  it("moves operational work through review before approval", () => {
+    expect(allowedChangeOrderTransitions("submitted")).toContain("triage")
+    expect(allowedChangeOrderTransitions("pricing")).toContain("internal_review")
+    expect(allowedChangeOrderTransitions("internal_review")).toContain(
+      "approved_for_owner"
+    )
+    expect(allowedChangeOrderTransitions("closed")).toEqual([])
+  })
+
+  it("requires approval authority for owner approval, signature, and Sage states", () => {
+    expect(
+      canTransitionChangeOrder({
+        from: "internal_review",
+        to: "approved_for_owner",
+        internal: true,
+        canApprove: false,
+      })
+    ).toBe(false)
+    expect(
+      canTransitionChangeOrder({
+        from: "internal_review",
+        to: "approved_for_owner",
+        internal: true,
+        canApprove: true,
+      })
+    ).toBe(true)
+    expect(
+      canTransitionChangeOrder({
+        from: "signature_pending",
+        to: "executed",
+        internal: true,
+        canApprove: false,
+      })
+    ).toBe(false)
+  })
+
+  it("lets an external requester answer a needs-information return only", () => {
+    expect(
+      canTransitionChangeOrder({
+        from: "needs_information",
+        to: "submitted",
+        internal: false,
+        canApprove: false,
+      })
+    ).toBe(true)
+    expect(
+      canTransitionChangeOrder({
+        from: "submitted",
+        to: "triage",
+        internal: false,
+        canApprove: false,
+      })
+    ).toBe(false)
+    expect(
+      canEditChangeOrderContent({
+        status: "needs_information",
+        internal: false,
+        isRequester: true,
+      })
+    ).toBe(true)
+  })
+
+  it("publishes only approval-and-later states to non-requesting owners", () => {
+    expect(isExternallyPublishedChangeOrderStatus("internal_review")).toBe(false)
+    expect(
+      isExternallyPublishedChangeOrderStatus("approved_for_owner")
+    ).toBe(true)
+    expect(isExternallyPublishedChangeOrderStatus("closed")).toBe(true)
+  })
+})

--- a/src/lib/change-orders/access.ts
+++ b/src/lib/change-orders/access.ts
@@ -1,0 +1,36 @@
+import { isExternallyPublishedChangeOrderStatus } from "@/lib/change-orders/status"
+import type { ChangeOrderStatus } from "@/lib/change-orders/status"
+
+export type ChangeOrderRequesterType =
+  | "internal"
+  | "owner"
+  | "subcontractor"
+
+export function changeOrderRequesterType(input: {
+  readonly internal: boolean
+  readonly projectRole: string | null
+}): ChangeOrderRequesterType | null {
+  if (input.internal) return "internal"
+  if (input.projectRole === "client" || input.projectRole === "owner") {
+    return "owner"
+  }
+  if (input.projectRole === "subcontractor") return "subcontractor"
+  return null
+}
+
+export function canViewChangeOrder(input: {
+  readonly internal: boolean
+  readonly viewerId: string
+  readonly viewerRequesterType: ChangeOrderRequesterType | null
+  readonly requesterUserId: string | null
+  readonly audience: string
+  readonly status: ChangeOrderStatus
+}): boolean {
+  if (input.internal) return true
+  if (input.requesterUserId === input.viewerId) return true
+  return (
+    input.viewerRequesterType === "owner" &&
+    input.audience === "owner" &&
+    isExternallyPublishedChangeOrderStatus(input.status)
+  )
+}

--- a/src/lib/change-orders/status.ts
+++ b/src/lib/change-orders/status.ts
@@ -1,0 +1,112 @@
+export const CHANGE_ORDER_STATUSES = [
+  "draft",
+  "submitted",
+  "triage",
+  "needs_information",
+  "pricing",
+  "internal_review",
+  "approved_for_owner",
+  "signature_pending",
+  "executed",
+  "sage_pending",
+  "synced",
+  "closed",
+  "declined",
+  "void",
+] as const
+
+export type ChangeOrderStatus = (typeof CHANGE_ORDER_STATUSES)[number]
+
+const TRANSITIONS: Readonly<
+  Record<ChangeOrderStatus, readonly ChangeOrderStatus[]>
+> = {
+  draft: ["submitted", "void"],
+  submitted: ["triage", "needs_information", "declined", "void"],
+  triage: ["needs_information", "pricing", "internal_review", "declined", "void"],
+  needs_information: ["submitted", "triage", "pricing", "declined", "void"],
+  pricing: ["needs_information", "internal_review", "declined", "void"],
+  internal_review: [
+    "needs_information",
+    "pricing",
+    "approved_for_owner",
+    "declined",
+    "void",
+  ],
+  approved_for_owner: [
+    "internal_review",
+    "signature_pending",
+    "declined",
+    "void",
+  ],
+  signature_pending: ["approved_for_owner", "executed", "declined", "void"],
+  executed: ["sage_pending", "closed"],
+  sage_pending: ["executed", "synced"],
+  synced: ["closed"],
+  closed: [],
+  declined: [],
+  void: [],
+}
+
+const APPROVAL_STATUSES = new Set<ChangeOrderStatus>([
+  "approved_for_owner",
+  "signature_pending",
+  "executed",
+  "sage_pending",
+  "synced",
+  "closed",
+])
+
+export function isChangeOrderStatus(
+  value: string
+): value is ChangeOrderStatus {
+  return CHANGE_ORDER_STATUSES.some((status) => status === value)
+}
+
+export function changeOrderStatusLabel(status: ChangeOrderStatus): string {
+  return status
+    .split("_")
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ")
+}
+
+export function allowedChangeOrderTransitions(
+  status: ChangeOrderStatus
+): readonly ChangeOrderStatus[] {
+  return TRANSITIONS[status]
+}
+
+export function canTransitionChangeOrder(input: {
+  readonly from: ChangeOrderStatus
+  readonly to: ChangeOrderStatus
+  readonly internal: boolean
+  readonly canApprove: boolean
+}): boolean {
+  if (!TRANSITIONS[input.from].includes(input.to)) return false
+  if (!input.internal) {
+    return input.from === "needs_information" && input.to === "submitted"
+  }
+  if (APPROVAL_STATUSES.has(input.to)) return input.canApprove
+  return true
+}
+
+export function isExternallyPublishedChangeOrderStatus(
+  status: ChangeOrderStatus
+): boolean {
+  return APPROVAL_STATUSES.has(status)
+}
+
+export function canEditChangeOrderContent(input: {
+  readonly status: ChangeOrderStatus
+  readonly internal: boolean
+  readonly isRequester: boolean
+}): boolean {
+  if (input.internal) {
+    return !["executed", "sage_pending", "synced", "closed", "void"].includes(
+      input.status
+    )
+  }
+  return (
+    input.isRequester &&
+    ["submitted", "needs_information"].includes(input.status)
+  )
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -151,6 +151,14 @@ export const PERMISSION_FEATURES: readonly PermissionFeature[] = [
     resource: "project",
   },
   {
+    id: "change-orders",
+    group: "Operations",
+    label: "Change Orders",
+    description:
+      "Project change requests, pricing, owner approval, signatures, and Sage handoff.",
+    resource: "changeorder",
+  },
+  {
     id: "finish-selections",
     group: "Client Experience",
     label: "Finish Selections",
@@ -398,6 +406,11 @@ const EXTERNAL_PROJECT_PERMISSIONS: RolePermissionSet = {
   help: [],
 }
 
+const EXTERNAL_CHANGE_REQUEST_PERMISSIONS: RolePermissionSet = {
+  ...EXTERNAL_PROJECT_PERMISSIONS,
+  changeorder: ["create", "read"],
+}
+
 const DEVELOPER_PERMISSIONS: RolePermissionSet = {
   project: ["read", "update"],
   schedule: ["create", "read", "update"],
@@ -444,8 +457,8 @@ const PERMISSIONS: RolePermissions = {
   field_superintendent: FIELD_PERMISSIONS,
   field_crew: FIELD_PERMISSIONS,
   field: FIELD_PERMISSIONS,
-  client: EXTERNAL_PROJECT_PERMISSIONS,
-  subcontractor: EXTERNAL_PROJECT_PERMISSIONS,
+  client: EXTERNAL_CHANGE_REQUEST_PERMISSIONS,
+  subcontractor: EXTERNAL_CHANGE_REQUEST_PERMISSIONS,
   supplier: EXTERNAL_PROJECT_PERMISSIONS,
   guest: EXTERNAL_PROJECT_PERMISSIONS,
 }

--- a/src/lib/project-audience-preview-routes.ts
+++ b/src/lib/project-audience-preview-routes.ts
@@ -6,6 +6,7 @@ export type ProjectAudienceWorkspaceSection =
   | "budget"
   | "commitments"
   | "rfis"
+  | "change-orders"
   | "conversations"
   | "photos"
   | "team"


### PR DESCRIPTION
## Summary

- add project-scoped change-order requests for internal staff, owners, and subcontractors
- add guarded workflow states from draft/submission through pricing, internal review, owner approval, signature readiness, execution, and Sage handoff
- add internal, owner, and subcontractor list/detail/create/edit routes and navigation
- add immutable append-only history and atomic record/document/history writes
- add strict audience rules so owners see approved owner records and subcontractors never see another subcontractor’s request
- keep transition notes internal by default; external requesters see only their own notes and explicit requests for more information

## Integration boundaries

- Foxit stops at `handoff_ready`; this PR sends no envelope
- Sage stops at `pending_manual_sync`; this PR performs no Sage write
- the `synced` transition is rejected until an approved connector owns it
- supporting files are safe HTTP(S) document links in this foundation; native upload storage is follow-up work

## Validation

- 9 focused workflow, role, and audience tests with 26 assertions
- TypeScript
- targeted ESLint
- `git diff --check`
- full production `next build`

## Deployment order

1. Merge/deploy #288 and retain its already-applied `0082` migration.
2. Apply `0083_project_change_orders.sql`.
3. Merge/deploy this PR.

Follow-ups: Foxit envelope adapter, Sage write adapter with explicit approval, native attachment uploads, lifecycle notifications, and printable contract generation.

Closes #279 for the guarded request/workflow foundation only.
