### PR TITLE
feat(feedback): make request tracking live

### DIFF
--- a/scripts/jarvis-agent-poller.py
+++ b/scripts/jarvis-agent-poller.py
@@ -271,6 +271,29 @@ def explicitly_requests_compass_feedback(message: str) -> bool:
     return any(re.search(pattern, value) for pattern in patterns)
 
 
+def asked_to_file_feedback(message: str) -> bool:
+    value = " ".join(message.lower().split())
+    return bool(
+        re.search(
+            (
+                r"\b(?:would|do) you (?:like|want) me to "
+                r"(?:file|submit|report|record)\b"
+                r"|\bshould i (?:file|submit|report|record)\b"
+                r"|\b(?:file|submit|report|record) "
+                r"(?:this|it|that|both|these|the request|the requests)\b"
+            ),
+            value,
+        )
+        and (
+            "feedback" in value
+            or "request" in value
+            or "issue" in value
+            or "bug" in value
+            or "file" in value
+        )
+    )
+
+
 def pending_feedback_report(payload: dict[str, Any]) -> str | None:
     messages = payload.get("messages")
     if not isinstance(messages, list):
@@ -321,7 +344,7 @@ def pending_feedback_report(payload: dict[str, Any]) -> str | None:
     )
     if not short_confirmation and not explicit_confirmation:
         return None
-    if FEEDBACK_CONFIRMATION_QUESTION not in str(previous["content"]):
+    if not asked_to_file_feedback(str(previous["content"])):
         return None
 
     report_content = str(report["content"]).strip()

--- a/scripts/test_jarvis_agent_poller.py
+++ b/scripts/test_jarvis_agent_poller.py
@@ -161,6 +161,25 @@ class CompassSearchContextTests(unittest.TestCase):
         self.assertTrue(MODULE.confirms_pending_feedback(confirmed))
         self.assertFalse(MODULE.confirms_pending_feedback(unrelated))
 
+    def test_feedback_confirmation_accepts_natural_filing_questions(
+        self,
+    ) -> None:
+        self.assertTrue(
+            MODULE.asked_to_file_feedback(
+                "Would you like me to file both requests?"
+            )
+        )
+        self.assertTrue(
+            MODULE.asked_to_file_feedback(
+                "Should I submit this to the Compass Feedback Desk?"
+            )
+        )
+        self.assertFalse(
+            MODULE.asked_to_file_feedback(
+                "I can explain how the Feedback Desk works."
+            )
+        )
+
     def test_feedback_confirmation_accepts_explicit_sentence_with_context(
         self,
     ) -> None:

--- a/src/app/actions/feedback-requests.ts
+++ b/src/app/actions/feedback-requests.ts
@@ -1,11 +1,26 @@
 "use server"
 
-import { and, desc, eq, or, sql } from "drizzle-orm"
+import { and, asc, desc, eq, or, sql } from "drizzle-orm"
 
 import { getDb } from "@/db"
-import { feedbackDeskItems } from "@/db/schema-jarvis"
+import {
+  feedbackDeskItems,
+  jarvisBridgeEvents,
+} from "@/db/schema-jarvis"
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
+import {
+  confirmedFeedbackReportFromPayload,
+  feedbackCandidateFromReport,
+} from "@/lib/jarvis/feedback-confirmation"
+import {
+  enqueueFeedbackDeskItem,
+} from "@/lib/jarvis/feedback-desk"
+import {
+  feedbackTimeline,
+  type FeedbackTimelineEntry,
+} from "@/lib/jarvis/feedback-timeline"
+import { syncFeedbackDeskItemsFromGithub } from "@/lib/jarvis/feedback-github-sync"
 import { requireOrg } from "@/lib/org-scope"
 
 export type MyFeedbackRequest = {
@@ -15,8 +30,14 @@ export type MyFeedbackRequest = {
   readonly priority: string
   readonly title: string
   readonly description: string
+  readonly githubIssueUrl: string | null
+  readonly githubDraftPullRequestUrl: string | null
   readonly createdAt: string
   readonly updatedAt: string
+}
+
+export type MyFeedbackRequestDetail = MyFeedbackRequest & {
+  readonly timeline: readonly FeedbackTimelineEntry[]
 }
 
 type MyFeedbackRequestsResult =
@@ -26,38 +47,143 @@ type MyFeedbackRequestsResult =
     }
   | { readonly success: false; readonly error: string }
 
+type MyFeedbackRequestResult =
+  | {
+      readonly success: true
+      readonly data: MyFeedbackRequestDetail
+    }
+  | { readonly success: false; readonly error: string }
+
+type FeedbackRefreshResult =
+  | {
+      readonly success: true
+      readonly updatedCount: number
+      readonly recoveredCount: number
+      readonly checkedAt: string
+    }
+  | { readonly success: false; readonly error: string }
+
+function reporterFilter(
+  userId: string,
+  email: string,
+  googleEmail: string | null,
+) {
+  const emailMatches = googleEmail && googleEmail !== email
+    ? or(
+        sql`lower(${feedbackDeskItems.reporterEmail}) = ${email}`,
+        sql`lower(${feedbackDeskItems.reporterEmail}) = ${googleEmail}`
+      )
+    : sql`lower(${feedbackDeskItems.reporterEmail}) = ${email}`
+  return or(
+    emailMatches,
+    sql`json_extract(${feedbackDeskItems.metadata}, '$.externalActorId') = ${userId}`,
+  )
+}
+
+function normalizedUserEmails(user: Awaited<ReturnType<typeof requireAuth>>): {
+  readonly email: string
+  readonly googleEmail: string | null
+} {
+  const email = user.email.trim().toLowerCase()
+  const googleEmail = user.googleEmail?.trim().toLowerCase() ?? null
+  return { email, googleEmail }
+}
+
+const requestSelection = {
+  id: feedbackDeskItems.id,
+  kind: feedbackDeskItems.kind,
+  status: feedbackDeskItems.status,
+  priority: feedbackDeskItems.priority,
+  title: feedbackDeskItems.title,
+  description: feedbackDeskItems.description,
+  githubIssueUrl: feedbackDeskItems.githubIssueUrl,
+  githubDraftPullRequestUrl:
+    feedbackDeskItems.githubDraftPullRequestUrl,
+  createdAt: feedbackDeskItems.createdAt,
+  updatedAt: feedbackDeskItems.updatedAt,
+}
+
+async function recoverConfirmedFeedbackRequests(
+  db: ReturnType<typeof getDb>,
+  input: Readonly<{
+    userId: string
+    organizationId: string
+    reporterName: string | null
+    reporterEmail: string
+  }>,
+): Promise<number> {
+  const events = await db
+    .select({
+      id: jarvisBridgeEvents.id,
+      payload: jarvisBridgeEvents.payload,
+      createdAt: jarvisBridgeEvents.createdAt,
+    })
+    .from(jarvisBridgeEvents)
+    .where(
+      and(
+        eq(jarvisBridgeEvents.organizationId, input.organizationId),
+        eq(jarvisBridgeEvents.direction, "outbound"),
+        eq(jarvisBridgeEvents.source, "ask-jarvis"),
+        eq(jarvisBridgeEvents.eventType, "agent.prompt"),
+        sql`json_extract(${jarvisBridgeEvents.payload}, '$.user.id') = ${input.userId}`,
+      ),
+    )
+    .orderBy(desc(jarvisBridgeEvents.createdAt))
+    .limit(250)
+  const existing = await db
+    .select({ sourceId: feedbackDeskItems.sourceId })
+    .from(feedbackDeskItems)
+    .where(
+      and(
+        eq(feedbackDeskItems.organizationId, input.organizationId),
+        eq(feedbackDeskItems.source, "ask-jarvis"),
+      ),
+    )
+  const existingSourceIds = new Set(existing.map((item) => item.sourceId))
+  let recoveredCount = 0
+
+  for (const event of events) {
+    if (existingSourceIds.has(event.id)) continue
+    const report = confirmedFeedbackReportFromPayload(event.payload)
+    if (!report) continue
+    const candidate = feedbackCandidateFromReport(report)
+    await enqueueFeedbackDeskItem(db, {
+      organizationId: input.organizationId,
+      source: "ask-jarvis",
+      sourceId: event.id,
+      kind: candidate.kind,
+      title: candidate.title,
+      description: candidate.description,
+      reporterName: input.reporterName,
+      reporterEmail: input.reporterEmail,
+      metadata: {
+        externalActorId: input.userId,
+        confirmationEventId: event.id,
+        recoveredFromConfirmedPrompt: true,
+        confirmedAt: event.createdAt,
+      },
+    })
+    existingSourceIds.add(event.id)
+    recoveredCount += 1
+  }
+  return recoveredCount
+}
+
 export async function getMyFeedbackRequests(): Promise<MyFeedbackRequestsResult> {
   try {
     const user = await requireAuth()
     const organizationId = requireOrg(user)
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
-    const email = user.email.trim().toLowerCase()
-    const googleEmail = user.googleEmail?.trim().toLowerCase()
-    const reporterMatches =
-      googleEmail && googleEmail !== email
-        ? or(
-            sql`lower(${feedbackDeskItems.reporterEmail}) = ${email}`,
-            sql`lower(${feedbackDeskItems.reporterEmail}) = ${googleEmail}`
-          )
-        : sql`lower(${feedbackDeskItems.reporterEmail}) = ${email}`
+    const { email, googleEmail } = normalizedUserEmails(user)
 
     const rows = await db
-      .select({
-        id: feedbackDeskItems.id,
-        kind: feedbackDeskItems.kind,
-        status: feedbackDeskItems.status,
-        priority: feedbackDeskItems.priority,
-        title: feedbackDeskItems.title,
-        description: feedbackDeskItems.description,
-        createdAt: feedbackDeskItems.createdAt,
-        updatedAt: feedbackDeskItems.updatedAt,
-      })
+      .select(requestSelection)
       .from(feedbackDeskItems)
       .where(
         and(
           eq(feedbackDeskItems.organizationId, organizationId),
-          reporterMatches
+          reporterFilter(user.id, email, googleEmail)
         )
       )
       .orderBy(desc(feedbackDeskItems.updatedAt))
@@ -71,6 +197,108 @@ export async function getMyFeedbackRequests(): Promise<MyFeedbackRequestsResult>
         error instanceof Error
           ? error.message
           : "Failed to load your requests",
+    }
+  }
+}
+
+export async function getMyFeedbackRequest(
+  requestId: string,
+): Promise<MyFeedbackRequestResult> {
+  try {
+    const user = await requireAuth()
+    const organizationId = requireOrg(user)
+    const { email, googleEmail } = normalizedUserEmails(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const row = await db
+      .select(requestSelection)
+      .from(feedbackDeskItems)
+      .where(
+        and(
+          eq(feedbackDeskItems.id, requestId),
+          eq(feedbackDeskItems.organizationId, organizationId),
+          reporterFilter(user.id, email, googleEmail),
+        ),
+      )
+      .get()
+
+    if (!row) {
+      return { success: false, error: "Request not found" }
+    }
+
+    const events = await db
+      .select({
+        eventType: jarvisBridgeEvents.eventType,
+        payload: jarvisBridgeEvents.payload,
+        result: jarvisBridgeEvents.result,
+        createdAt: jarvisBridgeEvents.createdAt,
+        completedAt: jarvisBridgeEvents.completedAt,
+      })
+      .from(jarvisBridgeEvents)
+      .where(eq(jarvisBridgeEvents.feedbackDeskItemId, row.id))
+      .orderBy(asc(jarvisBridgeEvents.createdAt))
+
+    return {
+      success: true,
+      data: {
+        ...row,
+        timeline: feedbackTimeline(row, events),
+      },
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to load your request",
+    }
+  }
+}
+
+export async function refreshMyFeedbackRequests(): Promise<FeedbackRefreshResult> {
+  try {
+    const user = await requireAuth()
+    const organizationId = requireOrg(user)
+    const { email, googleEmail } = normalizedUserEmails(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const recoveredCount = await recoverConfirmedFeedbackRequests(db, {
+      userId: user.id,
+      organizationId,
+      reporterName: user.displayName,
+      reporterEmail: email,
+    })
+    const rows = await db
+      .select()
+      .from(feedbackDeskItems)
+      .where(
+        and(
+          eq(feedbackDeskItems.organizationId, organizationId),
+          reporterFilter(user.id, email, googleEmail),
+        ),
+      )
+      .orderBy(desc(feedbackDeskItems.updatedAt))
+      .limit(100)
+    const updatedCount = await syncFeedbackDeskItemsFromGithub(
+      db,
+      env,
+      rows,
+    )
+
+    return {
+      success: true,
+      updatedCount,
+      recoveredCount,
+      checkedAt: new Date().toISOString(),
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to refresh request status",
     }
   }
 }

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -5,6 +5,7 @@ import { sql } from "drizzle-orm"
 import { enqueueFeedbackDeskItem } from "@/lib/jarvis/feedback-desk"
 import { linkFeedbackDeskItemToGithub } from "@/lib/jarvis/feedback-github"
 import { getJarvisEnvValue } from "@/lib/jarvis/auth"
+import { getCurrentUser } from "@/lib/auth"
 
 const FEEDBACK_TYPES = ["bug", "feature", "question", "general"] as const
 
@@ -49,6 +50,16 @@ export async function POST(request: Request) {
 
   const { env, cf } = await getCloudflareContext()
   const db = getDb(env.DB)
+  const currentUser = await getCurrentUser()
+  const reporterName =
+    currentUser?.displayName ?? name?.trim() ?? null
+  const reporterEmail =
+    currentUser?.email.trim().toLowerCase() ??
+    email?.trim().toLowerCase() ??
+    null
+  const organizationId =
+    currentUser?.organizationId ??
+    getJarvisEnvValue(env, "JARVIS_BRIDGE_ORGANIZATION_ID")
 
   const ip = (cf as { request?: Request })?.request?.headers?.get("cf-connecting-ip")
     ?? request.headers.get("cf-connecting-ip")
@@ -77,8 +88,8 @@ export async function POST(request: Request) {
     id,
     type,
     message: message.trim(),
-    name: name?.trim() || null,
-    email: email?.trim() || null,
+    name: reporterName,
+    email: reporterEmail,
     pageUrl: pageUrl || null,
     userAgent: userAgent || null,
     viewportWidth: viewportWidth || null,
@@ -89,22 +100,21 @@ export async function POST(request: Request) {
 
   try {
     const item = await enqueueFeedbackDeskItem(db, {
-      organizationId: getJarvisEnvValue(
-        env,
-        "JARVIS_BRIDGE_ORGANIZATION_ID",
-      ),
+      organizationId,
       source: "feedback-widget",
       sourceId: id,
       kind: type,
       title: message.trim().slice(0, 160),
       description: message.trim(),
-      reporterName: name?.trim(),
-      reporterEmail: email?.trim(),
+      reporterName,
+      reporterEmail,
       metadata: {
         pageUrl: pageUrl ?? null,
         userAgent: userAgent ?? null,
         viewportWidth: viewportWidth ?? null,
         viewportHeight: viewportHeight ?? null,
+        externalActorId: currentUser?.id ?? null,
+        authenticatedSubmission: currentUser !== null,
         untrustedUserContent: true,
       },
     })

--- a/src/app/api/integrations/jarvis/events/[id]/search/route.ts
+++ b/src/app/api/integrations/jarvis/events/[id]/search/route.ts
@@ -21,6 +21,7 @@ import {
   currentProjectIdFromPath,
   dailyLogHref,
   feedbackRequestHref,
+  jarvisSearchQueryForConversation,
   jarvisSearchTerms,
   ownerUpdateHref,
   projectHref,
@@ -68,17 +69,20 @@ function eventPayload(value: string): Record<string, unknown> | null {
   }
 }
 
-function latestUserMessage(payload: Record<string, unknown>): string {
+function recentUserMessages(
+  payload: Record<string, unknown>
+): readonly string[] {
   const messages = payload.messages
-  if (!Array.isArray(messages)) return ""
+  if (!Array.isArray(messages)) return []
 
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
+  const userMessages: string[] = []
+  for (let index = 0; index < messages.length; index += 1) {
     const message = messages[index]
     if (!isRecord(message) || message.role !== "user") continue
     const content = recordString(message, "content")?.trim() ?? ""
-    if (content.length > 0) return content.slice(0, 2_000)
+    if (content.length > 0) userMessages.push(content.slice(0, 2_000))
   }
-  return ""
+  return userMessages.slice(-2)
 }
 
 function payloadContextValue(
@@ -174,7 +178,9 @@ export async function GET(
     )
   }
 
-  const query = latestUserMessage(payload)
+  const query = jarvisSearchQueryForConversation(
+    recentUserMessages(payload)
+  )
   if (query.length === 0) {
     return Response.json({ query: "", results: [], count: 0 })
   }

--- a/src/app/api/integrations/jarvis/feedback/[id]/status/route.ts
+++ b/src/app/api/integrations/jarvis/feedback/[id]/status/route.ts
@@ -220,7 +220,7 @@ export async function POST(
         sourceId: id,
         title: `Request update: ${feedbackStatusLabel(parsed.data.status)}`,
         body: message,
-        href: `/dashboard/requests#request-${id}`,
+        href: `/dashboard/requests/${encodeURIComponent(id)}`,
         priority:
           parsed.data.status === "needs_info" ? "high" : "normal",
         audience: "requester",

--- a/src/app/dashboard/requests/[id]/page.tsx
+++ b/src/app/dashboard/requests/[id]/page.tsx
@@ -1,0 +1,144 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import {
+  IconArrowLeft,
+  IconBrandGithub,
+  IconCircleCheck,
+  IconClock,
+  IconExternalLink,
+} from "@tabler/icons-react"
+
+import { getMyFeedbackRequest } from "@/app/actions/feedback-requests"
+import { RequestRefreshControl } from "@/app/dashboard/requests/request-refresh-control"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { feedbackStatusLabel } from "@/lib/jarvis/feedback-lifecycle"
+
+export const dynamic = "force-dynamic"
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value))
+}
+
+export default async function RequestDetailPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}) {
+  const { id } = await params
+  const result = await getMyFeedbackRequest(id)
+  if (!result.success) notFound()
+  const request = result.data
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-4 md:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/dashboard/requests">
+            <IconArrowLeft className="size-4" />
+            All requests
+          </Link>
+        </Button>
+        <RequestRefreshControl />
+      </div>
+
+      <div>
+        <div className="mb-3 flex flex-wrap gap-2">
+          <Badge variant="secondary">
+            {feedbackStatusLabel(request.status)}
+          </Badge>
+          <Badge variant="outline">{request.kind}</Badge>
+          {request.priority !== "normal" && (
+            <Badge variant="outline">{request.priority} priority</Badge>
+          )}
+        </div>
+        <h1 className="text-2xl font-semibold tracking-tight md:text-3xl">
+          {request.title}
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Submitted {formatDate(request.createdAt)} · Last updated {formatDate(request.updatedAt)}
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Original request</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="whitespace-pre-wrap text-sm leading-6">
+            {request.description}
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex-row items-center justify-between gap-4">
+          <CardTitle className="text-base">Progress</CardTitle>
+          <span className="text-xs text-muted-foreground">Live record</span>
+        </CardHeader>
+        <CardContent>
+          <ol className="space-y-0">
+            {request.timeline.map((entry, index) => {
+              const isLatest = index === request.timeline.length - 1
+              return (
+                <li key={entry.id} className="relative flex gap-4 pb-7 last:pb-0">
+                  {index < request.timeline.length - 1 && (
+                    <span className="absolute left-[9px] top-5 h-[calc(100%-0.25rem)] w-px bg-border" />
+                  )}
+                  {isLatest ? (
+                    <IconCircleCheck className="relative z-10 mt-0.5 size-5 shrink-0 bg-background text-primary" />
+                  ) : (
+                    <IconClock className="relative z-10 mt-0.5 size-5 shrink-0 bg-background text-muted-foreground" />
+                  )}
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                      <p className="font-medium">{entry.label}</p>
+                      <time className="text-xs text-muted-foreground">
+                        {formatDate(entry.occurredAt)}
+                      </time>
+                    </div>
+                    <p className="mt-1 whitespace-pre-wrap text-sm text-muted-foreground">
+                      {entry.message}
+                    </p>
+                  </div>
+                </li>
+              )
+            })}
+          </ol>
+        </CardContent>
+      </Card>
+
+      {(request.githubIssueUrl || request.githubDraftPullRequestUrl) && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Implementation record</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-wrap gap-3">
+            {request.githubIssueUrl && (
+              <Button variant="outline" size="sm" asChild>
+                <a href={request.githubIssueUrl} target="_blank" rel="noreferrer">
+                  <IconBrandGithub className="size-4" />
+                  GitHub issue
+                  <IconExternalLink className="size-3" />
+                </a>
+              </Button>
+            )}
+            {request.githubDraftPullRequestUrl && (
+              <Button variant="outline" size="sm" asChild>
+                <a href={request.githubDraftPullRequestUrl} target="_blank" rel="noreferrer">
+                  <IconBrandGithub className="size-4" />
+                  Implementation PR
+                  <IconExternalLink className="size-3" />
+                </a>
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/src/app/dashboard/requests/page.tsx
+++ b/src/app/dashboard/requests/page.tsx
@@ -1,8 +1,11 @@
+import Link from "next/link"
 import {
+  IconArrowRight,
   IconMessageCircleQuestion,
 } from "@tabler/icons-react"
 
 import { getMyFeedbackRequests } from "@/app/actions/feedback-requests"
+import { RequestRefreshControl } from "@/app/dashboard/requests/request-refresh-control"
 import { Badge } from "@/components/ui/badge"
 import {
   Card,
@@ -12,6 +15,8 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { feedbackStatusLabel } from "@/lib/jarvis/feedback-lifecycle"
+
+export const dynamic = "force-dynamic"
 
 function formatDate(value: string): string {
   return new Intl.DateTimeFormat("en-US", {
@@ -26,17 +31,19 @@ export default async function RequestsPage() {
 
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-4 md:p-6">
-      <div>
-        <p className="text-sm font-medium text-primary">
-          Compass Feedback Desk
-        </p>
-        <h1 className="text-2xl font-semibold tracking-tight">
-          My requests
-        </h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Follow feature requests and problem reports from receipt
-          through deployment.
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-primary">
+            Compass Feedback Desk
+          </p>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            My requests
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Follow each request from receipt through implementation.
+          </p>
+        </div>
+        <RequestRefreshControl />
       </div>
 
       {!result.success && (
@@ -55,44 +62,53 @@ export default async function RequestsPage() {
             <div>
               <p className="font-medium">No requests yet</p>
               <p className="text-sm text-muted-foreground">
-                Requests submitted through Ask Jarvis or Compass
-                Feedback will appear here.
+                Requests submitted through Ask Jarvis or Compass Feedback
+                will appear here.
               </p>
             </div>
           </CardContent>
         </Card>
       )}
 
-      <div className="grid gap-4">
+      <div className="grid gap-3">
         {requests.map((request) => (
-          <Card key={request.id} id={`request-${request.id}`}>
-            <CardHeader className="gap-3">
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <CardTitle className="text-base">
-                    {request.title}
-                  </CardTitle>
-                  <CardDescription className="mt-1">
-                    Submitted {formatDate(request.createdAt)}
-                  </CardDescription>
+          <Link
+            key={request.id}
+            href={`/dashboard/requests/${encodeURIComponent(request.id)}`}
+            className="group rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <Card className="transition-colors group-hover:border-primary/45 group-hover:bg-muted/20">
+              <CardHeader className="gap-3">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <CardTitle className="text-base">
+                      {request.title}
+                    </CardTitle>
+                    <CardDescription className="mt-1">
+                      Submitted {formatDate(request.createdAt)}
+                    </CardDescription>
+                  </div>
+                  <IconArrowRight className="mt-1 size-5 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground" />
                 </div>
-                <div className="flex flex-wrap gap-2">
-                  <Badge variant="secondary">
-                    {feedbackStatusLabel(request.status)}
-                  </Badge>
-                  <Badge variant="outline">{request.kind}</Badge>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <p className="line-clamp-2 whitespace-pre-wrap text-sm text-muted-foreground">
+                  {request.description}
+                </p>
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="flex flex-wrap gap-2">
+                    <Badge variant="secondary">
+                      {feedbackStatusLabel(request.status)}
+                    </Badge>
+                    <Badge variant="outline">{request.kind}</Badge>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Updated {formatDate(request.updatedAt)}
+                  </p>
                 </div>
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              <p className="whitespace-pre-wrap text-sm text-muted-foreground">
-                {request.description}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                Last updated {formatDate(request.updatedAt)}
-              </p>
-            </CardContent>
-          </Card>
+              </CardContent>
+            </Card>
+          </Link>
         ))}
       </div>
     </div>

--- a/src/app/dashboard/requests/request-refresh-control.tsx
+++ b/src/app/dashboard/requests/request-refresh-control.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { IconRefresh } from "@tabler/icons-react"
+
+import { refreshMyFeedbackRequests } from "@/app/actions/feedback-requests"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+const REFRESH_INTERVAL_MILLISECONDS = 60_000
+
+export function RequestRefreshControl() {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [lastCheckedAt, setLastCheckedAt] = useState<Date | null>(null)
+  const lastRefreshStartedAt = useRef(0)
+
+  const refresh = useCallback(() => {
+    const now = Date.now()
+    if (now - lastRefreshStartedAt.current < 5_000) return
+    lastRefreshStartedAt.current = now
+    startTransition(async () => {
+      const result = await refreshMyFeedbackRequests()
+      if (result.success) {
+        setLastCheckedAt(new Date(result.checkedAt))
+        router.refresh()
+      }
+    })
+  }, [router])
+
+  useEffect(() => {
+    refresh()
+    const interval = window.setInterval(() => {
+      if (document.visibilityState === "visible") refresh()
+    }, REFRESH_INTERVAL_MILLISECONDS)
+    const handleFocus = () => refresh()
+    window.addEventListener("focus", handleFocus)
+    return () => {
+      window.clearInterval(interval)
+      window.removeEventListener("focus", handleFocus)
+    }
+  }, [refresh])
+
+  return (
+    <div className="flex items-center gap-3">
+      <p className="hidden text-xs text-muted-foreground sm:block">
+        {lastCheckedAt
+          ? `Checked ${lastCheckedAt.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`
+          : "Updates every minute"}
+      </p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={refresh}
+        disabled={isPending}
+      >
+        <IconRefresh className={cn("size-4", isPending && "animate-spin")} />
+        {isPending ? "Checking" : "Refresh status"}
+      </Button>
+    </div>
+  )
+}

--- a/src/lib/jarvis/__tests__/feedback-timeline.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-timeline.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+
+import { feedbackStatusFromGithub } from "@/lib/jarvis/feedback-github-sync"
+import { feedbackTimeline } from "@/lib/jarvis/feedback-timeline"
+import {
+  confirmedFeedbackReportFromPayload,
+  feedbackCandidateFromReport,
+} from "@/lib/jarvis/feedback-confirmation"
+
+describe("feedback request lifecycle", () => {
+  it("maps GitHub Project workflow stages to requester-facing statuses", () => {
+    expect(feedbackStatusFromGithub("Backlog", "OPEN")).toBe("triaged")
+    expect(feedbackStatusFromGithub("Ready", "OPEN")).toBe("planned")
+    expect(feedbackStatusFromGithub("In Progress", "OPEN")).toBe("in_progress")
+    expect(feedbackStatusFromGithub("In Review", "OPEN")).toBe("testing")
+    expect(feedbackStatusFromGithub("Done", "CLOSED")).toBe("deployed")
+    expect(feedbackStatusFromGithub(null, "CLOSED")).toBe("closed")
+  })
+
+  it("builds a request history from durable lifecycle events", () => {
+    const timeline = feedbackTimeline(
+      {
+        title: "Make requests interactive",
+        status: "in_progress",
+        createdAt: "2026-07-31T12:00:00.000Z",
+      },
+      [
+        {
+          eventType: "feedback.status_changed",
+          payload: JSON.stringify({ status: "new" }),
+          result: null,
+          createdAt: "2026-07-31T12:00:01.000Z",
+          completedAt: null,
+        },
+        {
+          eventType: "feedback.status_updated",
+          payload: "{}",
+          result: JSON.stringify({
+            status: "in_progress",
+            message: "Development started.",
+            updatedAt: "2026-07-31T13:00:00.000Z",
+          }),
+          createdAt: "2026-07-31T13:00:00.000Z",
+          completedAt: "2026-07-31T13:00:00.000Z",
+        },
+      ],
+    )
+
+    expect(timeline).toHaveLength(2)
+    expect(timeline[0]?.label).toBe("Submitted")
+    expect(timeline[1]).toMatchObject({
+      label: "In progress",
+      message: "Development started.",
+    })
+  })
+
+  it("recovers only explicitly confirmed Ask Jarvis requests", () => {
+    const report = "The request list is broken and should update regularly."
+    const payload = JSON.stringify({
+      messages: [
+        { role: "user", content: report },
+        {
+          role: "assistant",
+          content: "Would you like me to file both requests?",
+        },
+        { role: "user", content: "Yes, please." },
+      ],
+    })
+    expect(confirmedFeedbackReportFromPayload(payload)).toBe(report)
+    expect(feedbackCandidateFromReport(report)).toMatchObject({
+      kind: "bug",
+      description: report,
+    })
+
+    const unconfirmed = JSON.stringify({
+      messages: [
+        { role: "user", content: report },
+        { role: "assistant", content: "Here is how that works." },
+        { role: "user", content: "Thanks." },
+      ],
+    })
+    expect(confirmedFeedbackReportFromPayload(unconfirmed)).toBeNull()
+  })
+})

--- a/src/lib/jarvis/__tests__/search.test.ts
+++ b/src/lib/jarvis/__tests__/search.test.ts
@@ -5,6 +5,7 @@ import {
   currentProjectIdFromPath,
   dailyLogHref,
   feedbackRequestHref,
+  jarvisSearchQueryForConversation,
   jarvisSearchTerms,
   ownerUpdateHref,
   projectIdsForJarvisSearch,
@@ -73,6 +74,11 @@ describe("Jarvis Compass search", () => {
         "I think you can now provide some links to locations in Compass now."
       )
     ).toEqual([])
+    expect(
+      jarvisSearchTerms(
+        "Do you have any updates on the status of my requests through Compass?"
+      )
+    ).toEqual([])
   })
 
   it("narrows explicit record-type requests", () => {
@@ -89,6 +95,28 @@ describe("Jarvis Compass search", () => {
     expect(
       requestedJarvisSearchKinds("Verify the status of my feedback request")
     ).toEqual(["feedback_request"])
+    expect(
+      requestedJarvisSearchKinds(
+        "Do you have any updates on the status of my requests through Compass?"
+      )
+    ).toEqual(["feedback_request"])
+  })
+
+  it("keeps verified request-status scope for an immediate retry", () => {
+    expect(
+      jarvisSearchQueryForConversation([
+        "Do you have any updates on the status of my requests through Compass?",
+        "Check again please.",
+      ])
+    ).toBe(
+      "Do you have any updates on the status of my requests through Compass?"
+    )
+    expect(
+      jarvisSearchQueryForConversation([
+        "Show the open Loomis RFIs.",
+        "Check again please.",
+      ])
+    ).toBe("Check again please.")
   })
 
   it("builds encoded live Compass links", () => {

--- a/src/lib/jarvis/__tests__/search.test.ts
+++ b/src/lib/jarvis/__tests__/search.test.ts
@@ -105,7 +105,7 @@ describe("Jarvis Compass search", () => {
       "/dashboard/projects/proj%20one/rfis?status=all#rfi-rfi%20one"
     )
     expect(feedbackRequestHref("request one")).toBe(
-      "/dashboard/requests#request-request%20one"
+      "/dashboard/requests/request%20one"
     )
   })
 })

--- a/src/lib/jarvis/feedback-confirmation.ts
+++ b/src/lib/jarvis/feedback-confirmation.ts
@@ -1,0 +1,117 @@
+import type { FeedbackDeskKind } from "@/lib/jarvis/feedback-desk"
+
+type ConversationMessage = Readonly<{
+  role: "user" | "assistant"
+  content: string
+}>
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? Object.fromEntries(Object.entries(value))
+    : null
+}
+
+function conversationFromPayload(payload: string): readonly ConversationMessage[] {
+  try {
+    const parsed: unknown = JSON.parse(payload)
+    const messages = objectValue(parsed)?.messages
+    if (!Array.isArray(messages)) return []
+    const conversation: ConversationMessage[] = []
+    for (const value of messages) {
+      const message = objectValue(value)
+      const role = message?.role
+      const content = message?.content
+      if (
+        (role === "user" || role === "assistant") &&
+        typeof content === "string" &&
+        content.trim().length > 0
+      ) {
+        conversation.push({ role, content: content.trim() })
+      }
+    }
+    return conversation
+  } catch {
+    return []
+  }
+}
+
+export function explicitlyRequestsCompassFeedback(message: string): boolean {
+  const value = message.toLowerCase()
+  return [
+    /\b(?:bug|issue|problem|broken)\b/,
+    /\b(?:fails?|failed|error)\s+(?:to|when|while|message)\b/,
+    /\b(?:unable to|can['’]?t|cannot)\s+(?:upload|create|open|save|send|edit|delete|view|see|use|submit)\b/,
+    /\b(?:not working|doesn['’]?t work|isn['’]?t working)\b/,
+    /\b(?:incorrect|incomplete|missing|empty)\b/,
+    /\b(?:feature request|enhancement|feedback|suggestion|suggest)\b/,
+    /(?:^|[.!?]\s+)(?:please\s+|also\s+)?(?:add|fix|improve|remove|rename)\b/,
+    /\b(?:i|we)\s+(?:want|need|would like)\b/,
+    /\bshould\s+(?:be|have|show|allow|include|use|work)\b/,
+    /\b(?:can|could|would)\s+you\s+(?:add|change|fix|improve|remove|rename|update)\b/,
+  ].some((pattern) => pattern.test(value))
+}
+
+export function askedToFileFeedback(message: string): boolean {
+  const value = message.toLowerCase().replace(/\s+/g, " ")
+  const asksToFile =
+    /\b(?:would|do) you (?:like|want) me to (?:file|submit|report|record)\b/.test(value) ||
+    /\bshould i (?:file|submit|report|record)\b/.test(value) ||
+    /\b(?:file|submit|report|record) (?:this|it|that|both|these|the request|the requests)\b/.test(value)
+  return asksToFile &&
+    ["feedback", "request", "issue", "bug", "file"].some((word) =>
+      value.includes(word),
+    )
+}
+
+function confirmsFiling(message: string): boolean {
+  const value = message.trim().toLowerCase()
+  const shortConfirmation = /^(?:(?:yes|yep|yeah)(?:,\s*please)?(?:,?\s+(?:file|submit|report)\s+it)?|please\s+do|go\s+ahead|file\s+it|submit\s+it|report\s+it|do\s+it)[.!]?$/.test(value)
+  const explicitConfirmation =
+    /^(?:yes|yep|yeah|please\s+do|go\s+ahead|file|submit|report|do\s+it)\b/.test(value) &&
+    (/\b(?:file|submit|report|record)\b/.test(value) || value.includes("feedback desk"))
+  return shortConfirmation || explicitConfirmation
+}
+
+export function confirmedFeedbackReportFromPayload(payload: string): string | null {
+  const conversation = conversationFromPayload(payload)
+  if (conversation.length < 3) return null
+  const latest = conversation.at(-1)
+  const previous = conversation.at(-2)
+  const report = conversation.at(-3)
+  if (
+    latest?.role !== "user" ||
+    previous?.role !== "assistant" ||
+    report?.role !== "user" ||
+    !confirmsFiling(latest.content) ||
+    !askedToFileFeedback(previous.content) ||
+    !explicitlyRequestsCompassFeedback(report.content)
+  ) {
+    return null
+  }
+  return report.content
+}
+
+export function feedbackCandidateFromReport(report: string): Readonly<{
+  kind: FeedbackDeskKind
+  title: string
+  description: string
+}> {
+  const normalized = report.replace(/\s+/g, " ").trim()
+  const lowered = normalized.toLowerCase()
+  let kind: FeedbackDeskKind = "general"
+  if (/\b(?:bug|issue|problem|broken|error|fails?|failed|unable to|not working|doesn['’]?t work|isn['’]?t working|incorrect|incomplete|missing|empty)\b/.test(lowered)) {
+    kind = "bug"
+  } else if (/\b(?:feature request|enhancement|would like|please add|should (?:be|have|show|allow|include|use))\b/.test(lowered)) {
+    kind = "feature"
+  } else if (normalized.endsWith("?")) {
+    kind = "question"
+  }
+  return {
+    kind,
+    title:
+      normalized.length > 160
+        ? `${normalized.slice(0, 157).trimEnd()}...`
+        : normalized,
+    description: report.trim(),
+  }
+}

--- a/src/lib/jarvis/feedback-github-sync.ts
+++ b/src/lib/jarvis/feedback-github-sync.ts
@@ -1,0 +1,228 @@
+import { eq } from "drizzle-orm"
+
+import type { getDb } from "@/db"
+import { feedbackDeskItems, jarvisBridgeEvents, type FeedbackDeskItem } from "@/db/schema-jarvis"
+import { getJarvisEnvValue } from "@/lib/jarvis/auth"
+import {
+  GITHUB_FEEDBACK_PROJECT_TITLE,
+  feedbackReference,
+} from "@/lib/jarvis/feedback-github-content"
+import { feedbackStatusLabel, type FeedbackDeskStatus } from "@/lib/jarvis/feedback-lifecycle"
+
+type CompassDb = ReturnType<typeof getDb>
+type GithubProjectState = Readonly<{
+  issueNodeId: string
+  issueTitle: string
+  issueUrl: string
+  issueState: string
+  projectStatus: string | null
+}>
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? Object.fromEntries(Object.entries(value))
+    : null
+}
+
+function stringValue(record: Record<string, unknown> | null, key: string): string | null {
+  const value = record?.[key]
+  return typeof value === "string" ? value : null
+}
+
+function projectStatusFromFieldValues(value: unknown): string | null {
+  const nodes = objectValue(value)?.nodes
+  if (!Array.isArray(nodes)) return null
+  for (const node of nodes) {
+    const fieldValue = objectValue(node)
+    const field = objectValue(fieldValue?.field)
+    if (stringValue(field, "name")?.toLowerCase() === "status") {
+      return stringValue(fieldValue, "name")
+    }
+  }
+  return null
+}
+
+function projectStatesFromGraphql(value: unknown): readonly GithubProjectState[] {
+  const data = objectValue(objectValue(value)?.data)
+  const project = objectValue(data?.node)
+  const nodes = objectValue(project?.items)?.nodes
+  if (!Array.isArray(nodes)) return []
+  const results: GithubProjectState[] = []
+  for (const node of nodes) {
+    const projectItem = objectValue(node)
+    const content = objectValue(projectItem?.content)
+    const issueNodeId = stringValue(content, "id")
+    const issueTitle = stringValue(content, "title")
+    const issueUrl = stringValue(content, "url")
+    if (!issueNodeId || !issueTitle || !issueUrl) continue
+    results.push({
+      issueNodeId,
+      issueTitle,
+      issueUrl,
+      issueState: stringValue(content, "state") ?? "OPEN",
+      projectStatus: projectStatusFromFieldValues(projectItem?.fieldValues),
+    })
+  }
+  return results
+}
+
+export function feedbackStatusFromGithub(
+  projectStatus: string | null,
+  issueState: string,
+): FeedbackDeskStatus | null {
+  const status = projectStatus?.trim().toLowerCase() ?? ""
+  if (/(cancel|won't do|wont do|duplicate)/.test(status)) return "closed"
+  if (/(done|complete|deployed|released)/.test(status)) return "deployed"
+  if (/(test|review|verify|qa)/.test(status)) return "testing"
+  if (/(progress|develop|working)/.test(status)) return "in_progress"
+  if (/(ready|planned|scheduled|accepted)/.test(status)) return "planned"
+  if (/(triage|backlog)/.test(status)) return "triaged"
+  if (issueState.toUpperCase() === "CLOSED") return "closed"
+  return status.length > 0 ? "triaged" : null
+}
+
+async function githubProjectStates(env: CloudflareEnv): Promise<readonly GithubProjectState[]> {
+  const token = getJarvisEnvValue(env, "GITHUB_TOKEN")
+  const configuredProjectId = getJarvisEnvValue(env, "GITHUB_FEEDBACK_PROJECT_ID")
+  const repo = getJarvisEnvValue(env, "GITHUB_REPO")
+  if (!token) return []
+  try {
+    let projectId = configuredProjectId
+    if (!projectId && repo) {
+      const owner = repo.split("/")[0] ?? ""
+      const lookupResponse = await fetch("https://api.github.com/graphql", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+          "Content-Type": "application/json",
+          "User-Agent": "compass-feedback-desk",
+        },
+        body: JSON.stringify({
+          query: `query FeedbackProjectLookup($owner: String!) {
+            organization(login: $owner) {
+              projectsV2(first: 100) { nodes { id title } }
+            }
+          }`,
+          variables: { owner },
+        }),
+      })
+      if (lookupResponse.ok) {
+        const lookup = objectValue(await lookupResponse.json())
+        const data = objectValue(lookup?.data)
+        const organization = objectValue(data?.organization)
+        const projects = objectValue(organization?.projectsV2)?.nodes
+        if (Array.isArray(projects)) {
+          const matchingProject = projects.find((value) => {
+            const project = objectValue(value)
+            return stringValue(project, "title") === GITHUB_FEEDBACK_PROJECT_TITLE
+          })
+          projectId = stringValue(objectValue(matchingProject), "id")
+        }
+      }
+    }
+    if (!projectId) return []
+    const response = await fetch("https://api.github.com/graphql", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+        "User-Agent": "compass-feedback-desk",
+      },
+      body: JSON.stringify({
+        query: `query FeedbackProjectStatuses($projectId: ID!) {
+          node(id: $projectId) {
+            ... on ProjectV2 {
+              items(first: 100) {
+                nodes {
+                  content { ... on Issue { id title url state } }
+                  fieldValues(first: 20) {
+                    nodes {
+                      ... on ProjectV2ItemFieldSingleSelectValue {
+                        name
+                        field { ... on ProjectV2FieldCommon { name } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }`,
+        variables: { projectId },
+      }),
+    })
+    if (!response.ok) return []
+    return projectStatesFromGraphql(await response.json())
+  } catch {
+    return []
+  }
+}
+
+export async function syncFeedbackDeskItemsFromGithub(
+  db: CompassDb,
+  env: CloudflareEnv,
+  items: readonly FeedbackDeskItem[],
+): Promise<number> {
+  const states = await githubProjectStates(env)
+  if (states.length === 0) return 0
+  const stateByIssue = new Map(states.map((state) => [state.issueNodeId, state]))
+  let updatedCount = 0
+
+  for (const item of items) {
+    const reference = feedbackReference(item.id)
+    const referenceMatches = states.filter((state) =>
+      state.issueTitle.includes(reference),
+    )
+    const state = item.githubIssueNodeId
+      ? stateByIssue.get(item.githubIssueNodeId)
+      : referenceMatches.length === 1
+        ? referenceMatches[0]
+        : undefined
+    if (!state) continue
+    const nextStatus = feedbackStatusFromGithub(state.projectStatus, state.issueState)
+    const needsLink = item.githubIssueNodeId === null
+    const needsStatus = nextStatus !== null && nextStatus !== item.status
+    if (!needsLink && !needsStatus) continue
+
+    const now = new Date().toISOString()
+    const message = state.projectStatus
+      ? `The Feedback Desk moved this request to ${state.projectStatus}.`
+      : `The linked GitHub issue is now ${state.issueState.toLowerCase()}.`
+    await db.update(feedbackDeskItems).set({
+      status: nextStatus ?? item.status,
+      githubIssueNodeId: state.issueNodeId,
+      githubIssueUrl: state.issueUrl,
+      updatedAt: now,
+    })
+      .where(eq(feedbackDeskItems.id, item.id))
+    if (needsStatus && nextStatus) await db.insert(jarvisBridgeEvents).values({
+      id: crypto.randomUUID(),
+      organizationId: item.organizationId,
+      direction: "inbound",
+      source: "github",
+      eventType: "feedback.status_updated",
+      status: "completed",
+      idempotencyKey: `github-status:${item.id}:${nextStatus}:${state.projectStatus ?? state.issueState}`,
+      feedbackDeskItemId: item.id,
+      payload: JSON.stringify({
+        source: "github-project",
+        projectStatus: state.projectStatus,
+        issueState: state.issueState,
+      }),
+      result: JSON.stringify({
+        status: nextStatus,
+        label: feedbackStatusLabel(nextStatus),
+        message,
+        updatedAt: now,
+      }),
+      availableAt: now,
+      completedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoNothing()
+    updatedCount += 1
+  }
+  return updatedCount
+}

--- a/src/lib/jarvis/feedback-timeline.ts
+++ b/src/lib/jarvis/feedback-timeline.ts
@@ -1,0 +1,84 @@
+import { feedbackStatusLabel } from "@/lib/jarvis/feedback-lifecycle"
+
+type FeedbackTimelineItem = Readonly<{
+  status: string
+  title: string
+  createdAt: string
+}>
+
+type FeedbackTimelineEvent = Readonly<{
+  eventType: string
+  payload: string
+  result: string | null
+  createdAt: string
+  completedAt: string | null
+}>
+
+export type FeedbackTimelineEntry = Readonly<{
+  id: string
+  status: string
+  label: string
+  message: string
+  occurredAt: string
+}>
+
+function recordFromJson(value: string | null): Record<string, unknown> | null {
+  if (!value) return null
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return typeof parsed === "object" && parsed !== null
+      ? Object.fromEntries(Object.entries(parsed))
+      : null
+  } catch {
+    return null
+  }
+}
+
+function recordString(
+  record: Record<string, unknown> | null,
+  key: string,
+): string | null {
+  const value = record?.[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null
+}
+
+export function feedbackTimeline(
+  item: FeedbackTimelineItem,
+  events: readonly FeedbackTimelineEvent[],
+): readonly FeedbackTimelineEntry[] {
+  const entries: FeedbackTimelineEntry[] = [
+    {
+      id: `submitted:${item.createdAt}`,
+      status: "new",
+      label: "Submitted",
+      message: `“${item.title}” was received by the Compass Feedback Desk.`,
+      occurredAt: item.createdAt,
+    },
+  ]
+
+  for (const event of events) {
+    if (event.eventType !== "feedback.status_updated") continue
+    const data = recordFromJson(event.result) ?? recordFromJson(event.payload)
+    const status = recordString(data, "status")
+    if (!status) continue
+    const message =
+      recordString(data, "message") ??
+      `Request status changed to ${feedbackStatusLabel(status)}.`
+    const occurredAt =
+      recordString(data, "updatedAt") ??
+      event.completedAt ??
+      event.createdAt
+
+    entries.push({
+      id: `${event.eventType}:${occurredAt}:${status}`,
+      status,
+      label: feedbackStatusLabel(status),
+      message,
+      occurredAt,
+    })
+  }
+
+  return entries
+}

--- a/src/lib/jarvis/search.ts
+++ b/src/lib/jarvis/search.ts
@@ -17,6 +17,7 @@ export type JarvisSearchProject = {
 const GENERIC_SEARCH_WORDS: readonly string[] = [
   "about",
   "anything",
+  "any",
   "can",
   "capabilities",
   "changed",
@@ -26,6 +27,7 @@ const GENERIC_SEARCH_WORDS: readonly string[] = [
   "for",
   "from",
   "give",
+  "have",
   "latest",
   "link",
   "links",
@@ -50,8 +52,10 @@ const GENERIC_SEARCH_WORDS: readonly string[] = [
   "some",
   "tell",
   "that",
+  "the",
   "think",
   "this",
+  "through",
   "update",
   "updates",
   "what",
@@ -154,7 +158,9 @@ export function requestedJarvisSearchKinds(
 ): readonly JarvisCompassSearchKind[] {
   const value = normalized(query)
   if (
-    /\b(feedback|request|submission|report|bug|feature)\b/.test(value) &&
+    /\b(feedback|requests?|submissions?|reports?|bugs?|features?)\b/.test(
+      value
+    ) &&
     /\b(status|progress|triag|implement|deploy|verify|received|submitted)\w*\b/.test(
       value,
     )
@@ -165,6 +171,25 @@ export function requestedJarvisSearchKinds(
   if (value.includes("owner update")) return ["owner_update"]
   if (value.includes("daily log")) return ["daily_log"]
   return ["daily_log", "owner_update", "rfi"]
+}
+
+function isJarvisSearchRetry(query: string): boolean {
+  const value = normalized(query).replace(/[.!?]+$/, "")
+  return /^(?:please\s+)?(?:check|look|try)(?:\s+(?:it|that))?\s+again(?:\s+please)?$/.test(
+    value
+  )
+}
+
+export function jarvisSearchQueryForConversation(
+  userMessages: readonly string[]
+): string {
+  const latest = userMessages.at(-1)?.trim() ?? ""
+  if (!isJarvisSearchRetry(latest)) return latest
+
+  const previous = userMessages.at(-2)?.trim() ?? ""
+  return requestedJarvisSearchKinds(previous).includes("feedback_request")
+    ? previous
+    : latest
 }
 
 export function projectHref(projectId: string): string {

--- a/src/lib/jarvis/search.ts
+++ b/src/lib/jarvis/search.ts
@@ -200,5 +200,5 @@ export function rfiHref(projectId: string, rfiId: string): string {
 }
 
 export function feedbackRequestHref(requestId: string): string {
-  return `/dashboard/requests#request-${encodeURIComponent(requestId)}`
+  return `/dashboard/requests/${encodeURIComponent(requestId)}`
 }


### PR DESCRIPTION
## Summary
- turn My Requests into a live, clickable request tracker with one-minute refresh
- add request detail pages with durable lifecycle timelines and implementation links
- recover previously confirmed Ask Jarvis submissions that were not recorded
- synchronize linked GitHub Project status back into Compass
- preserve authenticated feedback identity even when optional contact fields are blank

## Verification
- `bun test src/lib/__tests__/ui-theme-discipline.test.ts src/lib/jarvis/__tests__/feedback-timeline.test.ts src/lib/jarvis/__tests__/search.test.ts`
- `python3 -m unittest scripts/test_jarvis_agent_poller.py`
- `bunx tsc --noEmit`
- `bun lint` (0 errors; existing warnings only)
- `bun run build`
