### PR TITLE
feat(change-orders): import Loomis and Loeffler records

### DIFF
--- a/scripts/build-buildertrend-change-order-operational-import.mjs
+++ b/scripts/build-buildertrend-change-order-operational-import.mjs
@@ -1,0 +1,19 @@
+import { readFile, writeFile } from "node:fs/promises"
+import { resolve } from "node:path"
+
+import { generateBuildertrendChangeOrderImportSql } from "./lib/buildertrend-change-order-import.mjs"
+
+const fixturePath = resolve(
+  "scripts/fixtures/buildertrend-loeffler-loomis-change-orders-2026-07-31.json"
+)
+const fixture = JSON.parse(await readFile(fixturePath, "utf8"))
+const output = generateBuildertrendChangeOrderImportSql(fixture)
+const outputIndex = process.argv.indexOf("--output")
+
+if (outputIndex >= 0) {
+  const outputPath = process.argv[outputIndex + 1]
+  if (!outputPath) throw new Error("--output requires a path")
+  await writeFile(resolve(outputPath), output, "utf8")
+} else {
+  process.stdout.write(output)
+}

--- a/scripts/fixtures/buildertrend-loeffler-loomis-change-orders-2026-07-31.json
+++ b/scripts/fixtures/buildertrend-loeffler-loomis-change-orders-2026-07-31.json
@@ -1,0 +1,43 @@
+{
+  "capturedAt": "2026-07-31T20:25:00.000Z",
+  "projects": [
+    {
+      "projectId": "proj-o-170-loomis",
+      "buildertrendProjectId": "35400494",
+      "projectNumber": "O-170-2684",
+      "requesterName": "Tanis Loomis",
+      "orders": [
+        { "recordId": "10168345", "number": "O-170-0007", "title": "Change Order #4: Millwork Budget Reallocation", "createdAt": "2026-07-28T19:09:00.000Z", "status": "Approved", "statusDate": "2026-07-28", "amountCents": 0, "documentCount": 2 },
+        { "recordId": "10069867", "number": "O-170-0006", "title": "June 2026 Variances", "createdAt": "2026-06-30T17:17:00.000Z", "status": "Approved", "statusDate": "2026-06-30", "amountCents": 147395, "documentCount": 0 },
+        { "recordId": "10029778", "number": "O-170-0005", "title": "O-170-0005", "createdAt": "2026-06-18T15:12:00.000Z", "status": "Approved", "statusDate": "2026-06-18", "amountCents": 50000, "documentCount": 0 },
+        { "recordId": "10015016", "number": "O-170-0004", "title": "Plumbing Fixture Change Order", "createdAt": "2026-06-15T16:48:00.000Z", "status": "Approved", "statusDate": "2026-06-15", "amountCents": 73770, "documentCount": 1 },
+        { "recordId": "9966932", "number": "O-170-0003", "title": "May 2026 Variances", "createdAt": "2026-06-01T22:38:00.000Z", "status": "Approved", "statusDate": "2026-06-01", "amountCents": 71306, "documentCount": 0 },
+        { "recordId": "9880516", "number": "O-170-0002", "title": "Recirculation Line for Plumbing", "createdAt": "2026-05-07T14:57:00.000Z", "status": "Approved", "statusDate": "2026-05-29", "amountCents": 43605, "documentCount": 0 },
+        { "recordId": "9850590", "number": "O-170-0001", "title": "April 2026 Variances", "createdAt": "2026-04-29T19:25:00.000Z", "status": "Approved", "statusDate": "2026-04-29", "amountCents": 264325, "documentCount": 1 }
+      ]
+    },
+    {
+      "projectId": "proj-o-202-loeffler",
+      "buildertrendProjectId": "41684371",
+      "projectNumber": "O-202-595",
+      "requesterName": "Alan and Deborah Loeffler",
+      "orders": [
+        { "recordId": "10061457", "number": "O-202-0015", "title": "June Variances 2026", "createdAt": "2026-06-26T23:04:00.000Z", "status": "Approved", "statusDate": "2026-06-26", "amountCents": 0, "documentCount": 1 },
+        { "recordId": "10043801", "number": "O-202-0014", "title": "Change Order #10 Cabinet Design Change", "createdAt": "2026-06-23T15:04:00.000Z", "status": "Approved", "statusDate": "2026-06-30", "amountCents": 228677, "documentCount": 1 },
+        { "recordId": "10015276", "number": "O-202-0013", "title": "Change Order #9: Under-stair Storage Door Add", "createdAt": "2026-06-15T17:20:00.000Z", "status": "Draft", "statusDate": "2026-06-15", "amountCents": 25750, "documentCount": 0 },
+        { "recordId": "9977129", "number": "O-202-0012", "title": "Change Order #8: Site Condition Septic Design Change", "createdAt": "2026-06-03T19:50:00.000Z", "status": "Approved", "statusDate": "2026-06-09", "amountCents": 1580039, "documentCount": 2 },
+        { "recordId": "9976891", "number": "O-202-0011", "title": "Change Order #7: Site Conditions Earthwork", "createdAt": "2026-06-03T19:21:00.000Z", "status": "Approved", "statusDate": "2026-06-12", "amountCents": 423150, "documentCount": 1 },
+        { "recordId": "9939342", "number": "O-202-0010", "title": "Change Order #6: Door Finishing Price Increase", "createdAt": "2026-05-22T20:51:00.000Z", "status": "Approved", "statusDate": "2026-05-22", "amountCents": 78500, "documentCount": 0 },
+        { "recordId": "9822091", "number": "O-202-0009", "title": "April 2026 Variances", "createdAt": "2026-04-23T21:16:00.000Z", "status": "Approved", "statusDate": "2026-04-23", "amountCents": 3667, "documentCount": 1 },
+        { "recordId": "9615799", "number": "O-202-0008", "title": "Change Order #5: Plumbing Fixtures Price Adjustment", "createdAt": "2026-03-30T15:19:00.000Z", "status": "Approved", "statusDate": "2026-03-30", "amountCents": 113806, "documentCount": 2 },
+        { "recordId": "9557124", "number": "O-202-0007", "title": "March 2026 Variances", "createdAt": "2026-03-20T23:44:00.000Z", "status": "Approved", "statusDate": "2026-03-20", "amountCents": 110889, "documentCount": 1 },
+        { "recordId": "9547773", "number": "O-202-0006", "title": "Change Order #4: Exterior Doors & Finishing", "createdAt": "2026-03-19T21:42:00.000Z", "status": "Approved", "statusDate": "2026-03-21", "amountCents": 65823, "documentCount": 0 },
+        { "recordId": "9399289", "number": "O-202-0005", "title": "Change Order #3 Site Conditions: Backfill Material", "createdAt": "2026-03-02T16:24:00.000Z", "status": "Approved", "statusDate": "2026-03-02", "amountCents": 650000, "documentCount": 0 },
+        { "recordId": "9335002", "number": "O-202-0004", "title": "January/February 2026 Variances", "createdAt": "2026-02-20T21:22:00.000Z", "status": "Approved", "statusDate": "2026-02-20", "amountCents": 59582, "documentCount": 1 },
+        { "recordId": "9334804", "number": "O-202-0003", "title": "Preconstruction Change Order: Corner Search Survey", "createdAt": "2026-02-20T21:10:00.000Z", "status": "Approved", "statusDate": "2026-02-20", "amountCents": 195050, "documentCount": 2 },
+        { "recordId": "9227089", "number": "O-202-0002", "title": "Change Order #2: Waterline & Septic Blasting", "createdAt": "2026-02-02T22:55:00.000Z", "status": "Approved", "statusDate": "2026-02-04", "amountCents": 561935, "documentCount": 0 },
+        { "recordId": "9169104", "number": "O-202-0001", "title": "Change Order #1: Overhead & Margin Adjustment", "createdAt": "2026-01-20T22:36:00.000Z", "status": "Approved", "statusDate": "2026-01-22", "amountCents": -141000, "documentCount": 0 }
+      ]
+    }
+  ]
+}

--- a/scripts/lib/buildertrend-change-order-import.mjs
+++ b/scripts/lib/buildertrend-change-order-import.mjs
@@ -100,12 +100,13 @@ function insertChangeOrder(project, order, capturedAt) {
 
 export function generateBuildertrendChangeOrderImportSql(fixture) {
   validateFixture(fixture)
-  const statements = ["BEGIN;"]
+  // Wrangler's remote D1 executor rejects SQL BEGIN/COMMIT statements. Each
+  // statement is conflict-safe so an interrupted import can be rerun safely.
+  const statements = []
   for (const project of fixture.projects) {
     for (const order of project.orders) {
       statements.push(insertChangeOrder(project, order, fixture.capturedAt))
     }
   }
-  statements.push("COMMIT;")
   return `${statements.join("\n")}\n`
 }

--- a/scripts/lib/buildertrend-change-order-import.mjs
+++ b/scripts/lib/buildertrend-change-order-import.mjs
@@ -1,0 +1,111 @@
+const PROJECT_IDS = new Set([
+  "proj-o-170-loomis",
+  "proj-o-202-loeffler",
+])
+
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} is required`)
+  }
+  return value.trim()
+}
+
+function sql(value) {
+  if (value === null) return "NULL"
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value)) throw new Error("Unsafe integer in import")
+    return String(value)
+  }
+  return `'${String(value).replaceAll("'", "''")}'`
+}
+
+function statusMapping(buildertrendStatus) {
+  if (buildertrendStatus === "Approved") {
+    return { compassStatus: "executed", audience: "owner" }
+  }
+  if (buildertrendStatus === "Draft") {
+    return { compassStatus: "draft", audience: "internal" }
+  }
+  throw new Error(`Unsupported Buildertrend status: ${buildertrendStatus}`)
+}
+
+function validateFixture(fixture) {
+  requiredString(fixture.capturedAt, "capturedAt")
+  if (!Array.isArray(fixture.projects) || fixture.projects.length !== 2) {
+    throw new Error("Import must contain exactly Loomis and Loeffler")
+  }
+
+  const seenProjects = new Set()
+  const seenRecords = new Set()
+  const seenNumbers = new Set()
+  for (const project of fixture.projects) {
+    const projectId = requiredString(project.projectId, "projectId")
+    if (!PROJECT_IDS.has(projectId) || seenProjects.has(projectId)) {
+      throw new Error(`Unexpected or duplicate project: ${projectId}`)
+    }
+    seenProjects.add(projectId)
+    requiredString(project.buildertrendProjectId, "buildertrendProjectId")
+    requiredString(project.requesterName, "requesterName")
+    if (!Array.isArray(project.orders)) throw new Error("orders must be an array")
+
+    for (const order of project.orders) {
+      const recordId = requiredString(order.recordId, "recordId")
+      const number = requiredString(order.number, "number")
+      const recordKey = `${projectId}:${recordId}`
+      const numberKey = `${projectId}:${number}`
+      if (seenRecords.has(recordKey) || seenNumbers.has(numberKey)) {
+        throw new Error(`Duplicate Buildertrend change order: ${recordKey}`)
+      }
+      seenRecords.add(recordKey)
+      seenNumbers.add(numberKey)
+      requiredString(order.title, "title")
+      requiredString(order.createdAt, "createdAt")
+      requiredString(order.statusDate, "statusDate")
+      statusMapping(requiredString(order.status, "status"))
+      if (!Number.isSafeInteger(order.amountCents)) {
+        throw new Error(`Invalid amount for ${number}`)
+      }
+      if (!Number.isSafeInteger(order.documentCount) || order.documentCount < 0) {
+        throw new Error(`Invalid document count for ${number}`)
+      }
+    }
+  }
+}
+
+function insertChangeOrder(project, order, capturedAt) {
+  const mapping = statusMapping(order.status)
+  const id = `bt-co-${project.buildertrendProjectId}-${order.recordId}`
+  const sourceHref = `https://buildertrend.net/app/ChangeOrders/${order.recordId}/${project.buildertrendProjectId}/Details`
+  const submittedAt = mapping.compassStatus === "draft" ? null : order.createdAt
+  const note = [
+    `Imported from Buildertrend on ${capturedAt.slice(0, 10)}.`,
+    `Buildertrend status: ${order.status} (${order.statusDate}).`,
+    `${order.documentCount} Buildertrend supporting document${order.documentCount === 1 ? "" : "s"} recorded; files are not exposed as legacy source links.`,
+  ].join(" ")
+  const metadata = JSON.stringify({
+    buildertrendProjectId: project.buildertrendProjectId,
+    buildertrendRecordId: order.recordId,
+    buildertrendStatus: order.status,
+    buildertrendStatusDate: order.statusDate,
+    buildertrendDocumentCount: order.documentCount,
+  })
+  const historyAt = `${order.statusDate}T18:00:00.000Z`
+
+  return [
+    `INSERT INTO project_change_orders (id, project_id, change_order_number, title, scope, reason, amount_cents, schedule_impact_days, status, audience, requester_type, requester_user_id, requester_name, requester_company, source_type, source_record_id, source_href, internal_notes, foxit_status, sage_status, created_by, submitted_at, created_at, updated_at) SELECT ${sql(id)}, ${sql(project.projectId)}, ${sql(order.number)}, ${sql(order.title)}, ${sql(order.title)}, NULL, ${sql(order.amountCents)}, NULL, ${sql(mapping.compassStatus)}, ${sql(mapping.audience)}, 'owner', NULL, ${sql(project.requesterName)}, NULL, 'buildertrend_import', ${sql(order.recordId)}, ${sql(sourceHref)}, ${sql(note)}, 'not_started', 'not_ready', NULL, ${sql(submittedAt)}, ${sql(order.createdAt)}, ${sql(capturedAt)} WHERE EXISTS (SELECT 1 FROM projects WHERE id = ${sql(project.projectId)} AND buildertrend_project_id = ${sql(project.buildertrendProjectId)}) ON CONFLICT(project_id, change_order_number) DO NOTHING;`,
+    `INSERT OR IGNORE INTO project_change_order_lines (id, project_id, change_order_id, line_number, description, phase_code, cost_code, amount_cents, created_at, updated_at) SELECT ${sql(`${id}-line-1`)}, ${sql(project.projectId)}, ${sql(id)}, 1, ${sql(order.title)}, NULL, NULL, ${sql(order.amountCents)}, ${sql(order.createdAt)}, ${sql(capturedAt)} WHERE EXISTS (SELECT 1 FROM project_change_orders WHERE id = ${sql(id)});`,
+    `INSERT OR IGNORE INTO project_change_order_history (id, project_id, change_order_id, event_type, from_status, to_status, actor_user_id, actor_name, actor_role, note, metadata_json, created_at) SELECT ${sql(`${id}-import`)}, ${sql(project.projectId)}, ${sql(id)}, 'buildertrend_import', NULL, ${sql(mapping.compassStatus)}, NULL, 'Buildertrend import', 'system', ${sql(note)}, ${sql(metadata)}, ${sql(historyAt)} WHERE EXISTS (SELECT 1 FROM project_change_orders WHERE id = ${sql(id)});`,
+  ].join("\n")
+}
+
+export function generateBuildertrendChangeOrderImportSql(fixture) {
+  validateFixture(fixture)
+  const statements = ["BEGIN;"]
+  for (const project of fixture.projects) {
+    for (const order of project.orders) {
+      statements.push(insertChangeOrder(project, order, fixture.capturedAt))
+    }
+  }
+  statements.push("COMMIT;")
+  return `${statements.join("\n")}\n`
+}

--- a/scripts/lib/buildertrend-change-order-import.test.mjs
+++ b/scripts/lib/buildertrend-change-order-import.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { generateBuildertrendChangeOrderImportSql } from "./buildertrend-change-order-import.mjs"
+
+const fixture = {
+  capturedAt: "2026-07-31T20:25:00.000Z",
+  projects: [
+    {
+      projectId: "proj-o-170-loomis",
+      buildertrendProjectId: "35400494",
+      requesterName: "Tanis Loomis",
+      orders: [
+        {
+          recordId: "1",
+          number: "O-170-0001",
+          title: "Owner's change",
+          createdAt: "2026-07-01T12:00:00.000Z",
+          status: "Approved",
+          statusDate: "2026-07-02",
+          amountCents: 125,
+          documentCount: 1,
+        },
+      ],
+    },
+    {
+      projectId: "proj-o-202-loeffler",
+      buildertrendProjectId: "41684371",
+      requesterName: "Alan and Deborah Loeffler",
+      orders: [
+        {
+          recordId: "2",
+          number: "O-202-0001",
+          title: "Draft change",
+          createdAt: "2026-07-03T12:00:00.000Z",
+          status: "Draft",
+          statusDate: "2026-07-03",
+          amountCents: -50,
+          documentCount: 0,
+        },
+      ],
+    },
+  ],
+}
+
+test("generates idempotent operational imports with faithful statuses", () => {
+  const output = generateBuildertrendChangeOrderImportSql(fixture)
+  assert.match(output, /'executed', 'owner'/)
+  assert.match(output, /'draft', 'internal'/)
+  assert.match(output, /ON CONFLICT\(project_id, change_order_number\) DO NOTHING/)
+  assert.match(output, /INSERT OR IGNORE INTO project_change_order_lines/)
+  assert.match(output, /INSERT OR IGNORE INTO project_change_order_history/)
+  assert.match(output, /Owner''s change/)
+})
+
+test("rejects duplicate change-order numbers", () => {
+  const duplicate = structuredClone(fixture)
+  duplicate.projects[0].orders.push({ ...duplicate.projects[0].orders[0], recordId: "3" })
+  assert.throws(
+    () => generateBuildertrendChangeOrderImportSql(duplicate),
+    /Duplicate Buildertrend change order/
+  )
+})

--- a/scripts/lib/buildertrend-change-order-import.test.mjs
+++ b/scripts/lib/buildertrend-change-order-import.test.mjs
@@ -51,6 +51,7 @@ test("generates idempotent operational imports with faithful statuses", () => {
   assert.match(output, /INSERT OR IGNORE INTO project_change_order_lines/)
   assert.match(output, /INSERT OR IGNORE INTO project_change_order_history/)
   assert.match(output, /Owner''s change/)
+  assert.doesNotMatch(output, /\b(?:BEGIN|COMMIT)\b/)
 })
 
 test("rejects duplicate change-order numbers", () => {

--- a/src/app/actions/project-change-orders.ts
+++ b/src/app/actions/project-change-orders.ts
@@ -3,6 +3,7 @@
 import { and, asc, desc, eq } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
+import { getUploadSessionUrl } from "@/app/actions/google-drive"
 import { getDb } from "@/db"
 import {
   projectBudgetLines,
@@ -12,6 +13,7 @@ import {
   projectChangeOrders,
   projectContacts,
   projectMembers,
+  projects,
   sageCostCodes,
 } from "@/db/schema"
 import { requireAuth, type AuthUser } from "@/lib/auth"
@@ -169,6 +171,10 @@ type ChangeOrderActionResult =
   | { readonly success: true; readonly id: string }
   | { readonly success: false; readonly error: string }
 
+type ChangeOrderUploadSessionResult =
+  | { readonly success: true; readonly uploadUrl: string }
+  | { readonly success: false; readonly error: string }
+
 function cleanText(value: string | null): string | null {
   const trimmed = value?.trim() ?? ""
   return trimmed.length > 0 ? trimmed : null
@@ -213,7 +219,7 @@ function cleanDocuments(
   documents: readonly ChangeOrderDocumentInput[]
 ): readonly ChangeOrderDocumentInput[] {
   if (documents.length > 20) {
-    throw new Error("A change order can have at most 20 document links")
+    throw new Error("A change order can have at most 20 supporting documents")
   }
   return documents
     .filter((document) => cleanText(document.url) !== null)
@@ -420,6 +426,34 @@ export async function getProjectChangeOrderCapabilities(
   return {
     canCreate: createAllowed && context.requesterType !== null,
     requesterType: context.requesterType,
+  }
+}
+
+export async function getProjectChangeOrderUploadSessionUrl(
+  projectId: string,
+  fileName: string,
+  mimeType: string
+): Promise<ChangeOrderUploadSessionResult> {
+  try {
+    const context = await changeOrderContext(projectId, "create")
+    const project = await context.db
+      .select({ googleDriveFolderId: projects.googleDriveFolderId })
+      .from(projects)
+      .where(eq(projects.id, projectId))
+      .get()
+    return await getUploadSessionUrl(
+      fileName,
+      mimeType,
+      project?.googleDriveFolderId ?? undefined
+    )
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Could not start the document upload.",
+    }
   }
 }
 

--- a/src/components/projects/project-change-order-create-form.tsx
+++ b/src/components/projects/project-change-order-create-form.tsx
@@ -1,10 +1,14 @@
 "use client"
 
 import * as React from "react"
-import { IconFilePlus } from "@tabler/icons-react"
+import { IconFilePlus, IconPaperclip } from "@tabler/icons-react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 
+import {
+  uploadChangeOrderDocuments,
+  validateChangeOrderDocumentCount,
+} from "@/components/projects/project-change-order-document-upload"
 import {
   createProjectChangeOrder,
   type ProjectChangeOrderFormOptions,
@@ -20,7 +24,6 @@ import {
 } from "@/components/projects/project-change-order-cost-lines-editor"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import {
   Sheet,
   SheetContent,
@@ -81,58 +84,63 @@ export function ProjectChangeOrderCreateForm({
   readonly formOptions: ProjectChangeOrderFormOptions
 }): React.ReactElement {
   const router = useRouter()
+  const formRef = React.useRef<HTMLFormElement>(null)
+  const fileInputRef = React.useRef<HTMLInputElement>(null)
   const [open, setOpen] = React.useState(false)
   const [saving, startSaving] = React.useTransition()
+  const [selectedFiles, setSelectedFiles] = React.useState<readonly File[]>([])
   const [requesterCompany, setRequesterCompany] = React.useState("")
   const [lines, setLines] = React.useState<readonly DraftChangeOrderCostLine[]>([
     newDraftChangeOrderCostLine(),
   ])
   const totalCents = draftChangeOrderTotalCents(lines)
 
-  function submit(formData: FormData): void {
+  function submit(event: React.FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    const form = formRef.current
+    if (!form) return
+    const formData = new FormData(form)
     startSaving(async () => {
-      const documentUrl = optionalText(formData, "documentUrl")
-      const result = await createProjectChangeOrder(projectId, {
-        title: requiredText(formData, "title"),
-        scope: requiredText(formData, "scope"),
-        reason: optionalText(formData, "reason"),
-        scheduleImpactDays: scheduleImpactDays(formData),
-        lines: lines.map(toChangeOrderCostLineInput),
-        audience:
-          optionalText(formData, "audience") === "owner"
-            ? "owner"
-            : optionalText(formData, "audience") === "sub_vendor"
-              ? "sub_vendor"
-              : "internal",
-        requesterCompany: requesterCompany.trim() || null,
-        sourceRecordId: null,
-        sourceHref: optionalText(formData, "sourceHref"),
-        initialStatus:
-          optionalText(formData, "initialStatus") === "submitted"
-            ? "submitted"
-            : "draft",
-        documents: documentUrl
-          ? [
-              {
-                label:
-                  optionalText(formData, "documentLabel") ??
-                  "Supporting document",
-                url: documentUrl,
-                notes: null,
-              },
-            ]
-          : [],
-      })
-      if (!result.success) {
-        toast.error(result.error)
-        return
+      try {
+        validateChangeOrderDocumentCount(0, selectedFiles)
+        const documents = await uploadChangeOrderDocuments(selectedFiles, projectId)
+        const result = await createProjectChangeOrder(projectId, {
+          title: requiredText(formData, "title"),
+          scope: requiredText(formData, "scope"),
+          reason: optionalText(formData, "reason"),
+          scheduleImpactDays: scheduleImpactDays(formData),
+          lines: lines.map(toChangeOrderCostLineInput),
+          audience:
+            optionalText(formData, "audience") === "owner"
+              ? "owner"
+              : optionalText(formData, "audience") === "sub_vendor"
+                ? "sub_vendor"
+                : "internal",
+          requesterCompany: requesterCompany.trim() || null,
+          sourceRecordId: null,
+          sourceHref: null,
+          initialStatus:
+            optionalText(formData, "initialStatus") === "submitted"
+              ? "submitted"
+              : "draft",
+          documents,
+        })
+        if (!result.success) throw new Error(result.error)
+
+        setOpen(false)
+        setRequesterCompany("")
+        setLines([newDraftChangeOrderCostLine()])
+        setSelectedFiles([])
+        if (fileInputRef.current) fileInputRef.current.value = ""
+        form.reset()
+        toast.success("Change order request created.")
+        router.push(`${detailBaseHref}/${encodeURIComponent(result.id)}`)
+        router.refresh()
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "Could not create change order."
+        )
       }
-      setOpen(false)
-      setRequesterCompany("")
-      setLines([newDraftChangeOrderCostLine()])
-      toast.success("Change order request created.")
-      router.push(`${detailBaseHref}/${encodeURIComponent(result.id)}`)
-      router.refresh()
     })
   }
 
@@ -152,7 +160,11 @@ export function ProjectChangeOrderCreateForm({
             impact. This does not approve work or send anything to Sage or Foxit.
           </SheetDescription>
         </SheetHeader>
-        <form action={submit} className="space-y-5 px-5 pb-6">
+        <form
+          ref={formRef}
+          onSubmit={submit}
+          className="space-y-5 px-5 pb-6"
+        >
           <div className="flex flex-wrap items-center justify-between gap-3 border-b py-3 text-sm">
             <span className="font-medium">Draft change request</span>
             <span className="text-muted-foreground">
@@ -252,34 +264,33 @@ export function ProjectChangeOrderCreateForm({
             </div>
           )}
 
-          <div className="grid gap-4 border-t pt-4 sm:grid-cols-2">
-            <Field label="Source link (optional)">
-              <Input
-                id="change-order-source"
-                name="sourceHref"
-                type="url"
-                placeholder="https://..."
-                className={DOCUMENT_INPUT_CLASS}
-              />
-            </Field>
-            <div>
-              <Label className="text-xs text-muted-foreground">
-                Supporting document
-              </Label>
-              <div className="mt-1 grid gap-2">
-                <Input
-                  name="documentLabel"
-                  placeholder="Document label"
-                  className={DOCUMENT_INPUT_CLASS}
-                />
-                <Input
-                  name="documentUrl"
-                  type="url"
-                  placeholder="https://..."
-                  className={DOCUMENT_INPUT_CLASS}
-                />
-              </div>
-            </div>
+          <div className="border-t pt-4">
+            <label className="flex items-start gap-2 text-sm font-medium">
+              <IconPaperclip className="mt-0.5 size-4 text-muted-foreground" />
+              <span>
+                Supporting documents
+                <span className="mt-1 block text-xs font-normal text-muted-foreground">
+                  Upload photos, proposals, drawings, or other change-order files
+                  to the project Drive folder.
+                </span>
+              </span>
+            </label>
+            <Input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              accept="image/*,.pdf,.doc,.docx,.xls,.xlsx,.txt"
+              className="mt-3"
+              onChange={(event) => {
+                const files = event.currentTarget.files
+                setSelectedFiles(files ? Array.from(files) : [])
+              }}
+            />
+            {selectedFiles.length > 0 && (
+              <p className="mt-2 text-xs text-muted-foreground">
+                {selectedFiles.length} file{selectedFiles.length === 1 ? "" : "s"} selected
+              </p>
+            )}
           </div>
 
           <SheetFooter className="border-t pt-4">

--- a/src/components/projects/project-change-order-detail.tsx
+++ b/src/components/projects/project-change-order-detail.tsx
@@ -10,6 +10,7 @@ import { ProjectChangeOrderEditForm } from "@/components/projects/project-change
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
+  changeOrderDisplayStatus,
   changeOrderStatusLabel,
   isChangeOrderStatus,
 } from "@/lib/change-orders/status"
@@ -67,7 +68,7 @@ export function ProjectChangeOrderDetail({
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
-            <Badge>{changeOrderStatusLabel(item.status)}</Badge>
+            <Badge>{changeOrderDisplayStatus(item.status, item.sourceType)}</Badge>
             <Badge variant="outline">{money(item.amountCents)}</Badge>
             <Badge variant="outline">
               {item.scheduleImpactDays === null
@@ -112,7 +113,7 @@ export function ProjectChangeOrderDetail({
             </div>
           ) : (
             <p className="mt-3 text-sm text-muted-foreground">
-              No supporting links.
+              No supporting documents.
             </p>
           )}
         </div>
@@ -144,6 +145,8 @@ export function ProjectChangeOrderDetail({
                 <p className="font-medium">
                   {event.eventType === "status_transition"
                     ? `${event.fromStatus ? historyStatusLabel(event.fromStatus) : "Created"} → ${historyStatusLabel(event.toStatus)}`
+                    : event.eventType === "buildertrend_import"
+                      ? "Imported from Buildertrend"
                     : event.eventType === "created"
                       ? "Request created"
                       : "Request updated"}

--- a/src/components/projects/project-change-order-document-upload.ts
+++ b/src/components/projects/project-change-order-document-upload.ts
@@ -1,0 +1,78 @@
+"use client"
+
+import {
+  getProjectChangeOrderUploadSessionUrl,
+  type ChangeOrderDocumentInput,
+} from "@/app/actions/project-change-orders"
+
+const MAX_CHANGE_ORDER_DOCUMENTS = 20
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function recordString(
+  record: Record<string, unknown>,
+  key: string
+): string | null {
+  const value = record[key]
+  return typeof value === "string" && value.trim().length > 0 ? value : null
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return null
+  }
+}
+
+export function validateChangeOrderDocumentCount(
+  existingCount: number,
+  files: readonly File[]
+): void {
+  if (existingCount + files.length > MAX_CHANGE_ORDER_DOCUMENTS) {
+    throw new Error(
+      `A change order can have at most ${MAX_CHANGE_ORDER_DOCUMENTS} supporting documents.`
+    )
+  }
+}
+
+export async function uploadChangeOrderDocuments(
+  files: readonly File[],
+  projectId: string
+): Promise<readonly ChangeOrderDocumentInput[]> {
+  validateChangeOrderDocumentCount(0, files)
+  const uploaded: ChangeOrderDocumentInput[] = []
+
+  for (const file of files) {
+    const mimeType = file.type || "application/octet-stream"
+    const session = await getProjectChangeOrderUploadSessionUrl(
+      projectId,
+      file.name,
+      mimeType
+    )
+    if (!session.success) throw new Error(session.error)
+
+    const response = await fetch(session.uploadUrl, {
+      method: "PUT",
+      headers: { "Content-Type": mimeType },
+      body: file,
+    })
+    if (!response.ok) throw new Error(`Upload failed for ${file.name}`)
+
+    const parsed = parseJson(await response.text())
+    const record = isRecord(parsed) ? parsed : {}
+    const storageId = recordString(record, "id")
+    const storageUrl =
+      recordString(record, "webViewLink") ??
+      (storageId ? `https://drive.google.com/open?id=${storageId}` : null)
+    if (!storageUrl) {
+      throw new Error(`Google Drive did not return a link for ${file.name}`)
+    }
+
+    uploaded.push({ label: file.name, url: storageUrl, notes: null })
+  }
+
+  return uploaded
+}

--- a/src/components/projects/project-change-order-edit-form.tsx
+++ b/src/components/projects/project-change-order-edit-form.tsx
@@ -5,6 +5,10 @@ import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 
 import {
+  uploadChangeOrderDocuments,
+  validateChangeOrderDocumentCount,
+} from "@/components/projects/project-change-order-document-upload"
+import {
   updateProjectChangeOrder,
   type ProjectChangeOrderFormOptions,
   type ProjectChangeOrderItem,
@@ -53,7 +57,10 @@ export function ProjectChangeOrderEditForm({
   readonly formOptions: ProjectChangeOrderFormOptions
 }): React.ReactElement {
   const router = useRouter()
+  const formRef = React.useRef<HTMLFormElement>(null)
+  const fileInputRef = React.useRef<HTMLInputElement>(null)
   const [documents, setDocuments] = React.useState(item.documents)
+  const [selectedFiles, setSelectedFiles] = React.useState<readonly File[]>([])
   const [lines, setLines] = React.useState<readonly DraftChangeOrderCostLine[]>(
     initialDraftChangeOrderCostLines(item.lines, item.amountCents)
   )
@@ -61,47 +68,77 @@ export function ProjectChangeOrderEditForm({
   const totalCents = draftChangeOrderTotalCents(lines)
   const readOnly = !item.canEdit && item.allowedTransitions.length === 0
 
-  function submit(formData: FormData): void {
+  function submit(event: React.FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    const form = formRef.current
+    if (!form) return
+    const formData = new FormData(form)
     startSaving(async () => {
-      const requestedStatus = requiredText(formData, "status")
-      const status =
-        isChangeOrderStatus(requestedStatus) &&
-        (requestedStatus === item.status ||
-          item.allowedTransitions.includes(requestedStatus))
-          ? requestedStatus
-          : item.status
-      const result = await updateProjectChangeOrder(item.projectId, item.id, {
-        title: requiredText(formData, "title"),
-        scope: requiredText(formData, "scope"),
-        reason: optionalText(formData, "reason"),
-        scheduleImpactDays: scheduleImpactDays(formData),
-        lines: lines.map(toChangeOrderCostLineInput),
-        audience:
-          optionalText(formData, "audience") === "owner"
-            ? "owner"
-            : optionalText(formData, "audience") === "sub_vendor"
-              ? "sub_vendor"
-              : "internal",
-        internalNotes: optionalText(formData, "internalNotes"),
-        status,
-        transitionNote: optionalText(formData, "transitionNote"),
-        documents: documents.map((document) => ({
-          label: document.label,
-          url: document.url,
-          notes: document.notes,
-        })),
-      })
-      if (!result.success) {
-        toast.error(result.error)
-        return
+      try {
+        validateChangeOrderDocumentCount(documents.length, selectedFiles)
+        const uploaded = await uploadChangeOrderDocuments(
+          selectedFiles,
+          item.projectId
+        )
+        const nextDocuments = [
+          ...documents.map((document) => ({
+            label: document.label,
+            url: document.url,
+            notes: document.notes,
+          })),
+          ...uploaded,
+        ]
+        const requestedStatus = requiredText(formData, "status")
+        const status =
+          isChangeOrderStatus(requestedStatus) &&
+          (requestedStatus === item.status ||
+            item.allowedTransitions.includes(requestedStatus))
+            ? requestedStatus
+            : item.status
+        const result = await updateProjectChangeOrder(item.projectId, item.id, {
+          title: requiredText(formData, "title"),
+          scope: requiredText(formData, "scope"),
+          reason: optionalText(formData, "reason"),
+          scheduleImpactDays: scheduleImpactDays(formData),
+          lines: lines.map(toChangeOrderCostLineInput),
+          audience:
+            optionalText(formData, "audience") === "owner"
+              ? "owner"
+              : optionalText(formData, "audience") === "sub_vendor"
+                ? "sub_vendor"
+                : "internal",
+          internalNotes: optionalText(formData, "internalNotes"),
+          status,
+          transitionNote: optionalText(formData, "transitionNote"),
+          documents: nextDocuments,
+        })
+        if (!result.success) throw new Error(result.error)
+
+        setDocuments((current) => [
+          ...current,
+          ...uploaded.map((document) => ({
+            id: crypto.randomUUID(),
+            ...document,
+          })),
+        ])
+        setSelectedFiles([])
+        if (fileInputRef.current) fileInputRef.current.value = ""
+        toast.success("Change order request updated.")
+        router.refresh()
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "Could not update change order."
+        )
       }
-      toast.success("Change order request updated.")
-      router.refresh()
     })
   }
 
   return (
-    <form action={submit} className="space-y-5 border-y bg-background p-4">
+    <form
+      ref={formRef}
+      onSubmit={submit}
+      className="space-y-5 border-y bg-background p-4"
+    >
       {readOnly && (
         <p className="border-l-2 border-l-muted-foreground px-3 py-2 text-sm text-muted-foreground">
           This record is read-only at its current workflow stage.
@@ -198,66 +235,19 @@ export function ProjectChangeOrderEditForm({
       )}
       {item.canEdit && (
         <div className="space-y-3 border-t pt-4">
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <p className="text-sm font-medium">Document links</p>
-              <p className="text-xs text-muted-foreground">
-                Links stay in Compass; no document is sent externally.
-              </p>
-            </div>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() =>
-                setDocuments((current) => [
-                  ...current,
-                  {
-                    id: crypto.randomUUID(),
-                    label: "",
-                    url: "",
-                    notes: null,
-                  },
-                ])
-              }
-            >
-              Add link
-            </Button>
+          <div>
+            <p className="text-sm font-medium">Supporting documents</p>
+            <p className="text-xs text-muted-foreground">
+              Upload photos, proposals, drawings, or other files to the project
+              Drive folder.
+            </p>
           </div>
-          {documents.map((document, index) => (
+          {documents.map((document) => (
             <div
               key={document.id}
-              className="grid gap-2 border-l-2 pl-3 sm:grid-cols-[1fr_2fr_auto]"
+              className="flex items-center justify-between gap-3 border-l-2 px-3 py-2"
             >
-              <Input
-                value={document.label}
-                aria-label={`Document ${index + 1} label`}
-                placeholder="Label"
-                onChange={(event) =>
-                  setDocuments((current) =>
-                    current.map((item) =>
-                      item.id === document.id
-                        ? { ...item, label: event.currentTarget.value }
-                        : item
-                    )
-                  )
-                }
-              />
-              <Input
-                value={document.url}
-                aria-label={`Document ${index + 1} URL`}
-                type="url"
-                placeholder="https://..."
-                onChange={(event) =>
-                  setDocuments((current) =>
-                    current.map((item) =>
-                      item.id === document.id
-                        ? { ...item, url: event.currentTarget.value }
-                        : item
-                    )
-                  )
-                }
-              />
+              <span className="min-w-0 truncate text-sm">{document.label}</span>
               <Button
                 type="button"
                 variant="ghost"
@@ -271,6 +261,21 @@ export function ProjectChangeOrderEditForm({
               </Button>
             </div>
           ))}
+          <Input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept="image/*,.pdf,.doc,.docx,.xls,.xlsx,.txt"
+            onChange={(event) => {
+              const files = event.currentTarget.files
+              setSelectedFiles(files ? Array.from(files) : [])
+            }}
+          />
+          {selectedFiles.length > 0 && (
+            <p className="text-xs text-muted-foreground">
+              {selectedFiles.length} file{selectedFiles.length === 1 ? "" : "s"} selected for upload
+            </p>
+          )}
         </div>
       )}
       <div className="grid gap-4 border-t pt-4 lg:grid-cols-[1fr_2fr_auto]">

--- a/src/components/projects/project-change-order-list.tsx
+++ b/src/components/projects/project-change-order-list.tsx
@@ -9,7 +9,7 @@ import type {
 import { ProjectChangeOrderCreateForm } from "@/components/projects/project-change-order-create-form"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { changeOrderStatusLabel } from "@/lib/change-orders/status"
+import { changeOrderDisplayStatus } from "@/lib/change-orders/status"
 
 function money(cents: number | null): string {
   if (cents === null) return "Amount not determined"
@@ -78,7 +78,7 @@ export function ProjectChangeOrderList({
                     {item.changeOrderNumber}
                   </p>
                   <Badge variant="outline">
-                    {changeOrderStatusLabel(item.status)}
+                    {changeOrderDisplayStatus(item.status, item.sourceType)}
                   </Badge>
                   <Badge variant="secondary">{item.requesterType}</Badge>
                 </div>

--- a/src/lib/change-orders/__tests__/status.test.ts
+++ b/src/lib/change-orders/__tests__/status.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  changeOrderDisplayStatus,
+  changeOrderStatusLabel,
+} from "@/lib/change-orders/status"
+
+describe("change-order status labels", () => {
+  it("preserves the Buildertrend approval meaning for imported records", () => {
+    expect(changeOrderDisplayStatus("executed", "buildertrend_import")).toBe(
+      "Approved · Buildertrend"
+    )
+    expect(changeOrderDisplayStatus("draft", "buildertrend_import")).toBe(
+      "Draft · Buildertrend"
+    )
+  })
+
+  it("uses the Compass workflow label for native records", () => {
+    expect(changeOrderDisplayStatus("executed", "internal_request")).toBe(
+      changeOrderStatusLabel("executed")
+    )
+  })
+})

--- a/src/lib/change-orders/status.ts
+++ b/src/lib/change-orders/status.ts
@@ -69,6 +69,17 @@ export function changeOrderStatusLabel(status: ChangeOrderStatus): string {
     .join(" ")
 }
 
+export function changeOrderDisplayStatus(
+  status: ChangeOrderStatus,
+  sourceType: string
+): string {
+  if (sourceType !== "buildertrend_import") {
+    return changeOrderStatusLabel(status)
+  }
+  if (status === "executed") return "Approved · Buildertrend"
+  return `${changeOrderStatusLabel(status)} · Buildertrend`
+}
+
 export function allowedChangeOrderTransitions(
   status: ChangeOrderStatus
 ): readonly ChangeOrderStatus[] {


### PR DESCRIPTION
## What changed

- imports all 7 Loomis and 15 Loeffler Buildertrend change orders into the operational Compass workflow
- preserves Buildertrend approval/draft status, amounts, requester names, source IDs, and audit history
- adds one operational cost line per imported change order so totals render consistently
- replaces source-link fields with multi-file supporting-document uploads to project-scoped Google Drive storage
- labels imported statuses clearly as Buildertrend-derived

## Safety

- import SQL verifies the exact Compass and Buildertrend project IDs
- reruns use conflict-safe inserts and do not overwrite later Compass edits
- legacy Buildertrend URLs remain internal provenance and are not exposed as document links
- upload sessions resolve the project Drive folder server-side after project and feature-permission checks

## Validation

- `node --test scripts/lib/buildertrend-change-order-import.test.mjs`
- `vitest run src/lib/change-orders/__tests__/cost-lines.test.ts src/lib/change-orders/__tests__/status.test.ts`
- `tsc --noEmit --pretty false`
- targeted ESLint on all changed application files
- SQLite replay: 7 Loomis / 15 Loeffler orders, 22 lines, 22 history events
- `next build --webpack`

The configured external autoreview was not run because the approval guard blocked transmitting this private branch diff to an external reviewer. The diff was reviewed locally instead; the resulting upload-folder trust issue was corrected before publishing.
