### PR TITLE
feat(estimates): import reconciled project totals

### DIFF
--- a/src/app/actions/project-estimates.ts
+++ b/src/app/actions/project-estimates.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { and, asc, desc, eq, ne } from "drizzle-orm"
+import { and, asc, desc, eq, inArray, ne } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
@@ -12,7 +12,9 @@ import {
   projectEstimates,
   sageTaxEntities,
 } from "@/db/schema-estimates"
+import { googleAuth } from "@/db/schema-google"
 import { requireAuth, type AuthUser } from "@/lib/auth"
+import { decrypt } from "@/lib/crypto"
 import { getCloudflareContext } from "@/lib/db"
 import { rebuildProjectContractBudget } from "@/lib/financials/contract-budget-store"
 import {
@@ -23,6 +25,17 @@ import {
   isEstimateStatus,
   type EstimateLedgerLine,
 } from "@/lib/financials/estimate-ledger"
+import {
+  CONTRACT_ADJUSTMENT_COST_CODES,
+  parseProjectTotalsRows,
+  spreadsheetIdFromUrl,
+} from "@/lib/financials/project-totals-import"
+import { SheetsClient } from "@/lib/google/client/sheets-client"
+import {
+  getGoogleConfig,
+  getGoogleCryptoSalt,
+  parseServiceAccountKey,
+} from "@/lib/google/config"
 import { requirePermission } from "@/lib/permissions"
 import { assertProjectAccess } from "@/lib/project-access"
 import { isInternalStaffRole } from "@/lib/user-roles"
@@ -161,6 +174,19 @@ export type ProjectEstimateBasisInput = {
 export type ProjectEstimateActionResult =
   | { readonly success: true; readonly id: string }
   | { readonly success: false; readonly error: string }
+
+export type ProjectEstimateImportActionResult =
+  | {
+      readonly success: true
+      readonly id: string
+      readonly lineCount: number
+      readonly totalCents: number
+      readonly roundingAdjustmentCents: number
+      readonly missingSageMappingCount: number
+    }
+  | { readonly success: false; readonly error: string }
+
+const PROJECT_TOTALS_RANGE = "Project Totals!A1:AA506"
 
 type CompassDb = ReturnType<typeof getDb>
 
@@ -459,14 +485,24 @@ export async function getProjectEstimateWorkspace(
       notes: row.notes,
       sortOrder: row.sortOrder,
     })),
-    costCodes: costCodeRows.map((row) => ({
-      value: row.code,
-      label: row.displayLabel,
-      description: row.description,
-      divisionCode: row.divisionCode,
-      divisionName: row.divisionDescription,
-      divisionLabel: row.divisionDisplayLabel,
-    })),
+    costCodes: [
+      ...costCodeRows.map((row) => ({
+        value: row.code,
+        label: row.displayLabel,
+        description: row.description,
+        divisionCode: row.divisionCode,
+        divisionName: row.divisionDescription,
+        divisionLabel: row.divisionDisplayLabel,
+      })),
+      ...CONTRACT_ADJUSTMENT_COST_CODES.map((item) => ({
+        value: item.value,
+        label: `${item.value} · ${item.description} · contract adjustment — not Sage mapped`,
+        description: item.description,
+        divisionCode: "99",
+        divisionName: "Contract Adjustments",
+        divisionLabel: "99 · Contract Adjustments",
+      })),
+    ],
     taxEntities: taxRows.map((row) => ({
       value: row.id,
       label: `${row.code} · ${row.name}`,
@@ -575,6 +611,155 @@ export async function updateProjectEstimateHeader(
   }
 }
 
+export async function importProjectEstimateFromGoogleSheet(
+  projectId: string,
+  estimateId: string
+): Promise<ProjectEstimateImportActionResult> {
+  try {
+    const access = await estimateAccess(projectId, true)
+    const estimate = await requireEditableEstimate(
+      access.db,
+      projectId,
+      estimateId
+    )
+    const spreadsheetId = spreadsheetIdFromUrl(estimate.sourceWorkbookUrl)
+    if (!spreadsheetId) {
+      throw new Error(
+        "Save a valid Google Sheets Source CSI workbook before importing."
+      )
+    }
+
+    const authRows = access.organizationId
+      ? await access.db
+          .select()
+          .from(googleAuth)
+          .where(eq(googleAuth.organizationId, access.organizationId))
+          .limit(1)
+      : await access.db.select().from(googleAuth).limit(1)
+    const auth = authRows[0]
+    if (!auth) {
+      throw new Error("Google Workspace service account is not connected.")
+    }
+
+    const { env } = await getCloudflareContext()
+    const config = getGoogleConfig(env)
+    const keyJson = await decrypt(
+      auth.serviceAccountKeyEncrypted,
+      config.encryptionKey,
+      getGoogleCryptoSalt()
+    )
+    const client = new SheetsClient(parseServiceAccountKey(keyJson))
+    const googleEmail = access.user.googleEmail ?? access.user.email
+    const rows = await client.getValues(googleEmail, {
+      spreadsheetId,
+      range: PROJECT_TOTALS_RANGE,
+      valueRenderOption: "UNFORMATTED_VALUE",
+    })
+    const parsed = parseProjectTotalsRows(rows)
+    if (!parsed.success) throw new Error(parsed.error)
+
+    const sourceCostCodes = parsed.lines
+      .filter((line) => line.divisionCode !== "99")
+      .map((line) => line.costCode)
+    const activeCostCodeRows = sourceCostCodes.length > 0
+      ? await access.db
+          .select({ code: sageCostCodes.code })
+          .from(sageCostCodes)
+          .where(
+            and(
+              eq(sageCostCodes.active, true),
+              inArray(sageCostCodes.code, sourceCostCodes)
+            )
+          )
+      : []
+    const activeCostCodes = new Set(activeCostCodeRows.map((row) => row.code))
+    const missingCostCodes = sourceCostCodes.filter(
+      (code) => !activeCostCodes.has(code)
+    )
+    const missingCostCodeSet = new Set(missingCostCodes)
+
+    const now = new Date().toISOString()
+    const lineValues = parsed.lines.map((line) => {
+      const mappingNote = missingCostCodeSet.has(line.costCode)
+        ? `Source CSI cost code ${line.costCode} is not active in Sage; remap before signature or accounting handoff.`
+        : null
+      return {
+        id: crypto.randomUUID(),
+        projectId,
+        estimateId,
+        divisionCode: line.divisionCode,
+        divisionName: line.divisionName,
+        costCode: line.costCode,
+        costCodeName: line.description,
+        description: line.description,
+        specifications: [line.specifications, mappingNote]
+          .filter(Boolean)
+          .join(" ") || null,
+        quantity: 1,
+        unit: "LS",
+        unitCostCents: line.amountCents,
+        directCostCents: line.amountCents,
+        markupRateBasisPoints: 0,
+        markupCents: 0,
+        taxable: false,
+        taxEntityId: null,
+        taxCode: null,
+        taxName: null,
+        taxRateBasisPoints: 0,
+        taxCents: 0,
+        lineTotalCents: line.amountCents,
+        ownerVisible: true,
+        sortOrder: line.sortOrder,
+        createdAt: now,
+        updatedAt: now,
+      }
+    })
+    const [firstLine, ...remainingLines] = lineValues
+    if (!firstLine) {
+      throw new Error("Project Totals did not produce any importable lines.")
+    }
+
+    await access.db.batch([
+      access.db
+        .delete(projectEstimateLines)
+        .where(eq(projectEstimateLines.estimateId, estimateId)),
+      access.db.insert(projectEstimateLines).values(firstLine),
+      ...remainingLines.map((lineValue) =>
+        access.db.insert(projectEstimateLines).values(lineValue)
+      ),
+      access.db
+        .update(projectEstimates)
+        .set({
+          sourceSystem: "google_csi_project_totals",
+          sourceWorkbookId: spreadsheetId,
+          sourceRevision: `Project Totals imported ${now}`,
+          directCostCents: parsed.displayedTotalCents,
+          markupCents: 0,
+          taxCents: 0,
+          estimateTotalCents: parsed.displayedTotalCents,
+          updatedAt: now,
+        })
+        .where(eq(projectEstimates.id, estimateId)),
+    ])
+
+    revalidateEstimate(projectId)
+    return {
+      success: true,
+      id: estimateId,
+      lineCount: parsed.lines.length,
+      totalCents: parsed.displayedTotalCents,
+      roundingAdjustmentCents: parsed.roundingAdjustmentCents,
+      missingSageMappingCount: missingCostCodes.length,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to import source CSI.",
+    }
+  }
+}
+
 export async function saveProjectEstimateLine(
   projectId: string,
   estimateId: string,
@@ -589,13 +774,25 @@ export async function saveProjectEstimateLine(
       estimateId
     )
     const costCode = requiredText(input.costCode, "Cost code")
-    const costRows = await access.db
-      .select()
-      .from(sageCostCodes)
-      .where(and(eq(sageCostCodes.code, costCode), eq(sageCostCodes.active, true)))
-      .limit(1)
+    const contractAdjustment = CONTRACT_ADJUSTMENT_COST_CODES.find(
+      (item) => item.value === costCode
+    )
+    const costRows = contractAdjustment
+      ? []
+      : await access.db
+          .select()
+          .from(sageCostCodes)
+          .where(
+            and(
+              eq(sageCostCodes.code, costCode),
+              eq(sageCostCodes.active, true)
+            )
+          )
+          .limit(1)
     const cost = costRows[0]
-    if (!cost) throw new Error("Choose an active Sage cost code.")
+    if (!cost && !contractAdjustment) {
+      throw new Error("Choose an active Sage cost code.")
+    }
     const taxEntityId = cleanText(input.taxEntityId) ?? estimate.defaultTaxEntityId
     const taxRows = taxEntityId
       ? await access.db
@@ -630,10 +827,11 @@ export async function saveProjectEstimateLine(
       .orderBy(desc(projectEstimateLines.sortOrder))
       .limit(1)
     const values = {
-      divisionCode: cost.divisionCode,
-      divisionName: cost.divisionDescription,
-      costCode: cost.code,
-      costCodeName: cost.description,
+      divisionCode: cost?.divisionCode ?? "99",
+      divisionName: cost?.divisionDescription ?? "Contract Adjustments",
+      costCode: cost?.code ?? contractAdjustment?.value ?? costCode,
+      costCodeName:
+        cost?.description ?? contractAdjustment?.description ?? costCode,
       description: requiredText(input.description, "Description"),
       specifications: cleanText(input.specifications),
       quantity,
@@ -780,6 +978,33 @@ export async function prepareProjectEstimateForFoxit(
       .where(eq(projectEstimateBasisDocuments.estimateId, estimateId))
       .orderBy(asc(projectEstimateBasisDocuments.sortOrder))
     if (lines.length === 0) throw new Error("Add estimate lines before signature.")
+    const sourceCostCodes = [
+      ...new Set(
+        lines
+          .filter((line) => line.divisionCode !== "99")
+          .map((line) => line.costCode)
+      ),
+    ]
+    const activeCostCodeRows = sourceCostCodes.length > 0
+      ? await access.db
+          .select({ code: sageCostCodes.code })
+          .from(sageCostCodes)
+          .where(
+            and(
+              eq(sageCostCodes.active, true),
+              inArray(sageCostCodes.code, sourceCostCodes)
+            )
+          )
+      : []
+    const activeCostCodes = new Set(activeCostCodeRows.map((row) => row.code))
+    const missingCostCodes = sourceCostCodes.filter(
+      (code) => !activeCostCodes.has(code)
+    )
+    if (missingCostCodes.length > 0) {
+      throw new Error(
+        `${missingCostCodes.length} estimate cost codes require Sage mapping before Foxit handoff: ${missingCostCodes.join(", ")}.`
+      )
+    }
     if (!cleanText(estimate.contractTerms)) {
       throw new Error("Add the contract terms before signature.")
     }

--- a/src/components/projects/project-estimate-workspace.tsx
+++ b/src/components/projects/project-estimate-workspace.tsx
@@ -8,6 +8,7 @@ import {
   IconFileExport,
   IconPlus,
   IconReceiptTax,
+  IconRefresh,
   IconSend,
   IconTrash,
 } from "@tabler/icons-react"
@@ -16,6 +17,7 @@ import {
   addProjectEstimateBasisDocument,
   createProjectEstimateDraft,
   deleteProjectEstimateLine,
+  importProjectEstimateFromGoogleSheet,
   prepareProjectEstimateForFoxit,
   recordSignedProjectEstimate,
   saveProjectEstimateLine,
@@ -138,6 +140,10 @@ export function ProjectEstimateWorkspacePanel({
   const availableCostCodes = workspace.costCodes.filter(
     (option) => option.divisionCode === line.divisionCode
   )
+  const mappedCostCodes = useMemo(
+    () => new Set(workspace.costCodes.map((option) => option.value)),
+    [workspace.costCodes]
+  )
   const groupedLines = useMemo(() => {
     const groups = new Map<string, ProjectEstimateLineItem[]>()
     for (const item of workspace.lines) {
@@ -221,6 +227,38 @@ export function ProjectEstimateWorkspacePanel({
         lineId
       )
       finish(result.success ? "Estimate line removed." : result.error)
+    })
+  }
+
+  function importSourceCsi(): void {
+    if (!estimate) return
+    if (
+      workspace.lines.length > 0 &&
+      !window.confirm(
+        "Importing Project Totals will replace every line in this editable draft. Continue?"
+      )
+    ) {
+      return
+    }
+    setMessage(null)
+    startTransition(async () => {
+      const result = await importProjectEstimateFromGoogleSheet(
+        projectId,
+        estimate.id
+      )
+      if (!result.success) {
+        finish(result.error)
+        return
+      }
+      const rounding = result.roundingAdjustmentCents === 0
+        ? ""
+        : ` A ${money(Math.abs(result.roundingAdjustmentCents))} source-rounding adjustment was recorded.`
+      const mappings = result.missingSageMappingCount === 0
+        ? ""
+        : ` ${result.missingSageMappingCount} source cost codes require Sage mapping before signature.`
+      finish(
+        `${result.lineCount} reconciled CSI lines imported for ${money(result.totalCents)}.${rounding}${mappings}`
+      )
     })
   }
 
@@ -455,13 +493,32 @@ export function ProjectEstimateWorkspacePanel({
       </form>
 
       <section className="clarity-panel-strong p-4">
-        <div className="mb-4">
-          <h2 className="font-semibold">CSI estimate</h2>
-          <p className="text-xs text-muted-foreground">
-            Select a division first, then add the Sage cost codes needed within
-            it. Each division subtotal updates from its lines.
-          </p>
+        <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="font-semibold">CSI estimate</h2>
+            <p className="text-xs text-muted-foreground">
+              Select a division first, then add the Sage cost codes needed within
+              it. Each division subtotal updates from its lines.
+            </p>
+          </div>
+          {editable && estimate.sourceWorkbookUrl && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={importSourceCsi}
+              disabled={isPending}
+            >
+              <IconRefresh
+                className={isPending ? "size-4 animate-spin" : "size-4"}
+              />
+              Import source CSI
+            </Button>
+          )}
         </div>
+        <p className="mb-4 text-xs text-muted-foreground">
+          Company overhead, margin, and contingency import as clearly labeled
+          contract adjustments; they are not represented as Sage cost-code mappings.
+        </p>
         {groupedLines.length === 0 ? (
           <p className="text-sm text-muted-foreground">No estimate lines yet.</p>
         ) : (
@@ -491,6 +548,11 @@ export function ProjectEstimateWorkspacePanel({
                           <p className="text-sm font-medium">
                             {item.costCode} · {item.description}
                           </p>
+                          {!mappedCostCodes.has(item.costCode) && (
+                            <Badge variant="outline" className="mt-1">
+                              Sage mapping required
+                            </Badge>
+                          )}
                           <p className="text-xs text-muted-foreground">
                             {item.quantity} {item.unit} × {money(item.unitCostCents)} ·
                             markup {percent(item.markupRateBasisPoints)}

--- a/src/lib/financials/__tests__/project-totals-import.test.ts
+++ b/src/lib/financials/__tests__/project-totals-import.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  parseProjectTotalsRows,
+  spreadsheetIdFromUrl,
+} from "@/lib/financials/project-totals-import"
+
+describe("parseProjectTotalsRows", () => {
+  it("imports cost codes and contract adjustments with an exact source total", () => {
+    const result = parseProjectTotalsRows([
+      ["03 30 00 - Cast-in-Place Concrete", "Foundation scope", null, null, 100.005],
+      ["06 10 00 - Rough Carpentry", null, null, null, 50.005],
+      ["Company Overhead & Margin"],
+      ["Company Overhead", null, null, null, 10],
+      ["Company Margin", null, null, null, 5],
+      ["Contingency", null, null, null, 2],
+      ["Project Total:", null, null, null, 167.01],
+      ["Adjusted Project Totals", null, null, null, 150],
+    ])
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.lines).toHaveLength(5)
+    expect(result.displayedTotalCents).toBe(16_701)
+    expect(result.lines.reduce((sum, line) => sum + line.amountCents, 0)).toBe(
+      16_701
+    )
+    expect(result.roundingAdjustmentCents).toBe(-1)
+    expect(result.lines.at(-1)).toMatchObject({
+      costCode: "99 30 00",
+      divisionName: "Contract Adjustments",
+      amountCents: 199,
+    })
+    expect(result.lines.at(-1)?.specifications).toContain(
+      "Source rounding reconciliation"
+    )
+  })
+
+  it("rejects duplicate source cost codes", () => {
+    const result = parseProjectTotalsRows([
+      ["27 00 00 - Communications", null, null, null, "$1,150.00"],
+      ["27 00 00 - Communications", null, null, null, "$1,150.00"],
+      ["Project Total:", null, null, null, "$2,300.00"],
+    ])
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        "Project Totals contains duplicate cost codes: 27 00 00. Resolve them before import.",
+    })
+  })
+
+  it("rejects a displayed total that does not reconcile to its lines", () => {
+    const result = parseProjectTotalsRows([
+      ["03 30 00 - Cast-in-Place Concrete", null, null, null, 100],
+      ["Project Total:", null, null, null, 101],
+    ])
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        "Project Totals does not reconcile: displayed $101.00 versus line total $100.00.",
+    })
+  })
+})
+
+describe("spreadsheetIdFromUrl", () => {
+  it("accepts a Google Sheets URL and rejects unrelated URLs", () => {
+    expect(
+      spreadsheetIdFromUrl(
+        "https://docs.google.com/spreadsheets/d/source-sheet-id/edit#gid=0"
+      )
+    ).toBe("source-sheet-id")
+    expect(spreadsheetIdFromUrl("https://example.com/not-a-sheet")).toBeNull()
+  })
+})

--- a/src/lib/financials/project-totals-import.ts
+++ b/src/lib/financials/project-totals-import.ts
@@ -1,0 +1,237 @@
+export type ProjectTotalsImportLine = {
+  readonly costCode: string
+  readonly divisionCode: string
+  readonly divisionName: string
+  readonly description: string
+  readonly specifications: string | null
+  readonly amountCents: number
+  readonly sortOrder: number
+}
+
+export type ProjectTotalsImportResult =
+  | {
+      readonly success: true
+      readonly lines: readonly ProjectTotalsImportLine[]
+      readonly displayedTotalCents: number
+      readonly roundingAdjustmentCents: number
+    }
+  | { readonly success: false; readonly error: string }
+
+export const CONTRACT_ADJUSTMENT_COST_CODES = [
+  {
+    value: "99 10 00",
+    description: "Company Overhead",
+  },
+  {
+    value: "99 20 00",
+    description: "Company Margin",
+  },
+  {
+    value: "99 30 00",
+    description: "Contingency",
+  },
+] as const
+
+const DIVISION_NAMES: Readonly<Record<string, string>> = {
+  "00": "Procurement Requirements",
+  "01": "General Requirements",
+  "02": "Existing Conditions",
+  "03": "Concrete",
+  "04": "Masonry",
+  "05": "Metals",
+  "06": "Wood, Plastics, and Composites",
+  "07": "Thermal and Moisture Protection",
+  "08": "Openings",
+  "09": "Finishes",
+  "10": "Specialties",
+  "11": "Equipment",
+  "12": "Furnishings",
+  "13": "Special Construction",
+  "14": "Conveying Equipment",
+  "21": "Fire Suppression",
+  "22": "Plumbing",
+  "23": "Heating, Ventilating, and Air Conditioning",
+  "26": "Electrical",
+  "27": "Communications",
+  "28": "Electronic Safety and Security",
+  "31": "Earthwork",
+  "32": "Exterior Improvements",
+  "33": "Utilities",
+  "48": "Electrical Power Generation Equipment",
+  "99": "Contract Adjustments",
+}
+
+function cleanText(value: unknown): string | null {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function parseCurrency(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null
+  }
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const negative = trimmed.startsWith("(") && trimmed.endsWith(")")
+  const parsed = Number(trimmed.replaceAll(/[$,\s()]/g, ""))
+  if (!Number.isFinite(parsed)) return null
+  return negative ? -parsed : parsed
+}
+
+function parseCostCodeLabel(
+  value: string
+): { readonly code: string; readonly description: string } | null {
+  const match = /^(\d{2}(?:\s\d{2}){0,2}(?:\.\d{2})*)\s+-\s+(.+)$/.exec(
+    value
+  )
+  const code = match?.[1]?.trim()
+  const description = match?.[2]?.trim()
+  return code && description ? { code, description } : null
+}
+
+function adjustmentForLabel(
+  value: string
+): (typeof CONTRACT_ADJUSTMENT_COST_CODES)[number] | null {
+  const normalized = value.trim().toLowerCase()
+  return (
+    CONTRACT_ADJUSTMENT_COST_CODES.find(
+      (item) => item.description.toLowerCase() === normalized
+    ) ?? null
+  )
+}
+
+function roundingNote(cents: number): string {
+  const amount = Math.abs(cents) / 100
+  const sign = cents >= 0 ? "+" : "-"
+  return `Source rounding reconciliation: ${sign}$${amount.toFixed(2)}.`
+}
+
+export function parseProjectTotalsRows(
+  rows: ReadonlyArray<ReadonlyArray<unknown>>
+): ProjectTotalsImportResult {
+  const parsedLines: Array<{
+    readonly costCode: string
+    readonly description: string
+    readonly specifications: string | null
+    readonly rawAmount: number
+  }> = []
+  let displayedTotal: number | null = null
+  let inAdjustmentSection = false
+
+  for (const row of rows) {
+    const label = cleanText(row[0])
+    if (!label) continue
+    const amount = parseCurrency(row[4])
+
+    if (label === "Project Total:") {
+      if (amount !== null && amount > 0) displayedTotal = amount
+      continue
+    }
+    if (label === "Company Overhead & Margin") {
+      inAdjustmentSection = true
+      continue
+    }
+    if (
+      label === "Project Totals" ||
+      label === "Project Subtotal:" ||
+      label.startsWith("Total:")
+    ) {
+      continue
+    }
+
+    const parsedCostCode = parseCostCodeLabel(label)
+    const adjustment = inAdjustmentSection
+      ? adjustmentForLabel(label)
+      : null
+    if ((!parsedCostCode && !adjustment) || amount === null || amount === 0) {
+      continue
+    }
+
+    parsedLines.push({
+      costCode: parsedCostCode?.code ?? adjustment?.value ?? "",
+      description:
+        parsedCostCode?.description ?? adjustment?.description ?? label,
+      specifications: cleanText(row[1]),
+      rawAmount: amount,
+    })
+  }
+
+  if (parsedLines.length === 0) {
+    return {
+      success: false,
+      error: "No non-zero Schedule of Values lines were found in Project Totals.",
+    }
+  }
+
+  const duplicates = [...new Set(
+    parsedLines
+      .filter(
+        (line, index) =>
+          parsedLines.findIndex((candidate) => candidate.costCode === line.costCode) !==
+          index
+      )
+      .map((line) => line.costCode)
+  )]
+  if (duplicates.length > 0) {
+    return {
+      success: false,
+      error: `Project Totals contains duplicate cost codes: ${duplicates.join(", ")}. Resolve them before import.`,
+    }
+  }
+
+  const rawLineTotal = parsedLines.reduce(
+    (sum, line) => sum + line.rawAmount,
+    0
+  )
+  const sourceTotal = displayedTotal ?? rawLineTotal
+  if (Math.abs(rawLineTotal - sourceTotal) >= 0.005) {
+    return {
+      success: false,
+      error: `Project Totals does not reconcile: displayed $${sourceTotal.toFixed(2)} versus line total $${rawLineTotal.toFixed(2)}.`,
+    }
+  }
+
+  const displayedTotalCents = Math.round(sourceTotal * 100)
+  const roundedTotalCents = parsedLines.reduce(
+    (sum, line) => sum + Math.round(line.rawAmount * 100),
+    0
+  )
+  const roundingAdjustmentCents = displayedTotalCents - roundedTotalCents
+  const contingencyIndex = parsedLines.findIndex(
+    (line) => line.costCode === "99 30 00"
+  )
+  const targetIndex =
+    contingencyIndex >= 0 ? contingencyIndex : parsedLines.length - 1
+
+  const lines = parsedLines.map((line, index): ProjectTotalsImportLine => {
+    const adjustment = index === targetIndex ? roundingAdjustmentCents : 0
+    const divisionCode = line.costCode.slice(0, 2)
+    const note = adjustment === 0
+      ? line.specifications
+      : [line.specifications, roundingNote(adjustment)].filter(Boolean).join(" ")
+    return {
+      costCode: line.costCode,
+      divisionCode,
+      divisionName: DIVISION_NAMES[divisionCode] ?? "Project Estimate",
+      description: line.description,
+      specifications: note || null,
+      amountCents: Math.round(line.rawAmount * 100) + adjustment,
+      sortOrder: index + 1,
+    }
+  })
+
+  return {
+    success: true,
+    lines,
+    displayedTotalCents,
+    roundingAdjustmentCents,
+  }
+}
+
+export function spreadsheetIdFromUrl(value: string | null): string | null {
+  if (!value) return null
+  const match = /\/spreadsheets\/d\/([^/]+)/.exec(value)
+  return match?.[1] ?? null
+}

--- a/src/lib/google/client/sheets-client.ts
+++ b/src/lib/google/client/sheets-client.ts
@@ -1,0 +1,53 @@
+import { getAccessToken } from "@/lib/google/auth/service-account"
+import {
+  GOOGLE_SHEETS_API,
+  type ServiceAccountKey,
+} from "@/lib/google/config"
+
+type SheetsValueRenderOption =
+  | "FORMATTED_VALUE"
+  | "UNFORMATTED_VALUE"
+  | "FORMULA"
+
+export class SheetsClient {
+  constructor(
+    private readonly serviceAccountKey: ServiceAccountKey
+  ) {}
+
+  async getValues(
+    userEmail: string,
+    input: {
+      readonly spreadsheetId: string
+      readonly range: string
+      readonly valueRenderOption?: SheetsValueRenderOption
+    }
+  ): Promise<ReadonlyArray<ReadonlyArray<unknown>>> {
+    const token = await getAccessToken(this.serviceAccountKey, userEmail)
+    const params = new URLSearchParams({
+      valueRenderOption: input.valueRenderOption ?? "UNFORMATTED_VALUE",
+    })
+    const range = encodeURIComponent(input.range)
+    const response = await fetch(
+      `${GOOGLE_SHEETS_API}/${input.spreadsheetId}/values/${range}?${params.toString()}`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    )
+
+    if (!response.ok) {
+      const body = await response.text()
+      throw new Error(
+        `Google Sheets API error (${response.status}): ${body.slice(0, 500)}`
+      )
+    }
+
+    const payload: unknown = await response.json()
+    if (
+      typeof payload !== "object" ||
+      payload === null ||
+      !("values" in payload) ||
+      !Array.isArray(payload.values)
+    ) {
+      return []
+    }
+    return payload.values.filter(Array.isArray)
+  }
+}

--- a/src/lib/google/config.ts
+++ b/src/lib/google/config.ts
@@ -3,10 +3,17 @@ export type GoogleConfig = {
 }
 
 export function getGoogleConfig(
-  env: Record<string, string | undefined>
+  env: unknown
 ): GoogleConfig {
+  const environmentKey =
+    typeof env === "object" &&
+    env !== null &&
+    "GOOGLE_SERVICE_ACCOUNT_ENCRYPTION_KEY" in env &&
+    typeof env.GOOGLE_SERVICE_ACCOUNT_ENCRYPTION_KEY === "string"
+      ? env.GOOGLE_SERVICE_ACCOUNT_ENCRYPTION_KEY
+      : undefined
   const encryptionKey =
-    env.GOOGLE_SERVICE_ACCOUNT_ENCRYPTION_KEY ??
+    environmentKey ??
     process.env.GOOGLE_SERVICE_ACCOUNT_ENCRYPTION_KEY
   if (!encryptionKey) {
     throw new Error(
@@ -56,6 +63,9 @@ export const GOOGLE_TOKEN_URL =
 
 export const GOOGLE_DRIVE_API =
   "https://www.googleapis.com/drive/v3"
+
+export const GOOGLE_SHEETS_API =
+  "https://sheets.googleapis.com/v4/spreadsheets"
 
 export const GOOGLE_UPLOAD_API =
   "https://www.googleapis.com/upload/drive/v3"


### PR DESCRIPTION
## Summary

- import an editable CA22 estimate draft from its saved Google Sheets `Project Totals` tab
- reconcile the source total exactly, reject duplicate cost codes, and record source rounding transparently
- preserve source CSI codes that are not active in Sage with visible mapping warnings
- block Foxit/accounting handoff until regular estimate lines have active Sage mappings
- label overhead, margin, and contingency as contract adjustments rather than Sage cost codes

## Loomis preflight

- source workbook: `O-170-2684-03 Barndo, Loomis CSI`
- 82 unique nonzero lines
- source total: `$583,214.97`
- per-line rounding reconciliation: `-$0.02` on contingency
- draft remains unsigned and no Sage/Foxit write occurs

## Validation

- `bun run lint` (0 errors; pre-existing warnings only)
- `bun run test` (95 files, 578 passed, 3 skipped)
- `bunx tsc --noEmit --pretty false`
- `bun run build`
- read-only production D1 check of active Sage cost codes
- read-only Google Sheets preflight against the Loomis `Project Totals` tab
