### PR TITLE
feat(dashboard): add office maintenance shortcut

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { getWorkCalendar } from "@/app/actions/work-calendar"
 import { DashboardLaunchpad } from "@/components/dashboard/dashboard-launchpad"
 import type { DashboardOfficeEvent } from "@/components/dashboard/dashboard-launchpad"
 import { getCurrentUser, toSidebarUser } from "@/lib/auth"
+import { canManageProjectRegistry } from "@/lib/permissions"
 
 export default async function Page(): Promise<React.ReactElement> {
   const currentUser = await getCurrentUser()
@@ -76,6 +77,7 @@ export default async function Page(): Promise<React.ReactElement> {
       initialTeamAvailability={initialTeamAvailability}
       officeCalendarEvents={officeCalendarEvents}
       officeProjectId={workCalendar?.defaultProjectId ?? null}
+      canManageOfficeMaintenance={canManageProjectRegistry(currentUser)}
     />
   )
 }

--- a/src/components/dashboard/dashboard-launchpad.tsx
+++ b/src/components/dashboard/dashboard-launchpad.tsx
@@ -28,6 +28,7 @@ import {
   IconPhotoEdit,
   IconPlus,
   IconReceipt,
+  IconSettings,
   IconSparkles,
   IconUserHeart,
   IconUsers,
@@ -1289,6 +1290,7 @@ export function DashboardLaunchpad({
   initialTeamAvailability,
   officeCalendarEvents,
   officeProjectId,
+  canManageOfficeMaintenance,
 }: {
   readonly overview: DashboardOverview
   readonly user: SidebarUser | null
@@ -1296,6 +1298,7 @@ export function DashboardLaunchpad({
   readonly initialTeamAvailability: readonly TeamAvailabilityMember[]
   readonly officeCalendarEvents: readonly DashboardOfficeEvent[]
   readonly officeProjectId: string | null
+  readonly canManageOfficeMaintenance: boolean
 }): React.ReactElement {
   const [mode, setMode] = useState<DashboardMode>("office")
   const [deskStatus, setDeskStatus] = useState<DeskStatus>(() =>
@@ -1341,6 +1344,14 @@ export function DashboardLaunchpad({
         </div>
 
         <div className="flex items-center gap-2 lg:justify-end">
+          {canManageOfficeMaintenance ? (
+            <Button asChild variant="outline" size="sm">
+              <Link href="/dashboard/projects?manage=1">
+                <IconSettings className="size-4" />
+                Office maintenance
+              </Link>
+            </Button>
+          ) : null}
           <CherishComposer />
           <TeamPulseDrawer overview={overview} />
         </div>


### PR DESCRIPTION
## Summary

- add Office Maintenance to the dashboard launchpad header
- reuse the existing project-registry maintenance destination
- show the shortcut only when the signed-in internal user can manage the project registry

## Validation

- targeted ESLint
- `bunx tsc --noEmit`
- production build via pre-push hook