### PR TITLE
feat(change-orders): add cost lines and schedule impact

### DIFF
--- a/drizzle/0086_change_order_cost_lines.sql
+++ b/drizzle/0086_change_order_cost_lines.sql
@@ -1,0 +1,26 @@
+ALTER TABLE `project_change_orders`
+  ADD `schedule_impact_days` integer;
+--> statement-breakpoint
+CREATE TABLE `project_change_order_lines` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_id` text NOT NULL,
+  `change_order_id` text NOT NULL,
+  `line_number` integer NOT NULL,
+  `description` text NOT NULL,
+  `phase_code` text,
+  `cost_code` text,
+  `amount_cents` integer,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`change_order_id`) REFERENCES `project_change_orders`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `project_change_order_lines_order_uq`
+  ON `project_change_order_lines` (`change_order_id`, `line_number`);
+--> statement-breakpoint
+CREATE INDEX `project_change_order_lines_project_idx`
+  ON `project_change_order_lines` (`project_id`);
+--> statement-breakpoint
+CREATE INDEX `project_change_order_lines_cost_code_idx`
+  ON `project_change_order_lines` (`project_id`, `cost_code`);

--- a/src/app/actions/project-change-orders.ts
+++ b/src/app/actions/project-change-orders.ts
@@ -5,12 +5,22 @@ import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
 import {
+  projectBudgetLines,
   projectChangeOrderDocuments,
   projectChangeOrderHistory,
+  projectChangeOrderLines,
   projectChangeOrders,
+  projectContacts,
   projectMembers,
+  sageCostCodes,
 } from "@/db/schema"
 import { requireAuth, type AuthUser } from "@/lib/auth"
+import {
+  changeOrderCostLinesTotalCents,
+  cleanChangeOrderCostLines,
+  cleanScheduleImpactDays,
+  type ChangeOrderCostLineInput,
+} from "@/lib/change-orders/cost-lines"
 import {
   allowedChangeOrderTransitions,
   canEditChangeOrderContent,
@@ -40,6 +50,30 @@ export type ChangeOrderDocumentInput = {
   readonly notes: string | null
 }
 
+export type ProjectChangeOrderPhaseOption = {
+  readonly value: string
+  readonly label: string
+}
+
+export type ProjectChangeOrderCostCodeOption = {
+  readonly value: string
+  readonly label: string
+  readonly description: string
+  readonly divisionCode: string
+}
+
+export type ProjectChangeOrderCompanyOption = {
+  readonly value: string
+  readonly label: string
+  readonly description: string
+}
+
+export type ProjectChangeOrderFormOptions = {
+  readonly phases: readonly ProjectChangeOrderPhaseOption[]
+  readonly costCodes: readonly ProjectChangeOrderCostCodeOption[]
+  readonly companies: readonly ProjectChangeOrderCompanyOption[]
+}
+
 export type ProjectChangeOrderItem = {
   readonly id: string
   readonly projectId: string
@@ -48,6 +82,7 @@ export type ProjectChangeOrderItem = {
   readonly scope: string
   readonly reason: string | null
   readonly amountCents: number | null
+  readonly scheduleImpactDays: number | null
   readonly status: ChangeOrderStatus
   readonly audience: ChangeOrderAudience
   readonly requesterType: ChangeOrderRequesterType
@@ -66,6 +101,14 @@ export type ProjectChangeOrderItem = {
   readonly canEdit: boolean
   readonly canApprove: boolean
   readonly allowedTransitions: readonly ChangeOrderStatus[]
+  readonly lines: readonly {
+    readonly id: string
+    readonly lineNumber: number
+    readonly description: string
+    readonly phaseCode: string | null
+    readonly costCode: string | null
+    readonly amountCents: number | null
+  }[]
   readonly documents: readonly {
     readonly id: string
     readonly label: string
@@ -88,7 +131,8 @@ export type CreateProjectChangeOrderInput = {
   readonly title: string
   readonly scope: string
   readonly reason: string | null
-  readonly amountCents: number | null
+  readonly scheduleImpactDays: number | null
+  readonly lines: readonly ChangeOrderCostLineInput[]
   readonly audience: ChangeOrderAudience
   readonly requesterCompany: string | null
   readonly sourceRecordId: string | null
@@ -101,7 +145,8 @@ export type UpdateProjectChangeOrderInput = {
   readonly title: string
   readonly scope: string
   readonly reason: string | null
-  readonly amountCents: number | null
+  readonly scheduleImpactDays: number | null
+  readonly lines: readonly ChangeOrderCostLineInput[]
   readonly audience: ChangeOrderAudience
   readonly internalNotes: string | null
   readonly status: ChangeOrderStatus
@@ -153,16 +198,6 @@ function cleanLimitedText(
 
 function validAudience(value: string): value is ChangeOrderAudience {
   return ["internal", "owner", "sub_vendor"].includes(value)
-}
-
-function cleanAmountCents(value: number | null): number | null {
-  if (value === null) return null
-  if (!Number.isFinite(value)) throw new Error("Requested amount is invalid")
-  const cents = Math.round(value)
-  if (!Number.isSafeInteger(cents) || Math.abs(cents) > 1_000_000_000_000) {
-    throw new Error("Requested amount is outside the supported range")
-  }
-  return cents
 }
 
 function safeDocumentUrl(value: string): string {
@@ -280,6 +315,7 @@ function actorName(user: AuthUser): string {
 function viewModel(
   row: typeof projectChangeOrders.$inferSelect,
   context: ChangeOrderContext,
+  lines: ProjectChangeOrderItem["lines"],
   documents: ProjectChangeOrderItem["documents"],
   history: ProjectChangeOrderItem["history"]
 ): ProjectChangeOrderItem | null {
@@ -326,6 +362,7 @@ function viewModel(
     scope: row.scope,
     reason: row.reason,
     amountCents: row.amountCents,
+    scheduleImpactDays: row.scheduleImpactDays,
     status,
     audience: row.audience,
     requesterType,
@@ -344,6 +381,7 @@ function viewModel(
     canEdit,
     canApprove,
     allowedTransitions: transitions.filter((status) => status !== "synced"),
+    lines,
     documents,
     history,
   }
@@ -363,7 +401,7 @@ export async function getProjectChangeOrders(
 
   return rows
     .filter((row) => canExternalViewerSee(row, context))
-    .map((row) => viewModel(row, context, [], []))
+    .map((row) => viewModel(row, context, [], [], []))
     .filter((row): row is ProjectChangeOrderItem => row !== null)
 }
 
@@ -382,6 +420,110 @@ export async function getProjectChangeOrderCapabilities(
   return {
     canCreate: createAllowed && context.requesterType !== null,
     requesterType: context.requesterType,
+  }
+}
+
+export async function getProjectChangeOrderFormOptions(
+  projectId: string,
+  viewAsAudience?: ProjectAudience
+): Promise<ProjectChangeOrderFormOptions> {
+  const authorizedContext = await changeOrderContext(projectId, "read")
+  const context = audiencePreviewContext(authorizedContext, viewAsAudience)
+  if (!context.internal) {
+    return { phases: [], costCodes: [], companies: [] }
+  }
+  const [sageRows, budgetRows, contactRows] = await Promise.all([
+    context.db
+      .select({
+        code: sageCostCodes.code,
+        description: sageCostCodes.description,
+        displayLabel: sageCostCodes.displayLabel,
+        divisionCode: sageCostCodes.divisionCode,
+        divisionDisplayLabel: sageCostCodes.divisionDisplayLabel,
+      })
+      .from(sageCostCodes)
+      .where(eq(sageCostCodes.active, true))
+      .orderBy(asc(sageCostCodes.divisionCode), asc(sageCostCodes.displayLabel)),
+    context.db
+      .select({
+        costCode: projectBudgetLines.costCode,
+        description: projectBudgetLines.description,
+        divisionCode: projectBudgetLines.csiDivision,
+        divisionName: projectBudgetLines.csiDivisionName,
+      })
+      .from(projectBudgetLines)
+      .where(eq(projectBudgetLines.projectId, projectId))
+      .orderBy(
+        asc(projectBudgetLines.csiDivision),
+        asc(projectBudgetLines.costCode)
+      ),
+    context.db
+      .select({
+        displayName: projectContacts.displayName,
+        companyName: projectContacts.companyName,
+        contactType: projectContacts.contactType,
+      })
+      .from(projectContacts)
+      .where(
+        and(
+          eq(projectContacts.projectId, projectId),
+          eq(projectContacts.active, true)
+        )
+      )
+      .orderBy(asc(projectContacts.companyName), asc(projectContacts.displayName)),
+  ])
+  const phaseMap = new Map<string, ProjectChangeOrderPhaseOption>()
+  const costCodeMap = new Map<string, ProjectChangeOrderCostCodeOption>()
+  const companyMap = new Map<string, ProjectChangeOrderCompanyOption>()
+
+  for (const row of sageRows) {
+    phaseMap.set(row.divisionCode, {
+      value: row.divisionCode,
+      label: row.divisionDisplayLabel,
+    })
+    costCodeMap.set(row.code, {
+      value: row.code,
+      label: row.displayLabel,
+      description: row.description,
+      divisionCode: row.divisionCode,
+    })
+  }
+  for (const row of budgetRows) {
+    if (!phaseMap.has(row.divisionCode)) {
+      phaseMap.set(row.divisionCode, {
+        value: row.divisionCode,
+        label: `${row.divisionCode} 00 00 ${row.divisionName}`,
+      })
+    }
+    if (!costCodeMap.has(row.costCode)) {
+      costCodeMap.set(row.costCode, {
+        value: row.costCode,
+        label: `${row.costCode} ${row.description}`,
+        description: row.description,
+        divisionCode: row.divisionCode,
+      })
+    }
+  }
+  for (const row of contactRows) {
+    const value = cleanText(row.companyName) ?? cleanText(row.displayName)
+    if (!value || companyMap.has(value.toLowerCase())) continue
+    companyMap.set(value.toLowerCase(), {
+      value,
+      label: value,
+      description: `${row.contactType} · ${row.displayName}`,
+    })
+  }
+
+  return {
+    phases: Array.from(phaseMap.values()).sort((left, right) =>
+      left.label.localeCompare(right.label)
+    ),
+    costCodes: Array.from(costCodeMap.values()).sort((left, right) =>
+      left.label.localeCompare(right.label)
+    ),
+    companies: Array.from(companyMap.values()).sort((left, right) =>
+      left.label.localeCompare(right.label)
+    ),
   }
 }
 
@@ -404,7 +546,19 @@ export async function getProjectChangeOrder(
     .get()
   if (!row || !canExternalViewerSee(row, context)) return null
 
-  const [documentRows, historyRows] = await Promise.all([
+  const [lineRows, documentRows, historyRows] = await Promise.all([
+    authorizedContext.db
+      .select({
+        id: projectChangeOrderLines.id,
+        lineNumber: projectChangeOrderLines.lineNumber,
+        description: projectChangeOrderLines.description,
+        phaseCode: projectChangeOrderLines.phaseCode,
+        costCode: projectChangeOrderLines.costCode,
+        amountCents: projectChangeOrderLines.amountCents,
+      })
+      .from(projectChangeOrderLines)
+      .where(eq(projectChangeOrderLines.changeOrderId, changeOrderId))
+      .orderBy(asc(projectChangeOrderLines.lineNumber)),
     authorizedContext.db
       .select({
         id: projectChangeOrderDocuments.id,
@@ -454,7 +608,7 @@ export async function getProjectChangeOrder(
               : null,
         }))
 
-  return viewModel(row, context, documentRows, visibleHistory)
+  return viewModel(row, context, lineRows, documentRows, visibleHistory)
 }
 
 export async function createProjectChangeOrder(
@@ -490,6 +644,11 @@ export async function createProjectChangeOrder(
       return { success: false, error: "Choose a valid audience." }
     }
     const documents = cleanDocuments(input.documents)
+    const lines = cleanChangeOrderCostLines(input.lines)
+    const amountCents = changeOrderCostLinesTotalCents(lines)
+    const scheduleImpactDays = cleanScheduleImpactDays(
+      input.scheduleImpactDays
+    )
     const sourceType =
       context.requesterType === "owner"
         ? "owner_request"
@@ -506,7 +665,8 @@ export async function createProjectChangeOrder(
       title: requireText(input.title, "Title", 200),
       scope: requireText(input.scope, "Scope", 10_000),
       reason: cleanLimitedText(input.reason, "Reason", 4_000),
-      amountCents: cleanAmountCents(input.amountCents),
+      amountCents,
+      scheduleImpactDays,
       status,
       audience,
       requesterType: context.requesterType,
@@ -536,6 +696,18 @@ export async function createProjectChangeOrder(
       createdBy: context.user.id,
       createdAt: now,
     }))
+    const lineRows = lines.map((line) => ({
+      id: crypto.randomUUID(),
+      projectId,
+      changeOrderId: id,
+      lineNumber: line.lineNumber,
+      description: line.description,
+      phaseCode: line.phaseCode,
+      costCode: line.costCode,
+      amountCents: line.amountCents,
+      createdAt: now,
+      updatedAt: now,
+    }))
     const historyRow = {
       id: crypto.randomUUID(),
       projectId,
@@ -547,11 +719,29 @@ export async function createProjectChangeOrder(
       actorName: actorName(context.user),
       actorRole: context.user.role,
       note: null,
-      metadataJson: JSON.stringify({ audience, sourceType }),
+      metadataJson: JSON.stringify({
+        audience,
+        sourceType,
+        lineCount: lineRows.length,
+        scheduleImpactDays,
+      }),
       createdAt: now,
     }
 
-    if (documentRows.length > 0) {
+    if (documentRows.length > 0 && lineRows.length > 0) {
+      await context.db.batch([
+        context.db.insert(projectChangeOrders).values(row),
+        context.db.insert(projectChangeOrderLines).values(lineRows),
+        context.db.insert(projectChangeOrderDocuments).values(documentRows),
+        context.db.insert(projectChangeOrderHistory).values(historyRow),
+      ])
+    } else if (lineRows.length > 0) {
+      await context.db.batch([
+        context.db.insert(projectChangeOrders).values(row),
+        context.db.insert(projectChangeOrderLines).values(lineRows),
+        context.db.insert(projectChangeOrderHistory).values(historyRow),
+      ])
+    } else if (documentRows.length > 0) {
       await context.db.batch([
         context.db.insert(projectChangeOrders).values(row),
         context.db.insert(projectChangeOrderDocuments).values(documentRows),
@@ -637,6 +827,7 @@ export async function updateProjectChangeOrder(
     }
     const now = new Date().toISOString()
     const documents = contentAllowed ? cleanDocuments(input.documents) : null
+    const lines = contentAllowed ? cleanChangeOrderCostLines(input.lines) : null
     const title = contentAllowed
       ? requireText(input.title, "Title", 200)
       : existing.title
@@ -646,9 +837,12 @@ export async function updateProjectChangeOrder(
     const reason = contentAllowed
       ? cleanLimitedText(input.reason, "Reason", 4_000)
       : existing.reason
-    const amountCents = contentAllowed
-      ? cleanAmountCents(input.amountCents)
+    const amountCents = lines
+      ? changeOrderCostLinesTotalCents(lines)
       : existing.amountCents
+    const scheduleImpactDays = contentAllowed
+      ? cleanScheduleImpactDays(input.scheduleImpactDays)
+      : existing.scheduleImpactDays
     const updateStatement = context.db
       .update(projectChangeOrders)
       .set({
@@ -656,6 +850,7 @@ export async function updateProjectChangeOrder(
         scope,
         reason,
         amountCents,
+        scheduleImpactDays,
         audience: contentAllowed ? audience : existing.audience,
         internalNotes: context.internal
           ? cleanLimitedText(input.internalNotes, "Internal notes", 4_000)
@@ -703,10 +898,12 @@ export async function updateProjectChangeOrder(
         metadataJson: JSON.stringify({
           audience: contentAllowed ? audience : existing.audience,
           documentCount: documents?.length ?? null,
+          lineCount: lines?.length ?? null,
+          scheduleImpactDays,
         }),
         createdAt: now,
       })
-    if (documents === null) {
+    if (documents === null || lines === null) {
       await context.db.batch([updateStatement, historyStatement])
     } else {
       const deleteDocumentsStatement = context.db
@@ -717,31 +914,69 @@ export async function updateProjectChangeOrder(
             eq(projectChangeOrderDocuments.projectId, projectId)
           )
         )
-      if (documents.length === 0) {
+      const deleteLinesStatement = context.db
+        .delete(projectChangeOrderLines)
+        .where(
+          and(
+            eq(projectChangeOrderLines.changeOrderId, changeOrderId),
+            eq(projectChangeOrderLines.projectId, projectId)
+          )
+        )
+      const lineRows = lines.map((line) => ({
+        id: crypto.randomUUID(),
+        projectId,
+        changeOrderId,
+        lineNumber: line.lineNumber,
+        description: line.description,
+        phaseCode: line.phaseCode,
+        costCode: line.costCode,
+        amountCents: line.amountCents,
+        createdAt: now,
+        updatedAt: now,
+      }))
+      const documentRows = documents.map((document) => ({
+        id: crypto.randomUUID(),
+        projectId,
+        changeOrderId,
+        label: document.label,
+        url: document.url,
+        notes: document.notes,
+        createdBy: context.user.id,
+        createdAt: now,
+      }))
+      if (documentRows.length === 0 && lineRows.length === 0) {
         await context.db.batch([
           updateStatement,
           deleteDocumentsStatement,
+          deleteLinesStatement,
           historyStatement,
         ])
-      } else {
+      } else if (documentRows.length > 0 && lineRows.length > 0) {
+        await context.db.batch([
+          updateStatement,
+          deleteDocumentsStatement,
+          context.db.insert(projectChangeOrderDocuments).values(documentRows),
+          deleteLinesStatement,
+          context.db.insert(projectChangeOrderLines).values(lineRows),
+          historyStatement,
+        ])
+      } else if (documentRows.length > 0) {
         const insertDocumentsStatement = context.db
           .insert(projectChangeOrderDocuments)
-          .values(
-            documents.map((document) => ({
-            id: crypto.randomUUID(),
-            projectId,
-            changeOrderId,
-            label: document.label,
-            url: document.url,
-            notes: document.notes,
-            createdBy: context.user.id,
-            createdAt: now,
-          }))
-          )
+          .values(documentRows)
         await context.db.batch([
           updateStatement,
           deleteDocumentsStatement,
           insertDocumentsStatement,
+          deleteLinesStatement,
+          historyStatement,
+        ])
+      } else {
+        await context.db.batch([
+          updateStatement,
+          deleteDocumentsStatement,
+          deleteLinesStatement,
+          context.db.insert(projectChangeOrderLines).values(lineRows),
           historyStatement,
         ])
       }

--- a/src/app/dashboard/projects/[id]/change-orders/[changeOrderId]/page.tsx
+++ b/src/app/dashboard/projects/[id]/change-orders/[changeOrderId]/page.tsx
@@ -1,7 +1,10 @@
 import type * as React from "react"
 import { notFound } from "next/navigation"
 
-import { getProjectChangeOrder } from "@/app/actions/project-change-orders"
+import {
+  getProjectChangeOrder,
+  getProjectChangeOrderFormOptions,
+} from "@/app/actions/project-change-orders"
 import { ProjectChangeOrderDetail } from "@/components/projects/project-change-order-detail"
 import { redirectIfFeaturePermissionDenied } from "@/lib/permission-redirect"
 
@@ -14,12 +17,13 @@ export default async function ProjectChangeOrderDetailPage({
   }>
 }): Promise<React.ReactElement> {
   const { id, changeOrderId } = await params
-  const item = await getProjectChangeOrder(id, changeOrderId).catch(
-    (error: unknown) => {
-      redirectIfFeaturePermissionDenied(error)
-      throw error
-    }
-  )
+  const [item, formOptions] = await Promise.all([
+    getProjectChangeOrder(id, changeOrderId),
+    getProjectChangeOrderFormOptions(id),
+  ]).catch((error: unknown) => {
+    redirectIfFeaturePermissionDenied(error)
+    throw error
+  })
   if (!item) notFound()
 
   const backHref =
@@ -30,6 +34,7 @@ export default async function ProjectChangeOrderDetailPage({
         item={item}
         backHref={backHref}
         internal
+        formOptions={formOptions}
       />
     </div>
   )

--- a/src/app/dashboard/projects/[id]/change-orders/page.tsx
+++ b/src/app/dashboard/projects/[id]/change-orders/page.tsx
@@ -4,6 +4,7 @@ import { IconArrowLeft } from "@tabler/icons-react"
 
 import {
   getProjectChangeOrderCapabilities,
+  getProjectChangeOrderFormOptions,
   getProjectChangeOrders,
 } from "@/app/actions/project-change-orders"
 import { getProjects } from "@/app/actions/projects"
@@ -18,10 +19,11 @@ export default async function ProjectChangeOrdersPage({
   readonly params: Promise<{ readonly id: string }>
 }): Promise<React.ReactElement> {
   const { id } = await params
-  const [projects, items, capabilities] = await Promise.all([
+  const [projects, items, capabilities, formOptions] = await Promise.all([
     getProjects(),
     getProjectChangeOrders(id),
     getProjectChangeOrderCapabilities(id),
+    getProjectChangeOrderFormOptions(id),
   ]).catch((error: unknown) => {
     redirectIfFeaturePermissionDenied(error)
     throw error
@@ -57,6 +59,7 @@ export default async function ProjectChangeOrdersPage({
         items={items}
         detailBaseHref={baseHref}
         internal
+        formOptions={formOptions}
         canCreate={capabilities.canCreate}
       />
     </div>

--- a/src/components/projects/project-audience-change-orders.tsx
+++ b/src/components/projects/project-audience-change-orders.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation"
 import {
   getProjectChangeOrder,
   getProjectChangeOrderCapabilities,
+  getProjectChangeOrderFormOptions,
   getProjectChangeOrders,
 } from "@/app/actions/project-change-orders"
 import {
@@ -59,7 +60,10 @@ export async function ProjectAudienceChangeOrders({
   const items = changeOrderId
     ? []
     : await getProjectChangeOrders(projectId, audience)
-  const capabilities = await getProjectChangeOrderCapabilities(projectId)
+  const [capabilities, formOptions] = await Promise.all([
+    getProjectChangeOrderCapabilities(projectId),
+    getProjectChangeOrderFormOptions(projectId, audience),
+  ])
   const messageShortcut = projectAudienceMessageShortcut({
     projectId: preview.project.id,
     audience,
@@ -88,6 +92,7 @@ export async function ProjectAudienceChangeOrders({
               item={item}
               backHref={baseHref}
               internal={false}
+              formOptions={formOptions}
             />
           ) : (
             <ProjectChangeOrderList
@@ -95,6 +100,7 @@ export async function ProjectAudienceChangeOrders({
               items={items}
               detailBaseHref={baseHref}
               internal={false}
+              formOptions={formOptions}
               canCreate={
                 !preview.viewerIsInternal && capabilities.canCreate
               }

--- a/src/components/projects/project-change-order-cost-lines-editor.tsx
+++ b/src/components/projects/project-change-order-cost-lines-editor.tsx
@@ -1,0 +1,422 @@
+"use client"
+
+import * as React from "react"
+import {
+  IconCheck,
+  IconChevronDown,
+  IconPlus,
+  IconTrash,
+} from "@tabler/icons-react"
+
+import type {
+  ProjectChangeOrderCostCodeOption,
+  ProjectChangeOrderItem,
+  ProjectChangeOrderPhaseOption,
+} from "@/app/actions/project-change-orders"
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import { Input } from "@/components/ui/input"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import type { ChangeOrderCostLineInput } from "@/lib/change-orders/cost-lines"
+
+export type DraftChangeOrderCostLine = {
+  readonly id: string
+  readonly description: string
+  readonly phaseCode: string
+  readonly costCode: string
+  readonly amount: string
+}
+
+type ChangeOrderLineField =
+  | "description"
+  | "phaseCode"
+  | "costCode"
+  | "amount"
+
+type CodingOption = {
+  readonly value: string
+  readonly label: string
+  readonly description?: string
+}
+
+const LINE_INPUT_CLASS =
+  "h-8 rounded-none border-0 bg-transparent px-1 shadow-none focus-visible:bg-background focus-visible:ring-0"
+
+function normalize(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+}
+
+export function ProjectChangeOrderOptionPicker({
+  value,
+  options,
+  placeholder,
+  ariaLabel,
+  disabled,
+  onValueChange,
+}: {
+  readonly value: string
+  readonly options: readonly CodingOption[]
+  readonly placeholder: string
+  readonly ariaLabel: string
+  readonly disabled: boolean
+  readonly onValueChange: (value: string) => void
+}): React.ReactElement {
+  const [open, setOpen] = React.useState(false)
+  const [query, setQuery] = React.useState("")
+  const normalizedQuery = normalize(query)
+  const selected = options.find((option) => option.value === value) ?? null
+  const filteredOptions = options.filter((option) =>
+    normalizedQuery.length === 0
+      ? true
+      : normalize(
+          `${option.value} ${option.label} ${option.description ?? ""}`
+        ).includes(normalizedQuery)
+  )
+  const typedValue = query.trim()
+  const canUseTypedValue =
+    typedValue.length > 0 && normalize(typedValue) !== normalize(value)
+
+  function chooseValue(nextValue: string): void {
+    onValueChange(nextValue)
+    setQuery("")
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          disabled={disabled}
+          aria-label={ariaLabel}
+          className="h-8 w-full min-w-0 justify-between rounded-none bg-transparent px-1 text-left text-xs font-normal hover:bg-background"
+        >
+          <span className="truncate">
+            {selected?.label ?? (value || placeholder)}
+          </span>
+          <IconChevronDown className="size-3.5 shrink-0 opacity-60" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[min(26rem,calc(100vw-3rem))] p-0"
+      >
+        <Command shouldFilter={false}>
+          <CommandInput
+            value={query}
+            onValueChange={setQuery}
+            placeholder={`Search ${placeholder.toLowerCase()}...`}
+          />
+          <CommandList className="compass-content-scroll max-h-72">
+            <CommandEmpty>No matching options.</CommandEmpty>
+            <CommandGroup>
+              {filteredOptions.map((option) => (
+                <CommandItem
+                  key={option.value}
+                  value={`${option.value} ${option.label}`}
+                  onSelect={() => chooseValue(option.value)}
+                >
+                  <IconCheck
+                    className={
+                      option.value === value
+                        ? "size-4 opacity-100"
+                        : "size-4 opacity-0"
+                    }
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate">{option.label}</span>
+                    {option.description && (
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {option.description}
+                      </span>
+                    )}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+          <div className="flex items-center justify-between gap-2 border-t p-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => chooseValue("")}
+            >
+              Clear
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={!canUseTypedValue}
+              onClick={() => chooseValue(typedValue)}
+            >
+              Use typed value
+            </Button>
+          </div>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export function newDraftChangeOrderCostLine(
+  initial?: Partial<Omit<DraftChangeOrderCostLine, "id">>
+): DraftChangeOrderCostLine {
+  return {
+    id: crypto.randomUUID(),
+    description: initial?.description ?? "",
+    phaseCode: initial?.phaseCode ?? "",
+    costCode: initial?.costCode ?? "",
+    amount: initial?.amount ?? "",
+  }
+}
+
+export function initialDraftChangeOrderCostLines(
+  lines: ProjectChangeOrderItem["lines"],
+  legacyAmountCents: number | null
+): readonly DraftChangeOrderCostLine[] {
+  if (lines.length > 0) {
+    return lines.map((line) =>
+      newDraftChangeOrderCostLine({
+        description: line.description,
+        phaseCode: line.phaseCode ?? "",
+        costCode: line.costCode ?? "",
+        amount:
+          line.amountCents === null
+            ? ""
+            : (line.amountCents / 100).toFixed(2),
+      })
+    )
+  }
+  return [
+    newDraftChangeOrderCostLine({
+      description: legacyAmountCents === null ? "" : "Existing change order amount",
+      amount:
+        legacyAmountCents === null ? "" : (legacyAmountCents / 100).toFixed(2),
+    }),
+  ]
+}
+
+function amountCents(value: string): number | null {
+  const trimmed = value.replaceAll(",", "").trim()
+  if (trimmed.length === 0) return null
+  const parsed = Number(trimmed)
+  return Number.isFinite(parsed) ? Math.round(parsed * 100) : Number.NaN
+}
+
+export function toChangeOrderCostLineInput(
+  line: DraftChangeOrderCostLine
+): ChangeOrderCostLineInput {
+  return {
+    description: line.description.trim() || null,
+    phaseCode: line.phaseCode.trim() || null,
+    costCode: line.costCode.trim() || null,
+    amountCents: amountCents(line.amount),
+  }
+}
+
+export function draftChangeOrderTotalCents(
+  lines: readonly DraftChangeOrderCostLine[]
+): number | null {
+  const populatedLines = lines.filter(
+    (line) =>
+      line.description.trim().length > 0 ||
+      line.phaseCode.trim().length > 0 ||
+      line.costCode.trim().length > 0 ||
+      line.amount.trim().length > 0
+  )
+  const amounts = populatedLines.map((line) => amountCents(line.amount))
+  if (
+    amounts.length === 0 ||
+    amounts.some((amount) => amount === null || !Number.isFinite(amount))
+  ) {
+    return null
+  }
+  return amounts.reduce<number>(
+    (total, amount) => total + (amount !== null ? amount : 0),
+    0
+  )
+}
+
+export function changeOrderMoney(cents: number | null): string {
+  if (cents === null) return "Not yet priced"
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(cents / 100)
+}
+
+function costCodesForPhase(
+  options: readonly ProjectChangeOrderCostCodeOption[],
+  phaseCode: string
+): readonly ProjectChangeOrderCostCodeOption[] {
+  const phase = phaseCode.trim()
+  return phase.length === 0
+    ? options
+    : options.filter((option) => option.divisionCode === phase)
+}
+
+export function ProjectChangeOrderCostLinesEditor({
+  lines,
+  phaseOptions,
+  costCodeOptions,
+  disabled = false,
+  onLinesChange,
+}: {
+  readonly lines: readonly DraftChangeOrderCostLine[]
+  readonly phaseOptions: readonly ProjectChangeOrderPhaseOption[]
+  readonly costCodeOptions: readonly ProjectChangeOrderCostCodeOption[]
+  readonly disabled?: boolean
+  readonly onLinesChange: (lines: readonly DraftChangeOrderCostLine[]) => void
+}): React.ReactElement {
+  function updateLine(
+    id: string,
+    field: ChangeOrderLineField,
+    value: string
+  ): void {
+    onLinesChange(
+      lines.map((line) =>
+        line.id === id ? { ...line, [field]: value } : line
+      )
+    )
+  }
+
+  function removeLine(id: string): void {
+    if (lines.length === 1) return
+    onLinesChange(lines.filter((line) => line.id !== id))
+  }
+
+  const totalCents = draftChangeOrderTotalCents(lines)
+  const codedCount = lines.filter((line) => line.costCode.trim().length > 0).length
+
+  return (
+    <div className="border-y">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b py-2">
+        <div>
+          <h3 className="text-xs font-semibold uppercase text-muted-foreground">
+            Cost lines
+          </h3>
+          <p className="text-xs text-muted-foreground">
+            Use one line per scope item or accounting cost code.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="text-sm font-semibold">
+            {changeOrderMoney(totalCents)}
+          </span>
+          {!disabled && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                onLinesChange([...lines, newDraftChangeOrderCostLine()])
+              }
+            >
+              <IconPlus className="size-4" />
+              Add line
+            </Button>
+          )}
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <div className="min-w-[800px]">
+          <div className="grid grid-cols-[2rem_minmax(14rem,1fr)_12rem_16rem_8rem_2.5rem] gap-2 border-b py-2 text-xs font-medium text-muted-foreground">
+            <span>#</span>
+            <span>Description</span>
+            <span>Phase</span>
+            <span>Cost code</span>
+            <span className="text-right">Amount</span>
+            <span />
+          </div>
+          {lines.map((line, index) => (
+            <div
+              key={line.id}
+              className="grid grid-cols-[2rem_minmax(14rem,1fr)_12rem_16rem_8rem_2.5rem] gap-2 border-b py-2 last:border-b-0"
+            >
+              <span className="pt-2 text-xs font-medium text-muted-foreground">
+                {index + 1}
+              </span>
+              <Input
+                value={line.description}
+                disabled={disabled}
+                onChange={(event) =>
+                  updateLine(line.id, "description", event.target.value)
+                }
+                placeholder="Scope or cost description"
+                className={LINE_INPUT_CLASS}
+              />
+              <ProjectChangeOrderOptionPicker
+                value={line.phaseCode}
+                options={phaseOptions}
+                placeholder="Phase"
+                ariaLabel={`Choose phase for change order line ${index + 1}`}
+                disabled={disabled}
+                onValueChange={(value) =>
+                  updateLine(line.id, "phaseCode", value)
+                }
+              />
+              <ProjectChangeOrderOptionPicker
+                value={line.costCode}
+                options={costCodesForPhase(costCodeOptions, line.phaseCode)}
+                placeholder="Cost code"
+                ariaLabel={`Choose cost code for change order line ${index + 1}`}
+                disabled={disabled}
+                onValueChange={(value) =>
+                  updateLine(line.id, "costCode", value)
+                }
+              />
+              <Input
+                value={line.amount}
+                disabled={disabled}
+                onChange={(event) =>
+                  updateLine(line.id, "amount", event.target.value)
+                }
+                inputMode="decimal"
+                placeholder="0.00"
+                aria-label={`Amount for change order line ${index + 1}`}
+                className={`${LINE_INPUT_CLASS} text-right`}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-9"
+                disabled={disabled || lines.length === 1}
+                onClick={() => removeLine(line.id)}
+                aria-label={`Remove change order line ${index + 1}`}
+              >
+                <IconTrash className="size-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-3 border-t py-3 text-sm">
+        <span className="text-muted-foreground">
+          {codedCount}/{lines.length} lines coded
+        </span>
+        <span>
+          Change order total: <strong>{changeOrderMoney(totalCents)}</strong>
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/projects/project-change-order-create-form.tsx
+++ b/src/components/projects/project-change-order-create-form.tsx
@@ -5,7 +5,19 @@ import { IconFilePlus } from "@tabler/icons-react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 
-import { createProjectChangeOrder } from "@/app/actions/project-change-orders"
+import {
+  createProjectChangeOrder,
+  type ProjectChangeOrderFormOptions,
+} from "@/app/actions/project-change-orders"
+import {
+  changeOrderMoney,
+  draftChangeOrderTotalCents,
+  newDraftChangeOrderCostLine,
+  ProjectChangeOrderCostLinesEditor,
+  ProjectChangeOrderOptionPicker,
+  toChangeOrderCostLineInput,
+  type DraftChangeOrderCostLine,
+} from "@/components/projects/project-change-order-cost-lines-editor"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -20,6 +32,11 @@ import {
 } from "@/components/ui/sheet"
 import { Textarea } from "@/components/ui/textarea"
 
+const DOCUMENT_INPUT_CLASS =
+  "rounded-none border-x-0 border-t-0 px-0 shadow-none focus-visible:border-foreground focus-visible:ring-0"
+const DOCUMENT_SELECT_CLASS =
+  "h-9 w-full rounded-none border-x-0 border-t-0 bg-background px-0 text-sm shadow-none outline-none focus:border-foreground"
+
 function optionalText(formData: FormData, name: string): string | null {
   const value = formData.get(name)
   if (typeof value !== "string") return null
@@ -31,25 +48,46 @@ function requiredText(formData: FormData, name: string): string {
   return optionalText(formData, name) ?? ""
 }
 
-function amountCents(formData: FormData): number | null {
-  const value = optionalText(formData, "amount")
+function scheduleImpactDays(formData: FormData): number | null {
+  const value = optionalText(formData, "scheduleImpactDays")
   if (!value) return null
-  const amount = Number(value.replaceAll(",", ""))
-  return Number.isFinite(amount) ? Math.round(amount * 100) : Number.NaN
+  return Number(value)
+}
+
+function Field({
+  label,
+  children,
+}: {
+  readonly label: string
+  readonly children: React.ReactNode
+}): React.ReactElement {
+  return (
+    <div className="space-y-1.5">
+      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+      {children}
+    </div>
+  )
 }
 
 export function ProjectChangeOrderCreateForm({
   projectId,
   detailBaseHref,
   internal,
+  formOptions,
 }: {
   readonly projectId: string
   readonly detailBaseHref: string
   readonly internal: boolean
+  readonly formOptions: ProjectChangeOrderFormOptions
 }): React.ReactElement {
   const router = useRouter()
   const [open, setOpen] = React.useState(false)
   const [saving, startSaving] = React.useTransition()
+  const [requesterCompany, setRequesterCompany] = React.useState("")
+  const [lines, setLines] = React.useState<readonly DraftChangeOrderCostLine[]>([
+    newDraftChangeOrderCostLine(),
+  ])
+  const totalCents = draftChangeOrderTotalCents(lines)
 
   function submit(formData: FormData): void {
     startSaving(async () => {
@@ -58,14 +96,15 @@ export function ProjectChangeOrderCreateForm({
         title: requiredText(formData, "title"),
         scope: requiredText(formData, "scope"),
         reason: optionalText(formData, "reason"),
-        amountCents: amountCents(formData),
+        scheduleImpactDays: scheduleImpactDays(formData),
+        lines: lines.map(toChangeOrderCostLineInput),
         audience:
           optionalText(formData, "audience") === "owner"
             ? "owner"
             : optionalText(formData, "audience") === "sub_vendor"
               ? "sub_vendor"
               : "internal",
-        requesterCompany: optionalText(formData, "requesterCompany"),
+        requesterCompany: requesterCompany.trim() || null,
         sourceRecordId: null,
         sourceHref: optionalText(formData, "sourceHref"),
         initialStatus:
@@ -89,6 +128,8 @@ export function ProjectChangeOrderCreateForm({
         return
       }
       setOpen(false)
+      setRequesterCompany("")
+      setLines([newDraftChangeOrderCostLine()])
       toast.success("Change order request created.")
       router.push(`${detailBaseHref}/${encodeURIComponent(result.id)}`)
       router.refresh()
@@ -103,104 +144,145 @@ export function ProjectChangeOrderCreateForm({
           Request change
         </Button>
       </SheetTrigger>
-      <SheetContent className="w-full overflow-y-auto sm:max-w-xl">
-        <SheetHeader>
+      <SheetContent className="w-[min(96vw,1180px)] overflow-y-auto sm:max-w-none">
+        <SheetHeader className="border-b px-5 py-4">
           <SheetTitle>Request a change order</SheetTitle>
           <SheetDescription>
-            Describe the requested scope and attach a supporting document link.
-            This does not approve work or send anything to Sage or Foxit.
+            Describe the scope, code each cost line, and record any schedule
+            impact. This does not approve work or send anything to Sage or Foxit.
           </SheetDescription>
         </SheetHeader>
-        <form action={submit} className="space-y-5 px-4 pb-6">
-          <div className="space-y-2">
-            <Label htmlFor="change-order-title">Title</Label>
-            <Input id="change-order-title" name="title" required />
+        <form action={submit} className="space-y-5 px-5 pb-6">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b py-3 text-sm">
+            <span className="font-medium">Draft change request</span>
+            <span className="text-muted-foreground">
+              {changeOrderMoney(totalCents)} total · schedule impact entered below
+            </span>
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="change-order-scope">Requested scope</Label>
-            <Textarea
-              id="change-order-scope"
-              name="scope"
-              rows={6}
-              required
-              placeholder="Describe what should change and the desired result."
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="change-order-reason">Reason</Label>
-            <Textarea id="change-order-reason" name="reason" rows={3} />
-          </div>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="change-order-amount">
-                Requested amount (optional)
-              </Label>
+
+          <div className="space-y-4">
+            <Field label="Change order title">
               <Input
-                id="change-order-amount"
-                name="amount"
-                type="number"
-                step="0.01"
-                inputMode="decimal"
+                id="change-order-title"
+                name="title"
+                required
+                placeholder="Owner-requested kitchen revision"
+                className={DOCUMENT_INPUT_CLASS}
               />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="change-order-company">Company</Label>
-              <Input id="change-order-company" name="requesterCompany" />
+            </Field>
+            <Field label="Requested scope">
+              <Textarea
+                id="change-order-scope"
+                name="scope"
+                rows={5}
+                required
+                placeholder="Describe what should change and the desired result."
+                className={`min-h-28 ${DOCUMENT_INPUT_CLASS}`}
+              />
+            </Field>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <Field label="Reason">
+                <Textarea
+                  id="change-order-reason"
+                  name="reason"
+                  rows={3}
+                  className={DOCUMENT_INPUT_CLASS}
+                />
+              </Field>
+              <div className="grid content-start gap-4">
+                <Field label="Requesting company">
+                  <ProjectChangeOrderOptionPicker
+                    value={requesterCompany}
+                    options={formOptions.companies}
+                    placeholder="Company"
+                    ariaLabel="Choose requesting company"
+                    disabled={false}
+                    onValueChange={setRequesterCompany}
+                  />
+                </Field>
+                <Field label="Schedule impact (days)">
+                  <Input
+                    id="change-order-schedule-impact"
+                    name="scheduleImpactDays"
+                    type="number"
+                    min="0"
+                    max="3650"
+                    step="1"
+                    inputMode="numeric"
+                    placeholder="0"
+                    className={DOCUMENT_INPUT_CLASS}
+                  />
+                </Field>
+              </div>
             </div>
           </div>
+
+          <ProjectChangeOrderCostLinesEditor
+            lines={lines}
+            phaseOptions={formOptions.phases}
+            costCodeOptions={formOptions.costCodes}
+            onLinesChange={setLines}
+          />
+
           {internal && (
             <div className="grid gap-4 sm:grid-cols-2">
-              <div className="space-y-2">
-                <Label htmlFor="change-order-audience">Audience</Label>
+              <Field label="Audience">
                 <select
                   id="change-order-audience"
                   name="audience"
-                  className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                  className={DOCUMENT_SELECT_CLASS}
                   defaultValue="internal"
                 >
                   <option value="internal">Internal only</option>
                   <option value="owner">Owner visible when approved</option>
                   <option value="sub_vendor">Sub/vendor request</option>
                 </select>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="change-order-initial-status">Save as</Label>
+              </Field>
+              <Field label="Save as">
                 <select
                   id="change-order-initial-status"
                   name="initialStatus"
-                  className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                  className={DOCUMENT_SELECT_CLASS}
                   defaultValue="draft"
                 >
                   <option value="draft">Draft</option>
                   <option value="submitted">Submitted for triage</option>
                 </select>
-              </div>
+              </Field>
             </div>
           )}
-          <div className="space-y-2">
-            <Label htmlFor="change-order-source">Source link (optional)</Label>
-            <Input
-              id="change-order-source"
-              name="sourceHref"
-              type="url"
-              placeholder="https://..."
-            />
-          </div>
-          <div className="border-t pt-4">
-            <p className="text-sm font-medium">Supporting document</p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Link a plan, estimate, photo folder, or other project document.
-            </p>
-            <div className="mt-3 grid gap-3">
-              <Input name="documentLabel" placeholder="Document label" />
+
+          <div className="grid gap-4 border-t pt-4 sm:grid-cols-2">
+            <Field label="Source link (optional)">
               <Input
-                name="documentUrl"
+                id="change-order-source"
+                name="sourceHref"
                 type="url"
                 placeholder="https://..."
+                className={DOCUMENT_INPUT_CLASS}
               />
+            </Field>
+            <div>
+              <Label className="text-xs text-muted-foreground">
+                Supporting document
+              </Label>
+              <div className="mt-1 grid gap-2">
+                <Input
+                  name="documentLabel"
+                  placeholder="Document label"
+                  className={DOCUMENT_INPUT_CLASS}
+                />
+                <Input
+                  name="documentUrl"
+                  type="url"
+                  placeholder="https://..."
+                  className={DOCUMENT_INPUT_CLASS}
+                />
+              </div>
             </div>
           </div>
-          <SheetFooter>
+
+          <SheetFooter className="border-t pt-4">
             <Button
               type="button"
               variant="outline"
@@ -209,7 +291,11 @@ export function ProjectChangeOrderCreateForm({
               Cancel
             </Button>
             <Button type="submit" disabled={saving}>
-              {saving ? "Creating…" : internal ? "Create request" : "Submit request"}
+              {saving
+                ? "Creating…"
+                : internal
+                  ? "Create request"
+                  : "Submit request"}
             </Button>
           </SheetFooter>
         </form>

--- a/src/components/projects/project-change-order-detail.tsx
+++ b/src/components/projects/project-change-order-detail.tsx
@@ -2,7 +2,10 @@ import type * as React from "react"
 import Link from "next/link"
 import { IconArrowLeft, IconExternalLink } from "@tabler/icons-react"
 
-import type { ProjectChangeOrderItem } from "@/app/actions/project-change-orders"
+import type {
+  ProjectChangeOrderFormOptions,
+  ProjectChangeOrderItem,
+} from "@/app/actions/project-change-orders"
 import { ProjectChangeOrderEditForm } from "@/components/projects/project-change-order-edit-form"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -36,10 +39,12 @@ export function ProjectChangeOrderDetail({
   item,
   backHref,
   internal,
+  formOptions,
 }: {
   readonly item: ProjectChangeOrderItem
   readonly backHref: string
   readonly internal: boolean
+  readonly formOptions: ProjectChangeOrderFormOptions
 }): React.ReactElement {
   return (
     <div className="space-y-5">
@@ -64,12 +69,21 @@ export function ProjectChangeOrderDetail({
           <div className="flex flex-wrap gap-2">
             <Badge>{changeOrderStatusLabel(item.status)}</Badge>
             <Badge variant="outline">{money(item.amountCents)}</Badge>
+            <Badge variant="outline">
+              {item.scheduleImpactDays === null
+                ? "Schedule impact not set"
+                : `${item.scheduleImpactDays} schedule day${item.scheduleImpactDays === 1 ? "" : "s"}`}
+            </Badge>
             <Badge variant="secondary">{item.audience}</Badge>
           </div>
         </div>
       </header>
 
-      <ProjectChangeOrderEditForm item={item} internal={internal} />
+      <ProjectChangeOrderEditForm
+        item={item}
+        internal={internal}
+        formOptions={formOptions}
+      />
 
       <section className="grid gap-4 lg:grid-cols-2">
         <div className="border-y bg-background p-4">

--- a/src/components/projects/project-change-order-edit-form.tsx
+++ b/src/components/projects/project-change-order-edit-form.tsx
@@ -6,8 +6,17 @@ import { toast } from "sonner"
 
 import {
   updateProjectChangeOrder,
+  type ProjectChangeOrderFormOptions,
   type ProjectChangeOrderItem,
 } from "@/app/actions/project-change-orders"
+import {
+  changeOrderMoney,
+  draftChangeOrderTotalCents,
+  initialDraftChangeOrderCostLines,
+  ProjectChangeOrderCostLinesEditor,
+  toChangeOrderCostLineInput,
+  type DraftChangeOrderCostLine,
+} from "@/components/projects/project-change-order-cost-lines-editor"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -28,31 +37,29 @@ function requiredText(formData: FormData, name: string): string {
   return optionalText(formData, name) ?? ""
 }
 
-function amountCents(formData: FormData): number | null {
-  const value = optionalText(formData, "amount")
+function scheduleImpactDays(formData: FormData): number | null {
+  const value = optionalText(formData, "scheduleImpactDays")
   if (!value) return null
-  const amount = Number(value.replaceAll(",", ""))
-  return Number.isFinite(amount) ? Math.round(amount * 100) : Number.NaN
+  return Number(value)
 }
 
 export function ProjectChangeOrderEditForm({
   item,
   internal,
+  formOptions,
 }: {
   readonly item: ProjectChangeOrderItem
   readonly internal: boolean
+  readonly formOptions: ProjectChangeOrderFormOptions
 }): React.ReactElement {
   const router = useRouter()
   const [documents, setDocuments] = React.useState(item.documents)
+  const [lines, setLines] = React.useState<readonly DraftChangeOrderCostLine[]>(
+    initialDraftChangeOrderCostLines(item.lines, item.amountCents)
+  )
   const [saving, startSaving] = React.useTransition()
-
-  if (!item.canEdit && item.allowedTransitions.length === 0) {
-    return (
-      <p className="border-y bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
-        This record is read-only at its current workflow stage.
-      </p>
-    )
-  }
+  const totalCents = draftChangeOrderTotalCents(lines)
+  const readOnly = !item.canEdit && item.allowedTransitions.length === 0
 
   function submit(formData: FormData): void {
     startSaving(async () => {
@@ -67,7 +74,8 @@ export function ProjectChangeOrderEditForm({
         title: requiredText(formData, "title"),
         scope: requiredText(formData, "scope"),
         reason: optionalText(formData, "reason"),
-        amountCents: amountCents(formData),
+        scheduleImpactDays: scheduleImpactDays(formData),
+        lines: lines.map(toChangeOrderCostLineInput),
         audience:
           optionalText(formData, "audience") === "owner"
             ? "owner"
@@ -94,6 +102,17 @@ export function ProjectChangeOrderEditForm({
 
   return (
     <form action={submit} className="space-y-5 border-y bg-background p-4">
+      {readOnly && (
+        <p className="border-l-2 border-l-muted-foreground px-3 py-2 text-sm text-muted-foreground">
+          This record is read-only at its current workflow stage.
+        </p>
+      )}
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b pb-3 text-sm">
+        <span className="font-medium">Change order details</span>
+        <span className="text-muted-foreground">
+          {changeOrderMoney(totalCents)} total
+        </span>
+      </div>
       <div className="grid gap-4 lg:grid-cols-2">
         <div className="space-y-2">
           <Label htmlFor="change-order-edit-title">Title</Label>
@@ -106,17 +125,18 @@ export function ProjectChangeOrderEditForm({
           />
         </div>
         <div className="space-y-2">
-          <Label htmlFor="change-order-edit-amount">Requested amount</Label>
+          <Label htmlFor="change-order-edit-schedule-impact">
+            Schedule impact (days)
+          </Label>
           <Input
-            id="change-order-edit-amount"
-            name="amount"
+            id="change-order-edit-schedule-impact"
+            name="scheduleImpactDays"
             type="number"
-            step="0.01"
-            defaultValue={
-              item.amountCents === null
-                ? ""
-                : (item.amountCents / 100).toFixed(2)
-            }
+            min="0"
+            max="3650"
+            step="1"
+            inputMode="numeric"
+            defaultValue={item.scheduleImpactDays ?? ""}
             disabled={!item.canEdit}
           />
         </div>
@@ -132,6 +152,13 @@ export function ProjectChangeOrderEditForm({
           required
         />
       </div>
+      <ProjectChangeOrderCostLinesEditor
+        lines={lines}
+        phaseOptions={formOptions.phases}
+        costCodeOptions={formOptions.costCodes}
+        disabled={!item.canEdit}
+        onLinesChange={setLines}
+      />
       <div className="space-y-2">
         <Label htmlFor="change-order-edit-reason">Reason</Label>
         <Textarea
@@ -253,6 +280,7 @@ export function ProjectChangeOrderEditForm({
             id="change-order-edit-status"
             name="status"
             defaultValue={item.status}
+            disabled={readOnly}
             className="h-9 w-full rounded-md border bg-background px-3 text-sm"
           >
             <option value={item.status}>
@@ -275,7 +303,11 @@ export function ProjectChangeOrderEditForm({
             placeholder="Explain the decision or information supplied."
           />
         </div>
-        <Button type="submit" className="self-end" disabled={saving}>
+        <Button
+          type="submit"
+          className="self-end"
+          disabled={saving || readOnly}
+        >
           {saving ? "Saving…" : "Save"}
         </Button>
       </div>

--- a/src/components/projects/project-change-order-list.tsx
+++ b/src/components/projects/project-change-order-list.tsx
@@ -2,7 +2,10 @@ import type * as React from "react"
 import Link from "next/link"
 import { IconFileInvoice } from "@tabler/icons-react"
 
-import type { ProjectChangeOrderItem } from "@/app/actions/project-change-orders"
+import type {
+  ProjectChangeOrderFormOptions,
+  ProjectChangeOrderItem,
+} from "@/app/actions/project-change-orders"
 import { ProjectChangeOrderCreateForm } from "@/components/projects/project-change-order-create-form"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -21,12 +24,14 @@ export function ProjectChangeOrderList({
   items,
   detailBaseHref,
   internal,
+  formOptions,
   canCreate = true,
 }: {
   readonly projectId: string
   readonly items: readonly ProjectChangeOrderItem[]
   readonly detailBaseHref: string
   readonly internal: boolean
+  readonly formOptions: ProjectChangeOrderFormOptions
   readonly canCreate?: boolean
 }): React.ReactElement {
   const openCount = items.filter(
@@ -54,6 +59,7 @@ export function ProjectChangeOrderList({
               projectId={projectId}
               detailBaseHref={detailBaseHref}
               internal={internal}
+              formOptions={formOptions}
             />
           )}
         </div>
@@ -82,6 +88,9 @@ export function ProjectChangeOrderList({
                 </p>
                 <p className="mt-2 text-xs text-muted-foreground">
                   {money(item.amountCents)} · Requested by {item.requesterName}
+                  {item.scheduleImpactDays !== null
+                    ? ` · ${item.scheduleImpactDays} schedule day${item.scheduleImpactDays === 1 ? "" : "s"}`
+                    : ""}
                 </p>
               </div>
               <Button asChild variant="outline" size="sm">

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1074,6 +1074,7 @@ export const projectChangeOrders = sqliteTable(
     scope: text("scope").notNull(),
     reason: text("reason"),
     amountCents: integer("amount_cents"),
+    scheduleImpactDays: integer("schedule_impact_days"),
     status: text("status").notNull().default("draft"),
     audience: text("audience").notNull().default("internal"),
     requesterType: text("requester_type").notNull(),
@@ -1112,6 +1113,37 @@ export const projectChangeOrders = sqliteTable(
     index("project_change_orders_requester_idx").on(
       table.projectId,
       table.requesterUserId
+    ),
+  ]
+)
+
+export const projectChangeOrderLines = sqliteTable(
+  "project_change_order_lines",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    changeOrderId: text("change_order_id")
+      .notNull()
+      .references(() => projectChangeOrders.id, { onDelete: "cascade" }),
+    lineNumber: integer("line_number").notNull(),
+    description: text("description").notNull(),
+    phaseCode: text("phase_code"),
+    costCode: text("cost_code"),
+    amountCents: integer("amount_cents"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("project_change_order_lines_order_uq").on(
+      table.changeOrderId,
+      table.lineNumber
+    ),
+    index("project_change_order_lines_project_idx").on(table.projectId),
+    index("project_change_order_lines_cost_code_idx").on(
+      table.projectId,
+      table.costCode
     ),
   ]
 )
@@ -1539,6 +1571,10 @@ export type ProjectRfiAttachment = typeof projectRfiAttachments.$inferSelect
 export type NewProjectRfiAttachment = typeof projectRfiAttachments.$inferInsert
 export type ProjectChangeOrder = typeof projectChangeOrders.$inferSelect
 export type NewProjectChangeOrder = typeof projectChangeOrders.$inferInsert
+export type ProjectChangeOrderLine =
+  typeof projectChangeOrderLines.$inferSelect
+export type NewProjectChangeOrderLine =
+  typeof projectChangeOrderLines.$inferInsert
 export type ProjectChangeOrderDocument =
   typeof projectChangeOrderDocuments.$inferSelect
 export type NewProjectChangeOrderDocument =

--- a/src/lib/change-orders/__tests__/cost-lines.test.ts
+++ b/src/lib/change-orders/__tests__/cost-lines.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  changeOrderCostLinesTotalCents,
+  cleanChangeOrderCostLines,
+  cleanScheduleImpactDays,
+} from "@/lib/change-orders/cost-lines"
+
+describe("change order cost lines", () => {
+  it("drops empty rows and preserves selected coding", () => {
+    expect(
+      cleanChangeOrderCostLines([
+        {
+          description: null,
+          phaseCode: null,
+          costCode: null,
+          amountCents: null,
+        },
+        {
+          description: "  Added casework  ",
+          phaseCode: "12",
+          costCode: "12 32 00",
+          amountCents: 125_050,
+        },
+      ])
+    ).toEqual([
+      {
+        lineNumber: 1,
+        description: "Added casework",
+        phaseCode: "12",
+        costCode: "12 32 00",
+        amountCents: 125_050,
+      },
+    ])
+  })
+
+  it("calculates signed totals for additions and credits", () => {
+    expect(
+      changeOrderCostLinesTotalCents([
+        { amountCents: 250_000 },
+        { amountCents: -25_000 },
+      ])
+    ).toBe(225_000)
+    expect(changeOrderCostLinesTotalCents([])).toBeNull()
+    expect(
+      changeOrderCostLinesTotalCents([{ amountCents: null }])
+    ).toBeNull()
+  })
+
+  it("requires descriptions on populated lines", () => {
+    expect(() =>
+      cleanChangeOrderCostLines([
+        {
+          description: null,
+          phaseCode: null,
+          costCode: "03 30 00",
+          amountCents: 500,
+        },
+      ])
+    ).toThrow("Line 1 needs a description")
+    expect(() =>
+      cleanChangeOrderCostLines([
+        {
+          description: "Invalid pricing",
+          phaseCode: null,
+          costCode: null,
+          amountCents: Number.NaN,
+        },
+      ])
+    ).toThrow("Line amount is invalid")
+  })
+
+  it("accepts bounded whole-day schedule impacts", () => {
+    expect(cleanScheduleImpactDays(null)).toBeNull()
+    expect(cleanScheduleImpactDays(0)).toBe(0)
+    expect(cleanScheduleImpactDays(45)).toBe(45)
+    expect(() => cleanScheduleImpactDays(1.5)).toThrow("whole number")
+    expect(() => cleanScheduleImpactDays(-1)).toThrow("whole number")
+  })
+})

--- a/src/lib/change-orders/cost-lines.ts
+++ b/src/lib/change-orders/cost-lines.ts
@@ -1,0 +1,97 @@
+export type ChangeOrderCostLineInput = {
+  readonly description: string | null
+  readonly phaseCode: string | null
+  readonly costCode: string | null
+  readonly amountCents: number | null
+}
+
+export type CleanChangeOrderCostLine = {
+  readonly lineNumber: number
+  readonly description: string
+  readonly phaseCode: string | null
+  readonly costCode: string | null
+  readonly amountCents: number | null
+}
+
+function cleanText(
+  value: string | null,
+  label: string,
+  maxLength: number
+): string | null {
+  const cleaned = value?.trim() ?? ""
+  if (cleaned.length === 0) return null
+  if (cleaned.length > maxLength) {
+    throw new Error(`${label} must be ${maxLength} characters or fewer`)
+  }
+  return cleaned
+}
+
+function cleanAmountCents(value: number | null): number | null {
+  if (value === null) return null
+  if (!Number.isFinite(value)) throw new Error("Line amount is invalid")
+  const cents = Math.round(value)
+  if (!Number.isSafeInteger(cents) || Math.abs(cents) > 1_000_000_000_000) {
+    throw new Error("Line amount is outside the supported range")
+  }
+  return cents
+}
+
+export function cleanChangeOrderCostLines(
+  lines: readonly ChangeOrderCostLineInput[]
+): readonly CleanChangeOrderCostLine[] {
+  if (lines.length > 100) {
+    throw new Error("A change order can have at most 100 cost lines")
+  }
+
+  const cleaned: CleanChangeOrderCostLine[] = []
+  for (const [index, line] of lines.entries()) {
+    const description = cleanText(line.description, "Line description", 500)
+    const phaseCode = cleanText(line.phaseCode, "Phase", 100)
+    const costCode = cleanText(line.costCode, "Cost code", 100)
+    const amountCents = cleanAmountCents(line.amountCents)
+    const hasContent =
+      description !== null ||
+      phaseCode !== null ||
+      costCode !== null ||
+      amountCents !== null
+    if (!hasContent) continue
+    if (!description) {
+      throw new Error(`Line ${index + 1} needs a description`)
+    }
+    cleaned.push({
+      lineNumber: cleaned.length + 1,
+      description,
+      phaseCode,
+      costCode,
+      amountCents,
+    })
+  }
+  return cleaned
+}
+
+export function changeOrderCostLinesTotalCents(
+  lines: readonly { readonly amountCents: number | null }[]
+): number | null {
+  if (
+    lines.length === 0 ||
+    lines.some((line) => line.amountCents === null)
+  ) {
+    return null
+  }
+  const total = lines.reduce(
+    (sum, line) => sum + (line.amountCents ?? 0),
+    0
+  )
+  if (!Number.isSafeInteger(total)) {
+    throw new Error("Change order total is outside the supported range")
+  }
+  return total
+}
+
+export function cleanScheduleImpactDays(value: number | null): number | null {
+  if (value === null) return null
+  if (!Number.isInteger(value) || value < 0 || value > 3_650) {
+    throw new Error("Schedule impact must be a whole number from 0 to 3650 days")
+  }
+  return value
+}


### PR DESCRIPTION
## What changed

- replaces the single lump-sum Change Order amount with repeatable cost lines
- adds searchable/manual phase and cost-code selectors using the same interaction pattern as the PO drawer
- calculates the Change Order total from its line items while preserving the parent total for lists and future Sage handoff
- adds whole-day schedule impact to create, edit, detail, and list views
- preserves legacy Change Orders by presenting an existing lump sum as a single editable line
- keeps internal Sage and project-budget coding options out of owner/sub preview contexts
- adds an additive D1 migration for schedule impact and Change Order cost lines

## User impact

Staff can price a Change Order line by line, code each line, see the running total, and record its schedule impact without leaving the drawer. Owner and subcontractor requesters retain safe manual-entry fallback without receiving internal accounting metadata.

## Validation

- `bun test src/lib/change-orders/__tests__/cost-lines.test.ts src/lib/__tests__/change-order-access.test.ts src/lib/__tests__/change-order-status.test.ts`
- `bunx tsc --noEmit`
- focused ESLint: no errors or warnings
- full `bun lint`: no errors; existing repository warnings only
- `bun run build`
- applied migrations 0083 and 0086 to a temporary SQLite database and inspected the resulting schema

## Deployment note

Apply `drizzle/0086_change_order_cost_lines.sql` before deploying the application code. The migration is additive, but the new pages query the new table immediately.
