### PR TITLE
fix(financials): show applied deposits in pay apps

### DIFF
--- a/src/app/preview/projects/[id]/owner/budget/page.tsx
+++ b/src/app/preview/projects/[id]/owner/budget/page.tsx
@@ -28,6 +28,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { projectAudienceMessageShortcut } from "@/lib/project-audience-direct-message"
 import { projectBrandFor } from "@/lib/project-branding"
+import { budgetPaymentBreakdown } from "@/lib/project-budget-snapshot"
 
 function hasDigest(error: unknown): error is { readonly digest: string } {
   return typeof error === "object" && error !== null && "digest" in error
@@ -169,62 +170,70 @@ export default async function OwnerBudgetPage({
                 </Badge>
               </div>
               <div className="mt-4 divide-y border">
-                {budget.applications.map((application, index) => (
-                  <article
-                    key={application.id}
-                    className="grid gap-3 p-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
-                  >
-                    <div className="min-w-0">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <p className="font-medium">
-                          Pay application {application.applicationNumber}
+                {budget.applications.map((application, index) => {
+                  const payment = budgetPaymentBreakdown(application)
+
+                  return (
+                    <article
+                      key={application.id}
+                      className="grid gap-3 p-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+                    >
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="font-medium">
+                            Pay application {application.applicationNumber}
+                          </p>
+                          {index === 0 && <Badge>Current</Badge>}
+                          <Badge variant="outline">
+                            {statusLabel(application.status)}
+                          </Badge>
+                        </div>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          Through {formatDate(application.periodTo)}
+                          {" · "}
+                          {money(payment.applicationTotal)} application total
+                          {" · "}
+                          {payment.depositApplied > 0
+                            ? `${money(payment.currentPaymentDue)} due after ${money(payment.depositApplied)} deposit`
+                            : `${money(payment.currentPaymentDue)} current payment`}
+                          {" · "}
+                          {money(application.contractSumToDate)} contract to date
                         </p>
-                        {index === 0 && <Badge>Current</Badge>}
-                        <Badge variant="outline">
-                          {statusLabel(application.status)}
-                        </Badge>
                       </div>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Through {formatDate(application.periodTo)}
-                        {" · "}
-                        {money(application.currentPaymentDue)} current payment
-                        {" · "}
-                        {money(application.contractSumToDate)} contract to date
-                      </p>
-                    </div>
-                    {application.documentAvailable ? (
-                      <div className="flex flex-wrap gap-2">
-                        <Button asChild size="sm" variant="outline">
-                          <a
-                            href={applicationDownloadHref(
-                              id,
-                              application.id
-                            )}
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            <IconExternalLink className="size-4" />
-                            Open PDF
-                          </a>
-                        </Button>
-                        <Button asChild size="sm" variant="outline">
-                          <a
-                            href={applicationDownloadHref(
-                              id,
-                              application.id,
-                              true
-                            )}
-                          >
-                            <IconDownload className="size-4" />
-                            Save
-                          </a>
-                        </Button>
-                      </div>
-                    ) : (
-                      <Badge variant="secondary">Document unavailable</Badge>
-                    )}
-                  </article>
-                ))}
+                      {application.documentAvailable ? (
+                        <div className="flex flex-wrap gap-2">
+                          <Button asChild size="sm" variant="outline">
+                            <a
+                              href={applicationDownloadHref(
+                                id,
+                                application.id
+                              )}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              <IconExternalLink className="size-4" />
+                              Open PDF
+                            </a>
+                          </Button>
+                          <Button asChild size="sm" variant="outline">
+                            <a
+                              href={applicationDownloadHref(
+                                id,
+                                application.id,
+                                true
+                              )}
+                            >
+                              <IconDownload className="size-4" />
+                              Save
+                            </a>
+                          </Button>
+                        </div>
+                      ) : (
+                        <Badge variant="secondary">Document unavailable</Badge>
+                      )}
+                    </article>
+                  )
+                })}
               </div>
             </section>
           )}

--- a/src/lib/__tests__/project-budget-snapshot.test.ts
+++ b/src/lib/__tests__/project-budget-snapshot.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  budgetPaymentBreakdown,
   sanitizeBudgetApplicationForOwner,
   sanitizeBudgetLineForOwner,
   scopeBudgetLinesToApplication,
@@ -107,5 +108,36 @@ describe("project budget snapshot boundary", () => {
     expect(safeLine.notes).toBeNull()
     expect(safeLine.vendorName).toBeNull()
     expect(safeLine.internalNotes).toBeNull()
+  })
+
+  it("includes a deposit already applied to the first payment application", () => {
+    const firstApplication: BudgetApplicationView = {
+      ...application("pay-app-1"),
+      totalCompletedStoredToDate: 68_782.88,
+      totalEarnedLessRetainage: 68_782.88,
+      previousCertificates: 0,
+      currentPaymentDue: 18_460.77,
+    }
+
+    expect(budgetPaymentBreakdown(firstApplication)).toEqual({
+      applicationTotal: 68_782.88,
+      currentPaymentDue: 18_460.77,
+      depositApplied: 50_322.11,
+    })
+  })
+
+  it("does not invent a deposit when the application has no positive balance", () => {
+    const laterApplication: BudgetApplicationView = {
+      ...application("pay-app-2"),
+      totalEarnedLessRetainage: 199_584.37,
+      previousCertificates: 68_782.88,
+      currentPaymentDue: 133_149.11,
+    }
+
+    expect(budgetPaymentBreakdown(laterApplication)).toEqual({
+      applicationTotal: 133_149.11,
+      currentPaymentDue: 133_149.11,
+      depositApplied: 0,
+    })
   })
 })

--- a/src/lib/project-budget-snapshot.ts
+++ b/src/lib/project-budget-snapshot.ts
@@ -19,6 +19,12 @@ export type BudgetApplicationView = {
   readonly lastSyncedAt: string | null
 }
 
+export type BudgetPaymentBreakdown = {
+  readonly applicationTotal: number
+  readonly currentPaymentDue: number
+  readonly depositApplied: number
+}
+
 export type BudgetLineView = {
   readonly id: string
   readonly sourceSystem: string
@@ -79,6 +85,35 @@ export function sanitizeBudgetApplicationForOwner(
     ...application,
     sourceUrl: null,
     lastSyncedAt: null,
+  }
+}
+
+function currency(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+export function budgetPaymentBreakdown(
+  application: BudgetApplicationView
+): BudgetPaymentBreakdown {
+  const impliedDeposit = currency(
+    application.totalEarnedLessRetainage -
+      application.previousCertificates -
+      application.currentPaymentDue
+  )
+  // On the first certified application, a positive difference is an amount
+  // already applied to the draw, such as a construction deposit.
+  const depositApplied =
+    Math.abs(application.previousCertificates) < 0.02 &&
+    impliedDeposit >= 0.02
+      ? impliedDeposit
+      : 0
+
+  return {
+    applicationTotal: currency(
+      application.currentPaymentDue + depositApplied
+    ),
+    currentPaymentDue: application.currentPaymentDue,
+    depositApplied,
   }
 }
 


### PR DESCRIPTION
## What changed

- shows the full certified application total in the owner pay-application history
- shows the remaining current payment separately when a construction deposit was already applied
- derives the applied deposit only on an initial application with no previous certificates
- adds focused regression coverage for the Loomis April accounting pattern and later applications

## Why

The April Loomis application currently displays only the $18,460.77 remaining payment. The certified G702 shows a $68,782.88 application total made up of the $50,322.11 deposit already applied plus the $18,460.77 current payment due.

This is a presentation correction only. It does not modify D1, Sage, or the certified source documents.

## Validation

- `bun test src/lib/__tests__/project-budget-snapshot.test.ts`
- targeted ESLint: no errors
- `bun run build`
- repository pre-commit and pre-push checks
