### PR TITLE
feat(buildertrend): add guarded identity reconciliation

### DIFF
--- a/docs/wip/buildertrend-cutover-recovery-baseline-2026-07-30.md
+++ b/docs/wip/buildertrend-cutover-recovery-baseline-2026-07-30.md
@@ -107,6 +107,20 @@ Recover in independent, reviewable branches:
 Historical imports must not overwrite newer Compass-authored work or trigger
 the normal notification lifecycle.
 
+### Identity reconciliation
+
+Buildertrend job and lead IDs are the source identities. Project numbers,
+customer names, email addresses, and accounting-customer records are review
+evidence only and must never collapse distinct Buildertrend jobs.
+
+Identity review manifests record immutable decisions and explicit
+relationships for same-owner projects, development phases, continuations,
+department transitions, and lead-to-project conversions. They may reference an
+existing Compass project or customer within the same organization, but they do
+not create projects, grant portal access, invite contacts, or modify the source
+staging record. Pooled accounting customers are provenance only and can never
+become portal identities through the identity-review workflow.
+
 ### Restricted preservation evidence
 
 Client-, dispute-, claim-, and project-specific preservation material belongs

--- a/drizzle/0085_buildertrend_identity_reconciliation.sql
+++ b/drizzle/0085_buildertrend_identity_reconciliation.sql
@@ -1,0 +1,256 @@
+CREATE TABLE `buildertrend_staging_identity_review_runs` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `review_key` text NOT NULL,
+  `manifest_fingerprint` text NOT NULL,
+  `status` text DEFAULT 'in_progress' NOT NULL CHECK (`status` IN ('in_progress', 'completed', 'manifest_conflict')),
+  `expected_decision_count` integer NOT NULL CHECK (`expected_decision_count` >= 0),
+  `expected_relationship_count` integer NOT NULL CHECK (`expected_relationship_count` >= 0),
+  `reviewed_by` text,
+  `reviewed_at` text NOT NULL,
+  `summary_json` text,
+  `created_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`reviewed_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `buildertrend_identity_review_runs_org_key_unique`
+ON `buildertrend_staging_identity_review_runs` (`organization_id`, `review_key`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_identity_review_runs_org_status_idx`
+ON `buildertrend_staging_identity_review_runs` (`organization_id`, `status`);
+--> statement-breakpoint
+CREATE TABLE `buildertrend_staging_identity_decisions` (
+  `id` text PRIMARY KEY NOT NULL,
+  `review_run_id` text NOT NULL,
+  `organization_id` text NOT NULL,
+  `source_record_id` text NOT NULL,
+  `source_key` text NOT NULL,
+  `source_identity_kind` text NOT NULL CHECK (`source_identity_kind` IN ('job', 'lead')),
+  `source_identity_id` text NOT NULL,
+  `lifecycle_status` text NOT NULL CHECK (`lifecycle_status` IN ('active', 'preconstruction', 'warranty', 'completed', 'inactive', 'archived', 'ignored')),
+  `disposition` text NOT NULL CHECK (`disposition` IN ('existing_project', 'project_candidate', 'lead_only', 'archive_only', 'ignored', 'unmatched')),
+  `department_code` text,
+  `matched_project_id` text,
+  `customer_provenance_id` text,
+  `customer_provenance_kind` text DEFAULT 'none' NOT NULL CHECK (`customer_provenance_kind` IN ('none', 'named_customer', 'pooled_accounting', 'prospect')),
+  `portal_identity_allowed` integer DEFAULT 0 NOT NULL CHECK (`portal_identity_allowed` = 0),
+  `review_status` text DEFAULT 'needs_review' NOT NULL CHECK (`review_status` IN ('needs_review', 'approved', 'rejected')),
+  `review_notes` text,
+  `created_at` text NOT NULL,
+  CHECK (`disposition` <> 'existing_project' OR `matched_project_id` IS NOT NULL),
+  CHECK (`customer_provenance_kind` = 'none' OR `customer_provenance_id` IS NOT NULL),
+  CHECK (`customer_provenance_kind` <> 'none' OR `customer_provenance_id` IS NULL),
+  FOREIGN KEY (`review_run_id`) REFERENCES `buildertrend_staging_identity_review_runs`(`id`) ON UPDATE no action ON DELETE restrict,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`source_record_id`) REFERENCES `buildertrend_staging_records`(`id`) ON UPDATE no action ON DELETE restrict,
+  FOREIGN KEY (`matched_project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`customer_provenance_id`) REFERENCES `customers`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `buildertrend_identity_decisions_run_source_unique`
+ON `buildertrend_staging_identity_decisions` (`review_run_id`, `source_record_id`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_identity_decisions_org_status_idx`
+ON `buildertrend_staging_identity_decisions` (`organization_id`, `review_status`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_identity_decisions_project_idx`
+ON `buildertrend_staging_identity_decisions` (`matched_project_id`);
+--> statement-breakpoint
+CREATE TABLE `buildertrend_staging_identity_relationships` (
+  `id` text PRIMARY KEY NOT NULL,
+  `review_run_id` text NOT NULL,
+  `organization_id` text NOT NULL,
+  `from_decision_id` text NOT NULL,
+  `to_decision_id` text NOT NULL,
+  `relationship_type` text NOT NULL CHECK (`relationship_type` IN ('same_owner', 'development_phase', 'continuation', 'department_transition', 'lead_conversion')),
+  `review_status` text DEFAULT 'needs_review' NOT NULL CHECK (`review_status` IN ('needs_review', 'approved', 'rejected')),
+  `review_notes` text,
+  `grants_portal_access` integer DEFAULT 0 NOT NULL CHECK (`grants_portal_access` = 0),
+  `created_at` text NOT NULL,
+  CHECK (`from_decision_id` <> `to_decision_id`),
+  FOREIGN KEY (`review_run_id`) REFERENCES `buildertrend_staging_identity_review_runs`(`id`) ON UPDATE no action ON DELETE restrict,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`from_decision_id`) REFERENCES `buildertrend_staging_identity_decisions`(`id`) ON UPDATE no action ON DELETE restrict,
+  FOREIGN KEY (`to_decision_id`) REFERENCES `buildertrend_staging_identity_decisions`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `buildertrend_identity_relationships_run_edge_unique`
+ON `buildertrend_staging_identity_relationships` (`review_run_id`, `from_decision_id`, `to_decision_id`, `relationship_type`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_identity_relationships_org_type_idx`
+ON `buildertrend_staging_identity_relationships` (`organization_id`, `relationship_type`);
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_identity_review_run_scope_guard`
+BEFORE INSERT ON `buildertrend_staging_identity_review_runs`
+WHEN (
+  NOT EXISTS (
+    SELECT 1
+    FROM `organizations`
+    WHERE `id` = NEW.`organization_id`
+  )
+  OR (
+    NEW.`reviewed_by` IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM `users`
+      WHERE `id` = NEW.`reviewed_by`
+        AND `organization_id` = NEW.`organization_id`
+    )
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'Buildertrend identity review runs must remain organization scoped');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_identity_decision_scope_guard`
+BEFORE INSERT ON `buildertrend_staging_identity_decisions`
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM `buildertrend_staging_identity_review_runs` review_run
+  JOIN `buildertrend_staging_records` source_record
+    ON source_record.`id` = NEW.`source_record_id`
+  WHERE review_run.`id` = NEW.`review_run_id`
+    AND review_run.`organization_id` = NEW.`organization_id`
+    AND source_record.`organization_id` = NEW.`organization_id`
+    AND source_record.`source_key` = NEW.`source_key`
+    AND (
+      (
+        NEW.`source_identity_kind` = 'job'
+        AND source_record.`buildertrend_job_id` = NEW.`source_identity_id`
+      )
+      OR (
+        NEW.`source_identity_kind` = 'lead'
+        AND source_record.`buildertrend_lead_id` = NEW.`source_identity_id`
+      )
+    )
+    AND (
+      NEW.`matched_project_id` IS NULL
+      OR EXISTS (
+        SELECT 1 FROM `projects`
+        WHERE `id` = NEW.`matched_project_id`
+          AND `organization_id` = NEW.`organization_id`
+      )
+    )
+    AND (
+      NEW.`customer_provenance_id` IS NULL
+      OR EXISTS (
+        SELECT 1 FROM `customers`
+        WHERE `id` = NEW.`customer_provenance_id`
+          AND `organization_id` = NEW.`organization_id`
+      )
+    )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'Buildertrend identity decisions must remain organization scoped');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_identity_relationship_scope_guard`
+BEFORE INSERT ON `buildertrend_staging_identity_relationships`
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM `buildertrend_staging_identity_review_runs` review_run
+  JOIN `buildertrend_staging_identity_decisions` from_decision
+    ON from_decision.`id` = NEW.`from_decision_id`
+  JOIN `buildertrend_staging_identity_decisions` to_decision
+    ON to_decision.`id` = NEW.`to_decision_id`
+  WHERE review_run.`id` = NEW.`review_run_id`
+    AND review_run.`organization_id` = NEW.`organization_id`
+    AND from_decision.`review_run_id` = NEW.`review_run_id`
+    AND to_decision.`review_run_id` = NEW.`review_run_id`
+    AND from_decision.`organization_id` = NEW.`organization_id`
+    AND to_decision.`organization_id` = NEW.`organization_id`
+    AND (
+      NEW.`review_status` <> 'approved'
+      OR (
+        from_decision.`review_status` = 'approved'
+        AND to_decision.`review_status` = 'approved'
+      )
+    )
+    AND (
+      NEW.`relationship_type` <> 'department_transition'
+      OR (
+        from_decision.`department_code` IS NOT NULL
+        AND to_decision.`department_code` IS NOT NULL
+        AND from_decision.`department_code` <> to_decision.`department_code`
+      )
+    )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'Buildertrend identity relationships must remain review-run and organization scoped');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_identity_lead_conversion_guard`
+BEFORE INSERT ON `buildertrend_staging_identity_relationships`
+WHEN NEW.`relationship_type` = 'lead_conversion'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `buildertrend_staging_identity_decisions` from_decision
+    JOIN `buildertrend_staging_identity_decisions` to_decision
+      ON to_decision.`id` = NEW.`to_decision_id`
+    WHERE from_decision.`id` = NEW.`from_decision_id`
+      AND from_decision.`source_identity_kind` = 'lead'
+      AND to_decision.`source_identity_kind` = 'job'
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'Buildertrend lead conversion must link a lead decision to a job decision');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_identity_review_completion_guard`
+BEFORE UPDATE OF `status` ON `buildertrend_staging_identity_review_runs`
+WHEN NEW.`status` = 'completed'
+  AND (
+    (SELECT COUNT(*) FROM `buildertrend_staging_identity_decisions`
+      WHERE `review_run_id` = NEW.`id`) <> NEW.`expected_decision_count`
+    OR
+    (SELECT COUNT(*) FROM `buildertrend_staging_identity_relationships`
+      WHERE `review_run_id` = NEW.`id`) <> NEW.`expected_relationship_count`
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'Buildertrend identity review cannot complete with unresolved references');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_identity_review_run_identity_guard`
+BEFORE UPDATE ON `buildertrend_staging_identity_review_runs`
+WHEN NEW.`id` IS NOT OLD.`id`
+  OR NEW.`organization_id` IS NOT OLD.`organization_id`
+  OR NEW.`review_key` IS NOT OLD.`review_key`
+  OR NEW.`manifest_fingerprint` IS NOT OLD.`manifest_fingerprint`
+  OR NEW.`expected_decision_count` IS NOT OLD.`expected_decision_count`
+  OR NEW.`expected_relationship_count` IS NOT OLD.`expected_relationship_count`
+  OR NEW.`reviewed_by` IS NOT OLD.`reviewed_by`
+  OR NEW.`reviewed_at` IS NOT OLD.`reviewed_at`
+  OR NEW.`created_at` IS NOT OLD.`created_at`
+BEGIN
+  SELECT RAISE(ABORT, 'Buildertrend identity review provenance is immutable');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_identity_review_run_delete_guard`
+BEFORE DELETE ON `buildertrend_staging_identity_review_runs`
+BEGIN
+  SELECT RAISE(ABORT, 'Buildertrend identity review runs cannot be deleted');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_identity_decision_update_guard`
+BEFORE UPDATE ON `buildertrend_staging_identity_decisions`
+BEGIN
+  SELECT RAISE(ABORT, 'Buildertrend identity decisions are immutable');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_identity_decision_delete_guard`
+BEFORE DELETE ON `buildertrend_staging_identity_decisions`
+BEGIN
+  SELECT RAISE(ABORT, 'Buildertrend identity decisions cannot be deleted');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_identity_relationship_update_guard`
+BEFORE UPDATE ON `buildertrend_staging_identity_relationships`
+BEGIN
+  SELECT RAISE(ABORT, 'Buildertrend identity relationships are immutable');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `buildertrend_identity_relationship_delete_guard`
+BEFORE DELETE ON `buildertrend_staging_identity_relationships`
+BEGIN
+  SELECT RAISE(ABORT, 'Buildertrend identity relationships cannot be deleted');
+END;

--- a/scripts/build-buildertrend-identity-review-sql.mjs
+++ b/scripts/build-buildertrend-identity-review-sql.mjs
@@ -1,0 +1,158 @@
+import {
+  readFile,
+  realpath,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises"
+import { basename, dirname, join, resolve } from "node:path"
+
+import {
+  buildBuildertrendIdentityReviewSql,
+  parseBuildertrendIdentityReviewManifest,
+} from "../src/lib/buildertrend/identity-reconciliation"
+
+function usage() {
+  console.error(
+    "Usage: bun scripts/build-buildertrend-identity-review-sql.mjs " +
+      "--input <review.json> --organization-id <org-id> " +
+      "[--output <review.sql>] [--dry-run]"
+  )
+}
+
+function parseArgs(argv) {
+  const valueOptions = new Set(["input", "organization-id", "output"])
+  const values = new Map()
+  let dryRun = false
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]
+    if (argument === "--dry-run") {
+      if (dryRun) throw new Error("--dry-run may only be provided once")
+      dryRun = true
+      continue
+    }
+    if (!argument?.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${argument ?? ""}`)
+    }
+    const option = argument.slice(2)
+    if (!valueOptions.has(option)) {
+      throw new Error(`Unknown option: ${argument}`)
+    }
+    if (values.has(option)) {
+      throw new Error(`${argument} may only be provided once`)
+    }
+
+    const value = argv[index + 1]
+    if (!value || value.startsWith("--")) {
+      throw new Error(`${argument} requires a value`)
+    }
+    values.set(option, value)
+    index += 1
+  }
+
+  const input = values.get("input")
+  const organizationId = values.get("organization-id")
+  const output = values.get("output")
+  if (!input || !organizationId || (!dryRun && !output)) {
+    throw new Error("Missing a required option")
+  }
+  if (output && resolve(input) === resolve(output)) {
+    throw new Error("--output must not overwrite --input")
+  }
+
+  return { dryRun, input, organizationId, output }
+}
+
+async function existingFileIdentity(path) {
+  try {
+    const canonicalPath = await realpath(path)
+    const metadata = await stat(canonicalPath)
+    return {
+      canonicalPath,
+      device: metadata.dev,
+      inode: metadata.ino,
+    }
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") {
+      return null
+    }
+    throw error
+  }
+}
+
+async function assertDistinctFiles(input, output) {
+  const inputIdentity = await existingFileIdentity(input)
+  if (!inputIdentity) throw new Error("--input does not exist")
+
+  const outputIdentity = await existingFileIdentity(output)
+  if (
+    outputIdentity &&
+    (outputIdentity.canonicalPath === inputIdentity.canonicalPath ||
+      (outputIdentity.device === inputIdentity.device &&
+        outputIdentity.inode === inputIdentity.inode))
+  ) {
+    throw new Error("--output must not overwrite --input")
+  }
+}
+
+async function writeFileAtomically(output, contents) {
+  const resolvedOutput = resolve(output)
+  const temporaryOutput = join(
+    dirname(resolvedOutput),
+    `.${basename(resolvedOutput)}.${process.pid}.${Date.now()}.tmp`
+  )
+
+  try {
+    await writeFile(temporaryOutput, contents, { flag: "wx" })
+    await rename(temporaryOutput, resolvedOutput)
+  } catch (error) {
+    try {
+      await unlink(temporaryOutput)
+    } catch {
+      // The temporary file may not have been created.
+    }
+    throw error
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  if (!options.dryRun && options.output) {
+    await assertDistinctFiles(options.input, options.output)
+  }
+
+  const input = JSON.parse(await readFile(options.input, "utf8"))
+  const parsed = parseBuildertrendIdentityReviewManifest(input)
+  if (!parsed.success) {
+    throw new Error(`Invalid identity review:\n${parsed.errors.join("\n")}`)
+  }
+
+  const build = await buildBuildertrendIdentityReviewSql(
+    options.organizationId,
+    parsed.data
+  )
+  if (!options.dryRun && options.output) {
+    await writeFileAtomically(options.output, build.sql)
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        dryRun: options.dryRun,
+        input: options.input,
+        output: options.dryRun ? null : options.output,
+        ...build.summary,
+      },
+      null,
+      2
+    )
+  )
+}
+
+main().catch((error) => {
+  usage()
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+})

--- a/scripts/fixtures/buildertrend-identity-review-example.json
+++ b/scripts/fixtures/buildertrend-identity-review-example.json
@@ -1,0 +1,56 @@
+{
+  "reviewKey": "identity-review-example-2026-07-31",
+  "reviewedAt": "2026-07-31T05:30:00.000Z",
+  "reviewedBy": "reviewer-user-id",
+  "decisions": [
+    {
+      "sourceKey": "lead:2001",
+      "sourceIdentity": {
+        "kind": "lead",
+        "id": "2001"
+      },
+      "lifecycleStatus": "preconstruction",
+      "disposition": "lead_only",
+      "departmentCode": "D",
+      "customerProvenance": {
+        "customerId": "customer-id",
+        "kind": "named_customer"
+      },
+      "reviewStatus": "approved",
+      "reviewNotes": "Reviewed lead identity; no access is granted."
+    },
+    {
+      "sourceKey": "job:1001",
+      "sourceIdentity": {
+        "kind": "job",
+        "id": "1001"
+      },
+      "lifecycleStatus": "active",
+      "disposition": "existing_project",
+      "departmentCode": "O",
+      "matchedProjectId": "project-id",
+      "customerProvenance": {
+        "customerId": "customer-id",
+        "kind": "named_customer"
+      },
+      "reviewStatus": "approved",
+      "reviewNotes": "Reviewed job identity; operational data remains unchanged."
+    }
+  ],
+  "relationships": [
+    {
+      "fromSourceKey": "lead:2001",
+      "toSourceKey": "job:1001",
+      "type": "lead_conversion",
+      "reviewStatus": "approved",
+      "reviewNotes": "Explicitly reviewed conversion from lead to job."
+    },
+    {
+      "fromSourceKey": "lead:2001",
+      "toSourceKey": "job:1001",
+      "type": "department_transition",
+      "reviewStatus": "approved",
+      "reviewNotes": "Explicitly reviewed Design-to-ORC transition."
+    }
+  ]
+}

--- a/src/db/schema-buildertrend.ts
+++ b/src/db/schema-buildertrend.ts
@@ -1,4 +1,5 @@
 import {
+  check,
   index,
   integer,
   real,
@@ -6,6 +7,7 @@ import {
   text,
   uniqueIndex,
 } from "drizzle-orm/sqlite-core"
+import { sql } from "drizzle-orm"
 
 import {
   customers,
@@ -287,6 +289,150 @@ export const buildertrendImportObservations = sqliteTable(
   ]
 )
 
+export const buildertrendIdentityReviewRuns = sqliteTable(
+  "buildertrend_staging_identity_review_runs",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    reviewKey: text("review_key").notNull(),
+    manifestFingerprint: text("manifest_fingerprint").notNull(),
+    status: text("status").notNull().default("in_progress"),
+    expectedDecisionCount: integer("expected_decision_count").notNull(),
+    expectedRelationshipCount: integer("expected_relationship_count")
+      .notNull(),
+    reviewedBy: text("reviewed_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    reviewedAt: text("reviewed_at").notNull(),
+    summaryJson: text("summary_json"),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("buildertrend_identity_review_runs_org_key_unique").on(
+      table.organizationId,
+      table.reviewKey
+    ),
+    index("buildertrend_identity_review_runs_org_status_idx").on(
+      table.organizationId,
+      table.status
+    ),
+  ]
+)
+
+export const buildertrendIdentityDecisions = sqliteTable(
+  "buildertrend_staging_identity_decisions",
+  {
+    id: text("id").primaryKey(),
+    reviewRunId: text("review_run_id")
+      .notNull()
+      .references(() => buildertrendIdentityReviewRuns.id, {
+        onDelete: "restrict",
+      }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    sourceRecordId: text("source_record_id")
+      .notNull()
+      .references(() => buildertrendSourceRecords.id, {
+        onDelete: "restrict",
+      }),
+    sourceKey: text("source_key").notNull(),
+    sourceIdentityKind: text("source_identity_kind").notNull(),
+    sourceIdentityId: text("source_identity_id").notNull(),
+    lifecycleStatus: text("lifecycle_status").notNull(),
+    disposition: text("disposition").notNull(),
+    departmentCode: text("department_code"),
+    matchedProjectId: text("matched_project_id").references(
+      () => projects.id,
+      { onDelete: "set null" }
+    ),
+    customerProvenanceId: text("customer_provenance_id").references(
+      () => customers.id,
+      { onDelete: "set null" }
+    ),
+    customerProvenanceKind: text("customer_provenance_kind")
+      .notNull()
+      .default("none"),
+    portalIdentityAllowed: integer("portal_identity_allowed", {
+      mode: "boolean",
+    })
+      .notNull()
+      .default(false),
+    reviewStatus: text("review_status").notNull().default("needs_review"),
+    reviewNotes: text("review_notes"),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("buildertrend_identity_decisions_run_source_unique").on(
+      table.reviewRunId,
+      table.sourceRecordId
+    ),
+    index("buildertrend_identity_decisions_org_status_idx").on(
+      table.organizationId,
+      table.reviewStatus
+    ),
+    index("buildertrend_identity_decisions_project_idx").on(
+      table.matchedProjectId
+    ),
+    check(
+      "buildertrend_identity_decisions_no_portal_access",
+      sql`${table.portalIdentityAllowed} = 0`
+    ),
+  ]
+)
+
+export const buildertrendIdentityRelationships = sqliteTable(
+  "buildertrend_staging_identity_relationships",
+  {
+    id: text("id").primaryKey(),
+    reviewRunId: text("review_run_id")
+      .notNull()
+      .references(() => buildertrendIdentityReviewRuns.id, {
+        onDelete: "restrict",
+      }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    fromDecisionId: text("from_decision_id")
+      .notNull()
+      .references(() => buildertrendIdentityDecisions.id, {
+        onDelete: "restrict",
+      }),
+    toDecisionId: text("to_decision_id")
+      .notNull()
+      .references(() => buildertrendIdentityDecisions.id, {
+        onDelete: "restrict",
+      }),
+    relationshipType: text("relationship_type").notNull(),
+    reviewStatus: text("review_status").notNull().default("needs_review"),
+    reviewNotes: text("review_notes"),
+    grantsPortalAccess: integer("grants_portal_access", {
+      mode: "boolean",
+    })
+      .notNull()
+      .default(false),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("buildertrend_identity_relationships_run_edge_unique").on(
+      table.reviewRunId,
+      table.fromDecisionId,
+      table.toDecisionId,
+      table.relationshipType
+    ),
+    index("buildertrend_identity_relationships_org_type_idx").on(
+      table.organizationId,
+      table.relationshipType
+    ),
+    check(
+      "buildertrend_identity_relationships_no_portal_access",
+      sql`${table.grantsPortalAccess} = 0`
+    ),
+  ]
+)
+
 export type BuildertrendImportRun = typeof buildertrendImportRuns.$inferSelect
 export type NewBuildertrendImportRun =
   typeof buildertrendImportRuns.$inferInsert
@@ -306,3 +452,15 @@ export type BuildertrendImportObservation =
   typeof buildertrendImportObservations.$inferSelect
 export type NewBuildertrendImportObservation =
   typeof buildertrendImportObservations.$inferInsert
+export type BuildertrendIdentityReviewRun =
+  typeof buildertrendIdentityReviewRuns.$inferSelect
+export type NewBuildertrendIdentityReviewRun =
+  typeof buildertrendIdentityReviewRuns.$inferInsert
+export type BuildertrendIdentityDecision =
+  typeof buildertrendIdentityDecisions.$inferSelect
+export type NewBuildertrendIdentityDecision =
+  typeof buildertrendIdentityDecisions.$inferInsert
+export type BuildertrendIdentityRelationship =
+  typeof buildertrendIdentityRelationships.$inferSelect
+export type NewBuildertrendIdentityRelationship =
+  typeof buildertrendIdentityRelationships.$inferInsert

--- a/src/lib/buildertrend/__tests__/identity-reconciliation-cli.test.ts
+++ b/src/lib/buildertrend/__tests__/identity-reconciliation-cli.test.ts
@@ -1,0 +1,128 @@
+import { spawnSync, type SpawnSyncReturns } from "node:child_process"
+import {
+  copyFileSync,
+  existsSync,
+  linkSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { basename, join, resolve } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+const script = resolve(
+  process.cwd(),
+  "scripts/build-buildertrend-identity-review-sql.mjs"
+)
+const fixture = resolve(
+  process.cwd(),
+  "scripts/fixtures/buildertrend-identity-review-example.json"
+)
+
+function runCli(args: readonly string[]): SpawnSyncReturns<string> {
+  return spawnSync("bun", [script, ...args], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  })
+}
+
+function requiredArgs(input: string): readonly string[] {
+  return ["--input", input, "--organization-id", "org-a"]
+}
+
+describe("Buildertrend identity review CLI", () => {
+  let directory: string
+  let input: string
+
+  beforeEach(() => {
+    directory = mkdtempSync(join(tmpdir(), "compass-buildertrend-identity-"))
+    input = join(directory, "review.json")
+    copyFileSync(fixture, input)
+  })
+
+  afterEach(() => {
+    rmSync(directory, { force: true, recursive: true })
+  })
+
+  it("performs a dry run without writing SQL", () => {
+    const output = join(directory, "review.sql")
+    const result = runCli([
+      ...requiredArgs(input),
+      "--output",
+      output,
+      "--dry-run",
+    ])
+
+    expect(result.status).toBe(0)
+    expect(existsSync(output)).toBe(false)
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      dryRun: true,
+      decisionCount: 2,
+      relationshipCount: 2,
+      leadConversionCount: 1,
+    })
+  })
+
+  it("rejects unknown, duplicate, and aliased output paths", () => {
+    const unknown = runCli([...requiredArgs(input), "--unknown"])
+    expect(unknown.status).toBe(1)
+    expect(unknown.stderr).toContain("Unknown option: --unknown")
+
+    const duplicate = runCli([
+      ...requiredArgs(input),
+      "--organization-id",
+      "org-a",
+      "--dry-run",
+    ])
+    expect(duplicate.status).toBe(1)
+    expect(duplicate.stderr).toContain(
+      "--organization-id may only be provided once"
+    )
+
+    const hardlink = join(directory, "hardlink.json")
+    linkSync(input, hardlink)
+    const hardlinkResult = runCli([
+      ...requiredArgs(input),
+      "--output",
+      hardlink,
+    ])
+    expect(hardlinkResult.status).toBe(1)
+    expect(hardlinkResult.stderr).toContain(
+      "--output must not overwrite --input"
+    )
+
+    const symlink = join(directory, "symlink.json")
+    symlinkSync(input, symlink)
+    const symlinkResult = runCli([
+      ...requiredArgs(input),
+      "--output",
+      symlink,
+    ])
+    expect(symlinkResult.status).toBe(1)
+    expect(symlinkResult.stderr).toContain(
+      "--output must not overwrite --input"
+    )
+  })
+
+  it("atomically writes review-only SQL", () => {
+    const output = join(directory, "review.sql")
+    writeFileSync(output, "old output")
+    const result = runCli([...requiredArgs(input), "--output", output])
+
+    expect(result.status).toBe(0)
+    const sql = readFileSync(output, "utf8")
+    expect(sql).toContain("buildertrend_staging_identity_decisions")
+    expect(sql).not.toMatch(
+      /INSERT(?: OR IGNORE)? INTO (?:projects|customers|users|project_members|notifications)\b/
+    )
+    expect(
+      readdirSync(directory).filter((name) =>
+        name.startsWith(`.${basename(output)}.`)
+      )
+    ).toEqual([])
+  })
+})

--- a/src/lib/buildertrend/__tests__/identity-reconciliation.test.ts
+++ b/src/lib/buildertrend/__tests__/identity-reconciliation.test.ts
@@ -1,0 +1,567 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+import {
+  buildBuildertrendIdentityReviewSql,
+  parseBuildertrendIdentityReviewManifest,
+  type BuildertrendIdentityReviewManifest,
+} from "../identity-reconciliation"
+
+const stagingMigration = readFileSync(
+  resolve(process.cwd(), "drizzle/0084_buildertrend_staging_foundation.sql"),
+  "utf8"
+).replaceAll("--> statement-breakpoint", "")
+const identityMigration = readFileSync(
+  resolve(
+    process.cwd(),
+    "drizzle/0085_buildertrend_identity_reconciliation.sql"
+  ),
+  "utf8"
+).replaceAll("--> statement-breakpoint", "")
+
+type TestStatement = {
+  readonly all: () => readonly unknown[]
+  readonly get: () => unknown
+  readonly run: () => unknown
+}
+
+type TestDatabase = {
+  readonly exec: (sql: string) => unknown
+  readonly prepare: (sql: string) => TestStatement
+  readonly close: () => void
+}
+
+type TestDatabaseModule = {
+  readonly Database: new (filename: string) => TestDatabase
+}
+
+function isTestDatabaseModule(value: unknown): value is TestDatabaseModule {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "Database" in value &&
+    typeof value.Database === "function"
+  )
+}
+
+async function openDatabase(): Promise<TestDatabase> {
+  if ("Bun" in globalThis) {
+    const bunSqliteSpecifier = "bun:sqlite"
+    const sqliteModule: unknown = await import(bunSqliteSpecifier)
+    if (!isTestDatabaseModule(sqliteModule)) {
+      throw new Error("bun:sqlite did not provide a Database constructor")
+    }
+    return new sqliteModule.Database(":memory:")
+  }
+
+  const { default: Database } = await import("better-sqlite3")
+  const database = new Database(":memory:")
+  return {
+    exec: (sql) => database.exec(sql),
+    prepare: (sql) => {
+      const statement = database.prepare(sql)
+      return {
+        all: () => statement.all(),
+        get: () => statement.get(),
+        run: () => statement.run(),
+      }
+    },
+    close: () => database.close(),
+  }
+}
+
+async function createDatabase(): Promise<TestDatabase> {
+  const database = await openDatabase()
+  database.exec(`
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE organizations (
+      id TEXT PRIMARY KEY NOT NULL
+    );
+    CREATE TABLE users (
+      id TEXT PRIMARY KEY NOT NULL,
+      organization_id TEXT,
+      FOREIGN KEY (organization_id) REFERENCES organizations(id)
+    );
+    CREATE TABLE projects (
+      id TEXT PRIMARY KEY NOT NULL,
+      organization_id TEXT,
+      project_number TEXT,
+      FOREIGN KEY (organization_id) REFERENCES organizations(id)
+    );
+    CREATE TABLE customers (
+      id TEXT PRIMARY KEY NOT NULL,
+      organization_id TEXT,
+      name TEXT,
+      FOREIGN KEY (organization_id) REFERENCES organizations(id)
+    );
+    CREATE TABLE vendors (
+      id TEXT PRIMARY KEY NOT NULL,
+      organization_id TEXT,
+      name TEXT,
+      FOREIGN KEY (organization_id) REFERENCES organizations(id)
+    );
+  `)
+  database.exec(stagingMigration)
+  database.exec(identityMigration)
+  database.exec(`
+    INSERT INTO organizations (id) VALUES ('org-a'), ('org-b');
+    INSERT INTO users (id, organization_id)
+    VALUES ('reviewer-a', 'org-a'), ('reviewer-b', 'org-b');
+    INSERT INTO projects (id, organization_id, project_number)
+    VALUES
+      ('project-a', 'org-a', 'O-100'),
+      ('project-a-continuation', 'org-a', 'O-100'),
+      ('project-b', 'org-b', 'O-100');
+    INSERT INTO customers (id, organization_id, name)
+    VALUES
+      ('pooled-a', 'org-a', 'Pooled accounting customer'),
+      ('pooled-b', 'org-b', 'Other organization customer');
+    INSERT INTO buildertrend_staging_records (
+      id, organization_id, source_key, source_scope, source_record_type,
+      buildertrend_job_id, buildertrend_record_id, buildertrend_record_number,
+      title, source_status, department_code, review_status, promotion_status,
+      sage_reconciliation_status, created_at, updated_at
+    ) VALUES
+      (
+        'source-job-1001', 'org-a', 'job:1001', 'job', 'job_inventory',
+        '1001', '1001', 'O-100', 'O-100 First phase', 'Active', 'O',
+        'needs_review', 'archive_only', 'not_reviewed',
+        '2026-07-31T05:30:00.000Z', '2026-07-31T05:30:00.000Z'
+      ),
+      (
+        'source-job-1002', 'org-a', 'job:1002', 'job', 'job_inventory',
+        '1002', '1002', 'O-100', 'O-100 Continuation', 'Warranty', 'O',
+        'needs_review', 'archive_only', 'not_reviewed',
+        '2026-07-31T05:30:00.000Z', '2026-07-31T05:30:00.000Z'
+      );
+    INSERT INTO buildertrend_staging_records (
+      id, organization_id, source_key, source_scope, source_record_type,
+      buildertrend_lead_id, buildertrend_record_id, title, source_status,
+      department_code, review_status, promotion_status,
+      sage_reconciliation_status, created_at, updated_at
+    ) VALUES (
+      'source-lead-2001', 'org-a', 'lead:2001', 'lead',
+      'lead_opportunity', '2001', '2001', 'D-100 Design lead',
+      'Preconstruction', 'D', 'needs_review', 'archive_only',
+      'not_reviewed', '2026-07-31T05:30:00.000Z',
+      '2026-07-31T05:30:00.000Z'
+    );
+  `)
+  return database
+}
+
+function manifest(
+  overrides?: Partial<BuildertrendIdentityReviewManifest>
+): BuildertrendIdentityReviewManifest {
+  return {
+    reviewKey: "identity-review-2026-07-31",
+    reviewedAt: "2026-07-31T05:30:00.000Z",
+    reviewedBy: "reviewer-a",
+    decisions: [
+      {
+        sourceKey: "lead:2001",
+        sourceIdentity: { kind: "lead", id: "2001" },
+        lifecycleStatus: "preconstruction",
+        disposition: "lead_only",
+        departmentCode: "D",
+        reviewStatus: "approved",
+      },
+      {
+        sourceKey: "job:1001",
+        sourceIdentity: { kind: "job", id: "1001" },
+        lifecycleStatus: "active",
+        disposition: "existing_project",
+        departmentCode: "O",
+        matchedProjectId: "project-a",
+        customerProvenance: {
+          customerId: "pooled-a",
+          kind: "pooled_accounting",
+        },
+        reviewStatus: "approved",
+      },
+      {
+        sourceKey: "job:1002",
+        sourceIdentity: { kind: "job", id: "1002" },
+        lifecycleStatus: "warranty",
+        disposition: "existing_project",
+        departmentCode: "O",
+        matchedProjectId: "project-a-continuation",
+        reviewStatus: "approved",
+      },
+    ],
+    relationships: [
+      {
+        fromSourceKey: "lead:2001",
+        toSourceKey: "job:1001",
+        type: "lead_conversion",
+        reviewStatus: "approved",
+      },
+      {
+        fromSourceKey: "lead:2001",
+        toSourceKey: "job:1001",
+        type: "department_transition",
+        reviewStatus: "approved",
+      },
+      {
+        fromSourceKey: "job:1001",
+        toSourceKey: "job:1002",
+        type: "continuation",
+        reviewStatus: "approved",
+      },
+    ],
+    ...overrides,
+  }
+}
+
+function scalar(
+  database: TestDatabase,
+  sql: string
+): string | number | null {
+  const row: unknown = database.prepare(`SELECT (${sql}) AS value`).get()
+  if (row === null || typeof row !== "object" || !("value" in row)) {
+    return null
+  }
+  const value = row.value
+  return typeof value === "string" || typeof value === "number"
+    ? value
+    : null
+}
+
+describe("Buildertrend identity reconciliation", () => {
+  it("parses explicit identities and rejects inferred or inconsistent edges", () => {
+    const parsed = parseBuildertrendIdentityReviewManifest(manifest())
+    expect(parsed.success).toBe(true)
+
+    const duplicateIdentity = parseBuildertrendIdentityReviewManifest(
+      manifest({
+        decisions: [
+          ...manifest().decisions,
+          {
+            sourceKey: "job:duplicate-alias",
+            sourceIdentity: { kind: "job", id: "1001" },
+            lifecycleStatus: "active",
+            disposition: "unmatched",
+            reviewStatus: "needs_review",
+          },
+        ],
+      })
+    )
+    expect(duplicateIdentity.success).toBe(false)
+    if (!duplicateIdentity.success) {
+      expect(duplicateIdentity.errors.join("\n")).toContain(
+        "Duplicate Buildertrend source identity"
+      )
+    }
+
+    const inferredConversion = parseBuildertrendIdentityReviewManifest(
+      manifest({
+        relationships: [
+          {
+            fromSourceKey: "job:1001",
+            toSourceKey: "lead:2001",
+            type: "lead_conversion",
+            reviewStatus: "approved",
+          },
+        ],
+      })
+    )
+    expect(inferredConversion.success).toBe(false)
+  })
+
+  it("records immutable reviewed identities without operational writes", async () => {
+    const database = await createDatabase()
+    const build = await buildBuildertrendIdentityReviewSql(
+      "org-a",
+      manifest()
+    )
+
+    expect(build.summary.decisionCount).toBe(3)
+    expect(build.summary.relationshipCount).toBe(3)
+    expect(build.summary.pooledCustomerCount).toBe(1)
+    expect(build.summary.leadConversionCount).toBe(1)
+    expect(build.sql).not.toMatch(
+      /INSERT(?: OR IGNORE)? INTO (?:projects|customers|users|project_members|notifications)\b/
+    )
+
+    database.exec(build.sql)
+    expect(
+      scalar(
+        database,
+        "SELECT COUNT(*) FROM buildertrend_staging_identity_decisions"
+      )
+    ).toBe(3)
+    expect(
+      scalar(
+        database,
+        "SELECT COUNT(*) FROM buildertrend_staging_identity_relationships"
+      )
+    ).toBe(3)
+    expect(
+      scalar(
+        database,
+        "SELECT status FROM buildertrend_staging_identity_review_runs"
+      )
+    ).toBe("completed")
+    expect(
+      scalar(
+        database,
+        "SELECT SUM(portal_identity_allowed) FROM buildertrend_staging_identity_decisions"
+      )
+    ).toBe(0)
+    expect(
+      scalar(
+        database,
+        "SELECT SUM(grants_portal_access) FROM buildertrend_staging_identity_relationships"
+      )
+    ).toBe(0)
+
+    expect(() =>
+      database.exec(
+        "UPDATE buildertrend_staging_identity_decisions SET review_status = 'rejected'"
+      )
+    ).toThrow("immutable")
+    expect(() =>
+      database.exec(
+        "DELETE FROM buildertrend_staging_identity_relationships"
+      )
+    ).toThrow("cannot be deleted")
+  })
+
+  it("enforces exact source identities and reviewed relationship evidence in D1", async () => {
+    const database = await createDatabase()
+    const build = await buildBuildertrendIdentityReviewSql(
+      "org-a",
+      manifest()
+    )
+    database.exec(build.sql)
+
+    try {
+      database.exec(`
+        INSERT INTO buildertrend_staging_identity_decisions (
+          id, review_run_id, organization_id, source_record_id, source_key,
+          source_identity_kind, source_identity_id, lifecycle_status,
+          disposition, customer_provenance_kind, portal_identity_allowed,
+          review_status, created_at
+        ) VALUES (
+          'forged-decision',
+          'buildertrend:identity-run:org-a:identity-review-2026-07-31',
+          'org-a', 'source-job-1001', 'job:1001', 'job', 'wrong-id',
+          'active', 'unmatched', 'none', 0, 'needs_review',
+          '2026-07-31T05:30:00.000Z'
+        );
+      `)
+    } catch {
+      // The database guard may abort the whole statement or report no change.
+    }
+    expect(
+      scalar(
+        database,
+        "SELECT COUNT(*) FROM buildertrend_staging_identity_decisions WHERE id = 'forged-decision'"
+      )
+    ).toBe(0)
+
+    database.exec(`
+      INSERT INTO buildertrend_staging_identity_review_runs (
+        id, organization_id, review_key, manifest_fingerprint, status,
+        expected_decision_count, expected_relationship_count, reviewed_at,
+        created_at
+      ) VALUES (
+        'manual-run', 'org-a', 'manual-review', 'manual-fingerprint',
+        'in_progress', 2, 1, '2026-07-31T05:30:00.000Z',
+        '2026-07-31T05:30:00.000Z'
+      );
+      INSERT INTO buildertrend_staging_identity_decisions (
+        id, review_run_id, organization_id, source_record_id, source_key,
+        source_identity_kind, source_identity_id, lifecycle_status,
+        disposition, department_code, customer_provenance_kind,
+        portal_identity_allowed, review_status, created_at
+      ) VALUES
+        (
+          'manual-lead', 'manual-run', 'org-a', 'source-lead-2001',
+          'lead:2001', 'lead', '2001', 'preconstruction', 'lead_only', 'D',
+          'none', 0, 'approved', '2026-07-31T05:30:00.000Z'
+        ),
+        (
+          'manual-job', 'manual-run', 'org-a', 'source-job-1001',
+          'job:1001', 'job', '1001', 'active', 'unmatched', 'D',
+          'none', 0, 'needs_review', '2026-07-31T05:30:00.000Z'
+        );
+    `)
+    try {
+      database.exec(`
+        INSERT INTO buildertrend_staging_identity_relationships (
+          id, review_run_id, organization_id, from_decision_id,
+          to_decision_id, relationship_type, review_status,
+          grants_portal_access, created_at
+        ) VALUES (
+          'unreviewed-transition', 'manual-run', 'org-a', 'manual-lead',
+          'manual-job', 'department_transition', 'approved', 0,
+          '2026-07-31T05:30:00.000Z'
+        );
+      `)
+    } catch {
+      // The database guard may abort the whole statement or report no change.
+    }
+    expect(
+      scalar(
+        database,
+        "SELECT COUNT(*) FROM buildertrend_staging_identity_relationships WHERE id = 'unreviewed-transition'"
+      )
+    ).toBe(0)
+  })
+
+  it("keeps reused project numbers distinct by exact Buildertrend job ID", async () => {
+    const database = await createDatabase()
+    const build = await buildBuildertrendIdentityReviewSql(
+      "org-a",
+      manifest()
+    )
+    database.exec(build.sql)
+
+    const rows: unknown = database
+      .prepare(
+        `SELECT
+          source_identity_id AS sourceIdentityId,
+          matched_project_id AS matchedProjectId
+        FROM buildertrend_staging_identity_decisions
+        WHERE source_identity_kind = 'job'
+        ORDER BY source_identity_id`
+      )
+      .all()
+
+    expect(rows).toEqual([
+      { sourceIdentityId: "1001", matchedProjectId: "project-a" },
+      {
+        sourceIdentityId: "1002",
+        matchedProjectId: "project-a-continuation",
+      },
+    ])
+  })
+
+  it("replays exactly and flags a changed manifest under the same review key", async () => {
+    const database = await createDatabase()
+    const first = await buildBuildertrendIdentityReviewSql(
+      "org-a",
+      manifest()
+    )
+    database.exec(first.sql)
+    database.exec(first.sql)
+    expect(
+      scalar(
+        database,
+        "SELECT COUNT(*) FROM buildertrend_staging_identity_review_runs"
+      )
+    ).toBe(1)
+
+    const changed = await buildBuildertrendIdentityReviewSql(
+      "org-a",
+      manifest({
+        decisions: manifest().decisions.map((decision) =>
+          decision.sourceKey === "job:1001"
+            ? { ...decision, reviewNotes: "Changed after completion" }
+            : decision
+        ),
+      })
+    )
+    database.exec(changed.sql)
+    expect(
+      scalar(
+        database,
+        "SELECT status FROM buildertrend_staging_identity_review_runs"
+      )
+    ).toBe("manifest_conflict")
+    expect(
+      scalar(
+        database,
+        "SELECT COUNT(*) FROM buildertrend_staging_identity_decisions"
+      )
+    ).toBe(3)
+  })
+
+  it("fails closed on cross-organization projects, customers, and reviewers", async () => {
+    const projectDatabase = await createDatabase()
+    const crossProject = await buildBuildertrendIdentityReviewSql(
+      "org-a",
+      manifest({
+        reviewKey: "cross-project",
+        decisions: manifest().decisions.map((decision) =>
+          decision.sourceKey === "job:1001"
+            ? { ...decision, matchedProjectId: "project-b" }
+            : decision
+        ),
+      })
+    )
+    projectDatabase.exec(crossProject.sql)
+    expect(
+      scalar(
+        projectDatabase,
+        "SELECT status FROM buildertrend_staging_identity_review_runs"
+      )
+    ).toBe("in_progress")
+    expect(
+      scalar(
+        projectDatabase,
+        "SELECT COUNT(*) FROM buildertrend_staging_identity_decisions"
+      )
+    ).toBe(2)
+    expect(
+      scalar(
+        projectDatabase,
+        "SELECT COUNT(*) FROM buildertrend_staging_identity_decisions WHERE matched_project_id = 'project-b'"
+      )
+    ).toBe(0)
+
+    const customerDatabase = await createDatabase()
+    const crossCustomer = await buildBuildertrendIdentityReviewSql(
+      "org-a",
+      manifest({
+        reviewKey: "cross-customer",
+        decisions: manifest().decisions.map((decision) =>
+          decision.sourceKey === "job:1001"
+            ? {
+                ...decision,
+                customerProvenance: {
+                  customerId: "pooled-b",
+                  kind: "pooled_accounting",
+                },
+              }
+            : decision
+        ),
+      })
+    )
+    customerDatabase.exec(crossCustomer.sql)
+    expect(
+      scalar(
+        customerDatabase,
+        "SELECT status FROM buildertrend_staging_identity_review_runs"
+      )
+    ).toBe("in_progress")
+    expect(
+      scalar(
+        customerDatabase,
+        "SELECT COUNT(*) FROM buildertrend_staging_identity_decisions WHERE customer_provenance_id = 'pooled-b'"
+      )
+    ).toBe(0)
+
+    const reviewerDatabase = await createDatabase()
+    const crossReviewer = await buildBuildertrendIdentityReviewSql(
+      "org-a",
+      manifest({
+        reviewKey: "cross-reviewer",
+        reviewedBy: "reviewer-b",
+      })
+    )
+    try {
+      reviewerDatabase.exec(crossReviewer.sql)
+    } catch {
+      // The scope trigger is expected to abort this review before persistence.
+    }
+    expect(
+      scalar(
+        reviewerDatabase,
+        "SELECT COUNT(*) FROM buildertrend_staging_identity_review_runs"
+      )
+    ).toBe(0)
+  })
+})

--- a/src/lib/buildertrend/identity-reconciliation.ts
+++ b/src/lib/buildertrend/identity-reconciliation.ts
@@ -1,0 +1,566 @@
+import { z } from "zod/v4"
+
+const requiredText = z.string().trim().min(1)
+const optionalText = requiredText.optional()
+const reviewStatusSchema = z.enum(["needs_review", "approved", "rejected"])
+const lifecycleStatusSchema = z.enum([
+  "active",
+  "preconstruction",
+  "warranty",
+  "completed",
+  "inactive",
+  "archived",
+  "ignored",
+])
+const dispositionSchema = z.enum([
+  "existing_project",
+  "project_candidate",
+  "lead_only",
+  "archive_only",
+  "ignored",
+  "unmatched",
+])
+const customerProvenanceKindSchema = z.enum([
+  "named_customer",
+  "pooled_accounting",
+  "prospect",
+])
+const relationshipTypeSchema = z.enum([
+  "same_owner",
+  "development_phase",
+  "continuation",
+  "department_transition",
+  "lead_conversion",
+])
+
+const sourceIdentitySchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("job"), id: requiredText }).strict(),
+  z.object({ kind: z.literal("lead"), id: requiredText }).strict(),
+])
+
+const identityDecisionSchema = z
+  .object({
+    sourceKey: requiredText,
+    sourceIdentity: sourceIdentitySchema,
+    lifecycleStatus: lifecycleStatusSchema,
+    disposition: dispositionSchema,
+    departmentCode: optionalText,
+    matchedProjectId: optionalText,
+    customerProvenance: z
+      .object({
+        customerId: requiredText,
+        kind: customerProvenanceKindSchema,
+      })
+      .strict()
+      .optional(),
+    reviewStatus: reviewStatusSchema.default("needs_review"),
+    reviewNotes: optionalText,
+  })
+  .strict()
+  .superRefine((decision, context) => {
+    if (
+      decision.disposition === "existing_project" &&
+      !decision.matchedProjectId
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "existing_project decisions require matchedProjectId",
+        path: ["matchedProjectId"],
+      })
+    }
+    if (
+      decision.disposition === "lead_only" &&
+      decision.sourceIdentity.kind !== "lead"
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "lead_only decisions require a lead source identity",
+        path: ["disposition"],
+      })
+    }
+    if (
+      decision.lifecycleStatus === "ignored" &&
+      decision.disposition !== "ignored" &&
+      decision.disposition !== "archive_only"
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "ignored lifecycle records must remain ignored or archive_only",
+        path: ["disposition"],
+      })
+    }
+    if (
+      decision.disposition === "ignored" &&
+      decision.lifecycleStatus !== "ignored"
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "ignored dispositions require the ignored lifecycle status",
+        path: ["lifecycleStatus"],
+      })
+    }
+  })
+
+const identityRelationshipSchema = z
+  .object({
+    fromSourceKey: requiredText,
+    toSourceKey: requiredText,
+    type: relationshipTypeSchema,
+    reviewStatus: reviewStatusSchema.default("needs_review"),
+    reviewNotes: optionalText,
+  })
+  .strict()
+  .refine(
+    (relationship) =>
+      relationship.fromSourceKey !== relationship.toSourceKey,
+    {
+      message: "identity relationships must connect distinct source records",
+      path: ["toSourceKey"],
+    }
+  )
+
+export const buildertrendIdentityReviewManifestSchema = z
+  .object({
+    reviewKey: requiredText,
+    reviewedAt: z.iso.datetime({ offset: true }),
+    reviewedBy: optionalText,
+    decisions: z.array(identityDecisionSchema).min(1).readonly(),
+    relationships: z
+      .array(identityRelationshipSchema)
+      .readonly()
+      .default([]),
+  })
+  .strict()
+
+export type BuildertrendIdentityReviewManifest = z.infer<
+  typeof buildertrendIdentityReviewManifestSchema
+>
+
+export type BuildertrendIdentityReviewParseResult =
+  | {
+      readonly success: true
+      readonly data: BuildertrendIdentityReviewManifest
+    }
+  | {
+      readonly success: false
+      readonly errors: readonly string[]
+    }
+
+export type BuildertrendIdentityReviewSummary = {
+  readonly reviewKey: string
+  readonly decisionCount: number
+  readonly relationshipCount: number
+  readonly approvedDecisionCount: number
+  readonly pooledCustomerCount: number
+  readonly leadConversionCount: number
+}
+
+export type BuildertrendIdentityReviewBuild = {
+  readonly sql: string
+  readonly statements: readonly string[]
+  readonly summary: BuildertrendIdentityReviewSummary
+}
+
+type IdentityDecision = BuildertrendIdentityReviewManifest["decisions"][number]
+type IdentityRelationship =
+  BuildertrendIdentityReviewManifest["relationships"][number]
+
+function stableTextCompare(left: string, right: string): number {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}
+
+function canonicalJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalJsonValue)
+  if (value === null || typeof value !== "object") return value
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => stableTextCompare(left, right))
+      .map(([key, nestedValue]) => [key, canonicalJsonValue(nestedValue)])
+  )
+}
+
+function canonicalManifest(
+  manifest: BuildertrendIdentityReviewManifest
+): BuildertrendIdentityReviewManifest {
+  return {
+    ...manifest,
+    decisions: [...manifest.decisions].sort((left, right) =>
+      stableTextCompare(left.sourceKey, right.sourceKey)
+    ),
+    relationships: [...manifest.relationships].sort((left, right) => {
+      const leftKey = `${left.fromSourceKey}:${left.toSourceKey}:${left.type}`
+      const rightKey = `${right.fromSourceKey}:${right.toSourceKey}:${right.type}`
+      return stableTextCompare(leftKey, rightKey)
+    }),
+  }
+}
+
+async function manifestFingerprint(
+  manifest: BuildertrendIdentityReviewManifest
+): Promise<string> {
+  const bytes = new TextEncoder().encode(
+    JSON.stringify(canonicalJsonValue(canonicalManifest(manifest)))
+  )
+  const digest = await crypto.subtle.digest("SHA-256", bytes)
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+function sqlText(value: string | null | undefined): string {
+  if (value === null || value === undefined || value === "") return "NULL"
+  return `'${value.replaceAll("'", "''")}'`
+}
+
+function stableId(
+  kind: "identity-run" | "identity-decision" | "identity-relationship",
+  organizationId: string,
+  key: string
+): string {
+  return `buildertrend:${kind}:${organizationId}:${key}`
+}
+
+function decisionId(
+  organizationId: string,
+  reviewKey: string,
+  sourceKey: string
+): string {
+  return stableId(
+    "identity-decision",
+    organizationId,
+    `${reviewKey}:${sourceKey}`
+  )
+}
+
+function decisionErrors(
+  manifest: BuildertrendIdentityReviewManifest
+): readonly string[] {
+  const errors: string[] = []
+  const decisions = new Map<string, IdentityDecision>()
+  const sourceIdentities = new Set<string>()
+
+  for (const decision of manifest.decisions) {
+    if (decisions.has(decision.sourceKey)) {
+      errors.push(`Duplicate decision sourceKey: ${decision.sourceKey}`)
+      continue
+    }
+    decisions.set(decision.sourceKey, decision)
+
+    const identityKey = `${decision.sourceIdentity.kind}:${decision.sourceIdentity.id}`
+    if (sourceIdentities.has(identityKey)) {
+      errors.push(`Duplicate Buildertrend source identity: ${identityKey}`)
+    }
+    sourceIdentities.add(identityKey)
+  }
+
+  const relationshipKeys = new Set<string>()
+  for (const relationship of manifest.relationships) {
+    const from = decisions.get(relationship.fromSourceKey)
+    const to = decisions.get(relationship.toSourceKey)
+    if (!from) {
+      errors.push(
+        `Relationship references missing sourceKey: ${relationship.fromSourceKey}`
+      )
+    }
+    if (!to) {
+      errors.push(
+        `Relationship references missing sourceKey: ${relationship.toSourceKey}`
+      )
+    }
+
+    const edgeKey = `${relationship.fromSourceKey}:${relationship.toSourceKey}:${relationship.type}`
+    if (relationshipKeys.has(edgeKey)) {
+      errors.push(`Duplicate identity relationship: ${edgeKey}`)
+    }
+    relationshipKeys.add(edgeKey)
+
+    if (
+      relationship.type === "lead_conversion" &&
+      from?.sourceIdentity.kind !== "lead"
+    ) {
+      errors.push("Lead conversion relationships must start with a lead")
+    }
+    if (
+      relationship.type === "lead_conversion" &&
+      to?.sourceIdentity.kind !== "job"
+    ) {
+      errors.push("Lead conversion relationships must end with a job")
+    }
+    if (
+      relationship.type === "department_transition" &&
+      from &&
+      to &&
+      (!from.departmentCode ||
+        !to.departmentCode ||
+        from.departmentCode === to.departmentCode)
+    ) {
+      errors.push(
+        "Department transitions require distinct explicit department codes"
+      )
+    }
+    if (
+      relationship.reviewStatus === "approved" &&
+      (from?.reviewStatus !== "approved" || to?.reviewStatus !== "approved")
+    ) {
+      errors.push(
+        "Approved relationships require both identity decisions to be approved"
+      )
+    }
+  }
+
+  return errors
+}
+
+export function parseBuildertrendIdentityReviewManifest(
+  input: unknown
+): BuildertrendIdentityReviewParseResult {
+  const parsed = buildertrendIdentityReviewManifestSchema.safeParse(input)
+  if (!parsed.success) {
+    return {
+      success: false,
+      errors: parsed.error.issues.map(
+        (issue) => `${issue.path.join(".") || "manifest"}: ${issue.message}`
+      ),
+    }
+  }
+
+  const errors = decisionErrors(parsed.data)
+  return errors.length > 0
+    ? { success: false, errors }
+    : { success: true, data: canonicalManifest(parsed.data) }
+}
+
+function sourceIdentityPredicate(decision: IdentityDecision): string {
+  const column =
+    decision.sourceIdentity.kind === "job"
+      ? "buildertrend_job_id"
+      : "buildertrend_lead_id"
+  return `source_record.${column} = ${sqlText(decision.sourceIdentity.id)}`
+}
+
+function projectPredicate(
+  organizationId: string,
+  matchedProjectId: string | undefined
+): string {
+  if (!matchedProjectId) return "1 = 1"
+  return `EXISTS (
+    SELECT 1 FROM projects project
+    WHERE project.id = ${sqlText(matchedProjectId)}
+      AND project.organization_id = ${sqlText(organizationId)}
+  )`
+}
+
+function customerPredicate(
+  organizationId: string,
+  decision: IdentityDecision
+): string {
+  if (!decision.customerProvenance) return "1 = 1"
+  return `EXISTS (
+    SELECT 1 FROM customers customer
+    WHERE customer.id = ${sqlText(decision.customerProvenance.customerId)}
+      AND customer.organization_id = ${sqlText(organizationId)}
+  )`
+}
+
+function insertDecisionSql(
+  organizationId: string,
+  runId: string,
+  reviewKey: string,
+  fingerprint: string,
+  reviewedAt: string,
+  decision: IdentityDecision
+): string {
+  const id = decisionId(organizationId, reviewKey, decision.sourceKey)
+  const customerId = decision.customerProvenance?.customerId
+  const customerKind = decision.customerProvenance?.kind ?? "none"
+
+  return `INSERT OR IGNORE INTO buildertrend_staging_identity_decisions (
+  id, review_run_id, organization_id, source_record_id, source_key,
+  source_identity_kind, source_identity_id, lifecycle_status, disposition,
+  department_code, matched_project_id, customer_provenance_id,
+  customer_provenance_kind, portal_identity_allowed, review_status,
+  review_notes, created_at
+)
+SELECT
+  ${sqlText(id)}, ${sqlText(runId)}, ${sqlText(organizationId)},
+  source_record.id, ${sqlText(decision.sourceKey)},
+  ${sqlText(decision.sourceIdentity.kind)},
+  ${sqlText(decision.sourceIdentity.id)},
+  ${sqlText(decision.lifecycleStatus)}, ${sqlText(decision.disposition)},
+  ${sqlText(decision.departmentCode)}, ${sqlText(decision.matchedProjectId)},
+  ${sqlText(customerId)}, ${sqlText(customerKind)}, 0,
+  ${sqlText(decision.reviewStatus)}, ${sqlText(decision.reviewNotes)},
+  ${sqlText(reviewedAt)}
+FROM buildertrend_staging_records source_record
+WHERE source_record.organization_id = ${sqlText(organizationId)}
+  AND source_record.source_key = ${sqlText(decision.sourceKey)}
+  AND ${sourceIdentityPredicate(decision)}
+  AND ${projectPredicate(organizationId, decision.matchedProjectId)}
+  AND ${customerPredicate(organizationId, decision)}
+  AND EXISTS (
+    SELECT 1
+    FROM buildertrend_staging_identity_review_runs active_review
+    WHERE active_review.id = ${sqlText(runId)}
+      AND active_review.organization_id = ${sqlText(organizationId)}
+      AND active_review.manifest_fingerprint = ${sqlText(fingerprint)}
+      AND active_review.status = 'in_progress'
+  )
+LIMIT 1;`
+}
+
+function insertRelationshipSql(
+  organizationId: string,
+  runId: string,
+  reviewKey: string,
+  fingerprint: string,
+  reviewedAt: string,
+  relationship: IdentityRelationship
+): string {
+  const fromId = decisionId(
+    organizationId,
+    reviewKey,
+    relationship.fromSourceKey
+  )
+  const toId = decisionId(
+    organizationId,
+    reviewKey,
+    relationship.toSourceKey
+  )
+  const relationshipKey = `${reviewKey}:${relationship.fromSourceKey}:${relationship.toSourceKey}:${relationship.type}`
+  const id = stableId(
+    "identity-relationship",
+    organizationId,
+    relationshipKey
+  )
+
+  return `INSERT OR IGNORE INTO buildertrend_staging_identity_relationships (
+  id, review_run_id, organization_id, from_decision_id, to_decision_id,
+  relationship_type, review_status, review_notes, grants_portal_access,
+  created_at
+)
+SELECT
+  ${sqlText(id)}, ${sqlText(runId)}, ${sqlText(organizationId)},
+  from_decision.id, to_decision.id, ${sqlText(relationship.type)},
+  ${sqlText(relationship.reviewStatus)}, ${sqlText(relationship.reviewNotes)},
+  0, ${sqlText(reviewedAt)}
+FROM buildertrend_staging_identity_decisions from_decision
+JOIN buildertrend_staging_identity_decisions to_decision
+  ON to_decision.id = ${sqlText(toId)}
+WHERE from_decision.id = ${sqlText(fromId)}
+  AND from_decision.review_run_id = ${sqlText(runId)}
+  AND to_decision.review_run_id = ${sqlText(runId)}
+  AND EXISTS (
+    SELECT 1
+    FROM buildertrend_staging_identity_review_runs active_review
+    WHERE active_review.id = ${sqlText(runId)}
+      AND active_review.organization_id = ${sqlText(organizationId)}
+      AND active_review.manifest_fingerprint = ${sqlText(fingerprint)}
+      AND active_review.status = 'in_progress'
+  )
+LIMIT 1;`
+}
+
+function summary(
+  manifest: BuildertrendIdentityReviewManifest
+): BuildertrendIdentityReviewSummary {
+  return {
+    reviewKey: manifest.reviewKey,
+    decisionCount: manifest.decisions.length,
+    relationshipCount: manifest.relationships.length,
+    approvedDecisionCount: manifest.decisions.filter(
+      (decision) => decision.reviewStatus === "approved"
+    ).length,
+    pooledCustomerCount: manifest.decisions.filter(
+      (decision) =>
+        decision.customerProvenance?.kind === "pooled_accounting"
+    ).length,
+    leadConversionCount: manifest.relationships.filter(
+      (relationship) => relationship.type === "lead_conversion"
+    ).length,
+  }
+}
+
+export async function buildBuildertrendIdentityReviewSql(
+  organizationId: string,
+  manifest: BuildertrendIdentityReviewManifest
+): Promise<BuildertrendIdentityReviewBuild> {
+  const normalizedOrganizationId = organizationId.trim()
+  if (!normalizedOrganizationId) {
+    throw new Error("organizationId is required")
+  }
+
+  const fingerprint = await manifestFingerprint(manifest)
+  const runId = stableId(
+    "identity-run",
+    normalizedOrganizationId,
+    manifest.reviewKey
+  )
+  const reviewSummary = summary(manifest)
+  const statements = [
+    "PRAGMA foreign_keys = ON;",
+    "BEGIN IMMEDIATE;",
+    `INSERT INTO buildertrend_staging_identity_review_runs (
+  id, organization_id, review_key, manifest_fingerprint, status,
+  expected_decision_count, expected_relationship_count, reviewed_by,
+  reviewed_at, summary_json, created_at
+) VALUES (
+  ${sqlText(runId)}, ${sqlText(normalizedOrganizationId)},
+  ${sqlText(manifest.reviewKey)}, ${sqlText(fingerprint)}, 'in_progress',
+  ${manifest.decisions.length}, ${manifest.relationships.length},
+  ${sqlText(manifest.reviewedBy)}, ${sqlText(manifest.reviewedAt)},
+  ${sqlText(JSON.stringify(reviewSummary))}, ${sqlText(manifest.reviewedAt)}
+)
+ON CONFLICT (organization_id, review_key) DO UPDATE SET
+  status = CASE
+    WHEN buildertrend_staging_identity_review_runs.manifest_fingerprint
+      = excluded.manifest_fingerprint
+    THEN 'in_progress'
+    ELSE 'manifest_conflict'
+  END;`,
+    ...manifest.decisions.map((decision) =>
+      insertDecisionSql(
+        normalizedOrganizationId,
+        runId,
+        manifest.reviewKey,
+        fingerprint,
+        manifest.reviewedAt,
+        decision
+      )
+    ),
+    ...manifest.relationships.map((relationship) =>
+      insertRelationshipSql(
+        normalizedOrganizationId,
+        runId,
+        manifest.reviewKey,
+        fingerprint,
+        manifest.reviewedAt,
+        relationship
+      )
+    ),
+    `UPDATE buildertrend_staging_identity_review_runs
+SET status = 'completed'
+WHERE id = ${sqlText(runId)}
+  AND manifest_fingerprint = ${sqlText(fingerprint)}
+  AND status = 'in_progress'
+  AND (
+    SELECT COUNT(*)
+    FROM buildertrend_staging_identity_decisions
+    WHERE review_run_id = ${sqlText(runId)}
+  ) = expected_decision_count
+  AND (
+    SELECT COUNT(*)
+    FROM buildertrend_staging_identity_relationships
+    WHERE review_run_id = ${sqlText(runId)}
+  ) = expected_relationship_count;`,
+    "COMMIT;",
+  ]
+
+  return {
+    sql: `${statements.join("\n\n")}\n`,
+    statements,
+    summary: reviewSummary,
+  }
+}


### PR DESCRIPTION
## Summary

- add immutable, organization-scoped review runs for Buildertrend job and lead identity decisions
- preserve exact Buildertrend job/lead IDs and explicit same-owner, development-phase, continuation, department-transition, and lead-conversion relationships
- keep project numbers, customer records, and pooled accounting customers as review evidence only
- add a strict manifest parser and deterministic SQL generator/CLI for review-only reconciliation
- prevent project/customer/user creation, invitations, notifications, source-record mutation, or portal-access grants

## Safety boundaries

- D1 checks force `portal_identity_allowed = 0` and `grants_portal_access = 0`
- database triggers enforce organization scope, exact source identity, approved relationship evidence, immutable provenance, and complete-count finalization
- changed content under an existing review key is quarantined as `manifest_conflict`
- missing or cross-organization references leave the run `in_progress`
- generated SQL writes only to the three Buildertrend identity staging tables and only reads operational project/customer references

## Validation

- 37 Buildertrend tests pass (160 assertions)
- TypeScript passes
- targeted ESLint passes
- full production build passes
- clean D1 migration chain applies through `0085_buildertrend_identity_reconciliation.sql`
- `git diff --check` passes

Closes #152
