### PR TITLE
feat(financials): connect estimates, budgets, and pay applications

### DIFF
--- a/drizzle/0087_estimate_contract_budget_ledger.sql
+++ b/drizzle/0087_estimate_contract_budget_ledger.sql
@@ -1,0 +1,194 @@
+CREATE TABLE `sage_tax_entities` (
+  `id` text PRIMARY KEY NOT NULL,
+  `source_record_id` text,
+  `code` text NOT NULL,
+  `name` text NOT NULL,
+  `rate_basis_points` integer DEFAULT 0 NOT NULL,
+  `active` integer DEFAULT true NOT NULL,
+  `sync_status` text DEFAULT 'synced' NOT NULL,
+  `last_synced_at` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL
+);
+CREATE UNIQUE INDEX `sage_tax_entities_code_uq` ON `sage_tax_entities` (`code`);
+CREATE INDEX `sage_tax_entities_active_idx` ON `sage_tax_entities` (`active`,`name`);
+
+CREATE TABLE `estimate_terms_templates` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `name` text NOT NULL,
+  `body` text NOT NULL,
+  `active` integer DEFAULT true NOT NULL,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+CREATE UNIQUE INDEX `estimate_terms_templates_org_name_uq` ON `estimate_terms_templates` (`organization_id`,`name`);
+CREATE INDEX `estimate_terms_templates_org_active_idx` ON `estimate_terms_templates` (`organization_id`,`active`);
+
+CREATE TABLE `project_estimates` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_id` text NOT NULL,
+  `estimate_number` text NOT NULL,
+  `version_number` integer DEFAULT 1 NOT NULL,
+  `title` text DEFAULT 'CA22 Construction Estimate' NOT NULL,
+  `status` text DEFAULT 'draft' NOT NULL,
+  `estimate_date` text,
+  `client_name` text,
+  `source_system` text DEFAULT 'compass' NOT NULL,
+  `source_workbook_id` text,
+  `source_workbook_url` text,
+  `source_revision` text,
+  `default_tax_entity_id` text,
+  `default_tax_code` text,
+  `default_tax_name` text,
+  `default_tax_rate_basis_points` integer DEFAULT 0 NOT NULL,
+  `terms_template_id` text,
+  `contract_terms` text,
+  `direct_cost_cents` integer DEFAULT 0 NOT NULL,
+  `markup_cents` integer DEFAULT 0 NOT NULL,
+  `tax_cents` integer DEFAULT 0 NOT NULL,
+  `estimate_total_cents` integer DEFAULT 0 NOT NULL,
+  `foxit_status` text DEFAULT 'not_started' NOT NULL,
+  `foxit_envelope_id` text,
+  `signature_package_url` text,
+  `signature_requested_at` text,
+  `signed_at` text,
+  `accepted_at` text,
+  `accepted_by` text,
+  `sage_status` text DEFAULT 'not_ready' NOT NULL,
+  `sage_record_id` text,
+  `last_sage_sync_at` text,
+  `source_hash` text,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`default_tax_entity_id`) REFERENCES `sage_tax_entities`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`terms_template_id`) REFERENCES `estimate_terms_templates`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`accepted_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+CREATE UNIQUE INDEX `project_estimates_project_number_version_uq` ON `project_estimates` (`project_id`,`estimate_number`,`version_number`);
+CREATE INDEX `project_estimates_project_status_idx` ON `project_estimates` (`project_id`,`status`,`version_number`);
+
+CREATE TABLE `project_estimate_lines` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_id` text NOT NULL,
+  `estimate_id` text NOT NULL,
+  `division_code` text NOT NULL,
+  `division_name` text NOT NULL,
+  `cost_code` text NOT NULL,
+  `cost_code_name` text NOT NULL,
+  `description` text NOT NULL,
+  `specifications` text,
+  `quantity` real DEFAULT 1 NOT NULL,
+  `unit` text DEFAULT 'LS' NOT NULL,
+  `unit_cost_cents` integer DEFAULT 0 NOT NULL,
+  `direct_cost_cents` integer DEFAULT 0 NOT NULL,
+  `markup_rate_basis_points` integer DEFAULT 0 NOT NULL,
+  `markup_cents` integer DEFAULT 0 NOT NULL,
+  `taxable` integer DEFAULT false NOT NULL,
+  `tax_entity_id` text,
+  `tax_code` text,
+  `tax_name` text,
+  `tax_rate_basis_points` integer DEFAULT 0 NOT NULL,
+  `tax_cents` integer DEFAULT 0 NOT NULL,
+  `line_total_cents` integer DEFAULT 0 NOT NULL,
+  `owner_visible` integer DEFAULT true NOT NULL,
+  `sort_order` integer DEFAULT 0 NOT NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`estimate_id`) REFERENCES `project_estimates`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`tax_entity_id`) REFERENCES `sage_tax_entities`(`id`) ON UPDATE no action ON DELETE set null
+);
+CREATE INDEX `project_estimate_lines_estimate_order_idx` ON `project_estimate_lines` (`estimate_id`,`division_code`,`sort_order`);
+CREATE INDEX `project_estimate_lines_project_cost_code_idx` ON `project_estimate_lines` (`project_id`,`cost_code`);
+
+CREATE TABLE `project_estimate_basis_documents` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_id` text NOT NULL,
+  `estimate_id` text NOT NULL,
+  `document_type` text NOT NULL,
+  `title` text NOT NULL,
+  `document_date` text,
+  `revision` text,
+  `drive_file_id` text,
+  `drive_url` text,
+  `notes` text,
+  `sort_order` integer DEFAULT 0 NOT NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`estimate_id`) REFERENCES `project_estimates`(`id`) ON UPDATE no action ON DELETE cascade
+);
+CREATE INDEX `project_estimate_basis_documents_estimate_idx` ON `project_estimate_basis_documents` (`estimate_id`,`sort_order`);
+
+CREATE TABLE `project_contract_budget_revisions` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_id` text NOT NULL,
+  `accepted_estimate_id` text NOT NULL,
+  `revision_number` integer NOT NULL,
+  `status` text DEFAULT 'current' NOT NULL,
+  `original_contract_sum_cents` integer DEFAULT 0 NOT NULL,
+  `approved_changes_cents` integer DEFAULT 0 NOT NULL,
+  `revised_contract_sum_cents` integer DEFAULT 0 NOT NULL,
+  `effective_at` text NOT NULL,
+  `source_hash` text NOT NULL,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`accepted_estimate_id`) REFERENCES `project_estimates`(`id`) ON UPDATE no action ON DELETE restrict,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+CREATE UNIQUE INDEX `project_contract_budget_revision_number_uq` ON `project_contract_budget_revisions` (`project_id`,`revision_number`);
+CREATE UNIQUE INDEX `project_contract_budget_source_hash_uq` ON `project_contract_budget_revisions` (`project_id`,`source_hash`);
+CREATE INDEX `project_contract_budget_current_idx` ON `project_contract_budget_revisions` (`project_id`,`status`,`revision_number`);
+
+CREATE TABLE `project_contract_budget_lines` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_id` text NOT NULL,
+  `revision_id` text NOT NULL,
+  `source_estimate_line_id` text,
+  `division_code` text NOT NULL,
+  `division_name` text NOT NULL,
+  `cost_code` text NOT NULL,
+  `description` text NOT NULL,
+  `original_estimate_cents` integer DEFAULT 0 NOT NULL,
+  `approved_change_cents` integer DEFAULT 0 NOT NULL,
+  `adjusted_budget_cents` integer DEFAULT 0 NOT NULL,
+  `owner_visible` integer DEFAULT true NOT NULL,
+  `sort_order` integer DEFAULT 0 NOT NULL,
+  `created_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`revision_id`) REFERENCES `project_contract_budget_revisions`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`source_estimate_line_id`) REFERENCES `project_estimate_lines`(`id`) ON UPDATE no action ON DELETE set null
+);
+CREATE UNIQUE INDEX `project_contract_budget_line_cost_code_uq` ON `project_contract_budget_lines` (`revision_id`,`cost_code`);
+CREATE INDEX `project_contract_budget_lines_project_idx` ON `project_contract_budget_lines` (`project_id`,`revision_id`);
+
+CREATE TABLE `project_contract_budget_adjustments` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_id` text NOT NULL,
+  `revision_id` text NOT NULL,
+  `change_order_id` text NOT NULL,
+  `change_order_line_id` text NOT NULL,
+  `cost_code` text NOT NULL,
+  `description` text NOT NULL,
+  `amount_cents` integer NOT NULL,
+  `executed_at` text NOT NULL,
+  `created_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`revision_id`) REFERENCES `project_contract_budget_revisions`(`id`) ON UPDATE no action ON DELETE cascade
+);
+CREATE UNIQUE INDEX `project_contract_budget_adjustment_line_uq` ON `project_contract_budget_adjustments` (`revision_id`,`change_order_line_id`);
+CREATE INDEX `project_contract_budget_adjustments_change_order_idx` ON `project_contract_budget_adjustments` (`project_id`,`change_order_id`);
+
+ALTER TABLE `project_budget_applications` ADD `budget_revision_id` text;
+ALTER TABLE `project_budget_lines` ADD `budget_revision_line_id` text;
+ALTER TABLE `project_budget_lines` ADD `previous_work_completed` real DEFAULT 0 NOT NULL;
+ALTER TABLE `project_budget_lines` ADD `current_work_completed` real DEFAULT 0 NOT NULL;
+ALTER TABLE `project_budget_lines` ADD `stored_materials` real DEFAULT 0 NOT NULL;

--- a/src/app/actions/project-change-orders.ts
+++ b/src/app/actions/project-change-orders.ts
@@ -37,6 +37,7 @@ import {
   type ChangeOrderRequesterType,
 } from "@/lib/change-orders/access"
 import { getCloudflareContext } from "@/lib/db"
+import { rebuildProjectContractBudget } from "@/lib/financials/contract-budget-store"
 import {
   canFeature,
   requireFeaturePermission,
@@ -877,6 +878,39 @@ export async function updateProjectChangeOrder(
     const scheduleImpactDays = contentAllowed
       ? cleanScheduleImpactDays(input.scheduleImpactDays)
       : existing.scheduleImpactDays
+    if (input.status === "executed") {
+      const executionLines =
+        lines ??
+        (await context.db
+          .select({
+            costCode: projectChangeOrderLines.costCode,
+            amountCents: projectChangeOrderLines.amountCents,
+          })
+          .from(projectChangeOrderLines)
+          .where(
+            and(
+              eq(projectChangeOrderLines.changeOrderId, changeOrderId),
+              eq(projectChangeOrderLines.projectId, projectId)
+            )
+          ))
+      if (executionLines.length === 0) {
+        return {
+          success: false,
+          error: "Add at least one cost-coded line before execution.",
+        }
+      }
+      if (
+        executionLines.some(
+          (line) => !line.costCode || line.amountCents === null
+        )
+      ) {
+        return {
+          success: false,
+          error:
+            "Every executed change-order line needs a cost code and amount so it can revise the G703.",
+        }
+      }
+    }
     const updateStatement = context.db
       .update(projectChangeOrders)
       .set({
@@ -1014,6 +1048,13 @@ export async function updateProjectChangeOrder(
           historyStatement,
         ])
       }
+    }
+    if (statusChanged && input.status === "executed") {
+      await rebuildProjectContractBudget({
+        db: context.db,
+        projectId,
+        actorUserId: context.user.id,
+      })
     }
     revalidateChangeOrderPaths(projectId)
     return { success: true, id: changeOrderId }

--- a/src/app/actions/project-estimates.ts
+++ b/src/app/actions/project-estimates.ts
@@ -1,0 +1,942 @@
+"use server"
+
+import { and, asc, desc, eq, ne } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import { projects, sageCostCodes } from "@/db/schema"
+import {
+  estimateTermsTemplates,
+  projectEstimateBasisDocuments,
+  projectEstimateLines,
+  projectEstimates,
+  sageTaxEntities,
+} from "@/db/schema-estimates"
+import { requireAuth, type AuthUser } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { rebuildProjectContractBudget } from "@/lib/financials/contract-budget-store"
+import {
+  calculateEstimateLine,
+  calculateEstimateTotals,
+  estimateCanBeEdited,
+  estimateSourceHash,
+  isEstimateStatus,
+  type EstimateLedgerLine,
+} from "@/lib/financials/estimate-ledger"
+import { requirePermission } from "@/lib/permissions"
+import { assertProjectAccess } from "@/lib/project-access"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+export type ProjectEstimateSummary = {
+  readonly id: string
+  readonly estimateNumber: string
+  readonly versionNumber: number
+  readonly title: string
+  readonly status: string
+  readonly estimateDate: string | null
+  readonly clientName: string | null
+  readonly sourceWorkbookUrl: string | null
+  readonly defaultTaxEntityId: string | null
+  readonly defaultTaxCode: string | null
+  readonly defaultTaxName: string | null
+  readonly defaultTaxRateBasisPoints: number
+  readonly termsTemplateId: string | null
+  readonly contractTerms: string | null
+  readonly directCostCents: number
+  readonly markupCents: number
+  readonly taxCents: number
+  readonly estimateTotalCents: number
+  readonly foxitStatus: string
+  readonly foxitEnvelopeId: string | null
+  readonly signaturePackageUrl: string | null
+  readonly signedAt: string | null
+  readonly acceptedAt: string | null
+  readonly sageStatus: string
+}
+
+export type ProjectEstimateLineItem = {
+  readonly id: string
+  readonly divisionCode: string
+  readonly divisionName: string
+  readonly costCode: string
+  readonly costCodeName: string
+  readonly description: string
+  readonly specifications: string | null
+  readonly quantity: number
+  readonly unit: string
+  readonly unitCostCents: number
+  readonly directCostCents: number
+  readonly markupRateBasisPoints: number
+  readonly markupCents: number
+  readonly taxable: boolean
+  readonly taxEntityId: string | null
+  readonly taxCode: string | null
+  readonly taxName: string | null
+  readonly taxRateBasisPoints: number
+  readonly taxCents: number
+  readonly lineTotalCents: number
+  readonly ownerVisible: boolean
+  readonly sortOrder: number
+}
+
+export type ProjectEstimateBasisItem = {
+  readonly id: string
+  readonly documentType: string
+  readonly title: string
+  readonly documentDate: string | null
+  readonly revision: string | null
+  readonly driveUrl: string | null
+  readonly notes: string | null
+  readonly sortOrder: number
+}
+
+export type ProjectEstimateCostCodeOption = {
+  readonly value: string
+  readonly label: string
+  readonly description: string
+  readonly divisionCode: string
+  readonly divisionName: string
+  readonly divisionLabel: string
+}
+
+export type ProjectEstimateTaxOption = {
+  readonly value: string
+  readonly label: string
+  readonly code: string
+  readonly rateBasisPoints: number
+}
+
+export type ProjectEstimateTermsOption = {
+  readonly value: string
+  readonly label: string
+  readonly body: string
+}
+
+export type ProjectEstimateWorkspace = {
+  readonly canEdit: boolean
+  readonly projectNumber: string | null
+  readonly projectName: string
+  readonly estimates: readonly ProjectEstimateSummary[]
+  readonly activeEstimate: ProjectEstimateSummary | null
+  readonly lines: readonly ProjectEstimateLineItem[]
+  readonly basisDocuments: readonly ProjectEstimateBasisItem[]
+  readonly costCodes: readonly ProjectEstimateCostCodeOption[]
+  readonly taxEntities: readonly ProjectEstimateTaxOption[]
+  readonly termsTemplates: readonly ProjectEstimateTermsOption[]
+}
+
+export type ProjectEstimateHeaderInput = {
+  readonly estimateNumber: string | null
+  readonly title: string | null
+  readonly estimateDate: string | null
+  readonly clientName: string | null
+  readonly sourceWorkbookUrl: string | null
+  readonly defaultTaxEntityId: string | null
+  readonly termsTemplateId: string | null
+  readonly contractTerms: string | null
+}
+
+export type ProjectEstimateLineInput = {
+  readonly costCode: string | null
+  readonly description: string | null
+  readonly specifications: string | null
+  readonly quantity: number | null
+  readonly unit: string | null
+  readonly unitCost: number | null
+  readonly markupPercent: number | null
+  readonly taxable: boolean
+  readonly taxEntityId: string | null
+  readonly ownerVisible: boolean
+}
+
+export type ProjectEstimateBasisInput = {
+  readonly documentType: string | null
+  readonly title: string | null
+  readonly documentDate: string | null
+  readonly revision: string | null
+  readonly driveUrl: string | null
+  readonly notes: string | null
+}
+
+export type ProjectEstimateActionResult =
+  | { readonly success: true; readonly id: string }
+  | { readonly success: false; readonly error: string }
+
+type CompassDb = ReturnType<typeof getDb>
+
+type EstimateAccess = {
+  readonly db: CompassDb
+  readonly user: AuthUser
+  readonly projectNumber: string | null
+  readonly projectName: string
+  readonly organizationId: string | null
+  readonly canEdit: boolean
+}
+
+async function estimateAccess(
+  projectId: string,
+  update: boolean
+): Promise<EstimateAccess> {
+  const user = await requireAuth()
+  requirePermission(user, "budget", update ? "update" : "read")
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const access = await assertProjectAccess(db, user, projectId)
+  const projectRows = await db
+    .select({
+      name: projects.name,
+      organizationId: projects.organizationId,
+    })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .limit(1)
+  const project = projectRows[0]
+  if (!project) throw new Error("Project not found")
+  const canEdit = update && isInternalStaffRole(user.role)
+  if (update && !canEdit) {
+    throw new Error("Only authorized internal staff can edit estimates.")
+  }
+  return {
+    db,
+    user,
+    projectNumber: access.projectNumber,
+    projectName: project.name,
+    organizationId: project.organizationId,
+    canEdit,
+  }
+}
+
+function cleanText(value: string | null): string | null {
+  const cleaned = value?.trim() ?? ""
+  return cleaned.length > 0 ? cleaned : null
+}
+
+function requiredText(value: string | null, label: string): string {
+  const cleaned = cleanText(value)
+  if (!cleaned) throw new Error(`${label} is required.`)
+  return cleaned
+}
+
+function safeUrl(value: string | null): string | null {
+  const cleaned = cleanText(value)
+  if (!cleaned) return null
+  try {
+    const url = new URL(cleaned)
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null
+    return url.toString()
+  } catch {
+    return null
+  }
+}
+
+function estimateSummary(
+  row: typeof projectEstimates.$inferSelect
+): ProjectEstimateSummary {
+  return {
+    id: row.id,
+    estimateNumber: row.estimateNumber,
+    versionNumber: row.versionNumber,
+    title: row.title,
+    status: row.status,
+    estimateDate: row.estimateDate,
+    clientName: row.clientName,
+    sourceWorkbookUrl: row.sourceWorkbookUrl,
+    defaultTaxEntityId: row.defaultTaxEntityId,
+    defaultTaxCode: row.defaultTaxCode,
+    defaultTaxName: row.defaultTaxName,
+    defaultTaxRateBasisPoints: row.defaultTaxRateBasisPoints,
+    termsTemplateId: row.termsTemplateId,
+    contractTerms: row.contractTerms,
+    directCostCents: row.directCostCents,
+    markupCents: row.markupCents,
+    taxCents: row.taxCents,
+    estimateTotalCents: row.estimateTotalCents,
+    foxitStatus: row.foxitStatus,
+    foxitEnvelopeId: row.foxitEnvelopeId,
+    signaturePackageUrl: row.signaturePackageUrl,
+    signedAt: row.signedAt,
+    acceptedAt: row.acceptedAt,
+    sageStatus: row.sageStatus,
+  }
+}
+
+function estimateLineItem(
+  row: typeof projectEstimateLines.$inferSelect
+): ProjectEstimateLineItem {
+  return {
+    id: row.id,
+    divisionCode: row.divisionCode,
+    divisionName: row.divisionName,
+    costCode: row.costCode,
+    costCodeName: row.costCodeName,
+    description: row.description,
+    specifications: row.specifications,
+    quantity: row.quantity,
+    unit: row.unit,
+    unitCostCents: row.unitCostCents,
+    directCostCents: row.directCostCents,
+    markupRateBasisPoints: row.markupRateBasisPoints,
+    markupCents: row.markupCents,
+    taxable: row.taxable,
+    taxEntityId: row.taxEntityId,
+    taxCode: row.taxCode,
+    taxName: row.taxName,
+    taxRateBasisPoints: row.taxRateBasisPoints,
+    taxCents: row.taxCents,
+    lineTotalCents: row.lineTotalCents,
+    ownerVisible: row.ownerVisible,
+    sortOrder: row.sortOrder,
+  }
+}
+
+function ledgerLine(
+  row: typeof projectEstimateLines.$inferSelect
+): EstimateLedgerLine {
+  return {
+    id: row.id,
+    divisionCode: row.divisionCode,
+    divisionName: row.divisionName,
+    costCode: row.costCode,
+    description: row.description,
+    directCostCents: row.directCostCents,
+    markupCents: row.markupCents,
+    taxCents: row.taxCents,
+    lineTotalCents: row.lineTotalCents,
+    ownerVisible: row.ownerVisible,
+    sortOrder: row.sortOrder,
+  }
+}
+
+function activeEstimate(
+  estimates: readonly ProjectEstimateSummary[],
+  estimateId?: string
+): ProjectEstimateSummary | null {
+  if (estimateId) {
+    return estimates.find((estimate) => estimate.id === estimateId) ?? null
+  }
+  return (
+    estimates.find((estimate) =>
+      ["draft", "internal_review", "signature_pending"].includes(
+        estimate.status
+      )
+    ) ??
+    estimates.find((estimate) => estimate.status === "accepted") ??
+    estimates[0] ??
+    null
+  )
+}
+
+function revalidateEstimate(projectId: string): void {
+  revalidatePath(`/dashboard/projects/${projectId}/estimate`)
+  revalidatePath(`/dashboard/projects/${projectId}/budget`)
+  revalidatePath(`/dashboard/projects/${projectId}/financials`)
+  revalidatePath(`/dashboard/projects/${projectId}/preview/owner`)
+}
+
+async function requireEditableEstimate(
+  db: CompassDb,
+  projectId: string,
+  estimateId: string
+): Promise<typeof projectEstimates.$inferSelect> {
+  const rows = await db
+    .select()
+    .from(projectEstimates)
+    .where(
+      and(
+        eq(projectEstimates.id, estimateId),
+        eq(projectEstimates.projectId, projectId)
+      )
+    )
+    .limit(1)
+  const estimate = rows[0]
+  if (!estimate || !isEstimateStatus(estimate.status)) {
+    throw new Error("Estimate not found.")
+  }
+  if (!estimateCanBeEdited(estimate.status)) {
+    throw new Error(
+      "This estimate is locked. Create a revision instead of changing accepted contract values."
+    )
+  }
+  return estimate
+}
+
+async function refreshEstimateTotals(
+  db: CompassDb,
+  estimateId: string,
+  now: string
+): Promise<void> {
+  const rows = await db
+    .select()
+    .from(projectEstimateLines)
+    .where(eq(projectEstimateLines.estimateId, estimateId))
+  const totals = calculateEstimateTotals(rows.map(ledgerLine))
+  await db
+    .update(projectEstimates)
+    .set({ ...totals, updatedAt: now })
+    .where(eq(projectEstimates.id, estimateId))
+    .run()
+}
+
+export async function getProjectEstimateWorkspace(
+  projectId: string,
+  estimateId?: string
+): Promise<ProjectEstimateWorkspace> {
+  const access = await estimateAccess(projectId, false)
+  const canEdit = isInternalStaffRole(access.user.role)
+  const estimateRows = await access.db
+    .select()
+    .from(projectEstimates)
+    .where(eq(projectEstimates.projectId, projectId))
+    .orderBy(
+      desc(projectEstimates.versionNumber),
+      desc(projectEstimates.updatedAt)
+    )
+  const estimates = estimateRows.map(estimateSummary)
+  const selected = activeEstimate(estimates, estimateId)
+  const [lineRows, basisRows, costCodeRows, taxRows, templateRows] =
+    await Promise.all([
+      selected
+        ? access.db
+            .select()
+            .from(projectEstimateLines)
+            .where(eq(projectEstimateLines.estimateId, selected.id))
+            .orderBy(
+              asc(projectEstimateLines.divisionCode),
+              asc(projectEstimateLines.sortOrder)
+            )
+        : Promise.resolve([]),
+      selected
+        ? access.db
+            .select()
+            .from(projectEstimateBasisDocuments)
+            .where(eq(projectEstimateBasisDocuments.estimateId, selected.id))
+            .orderBy(asc(projectEstimateBasisDocuments.sortOrder))
+        : Promise.resolve([]),
+      access.db
+        .select()
+        .from(sageCostCodes)
+        .where(eq(sageCostCodes.active, true))
+        .orderBy(
+          asc(sageCostCodes.divisionCode),
+          asc(sageCostCodes.displayLabel)
+        ),
+      access.db
+        .select()
+        .from(sageTaxEntities)
+        .where(eq(sageTaxEntities.active, true))
+        .orderBy(asc(sageTaxEntities.name)),
+      access.organizationId
+        ? access.db
+            .select()
+            .from(estimateTermsTemplates)
+            .where(
+              and(
+                eq(
+                  estimateTermsTemplates.organizationId,
+                  access.organizationId
+                ),
+                eq(estimateTermsTemplates.active, true)
+              )
+            )
+            .orderBy(asc(estimateTermsTemplates.name))
+        : Promise.resolve([]),
+    ])
+
+  return {
+    canEdit,
+    projectNumber: access.projectNumber,
+    projectName: access.projectName,
+    estimates,
+    activeEstimate: selected,
+    lines: lineRows.map(estimateLineItem),
+    basisDocuments: basisRows.map((row) => ({
+      id: row.id,
+      documentType: row.documentType,
+      title: row.title,
+      documentDate: row.documentDate,
+      revision: row.revision,
+      driveUrl: row.driveUrl,
+      notes: row.notes,
+      sortOrder: row.sortOrder,
+    })),
+    costCodes: costCodeRows.map((row) => ({
+      value: row.code,
+      label: row.displayLabel,
+      description: row.description,
+      divisionCode: row.divisionCode,
+      divisionName: row.divisionDescription,
+      divisionLabel: row.divisionDisplayLabel,
+    })),
+    taxEntities: taxRows.map((row) => ({
+      value: row.id,
+      label: `${row.code} · ${row.name}`,
+      code: row.code,
+      rateBasisPoints: row.rateBasisPoints,
+    })),
+    termsTemplates: templateRows.map((row) => ({
+      value: row.id,
+      label: row.name,
+      body: row.body,
+    })),
+  }
+}
+
+export async function createProjectEstimateDraft(
+  projectId: string
+): Promise<ProjectEstimateActionResult> {
+  try {
+    const access = await estimateAccess(projectId, true)
+    const prior = await access.db
+      .select({ versionNumber: projectEstimates.versionNumber })
+      .from(projectEstimates)
+      .where(eq(projectEstimates.projectId, projectId))
+      .orderBy(desc(projectEstimates.versionNumber))
+      .limit(1)
+    const versionNumber = (prior[0]?.versionNumber ?? 0) + 1
+    const estimateNumber = `${access.projectNumber ?? "PROJECT"}-00`
+    const id = crypto.randomUUID()
+    const now = new Date().toISOString()
+    await access.db.insert(projectEstimates).values({
+      id,
+      projectId,
+      estimateNumber,
+      versionNumber,
+      title: "CA22 Construction Estimate",
+      status: "draft",
+      estimateDate: now.slice(0, 10),
+      sourceSystem: "compass",
+      createdBy: access.user.id,
+      createdAt: now,
+      updatedAt: now,
+    })
+    revalidateEstimate(projectId)
+    return { success: true, id }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to create estimate.",
+    }
+  }
+}
+
+export async function updateProjectEstimateHeader(
+  projectId: string,
+  estimateId: string,
+  input: ProjectEstimateHeaderInput
+): Promise<ProjectEstimateActionResult> {
+  try {
+    const access = await estimateAccess(projectId, true)
+    await requireEditableEstimate(access.db, projectId, estimateId)
+    const taxEntityRows = input.defaultTaxEntityId
+      ? await access.db
+          .select()
+          .from(sageTaxEntities)
+          .where(eq(sageTaxEntities.id, input.defaultTaxEntityId))
+          .limit(1)
+      : []
+    const taxEntity = taxEntityRows[0]
+    const termsTemplateRows = input.termsTemplateId
+      ? await access.db
+          .select()
+          .from(estimateTermsTemplates)
+          .where(eq(estimateTermsTemplates.id, input.termsTemplateId))
+          .limit(1)
+      : []
+    const termsTemplate = termsTemplateRows[0]
+    const contractTerms =
+      cleanText(input.contractTerms) ?? termsTemplate?.body ?? null
+    await access.db
+      .update(projectEstimates)
+      .set({
+        estimateNumber: requiredText(input.estimateNumber, "Estimate number"),
+        title: requiredText(input.title, "Estimate title"),
+        estimateDate: cleanText(input.estimateDate),
+        clientName: cleanText(input.clientName),
+        sourceWorkbookUrl: safeUrl(input.sourceWorkbookUrl),
+        defaultTaxEntityId: taxEntity?.id ?? null,
+        defaultTaxCode: taxEntity?.code ?? null,
+        defaultTaxName: taxEntity?.name ?? null,
+        defaultTaxRateBasisPoints: taxEntity?.rateBasisPoints ?? 0,
+        termsTemplateId: termsTemplate?.id ?? null,
+        contractTerms,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(projectEstimates.id, estimateId))
+      .run()
+    revalidateEstimate(projectId)
+    return { success: true, id: estimateId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to save estimate.",
+    }
+  }
+}
+
+export async function saveProjectEstimateLine(
+  projectId: string,
+  estimateId: string,
+  lineId: string | null,
+  input: ProjectEstimateLineInput
+): Promise<ProjectEstimateActionResult> {
+  try {
+    const access = await estimateAccess(projectId, true)
+    const estimate = await requireEditableEstimate(
+      access.db,
+      projectId,
+      estimateId
+    )
+    const costCode = requiredText(input.costCode, "Cost code")
+    const costRows = await access.db
+      .select()
+      .from(sageCostCodes)
+      .where(and(eq(sageCostCodes.code, costCode), eq(sageCostCodes.active, true)))
+      .limit(1)
+    const cost = costRows[0]
+    if (!cost) throw new Error("Choose an active Sage cost code.")
+    const taxEntityId = cleanText(input.taxEntityId) ?? estimate.defaultTaxEntityId
+    const taxRows = taxEntityId
+      ? await access.db
+          .select()
+          .from(sageTaxEntities)
+          .where(and(eq(sageTaxEntities.id, taxEntityId), eq(sageTaxEntities.active, true)))
+          .limit(1)
+      : []
+    const tax = taxRows[0]
+    if (input.taxable && !tax) {
+      throw new Error("Choose the Sage tax entity for a taxable line.")
+    }
+    const quantity = input.quantity ?? 1
+    const unitCostCents = Math.round((input.unitCost ?? 0) * 100)
+    const markupRateBasisPoints = Math.round((input.markupPercent ?? 0) * 100)
+    const calculation = calculateEstimateLine({
+      quantity,
+      unitCostCents,
+      markupRateBasisPoints,
+      taxable: input.taxable,
+      taxRateBasisPoints: tax?.rateBasisPoints ?? 0,
+    })
+    if (calculation.lineTotalCents <= 0) {
+      throw new Error("Enter a quantity and unit cost greater than zero.")
+    }
+    const now = new Date().toISOString()
+    const id = lineId ?? crypto.randomUUID()
+    const prior = await access.db
+      .select({ sortOrder: projectEstimateLines.sortOrder })
+      .from(projectEstimateLines)
+      .where(eq(projectEstimateLines.estimateId, estimateId))
+      .orderBy(desc(projectEstimateLines.sortOrder))
+      .limit(1)
+    const values = {
+      divisionCode: cost.divisionCode,
+      divisionName: cost.divisionDescription,
+      costCode: cost.code,
+      costCodeName: cost.description,
+      description: requiredText(input.description, "Description"),
+      specifications: cleanText(input.specifications),
+      quantity,
+      unit: cleanText(input.unit) ?? "LS",
+      unitCostCents,
+      ...calculation,
+      markupRateBasisPoints,
+      taxable: input.taxable,
+      taxEntityId: tax?.id ?? null,
+      taxCode: tax?.code ?? null,
+      taxName: tax?.name ?? null,
+      taxRateBasisPoints: tax?.rateBasisPoints ?? 0,
+      ownerVisible: input.ownerVisible,
+      updatedAt: now,
+    }
+    if (lineId) {
+      const existing = await access.db
+        .select({ id: projectEstimateLines.id })
+        .from(projectEstimateLines)
+        .where(
+          and(
+            eq(projectEstimateLines.id, lineId),
+            eq(projectEstimateLines.estimateId, estimateId)
+          )
+        )
+        .limit(1)
+      if (!existing[0]) throw new Error("Estimate line not found.")
+      await access.db
+        .update(projectEstimateLines)
+        .set(values)
+        .where(eq(projectEstimateLines.id, lineId))
+        .run()
+    } else {
+      await access.db.insert(projectEstimateLines).values({
+        id,
+        projectId,
+        estimateId,
+        ...values,
+        sortOrder: (prior[0]?.sortOrder ?? 0) + 1,
+        createdAt: now,
+      })
+    }
+    await refreshEstimateTotals(access.db, estimateId, now)
+    revalidateEstimate(projectId)
+    return { success: true, id }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to save estimate line.",
+    }
+  }
+}
+
+export async function deleteProjectEstimateLine(
+  projectId: string,
+  estimateId: string,
+  lineId: string
+): Promise<ProjectEstimateActionResult> {
+  try {
+    const access = await estimateAccess(projectId, true)
+    await requireEditableEstimate(access.db, projectId, estimateId)
+    await access.db
+      .delete(projectEstimateLines)
+      .where(
+        and(
+          eq(projectEstimateLines.id, lineId),
+          eq(projectEstimateLines.estimateId, estimateId)
+        )
+      )
+      .run()
+    await refreshEstimateTotals(access.db, estimateId, new Date().toISOString())
+    revalidateEstimate(projectId)
+    return { success: true, id: lineId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to delete estimate line.",
+    }
+  }
+}
+
+export async function addProjectEstimateBasisDocument(
+  projectId: string,
+  estimateId: string,
+  input: ProjectEstimateBasisInput
+): Promise<ProjectEstimateActionResult> {
+  try {
+    const access = await estimateAccess(projectId, true)
+    await requireEditableEstimate(access.db, projectId, estimateId)
+    const prior = await access.db
+      .select({ sortOrder: projectEstimateBasisDocuments.sortOrder })
+      .from(projectEstimateBasisDocuments)
+      .where(eq(projectEstimateBasisDocuments.estimateId, estimateId))
+      .orderBy(desc(projectEstimateBasisDocuments.sortOrder))
+      .limit(1)
+    const id = crypto.randomUUID()
+    const now = new Date().toISOString()
+    await access.db.insert(projectEstimateBasisDocuments).values({
+      id,
+      projectId,
+      estimateId,
+      documentType: requiredText(input.documentType, "Document type"),
+      title: requiredText(input.title, "Document title"),
+      documentDate: cleanText(input.documentDate),
+      revision: cleanText(input.revision),
+      driveUrl: safeUrl(input.driveUrl),
+      notes: cleanText(input.notes),
+      sortOrder: (prior[0]?.sortOrder ?? 0) + 1,
+      createdAt: now,
+      updatedAt: now,
+    })
+    revalidateEstimate(projectId)
+    return { success: true, id }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to add basis document.",
+    }
+  }
+}
+
+export async function prepareProjectEstimateForFoxit(
+  projectId: string,
+  estimateId: string
+): Promise<ProjectEstimateActionResult> {
+  try {
+    const access = await estimateAccess(projectId, true)
+    const estimate = await requireEditableEstimate(
+      access.db,
+      projectId,
+      estimateId
+    )
+    const lines = await access.db
+      .select()
+      .from(projectEstimateLines)
+      .where(eq(projectEstimateLines.estimateId, estimateId))
+      .orderBy(asc(projectEstimateLines.sortOrder))
+    const basisDocuments = await access.db
+      .select()
+      .from(projectEstimateBasisDocuments)
+      .where(eq(projectEstimateBasisDocuments.estimateId, estimateId))
+      .orderBy(asc(projectEstimateBasisDocuments.sortOrder))
+    if (lines.length === 0) throw new Error("Add estimate lines before signature.")
+    if (!cleanText(estimate.contractTerms)) {
+      throw new Error("Add the contract terms before signature.")
+    }
+    const sourceHash = await estimateSourceHash({
+      estimateId,
+      versionNumber: estimate.versionNumber,
+      title: estimate.title,
+      contractTerms: estimate.contractTerms,
+      lines: lines.map((line) => ({
+        id: line.id,
+        divisionCode: line.divisionCode,
+        costCode: line.costCode,
+        description: line.description,
+        specifications: line.specifications,
+        quantity: line.quantity,
+        unit: line.unit,
+        unitCostCents: line.unitCostCents,
+        markupRateBasisPoints: line.markupRateBasisPoints,
+        taxable: line.taxable,
+        taxCode: line.taxCode,
+        taxRateBasisPoints: line.taxRateBasisPoints,
+        lineTotalCents: line.lineTotalCents,
+        ownerVisible: line.ownerVisible,
+        sortOrder: line.sortOrder,
+      })),
+      basisDocuments: basisDocuments.map((document) => ({
+        id: document.id,
+        documentType: document.documentType,
+        title: document.title,
+        documentDate: document.documentDate,
+        revision: document.revision,
+        driveFileId: document.driveFileId,
+        driveUrl: document.driveUrl,
+        notes: document.notes,
+        sortOrder: document.sortOrder,
+      })),
+    })
+    const now = new Date().toISOString()
+    await access.db
+      .update(projectEstimates)
+      .set({
+        status: "signature_pending",
+        foxitStatus: "handoff_ready",
+        signatureRequestedAt: now,
+        sourceHash,
+        updatedAt: now,
+      })
+      .where(eq(projectEstimates.id, estimateId))
+      .run()
+    revalidateEstimate(projectId)
+    return { success: true, id: estimateId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to prepare signature.",
+    }
+  }
+}
+
+export async function recordSignedProjectEstimate(
+  projectId: string,
+  estimateId: string,
+  input: {
+    readonly signedDocumentUrl: string | null
+    readonly foxitEnvelopeId: string | null
+  }
+): Promise<ProjectEstimateActionResult> {
+  try {
+    const access = await estimateAccess(projectId, true)
+    const rows = await access.db
+      .select()
+      .from(projectEstimates)
+      .where(
+        and(
+          eq(projectEstimates.id, estimateId),
+          eq(projectEstimates.projectId, projectId)
+        )
+      )
+      .limit(1)
+    const estimate = rows[0]
+    if (!estimate || estimate.status !== "signature_pending") {
+      throw new Error("Only a signature-pending estimate can be accepted.")
+    }
+    const signaturePackageUrl = safeUrl(input.signedDocumentUrl)
+    if (!signaturePackageUrl) {
+      throw new Error("Add the signed Foxit document link before acceptance.")
+    }
+    const now = new Date().toISOString()
+    // A project has one accepted contractual baseline. Preserve prior versions
+    // for the audit trail while ensuring downstream budgets resolve unambiguously.
+    await access.db
+      .update(projectEstimates)
+      .set({ status: "superseded", updatedAt: now })
+      .where(
+        and(
+          eq(projectEstimates.projectId, projectId),
+          eq(projectEstimates.status, "accepted"),
+          ne(projectEstimates.id, estimateId)
+        )
+      )
+      .run()
+    await access.db
+      .update(projectEstimates)
+      .set({
+        status: "accepted",
+        foxitStatus: "completed",
+        foxitEnvelopeId: cleanText(input.foxitEnvelopeId),
+        signaturePackageUrl,
+        signedAt: now,
+        acceptedAt: now,
+        acceptedBy: access.user.id,
+        sageStatus: "ready",
+        updatedAt: now,
+      })
+      .where(eq(projectEstimates.id, estimateId))
+      .run()
+    const budget = await rebuildProjectContractBudget({
+      db: access.db,
+      projectId,
+      actorUserId: access.user.id,
+    })
+    if (!budget.success) {
+      return {
+        success: false,
+        error: `Estimate accepted, but the contract budget needs review: ${budget.error}`,
+      }
+    }
+    revalidateEstimate(projectId)
+    return { success: true, id: estimateId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to accept estimate.",
+    }
+  }
+}
+
+export async function rebuildCurrentProjectContractBudget(
+  projectId: string
+): Promise<ProjectEstimateActionResult> {
+  try {
+    const access = await estimateAccess(projectId, true)
+    const result = await rebuildProjectContractBudget({
+      db: access.db,
+      projectId,
+      actorUserId: access.user.id,
+    })
+    if (!result.success) return result
+    revalidateEstimate(projectId)
+    return { success: true, id: result.revisionId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to rebuild budget.",
+    }
+  }
+}

--- a/src/app/actions/project-financial-workflows.ts
+++ b/src/app/actions/project-financial-workflows.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { and, asc, eq, inArray } from "drizzle-orm"
+import { and, asc, desc, eq, inArray, ne } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
@@ -11,6 +11,10 @@ import {
   projects,
   sageCostCodes,
 } from "@/db/schema"
+import {
+  projectContractBudgetLines,
+  projectContractBudgetRevisions,
+} from "@/db/schema-estimates"
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { requireOrg } from "@/lib/org-scope"
@@ -18,6 +22,7 @@ import { requirePermission } from "@/lib/permissions"
 
 export type ProjectFinancialWorkflowItem = {
   readonly id: string
+  readonly sourceRecordId: string | null
   readonly type: "vendor_bill" | "owner_pay_application" | "rfq"
   readonly number: string | null
   readonly title: string
@@ -74,6 +79,42 @@ export type ProjectFinancialCostCodeOption = {
 export type ProjectFinancialCodingOptions = {
   readonly phases: readonly ProjectFinancialPhaseOption[]
   readonly costCodes: readonly ProjectFinancialCostCodeOption[]
+}
+
+export type ProjectOwnerPayApplicationLine = {
+  readonly id: string
+  readonly costCode: string
+  readonly divisionCode: string
+  readonly divisionName: string
+  readonly description: string
+  readonly originalEstimate: number
+  readonly totalChanges: number
+  readonly adjustedEstimate: number
+  readonly previousWorkCompleted: number
+  readonly currentWorkCompleted: number
+  readonly storedMaterials: number
+  readonly totalCompletedStored: number
+  readonly retainageHeld: number
+  readonly balanceToFinish: number
+  readonly ownerVisible: boolean
+}
+
+export type ProjectOwnerPayApplicationDraft = {
+  readonly id: string
+  readonly applicationNumber: string
+  readonly periodTo: string | null
+  readonly status: string
+  readonly budgetRevisionId: string | null
+  readonly originalContractSum: number
+  readonly netChanges: number
+  readonly contractSumToDate: number
+  readonly totalCompletedStoredToDate: number
+  readonly retainageHeld: number
+  readonly totalEarnedLessRetainage: number
+  readonly previousCertificates: number
+  readonly currentPaymentDue: number
+  readonly balanceToFinish: number
+  readonly lines: readonly ProjectOwnerPayApplicationLine[]
 }
 
 type ProjectFinancialWorkflowActionResult =
@@ -234,6 +275,7 @@ export async function getProjectFinancialWorkflowItems(
 
   return rows.map((row) => ({
     id: row.id,
+    sourceRecordId: row.sourceRecordId,
     type:
       row.sourceRecordType === "vendor_bill" ||
       row.sourceRecordType === "owner_pay_application"
@@ -255,6 +297,342 @@ export async function getProjectFinancialWorkflowItems(
         : null),
     updatedAt: row.updatedAt,
   }))
+}
+
+export async function getProjectOwnerPayApplicationDraft(
+  projectId: string,
+  applicationId: string
+): Promise<ProjectOwnerPayApplicationDraft | null> {
+  const { db } = await verifyProjectReadAccess(projectId)
+  const applicationRows = await db
+    .select()
+    .from(projectBudgetApplications)
+    .where(
+      and(
+        eq(projectBudgetApplications.id, applicationId),
+        eq(projectBudgetApplications.projectId, projectId),
+        eq(projectBudgetApplications.sourceSystem, "compass_contract_budget")
+      )
+    )
+    .limit(1)
+  const application = applicationRows[0]
+  if (!application) return null
+  const lines = await db
+    .select()
+    .from(projectBudgetLines)
+    .where(
+      and(
+        eq(projectBudgetLines.projectId, projectId),
+        eq(projectBudgetLines.applicationId, applicationId)
+      )
+    )
+    .orderBy(
+      asc(projectBudgetLines.csiDivision),
+      asc(projectBudgetLines.sortOrder)
+    )
+
+  return {
+    id: application.id,
+    applicationNumber: application.applicationNumber,
+    periodTo: application.periodTo,
+    status: application.status,
+    budgetRevisionId: application.budgetRevisionId,
+    originalContractSum: application.originalContractSum,
+    netChanges: application.netChanges,
+    contractSumToDate: application.contractSumToDate,
+    totalCompletedStoredToDate: application.totalCompletedStoredToDate,
+    retainageHeld: application.retainageHeld,
+    totalEarnedLessRetainage: application.totalEarnedLessRetainage,
+    previousCertificates: application.previousCertificates,
+    currentPaymentDue: application.currentPaymentDue,
+    balanceToFinish: application.balanceToFinish,
+    lines: lines.map((line) => ({
+      id: line.id,
+      costCode: line.costCode,
+      divisionCode: line.csiDivision,
+      divisionName: line.csiDivisionName,
+      description: line.description,
+      originalEstimate: line.originalEstimate,
+      totalChanges: line.totalChanges,
+      adjustedEstimate: line.adjustedEstimate,
+      previousWorkCompleted: line.previousWorkCompleted,
+      currentWorkCompleted: line.currentWorkCompleted,
+      storedMaterials: line.storedMaterials,
+      totalCompletedStored: line.totalCosts,
+      retainageHeld: line.retainageHeld,
+      balanceToFinish: line.balanceToFinish,
+      ownerVisible: line.ownerVisible,
+    })),
+  }
+}
+
+function nonnegativeAmount(value: number | null, label: string): number {
+  if (value === null || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${label} must be zero or greater.`)
+  }
+  return Math.round(value * 100) / 100
+}
+
+async function refreshOwnerPayApplication(
+  db: ReturnType<typeof getDb>,
+  projectId: string,
+  applicationId: string,
+  now: string
+): Promise<void> {
+  const applicationRows = await db
+    .select()
+    .from(projectBudgetApplications)
+    .where(eq(projectBudgetApplications.id, applicationId))
+    .limit(1)
+  const application = applicationRows[0]
+  if (!application) throw new Error("Pay application not found.")
+  const lines = await db
+    .select()
+    .from(projectBudgetLines)
+    .where(eq(projectBudgetLines.applicationId, applicationId))
+  const totalCompletedStoredToDate = lines.reduce(
+    (sum, line) => sum + line.totalCosts,
+    0
+  )
+  const retainageHeld = lines.reduce(
+    (sum, line) => sum + line.retainageHeld,
+    0
+  )
+  const totalEarnedLessRetainage =
+    Math.round((totalCompletedStoredToDate - retainageHeld) * 100) / 100
+  const currentPaymentDue =
+    Math.round(
+      (totalEarnedLessRetainage - application.previousCertificates) * 100
+    ) / 100
+  const balanceToFinish =
+    Math.round(
+      (application.contractSumToDate - totalEarnedLessRetainage) * 100
+    ) / 100
+  await db
+    .update(projectBudgetApplications)
+    .set({
+      totalCompletedStoredToDate,
+      retainageHeld,
+      totalEarnedLessRetainage,
+      currentPaymentDue,
+      balanceToFinish,
+      updatedAt: now,
+    })
+    .where(eq(projectBudgetApplications.id, applicationId))
+    .run()
+  await db
+    .update(projectOperations)
+    .set({ amount: currentPaymentDue, updatedAt: now })
+    .where(
+      and(
+        eq(projectOperations.projectId, projectId),
+        eq(projectOperations.sourceRecordId, applicationId)
+      )
+    )
+    .run()
+}
+
+export async function updateProjectOwnerPayApplicationLine(
+  projectId: string,
+  applicationId: string,
+  lineId: string,
+  input: {
+    readonly currentWorkCompleted: number | null
+    readonly storedMaterials: number | null
+    readonly retainagePercent: number | null
+    readonly ownerVisible: boolean
+  }
+): Promise<ProjectFinancialWorkflowActionResult> {
+  try {
+    const { db } = await verifyProjectUpdateAccess(projectId)
+    const applicationRows = await db
+      .select({ status: projectBudgetApplications.status })
+      .from(projectBudgetApplications)
+      .where(
+        and(
+          eq(projectBudgetApplications.id, applicationId),
+          eq(projectBudgetApplications.projectId, projectId),
+          eq(projectBudgetApplications.sourceSystem, "compass_contract_budget")
+        )
+      )
+      .limit(1)
+    if (applicationRows[0]?.status !== "draft") {
+      throw new Error("Only a draft pay application can be edited.")
+    }
+    const lineRows = await db
+      .select()
+      .from(projectBudgetLines)
+      .where(
+        and(
+          eq(projectBudgetLines.id, lineId),
+          eq(projectBudgetLines.applicationId, applicationId),
+          eq(projectBudgetLines.projectId, projectId)
+        )
+      )
+      .limit(1)
+    const line = lineRows[0]
+    if (!line) throw new Error("Pay application line not found.")
+    const currentWorkCompleted = nonnegativeAmount(
+      input.currentWorkCompleted,
+      "Current work"
+    )
+    const storedMaterials = nonnegativeAmount(
+      input.storedMaterials,
+      "Stored materials"
+    )
+    const retainagePercent = nonnegativeAmount(
+      input.retainagePercent,
+      "Retainage"
+    )
+    if (retainagePercent > 100) {
+      throw new Error("Retainage cannot exceed 100%.")
+    }
+    const totalCompletedStored =
+      line.previousWorkCompleted + currentWorkCompleted + storedMaterials
+    if (totalCompletedStored > line.adjustedEstimate + 0.01) {
+      throw new Error(
+        "Completed work and stored materials cannot exceed the adjusted budget line."
+      )
+    }
+    const retainageHeld =
+      Math.round(totalCompletedStored * retainagePercent) / 100
+    const now = new Date().toISOString()
+    await db
+      .update(projectBudgetLines)
+      .set({
+        currentWorkCompleted,
+        storedMaterials,
+        priorCosts: line.previousWorkCompleted,
+        currentCosts: currentWorkCompleted + storedMaterials,
+        totalCosts: totalCompletedStored,
+        percentComplete:
+          line.adjustedEstimate > 0
+            ? Math.round((totalCompletedStored / line.adjustedEstimate) * 1_000) /
+              10
+            : 0,
+        balanceToFinish: line.adjustedEstimate - totalCompletedStored,
+        retainageHeld,
+        ownerVisible: input.ownerVisible,
+        updatedAt: now,
+      })
+      .where(eq(projectBudgetLines.id, lineId))
+      .run()
+    await refreshOwnerPayApplication(db, projectId, applicationId, now)
+    revalidateFinancialPaths(projectId)
+    return { success: true, id: lineId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to update pay application.",
+    }
+  }
+}
+
+export async function markProjectOwnerPayApplicationReady(
+  projectId: string,
+  applicationId: string
+): Promise<ProjectFinancialWorkflowActionResult> {
+  try {
+    const { db } = await verifyProjectUpdateAccess(projectId)
+    const rows = await db
+      .select()
+      .from(projectBudgetApplications)
+      .where(
+        and(
+          eq(projectBudgetApplications.id, applicationId),
+          eq(projectBudgetApplications.projectId, projectId),
+          eq(projectBudgetApplications.status, "draft")
+        )
+      )
+      .limit(1)
+    const application = rows[0]
+    if (!application) throw new Error("Draft pay application not found.")
+    if (application.currentPaymentDue <= 0) {
+      throw new Error("Enter current work or stored materials before Sage review.")
+    }
+    const lines = await db
+      .select()
+      .from(projectBudgetLines)
+      .where(eq(projectBudgetLines.applicationId, applicationId))
+      .orderBy(
+        asc(projectBudgetLines.csiDivision),
+        asc(projectBudgetLines.sortOrder)
+      )
+    if (lines.length === 0) {
+      throw new Error("The pay application has no G703 lines.")
+    }
+    const now = new Date().toISOString()
+    const sageReviewPayload = JSON.stringify({
+      schemaVersion: 1,
+      source: "compass_owner_pay_application",
+      writeApprovalRequired: true,
+      applicationId,
+      applicationNumber: application.applicationNumber,
+      periodTo: application.periodTo,
+      budgetRevisionId: application.budgetRevisionId,
+      g702: {
+        originalContractSum: application.originalContractSum,
+        netChanges: application.netChanges,
+        contractSumToDate: application.contractSumToDate,
+        totalCompletedStoredToDate: application.totalCompletedStoredToDate,
+        retainageHeld: application.retainageHeld,
+        totalEarnedLessRetainage: application.totalEarnedLessRetainage,
+        previousCertificates: application.previousCertificates,
+        currentPaymentDue: application.currentPaymentDue,
+        balanceToFinish: application.balanceToFinish,
+      },
+      g703: lines.map((line) => ({
+        sourceLineId: line.id,
+        budgetRevisionLineId: line.budgetRevisionLineId,
+        divisionCode: line.csiDivision,
+        costCode: line.costCode,
+        description: line.description,
+        originalEstimate: line.originalEstimate,
+        totalChanges: line.totalChanges,
+        adjustedEstimate: line.adjustedEstimate,
+        previousWorkCompleted: line.previousWorkCompleted,
+        currentWorkCompleted: line.currentWorkCompleted,
+        storedMaterials: line.storedMaterials,
+        totalCompletedStored: line.totalCosts,
+        retainageHeld: line.retainageHeld,
+        balanceToFinish: line.balanceToFinish,
+      })),
+    })
+    await db
+      .update(projectBudgetApplications)
+      .set({
+        status: "internal_review",
+        syncStatus: "needs_review",
+        updatedAt: now,
+      })
+      .where(eq(projectBudgetApplications.id, applicationId))
+      .run()
+    await db
+      .update(projectOperations)
+      .set({
+        status: "internal_review",
+        sageWriteStatus: "draft_ready",
+        sagePayloadJson: sageReviewPayload,
+        syncStatus: "needs_review",
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(projectOperations.projectId, projectId),
+          eq(projectOperations.sourceRecordId, applicationId)
+        )
+      )
+      .run()
+    revalidateFinancialPaths(projectId)
+    return { success: true, id: applicationId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to stage Sage review.",
+    }
+  }
 }
 
 export async function getProjectFinancialCodingOptions(
@@ -385,7 +763,7 @@ export async function createProjectVendorBillDraft(
         description,
       }),
       syncDirection: "write",
-      syncStatus: "pending_sage",
+      syncStatus: "compass_only",
       createdAt: now,
       updatedAt: now,
     })
@@ -469,17 +847,175 @@ export async function createProjectOwnerPayApplicationDraft(
     const { db, project } = await verifyProjectUpdateAccess(projectId)
     const now = new Date().toISOString()
     const id = crypto.randomUUID()
+    const applicationId = crypto.randomUUID()
     const recordNumber =
       cleanText(input.applicationNumber) ??
       (await nextRecordNumber(db, projectId, "owner_pay_application"))
     const periodTo = cleanText(input.periodTo)
-    const amount = finiteAmount(input.amount)
+    const revisionRows = await db
+      .select()
+      .from(projectContractBudgetRevisions)
+      .where(
+        and(
+          eq(projectContractBudgetRevisions.projectId, projectId),
+          eq(projectContractBudgetRevisions.status, "current")
+        )
+      )
+      .orderBy(desc(projectContractBudgetRevisions.revisionNumber))
+      .limit(1)
+    const revision = revisionRows[0]
+    if (!revision) {
+      throw new Error(
+        "Accept the signed estimate and build the contract budget before creating a pay application."
+      )
+    }
+    const revisionLines = await db
+      .select()
+      .from(projectContractBudgetLines)
+      .where(eq(projectContractBudgetLines.revisionId, revision.id))
+      .orderBy(
+        asc(projectContractBudgetLines.divisionCode),
+        asc(projectContractBudgetLines.sortOrder)
+      )
+    if (revisionLines.length === 0) {
+      throw new Error("The current contract budget has no lines.")
+    }
+    const duplicateRows = await db
+      .select({ id: projectBudgetApplications.id })
+      .from(projectBudgetApplications)
+      .where(
+        and(
+          eq(projectBudgetApplications.projectId, projectId),
+          eq(projectBudgetApplications.applicationNumber, recordNumber)
+        )
+      )
+      .limit(1)
+    if (duplicateRows[0]) {
+      throw new Error("That pay application number already exists.")
+    }
+    const priorApplications = await db
+      .select()
+      .from(projectBudgetApplications)
+      .where(
+        and(
+          eq(projectBudgetApplications.projectId, projectId),
+          ne(projectBudgetApplications.status, "budget_current"),
+          ne(projectBudgetApplications.status, "budget_superseded"),
+          ne(projectBudgetApplications.status, "building")
+        )
+      )
+      .orderBy(
+        desc(projectBudgetApplications.periodTo),
+        desc(projectBudgetApplications.createdAt)
+      )
+      .limit(1)
+    const priorApplication = priorApplications[0]
+    const priorLines = priorApplication
+      ? await db
+          .select()
+          .from(projectBudgetLines)
+          .where(eq(projectBudgetLines.applicationId, priorApplication.id))
+      : []
+    const priorByCostCode = new Map(
+      priorLines.map((line) => [
+        line.costCode,
+        {
+          totalCompletedStored: line.totalCosts,
+          retainageHeld: line.retainageHeld,
+        },
+      ])
+    )
+    const originalContractSum = revision.originalContractSumCents / 100
+    const netChanges = revision.approvedChangesCents / 100
+    const contractSumToDate = revision.revisedContractSumCents / 100
+    const previousCertificates =
+      priorApplication?.totalEarnedLessRetainage ?? 0
+    const priorCompletedStored =
+      priorApplication?.totalCompletedStoredToDate ?? 0
+    const priorRetainage = priorApplication?.retainageHeld ?? 0
+
+    await db.insert(projectBudgetApplications).values({
+      id: applicationId,
+      projectId,
+      sourceSystem: "compass_contract_budget",
+      sourceRecordId: revision.id,
+      applicationNumber: recordNumber,
+      periodTo,
+      status: "building",
+      originalContractSum,
+      netChanges,
+      contractSumToDate,
+      totalCompletedStoredToDate: priorCompletedStored,
+      retainageHeld: priorRetainage,
+      totalEarnedLessRetainage: previousCertificates,
+      previousCertificates,
+      currentPaymentDue: 0,
+      balanceToFinish: contractSumToDate - previousCertificates,
+      ownerVisible: false,
+      sourceUrl: safeHttpUrl(input.supportingPackageUrl),
+      budgetRevisionId: revision.id,
+      syncStatus: "compass_only",
+      lastSyncedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    await db.insert(projectBudgetLines).values(
+      revisionLines.map((line) => {
+        const originalEstimate = line.originalEstimateCents / 100
+        const totalChanges = line.approvedChangeCents / 100
+        const adjustedEstimate = line.adjustedBudgetCents / 100
+        const prior = priorByCostCode.get(line.costCode)
+        const priorCosts = prior?.totalCompletedStored ?? 0
+        return {
+          id: crypto.randomUUID(),
+          projectId,
+          applicationId,
+          budgetRevisionLineId: line.id,
+          sourceSystem: "compass_contract_budget",
+          sourceRecordId: line.id,
+          sourceRecordNumber: line.costCode,
+          costCode: line.costCode,
+          csiDivision: line.divisionCode,
+          csiDivisionName: line.divisionName,
+          description: line.description,
+          notes: null,
+          originalEstimate,
+          priorChanges: totalChanges,
+          currentChanges: 0,
+          totalChanges,
+          adjustedEstimate,
+          previousWorkCompleted: priorCosts,
+          currentWorkCompleted: 0,
+          storedMaterials: 0,
+          priorCosts,
+          currentCosts: 0,
+          totalCosts: priorCosts,
+          percentComplete:
+            adjustedEstimate > 0
+              ? Math.round((priorCosts / adjustedEstimate) * 1_000) / 10
+              : 0,
+          balanceToFinish: adjustedEstimate - priorCosts,
+          retainageHeld: prior?.retainageHeld ?? 0,
+          vendorName: null,
+          ownerLabel: line.description,
+          ownerVisible: line.ownerVisible,
+          internalNotes: `Contract budget revision ${revision.revisionNumber}.`,
+          sortOrder: line.sortOrder,
+          syncStatus: "compass_only",
+          lastSyncedAt: null,
+          createdAt: now,
+          updatedAt: now,
+        }
+      })
+    )
 
     await db.insert(projectOperations).values({
       id,
       projectId,
       sourceSystem: "compass",
       sourceRecordType: "owner_pay_application",
+      sourceRecordId: applicationId,
       sourceRecordNumber: recordNumber,
       title: `${typeLabel("owner_pay_application")} ${recordNumber}`,
       description: cleanText(input.notes),
@@ -487,7 +1023,7 @@ export async function createProjectOwnerPayApplicationDraft(
       priority: "normal",
       assigneeType: "owner",
       dueDate: periodTo,
-      amount,
+      amount: 0,
       externalUrl: safeHttpUrl(input.supportingPackageUrl),
       sageJobId: project.sageJobId,
       sageJobNumber: project.sageJobNumber,
@@ -499,16 +1035,30 @@ export async function createProjectOwnerPayApplicationDraft(
         jobNumber: project.sageJobNumber,
         applicationNumber: recordNumber,
         periodTo,
-        amount,
+        amount: 0,
+        budgetRevisionId: revision.id,
+        budgetRevisionNumber: revision.revisionNumber,
+        originalContractSum,
+        netChanges,
+        contractSumToDate,
+        previousCertificates,
+        lineCount: revisionLines.length,
         notes: cleanText(input.notes),
         supportingPackageUrl: safeHttpUrl(input.supportingPackageUrl),
         format: "AIA_G702_G703_STYLE",
       }),
       syncDirection: "write",
-      syncStatus: "pending_sage",
+      // A draft is not a Sage write request. The reviewed G702/G703 snapshot
+      // is staged separately and still requires explicit write approval.
+      syncStatus: "compass_only",
       createdAt: now,
       updatedAt: now,
     })
+    await db
+      .update(projectBudgetApplications)
+      .set({ status: "draft", updatedAt: now })
+      .where(eq(projectBudgetApplications.id, applicationId))
+      .run()
 
     revalidateFinancialPaths(projectId)
     return { success: true, id }

--- a/src/app/dashboard/projects/[id]/estimate/page.tsx
+++ b/src/app/dashboard/projects/[id]/estimate/page.tsx
@@ -1,0 +1,40 @@
+export const dynamic = "force-dynamic"
+
+import Link from "next/link"
+import { IconArrowLeft, IconCalculator } from "@tabler/icons-react"
+
+import { getProjectEstimateWorkspace } from "@/app/actions/project-estimates"
+import { ProjectContextSwitcher } from "@/components/projects/project-context-switcher"
+import { ProjectEstimateWorkspacePanel } from "@/components/projects/project-estimate-workspace"
+
+export default async function ProjectEstimatePage({
+  params,
+  searchParams,
+}: {
+  readonly params: Promise<{ id: string }>
+  readonly searchParams: Promise<{ estimateId?: string }>
+}): Promise<React.ReactElement> {
+  const [{ id }, query] = await Promise.all([params, searchParams])
+  const workspace = await getProjectEstimateWorkspace(id, query.estimateId)
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto p-4 md:p-6">
+      <div className="mb-5 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <Link href={`/dashboard/projects/${id}`} className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground">
+            <IconArrowLeft className="size-4" />Project
+          </Link>
+          <div className="mt-3 flex items-center gap-2">
+            <IconCalculator className="size-5 text-primary" />
+            <h1 className="text-2xl font-semibold tracking-tight">Estimate</h1>
+          </div>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            Division-first CA22 estimate, contract basis, Foxit approval, and Sage-ready budget handoff.
+          </p>
+        </div>
+        <ProjectContextSwitcher currentProjectId={id} targetSection="estimate" placeholder="Switch estimate project..." className="w-full sm:w-[280px]" />
+      </div>
+      <ProjectEstimateWorkspacePanel projectId={id} workspace={workspace} />
+    </div>
+  )
+}

--- a/src/app/dashboard/projects/[id]/financials/pay-applications/[applicationId]/page.tsx
+++ b/src/app/dashboard/projects/[id]/financials/pay-applications/[applicationId]/page.tsx
@@ -1,0 +1,36 @@
+export const dynamic = "force-dynamic"
+
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { IconArrowLeft, IconFileDollar } from "@tabler/icons-react"
+
+import { getProjectOwnerPayApplicationDraft } from "@/app/actions/project-financial-workflows"
+import { ProjectOwnerPayApplicationEditor } from "@/components/projects/project-owner-pay-application-editor"
+
+export default async function ProjectPayApplicationPage({
+  params,
+}: {
+  readonly params: Promise<{ id: string; applicationId: string }>
+}): Promise<React.ReactElement> {
+  const { id, applicationId } = await params
+  const application = await getProjectOwnerPayApplicationDraft(id, applicationId)
+  if (!application) notFound()
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto p-4 md:p-6">
+      <div className="mb-5">
+        <Link href={`/dashboard/projects/${id}/financials`} className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground">
+          <IconArrowLeft className="size-4" />Project financials
+        </Link>
+        <div className="mt-3 flex items-center gap-2">
+          <IconFileDollar className="size-5 text-primary" />
+          <h1 className="text-2xl font-semibold tracking-tight">G702 / G703 Pay Application</h1>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Enter current work, stored materials, and retainage against the locked contract budget.
+        </p>
+      </div>
+      <ProjectOwnerPayApplicationEditor projectId={id} application={application} />
+    </div>
+  )
+}

--- a/src/app/print/projects/[id]/estimate/page.tsx
+++ b/src/app/print/projects/[id]/estimate/page.tsx
@@ -1,0 +1,149 @@
+export const dynamic = "force-dynamic"
+
+import Image from "next/image"
+
+import { getProjectEstimateWorkspace } from "@/app/actions/project-estimates"
+import { getProjects } from "@/app/actions/projects"
+import { projectBrandFor } from "@/lib/project-branding"
+
+function money(cents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(cents / 100)
+}
+
+export default async function ProjectEstimatePrintPage({
+  params,
+  searchParams,
+}: {
+  readonly params: Promise<{ id: string }>
+  readonly searchParams: Promise<{ estimateId?: string }>
+}): Promise<React.ReactElement> {
+  const [{ id }, query] = await Promise.all([params, searchParams])
+  const [workspace, projects] = await Promise.all([
+    getProjectEstimateWorkspace(id, query.estimateId),
+    getProjects(),
+  ])
+  const estimate = workspace.activeEstimate
+  const project = projects.find((item) => item.id === id)
+  const brand = projectBrandFor({
+    projectId: id,
+    projectNumber: workspace.projectNumber,
+  })
+  const divisions = new Map<string, typeof workspace.lines>()
+  for (const line of workspace.lines) {
+    const current = divisions.get(line.divisionCode) ?? []
+    divisions.set(line.divisionCode, [...current, line])
+  }
+
+  if (!estimate) {
+    return <main className="p-8">Estimate not found.</main>
+  }
+
+  return (
+    <main className="mx-auto max-w-[8.5in] bg-white p-8 text-black print:max-w-none print:p-0">
+      <header className="flex items-start justify-between gap-6 border-b-2 border-black pb-5">
+        <div className="flex items-center gap-4">
+          <Image
+            src={brand.logoSrc}
+            alt={brand.logoAlt}
+            width={80}
+            height={80}
+            className="size-20 object-contain"
+            priority
+          />
+          <div>
+            <p className="text-lg font-bold">{brand.companyName}</p>
+            {brand.mailingAddress.map((line) => (
+              <p key={line} className="text-sm">{line}</p>
+            ))}
+          </div>
+        </div>
+        <div className="text-right">
+          <h1 className="text-xl font-bold">CA22 Construction Estimate</h1>
+          <p className="mt-1 text-sm">{estimate.estimateNumber}</p>
+          <p className="text-sm">Version {estimate.versionNumber}</p>
+        </div>
+      </header>
+
+      <section className="mt-5 grid grid-cols-2 gap-6 text-sm">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide">Project</p>
+          <p className="mt-1 font-semibold">{project?.name ?? workspace.projectName}</p>
+          <p>{workspace.projectNumber}</p>
+        </div>
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide">Prepared for</p>
+          <p className="mt-1 font-semibold">{estimate.clientName ?? "Project owner"}</p>
+          <p>{estimate.estimateDate ?? ""}</p>
+        </div>
+      </section>
+
+      <section className="mt-6">
+        <div className="grid grid-cols-[1fr_1.2in] border-b border-black pb-1 text-xs font-semibold uppercase tracking-wide">
+          <span>CSI division and cost code</span>
+          <span className="text-right">Amount</span>
+        </div>
+        {[...divisions.entries()].map(([divisionCode, lines]) => {
+          const subtotal = lines.reduce((sum, line) => sum + line.lineTotalCents, 0)
+          return (
+            <div key={divisionCode} className="break-inside-avoid border-b py-3">
+              <div className="flex items-center justify-between gap-3 font-semibold">
+                <span>{divisionCode} · {lines[0]?.divisionName}</span>
+                <span>{money(subtotal)}</span>
+              </div>
+              <div className="mt-1 space-y-1">
+                {lines.map((line) => (
+                  <div key={line.id} className="grid grid-cols-[1fr_1.2in] gap-3 text-sm">
+                    <div>
+                      <span className="font-medium">{line.costCode}</span>
+                      <span> · {line.description}</span>
+                      {line.specifications && <p className="text-xs text-neutral-600">{line.specifications}</p>}
+                    </div>
+                    <span className="text-right">{money(line.lineTotalCents)}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )
+        })}
+      </section>
+
+      <section className="ml-auto mt-5 w-full max-w-sm space-y-1 text-sm">
+        <div className="flex justify-between"><span>Direct cost</span><span>{money(estimate.directCostCents)}</span></div>
+        <div className="flex justify-between"><span>Line markup</span><span>{money(estimate.markupCents)}</span></div>
+        <div className="flex justify-between"><span>Sales tax</span><span>{money(estimate.taxCents)}</span></div>
+        <div className="flex justify-between border-t border-black pt-2 text-base font-bold"><span>Construction estimate</span><span>{money(estimate.estimateTotalCents)}</span></div>
+      </section>
+
+      {workspace.basisDocuments.length > 0 && (
+        <section className="mt-8 break-inside-avoid">
+          <h2 className="border-b pb-1 text-sm font-bold uppercase tracking-wide">Estimate basis</h2>
+          <ul className="mt-2 space-y-1 text-sm">
+            {workspace.basisDocuments.map((document) => (
+              <li key={document.id}>
+                <span className="font-medium">{document.title}</span>
+                {document.documentDate ? ` · ${document.documentDate}` : ""}
+                {document.revision ? ` · revision ${document.revision}` : ""}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {estimate.contractTerms && (
+        <section className="mt-8 break-inside-avoid">
+          <h2 className="border-b pb-1 text-sm font-bold uppercase tracking-wide">Pertinent contract terms</h2>
+          <p className="mt-2 whitespace-pre-wrap text-sm leading-6">{estimate.contractTerms}</p>
+        </section>
+      )}
+
+      <footer className="mt-10 border-t pt-3 text-xs text-neutral-600">
+        Accepted estimate versions are locked in Compass. Revisions to the contract
+        sum are recorded through executed change orders and the G703.
+      </footer>
+    </main>
+  )
+}

--- a/src/components/nav-projects.tsx
+++ b/src/components/nav-projects.tsx
@@ -49,6 +49,7 @@ type ProjectSectionKey =
   | "rfqs"
   | "purchase-orders"
   | "change-orders"
+  | "estimate"
   | "budget"
   | "financials"
   | "contacts"
@@ -136,6 +137,12 @@ const PROJECT_SECTION_ITEMS: readonly ProjectSectionItem[] = [
     section: "change-orders",
   },
   {
+    title: "Estimate",
+    hrefSuffix: "estimate",
+    icon: IconFileDollar,
+    section: "estimate",
+  },
+  {
     title: "Budget / G703",
     hrefSuffix: "budget",
     icon: IconFileDollar,
@@ -207,6 +214,7 @@ function activeProjectSection(pathname: string | null): ProjectSectionKey {
     case "contacts":
     case "daily-logs":
     case "financials":
+    case "estimate":
     case "owner-updates":
     case "photos":
     case "selections":

--- a/src/components/projects/project-estimate-workspace.tsx
+++ b/src/components/projects/project-estimate-workspace.tsx
@@ -1,0 +1,701 @@
+"use client"
+
+import { useMemo, useState, useTransition, type FormEvent } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import {
+  IconFileDescription,
+  IconFileExport,
+  IconPlus,
+  IconReceiptTax,
+  IconSend,
+  IconTrash,
+} from "@tabler/icons-react"
+
+import {
+  addProjectEstimateBasisDocument,
+  createProjectEstimateDraft,
+  deleteProjectEstimateLine,
+  prepareProjectEstimateForFoxit,
+  recordSignedProjectEstimate,
+  saveProjectEstimateLine,
+  updateProjectEstimateHeader,
+  type ProjectEstimateLineItem,
+  type ProjectEstimateWorkspace,
+} from "@/app/actions/project-estimates"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+
+function money(cents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(cents / 100)
+}
+
+function percent(basisPoints: number): string {
+  return `${(basisPoints / 100).toFixed(2)}%`
+}
+
+function formText(formData: FormData, name: string): string | null {
+  const value = String(formData.get(name) ?? "").trim()
+  return value.length > 0 ? value : null
+}
+
+function formNumber(formData: FormData, name: string): number | null {
+  const value = Number(String(formData.get(name) ?? "").replaceAll(",", ""))
+  return Number.isFinite(value) ? value : null
+}
+
+function statusLabel(value: string): string {
+  return value.replaceAll("_", " ")
+}
+
+type LineDraft = {
+  readonly id: string | null
+  readonly divisionCode: string
+  readonly costCode: string
+  readonly description: string
+  readonly specifications: string
+  readonly quantity: string
+  readonly unit: string
+  readonly unitCost: string
+  readonly markupPercent: string
+  readonly taxable: boolean
+  readonly taxEntityId: string
+  readonly ownerVisible: boolean
+}
+
+const EMPTY_LINE: LineDraft = {
+  id: null,
+  divisionCode: "",
+  costCode: "",
+  description: "",
+  specifications: "",
+  quantity: "1",
+  unit: "LS",
+  unitCost: "",
+  markupPercent: "0",
+  taxable: false,
+  taxEntityId: "",
+  ownerVisible: true,
+}
+
+function lineDraft(line: ProjectEstimateLineItem): LineDraft {
+  return {
+    id: line.id,
+    divisionCode: line.divisionCode,
+    costCode: line.costCode,
+    description: line.description,
+    specifications: line.specifications ?? "",
+    quantity: String(line.quantity),
+    unit: line.unit,
+    unitCost: String(line.unitCostCents / 100),
+    markupPercent: String(line.markupRateBasisPoints / 100),
+    taxable: line.taxable,
+    taxEntityId: line.taxEntityId ?? "",
+    ownerVisible: line.ownerVisible,
+  }
+}
+
+export function ProjectEstimateWorkspacePanel({
+  projectId,
+  workspace,
+}: {
+  readonly projectId: string
+  readonly workspace: ProjectEstimateWorkspace
+}): React.ReactElement {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [message, setMessage] = useState<string | null>(null)
+  const [line, setLine] = useState<LineDraft>(EMPTY_LINE)
+  const estimate = workspace.activeEstimate
+  const editable =
+    workspace.canEdit &&
+    Boolean(estimate && ["draft", "internal_review"].includes(estimate.status))
+
+  const divisions = useMemo(() => {
+    const options = new Map<string, string>()
+    for (const option of workspace.costCodes) {
+      options.set(option.divisionCode, option.divisionLabel)
+    }
+    return [...options.entries()].sort((left, right) =>
+      left[0].localeCompare(right[0])
+    )
+  }, [workspace.costCodes])
+  const availableCostCodes = workspace.costCodes.filter(
+    (option) => option.divisionCode === line.divisionCode
+  )
+  const groupedLines = useMemo(() => {
+    const groups = new Map<string, ProjectEstimateLineItem[]>()
+    for (const item of workspace.lines) {
+      const current = groups.get(item.divisionCode) ?? []
+      current.push(item)
+      groups.set(item.divisionCode, current)
+    }
+    return [...groups.entries()].sort((left, right) =>
+      left[0].localeCompare(right[0])
+    )
+  }, [workspace.lines])
+
+  function finish(messageText: string): void {
+    setMessage(messageText)
+    router.refresh()
+  }
+
+  function createEstimate(): void {
+    setMessage(null)
+    startTransition(async () => {
+      const result = await createProjectEstimateDraft(projectId)
+      finish(result.success ? "Estimate draft created." : result.error)
+    })
+  }
+
+  function saveHeader(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    if (!estimate) return
+    const formData = new FormData(event.currentTarget)
+    setMessage(null)
+    startTransition(async () => {
+      const result = await updateProjectEstimateHeader(projectId, estimate.id, {
+        estimateNumber: formText(formData, "estimateNumber"),
+        title: formText(formData, "title"),
+        estimateDate: formText(formData, "estimateDate"),
+        clientName: formText(formData, "clientName"),
+        sourceWorkbookUrl: formText(formData, "sourceWorkbookUrl"),
+        defaultTaxEntityId: formText(formData, "defaultTaxEntityId"),
+        termsTemplateId: formText(formData, "termsTemplateId"),
+        contractTerms: formText(formData, "contractTerms"),
+      })
+      finish(result.success ? "Estimate details saved." : result.error)
+    })
+  }
+
+  function saveLine(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    if (!estimate) return
+    const formData = new FormData(event.currentTarget)
+    setMessage(null)
+    startTransition(async () => {
+      const result = await saveProjectEstimateLine(
+        projectId,
+        estimate.id,
+        line.id,
+        {
+          costCode: line.costCode,
+          description: formText(formData, "description"),
+          specifications: formText(formData, "specifications"),
+          quantity: formNumber(formData, "quantity"),
+          unit: formText(formData, "unit"),
+          unitCost: formNumber(formData, "unitCost"),
+          markupPercent: formNumber(formData, "markupPercent"),
+          taxable: line.taxable,
+          taxEntityId: line.taxEntityId || null,
+          ownerVisible: line.ownerVisible,
+        }
+      )
+      if (result.success) setLine(EMPTY_LINE)
+      finish(result.success ? "Estimate line saved." : result.error)
+    })
+  }
+
+  function removeLine(lineId: string): void {
+    if (!estimate) return
+    setMessage(null)
+    startTransition(async () => {
+      const result = await deleteProjectEstimateLine(
+        projectId,
+        estimate.id,
+        lineId
+      )
+      finish(result.success ? "Estimate line removed." : result.error)
+    })
+  }
+
+  function addBasis(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    if (!estimate) return
+    const form = event.currentTarget
+    const formData = new FormData(form)
+    setMessage(null)
+    startTransition(async () => {
+      const result = await addProjectEstimateBasisDocument(
+        projectId,
+        estimate.id,
+        {
+          documentType: formText(formData, "documentType"),
+          title: formText(formData, "documentTitle"),
+          documentDate: formText(formData, "documentDate"),
+          revision: formText(formData, "revision"),
+          driveUrl: formText(formData, "driveUrl"),
+          notes: formText(formData, "documentNotes"),
+        }
+      )
+      if (result.success) form.reset()
+      finish(result.success ? "Estimate basis added." : result.error)
+    })
+  }
+
+  function prepareFoxit(): void {
+    if (!estimate) return
+    setMessage(null)
+    startTransition(async () => {
+      const result = await prepareProjectEstimateForFoxit(projectId, estimate.id)
+      finish(
+        result.success
+          ? "CA22 estimate locked and ready for Foxit signature handoff."
+          : result.error
+      )
+    })
+  }
+
+  function acceptSigned(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    if (!estimate) return
+    const formData = new FormData(event.currentTarget)
+    setMessage(null)
+    startTransition(async () => {
+      const result = await recordSignedProjectEstimate(projectId, estimate.id, {
+        signedDocumentUrl: formText(formData, "signedDocumentUrl"),
+        foxitEnvelopeId: formText(formData, "foxitEnvelopeId"),
+      })
+      finish(
+        result.success
+          ? "Signed estimate accepted and contract budget created."
+          : result.error
+      )
+    })
+  }
+
+  if (!estimate) {
+    return (
+      <section className="clarity-panel-strong p-6">
+        <h2 className="text-lg font-semibold">Start the project estimate</h2>
+        <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+          Build the CA22 estimate by CSI division and Sage cost code. Acceptance
+          creates the original contract budget; later changes must come through
+          executed change orders.
+        </p>
+        {workspace.canEdit && (
+          <Button className="mt-4" onClick={createEstimate} disabled={isPending}>
+            <IconPlus className="size-4" />
+            Create estimate
+          </Button>
+        )}
+      </section>
+    )
+  }
+
+  return (
+    <div className="space-y-5">
+      {message && (
+        <div className="rounded-md border bg-muted/35 px-3 py-2 text-sm">
+          {message}
+        </div>
+      )}
+
+      <section className="clarity-panel-strong overflow-hidden">
+        <div className="flex flex-wrap items-start justify-between gap-3 border-b px-4 py-3">
+          <div>
+            <div className="flex items-center gap-2">
+              <h2 className="font-semibold">{estimate.title}</h2>
+              <Badge variant="outline">v{estimate.versionNumber}</Badge>
+              <Badge>{statusLabel(estimate.status)}</Badge>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {estimate.estimateNumber} · Foxit {statusLabel(estimate.foxitStatus)} ·
+              Sage {statusLabel(estimate.sageStatus)}
+            </p>
+          </div>
+          <Button variant="outline" asChild>
+            <Link
+              href={`/print/projects/${projectId}/estimate?estimateId=${estimate.id}`}
+              target="_blank"
+            >
+              <IconFileExport className="size-4" />
+              CA22 preview
+            </Link>
+          </Button>
+        </div>
+        <div className="grid divide-y sm:grid-cols-2 sm:divide-x sm:divide-y-0 xl:grid-cols-4">
+          {[
+            ["Direct cost", estimate.directCostCents],
+            ["Line markup", estimate.markupCents],
+            ["Sales tax", estimate.taxCents],
+            ["Estimate total", estimate.estimateTotalCents],
+          ].map(([label, value]) => (
+            <div key={String(label)} className="px-4 py-3">
+              <p className="text-xs text-muted-foreground">{label}</p>
+              <p className="mt-1 text-lg font-semibold">{money(Number(value))}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <form className="clarity-panel-strong p-4" onSubmit={saveHeader}>
+        <div className="mb-4 flex items-center gap-2">
+          <IconFileDescription className="size-5 text-primary" />
+          <h2 className="font-semibold">Estimate and contract basis</h2>
+        </div>
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="estimateNumber">Estimate number</Label>
+            <Input
+              id="estimateNumber"
+              name="estimateNumber"
+              defaultValue={estimate.estimateNumber}
+              disabled={!editable}
+            />
+          </div>
+          <div className="space-y-1.5 xl:col-span-2">
+            <Label htmlFor="estimateTitle">Document name</Label>
+            <Input
+              id="estimateTitle"
+              name="title"
+              defaultValue={estimate.title}
+              disabled={!editable}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="estimateDate">Estimate date</Label>
+            <Input
+              id="estimateDate"
+              name="estimateDate"
+              type="date"
+              defaultValue={estimate.estimateDate ?? ""}
+              disabled={!editable}
+            />
+          </div>
+          <div className="space-y-1.5 md:col-span-2">
+            <Label htmlFor="clientName">Client(s)</Label>
+            <Input
+              id="clientName"
+              name="clientName"
+              defaultValue={estimate.clientName ?? ""}
+              disabled={!editable}
+            />
+          </div>
+          <div className="space-y-1.5 md:col-span-2">
+            <Label htmlFor="sourceWorkbookUrl">Source CSI workbook</Label>
+            <Input
+              id="sourceWorkbookUrl"
+              name="sourceWorkbookUrl"
+              type="url"
+              defaultValue={estimate.sourceWorkbookUrl ?? ""}
+              disabled={!editable}
+            />
+          </div>
+          <div className="space-y-1.5 md:col-span-2">
+            <Label htmlFor="defaultTaxEntityId">Project tax entity</Label>
+            <Select
+              name="defaultTaxEntityId"
+              defaultValue={estimate.defaultTaxEntityId ?? undefined}
+              disabled={!editable}
+            >
+              <SelectTrigger id="defaultTaxEntityId">
+                <SelectValue placeholder="Select a Sage tax entity" />
+              </SelectTrigger>
+              <SelectContent>
+                {workspace.taxEntities.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label} · {percent(option.rateBasisPoints)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5 md:col-span-2">
+            <Label htmlFor="termsTemplateId">Contract terms template</Label>
+            <Select
+              name="termsTemplateId"
+              defaultValue={estimate.termsTemplateId ?? undefined}
+              disabled={!editable}
+            >
+              <SelectTrigger id="termsTemplateId">
+                <SelectValue placeholder="Choose a terms template" />
+              </SelectTrigger>
+              <SelectContent>
+                {workspace.termsTemplates.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5 md:col-span-2 xl:col-span-4">
+            <Label htmlFor="contractTerms">Pertinent contract terms</Label>
+            <Textarea
+              id="contractTerms"
+              name="contractTerms"
+              rows={6}
+              defaultValue={estimate.contractTerms ?? ""}
+              disabled={!editable}
+              placeholder="Use a template or draft the estimate-specific terms here."
+            />
+          </div>
+        </div>
+        {editable && (
+          <div className="mt-4 flex justify-end">
+            <Button type="submit" disabled={isPending}>Save draft details</Button>
+          </div>
+        )}
+      </form>
+
+      <section className="clarity-panel-strong p-4">
+        <div className="mb-4">
+          <h2 className="font-semibold">CSI estimate</h2>
+          <p className="text-xs text-muted-foreground">
+            Select a division first, then add the Sage cost codes needed within
+            it. Each division subtotal updates from its lines.
+          </p>
+        </div>
+        {groupedLines.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No estimate lines yet.</p>
+        ) : (
+          <div className="space-y-4">
+            {groupedLines.map(([divisionCode, items]) => {
+              const subtotal = items.reduce(
+                (sum, item) => sum + item.lineTotalCents,
+                0
+              )
+              return (
+                <div key={divisionCode} className="border-l-2 border-l-primary pl-4">
+                  <div className="flex items-center justify-between gap-3 border-b pb-2">
+                    <div>
+                      <h3 className="text-sm font-semibold">
+                        {divisionCode} · {items[0]?.divisionName}
+                      </h3>
+                      <p className="text-xs text-muted-foreground">
+                        {items.length} cost-code {items.length === 1 ? "line" : "lines"}
+                      </p>
+                    </div>
+                    <p className="font-semibold">{money(subtotal)}</p>
+                  </div>
+                  <div className="divide-y">
+                    {items.map((item) => (
+                      <div key={item.id} className="grid gap-2 py-3 lg:grid-cols-[minmax(0,1fr)_auto]">
+                        <div>
+                          <p className="text-sm font-medium">
+                            {item.costCode} · {item.description}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {item.quantity} {item.unit} × {money(item.unitCostCents)} ·
+                            markup {percent(item.markupRateBasisPoints)}
+                            {item.taxable
+                              ? ` · ${item.taxCode ?? "tax"} ${percent(item.taxRateBasisPoints)}`
+                              : " · non-taxable"}
+                          </p>
+                        </div>
+                        <div className="flex items-center justify-end gap-2">
+                          <span className="font-medium">{money(item.lineTotalCents)}</span>
+                          {editable && (
+                            <>
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                onClick={() => setLine(lineDraft(item))}
+                              >
+                                Edit
+                              </Button>
+                              <Button
+                                type="button"
+                                size="icon"
+                                variant="ghost"
+                                aria-label={`Delete ${item.description}`}
+                                onClick={() => removeLine(item.id)}
+                              >
+                                <IconTrash className="size-4" />
+                              </Button>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+
+        {editable && (
+          <form className="mt-5 border-t pt-4" onSubmit={saveLine}>
+            <h3 className="mb-3 text-sm font-semibold">
+              {line.id ? "Edit estimate line" : "Add estimate line"}
+            </h3>
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              <div className="space-y-1.5">
+                <Label>CSI division</Label>
+                <Select
+                  value={line.divisionCode}
+                  onValueChange={(value) =>
+                    setLine({ ...line, divisionCode: value, costCode: "" })
+                  }
+                >
+                  <SelectTrigger><SelectValue placeholder="Choose division first" /></SelectTrigger>
+                  <SelectContent>
+                    {divisions.map(([value, label]) => (
+                      <SelectItem key={value} value={value}>{label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5 xl:col-span-2">
+                <Label>Cost code</Label>
+                <Select
+                  value={line.costCode}
+                  onValueChange={(value) => setLine({ ...line, costCode: value })}
+                  disabled={!line.divisionCode}
+                >
+                  <SelectTrigger><SelectValue placeholder="Choose cost code" /></SelectTrigger>
+                  <SelectContent>
+                    {availableCostCodes.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="estimateUnit">Unit</Label>
+                <Input id="estimateUnit" name="unit" value={line.unit} onChange={(event) => setLine({ ...line, unit: event.target.value })} />
+              </div>
+              <div className="space-y-1.5 md:col-span-2 xl:col-span-4">
+                <Label htmlFor="estimateDescription">Description</Label>
+                <Input id="estimateDescription" name="description" value={line.description} onChange={(event) => setLine({ ...line, description: event.target.value })} required />
+              </div>
+              <div className="space-y-1.5 md:col-span-2 xl:col-span-4">
+                <Label htmlFor="estimateSpecifications">Specifications / scope notes</Label>
+                <Textarea id="estimateSpecifications" name="specifications" value={line.specifications} onChange={(event) => setLine({ ...line, specifications: event.target.value })} rows={3} />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="estimateQuantity">Quantity</Label>
+                <Input id="estimateQuantity" name="quantity" inputMode="decimal" value={line.quantity} onChange={(event) => setLine({ ...line, quantity: event.target.value })} />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="estimateUnitCost">Unit cost</Label>
+                <Input id="estimateUnitCost" name="unitCost" inputMode="decimal" value={line.unitCost} onChange={(event) => setLine({ ...line, unitCost: event.target.value })} />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="estimateMarkup">Line markup %</Label>
+                <Input id="estimateMarkup" name="markupPercent" inputMode="decimal" value={line.markupPercent} onChange={(event) => setLine({ ...line, markupPercent: event.target.value })} />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Tax entity</Label>
+                <Select value={line.taxEntityId} onValueChange={(value) => setLine({ ...line, taxEntityId: value })} disabled={!line.taxable}>
+                  <SelectTrigger><SelectValue placeholder="Project default" /></SelectTrigger>
+                  <SelectContent>
+                    {workspace.taxEntities.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>{option.label} · {percent(option.rateBasisPoints)}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="mt-3 flex flex-wrap items-center gap-5">
+              <label className="flex items-center gap-2 text-sm">
+                <Checkbox checked={line.taxable} onCheckedChange={(checked) => setLine({ ...line, taxable: checked === true })} />
+                Taxable line
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <Checkbox checked={line.ownerVisible} onCheckedChange={(checked) => setLine({ ...line, ownerVisible: checked === true })} />
+                Owner-visible
+              </label>
+              <div className="ml-auto flex gap-2">
+                {line.id && <Button type="button" variant="ghost" onClick={() => setLine(EMPTY_LINE)}>Cancel edit</Button>}
+                <Button type="submit" disabled={isPending || !line.costCode}>
+                  <IconPlus className="size-4" /> {line.id ? "Save line" : "Add line"}
+                </Button>
+              </div>
+            </div>
+          </form>
+        )}
+      </section>
+
+      <section className="clarity-panel-strong p-4">
+        <h2 className="font-semibold">Plans, specifications, and estimate basis</h2>
+        <div className="mt-3 divide-y">
+          {workspace.basisDocuments.map((document) => (
+            <div key={document.id} className="flex items-start justify-between gap-3 py-2 text-sm">
+              <div>
+                <p className="font-medium">{document.title}</p>
+                <p className="text-xs text-muted-foreground">
+                  {statusLabel(document.documentType)} · {document.documentDate ?? "date not set"}
+                  {document.revision ? ` · revision ${document.revision}` : ""}
+                </p>
+              </div>
+              {document.driveUrl && <Button variant="outline" size="sm" asChild><Link href={document.driveUrl} target="_blank">Open</Link></Button>}
+            </div>
+          ))}
+        </div>
+        {editable && (
+          <form className="mt-3 grid gap-3 border-t pt-4 md:grid-cols-2 xl:grid-cols-4" onSubmit={addBasis}>
+            <div className="space-y-1.5">
+              <Label htmlFor="documentType">Type</Label>
+              <Select name="documentType" defaultValue="architectural_plans">
+                <SelectTrigger id="documentType"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="architectural_plans">Architectural plans</SelectItem>
+                  <SelectItem value="structural_plans">Structural plans</SelectItem>
+                  <SelectItem value="specifications">Specifications</SelectItem>
+                  <SelectItem value="geotechnical">Geotechnical</SelectItem>
+                  <SelectItem value="other">Other</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5 xl:col-span-2"><Label htmlFor="documentTitle">Title</Label><Input id="documentTitle" name="documentTitle" required /></div>
+            <div className="space-y-1.5"><Label htmlFor="basisDate">Document date</Label><Input id="basisDate" name="documentDate" type="date" /></div>
+            <div className="space-y-1.5"><Label htmlFor="basisRevision">Revision</Label><Input id="basisRevision" name="revision" /></div>
+            <div className="space-y-1.5 xl:col-span-2"><Label htmlFor="basisDriveUrl">Google Drive link</Label><Input id="basisDriveUrl" name="driveUrl" type="url" /></div>
+            <div className="flex items-end"><Button type="submit" disabled={isPending}><IconPlus className="size-4" />Add basis</Button></div>
+          </form>
+        )}
+      </section>
+
+      <section className="clarity-panel-strong p-4">
+        <div className="flex items-start gap-3">
+          <IconReceiptTax className="mt-0.5 size-5 text-primary" />
+          <div className="flex-1">
+            <h2 className="font-semibold">Approval and accounting handoff</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Preparing the package locks this version. Recording the completed
+              Foxit package accepts it and creates the original G703 budget.
+            </p>
+            {editable && (
+              <Button className="mt-3" onClick={prepareFoxit} disabled={isPending || workspace.lines.length === 0}>
+                <IconSend className="size-4" />Prepare CA22 for Foxit
+              </Button>
+            )}
+            {estimate.status === "signature_pending" && workspace.canEdit && (
+              <form className="mt-4 grid gap-3 border-t pt-4 md:grid-cols-2" onSubmit={acceptSigned}>
+                <div className="space-y-1.5"><Label htmlFor="signedDocumentUrl">Signed Foxit document link</Label><Input id="signedDocumentUrl" name="signedDocumentUrl" type="url" required /></div>
+                <div className="space-y-1.5"><Label htmlFor="foxitEnvelopeId">Foxit envelope ID</Label><Input id="foxitEnvelopeId" name="foxitEnvelopeId" /></div>
+                <div className="md:col-span-2"><Button type="submit" disabled={isPending}>Record signatures and accept estimate</Button></div>
+              </form>
+            )}
+            {estimate.status === "accepted" && (
+              <p className="mt-3 text-sm font-medium text-emerald-700">
+                Accepted estimate is locked. Budget changes now require an executed change order.
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/projects/project-financial-workspace.tsx
+++ b/src/components/projects/project-financial-workspace.tsx
@@ -277,28 +277,24 @@ export function ProjectFinancialWorkspace({
 
         <FinancialFormPanel
           title="Owner Pay Application"
-          description="Stage an AIA-style draw request."
+          description="Create the next G702/G703 draw from the current accepted contract budget."
           accentClassName="border-l-brand-hps-primary"
           icon={<IconFileDollar className="size-5" />}
-          actionLabel="Stage Pay App"
+          actionLabel="Create From Budget"
           isPending={isPending}
           onSubmit={handlePayApplication}
         >
             <FormField label="Application number" htmlFor="applicationNumber">
               <Input id="applicationNumber" name="applicationNumber" />
             </FormField>
-            <div className="grid gap-3 sm:grid-cols-2">
-              <FormField label="Period to" htmlFor="periodTo">
-                <Input id="periodTo" name="periodTo" type="date" />
-              </FormField>
-              <FormField label="Amount" htmlFor="payApplicationAmount">
-                <Input
-                  id="payApplicationAmount"
-                  name="amount"
-                  inputMode="decimal"
-                />
-              </FormField>
-            </div>
+            <FormField label="Period to" htmlFor="periodTo">
+              <Input id="periodTo" name="periodTo" type="date" />
+            </FormField>
+            <p className="text-xs text-muted-foreground">
+              Contract value, approved changes, prior billing, and cost-code
+              lines come from the locked budget revision. Enter current work
+              and stored materials on the generated G703 before Sage review.
+            </p>
             <FormField label="Notes" htmlFor="payApplicationNotes">
               <Textarea id="payApplicationNotes" name="notes" rows={7} />
             </FormField>
@@ -397,6 +393,21 @@ export function ProjectFinancialWorkspace({
                           </a>
                         </Button>
                       )}
+                      {item.type === "owner_pay_application" &&
+                        item.sourceRecordId && (
+                          <Button
+                            asChild
+                            size="sm"
+                            variant="link"
+                            className="mt-1 h-auto justify-start p-0"
+                          >
+                            <a
+                              href={`/dashboard/projects/${projectId}/financials/pay-applications/${item.sourceRecordId}`}
+                            >
+                              Edit G702 / G703
+                            </a>
+                          </Button>
+                        )}
                     </div>
                     <span>{money(item.amount)}</span>
                     <span>{dateText(item.dueDate)}</span>

--- a/src/components/projects/project-owner-pay-application-editor.tsx
+++ b/src/components/projects/project-owner-pay-application-editor.tsx
@@ -1,0 +1,220 @@
+"use client"
+
+import { useState, useTransition, type FormEvent } from "react"
+import { useRouter } from "next/navigation"
+import { IconCircleCheck, IconDeviceFloppy } from "@tabler/icons-react"
+
+import {
+  markProjectOwnerPayApplicationReady,
+  updateProjectOwnerPayApplicationLine,
+  type ProjectOwnerPayApplicationDraft,
+  type ProjectOwnerPayApplicationLine,
+} from "@/app/actions/project-financial-workflows"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+
+function money(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+function fieldNumber(formData: FormData, name: string): number | null {
+  const raw = String(formData.get(name) ?? "").replaceAll(/[$,]/g, "").trim()
+  if (!raw) return 0
+  const value = Number(raw)
+  return Number.isFinite(value) ? value : null
+}
+
+function PayApplicationLineEditor({
+  projectId,
+  applicationId,
+  line,
+  editable,
+  onMessage,
+}: {
+  readonly projectId: string
+  readonly applicationId: string
+  readonly line: ProjectOwnerPayApplicationLine
+  readonly editable: boolean
+  readonly onMessage: (message: string) => void
+}): React.ReactElement {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [ownerVisible, setOwnerVisible] = useState(line.ownerVisible)
+  const impliedRetainage =
+    line.totalCompletedStored > 0
+      ? (line.retainageHeld / line.totalCompletedStored) * 100
+      : 0
+
+  function save(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    startTransition(async () => {
+      const result = await updateProjectOwnerPayApplicationLine(
+        projectId,
+        applicationId,
+        line.id,
+        {
+          currentWorkCompleted: fieldNumber(formData, "currentWorkCompleted"),
+          storedMaterials: fieldNumber(formData, "storedMaterials"),
+          retainagePercent: fieldNumber(formData, "retainagePercent"),
+          ownerVisible,
+        }
+      )
+      onMessage(result.success ? `${line.costCode} saved.` : result.error)
+      router.refresh()
+    })
+  }
+
+  return (
+    <form
+      onSubmit={save}
+      className="grid gap-2 border-b px-3 py-3 text-sm lg:grid-cols-[minmax(14rem,1.6fr)_repeat(7,minmax(7rem,.7fr))_auto] lg:items-center"
+    >
+      <div className="min-w-0">
+        <p className="font-medium">{line.costCode} · {line.description}</p>
+        <p className="text-xs text-muted-foreground">
+          {line.divisionCode} · {line.divisionName}
+        </p>
+      </div>
+      <span className="text-right">{money(line.adjustedEstimate)}</span>
+      <span className="text-right">{money(line.previousWorkCompleted)}</span>
+      <Input
+        name="currentWorkCompleted"
+        inputMode="decimal"
+        defaultValue={line.currentWorkCompleted || ""}
+        disabled={!editable}
+        aria-label={`Current work for ${line.costCode}`}
+      />
+      <Input
+        name="storedMaterials"
+        inputMode="decimal"
+        defaultValue={line.storedMaterials || ""}
+        disabled={!editable}
+        aria-label={`Stored materials for ${line.costCode}`}
+      />
+      <Input
+        name="retainagePercent"
+        inputMode="decimal"
+        defaultValue={impliedRetainage || ""}
+        disabled={!editable}
+        aria-label={`Retainage percent for ${line.costCode}`}
+      />
+      <span className="text-right">{money(line.totalCompletedStored)}</span>
+      <span className="text-right">{money(line.balanceToFinish)}</span>
+      <div className="flex items-center justify-end gap-2">
+        <label className="flex items-center gap-1 text-xs text-muted-foreground">
+          <Checkbox
+            checked={ownerVisible}
+            onCheckedChange={(checked) => setOwnerVisible(checked === true)}
+            disabled={!editable}
+          />
+          Owner
+        </label>
+        {editable && (
+          <Button type="submit" size="icon" variant="outline" disabled={isPending}>
+            <IconDeviceFloppy className="size-4" />
+            <span className="sr-only">Save {line.costCode}</span>
+          </Button>
+        )}
+      </div>
+    </form>
+  )
+}
+
+export function ProjectOwnerPayApplicationEditor({
+  projectId,
+  application,
+}: {
+  readonly projectId: string
+  readonly application: ProjectOwnerPayApplicationDraft
+}): React.ReactElement {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [message, setMessage] = useState<string | null>(null)
+  const editable = application.status === "draft"
+
+  function readyForReview(): void {
+    setMessage(null)
+    startTransition(async () => {
+      const result = await markProjectOwnerPayApplicationReady(
+        projectId,
+        application.id
+      )
+      setMessage(
+        result.success
+          ? "Pay application is ready for internal Sage review."
+          : result.error
+      )
+      router.refresh()
+    })
+  }
+
+  return (
+    <div className="space-y-5">
+      {message && <div className="rounded-md border bg-muted/35 px-3 py-2 text-sm">{message}</div>}
+      <section className="clarity-panel-strong overflow-hidden">
+        <div className="flex flex-wrap items-start justify-between gap-3 border-b px-4 py-3">
+          <div>
+            <div className="flex items-center gap-2">
+              <h2 className="font-semibold">Pay application {application.applicationNumber}</h2>
+              <Badge>{application.status.replaceAll("_", " ")}</Badge>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Period to {application.periodTo ?? "not set"} · Contract budget revision locked to this draw
+            </p>
+          </div>
+          {editable && (
+            <Button onClick={readyForReview} disabled={isPending || application.currentPaymentDue <= 0}>
+              <IconCircleCheck className="size-4" />Ready for Sage review
+            </Button>
+          )}
+        </div>
+        <div className="grid divide-y sm:grid-cols-2 sm:divide-x sm:divide-y-0 xl:grid-cols-4">
+          {[
+            ["Contract to date", application.contractSumToDate],
+            ["Completed + stored", application.totalCompletedStoredToDate],
+            ["Current payment due", application.currentPaymentDue],
+            ["Balance to finish", application.balanceToFinish],
+          ].map(([label, value]) => (
+            <div key={String(label)} className="px-4 py-3">
+              <p className="text-xs text-muted-foreground">{label}</p>
+              <p className="mt-1 text-lg font-semibold">{money(Number(value))}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="clarity-panel overflow-x-auto">
+        <div className="min-w-[1080px]">
+          <div className="grid grid-cols-[minmax(14rem,1.6fr)_repeat(7,minmax(7rem,.7fr))_auto] gap-2 border-b bg-muted/35 px-3 py-2 text-xs font-medium uppercase text-muted-foreground">
+            <span>Cost code</span>
+            <span className="text-right">Adjusted</span>
+            <span className="text-right">Previous</span>
+            <span>Current work</span>
+            <span>Stored</span>
+            <span>Retainage %</span>
+            <span className="text-right">Total</span>
+            <span className="text-right">Balance</span>
+            <span className="text-right">Visibility</span>
+          </div>
+          {application.lines.map((line) => (
+            <PayApplicationLineEditor
+              key={line.id}
+              projectId={projectId}
+              applicationId={application.id}
+              line={line}
+              editable={editable}
+              onMessage={setMessage}
+            />
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -12,6 +12,7 @@ import * as conversationsSchema from "./schema-conversations"
 import * as jarvisSchema from "./schema-jarvis"
 import * as sageSchema from "./schema-sage"
 import * as buildertrendSchema from "./schema-buildertrend"
+import * as estimatesSchema from "./schema-estimates"
 
 const allSchemas = {
   ...schema,
@@ -27,6 +28,7 @@ const allSchemas = {
   ...jarvisSchema,
   ...sageSchema,
   ...buildertrendSchema,
+  ...estimatesSchema,
 }
 
 // Legacy function - kept for backwards compatibility

--- a/src/db/schema-estimates.ts
+++ b/src/db/schema-estimates.ts
@@ -1,0 +1,341 @@
+import {
+  index,
+  integer,
+  real,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core"
+
+import { organizations, projects, users } from "./schema"
+
+export const sageTaxEntities = sqliteTable(
+  "sage_tax_entities",
+  {
+    id: text("id").primaryKey(),
+    sourceRecordId: text("source_record_id"),
+    code: text("code").notNull(),
+    name: text("name").notNull(),
+    rateBasisPoints: integer("rate_basis_points").notNull().default(0),
+    active: integer("active", { mode: "boolean" }).notNull().default(true),
+    syncStatus: text("sync_status").notNull().default("synced"),
+    lastSyncedAt: text("last_synced_at"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("sage_tax_entities_code_uq").on(table.code),
+    index("sage_tax_entities_active_idx").on(table.active, table.name),
+  ]
+)
+
+export const estimateTermsTemplates = sqliteTable(
+  "estimate_terms_templates",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    body: text("body").notNull(),
+    active: integer("active", { mode: "boolean" }).notNull().default(true),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("estimate_terms_templates_org_name_uq").on(
+      table.organizationId,
+      table.name
+    ),
+    index("estimate_terms_templates_org_active_idx").on(
+      table.organizationId,
+      table.active
+    ),
+  ]
+)
+
+export const projectEstimates = sqliteTable(
+  "project_estimates",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    estimateNumber: text("estimate_number").notNull(),
+    versionNumber: integer("version_number").notNull().default(1),
+    title: text("title").notNull().default("CA22 Construction Estimate"),
+    status: text("status").notNull().default("draft"),
+    estimateDate: text("estimate_date"),
+    clientName: text("client_name"),
+    sourceSystem: text("source_system").notNull().default("compass"),
+    sourceWorkbookId: text("source_workbook_id"),
+    sourceWorkbookUrl: text("source_workbook_url"),
+    sourceRevision: text("source_revision"),
+    defaultTaxEntityId: text("default_tax_entity_id").references(
+      () => sageTaxEntities.id,
+      { onDelete: "set null" }
+    ),
+    defaultTaxCode: text("default_tax_code"),
+    defaultTaxName: text("default_tax_name"),
+    defaultTaxRateBasisPoints: integer("default_tax_rate_basis_points")
+      .notNull()
+      .default(0),
+    termsTemplateId: text("terms_template_id").references(
+      () => estimateTermsTemplates.id,
+      { onDelete: "set null" }
+    ),
+    contractTerms: text("contract_terms"),
+    directCostCents: integer("direct_cost_cents").notNull().default(0),
+    markupCents: integer("markup_cents").notNull().default(0),
+    taxCents: integer("tax_cents").notNull().default(0),
+    estimateTotalCents: integer("estimate_total_cents").notNull().default(0),
+    foxitStatus: text("foxit_status").notNull().default("not_started"),
+    foxitEnvelopeId: text("foxit_envelope_id"),
+    signaturePackageUrl: text("signature_package_url"),
+    signatureRequestedAt: text("signature_requested_at"),
+    signedAt: text("signed_at"),
+    acceptedAt: text("accepted_at"),
+    acceptedBy: text("accepted_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    sageStatus: text("sage_status").notNull().default("not_ready"),
+    sageRecordId: text("sage_record_id"),
+    lastSageSyncAt: text("last_sage_sync_at"),
+    sourceHash: text("source_hash"),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("project_estimates_project_number_version_uq").on(
+      table.projectId,
+      table.estimateNumber,
+      table.versionNumber
+    ),
+    index("project_estimates_project_status_idx").on(
+      table.projectId,
+      table.status,
+      table.versionNumber
+    ),
+  ]
+)
+
+export const projectEstimateLines = sqliteTable(
+  "project_estimate_lines",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    estimateId: text("estimate_id")
+      .notNull()
+      .references(() => projectEstimates.id, { onDelete: "cascade" }),
+    divisionCode: text("division_code").notNull(),
+    divisionName: text("division_name").notNull(),
+    costCode: text("cost_code").notNull(),
+    costCodeName: text("cost_code_name").notNull(),
+    description: text("description").notNull(),
+    specifications: text("specifications"),
+    quantity: real("quantity").notNull().default(1),
+    unit: text("unit").notNull().default("LS"),
+    unitCostCents: integer("unit_cost_cents").notNull().default(0),
+    directCostCents: integer("direct_cost_cents").notNull().default(0),
+    markupRateBasisPoints: integer("markup_rate_basis_points")
+      .notNull()
+      .default(0),
+    markupCents: integer("markup_cents").notNull().default(0),
+    taxable: integer("taxable", { mode: "boolean" }).notNull().default(false),
+    taxEntityId: text("tax_entity_id").references(() => sageTaxEntities.id, {
+      onDelete: "set null",
+    }),
+    taxCode: text("tax_code"),
+    taxName: text("tax_name"),
+    taxRateBasisPoints: integer("tax_rate_basis_points").notNull().default(0),
+    taxCents: integer("tax_cents").notNull().default(0),
+    lineTotalCents: integer("line_total_cents").notNull().default(0),
+    ownerVisible: integer("owner_visible", { mode: "boolean" })
+      .notNull()
+      .default(true),
+    sortOrder: integer("sort_order").notNull().default(0),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    index("project_estimate_lines_estimate_order_idx").on(
+      table.estimateId,
+      table.divisionCode,
+      table.sortOrder
+    ),
+    index("project_estimate_lines_project_cost_code_idx").on(
+      table.projectId,
+      table.costCode
+    ),
+  ]
+)
+
+export const projectEstimateBasisDocuments = sqliteTable(
+  "project_estimate_basis_documents",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    estimateId: text("estimate_id")
+      .notNull()
+      .references(() => projectEstimates.id, { onDelete: "cascade" }),
+    documentType: text("document_type").notNull(),
+    title: text("title").notNull(),
+    documentDate: text("document_date"),
+    revision: text("revision"),
+    driveFileId: text("drive_file_id"),
+    driveUrl: text("drive_url"),
+    notes: text("notes"),
+    sortOrder: integer("sort_order").notNull().default(0),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    index("project_estimate_basis_documents_estimate_idx").on(
+      table.estimateId,
+      table.sortOrder
+    ),
+  ]
+)
+
+export const projectContractBudgetRevisions = sqliteTable(
+  "project_contract_budget_revisions",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    acceptedEstimateId: text("accepted_estimate_id")
+      .notNull()
+      .references(() => projectEstimates.id, { onDelete: "restrict" }),
+    revisionNumber: integer("revision_number").notNull(),
+    status: text("status").notNull().default("current"),
+    originalContractSumCents: integer("original_contract_sum_cents")
+      .notNull()
+      .default(0),
+    approvedChangesCents: integer("approved_changes_cents")
+      .notNull()
+      .default(0),
+    revisedContractSumCents: integer("revised_contract_sum_cents")
+      .notNull()
+      .default(0),
+    effectiveAt: text("effective_at").notNull(),
+    sourceHash: text("source_hash").notNull(),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("project_contract_budget_revision_number_uq").on(
+      table.projectId,
+      table.revisionNumber
+    ),
+    uniqueIndex("project_contract_budget_source_hash_uq").on(
+      table.projectId,
+      table.sourceHash
+    ),
+    index("project_contract_budget_current_idx").on(
+      table.projectId,
+      table.status,
+      table.revisionNumber
+    ),
+  ]
+)
+
+export const projectContractBudgetLines = sqliteTable(
+  "project_contract_budget_lines",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    revisionId: text("revision_id")
+      .notNull()
+      .references(() => projectContractBudgetRevisions.id, {
+        onDelete: "cascade",
+      }),
+    sourceEstimateLineId: text("source_estimate_line_id").references(
+      () => projectEstimateLines.id,
+      { onDelete: "set null" }
+    ),
+    divisionCode: text("division_code").notNull(),
+    divisionName: text("division_name").notNull(),
+    costCode: text("cost_code").notNull(),
+    description: text("description").notNull(),
+    originalEstimateCents: integer("original_estimate_cents")
+      .notNull()
+      .default(0),
+    approvedChangeCents: integer("approved_change_cents")
+      .notNull()
+      .default(0),
+    adjustedBudgetCents: integer("adjusted_budget_cents")
+      .notNull()
+      .default(0),
+    ownerVisible: integer("owner_visible", { mode: "boolean" })
+      .notNull()
+      .default(true),
+    sortOrder: integer("sort_order").notNull().default(0),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("project_contract_budget_line_cost_code_uq").on(
+      table.revisionId,
+      table.costCode
+    ),
+    index("project_contract_budget_lines_project_idx").on(
+      table.projectId,
+      table.revisionId
+    ),
+  ]
+)
+
+export const projectContractBudgetAdjustments = sqliteTable(
+  "project_contract_budget_adjustments",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    revisionId: text("revision_id")
+      .notNull()
+      .references(() => projectContractBudgetRevisions.id, {
+        onDelete: "cascade",
+      }),
+    changeOrderId: text("change_order_id").notNull(),
+    changeOrderLineId: text("change_order_line_id").notNull(),
+    costCode: text("cost_code").notNull(),
+    description: text("description").notNull(),
+    amountCents: integer("amount_cents").notNull(),
+    executedAt: text("executed_at").notNull(),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("project_contract_budget_adjustment_line_uq").on(
+      table.revisionId,
+      table.changeOrderLineId
+    ),
+    index("project_contract_budget_adjustments_change_order_idx").on(
+      table.projectId,
+      table.changeOrderId
+    ),
+  ]
+)
+
+export type ProjectEstimate = typeof projectEstimates.$inferSelect
+export type ProjectEstimateLine = typeof projectEstimateLines.$inferSelect
+export type ProjectEstimateBasisDocument =
+  typeof projectEstimateBasisDocuments.$inferSelect
+export type ProjectContractBudgetRevision =
+  typeof projectContractBudgetRevisions.$inferSelect
+export type ProjectContractBudgetLine =
+  typeof projectContractBudgetLines.$inferSelect

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -972,6 +972,7 @@ export const projectBudgetApplications = sqliteTable("project_budget_application
     .notNull()
     .default(false),
   sourceUrl: text("source_url"),
+  budgetRevisionId: text("budget_revision_id"),
   syncStatus: text("sync_status").notNull().default("synced"),
   lastSyncedAt: text("last_synced_at"),
   createdAt: text("created_at").notNull(),
@@ -987,6 +988,7 @@ export const projectBudgetLines = sqliteTable("project_budget_lines", {
     () => projectBudgetApplications.id,
     { onDelete: "set null" }
   ),
+  budgetRevisionLineId: text("budget_revision_line_id"),
   sourceSystem: text("source_system").notNull().default("sage"),
   sourceRecordId: text("source_record_id"),
   sourceRecordNumber: text("source_record_number"),
@@ -1000,6 +1002,9 @@ export const projectBudgetLines = sqliteTable("project_budget_lines", {
   currentChanges: real("current_changes").notNull().default(0),
   totalChanges: real("total_changes").notNull().default(0),
   adjustedEstimate: real("adjusted_estimate").notNull().default(0),
+  previousWorkCompleted: real("previous_work_completed").notNull().default(0),
+  currentWorkCompleted: real("current_work_completed").notNull().default(0),
+  storedMaterials: real("stored_materials").notNull().default(0),
   priorCosts: real("prior_costs").notNull().default(0),
   currentCosts: real("current_costs").notNull().default(0),
   totalCosts: real("total_costs").notNull().default(0),

--- a/src/lib/financials/__tests__/estimate-ledger.test.ts
+++ b/src/lib/financials/__tests__/estimate-ledger.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildContractBudget,
+  calculateEstimateLine,
+  calculateEstimateTotals,
+  estimateCanBeAccepted,
+  estimateCanBeEdited,
+  estimateSourceHash,
+  type EstimateLedgerLine,
+} from "@/lib/financials/estimate-ledger"
+
+function estimateLine(
+  input: Partial<EstimateLedgerLine> & Pick<EstimateLedgerLine, "id">
+): EstimateLedgerLine {
+  return {
+    id: input.id,
+    divisionCode: input.divisionCode ?? "03",
+    divisionName: input.divisionName ?? "Concrete",
+    costCode: input.costCode ?? "03 11 13",
+    description: input.description ?? "Forming boards",
+    directCostCents: input.directCostCents ?? 100_000,
+    markupCents: input.markupCents ?? 10_000,
+    taxCents: input.taxCents ?? 5_500,
+    lineTotalCents: input.lineTotalCents ?? 115_500,
+    ownerVisible: input.ownerVisible ?? true,
+    sortOrder: input.sortOrder ?? 1,
+  }
+}
+
+describe("estimate ledger", () => {
+  it("calculates line markup and tax without floating point drift", () => {
+    expect(
+      calculateEstimateLine({
+        quantity: 2.5,
+        unitCostCents: 12_345,
+        markupRateBasisPoints: 1_500,
+        taxable: true,
+        taxRateBasisPoints: 513,
+      })
+    ).toEqual({
+      directCostCents: 30_863,
+      markupCents: 4_629,
+      taxCents: 1_821,
+      lineTotalCents: 37_313,
+    })
+  })
+
+  it("rolls estimate totals once across all lines", () => {
+    expect(
+      calculateEstimateTotals([
+        estimateLine({ id: "one" }),
+        estimateLine({
+          id: "two",
+          directCostCents: 20_000,
+          markupCents: 0,
+          taxCents: 0,
+          lineTotalCents: 20_000,
+        }),
+      ])
+    ).toEqual({
+      directCostCents: 120_000,
+      markupCents: 10_000,
+      taxCents: 5_500,
+      estimateTotalCents: 135_500,
+    })
+  })
+
+  it("builds a contract budget from accepted lines and executed changes", () => {
+    const budget = buildContractBudget({
+      estimateLines: [
+        estimateLine({ id: "line-a", lineTotalCents: 100_000 }),
+        estimateLine({
+          id: "line-b",
+          lineTotalCents: 50_000,
+          costCode: "03 11 13",
+        }),
+        estimateLine({
+          id: "line-c",
+          divisionCode: "09",
+          divisionName: "Finishes",
+          costCode: "09 91 00",
+          description: "Painting",
+          lineTotalCents: 75_000,
+          sortOrder: 2,
+        }),
+      ],
+      adjustments: [
+        {
+          id: "co-line-1",
+          changeOrderId: "co-1",
+          costCode: "03 11 13",
+          description: "Additional forming",
+          amountCents: 10_000,
+          executedAt: "2026-08-01T10:00:00.000Z",
+        },
+        {
+          id: "co-line-2",
+          changeOrderId: "co-2",
+          costCode: "26 00 00",
+          description: "Added electrical scope",
+          amountCents: 20_000,
+          executedAt: "2026-08-01T11:00:00.000Z",
+        },
+      ],
+    })
+
+    expect(budget.originalContractSumCents).toBe(225_000)
+    expect(budget.approvedChangesCents).toBe(30_000)
+    expect(budget.revisedContractSumCents).toBe(255_000)
+    expect(budget.lines).toHaveLength(3)
+    expect(budget.lines[0]).toMatchObject({
+      costCode: "03 11 13",
+      originalEstimateCents: 150_000,
+      approvedChangeCents: 10_000,
+      adjustedBudgetCents: 160_000,
+    })
+  })
+
+  it("locks accepted and signature-pending estimates", () => {
+    expect(estimateCanBeEdited("draft")).toBe(true)
+    expect(estimateCanBeEdited("accepted")).toBe(false)
+    expect(
+      estimateCanBeAccepted({
+        status: "signature_pending",
+        foxitStatus: "completed",
+        lineCount: 1,
+      })
+    ).toBe(true)
+    expect(
+      estimateCanBeAccepted({
+        status: "signature_pending",
+        foxitStatus: "handoff_ready",
+        lineCount: 1,
+      })
+    ).toBe(false)
+  })
+
+  it("hashes the full signed estimate basis, not only its totals", async () => {
+    const input = {
+      estimateId: "estimate-1",
+      versionNumber: 1,
+      title: "CA22 Construction Estimate",
+      contractTerms: "Base terms",
+      lines: [
+        {
+          id: "line-1",
+          divisionCode: "03",
+          costCode: "03 11 13",
+          description: "Concrete forming",
+          specifications: "Per architectural plans",
+          quantity: 1,
+          unit: "LS",
+          unitCostCents: 100_000,
+          markupRateBasisPoints: 1_000,
+          taxable: false,
+          taxCode: null,
+          taxRateBasisPoints: 0,
+          lineTotalCents: 110_000,
+          ownerVisible: true,
+          sortOrder: 1,
+        },
+      ],
+      basisDocuments: [
+        {
+          id: "basis-1",
+          documentType: "architectural_plans",
+          title: "Architectural plans",
+          documentDate: "2026-07-15",
+          revision: "A",
+          driveFileId: "drive-1",
+          driveUrl: "https://drive.google.com/file/d/drive-1/view",
+          notes: null,
+          sortOrder: 1,
+        },
+      ],
+    }
+    const original = await estimateSourceHash(input)
+    const revised = await estimateSourceHash({
+      ...input,
+      lines: [{ ...input.lines[0], specifications: "Per revision B" }],
+    })
+    const differentBasis = await estimateSourceHash({
+      ...input,
+      basisDocuments: [
+        { ...input.basisDocuments[0], documentDate: "2026-07-31" },
+      ],
+    })
+
+    expect(revised).not.toBe(original)
+    expect(differentBasis).not.toBe(original)
+  })
+})

--- a/src/lib/financials/contract-budget-store.ts
+++ b/src/lib/financials/contract-budget-store.ts
@@ -1,0 +1,346 @@
+import { and, desc, eq, inArray } from "drizzle-orm"
+
+import { getDb } from "@/db"
+import {
+  projectBudgetApplications,
+  projectBudgetLines,
+  projectChangeOrderLines,
+  projectChangeOrders,
+} from "@/db/schema"
+import {
+  projectContractBudgetAdjustments,
+  projectContractBudgetLines,
+  projectContractBudgetRevisions,
+  projectEstimateLines,
+  projectEstimates,
+} from "@/db/schema-estimates"
+import {
+  buildContractBudget,
+  contractBudgetSourceHash,
+  type ContractAdjustment,
+  type EstimateLedgerLine,
+} from "@/lib/financials/estimate-ledger"
+
+export type ContractBudgetRebuildResult =
+  | {
+      readonly success: true
+      readonly revisionId: string
+      readonly revisionNumber: number
+      readonly changed: boolean
+    }
+  | { readonly success: false; readonly error: string }
+
+type CompassDb = ReturnType<typeof getDb>
+
+const BUDGET_CHANGE_ORDER_STATUSES = [
+  "executed",
+  "sage_pending",
+  "synced",
+  "closed",
+]
+
+function estimateLedgerLine(
+  row: typeof projectEstimateLines.$inferSelect
+): EstimateLedgerLine {
+  return {
+    id: row.id,
+    divisionCode: row.divisionCode,
+    divisionName: row.divisionName,
+    costCode: row.costCode,
+    description: row.description,
+    directCostCents: row.directCostCents,
+    markupCents: row.markupCents,
+    taxCents: row.taxCents,
+    lineTotalCents: row.lineTotalCents,
+    ownerVisible: row.ownerVisible,
+    sortOrder: row.sortOrder,
+  }
+}
+
+export async function rebuildProjectContractBudget(input: {
+  readonly db: CompassDb
+  readonly projectId: string
+  readonly actorUserId: string | null
+}): Promise<ContractBudgetRebuildResult> {
+  const acceptedRows = await input.db
+    .select()
+    .from(projectEstimates)
+    .where(
+      and(
+        eq(projectEstimates.projectId, input.projectId),
+        eq(projectEstimates.status, "accepted")
+      )
+    )
+    .orderBy(desc(projectEstimates.versionNumber))
+    .limit(1)
+  const accepted = acceptedRows[0]
+  if (!accepted) {
+    return {
+      success: false,
+      error: "Accept a signed estimate before building the contract budget.",
+    }
+  }
+
+  const estimateRows = await input.db
+    .select()
+    .from(projectEstimateLines)
+    .where(eq(projectEstimateLines.estimateId, accepted.id))
+    .orderBy(
+      projectEstimateLines.divisionCode,
+      projectEstimateLines.sortOrder
+    )
+  if (estimateRows.length === 0) {
+    return { success: false, error: "The accepted estimate has no lines." }
+  }
+
+  const changeRows = await input.db
+    .select({
+      id: projectChangeOrderLines.id,
+      changeOrderId: projectChangeOrderLines.changeOrderId,
+      costCode: projectChangeOrderLines.costCode,
+      description: projectChangeOrderLines.description,
+      amountCents: projectChangeOrderLines.amountCents,
+      executedAt: projectChangeOrders.executedAt,
+    })
+    .from(projectChangeOrderLines)
+    .innerJoin(
+      projectChangeOrders,
+      eq(projectChangeOrders.id, projectChangeOrderLines.changeOrderId)
+    )
+    .where(
+      and(
+        eq(projectChangeOrderLines.projectId, input.projectId),
+        inArray(projectChangeOrders.status, BUDGET_CHANGE_ORDER_STATUSES)
+      )
+    )
+
+  const incompleteChange = changeRows.find(
+    (row) => !row.costCode || row.amountCents === null || !row.executedAt
+  )
+  if (incompleteChange) {
+    return {
+      success: false,
+      error:
+        "Every executed change-order line needs a cost code, amount, and execution date before the budget can be revised.",
+    }
+  }
+
+  const adjustments: ContractAdjustment[] = []
+  for (const row of changeRows) {
+    if (!row.costCode || row.amountCents === null || !row.executedAt) continue
+    adjustments.push({
+      id: row.id,
+      changeOrderId: row.changeOrderId,
+      costCode: row.costCode,
+      description: row.description,
+      amountCents: row.amountCents,
+      executedAt: row.executedAt,
+    })
+  }
+
+  const sourceHash = await contractBudgetSourceHash({
+    estimateId: accepted.id,
+    estimateSourceHash: accepted.sourceHash,
+    adjustments,
+  })
+  const matchingRows = await input.db
+    .select({
+      id: projectContractBudgetRevisions.id,
+      revisionNumber: projectContractBudgetRevisions.revisionNumber,
+      status: projectContractBudgetRevisions.status,
+    })
+    .from(projectContractBudgetRevisions)
+    .where(
+      and(
+        eq(projectContractBudgetRevisions.projectId, input.projectId),
+        eq(projectContractBudgetRevisions.sourceHash, sourceHash)
+      )
+    )
+    .limit(1)
+  const matching = matchingRows[0]
+  if (matching?.status === "current") {
+    return {
+      success: true,
+      revisionId: matching.id,
+      revisionNumber: matching.revisionNumber,
+      changed: false,
+    }
+  }
+
+  const priorRows = await input.db
+    .select({ revisionNumber: projectContractBudgetRevisions.revisionNumber })
+    .from(projectContractBudgetRevisions)
+    .where(eq(projectContractBudgetRevisions.projectId, input.projectId))
+    .orderBy(desc(projectContractBudgetRevisions.revisionNumber))
+    .limit(1)
+  const revisionNumber = (priorRows[0]?.revisionNumber ?? 0) + 1
+  const revisionId = crypto.randomUUID()
+  const now = new Date().toISOString()
+  const budget = buildContractBudget({
+    estimateLines: estimateRows.map(estimateLedgerLine),
+    adjustments,
+  })
+
+  await input.db.insert(projectContractBudgetRevisions).values({
+    id: revisionId,
+    projectId: input.projectId,
+    acceptedEstimateId: accepted.id,
+    revisionNumber,
+    status: "building",
+    originalContractSumCents: budget.originalContractSumCents,
+    approvedChangesCents: budget.approvedChangesCents,
+    revisedContractSumCents: budget.revisedContractSumCents,
+    effectiveAt: now,
+    sourceHash,
+    createdBy: input.actorUserId,
+    createdAt: now,
+  })
+
+  for (const line of budget.lines) {
+    await input.db.insert(projectContractBudgetLines).values({
+      id: crypto.randomUUID(),
+      projectId: input.projectId,
+      revisionId,
+      sourceEstimateLineId: line.sourceEstimateLineId,
+      divisionCode: line.divisionCode,
+      divisionName: line.divisionName,
+      costCode: line.costCode,
+      description: line.description,
+      originalEstimateCents: line.originalEstimateCents,
+      approvedChangeCents: line.approvedChangeCents,
+      adjustedBudgetCents: line.adjustedBudgetCents,
+      ownerVisible: line.ownerVisible,
+      sortOrder: line.sortOrder,
+      createdAt: now,
+    })
+  }
+
+  for (const adjustment of adjustments) {
+    await input.db.insert(projectContractBudgetAdjustments).values({
+      id: crypto.randomUUID(),
+      projectId: input.projectId,
+      revisionId,
+      changeOrderId: adjustment.changeOrderId,
+      changeOrderLineId: adjustment.id,
+      costCode: adjustment.costCode,
+      description: adjustment.description,
+      amountCents: adjustment.amountCents,
+      executedAt: adjustment.executedAt,
+      createdAt: now,
+    })
+  }
+
+  const projectionId = `contract-budget-view:${revisionId}`
+  await input.db.insert(projectBudgetApplications).values({
+    id: projectionId,
+    projectId: input.projectId,
+    sourceSystem: "compass_contract_budget_projection",
+    sourceRecordId: revisionId,
+    applicationNumber: `Contract Budget R${revisionNumber}`,
+    periodTo: now.slice(0, 10),
+    status: "budget_current",
+    originalContractSum: budget.originalContractSumCents / 100,
+    netChanges: budget.approvedChangesCents / 100,
+    contractSumToDate: budget.revisedContractSumCents / 100,
+    totalCompletedStoredToDate: 0,
+    retainageHeld: 0,
+    totalEarnedLessRetainage: 0,
+    previousCertificates: 0,
+    currentPaymentDue: 0,
+    balanceToFinish: budget.revisedContractSumCents / 100,
+    ownerVisible: true,
+    sourceUrl: null,
+    budgetRevisionId: revisionId,
+    syncStatus: "compass_only",
+    lastSyncedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  })
+  if (budget.lines.length > 0) {
+    const revisionLines = await input.db
+      .select()
+      .from(projectContractBudgetLines)
+      .where(eq(projectContractBudgetLines.revisionId, revisionId))
+    await input.db.insert(projectBudgetLines).values(
+      revisionLines.map((line) => ({
+        id: crypto.randomUUID(),
+        projectId: input.projectId,
+        applicationId: projectionId,
+        budgetRevisionLineId: line.id,
+        sourceSystem: "compass_contract_budget_projection",
+        sourceRecordId: line.id,
+        sourceRecordNumber: line.costCode,
+        costCode: line.costCode,
+        csiDivision: line.divisionCode,
+        csiDivisionName: line.divisionName,
+        description: line.description,
+        notes: null,
+        originalEstimate: line.originalEstimateCents / 100,
+        priorChanges: line.approvedChangeCents / 100,
+        currentChanges: 0,
+        totalChanges: line.approvedChangeCents / 100,
+        adjustedEstimate: line.adjustedBudgetCents / 100,
+        previousWorkCompleted: 0,
+        currentWorkCompleted: 0,
+        storedMaterials: 0,
+        priorCosts: 0,
+        currentCosts: 0,
+        totalCosts: 0,
+        percentComplete: 0,
+        balanceToFinish: line.adjustedBudgetCents / 100,
+        retainageHeld: 0,
+        vendorName: null,
+        ownerLabel: line.description,
+        ownerVisible: line.ownerVisible,
+        internalNotes: `Derived from accepted estimate and executed change orders, revision ${revisionNumber}.`,
+        sortOrder: line.sortOrder,
+        syncStatus: "compass_only",
+        lastSyncedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      }))
+    )
+  }
+
+  await input.db
+    .update(projectContractBudgetRevisions)
+    .set({ status: "superseded" })
+    .where(
+      and(
+        eq(projectContractBudgetRevisions.projectId, input.projectId),
+        eq(projectContractBudgetRevisions.status, "current")
+      )
+    )
+    .run()
+  await input.db
+    .update(projectBudgetApplications)
+    .set({ status: "budget_superseded", updatedAt: now })
+    .where(
+      and(
+        eq(projectBudgetApplications.projectId, input.projectId),
+        eq(projectBudgetApplications.status, "budget_current"),
+        eq(
+          projectBudgetApplications.sourceSystem,
+          "compass_contract_budget_projection"
+        )
+      )
+    )
+    .run()
+  await input.db
+    .update(projectContractBudgetRevisions)
+    .set({ status: "current" })
+    .where(eq(projectContractBudgetRevisions.id, revisionId))
+    .run()
+  await input.db
+    .update(projectBudgetApplications)
+    .set({ status: "budget_current", updatedAt: now })
+    .where(eq(projectBudgetApplications.id, projectionId))
+    .run()
+
+  return {
+    success: true,
+    revisionId,
+    revisionNumber,
+    changed: true,
+  }
+}

--- a/src/lib/financials/estimate-ledger.ts
+++ b/src/lib/financials/estimate-ledger.ts
@@ -1,0 +1,327 @@
+export const ESTIMATE_STATUSES = [
+  "draft",
+  "internal_review",
+  "signature_pending",
+  "accepted",
+  "superseded",
+  "void",
+] as const
+
+export type EstimateStatus = (typeof ESTIMATE_STATUSES)[number]
+
+export type EstimateLineCalculationInput = {
+  readonly quantity: number
+  readonly unitCostCents: number
+  readonly markupRateBasisPoints: number
+  readonly taxable: boolean
+  readonly taxRateBasisPoints: number
+}
+
+export type EstimateLineCalculation = {
+  readonly directCostCents: number
+  readonly markupCents: number
+  readonly taxCents: number
+  readonly lineTotalCents: number
+}
+
+export type EstimateLedgerLine = EstimateLineCalculation & {
+  readonly id: string
+  readonly divisionCode: string
+  readonly divisionName: string
+  readonly costCode: string
+  readonly description: string
+  readonly ownerVisible: boolean
+  readonly sortOrder: number
+}
+
+export type EstimateLedgerTotals = {
+  readonly directCostCents: number
+  readonly markupCents: number
+  readonly taxCents: number
+  readonly estimateTotalCents: number
+}
+
+export type ContractAdjustment = {
+  readonly id: string
+  readonly changeOrderId: string
+  readonly costCode: string
+  readonly description: string
+  readonly amountCents: number
+  readonly executedAt: string
+}
+
+export type ContractBudgetLine = {
+  readonly sourceEstimateLineId: string | null
+  readonly divisionCode: string
+  readonly divisionName: string
+  readonly costCode: string
+  readonly description: string
+  readonly originalEstimateCents: number
+  readonly approvedChangeCents: number
+  readonly adjustedBudgetCents: number
+  readonly ownerVisible: boolean
+  readonly sortOrder: number
+}
+
+export type ContractBudget = {
+  readonly lines: readonly ContractBudgetLine[]
+  readonly originalContractSumCents: number
+  readonly approvedChangesCents: number
+  readonly revisedContractSumCents: number
+}
+
+function safeInteger(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.round(value)
+}
+
+function safeRate(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.min(1_000_000, Math.max(0, Math.round(value)))
+}
+
+export function calculateEstimateLine(
+  input: EstimateLineCalculationInput
+): EstimateLineCalculation {
+  const quantity = Number.isFinite(input.quantity)
+    ? Math.max(0, input.quantity)
+    : 0
+  const unitCostCents = Math.max(0, safeInteger(input.unitCostCents))
+  const markupRate = safeRate(input.markupRateBasisPoints)
+  const taxRate = safeRate(input.taxRateBasisPoints)
+  const directCostCents = safeInteger(quantity * unitCostCents)
+  const markupCents = safeInteger(
+    (directCostCents * markupRate) / 10_000
+  )
+  const taxableSubtotal = directCostCents + markupCents
+  const taxCents = input.taxable
+    ? safeInteger((taxableSubtotal * taxRate) / 10_000)
+    : 0
+
+  return {
+    directCostCents,
+    markupCents,
+    taxCents,
+    lineTotalCents: taxableSubtotal + taxCents,
+  }
+}
+
+export function calculateEstimateTotals(
+  lines: readonly EstimateLedgerLine[]
+): EstimateLedgerTotals {
+  return lines.reduce<EstimateLedgerTotals>(
+    (totals, line) => ({
+      directCostCents: totals.directCostCents + line.directCostCents,
+      markupCents: totals.markupCents + line.markupCents,
+      taxCents: totals.taxCents + line.taxCents,
+      estimateTotalCents: totals.estimateTotalCents + line.lineTotalCents,
+    }),
+    {
+      directCostCents: 0,
+      markupCents: 0,
+      taxCents: 0,
+      estimateTotalCents: 0,
+    }
+  )
+}
+
+export function isEstimateStatus(value: string): value is EstimateStatus {
+  return ESTIMATE_STATUSES.some((status) => status === value)
+}
+
+export function estimateCanBeEdited(status: EstimateStatus): boolean {
+  return status === "draft" || status === "internal_review"
+}
+
+export function estimateCanBeAccepted(input: {
+  readonly status: EstimateStatus
+  readonly foxitStatus: string
+  readonly lineCount: number
+}): boolean {
+  return (
+    input.status === "signature_pending" &&
+    input.foxitStatus === "completed" &&
+    input.lineCount > 0
+  )
+}
+
+function defaultDivisionName(code: string): string {
+  return `CSI Division ${code.slice(0, 2)}`
+}
+
+export function buildContractBudget(input: {
+  readonly estimateLines: readonly EstimateLedgerLine[]
+  readonly adjustments: readonly ContractAdjustment[]
+}): ContractBudget {
+  const grouped = new Map<string, ContractBudgetLine>()
+
+  for (const line of input.estimateLines) {
+    const current = grouped.get(line.costCode)
+    if (current) {
+      const originalEstimateCents =
+        current.originalEstimateCents + line.lineTotalCents
+      grouped.set(line.costCode, {
+        ...current,
+        sourceEstimateLineId: null,
+        originalEstimateCents,
+        adjustedBudgetCents:
+          originalEstimateCents + current.approvedChangeCents,
+        ownerVisible: current.ownerVisible || line.ownerVisible,
+        sortOrder: Math.min(current.sortOrder, line.sortOrder),
+      })
+      continue
+    }
+
+    grouped.set(line.costCode, {
+      sourceEstimateLineId: line.id,
+      divisionCode: line.divisionCode,
+      divisionName: line.divisionName,
+      costCode: line.costCode,
+      description: line.description,
+      originalEstimateCents: line.lineTotalCents,
+      approvedChangeCents: 0,
+      adjustedBudgetCents: line.lineTotalCents,
+      ownerVisible: line.ownerVisible,
+      sortOrder: line.sortOrder,
+    })
+  }
+
+  for (const adjustment of input.adjustments) {
+    const current = grouped.get(adjustment.costCode)
+    if (current) {
+      const approvedChangeCents =
+        current.approvedChangeCents + adjustment.amountCents
+      grouped.set(adjustment.costCode, {
+        ...current,
+        approvedChangeCents,
+        adjustedBudgetCents:
+          current.originalEstimateCents + approvedChangeCents,
+      })
+      continue
+    }
+
+    const divisionCode = adjustment.costCode.slice(0, 2)
+    grouped.set(adjustment.costCode, {
+      sourceEstimateLineId: null,
+      divisionCode,
+      divisionName: defaultDivisionName(divisionCode),
+      costCode: adjustment.costCode,
+      description: adjustment.description,
+      originalEstimateCents: 0,
+      approvedChangeCents: adjustment.amountCents,
+      adjustedBudgetCents: adjustment.amountCents,
+      ownerVisible: true,
+      sortOrder: 100_000 + grouped.size,
+    })
+  }
+
+  const lines = [...grouped.values()].sort((left, right) => {
+    const divisionOrder = left.divisionCode.localeCompare(right.divisionCode)
+    if (divisionOrder !== 0) return divisionOrder
+    const sortOrder = left.sortOrder - right.sortOrder
+    if (sortOrder !== 0) return sortOrder
+    return left.costCode.localeCompare(right.costCode)
+  })
+  const originalContractSumCents = lines.reduce(
+    (sum, line) => sum + line.originalEstimateCents,
+    0
+  )
+  const approvedChangesCents = lines.reduce(
+    (sum, line) => sum + line.approvedChangeCents,
+    0
+  )
+
+  return {
+    lines,
+    originalContractSumCents,
+    approvedChangesCents,
+    revisedContractSumCents:
+      originalContractSumCents + approvedChangesCents,
+  }
+}
+
+export async function contractBudgetSourceHash(input: {
+  readonly estimateId: string
+  readonly estimateSourceHash: string | null
+  readonly adjustments: readonly ContractAdjustment[]
+}): Promise<string> {
+  const adjustments = [...input.adjustments]
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map((item) => ({
+      id: item.id,
+      changeOrderId: item.changeOrderId,
+      costCode: item.costCode,
+      amountCents: item.amountCents,
+      executedAt: item.executedAt,
+    }))
+  const bytes = new TextEncoder().encode(
+    JSON.stringify({
+      estimateId: input.estimateId,
+      estimateSourceHash: input.estimateSourceHash,
+      adjustments,
+    })
+  )
+  const digest = await crypto.subtle.digest("SHA-256", bytes)
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+export async function estimateSourceHash(input: {
+  readonly estimateId: string
+  readonly versionNumber: number
+  readonly title: string
+  readonly contractTerms: string | null
+  readonly lines: readonly {
+    readonly id: string
+    readonly divisionCode: string
+    readonly costCode: string
+    readonly description: string
+    readonly specifications: string | null
+    readonly quantity: number
+    readonly unit: string
+    readonly unitCostCents: number
+    readonly markupRateBasisPoints: number
+    readonly taxable: boolean
+    readonly taxCode: string | null
+    readonly taxRateBasisPoints: number
+    readonly lineTotalCents: number
+    readonly ownerVisible: boolean
+    readonly sortOrder: number
+  }[]
+  readonly basisDocuments: readonly {
+    readonly id: string
+    readonly documentType: string
+    readonly title: string
+    readonly documentDate: string | null
+    readonly revision: string | null
+    readonly driveFileId: string | null
+    readonly driveUrl: string | null
+    readonly notes: string | null
+    readonly sortOrder: number
+  }[]
+}): Promise<string> {
+  const lines = [...input.lines]
+    .sort((left, right) => {
+      const sortOrder = left.sortOrder - right.sortOrder
+      if (sortOrder !== 0) return sortOrder
+      return left.id.localeCompare(right.id)
+    })
+  const basisDocuments = [...input.basisDocuments].sort(
+    (left, right) => left.sortOrder - right.sortOrder
+  )
+  const bytes = new TextEncoder().encode(
+    JSON.stringify({
+      estimateId: input.estimateId,
+      versionNumber: input.versionNumber,
+      title: input.title,
+      contractTerms: input.contractTerms,
+      lines,
+      basisDocuments,
+    })
+  )
+  const digest = await crypto.subtle.digest("SHA-256", bytes)
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+}


### PR DESCRIPTION
## What changed

- adds a division-first CA22 Construction Estimate workspace using active Sage cost codes
- supports per-line quantity, unit cost, markup, taxable designation, Sage tax entity, specifications, owner visibility, and division subtotals
- records plans, specifications, revisions, dates, Drive links, and reusable/manual contract terms
- provides a printable CA22 preview and a Foxit handoff-ready signature package state
- locks accepted estimates and supersedes prior accepted baselines
- builds a versioned contract budget/G703 from the accepted estimate plus executed, cost-coded change orders
- rebuilds the current budget automatically when a change order is executed
- creates G702/G703 pay applications from the current locked budget revision
- carries prior completed work and retainage forward by cost code
- stages a full review-gated Sage payload only after the pay application is marked ready

## Why

The estimate, approved change orders, contract budget/G703, and owner pay applications previously behaved as separate records. This creates one auditable contract ledger:

accepted CA22 estimate → original contract budget → executed change orders → revised G703 → pay applications.

The implementation is grounded in the live Loomis and Loeffler CSI workbook structures in Google Drive, including division tabs, Project Totals, G702, G703, and Sage Processor patterns.

## Safety and external boundaries

- **Apply `drizzle/0087_estimate_contract_budget_ledger.sql` before deploying application code.**
- Sage output remains review-gated. This PR creates the exact G702/G703 snapshot and does not enable an automatic Sage write.
- Foxit is a handoff/manual completion workflow in this PR; the external Foxit API connector remains separate.
- Sage tax-entity storage and selection are included; populating it from the live Sage bridge remains separate.
- Accepted estimate versions and budget revisions are immutable/audited rather than overwritten.

## Validation

- production build passes
- TypeScript passes
- targeted ESLint passes
- 20 focused financial, change-order access/status, and Sage snapshot tests pass
- all 77 migrations apply successfully from an empty local SQLite database
- `git diff --check` passes

The build continues to report the repository's existing Next.js NFT file-tracing warnings; this change adds no build errors.