### PR TITLE
fix(dashboard): open office maintenance drawer

### DIFF
--- a/src/components/dashboard/dashboard-launchpad.tsx
+++ b/src/components/dashboard/dashboard-launchpad.tsx
@@ -28,7 +28,6 @@ import {
   IconPhotoEdit,
   IconPlus,
   IconReceipt,
-  IconSettings,
   IconSparkles,
   IconUserHeart,
   IconUsers,
@@ -46,6 +45,7 @@ import {
 } from "@/app/actions/presence"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { OfficeMaintenanceDrawer } from "@/components/projects/office-maintenance-drawer"
 import {
   Dialog,
   DialogContent,
@@ -1345,12 +1345,7 @@ export function DashboardLaunchpad({
 
         <div className="flex items-center gap-2 lg:justify-end">
           {canManageOfficeMaintenance ? (
-            <Button asChild variant="outline" size="sm">
-              <Link href="/dashboard/projects?manage=1">
-                <IconSettings className="size-4" />
-                Office maintenance
-              </Link>
-            </Button>
+            <OfficeMaintenanceDrawer projects={overview.projects} />
           ) : null}
           <CherishComposer />
           <TeamPulseDrawer overview={overview} />

--- a/src/components/projects/office-maintenance-drawer.tsx
+++ b/src/components/projects/office-maintenance-drawer.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import Link from "next/link"
+import { IconSettings, IconTemplate } from "@tabler/icons-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
+
+type OfficeMaintenanceProject = Readonly<{
+  status: string
+  projectNumber: string | null
+  googleDriveFolderId: string | null
+}>
+
+function statusNeedsCleanup(status: string): boolean {
+  const normalized = status
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+  if ([
+    "open",
+    "active",
+    "current",
+    "construction",
+    "in progress",
+    "scheduled",
+    "preconstruction",
+  ].includes(normalized)) {
+    return false
+  }
+  if (normalized.includes("warranty") || normalized.includes("service")) {
+    return false
+  }
+  return !["closed", "complete", "completed"].includes(normalized)
+}
+
+function needsDepartment(projectNumber: string | null): boolean {
+  const prefix = projectNumber?.trim().slice(0, 1).toUpperCase()
+  return prefix !== "O" && prefix !== "H" && prefix !== "N" && prefix !== "D"
+}
+
+export function OfficeMaintenanceDrawer({
+  projects,
+}: {
+  readonly projects: readonly OfficeMaintenanceProject[]
+}): React.ReactElement {
+  const statusCleanupCount = projects.filter((project) =>
+    statusNeedsCleanup(project.status)
+  ).length
+  const driveLinkedCount = projects.filter(
+    (project) => project.googleDriveFolderId !== null
+  ).length
+  const departmentNeededCount = projects.filter((project) =>
+    needsDepartment(project.projectNumber)
+  ).length
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline" size="sm">
+          <IconSettings className="size-4" />
+          Office maintenance
+        </Button>
+      </SheetTrigger>
+      <SheetContent className="w-full sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle>Office maintenance</SheetTitle>
+          <SheetDescription>
+            Project registry cleanup and integration housekeeping.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="divide-y border-y px-4">
+          <div className="flex items-center justify-between py-4 text-sm">
+            <span>Statuses needing cleanup</span>
+            <strong>{statusCleanupCount}</strong>
+          </div>
+          <div className="flex items-center justify-between py-4 text-sm">
+            <span>Drive-linked projects</span>
+            <strong>{driveLinkedCount}</strong>
+          </div>
+          <div className="flex items-center justify-between py-4 text-sm">
+            <span>Department assignment needed</span>
+            <strong>{departmentNeededCount}</strong>
+          </div>
+        </div>
+        <div className="space-y-2 px-4">
+          <Button asChild variant="outline" className="w-full">
+            <Link href="/dashboard/templates">
+              <IconTemplate className="size-4" />
+              Open Template Library
+            </Link>
+          </Button>
+          <Button asChild className="w-full">
+            <Link href="/dashboard/projects?manage=1">
+              Open advanced registry tools
+            </Link>
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/components/projects/project-hub-launchpad.tsx
+++ b/src/components/projects/project-hub-launchpad.tsx
@@ -14,7 +14,6 @@ import {
   IconPaint,
   IconPlus,
   IconSettings,
-  IconTemplate,
   IconTool,
 } from "@tabler/icons-react"
 
@@ -43,14 +42,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from "@/components/ui/sheet"
+import { OfficeMaintenanceDrawer } from "@/components/projects/office-maintenance-drawer"
 import { cn } from "@/lib/utils"
 
 type DepartmentFilter = "ALL" | "O" | "H" | "N" | "D" | "OTHER"
@@ -297,62 +289,6 @@ function ProjectCard({
   )
 }
 
-function MaintenanceDrawer({
-  projects,
-}: {
-  readonly projects: readonly ProjectListItem[]
-}): React.ReactElement {
-  const cleanupCount = projects.filter((project) => statusForProject(project) === "all").length
-  const accountingLinked = projects.filter((project) => project.googleDriveFolderId !== null).length
-  const departmentNeeded = projects.filter((project) => departmentForProject(project) === "OTHER").length
-
-  return (
-    <Sheet>
-      <SheetTrigger asChild>
-        <Button variant="outline" size="sm">
-          <IconSettings className="size-4" />
-          Office maintenance
-        </Button>
-      </SheetTrigger>
-      <SheetContent className="w-full sm:max-w-md">
-        <SheetHeader>
-          <SheetTitle>Office maintenance</SheetTitle>
-          <SheetDescription>
-            Project registry cleanup and integration housekeeping.
-          </SheetDescription>
-        </SheetHeader>
-        <div className="divide-y border-y px-4">
-          <div className="flex items-center justify-between py-4 text-sm">
-            <span>Statuses needing cleanup</span>
-            <strong>{cleanupCount}</strong>
-          </div>
-          <div className="flex items-center justify-between py-4 text-sm">
-            <span>Drive-linked projects</span>
-            <strong>{accountingLinked}</strong>
-          </div>
-          <div className="flex items-center justify-between py-4 text-sm">
-            <span>Department assignment needed</span>
-            <strong>{departmentNeeded}</strong>
-          </div>
-        </div>
-        <div className="space-y-2 px-4">
-          <Button asChild variant="outline" className="w-full">
-            <Link href="/dashboard/templates">
-              <IconTemplate className="size-4" />
-              Open Template Library
-            </Link>
-          </Button>
-          <Button asChild className="w-full">
-            <Link href="/dashboard/projects?manage=1">
-              Open advanced registry tools
-            </Link>
-          </Button>
-        </div>
-      </SheetContent>
-    </Sheet>
-  )
-}
-
 function NewProjectDialog({
   activeDepartment,
 }: {
@@ -556,7 +492,9 @@ export function ProjectHubLaunchpad({
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
-          {canManageProjects ? <MaintenanceDrawer projects={projects} /> : null}
+          {canManageProjects ? (
+            <OfficeMaintenanceDrawer projects={projects} />
+          ) : null}
           {canManageProjects ? (
             <NewProjectDialog activeDepartment={department} />
           ) : null}


### PR DESCRIPTION
## Summary

- make the dashboard Office Maintenance control open the maintenance drawer instead of navigating directly to Project Hub
- extract one shared maintenance drawer used by both Dashboard and Project Hub
- preserve status, Drive-link, and department cleanup counts plus Template Library and advanced registry actions
- retain the existing project-registry permission gate

## Validation

- targeted ESLint
- `bunx tsc --noEmit`
- production build via pre-push hook