### PR TITLE
feat(conversations): support private group messages

### DIFF
--- a/src/app/actions/conversations.ts
+++ b/src/app/actions/conversations.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import { getCloudflareContext } from "@/lib/db"
-import { eq, and, sql, ne } from "drizzle-orm"
+import { eq, and, sql, ne, inArray } from "drizzle-orm"
 import { getDb } from "@/db"
 import {
   channels,
@@ -18,20 +18,10 @@ import { revalidatePath } from "next/cache"
 import { requireOrg } from "@/lib/org-scope"
 import { isDemoUser } from "@/lib/demo"
 import { isInternalStaffRole } from "@/lib/user-roles"
-
-async function directChannelId(
-  organizationId: string,
-  firstUserId: string,
-  secondUserId: string
-): Promise<string> {
-  const participants = [firstUserId, secondUserId].sort().join(":")
-  const bytes = new TextEncoder().encode(`${organizationId}:${participants}`)
-  const digest = await crypto.subtle.digest("SHA-256", bytes)
-  const hash = Array.from(new Uint8Array(digest))
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("")
-  return `direct-${hash.slice(0, 32)}`
-}
+import {
+  directChannelId,
+  directParticipantIds,
+} from "@/lib/conversations/direct-channel"
 
 async function ensureChannelMember(
   db: ReturnType<typeof getDb>,
@@ -134,7 +124,7 @@ export async function listDirectMessageRecipients() {
   }
 }
 
-export async function createDirectMessage(targetUserId: string) {
+export async function createDirectMessage(targetUserIds: readonly string[]) {
   try {
     const user = await getCurrentUser()
     if (!user || !isInternalStaffRole(user.role)) {
@@ -143,14 +133,20 @@ export async function createDirectMessage(targetUserId: string) {
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
-    if (targetUserId === user.id) {
-      return { success: false, error: "Choose another team member" }
+    const requestedTargetIds = Array.from(
+      new Set(targetUserIds.filter((targetUserId) => targetUserId !== user.id))
+    )
+    if (requestedTargetIds.length === 0) {
+      return { success: false, error: "Choose at least one team member" }
+    }
+    if (requestedTargetIds.length > 20) {
+      return { success: false, error: "Choose no more than 20 team members" }
     }
 
     const organizationId = requireOrg(user)
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
-    const target = await db
+    const targets = await db
       .select({
         id: users.id,
         name: users.displayName,
@@ -165,18 +161,19 @@ export async function createDirectMessage(targetUserId: string) {
           eq(organizationMembers.organizationId, organizationId)
         )
       )
-      .where(and(eq(users.id, targetUserId), eq(users.isActive, true)))
-      .get()
+      .where(
+        and(inArray(users.id, requestedTargetIds), eq(users.isActive, true))
+      )
 
-    if (!target || !isInternalStaffRole(target.role)) {
-      return { success: false, error: "Team member not found" }
+    if (
+      targets.length !== requestedTargetIds.length ||
+      targets.some((target) => !isInternalStaffRole(target.role))
+    ) {
+      return { success: false, error: "One or more team members were not found" }
     }
 
-    const channelId = await directChannelId(
-      organizationId,
-      user.id,
-      target.id
-    )
+    const participantIds = directParticipantIds(user.id, requestedTargetIds)
+    const channelId = await directChannelId(organizationId, participantIds)
     const now = new Date().toISOString()
     const existingChannel = await db
       .select({ id: channels.id })
@@ -185,11 +182,18 @@ export async function createDirectMessage(targetUserId: string) {
       .get()
 
     if (!existingChannel) {
+      const participantNames = [
+        user.displayName ?? user.email,
+        ...targets.map((target) => target.name ?? target.email),
+      ].sort((first, second) => first.localeCompare(second))
       await db.insert(channels).values({
         id: channelId,
-        name: `${user.displayName ?? user.email} · ${target.name ?? target.email}`,
+        name: participantNames.join(" · "),
         type: "text",
-        description: "Private direct message",
+        description:
+          participantIds.length === 2
+            ? "Private direct message"
+            : "Private group message",
         organizationId,
         projectId: null,
         categoryId: null,
@@ -203,8 +207,9 @@ export async function createDirectMessage(targetUserId: string) {
       })
     }
 
-    await ensureChannelMember(db, channelId, user.id, now)
-    await ensureChannelMember(db, channelId, target.id, now)
+    for (const participantId of participantIds) {
+      await ensureChannelMember(db, channelId, participantId, now)
+    }
 
     revalidatePath("/dashboard/conversations")
     return { success: true, data: { channelId } }

--- a/src/components/conversations/direct-message-dialog.tsx
+++ b/src/components/conversations/direct-message-dialog.tsx
@@ -10,15 +10,18 @@ import {
   listDirectMessageRecipients,
 } from "@/app/actions/conversations"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import { cn } from "@/lib/utils"
 
 type DirectMessageRecipient = {
   readonly id: string
@@ -40,7 +43,8 @@ export function DirectMessageDialog({
   >([])
   const [query, setQuery] = React.useState("")
   const [loading, setLoading] = React.useState(false)
-  const [startingId, setStartingId] = React.useState<string | null>(null)
+  const [selectedIds, setSelectedIds] = React.useState<readonly string[]>([])
+  const [starting, setStarting] = React.useState(false)
 
   React.useEffect(() => {
     if (!open) return
@@ -60,6 +64,12 @@ export function DirectMessageDialog({
     }
   }, [open])
 
+  React.useEffect(() => {
+    if (open) return
+    setQuery("")
+    setSelectedIds([])
+  }, [open])
+
   const normalizedQuery = query.trim().toLocaleLowerCase()
   const filteredRecipients = recipients.filter((recipient) =>
     `${recipient.name} ${recipient.email}`
@@ -67,18 +77,31 @@ export function DirectMessageDialog({
       .includes(normalizedQuery)
   )
 
-  async function startMessage(recipientId: string): Promise<void> {
-    setStartingId(recipientId)
-    const result = await createDirectMessage(recipientId)
-    setStartingId(null)
-    if (!result.success || !result.data) {
-      toast.error(result.error ?? "Could not start the message.")
-      return
+  function toggleRecipient(recipientId: string, selected: boolean): void {
+    setSelectedIds((current) =>
+      selected
+        ? Array.from(new Set([...current, recipientId]))
+        : current.filter((id) => id !== recipientId)
+    )
+  }
+
+  async function startMessage(): Promise<void> {
+    if (selectedIds.length === 0) return
+    setStarting(true)
+    try {
+      const result = await createDirectMessage(selectedIds)
+      if (!result.success || !result.data) {
+        toast.error(result.error ?? "Could not start the conversation.")
+        return
+      }
+      onOpenChange(false)
+      router.push(`/dashboard/conversations/${result.data.channelId}`)
+      router.refresh()
+    } catch {
+      toast.error("Could not start the conversation.")
+    } finally {
+      setStarting(false)
     }
-    onOpenChange(false)
-    setQuery("")
-    router.push(`/dashboard/conversations/${result.data.channelId}`)
-    router.refresh()
   }
 
   return (
@@ -87,7 +110,7 @@ export function DirectMessageDialog({
         <DialogHeader>
           <DialogTitle>New direct message</DialogTitle>
           <DialogDescription>
-            Start a private conversation with an internal team member.
+            Select one or more internal team members for a private conversation.
           </DialogDescription>
         </DialogHeader>
         <div className="relative">
@@ -112,35 +135,60 @@ export function DirectMessageDialog({
                 No matching team members.
               </p>
             ) : (
-              filteredRecipients.map((recipient) => (
-                <Button
-                  key={recipient.id}
-                  type="button"
-                  variant="ghost"
-                  className="h-auto w-full justify-start gap-3 px-3 py-2 text-left"
-                  disabled={startingId !== null}
-                  onClick={() => void startMessage(recipient.id)}
-                >
-                  <span className="grid size-9 shrink-0 place-items-center rounded-full bg-primary/10 text-primary">
-                    {startingId === recipient.id ? (
-                      <IconLoader2 className="size-4 animate-spin" />
-                    ) : (
-                      <IconMessageCircle className="size-4" />
+              filteredRecipients.map((recipient) => {
+                const selected = selectedIds.includes(recipient.id)
+                return (
+                  <div
+                    key={recipient.id}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-3 px-3 py-2 text-left hover:bg-accent has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50",
+                      selected && "bg-accent"
                     )}
-                  </span>
-                  <span className="min-w-0">
-                    <span className="block truncate text-sm font-medium">
-                      {recipient.name}
+                    onClick={() => {
+                      if (!starting) toggleRecipient(recipient.id, !selected)
+                    }}
+                  >
+                    <span className="grid size-9 shrink-0 place-items-center rounded-full bg-primary/10 text-primary">
+                      <IconMessageCircle className="size-4" />
                     </span>
-                    <span className="block truncate text-xs text-muted-foreground">
-                      {recipient.email}
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium">
+                        {recipient.name}
+                      </span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {recipient.email}
+                      </span>
                     </span>
-                  </span>
-                </Button>
-              ))
+                    <Checkbox
+                      checked={selected}
+                      disabled={starting}
+                      onClick={(event) => event.stopPropagation()}
+                      onCheckedChange={(checked) =>
+                        toggleRecipient(recipient.id, checked === true)
+                      }
+                      aria-label={`Include ${recipient.name}`}
+                    />
+                  </div>
+                )
+              })
             )}
           </div>
         </ScrollArea>
+        <DialogFooter className="items-center sm:justify-between">
+          <span className="text-sm text-muted-foreground">
+            {selectedIds.length === 0
+              ? "Choose at least one person"
+              : `${selectedIds.length} team member${selectedIds.length === 1 ? "" : "s"} selected`}
+          </span>
+          <Button
+            type="button"
+            disabled={selectedIds.length === 0 || starting}
+            onClick={() => void startMessage()}
+          >
+            {starting ? <IconLoader2 className="size-4 animate-spin" /> : null}
+            Start conversation
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   )

--- a/src/lib/conversations/__tests__/direct-channel.test.ts
+++ b/src/lib/conversations/__tests__/direct-channel.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  directChannelId,
+  directParticipantIds,
+} from "@/lib/conversations/direct-channel"
+
+describe("direct conversation identity", () => {
+  it("deduplicates and sorts the complete participant set", () => {
+    expect(directParticipantIds("user-b", ["user-c", "user-a", "user-c"])).toEqual([
+      "user-a",
+      "user-b",
+      "user-c",
+    ])
+  })
+
+  it("uses the same channel for the same participants in any order", async () => {
+    const first = await directChannelId("org-1", ["user-a", "user-b", "user-c"])
+    const second = await directChannelId("org-1", ["user-c", "user-a", "user-b"])
+
+    expect(second).toBe(first)
+  })
+
+  it("keeps different private groups in different channels", async () => {
+    const first = await directChannelId("org-1", ["user-a", "user-b"])
+    const second = await directChannelId("org-1", ["user-a", "user-b", "user-c"])
+
+    expect(second).not.toBe(first)
+  })
+})

--- a/src/lib/conversations/direct-channel.ts
+++ b/src/lib/conversations/direct-channel.ts
@@ -1,0 +1,19 @@
+export function directParticipantIds(
+  currentUserId: string,
+  targetUserIds: readonly string[]
+): readonly string[] {
+  return Array.from(new Set([currentUserId, ...targetUserIds])).sort()
+}
+
+export async function directChannelId(
+  organizationId: string,
+  participantIds: readonly string[]
+): Promise<string> {
+  const participants = [...participantIds].sort().join(":")
+  const bytes = new TextEncoder().encode(`${organizationId}:${participants}`)
+  const digest = await crypto.subtle.digest("SHA-256", bytes)
+  const hash = Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+  return `direct-${hash.slice(0, 32)}`
+}


### PR DESCRIPTION
## Summary
- allow staff to select one or more internal team members in the direct-message dialog
- preserve existing one-to-one thread identities while creating stable private groups for exact participant sets
- validate every participant against active internal organization membership
- make each recipient row clickable with an accessible checkbox and selected-count feedback

## Verification
- `bunx tsc --noEmit`
- focused ESLint on changed files
- `bunx vitest run src/lib/conversations/__tests__/direct-channel.test.ts`
- full production `bun run build`

## Review note
The structured autoreview helper was attempted twice but could not initialize because its isolated runtime could not write its own local state database. The diff was manually reviewed; this found and corrected the full-row selection behavior before commit.
