### PR TITLE
fix(financials): complete budget and package workflows

### DIFF
--- a/src/app/actions/project-financial-workflows.ts
+++ b/src/app/actions/project-financial-workflows.ts
@@ -4,7 +4,13 @@ import { and, asc, eq, inArray } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
-import { projectOperations, projects } from "@/db/schema"
+import {
+  projectBudgetApplications,
+  projectBudgetLines,
+  projectOperations,
+  projects,
+  sageCostCodes,
+} from "@/db/schema"
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { requireOrg } from "@/lib/org-scope"
@@ -21,6 +27,7 @@ export type ProjectFinancialWorkflowItem = {
   readonly dueDate: string | null
   readonly syncStatus: string
   readonly sageWriteStatus: string
+  readonly supportingPackageUrl: string | null
   readonly updatedAt: string
 }
 
@@ -49,6 +56,24 @@ export type CreateProjectOwnerPayApplicationInput = {
   readonly periodTo: string | null
   readonly amount: number | null
   readonly notes: string | null
+  readonly supportingPackageUrl: string | null
+}
+
+export type ProjectFinancialPhaseOption = {
+  readonly value: string
+  readonly label: string
+}
+
+export type ProjectFinancialCostCodeOption = {
+  readonly value: string
+  readonly label: string
+  readonly description: string
+  readonly divisionCode: string
+}
+
+export type ProjectFinancialCodingOptions = {
+  readonly phases: readonly ProjectFinancialPhaseOption[]
+  readonly costCodes: readonly ProjectFinancialCostCodeOption[]
 }
 
 type ProjectFinancialWorkflowActionResult =
@@ -122,6 +147,20 @@ function finiteAmount(value: number | null): number | null {
   return Number.isFinite(value) ? value : null
 }
 
+function safeHttpUrl(value: string | null): string | null {
+  const candidate = cleanText(value)
+  if (!candidate) return null
+
+  try {
+    const url = new URL(candidate)
+    return url.protocol === "https:" || url.protocol === "http:"
+      ? url.toString()
+      : null
+  } catch {
+    return null
+  }
+}
+
 function prefixForType(type: ProjectFinancialWorkflowItem["type"]): string {
   if (type === "vendor_bill") return "BILL"
   if (type === "owner_pay_application") return "PAYAPP"
@@ -164,20 +203,34 @@ export async function getProjectFinancialWorkflowItems(
   projectId: string
 ): Promise<readonly ProjectFinancialWorkflowItem[]> {
   const { db } = await verifyProjectReadAccess(projectId)
-  const rows = await db
-    .select()
-    .from(projectOperations)
-    .where(
-      and(
-        eq(projectOperations.projectId, projectId),
-        inArray(projectOperations.sourceRecordType, [
-          "vendor_bill",
-          "owner_pay_application",
-          "rfq",
-        ])
+  const [rows, applications] = await Promise.all([
+    db
+      .select()
+      .from(projectOperations)
+      .where(
+        and(
+          eq(projectOperations.projectId, projectId),
+          inArray(projectOperations.sourceRecordType, [
+            "vendor_bill",
+            "owner_pay_application",
+          ])
+        )
       )
-    )
-    .orderBy(asc(projectOperations.dueDate), asc(projectOperations.updatedAt))
+      .orderBy(asc(projectOperations.dueDate), asc(projectOperations.updatedAt)),
+    db
+      .select({
+        applicationNumber: projectBudgetApplications.applicationNumber,
+        sourceUrl: projectBudgetApplications.sourceUrl,
+      })
+      .from(projectBudgetApplications)
+      .where(eq(projectBudgetApplications.projectId, projectId)),
+  ])
+  const applicationPackageUrls = new Map(
+    applications.flatMap((application) => {
+      const url = safeHttpUrl(application.sourceUrl)
+      return url ? [[application.applicationNumber, url] as const] : []
+    })
+  )
 
   return rows.map((row) => ({
     id: row.id,
@@ -194,8 +247,87 @@ export async function getProjectFinancialWorkflowItems(
     dueDate: row.dueDate,
     syncStatus: row.syncStatus,
     sageWriteStatus: row.sageWriteStatus,
+    supportingPackageUrl:
+      safeHttpUrl(row.externalUrl) ??
+      (row.sourceRecordType === "owner_pay_application" &&
+      row.sourceRecordNumber
+        ? applicationPackageUrls.get(row.sourceRecordNumber) ?? null
+        : null),
     updatedAt: row.updatedAt,
   }))
+}
+
+export async function getProjectFinancialCodingOptions(
+  projectId: string
+): Promise<ProjectFinancialCodingOptions> {
+  const { db } = await verifyProjectReadAccess(projectId)
+  const [sageRows, budgetRows] = await Promise.all([
+    db
+      .select({
+        code: sageCostCodes.code,
+        description: sageCostCodes.description,
+        displayLabel: sageCostCodes.displayLabel,
+        divisionCode: sageCostCodes.divisionCode,
+        divisionDisplayLabel: sageCostCodes.divisionDisplayLabel,
+      })
+      .from(sageCostCodes)
+      .where(eq(sageCostCodes.active, true))
+      .orderBy(asc(sageCostCodes.divisionCode), asc(sageCostCodes.displayLabel)),
+    db
+      .select({
+        costCode: projectBudgetLines.costCode,
+        description: projectBudgetLines.description,
+        divisionCode: projectBudgetLines.csiDivision,
+        divisionName: projectBudgetLines.csiDivisionName,
+      })
+      .from(projectBudgetLines)
+      .where(eq(projectBudgetLines.projectId, projectId))
+      .orderBy(
+        asc(projectBudgetLines.csiDivision),
+        asc(projectBudgetLines.costCode)
+      ),
+  ])
+  const phases = new Map<string, ProjectFinancialPhaseOption>()
+  const costCodes = new Map<string, ProjectFinancialCostCodeOption>()
+
+  for (const row of sageRows) {
+    phases.set(row.divisionCode, {
+      value: row.divisionCode,
+      label: row.divisionDisplayLabel,
+    })
+    costCodes.set(row.code, {
+      value: row.code,
+      label: row.displayLabel,
+      description: row.description,
+      divisionCode: row.divisionCode,
+    })
+  }
+
+  for (const row of budgetRows) {
+    if (!phases.has(row.divisionCode)) {
+      phases.set(row.divisionCode, {
+        value: row.divisionCode,
+        label: `${row.divisionCode} 00 00 ${row.divisionName}`,
+      })
+    }
+    if (!costCodes.has(row.costCode)) {
+      costCodes.set(row.costCode, {
+        value: row.costCode,
+        label: `${row.costCode} ${row.description}`,
+        description: row.description,
+        divisionCode: row.divisionCode,
+      })
+    }
+  }
+
+  return {
+    phases: Array.from(phases.values()).sort((left, right) =>
+      left.label.localeCompare(right.label)
+    ),
+    costCodes: Array.from(costCodes.values()).sort((left, right) =>
+      left.label.localeCompare(right.label)
+    ),
+  }
 }
 
 export async function createProjectVendorBillDraft(
@@ -356,6 +488,7 @@ export async function createProjectOwnerPayApplicationDraft(
       assigneeType: "owner",
       dueDate: periodTo,
       amount,
+      externalUrl: safeHttpUrl(input.supportingPackageUrl),
       sageJobId: project.sageJobId,
       sageJobNumber: project.sageJobNumber,
       sageWriteStatus: "draft_ready",
@@ -368,6 +501,7 @@ export async function createProjectOwnerPayApplicationDraft(
         periodTo,
         amount,
         notes: cleanText(input.notes),
+        supportingPackageUrl: safeHttpUrl(input.supportingPackageUrl),
         format: "AIA_G702_G703_STYLE",
       }),
       syncDirection: "write",

--- a/src/app/dashboard/projects/[id]/budget/page.tsx
+++ b/src/app/dashboard/projects/[id]/budget/page.tsx
@@ -1,6 +1,7 @@
 export const dynamic = "force-dynamic"
 
 import Link from "next/link"
+import Image from "next/image"
 import {
   IconArrowLeft,
   IconEye,
@@ -12,6 +13,7 @@ import {
   getProjectBudgetSummary,
   type ProjectBudgetSummary,
 } from "@/app/actions/project-budget"
+import { getProjects, type ProjectListItem } from "@/app/actions/projects"
 import {
   getSagePayApplicationSyncState,
   type SagePayApplicationSyncState,
@@ -20,9 +22,11 @@ import {
   ProjectBudgetG703Table,
   ProjectBudgetPanel,
 } from "@/components/projects/project-budget-panel"
+import { ProjectBudgetPrintButton } from "@/components/projects/project-budget-print-button"
 import { ProjectContextSwitcher } from "@/components/projects/project-context-switcher"
 import { SagePayApplicationSyncControl } from "@/components/projects/sage-pay-application-sync-control"
 import { Badge } from "@/components/ui/badge"
+import { projectBrandFor } from "@/lib/project-branding"
 
 export default async function ProjectBudgetPage({
   params,
@@ -34,14 +38,17 @@ export default async function ProjectBudgetPage({
   let internalBudget: ProjectBudgetSummary | null = null
   let ownerBudget: ProjectBudgetSummary | null = null
   let sageSyncState: SagePayApplicationSyncState | null = null
+  let project: ProjectListItem | null = null
 
   try {
-    const [internal, owner] = await Promise.all([
+    const [internal, owner, projectOptions] = await Promise.all([
       getProjectBudgetSummary(id, "internal"),
       getProjectBudgetSummary(id, "owner"),
+      getProjects(),
     ])
     internalBudget = internal
     ownerBudget = owner
+    project = projectOptions.find((option) => option.id === id) ?? null
   } catch (error) {
     console.warn("Budget unavailable", error)
   }
@@ -50,6 +57,10 @@ export default async function ProjectBudgetPage({
   } catch (error) {
     console.warn("Sage sync unavailable", error)
   }
+  const brand = projectBrandFor({
+    projectId: id,
+    projectNumber: project?.projectNumber ?? null,
+  })
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto p-4 md:p-6">
@@ -100,17 +111,56 @@ export default async function ProjectBudgetPage({
       )}
 
       <div className="mb-6">
-        <ProjectBudgetPanel projectId={id} summary={internalBudget} />
+        <ProjectBudgetPanel
+          projectId={id}
+          summary={internalBudget}
+          detailHref={null}
+          divisionLimit={null}
+        />
       </div>
 
       {internalBudget && internalBudget.allLines.length > 0 && (
-        <div className="mb-6">
+        <div
+          className="mb-6"
+          data-project-budget-print-source="true"
+        >
+          <header className="hidden border-b pb-3 print:flex print:items-start print:justify-between print:gap-4">
+            <div className="flex items-center gap-3">
+              <Image
+                src={brand.logoSrc}
+                alt={brand.logoAlt}
+                width={64}
+                height={64}
+                priority
+                className="size-14 object-contain"
+              />
+              <div>
+                <p className="text-lg font-semibold">{brand.companyName}</p>
+                <p className="text-sm text-muted-foreground">
+                  {project?.projectNumber ?? project?.name ?? "Project"}
+                </p>
+              </div>
+            </div>
+            <div className="text-right text-xs">
+              <p className="font-semibold">Internal G703 Schedule of Values</p>
+              <p className="mt-1 text-muted-foreground">
+                {internalBudget.currentApplication
+                  ? `Pay application ${internalBudget.currentApplication.applicationNumber}`
+                  : "Current budget"}
+              </p>
+            </div>
+          </header>
           <div className="mb-3 flex items-center justify-between gap-3">
             <div>
               <h2 className="text-sm font-semibold">Internal G703</h2>
               <p className="text-xs text-muted-foreground">
-                All mapped lines and internal-only detail.
+                All mapped lines and internal-only detail. Page access follows
+                the Budget / G703 permission; each Owner/Internal badge is
+                stored on its individual budget line.
               </p>
+            </div>
+            <div className="print:hidden">
+              <ProjectBudgetPrintButton />
             </div>
           </div>
           <ProjectBudgetG703Table summary={internalBudget} />

--- a/src/app/dashboard/projects/[id]/financials/page.tsx
+++ b/src/app/dashboard/projects/[id]/financials/page.tsx
@@ -4,9 +4,12 @@ import Link from "next/link"
 import { IconArrowLeft, IconFileDollar } from "@tabler/icons-react"
 
 import {
+  getProjectFinancialCodingOptions,
   getProjectFinancialWorkflowItems,
+  type ProjectFinancialCodingOptions,
   type ProjectFinancialWorkflowItem,
 } from "@/app/actions/project-financial-workflows"
+import { getProjects } from "@/app/actions/projects"
 import { ProjectContextSwitcher } from "@/components/projects/project-context-switcher"
 import { ProjectContextWatermarkShell } from "@/components/projects/project-context-watermark-shell"
 import { ProjectFinancialWorkspace } from "@/components/projects/project-financial-workspace"
@@ -18,11 +21,25 @@ export default async function ProjectFinancialsPage({
 }): Promise<React.ReactElement> {
   const { id } = await params
   let items: readonly ProjectFinancialWorkflowItem[] = []
+  let codingOptions: ProjectFinancialCodingOptions = {
+    phases: [],
+    costCodes: [],
+  }
+  let projectDriveFolderId: string | null = null
 
   try {
     items = await getProjectFinancialWorkflowItems(id)
   } catch (error) {
     console.warn("Project financial workflow unavailable", error)
+  }
+  const projectOptions = await getProjects()
+  projectDriveFolderId =
+    projectOptions.find((project) => project.id === id)?.googleDriveFolderId ??
+    null
+  try {
+    codingOptions = await getProjectFinancialCodingOptions(id)
+  } catch (error) {
+    console.warn("Project financial coding options unavailable", error)
   }
 
   return (
@@ -44,7 +61,8 @@ export default async function ProjectFinancialsPage({
               </h1>
             </div>
             <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
-              Vendor bills, owner pay applications, and quote requests.
+              Vendor bills, owner pay applications, and their supporting
+              packages.
             </p>
           </div>
           <ProjectContextSwitcher
@@ -55,7 +73,13 @@ export default async function ProjectFinancialsPage({
           />
         </div>
 
-        <ProjectFinancialWorkspace projectId={id} items={items} />
+        <ProjectFinancialWorkspace
+          projectId={id}
+          items={items}
+          phaseOptions={codingOptions.phases}
+          costCodeOptions={codingOptions.costCodes}
+          projectDriveFolderId={projectDriveFolderId}
+        />
       </div>
     </ProjectContextWatermarkShell>
   )

--- a/src/app/dashboard/projects/[id]/page.tsx
+++ b/src/app/dashboard/projects/[id]/page.tsx
@@ -419,7 +419,6 @@ export default async function ProjectSummaryPage({
         <div className="mb-4 sm:mb-6">
           <ProjectWorkspaceShell
             projectId={id}
-            projectNumber={project?.projectNumber ?? null}
             totalTaskCount={totalCount}
             pastDueCount={pastDue.length}
             operationsSummary={operationsSummary}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -492,11 +492,11 @@ em-emoji-picker {
     overflow: visible !important;
   }
 
-  body.owner-budget-printing > :not([data-owner-budget-print-root="true"]) {
+  body.owner-budget-printing > :not([data-project-budget-print-root="true"]) {
     display: none !important;
   }
 
-  body.owner-budget-printing [data-owner-budget-print-root="true"] {
+  body.owner-budget-printing [data-project-budget-print-root="true"] {
     display: block !important;
     position: static !important;
     width: 100%;

--- a/src/app/preview/projects/[id]/owner/budget/page.tsx
+++ b/src/app/preview/projects/[id]/owner/budget/page.tsx
@@ -258,7 +258,7 @@ export default async function OwnerBudgetPage({
 
           <div
             className="mt-5"
-            data-owner-budget-print-source="true"
+            data-project-budget-print-source="true"
           >
             <header className="hidden border-b pb-3 print:flex print:items-start print:justify-between print:gap-4">
               <div className="flex items-center gap-3">

--- a/src/components/projects/project-budget-print-button.tsx
+++ b/src/components/projects/project-budget-print-button.tsx
@@ -31,7 +31,7 @@ async function waitForImage(image: HTMLImageElement): Promise<void> {
 export function ProjectBudgetPrintButton(): React.ReactElement {
   async function printBudget(): Promise<void> {
     const selected = document.querySelector(
-      '[data-owner-budget-print-source="true"]'
+      '[data-project-budget-print-source="true"]'
     )
     if (!(selected instanceof HTMLElement)) {
       window.print()
@@ -44,7 +44,7 @@ export function ProjectBudgetPrintButton(): React.ReactElement {
       return
     }
 
-    printRoot.setAttribute("data-owner-budget-print-root", "true")
+    printRoot.setAttribute("data-project-budget-print-root", "true")
     printRoot.classList.add("owner-budget-print-root")
     document.body.classList.add("owner-budget-printing")
     document.body.appendChild(printRoot)

--- a/src/components/projects/project-financial-workspace.tsx
+++ b/src/components/projects/project-financial-workspace.tsx
@@ -10,17 +10,19 @@ import {
 import { useRouter } from "next/navigation"
 import {
   IconFileDollar,
+  IconExternalLink,
   IconReceipt,
   IconSend,
-  IconShoppingCartQuestion,
 } from "@tabler/icons-react"
 
 import {
   createProjectOwnerPayApplicationDraft,
-  createProjectRfqDraft,
   createProjectVendorBillDraft,
+  type ProjectFinancialCostCodeOption,
+  type ProjectFinancialPhaseOption,
   type ProjectFinancialWorkflowItem,
 } from "@/app/actions/project-financial-workflows"
+import { ProjectSelectionComboboxInput } from "@/components/projects/project-selection-combobox-input"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -144,17 +146,23 @@ function FinancialFormPanel({
 export function ProjectFinancialWorkspace({
   projectId,
   items,
-  mode = "all",
+  phaseOptions,
+  costCodeOptions,
+  projectDriveFolderId,
 }: {
   readonly projectId: string
   readonly items: readonly ProjectFinancialWorkflowItem[]
-  readonly mode?: "all" | "rfq"
+  readonly phaseOptions: readonly ProjectFinancialPhaseOption[]
+  readonly costCodeOptions: readonly ProjectFinancialCostCodeOption[]
+  readonly projectDriveFolderId: string | null
 }): ReactElement {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [message, setMessage] = useState<string | null>(null)
-  const visibleItems =
-    mode === "rfq" ? items.filter((item) => item.type === "rfq") : items
+  const [vendorBillFormVersion, setVendorBillFormVersion] = useState(0)
+  const projectDriveUrl = projectDriveFolderId
+    ? `https://drive.google.com/drive/folders/${encodeURIComponent(projectDriveFolderId)}`
+    : null
 
   function handleVendorBill(event: FormEvent<HTMLFormElement>): void {
     event.preventDefault()
@@ -173,27 +181,10 @@ export function ProjectFinancialWorkspace({
         description: textField(formData, "description"),
       })
       setMessage(result.success ? "Vendor bill staged for review." : result.error)
-      if (result.success) form.reset()
-      router.refresh()
-    })
-  }
-
-  function handleRfq(event: FormEvent<HTMLFormElement>): void {
-    event.preventDefault()
-    const form = event.currentTarget
-    const formData = new FormData(form)
-    setMessage(null)
-    startTransition(async () => {
-      const result = await createProjectRfqDraft(projectId, {
-        title: requiredTextField(formData, "title"),
-        vendorCategory: textField(formData, "vendorCategory"),
-        requestedFrom: textField(formData, "requestedFrom"),
-        responseDueDate: textField(formData, "responseDueDate"),
-        priority: textField(formData, "priority") ?? "normal",
-        scope: textField(formData, "scope"),
-      })
-      setMessage(result.success ? "RFQ draft created." : result.error)
-      if (result.success) form.reset()
+      if (result.success) {
+        form.reset()
+        setVendorBillFormVersion((version) => version + 1)
+      }
       router.refresh()
     })
   }
@@ -209,6 +200,7 @@ export function ProjectFinancialWorkspace({
         periodTo: textField(formData, "periodTo"),
         amount: moneyField(formData, "amount"),
         notes: textField(formData, "notes"),
+        supportingPackageUrl: textField(formData, "supportingPackageUrl"),
       })
       setMessage(
         result.success ? "Owner pay application staged." : result.error
@@ -226,21 +218,17 @@ export function ProjectFinancialWorkspace({
         </div>
       )}
 
-      <section
-        className={
-          mode === "rfq" ? "grid max-w-4xl gap-4" : "grid gap-4 xl:grid-cols-3"
-        }
-      >
-        {mode === "all" && (
-          <FinancialFormPanel
-            title="Enter Vendor Bill"
-            description="Stage a project bill for Sage review."
-            accentClassName="border-l-brand-compass-blue"
-            icon={<IconReceipt className="size-5" />}
-            actionLabel="Stage Bill"
-            isPending={isPending}
-            onSubmit={handleVendorBill}
-          >
+      <section className="grid gap-4 xl:grid-cols-2">
+        <FinancialFormPanel
+          key={`vendor-bill-${vendorBillFormVersion}`}
+          title="Enter Vendor Bill"
+          description="Stage a project bill for Sage review."
+          accentClassName="border-l-brand-compass-blue"
+          icon={<IconReceipt className="size-5" />}
+          actionLabel="Stage Bill"
+          isPending={isPending}
+          onSubmit={handleVendorBill}
+        >
             <FormField label="Vendor" htmlFor="vendorName">
               <Input id="vendorName" name="vendorName" required />
             </FormField>
@@ -262,28 +250,40 @@ export function ProjectFinancialWorkspace({
             </div>
             <div className="grid gap-3 sm:grid-cols-2">
               <FormField label="Phase" htmlFor="vendorBillPhase">
-                <Input id="vendorBillPhase" name="phaseCode" />
+                <ProjectSelectionComboboxInput
+                  id="vendorBillPhase"
+                  name="phaseCode"
+                  options={phaseOptions}
+                  placeholder="Choose or type a phase"
+                  emptyMessage="No matching phases."
+                  manualInputLabel="Use custom phase"
+                />
               </FormField>
               <FormField label="Cost code" htmlFor="vendorBillCostCode">
-                <Input id="vendorBillCostCode" name="costCode" />
+                <ProjectSelectionComboboxInput
+                  id="vendorBillCostCode"
+                  name="costCode"
+                  options={costCodeOptions}
+                  placeholder="Choose or type a cost code"
+                  emptyMessage="No matching cost codes."
+                  manualInputLabel="Use custom cost code"
+                />
               </FormField>
             </div>
             <FormField label="Description" htmlFor="vendorBillDescription">
               <Textarea id="vendorBillDescription" name="description" rows={3} />
             </FormField>
-          </FinancialFormPanel>
-        )}
+        </FinancialFormPanel>
 
-        {mode === "all" && (
-          <FinancialFormPanel
-            title="Owner Pay Application"
-            description="Stage an AIA-style draw request."
-            accentClassName="border-l-brand-hps-primary"
-            icon={<IconFileDollar className="size-5" />}
-            actionLabel="Stage Pay App"
-            isPending={isPending}
-            onSubmit={handlePayApplication}
-          >
+        <FinancialFormPanel
+          title="Owner Pay Application"
+          description="Stage an AIA-style draw request."
+          accentClassName="border-l-brand-hps-primary"
+          icon={<IconFileDollar className="size-5" />}
+          actionLabel="Stage Pay App"
+          isPending={isPending}
+          onSubmit={handlePayApplication}
+        >
             <FormField label="Application number" htmlFor="applicationNumber">
               <Input id="applicationNumber" name="applicationNumber" />
             </FormField>
@@ -302,44 +302,24 @@ export function ProjectFinancialWorkspace({
             <FormField label="Notes" htmlFor="payApplicationNotes">
               <Textarea id="payApplicationNotes" name="notes" rows={7} />
             </FormField>
-          </FinancialFormPanel>
-        )}
-
-        <FinancialFormPanel
-          id="rfq"
-          title="Request for Quote"
-          description="Draft scope by vendor category."
-          accentClassName="border-l-brand-nutech-gold"
-          icon={<IconShoppingCartQuestion className="size-5" />}
-          actionLabel="Create RFQ"
-          isPending={isPending}
-          onSubmit={handleRfq}
-        >
-            <FormField label="Title" htmlFor="rfqTitle">
-              <Input id="rfqTitle" name="title" required />
-            </FormField>
-            <div className="grid gap-3 sm:grid-cols-2">
-              <FormField label="Vendor category" htmlFor="vendorCategory">
-                <Input
-                  id="vendorCategory"
-                  name="vendorCategory"
-                  placeholder="Concrete, plumbing, windows..."
-                />
-              </FormField>
-              <FormField label="Requested from" htmlFor="requestedFrom">
-                <Input id="requestedFrom" name="requestedFrom" />
-              </FormField>
-            </div>
-            <div className="grid gap-3 sm:grid-cols-2">
-              <FormField label="Response due" htmlFor="responseDueDate">
-                <Input id="responseDueDate" name="responseDueDate" type="date" />
-              </FormField>
-              <FormField label="Priority" htmlFor="rfqPriority">
-                <Input id="rfqPriority" name="priority" defaultValue="normal" />
-              </FormField>
-            </div>
-            <FormField label="Scope" htmlFor="rfqScope">
-              <Textarea id="rfqScope" name="scope" rows={4} />
+            <FormField
+              label="Supporting package link"
+              htmlFor="supportingPackageUrl"
+            >
+              <Input
+                id="supportingPackageUrl"
+                name="supportingPackageUrl"
+                type="url"
+                placeholder="https://drive.google.com/..."
+              />
+              {projectDriveUrl && (
+                <Button asChild size="sm" variant="outline">
+                  <a href={projectDriveUrl} target="_blank" rel="noreferrer">
+                    <IconExternalLink className="size-4" />
+                    Open project Drive
+                  </a>
+                </Button>
+              )}
             </FormField>
         </FinancialFormPanel>
       </section>
@@ -347,23 +327,17 @@ export function ProjectFinancialWorkspace({
       <section className="clarity-panel overflow-hidden">
         <div className="clarity-section-header flex flex-wrap items-center justify-between gap-3 px-4 py-3">
           <div>
-            <h2 className="text-sm font-semibold">
-              {mode === "rfq" ? "RFQ Queue" : "Project Financial Queue"}
-            </h2>
+            <h2 className="text-sm font-semibold">Project Financial Queue</h2>
             <p className="text-xs text-muted-foreground">
-              {mode === "rfq"
-                ? "Quote requests stay visible here and feed the sync review queue when needed."
-                : "Drafts entered here feed developer-mode Sage sync review."}
+              Drafts entered here feed developer-mode Sage sync review.
             </p>
           </div>
-          <Badge variant="outline">{visibleItems.length} records</Badge>
+          <Badge variant="outline">{items.length} records</Badge>
         </div>
 
-        {visibleItems.length === 0 ? (
+        {items.length === 0 ? (
           <p className="px-4 py-4 text-sm text-muted-foreground">
-            {mode === "rfq"
-              ? "No RFQs have been drafted for this project yet."
-              : "No project financial records have been staged yet."}
+            No project financial records have been staged yet.
           </p>
         ) : (
           <div className="m-4 overflow-hidden rounded-md border">
@@ -374,35 +348,65 @@ export function ProjectFinancialWorkspace({
               <span>Status</span>
             </div>
             <div className="divide-y">
-              {visibleItems.map((item) => (
-                <div
-                  key={item.id}
-                  className="grid gap-2 px-3 py-3 text-sm sm:grid-cols-[1fr_.7fr_.7fr_.8fr] sm:items-center sm:gap-3"
-                >
-                  <div className="min-w-0">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="font-medium">{workflowLabel(item.type)}</span>
-                      {item.number && (
-                        <span className="text-xs text-muted-foreground">
-                          {item.number}
+              {items.map((item) => {
+                const supportingHref =
+                  item.supportingPackageUrl ??
+                  (item.type === "owner_pay_application"
+                    ? projectDriveUrl
+                    : null)
+                return (
+                  <div
+                    key={item.id}
+                    className="grid gap-2 px-3 py-3 text-sm sm:grid-cols-[1fr_.7fr_.7fr_.8fr] sm:items-center sm:gap-3"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-medium">
+                          {workflowLabel(item.type)}
                         </span>
+                        {item.number && (
+                          <span className="text-xs text-muted-foreground">
+                            {item.number}
+                          </span>
+                        )}
+                      </div>
+                      <p className="truncate text-muted-foreground">
+                        {item.title}
+                      </p>
+                      {item.companyName && (
+                        <p className="truncate text-xs text-muted-foreground">
+                          {item.companyName}
+                        </p>
+                      )}
+                      {supportingHref && (
+                        <Button
+                          asChild
+                          size="sm"
+                          variant="link"
+                          className="mt-1 h-auto justify-start p-0"
+                        >
+                          <a
+                            href={supportingHref}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            <IconExternalLink className="size-4" />
+                            {item.supportingPackageUrl
+                              ? "Open supporting package"
+                              : "Open project Drive"}
+                          </a>
+                        </Button>
                       )}
                     </div>
-                    <p className="truncate text-muted-foreground">{item.title}</p>
-                    {item.companyName && (
-                      <p className="truncate text-xs text-muted-foreground">
-                        {item.companyName}
-                      </p>
-                    )}
+                    <span>{money(item.amount)}</span>
+                    <span>{dateText(item.dueDate)}</span>
+                    <div className="flex flex-wrap gap-2">
+                      <Badge variant="outline">{item.status}</Badge>
+                      <Badge variant="secondary">{syncLabel(item)}</Badge>
+                    </div>
                   </div>
-                  <span>{money(item.amount)}</span>
-                  <span>{dateText(item.dueDate)}</span>
-                  <div className="flex flex-wrap gap-2">
-                    <Badge variant="outline">{item.status}</Badge>
-                    <Badge variant="secondary">{syncLabel(item)}</Badge>
-                  </div>
-                </div>
-              ))}
+                )
+              })}
             </div>
           </div>
         )}

--- a/src/components/projects/project-manager-workflow-panel.tsx
+++ b/src/components/projects/project-manager-workflow-panel.tsx
@@ -6,7 +6,6 @@ import {
   IconAddressBook,
   IconCalendarStats,
   IconChevronRight,
-  IconFolder,
   IconFileDollar,
   IconHomeShare,
   IconMessageCircleQuestion,
@@ -312,7 +311,6 @@ function WorkflowCard({
 
 export function ProjectManagerWorkflowPanel({
   projectId,
-  projectNumber,
   totalTaskCount,
   pastDueCount,
   operationsSummary,
@@ -328,7 +326,6 @@ export function ProjectManagerWorkflowPanel({
   showRoleControls = true,
 }: {
   readonly projectId: string
-  readonly projectNumber: string | null
   readonly totalTaskCount: number
   readonly pastDueCount: number
   readonly operationsSummary: ProjectOperationsSummary | null
@@ -349,18 +346,6 @@ export function ProjectManagerWorkflowPanel({
   )
   const needsContactReview = reviewCount(contactsSummary) > 0
   const steps: readonly WorkflowStep[] = [
-    {
-      id: "context",
-      label: "Confirm context",
-      href: "/dashboard/projects",
-      eyebrow: projectNumber ?? "Project search",
-      status: "Switch job",
-      detail:
-        "Jump to another project when needed.",
-      icon: <IconFolder className="size-5" />,
-      tone: "project",
-      urgent: false,
-    },
     {
       id: "schedule",
       label: "Review schedule",

--- a/src/components/projects/project-workspace-shell.tsx
+++ b/src/components/projects/project-workspace-shell.tsx
@@ -172,7 +172,6 @@ function ProjectWorkspaceControlsPortal({
 
 export function ProjectWorkspaceShell({
   projectId,
-  projectNumber,
   totalTaskCount,
   pastDueCount,
   operationsSummary,
@@ -187,7 +186,6 @@ export function ProjectWorkspaceShell({
   allowedRoleIds,
 }: {
   readonly projectId: string
-  readonly projectNumber: string | null
   readonly totalTaskCount: number
   readonly pastDueCount: number
   readonly operationsSummary: ProjectOperationsSummary | null
@@ -262,7 +260,6 @@ export function ProjectWorkspaceShell({
 
       <ProjectManagerWorkflowPanel
         projectId={projectId}
-        projectNumber={projectNumber}
         totalTaskCount={totalTaskCount}
         pastDueCount={pastDueCount}
         operationsSummary={operationsSummary}


### PR DESCRIPTION
## What changed

- shows every internal Budget/G703 category and adds a print-only branded G703 output
- removes the dead Open Budget self-link and the obsolete Confirm Context workflow step
- clarifies that Budget/G703 page access comes from permissions, while Owner/Internal visibility is stored per budget line
- replaces free-text vendor-bill Phase and Cost Code fields with searchable, manually editable Compass selectors backed by Sage cost codes and project budget lines
- removes the duplicate RFQ form and RFQ records from the Project Financial Queue; the dedicated RFQ workflow remains unchanged
- lets staff attach an exact supporting-package URL to an owner pay application and open it from the queue
- provides the project Google Drive folder as a safe fallback when a specific package link has not yet been attached

## Why

The internal financial workspace had drifted from the owner G703 improvements and contained several controls that were incomplete, duplicated, or led nowhere. These changes make the current draw workflow usable while preserving Sage as the accounting source of truth and Google Drive as the supporting-document repository.

## Validation

- production build passed
- TypeScript passed
- full ESLint passed with zero errors (existing repository warnings only)
- focused Budget/G703 tests passed: 5 tests, 15 assertions
- git diff check passed
- repository-wide bun test: 466 passed; the remaining unrelated failures are existing Bun runner incompatibilities with better-sqlite3 and vi.hoisted