### PR TITLE
fix(financials): preserve pay app deposits

### DIFF
--- a/src/app/actions/project-financial-workflows.ts
+++ b/src/app/actions/project-financial-workflows.ts
@@ -19,6 +19,10 @@ import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { requireOrg } from "@/lib/org-scope"
 import { requirePermission } from "@/lib/permissions"
+import {
+  budgetPaymentBreakdown,
+  type BudgetPaymentBreakdown,
+} from "@/lib/project-budget-snapshot"
 
 export type ProjectFinancialWorkflowItem = {
   readonly id: string
@@ -29,6 +33,7 @@ export type ProjectFinancialWorkflowItem = {
   readonly companyName: string | null
   readonly status: string
   readonly amount: number | null
+  readonly paymentBreakdown: BudgetPaymentBreakdown | null
   readonly dueDate: string | null
   readonly syncStatus: string
   readonly sageWriteStatus: string
@@ -260,43 +265,58 @@ export async function getProjectFinancialWorkflowItems(
       .orderBy(asc(projectOperations.dueDate), asc(projectOperations.updatedAt)),
     db
       .select({
-        applicationNumber: projectBudgetApplications.applicationNumber,
+        id: projectBudgetApplications.id,
+        sourceRecordId: projectBudgetApplications.sourceRecordId,
+        totalEarnedLessRetainage:
+          projectBudgetApplications.totalEarnedLessRetainage,
+        previousCertificates: projectBudgetApplications.previousCertificates,
+        currentPaymentDue: projectBudgetApplications.currentPaymentDue,
         sourceUrl: projectBudgetApplications.sourceUrl,
       })
       .from(projectBudgetApplications)
       .where(eq(projectBudgetApplications.projectId, projectId)),
   ])
-  const applicationPackageUrls = new Map(
+  const applicationsBySourceId = new Map(
     applications.flatMap((application) => {
-      const url = safeHttpUrl(application.sourceUrl)
-      return url ? [[application.applicationNumber, url] as const] : []
+      const keys = [application.id, application.sourceRecordId].filter(
+        (value): value is string => Boolean(value)
+      )
+      return keys.map((key) => [key, application] as const)
     })
   )
 
-  return rows.map((row) => ({
-    id: row.id,
-    sourceRecordId: row.sourceRecordId,
-    type:
-      row.sourceRecordType === "vendor_bill" ||
-      row.sourceRecordType === "owner_pay_application"
-        ? row.sourceRecordType
-        : "rfq",
-    number: row.sourceRecordNumber,
-    title: row.title,
-    companyName: row.companyName,
-    status: row.status,
-    amount: row.amount,
-    dueDate: row.dueDate,
-    syncStatus: row.syncStatus,
-    sageWriteStatus: row.sageWriteStatus,
-    supportingPackageUrl:
-      safeHttpUrl(row.externalUrl) ??
-      (row.sourceRecordType === "owner_pay_application" &&
-      row.sourceRecordNumber
-        ? applicationPackageUrls.get(row.sourceRecordNumber) ?? null
-        : null),
-    updatedAt: row.updatedAt,
-  }))
+  return rows.map((row) => {
+    const application =
+      row.sourceRecordType === "owner_pay_application" && row.sourceRecordId
+        ? applicationsBySourceId.get(row.sourceRecordId) ?? null
+        : null
+    const paymentBreakdown = application
+      ? budgetPaymentBreakdown(application)
+      : null
+
+    return {
+      id: row.id,
+      sourceRecordId: row.sourceRecordId,
+      type:
+        row.sourceRecordType === "vendor_bill" ||
+        row.sourceRecordType === "owner_pay_application"
+          ? row.sourceRecordType
+          : "rfq",
+      number: row.sourceRecordNumber,
+      title: row.title,
+      companyName: row.companyName,
+      status: row.status,
+      amount: paymentBreakdown?.applicationTotal ?? row.amount,
+      paymentBreakdown,
+      dueDate: row.dueDate,
+      syncStatus: row.syncStatus,
+      sageWriteStatus: row.sageWriteStatus,
+      supportingPackageUrl:
+        safeHttpUrl(row.externalUrl) ??
+        safeHttpUrl(application?.sourceUrl ?? null),
+      updatedAt: row.updatedAt,
+    }
+  })
 }
 
 export async function getProjectOwnerPayApplicationDraft(

--- a/src/components/projects/project-financial-workspace.tsx
+++ b/src/components/projects/project-financial-workspace.tsx
@@ -409,7 +409,17 @@ export function ProjectFinancialWorkspace({
                           </Button>
                         )}
                     </div>
-                    <span>{money(item.amount)}</span>
+                    <div>
+                      <span>{money(item.amount)}</span>
+                      {item.paymentBreakdown &&
+                        item.paymentBreakdown.depositApplied > 0 && (
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {money(item.paymentBreakdown.currentPaymentDue)} due
+                            after {money(item.paymentBreakdown.depositApplied)}
+                            {" deposit"}
+                          </p>
+                        )}
+                    </div>
                     <span>{dateText(item.dueDate)}</span>
                     <div className="flex flex-wrap gap-2">
                       <Badge variant="outline">{item.status}</Badge>

--- a/src/lib/project-budget-snapshot.ts
+++ b/src/lib/project-budget-snapshot.ts
@@ -25,6 +25,13 @@ export type BudgetPaymentBreakdown = {
   readonly depositApplied: number
 }
 
+type BudgetPaymentSource = Pick<
+  BudgetApplicationView,
+  | "totalEarnedLessRetainage"
+  | "previousCertificates"
+  | "currentPaymentDue"
+>
+
 export type BudgetLineView = {
   readonly id: string
   readonly sourceSystem: string
@@ -93,7 +100,7 @@ function currency(value: number): number {
 }
 
 export function budgetPaymentBreakdown(
-  application: BudgetApplicationView
+  application: BudgetPaymentSource
 ): BudgetPaymentBreakdown {
   const impliedDeposit = currency(
     application.totalEarnedLessRetainage -


### PR DESCRIPTION
## What changed

- resolve Financial Queue pay applications back to their G702/G703 application records
- display the full application total when a contract deposit was already applied
- show the remaining amount due and deposit amount beneath the full total
- use the matching application source to restore supporting-package links

## Root cause

Loomis Pay Application 1 had two valid values: $68,782.88 earned on the application and $18,460.77 remaining due after the $50,322.11 contract deposit. The Financial Queue trusted a duplicate operation amount containing only the remaining balance, so that view collapsed the full pay request to $18,460.77.

The guarded production data correction was applied separately and recorded in the Compass activity log. This PR prevents the duplicate operation row from overriding the authoritative G702/G703 breakdown in future views or refreshes.

## Validation

- `bun test src/lib/__tests__/project-budget-snapshot.test.ts`
- targeted ESLint
- `bunx tsc --noEmit`
- `bun run build`
- full pre-commit lint (0 errors; existing warnings only)
- pre-push production build
