### PR TITLE
feat: import Buildertrend template content

### DIFF
--- a/docs/wip/buildertrend-template-library-2026-07-31.md
+++ b/docs/wip/buildertrend-template-library-2026-07-31.md
@@ -111,14 +111,16 @@ count-verified content capture can be converted with:
 
 ```bash
 bun scripts/build-buildertrend-template-content-sql.mjs \
+  --inventory scripts/fixtures/buildertrend-active-template-capture-2026-07-31.json \
   --capture <buildertrend-template-content.json> \
   --output <reviewed-content-import.sql>
 ```
 
-The content importer rejects archived templates and rejects any task,
+The content importer requires exact coverage of all 40 reviewed active
+template IDs, rejects archived or unexpected templates, and rejects any task,
 selection, or bid-package module whose captured item count differs from the
-Buildertrend module count. Buildertrend URLs are removed recursively from both
-display content and stored payloads. Template source links are no longer
+reviewed Buildertrend inventory. Buildertrend URLs are removed recursively from
+both display content and stored payloads. Template source links are no longer
 exposed in Compass.
 
 Internal staff can classify templates by department (ORC, HPS, Nu-Tech, or
@@ -151,3 +153,12 @@ Schedule definitions are complete. Task/checklist, selection-choice, and bid
 package content must pass exact module-count reconciliation before the content
 import is generated or applied. Financial features remain definitions until
 their Sage mappings and approval behavior are explicitly reviewed.
+
+Buildertrend does not expose a single spreadsheet export for a project
+template. In the authenticated template workspace, Bid Packages offers a
+template-scoped Excel export, Selections offers a print report, Schedule offers
+import/copy actions only, and the documented Tasks Excel action is not exposed
+in the template-scoped task list. A partial export must not be treated as a
+complete template capture. The remaining modules therefore require either a
+Buildertrend Data Entry/Support export or a count-reconciled authenticated
+capture before the verified Compass import can run.

--- a/docs/wip/buildertrend-template-library-2026-07-31.md
+++ b/docs/wip/buildertrend-template-library-2026-07-31.md
@@ -20,6 +20,8 @@ records. The foundation stores:
 - immutable numbered versions;
 - per-version module inventories;
 - relative schedule items and dependencies;
+- normalized task, selection, and bid-package content with the complete source
+  payload retained locally per item;
 - each project application and the generated schedule-item mappings.
 
 A Buildertrend inventory row begins as `inventory_only`. It cannot be applied
@@ -104,6 +106,26 @@ before SQL is generated. Generated files intentionally omit explicit
 transaction statements because D1 file execution supplies its own transaction
 boundary.
 
+After migration `0089_template_content_classification.sql` is applied, a
+count-verified content capture can be converted with:
+
+```bash
+bun scripts/build-buildertrend-template-content-sql.mjs \
+  --capture <buildertrend-template-content.json> \
+  --output <reviewed-content-import.sql>
+```
+
+The content importer rejects archived templates and rejects any task,
+selection, or bid-package module whose captured item count differs from the
+Buildertrend module count. Buildertrend URLs are removed recursively from both
+display content and stored payloads. Template source links are no longer
+exposed in Compass.
+
+Internal staff can classify templates by department (ORC, HPS, Nu-Tech, or
+Design) and category. Templates that have never been applied may be deleted;
+applied templates remain available to the audit trail and must be made inactive
+instead.
+
 ## Capture Progress
 
 The authenticated My Templates grid provided stable Buildertrend IDs, direct
@@ -123,9 +145,9 @@ visibility, and notes. They are recorded as pending field review in module
 provenance instead of being guessed. Schedule content itself can be published
 after the automated item, dependency, archive-exclusion, and cycle checks pass.
 
-## Next Capture Pass
+## Remaining Capture Gate
 
-Schedule definitions are the first completed promotion target. Task/checklist
-templates follow next, then folders, specifications, and finish selections.
-Financial features remain definitions until their Sage mappings and approval
-behavior are explicitly reviewed.
+Schedule definitions are complete. Task/checklist, selection-choice, and bid
+package content must pass exact module-count reconciliation before the content
+import is generated or applied. Financial features remain definitions until
+their Sage mappings and approval behavior are explicitly reviewed.

--- a/docs/wip/buildertrend-template-library-2026-07-31.md
+++ b/docs/wip/buildertrend-template-library-2026-07-31.md
@@ -83,7 +83,9 @@ bun scripts/build-buildertrend-template-inventory-sql.mjs \
 ```
 
 The expected dry-run result is 40 imported active-source rows and 27 excluded
-archived rows.
+archived rows. Apply this full inventory import before either pilot import so
+the 34 non-pilot active templates exist in Compass as `inventory_only` records.
+The pilot commands never create those 34 rows themselves.
 
 Capture stable Buildertrend IDs, module counts, and reviewed schedule content:
 
@@ -93,6 +95,19 @@ bun scripts/build-buildertrend-template-capture-sql.mjs \
   --capture scripts/fixtures/buildertrend-active-template-capture-2026-07-31.json \
   --organization-id <organization-id> \
   --dry-run
+```
+
+For the six-template pilot, add the reviewed allowlist. It imports only those
+six active templates, retains the 27 archived exclusions, and leaves the other
+34 active templates inventory-only and unverified:
+
+```bash
+bun scripts/build-buildertrend-template-capture-sql.mjs \
+  --inventory scripts/fixtures/buildertrend-active-template-inventory-2026-07-31.json \
+  --capture scripts/fixtures/buildertrend-active-template-capture-2026-07-31.json \
+  --pilot-manifest scripts/fixtures/buildertrend-template-pilot-2026-08-03.json \
+  --organization-id <organization-id> \
+  --output <reviewed-pilot-import.sql>
 ```
 
 The capture import is idempotent and draft-only unless
@@ -106,7 +121,10 @@ before SQL is generated. Generated files intentionally omit explicit
 transaction statements because D1 file execution supplies its own transaction
 boundary.
 
-After migration `0089_template_content_classification.sql` is applied, a
+Before deploying code that reads template content, apply migration
+`0089_template_content_classification.sql`; the template detail page queries
+that table unconditionally. The release order is: migrate `0089`, generate and
+review the import SQL, apply the import, then deploy the application code. A
 count-verified content capture can be converted with:
 
 ```bash
@@ -117,16 +135,29 @@ bun scripts/build-buildertrend-template-content-sql.mjs \
 ```
 
 The content importer requires exact coverage of all 40 reviewed active
-template IDs, rejects archived or unexpected templates, and rejects any task,
-selection, or bid-package module whose captured item count differs from the
-reviewed Buildertrend inventory. Buildertrend URLs are removed recursively from
-both display content and stored payloads. Template source links are no longer
-exposed in Compass.
+template IDs by default. With the same reviewed `--pilot-manifest`, it accepts
+only the six pilot IDs and leaves the other 34 active templates unverified. It
+rejects archived or unexpected templates, duplicate source item IDs within a
+module, and any task, schedule-item, selection, or bid-package module whose
+captured item count differs from the reviewed Buildertrend inventory. Schedule
+items are first-class captured content, including source IDs, phases,
+durations, visibility fields, colors, and predecessor relationships; they are
+not inferred from the inventory count. All content writes are draft-version
+guarded; published versions are immutable. Buildertrend URLs are removed
+recursively from both display content and stored payloads. Template source
+links are no longer exposed in Compass, including on an inventory replay.
 
-Internal staff can classify templates by department (ORC, HPS, Nu-Tech, or
-Design) and category. Templates that have never been applied may be deleted;
-applied templates remain available to the audit trail and must be made inactive
-instead.
+After import, internal staff opens each captured template in Compass, reviews
+its module totals and any documented conversion warnings, then uses **Review
+and publish** from the Template Library. Publication rechecks the stored task,
+schedule, selection, and bid-package counts against the reviewed source counts.
+Only a matching draft becomes verified, active, and available to apply to a
+project.
+
+Templates use functional categories. Department is assigned by the destination
+job or project when staff applies a template, not by the template import.
+Templates that have never been applied may be deleted; applied templates remain
+available to the audit trail and must be made inactive instead.
 
 ## Capture Progress
 

--- a/drizzle/0089_template_content_classification.sql
+++ b/drizzle/0089_template_content_classification.sql
@@ -1,0 +1,28 @@
+CREATE TABLE `project_template_content_items` (
+	`id` text PRIMARY KEY NOT NULL,
+	`version_id` text NOT NULL,
+	`module_type` text NOT NULL,
+	`source_item_id` text,
+	`parent_source_item_id` text,
+	`title` text NOT NULL,
+	`category` text,
+	`description` text,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	`payload_json` text,
+	FOREIGN KEY (`version_id`) REFERENCES `project_template_versions`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `project_template_content_version_module_source_unique` ON `project_template_content_items` (`version_id`,`module_type`,`source_item_id`);
+--> statement-breakpoint
+CREATE INDEX `project_template_content_version_module_order_idx` ON `project_template_content_items` (`version_id`,`module_type`,`sort_order`);
+--> statement-breakpoint
+UPDATE `project_templates`
+SET `department_code` = CASE
+  WHEN `department_code` = 'D' THEN 'Design'
+  WHEN `department_code` = 'N' THEN 'Nu-Tech'
+  WHEN `department_code` = 'H' THEN 'HPS'
+  WHEN `department_code` = 'O' OR `department_code` IS NULL THEN 'ORC'
+  ELSE `department_code`
+END,
+`source_url` = NULL
+WHERE `source_system` = 'buildertrend';

--- a/scripts/assemble-buildertrend-template-content-pilot.mjs
+++ b/scripts/assemble-buildertrend-template-content-pilot.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises"
+
+import {
+  assembleBuildertrendTemplateContentPilot,
+  buildBuildertrendTemplateContentPilotInventory,
+  readPilotContentFragments,
+} from "./lib/buildertrend-template-content-pilot.mjs"
+
+function optionValue(args, option) {
+  const index = args.indexOf(option)
+  if (index < 0) return null
+  const value = args[index + 1]
+  return value && !value.startsWith("--") ? value : null
+}
+
+const args = process.argv.slice(2)
+const manifestPath = optionValue(args, "--manifest")
+const reviewedCapturePath = optionValue(args, "--reviewed-capture")
+const basePath = optionValue(args, "--base")
+const fragmentsPath = optionValue(args, "--fragments")
+const outputPath = optionValue(args, "--output")
+const inventoryOutputPath = optionValue(args, "--inventory-output")
+const check = args.includes("--check")
+const allowIncomplete = args.includes("--allow-incomplete")
+
+if (!manifestPath || !reviewedCapturePath || (!basePath && !fragmentsPath) || (!check && !outputPath)) {
+  throw new Error(
+    "Usage: bun scripts/assemble-buildertrend-template-content-pilot.mjs " +
+      "--manifest <pilot.json> --reviewed-capture <40-active-capture.json> " +
+      "[--base <existing-capture.json>] [--fragments <directory>] " +
+      "[--output <capture.json> | --check] [--inventory-output <pilot-inventory.json>] " +
+      "[--allow-incomplete]"
+  )
+}
+
+const documents = []
+if (basePath) {
+  documents.push({ source: basePath, document: JSON.parse(await readFile(basePath, "utf8")) })
+}
+if (fragmentsPath) documents.push(...await readPilotContentFragments(fragmentsPath))
+
+const result = assembleBuildertrendTemplateContentPilot({
+  manifest: JSON.parse(await readFile(manifestPath, "utf8")),
+  reviewedCapture: JSON.parse(await readFile(reviewedCapturePath, "utf8")),
+  documents,
+  allowIncomplete,
+})
+
+if (outputPath) await writeFile(outputPath, `${JSON.stringify(result, null, 2)}\n`)
+if (inventoryOutputPath) {
+  const pilotInventory = buildBuildertrendTemplateContentPilotInventory(result)
+  await writeFile(inventoryOutputPath, `${JSON.stringify(pilotInventory, null, 2)}\n`)
+}
+console.log(JSON.stringify({
+  complete: result.assembly.complete,
+  templateCount: result.templates.length,
+  missing: result.assembly.missing,
+  output: outputPath,
+  inventoryOutput: inventoryOutputPath,
+}, null, 2))

--- a/scripts/assemble-buildertrend-template-content-pilot.test.mjs
+++ b/scripts/assemble-buildertrend-template-content-pilot.test.mjs
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  assembleBuildertrendTemplateContentPilot,
+  buildBuildertrendTemplateContentPilotInventory,
+} from "./lib/buildertrend-template-content-pilot.mjs"
+
+const pilotTemplates = [
+  ["1", "Drywall", { tasks: 1, scheduleItems: 1 }],
+  ["2", "Roofing", { tasks: 1, selections: 1 }],
+  ["3", "Design", { tasks: 1 }],
+  ["4", "LiteDeck", { tasks: 1 }],
+  ["5", "ICF", { tasks: 1 }],
+  ["6", "Cabinetry", { tasks: 1, bidPackages: 1 }],
+]
+
+const manifest = {
+  scope: {
+    activeTemplatesInSource: 40,
+    pilotTemplatesIncluded: 6,
+    remainingActiveTemplatesUnverified: 34,
+    archivedTemplatesExcluded: 27,
+    archivedTemplatesIncluded: 0,
+  },
+  templates: pilotTemplates.map(([sourceTemplateId, sourceName]) => ({ sourceTemplateId, sourceName })),
+}
+
+const reviewedCapture = {
+  expectedActiveCount: 40,
+  excludedArchivedCount: 27,
+  templates: [
+    ...pilotTemplates.map(([sourceTemplateId, name, moduleCounts]) => ({
+      sourceTemplateId,
+      name,
+      moduleCounts,
+      ...(moduleCounts.scheduleItems
+        ? {
+            schedule: {
+              items: [{ sourceItemId: `${sourceTemplateId}-schedule`, title: "Schedule" }],
+              dependencies: [],
+            },
+          }
+        : {}),
+    })),
+    ...Array.from({ length: 34 }, (_, index) => ({
+      sourceTemplateId: `other-${index}`,
+      name: `Other ${index}`,
+      moduleCounts: {},
+    })),
+  ],
+}
+
+function fragment(sourceTemplateId, name, values) {
+  return { source: `${sourceTemplateId}.json`, document: { sourceTemplateId, name, ...values } }
+}
+
+function completeDocuments() {
+  return pilotTemplates.map(([id, name, counts]) => fragment(id, name, {
+    tasks: Array.from({ length: counts.tasks ?? 0 }, (_, index) => ({ sourceItemId: `${id}-task-${index}`, title: "Task" })),
+    selections: Array.from({ length: counts.selections ?? 0 }, (_, index) => ({ sourceItemId: `${id}-selection-${index}`, title: "Selection" })),
+    bidPackages: Array.from({ length: counts.bidPackages ?? 0 }, (_, index) => ({ sourceItemId: `${id}-bid-${index}`, title: "Bid" })),
+  }))
+}
+
+test("assembles six reviewed pilot templates and reuses reviewed schedule evidence", () => {
+  const result = assembleBuildertrendTemplateContentPilot({
+    manifest,
+    reviewedCapture,
+    documents: completeDocuments(),
+    capturedAt: "2026-08-03T00:00:00.000Z",
+  })
+
+  assert.equal(result.fixtureVersion, 3)
+  assert.equal(result.templates.length, 6)
+  assert.equal(result.excludedArchivedCount, 27)
+  assert.equal(result.assembly.remainingActiveTemplatesUnverified, 34)
+  assert.equal(result.assembly.complete, true)
+  assert.equal(result.templates[0].schedule.items.length, 1)
+  assert.deepEqual(result.templates[0].scheduleItems[0].predecessors, [])
+  assert.deepEqual(buildBuildertrendTemplateContentPilotInventory(result).templates[0], {
+    sourceTemplateId: "1",
+    name: "Drywall",
+    moduleCounts: { tasks: 1, scheduleItems: 1, selections: 0, bidPackages: 0 },
+  })
+})
+
+test("reports every missing module without manufacturing placeholder content", () => {
+  const result = assembleBuildertrendTemplateContentPilot({
+    manifest,
+    reviewedCapture,
+    documents: [completeDocuments()[0]],
+    allowIncomplete: true,
+  })
+
+  assert.equal(result.assembly.complete, false)
+  assert.match(
+    result.assembly.missing.map((item) => `${item.name}:${item.module}`).join(","),
+    /Roofing:tasks/
+  )
+  assert.equal(result.templates[1].tasks, undefined)
+})
+
+test("rejects incomplete pilots in release-check mode", () => {
+  assert.throws(
+    () => assembleBuildertrendTemplateContentPilot({
+      manifest,
+      reviewedCapture,
+      documents: [completeDocuments()[0]],
+    }),
+    /Six-template pilot content is incomplete/
+  )
+})
+
+test("does not emit a paired import inventory from an incomplete capture", () => {
+  const result = assembleBuildertrendTemplateContentPilot({
+    manifest,
+    reviewedCapture,
+    documents: [completeDocuments()[0]],
+    allowIncomplete: true,
+  })
+  assert.throws(
+    () => buildBuildertrendTemplateContentPilotInventory(result),
+    /cannot be emitted from an incomplete content capture/
+  )
+})
+
+test("rejects non-pilot or archived fragments", () => {
+  assert.throws(
+    () => assembleBuildertrendTemplateContentPilot({
+      manifest,
+      reviewedCapture,
+      documents: [fragment("archived-1", "Archive - Old", { tasks: [] })],
+      allowIncomplete: true,
+    }),
+    /non-pilot or archived template/
+  )
+})
+
+test("rejects fragment counts that conflict with reviewed Buildertrend evidence", () => {
+  const bad = fragment("2", "Roofing", {
+    moduleCounts: { tasks: 2, selections: 1 },
+    tasks: [{ sourceItemId: "2-task", title: "Task" }],
+  })
+  assert.throws(
+    () => assembleBuildertrendTemplateContentPilot({
+      manifest,
+      reviewedCapture,
+      documents: [bad],
+      allowIncomplete: true,
+    }),
+    /module-count metadata that conflicts/
+  )
+})
+
+test("rejects conflicting duplicate module fragments", () => {
+  const first = fragment("2", "Roofing", { tasks: [{ sourceItemId: "task-a", title: "A" }] })
+  const second = fragment("2", "Roofing", { tasks: [{ sourceItemId: "task-b", title: "B" }] })
+  assert.throws(
+    () => assembleBuildertrendTemplateContentPilot({
+      manifest,
+      reviewedCapture,
+      documents: [first, second],
+      allowIncomplete: true,
+    }),
+    /conflicting values/
+  )
+})
+
+test("rejects conversion exceptions that point outside captured module content", () => {
+  const documents = completeDocuments()
+  documents[0] = {
+    source: "drywall.json",
+    document: {
+      template: documents[0].document,
+      conversionExceptions: [{
+        templateSourceTemplateId: "1",
+        module: "tasks",
+        sourceItemId: "missing-task",
+        field: "costType",
+        sourceValue: "Labor",
+        loss: "Not represented.",
+        recoveryPlan: "Map later.",
+      }],
+    },
+  }
+  assert.throws(
+    () => assembleBuildertrendTemplateContentPilot({ manifest, reviewedCapture, documents }),
+    /sourceItemId does not identify captured tasks content/
+  )
+})

--- a/scripts/build-buildertrend-template-capture-sql.mjs
+++ b/scripts/build-buildertrend-template-capture-sql.mjs
@@ -5,6 +5,7 @@ import {
   parseBuildertrendTemplateCapture,
 } from "../src/lib/templates/buildertrend-template-capture"
 import { parseBuildertrendTemplateInventory } from "../src/lib/templates/buildertrend-template-inventory"
+import { buildBuildertrendTemplatePilot } from "./lib/buildertrend-template-pilot.mjs"
 
 function optionValue(argumentsList, option) {
   const index = argumentsList.indexOf(option)
@@ -23,6 +24,7 @@ async function main() {
   const capturePath = optionValue(argumentsList, "--capture")
   const organizationId = optionValue(argumentsList, "--organization-id")
   const output = optionValue(argumentsList, "--output")
+  const pilotManifestPath = optionValue(argumentsList, "--pilot-manifest")
   const dryRun = argumentsList.includes("--dry-run")
   const publishCapturedSchedules = argumentsList.includes(
     "--publish-captured-schedules"
@@ -34,20 +36,30 @@ async function main() {
     (!dryRun && !output)
   ) {
     throw new Error(
-      "Usage: bun scripts/build-buildertrend-template-capture-sql.mjs " +
+        "Usage: bun scripts/build-buildertrend-template-capture-sql.mjs " +
         "--inventory <inventory.json> --capture <capture.json> " +
         "--organization-id <org-id> [--output <import.sql>] [--dry-run] " +
-        "[--publish-captured-schedules]"
+        "[--publish-captured-schedules] [--pilot-manifest <reviewed-pilot.json>]"
     )
   }
 
-  const inventory = parseBuildertrendTemplateInventory(
-    await parseJsonFile(inventoryPath)
-  )
+  let inventoryValue = await parseJsonFile(inventoryPath)
+  let captureValue = await parseJsonFile(capturePath)
+  let pilot = null
+  if (pilotManifestPath) {
+    pilot = buildBuildertrendTemplatePilot({
+      inventory: inventoryValue,
+      capture: captureValue,
+      manifest: await parseJsonFile(pilotManifestPath),
+    })
+    inventoryValue = pilot.inventory
+    captureValue = pilot.capture
+  }
+  const inventory = parseBuildertrendTemplateInventory(inventoryValue)
   if (!inventory.success) {
     throw new Error(`Invalid template inventory:\n${inventory.errors.join("\n")}`)
   }
-  const capture = parseBuildertrendTemplateCapture(await parseJsonFile(capturePath))
+  const capture = parseBuildertrendTemplateCapture(captureValue)
   if (!capture.success) {
     throw new Error(`Invalid template capture:\n${capture.errors.join("\n")}`)
   }
@@ -66,6 +78,13 @@ async function main() {
         capturedScheduleCount: build.capturedScheduleCount,
         capturedScheduleItemCount: build.capturedScheduleItemCount,
         publishCapturedSchedules,
+        ...(pilot
+          ? {
+              pilotTemplateCount: pilot.capture.templates.length,
+              remainingActiveTemplatesUnverified:
+                pilot.remainingActiveTemplatesUnverified,
+            }
+          : {}),
         excludedArchivedCount: capture.data.excludedArchivedCount,
         output: dryRun ? null : output,
       },

--- a/scripts/build-buildertrend-template-content-sql.mjs
+++ b/scripts/build-buildertrend-template-content-sql.mjs
@@ -1,0 +1,162 @@
+import { createHash } from "node:crypto"
+import { readFile, writeFile } from "node:fs/promises"
+
+function optionValue(args, option) {
+  const index = args.indexOf(option)
+  if (index < 0) return null
+  const value = args[index + 1]
+  return value && !value.startsWith("--") ? value : null
+}
+
+function sql(value) {
+  if (value === null || value === undefined) return "NULL"
+  if (typeof value === "number") return String(value)
+  return `'${String(value).replaceAll("'", "''")}'`
+}
+
+function cleanText(value) {
+  if (typeof value !== "string") return value
+  return value
+    .replace(/https?:\/\/buildertrend\.net\/\S+/gi, "")
+    .replace(/Schedule Items:\s*$/g, "")
+    .trim()
+}
+
+function cleanPayload(value) {
+  if (Array.isArray(value)) return value.map(cleanPayload)
+  if (!value || typeof value !== "object") return cleanText(value)
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => !["href", "sourceUrl", "scheduleHref"].includes(key))
+      .map(([key, nested]) => [key, cleanPayload(nested)])
+  )
+}
+
+function assertItem(item, path) {
+  if (!item || typeof item !== "object") throw new Error(`${path} must be an object.`)
+  if (typeof item.sourceItemId !== "string" || !item.sourceItemId.trim()) {
+    throw new Error(`${path}.sourceItemId is required.`)
+  }
+  if (typeof item.title !== "string" || !item.title.trim()) {
+    throw new Error(`${path}.title is required.`)
+  }
+}
+
+function contentId(templateId, moduleType, sourceItemId) {
+  const digest = createHash("sha256")
+    .update(`${templateId}:${moduleType}:${sourceItemId}`)
+    .digest("hex")
+    .slice(0, 24)
+  return `bt-template-content:${digest}`
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  const capturePath = optionValue(args, "--capture")
+  const outputPath = optionValue(args, "--output")
+  const dryRun = args.includes("--dry-run")
+  if (!capturePath || (!dryRun && !outputPath)) {
+    throw new Error(
+      "Usage: bun scripts/build-buildertrend-template-content-sql.mjs " +
+        "--capture <content.json> [--output <import.sql>] [--dry-run]"
+    )
+  }
+  const capture = JSON.parse(await readFile(capturePath, "utf8"))
+  if (!Array.isArray(capture.templates)) throw new Error("capture.templates must be an array.")
+
+  const statements = ["PRAGMA foreign_keys=ON;"]
+  const totals = { tasks: 0, selections: 0, bidPackages: 0 }
+  for (const [templateIndex, template] of capture.templates.entries()) {
+    if (!template || typeof template !== "object") {
+      throw new Error(`templates[${templateIndex}] must be an object.`)
+    }
+    if (typeof template.sourceTemplateId !== "string" || !template.sourceTemplateId) {
+      throw new Error(`templates[${templateIndex}].sourceTemplateId is required.`)
+    }
+    if (typeof template.name !== "string" || !template.name) {
+      throw new Error(`templates[${templateIndex}].name is required.`)
+    }
+    if (/^archive/i.test(template.name)) {
+      throw new Error(`Archived template “${template.name}” cannot be imported.`)
+    }
+    const versionId = `bt-template-version:${template.sourceTemplateId}:1`
+    const modules = [
+      ["tasks", "tasks"],
+      ["selections", "selections"],
+      ["bidPackages", "bid_packages"],
+    ]
+    for (const [sourceKey, moduleType] of modules) {
+      const items = template[sourceKey] ?? []
+      if (!Array.isArray(items)) {
+        throw new Error(`templates[${templateIndex}].${sourceKey} must be an array.`)
+      }
+      const expected = Number(template.moduleCounts?.[sourceKey] ?? 0)
+      if (items.length !== expected) {
+        throw new Error(
+          `${template.name} ${sourceKey} count mismatch: expected ${expected}, captured ${items.length}.`
+        )
+      }
+      totals[sourceKey] += items.length
+      statements.push(
+        `DELETE FROM project_template_content_items WHERE version_id=${sql(versionId)} AND module_type=${sql(moduleType)};`
+      )
+      items.forEach((item, itemIndex) => {
+        assertItem(item, `templates[${templateIndex}].${sourceKey}[${itemIndex}]`)
+        const cleaned = cleanPayload(item)
+        const description = cleanText(
+          item.description ?? item.detail?.fullText ?? item.detail?.description ?? null
+        )
+        statements.push(
+          `INSERT INTO project_template_content_items (` +
+            `id, version_id, module_type, source_item_id, parent_source_item_id, ` +
+            `title, category, description, sort_order, payload_json` +
+            `) VALUES (` +
+            [
+              sql(contentId(template.sourceTemplateId, moduleType, item.sourceItemId)),
+              sql(versionId),
+              sql(moduleType),
+              sql(item.sourceItemId),
+              sql(item.parentSourceItemId ?? null),
+              sql(cleanText(item.title)),
+              sql(cleanText(item.category ?? item.tags ?? null)),
+              sql(description),
+              Number.isInteger(item.sortOrder) ? item.sortOrder : itemIndex,
+              sql(JSON.stringify(cleaned)),
+            ].join(", ") +
+            `);`
+        )
+      })
+      statements.push(
+        `UPDATE project_template_modules SET ` +
+          `normalization_status='captured', ` +
+          `source_payload_json=${sql(JSON.stringify({ sourceItemCount: items.length, capturedAt: capture.capturedAt }))} ` +
+          `WHERE version_id=${sql(versionId)} AND module_type=${sql(moduleType)};`
+      )
+    }
+    statements.push(
+      `UPDATE project_templates SET review_status='verified', lifecycle_status='active', ` +
+        `source_url=NULL, updated_at=${sql(capture.capturedAt)} ` +
+        `WHERE source_system='buildertrend' AND source_template_id=${sql(template.sourceTemplateId)};`
+    )
+  }
+
+  const sqlText = `${statements.join("\n")}\n`
+  if (!dryRun && outputPath) await writeFile(outputPath, sqlText, "utf8")
+  console.log(
+    JSON.stringify(
+      {
+        templateCount: capture.templates.length,
+        ...totals,
+        excludedArchivedCount: capture.excludedArchivedCount ?? null,
+        output: dryRun ? null : outputPath,
+      },
+      null,
+      2
+    )
+  )
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+})

--- a/scripts/build-buildertrend-template-content-sql.mjs
+++ b/scripts/build-buildertrend-template-content-sql.mjs
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto"
 import { readFile, writeFile } from "node:fs/promises"
 
+import { buildBuildertrendTemplatePilot } from "./lib/buildertrend-template-pilot.mjs"
+
 function optionValue(args, option) {
   const index = args.indexOf(option)
   if (index < 0) return null
@@ -42,6 +44,56 @@ function assertItem(item, path) {
   }
 }
 
+function assertScheduleRelationships(items, path) {
+  const sourceItemIds = new Set(items.map((item) => item.sourceItemId))
+  const relationshipKeys = new Set()
+  for (const [itemIndex, item] of items.entries()) {
+    const itemPath = `${path}[${itemIndex}]`
+    if (!Array.isArray(item.predecessors)) {
+      throw new Error(`${itemPath}.predecessors must be an array.`)
+    }
+    for (const [predecessorIndex, predecessor] of item.predecessors.entries()) {
+      const predecessorPath = `${itemPath}.predecessors[${predecessorIndex}]`
+      if (!predecessor || typeof predecessor !== "object" || Array.isArray(predecessor)) {
+        throw new Error(`${predecessorPath} must be an object.`)
+      }
+      requireNonEmptyString(
+        predecessor.predecessorSourceItemId,
+        `${predecessorPath}.predecessorSourceItemId`
+      )
+      requireNonEmptyString(
+        predecessor.successorSourceItemId,
+        `${predecessorPath}.successorSourceItemId`
+      )
+      if (!sourceItemIds.has(predecessor.predecessorSourceItemId)) {
+        throw new Error(
+          `${predecessorPath}.predecessorSourceItemId does not identify a captured schedule item.`
+        )
+      }
+      if (predecessor.successorSourceItemId !== item.sourceItemId) {
+        throw new Error(
+          `${predecessorPath}.successorSourceItemId must match its schedule item.`
+        )
+      }
+      if (!["FS", "SS", "FF", "SF"].includes(predecessor.type)) {
+        throw new Error(`${predecessorPath}.type must be FS, SS, FF, or SF.`)
+      }
+      if (!Number.isInteger(predecessor.lagDays)) {
+        throw new Error(`${predecessorPath}.lagDays must be an integer.`)
+      }
+      const relationshipKey = [
+        predecessor.predecessorSourceItemId,
+        predecessor.successorSourceItemId,
+        predecessor.type,
+      ].join(":")
+      if (relationshipKeys.has(relationshipKey)) {
+        throw new Error(`${path} has duplicate predecessor relationship ${relationshipKey}.`)
+      }
+      relationshipKeys.add(relationshipKey)
+    }
+  }
+}
+
 function contentId(templateId, moduleType, sourceItemId) {
   const digest = createHash("sha256")
     .update(`${templateId}:${moduleType}:${sourceItemId}`)
@@ -52,6 +104,7 @@ function contentId(templateId, moduleType, sourceItemId) {
 
 const modules = [
   ["tasks", "tasks"],
+  ["scheduleItems", "schedule"],
   ["selections", "selections"],
   ["bidPackages", "bid_packages"],
 ]
@@ -90,7 +143,9 @@ function parseConversionExceptions(capture, capturedTemplatesById) {
       requireNonEmptyString(exception.sourceItemId, `${path}.sourceItemId`)
     }
     if (!moduleSourceKeys.has(exception.module)) {
-      throw new Error(`${path}.module must be one of tasks, selections, bidPackages.`)
+      throw new Error(
+        `${path}.module must be one of tasks, scheduleItems, selections, bidPackages.`
+      )
     }
 
     const template = capturedTemplatesById.get(exception.templateSourceTemplateId)
@@ -132,16 +187,27 @@ async function main() {
   const capturePath = optionValue(args, "--capture")
   const inventoryPath = optionValue(args, "--inventory")
   const outputPath = optionValue(args, "--output")
+  const pilotManifestPath = optionValue(args, "--pilot-manifest")
   const dryRun = args.includes("--dry-run")
   if (!capturePath || !inventoryPath || (!dryRun && !outputPath)) {
     throw new Error(
       "Usage: bun scripts/build-buildertrend-template-content-sql.mjs " +
         "--inventory <reviewed-inventory.json> --capture <content.json> " +
-        "[--output <import.sql>] [--dry-run]"
+        "[--output <import.sql>] [--dry-run] [--pilot-manifest <reviewed-pilot.json>]"
     )
   }
-  const capture = JSON.parse(await readFile(capturePath, "utf8"))
-  const inventory = JSON.parse(await readFile(inventoryPath, "utf8"))
+  let capture = JSON.parse(await readFile(capturePath, "utf8"))
+  let inventory = JSON.parse(await readFile(inventoryPath, "utf8"))
+  let pilot = null
+  if (pilotManifestPath) {
+    pilot = buildBuildertrendTemplatePilot({
+      inventory,
+      capture,
+      manifest: JSON.parse(await readFile(pilotManifestPath, "utf8")),
+    })
+    capture = pilot.capture
+    inventory = pilot.inventory
+  }
   if (!Array.isArray(capture.templates)) throw new Error("capture.templates must be an array.")
   if (!Array.isArray(inventory.templates)) {
     throw new Error("inventory.templates must be an array.")
@@ -219,7 +285,7 @@ async function main() {
   )
 
   const statements = ["PRAGMA foreign_keys=ON;"]
-  const totals = { tasks: 0, selections: 0, bidPackages: 0 }
+  const totals = { tasks: 0, scheduleItems: 0, selections: 0, bidPackages: 0 }
   for (const [templateIndex, template] of capture.templates.entries()) {
     if (!template || typeof template !== "object") {
       throw new Error(`templates[${templateIndex}] must be an object.`)
@@ -252,14 +318,28 @@ async function main() {
           `${template.name} ${sourceKey} count mismatch: expected ${expected}, captured ${items.length}.`
         )
       }
+      const sourceItemIds = new Set()
+      for (const [itemIndex, item] of items.entries()) {
+        assertItem(item, `templates[${templateIndex}].${sourceKey}[${itemIndex}]`)
+        if (sourceItemIds.has(item.sourceItemId)) {
+          throw new Error(
+            `${template.name} ${sourceKey} has duplicate sourceItemId ${item.sourceItemId}.`
+          )
+        }
+        sourceItemIds.add(item.sourceItemId)
+      }
+      if (sourceKey === "scheduleItems") {
+        assertScheduleRelationships(items, `templates[${templateIndex}].scheduleItems`)
+      }
       totals[sourceKey] += items.length
       const exceptions =
         exceptionsByTemplateModule.get(`${template.sourceTemplateId}:${sourceKey}`) ?? []
       statements.push(
-        `DELETE FROM project_template_content_items WHERE version_id=${sql(versionId)} AND module_type=${sql(moduleType)};`
+        `DELETE FROM project_template_content_items WHERE version_id=${sql(versionId)} ` +
+          `AND module_type=${sql(moduleType)} AND EXISTS (` +
+          `SELECT 1 FROM project_template_versions WHERE id=${sql(versionId)} AND status='draft');`
       )
       items.forEach((item, itemIndex) => {
-        assertItem(item, `templates[${templateIndex}].${sourceKey}[${itemIndex}]`)
         const itemExceptions = exceptions.filter(
           (exception) => exception.sourceItemId === item.sourceItemId
         )
@@ -275,7 +355,7 @@ async function main() {
           `INSERT INTO project_template_content_items (` +
             `id, version_id, module_type, source_item_id, parent_source_item_id, ` +
             `title, category, description, sort_order, payload_json` +
-            `) VALUES (` +
+          `) SELECT ` +
             [
               sql(contentId(template.sourceTemplateId, moduleType, item.sourceItemId)),
               sql(versionId),
@@ -288,7 +368,8 @@ async function main() {
               Number.isInteger(item.sortOrder) ? item.sortOrder : itemIndex,
               sql(JSON.stringify(payload)),
             ].join(", ") +
-            `);`
+            ` WHERE EXISTS (SELECT 1 FROM project_template_versions ` +
+            `WHERE id=${sql(versionId)} AND status='draft');`
         )
       })
       statements.push(
@@ -303,13 +384,19 @@ async function main() {
               conversionExceptions: exceptions,
             })
           )} ` +
-          `WHERE version_id=${sql(versionId)} AND module_type=${sql(moduleType)};`
+          `WHERE version_id=${sql(versionId)} AND module_type=${sql(moduleType)} ` +
+          `AND EXISTS (SELECT 1 FROM project_template_versions ` +
+          `WHERE id=${sql(versionId)} AND status='draft');`
       )
     }
     statements.push(
-      `UPDATE project_templates SET review_status='verified', lifecycle_status='active', ` +
+      `UPDATE project_templates SET ` +
+        `review_status=CASE WHEN review_status='verified' THEN review_status ELSE 'content_captured' END, ` +
+        `lifecycle_status=CASE WHEN review_status='verified' THEN lifecycle_status ELSE 'draft' END, ` +
         `source_url=NULL, updated_at=${sql(capture.capturedAt)} ` +
-        `WHERE source_system='buildertrend' AND source_template_id=${sql(template.sourceTemplateId)};`
+      `WHERE source_system='buildertrend' AND source_template_id=${sql(template.sourceTemplateId)} ` +
+        `AND EXISTS (SELECT 1 FROM project_template_versions ` +
+        `WHERE id=${sql(versionId)} AND status='draft');`
     )
   }
 
@@ -321,6 +408,13 @@ async function main() {
         templateCount: capture.templates.length,
         ...totals,
         excludedArchivedCount: capture.excludedArchivedCount ?? null,
+        ...(pilot
+          ? {
+              pilotTemplateCount: pilot.capture.templates.length,
+              remainingActiveTemplatesUnverified:
+                pilot.remainingActiveTemplatesUnverified,
+            }
+          : {}),
         output: dryRun ? null : outputPath,
       },
       null,

--- a/scripts/build-buildertrend-template-content-sql.mjs
+++ b/scripts/build-buildertrend-template-content-sql.mjs
@@ -50,19 +50,173 @@ function contentId(templateId, moduleType, sourceItemId) {
   return `bt-template-content:${digest}`
 }
 
+const modules = [
+  ["tasks", "tasks"],
+  ["selections", "selections"],
+  ["bidPackages", "bid_packages"],
+]
+
+function requireNonEmptyString(value, path) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${path} must be a non-empty string.`)
+  }
+}
+
+function parseConversionExceptions(capture, capturedTemplatesById) {
+  if (capture.conversionExceptions === undefined) return new Map()
+  if (!Array.isArray(capture.conversionExceptions)) {
+    throw new Error("capture.conversionExceptions must be an array.")
+  }
+
+  const moduleSourceKeys = new Set(modules.map(([sourceKey]) => sourceKey))
+  const exceptionsByTemplateModule = new Map()
+  for (const [exceptionIndex, exception] of capture.conversionExceptions.entries()) {
+    const path = `capture.conversionExceptions[${exceptionIndex}]`
+    if (!exception || typeof exception !== "object" || Array.isArray(exception)) {
+      throw new Error(`${path} must be an object.`)
+    }
+    requireNonEmptyString(exception.templateSourceTemplateId, `${path}.templateSourceTemplateId`)
+    requireNonEmptyString(exception.module, `${path}.module`)
+    requireNonEmptyString(exception.field, `${path}.field`)
+    requireNonEmptyString(exception.loss, `${path}.loss`)
+    requireNonEmptyString(exception.recoveryPlan, `${path}.recoveryPlan`)
+    if (!("sourceValue" in exception)) {
+      throw new Error(`${path}.sourceValue is required.`)
+    }
+    if (!("sourceItemId" in exception)) {
+      throw new Error(`${path}.sourceItemId is required; use null for a module-level exception.`)
+    }
+    if (exception.sourceItemId !== null) {
+      requireNonEmptyString(exception.sourceItemId, `${path}.sourceItemId`)
+    }
+    if (!moduleSourceKeys.has(exception.module)) {
+      throw new Error(`${path}.module must be one of tasks, selections, bidPackages.`)
+    }
+
+    const template = capturedTemplatesById.get(exception.templateSourceTemplateId)
+    if (!template) {
+      throw new Error(`${path}.templateSourceTemplateId does not identify a captured template.`)
+    }
+    const items = template[exception.module] ?? []
+    if (!Array.isArray(items)) {
+      throw new Error(`${path}.module does not identify an item array on its template.`)
+    }
+    if (
+      exception.sourceItemId !== null &&
+      !items.some((item) => item?.sourceItemId === exception.sourceItemId)
+    ) {
+      throw new Error(
+        `${path}.sourceItemId does not identify a captured ${exception.module} item.`
+      )
+    }
+
+    const normalized = {
+      templateSourceTemplateId: exception.templateSourceTemplateId,
+      module: exception.module,
+      sourceItemId: exception.sourceItemId,
+      field: exception.field,
+      sourceValue: exception.sourceValue,
+      loss: exception.loss,
+      recoveryPlan: exception.recoveryPlan,
+    }
+    const key = `${exception.templateSourceTemplateId}:${exception.module}`
+    const current = exceptionsByTemplateModule.get(key) ?? []
+    current.push(normalized)
+    exceptionsByTemplateModule.set(key, current)
+  }
+  return exceptionsByTemplateModule
+}
+
 async function main() {
   const args = process.argv.slice(2)
   const capturePath = optionValue(args, "--capture")
+  const inventoryPath = optionValue(args, "--inventory")
   const outputPath = optionValue(args, "--output")
   const dryRun = args.includes("--dry-run")
-  if (!capturePath || (!dryRun && !outputPath)) {
+  if (!capturePath || !inventoryPath || (!dryRun && !outputPath)) {
     throw new Error(
       "Usage: bun scripts/build-buildertrend-template-content-sql.mjs " +
-        "--capture <content.json> [--output <import.sql>] [--dry-run]"
+        "--inventory <reviewed-inventory.json> --capture <content.json> " +
+        "[--output <import.sql>] [--dry-run]"
     )
   }
   const capture = JSON.parse(await readFile(capturePath, "utf8"))
+  const inventory = JSON.parse(await readFile(inventoryPath, "utf8"))
   if (!Array.isArray(capture.templates)) throw new Error("capture.templates must be an array.")
+  if (!Array.isArray(inventory.templates)) {
+    throw new Error("inventory.templates must be an array.")
+  }
+
+  const expectedActiveCount = Number(inventory.expectedActiveCount)
+  if (!Number.isInteger(expectedActiveCount) || expectedActiveCount <= 0) {
+    throw new Error("inventory.expectedActiveCount must be a positive integer.")
+  }
+  if (inventory.templates.length !== expectedActiveCount) {
+    throw new Error(
+      `Inventory count mismatch: expected ${expectedActiveCount}, found ${inventory.templates.length}.`
+    )
+  }
+
+  const inventoryById = new Map()
+  for (const [templateIndex, template] of inventory.templates.entries()) {
+    if (!template || typeof template !== "object") {
+      throw new Error(`inventory.templates[${templateIndex}] must be an object.`)
+    }
+    if (typeof template.sourceTemplateId !== "string" || !template.sourceTemplateId) {
+      throw new Error(
+        `inventory.templates[${templateIndex}].sourceTemplateId is required.`
+      )
+    }
+    if (typeof template.name !== "string" || !template.name) {
+      throw new Error(`inventory.templates[${templateIndex}].name is required.`)
+    }
+    if (/^archive/i.test(template.name)) {
+      throw new Error(`Archived inventory template “${template.name}” is not allowed.`)
+    }
+    if (inventoryById.has(template.sourceTemplateId)) {
+      throw new Error(`Duplicate inventory template ID ${template.sourceTemplateId}.`)
+    }
+    inventoryById.set(template.sourceTemplateId, template)
+  }
+
+  const capturedIds = new Set()
+  const capturedTemplatesById = new Map()
+  for (const [templateIndex, template] of capture.templates.entries()) {
+    if (!template || typeof template !== "object") {
+      throw new Error(`templates[${templateIndex}] must be an object.`)
+    }
+    if (typeof template.sourceTemplateId !== "string" || !template.sourceTemplateId) {
+      throw new Error(`templates[${templateIndex}].sourceTemplateId is required.`)
+    }
+    if (capturedIds.has(template.sourceTemplateId)) {
+      throw new Error(`Duplicate captured template ID ${template.sourceTemplateId}.`)
+    }
+    capturedIds.add(template.sourceTemplateId)
+    capturedTemplatesById.set(template.sourceTemplateId, template)
+  }
+  const missingIds = [...inventoryById.keys()].filter((id) => !capturedIds.has(id))
+  const unexpectedIds = [...capturedIds].filter((id) => !inventoryById.has(id))
+  if (missingIds.length > 0 || unexpectedIds.length > 0) {
+    throw new Error(
+      `Template coverage mismatch: missing [${missingIds.join(", ")}], ` +
+        `unexpected [${unexpectedIds.join(", ")}].`
+    )
+  }
+  if (capture.templates.length !== expectedActiveCount) {
+    throw new Error(
+      `Content capture count mismatch: expected ${expectedActiveCount}, found ${capture.templates.length}.`
+    )
+  }
+  if (capture.excludedArchivedCount !== inventory.excludedArchivedCount) {
+    throw new Error(
+      `Archived exclusion mismatch: expected ${inventory.excludedArchivedCount}, ` +
+        `received ${capture.excludedArchivedCount}.`
+    )
+  }
+  const exceptionsByTemplateModule = parseConversionExceptions(
+    capture,
+    capturedTemplatesById
+  )
 
   const statements = ["PRAGMA foreign_keys=ON;"]
   const totals = { tasks: 0, selections: 0, bidPackages: 0 }
@@ -79,30 +233,41 @@ async function main() {
     if (/^archive/i.test(template.name)) {
       throw new Error(`Archived template “${template.name}” cannot be imported.`)
     }
+    const inventoryTemplate = inventoryById.get(template.sourceTemplateId)
+    if (!inventoryTemplate || inventoryTemplate.name !== template.name) {
+      throw new Error(
+        `Template identity mismatch for ${template.sourceTemplateId}: ` +
+          `expected “${inventoryTemplate?.name ?? "unknown"}”, received “${template.name}”.`
+      )
+    }
     const versionId = `bt-template-version:${template.sourceTemplateId}:1`
-    const modules = [
-      ["tasks", "tasks"],
-      ["selections", "selections"],
-      ["bidPackages", "bid_packages"],
-    ]
     for (const [sourceKey, moduleType] of modules) {
       const items = template[sourceKey] ?? []
       if (!Array.isArray(items)) {
         throw new Error(`templates[${templateIndex}].${sourceKey} must be an array.`)
       }
-      const expected = Number(template.moduleCounts?.[sourceKey] ?? 0)
+      const expected = Number(inventoryTemplate.moduleCounts?.[sourceKey] ?? 0)
       if (items.length !== expected) {
         throw new Error(
           `${template.name} ${sourceKey} count mismatch: expected ${expected}, captured ${items.length}.`
         )
       }
       totals[sourceKey] += items.length
+      const exceptions =
+        exceptionsByTemplateModule.get(`${template.sourceTemplateId}:${sourceKey}`) ?? []
       statements.push(
         `DELETE FROM project_template_content_items WHERE version_id=${sql(versionId)} AND module_type=${sql(moduleType)};`
       )
       items.forEach((item, itemIndex) => {
         assertItem(item, `templates[${templateIndex}].${sourceKey}[${itemIndex}]`)
+        const itemExceptions = exceptions.filter(
+          (exception) => exception.sourceItemId === item.sourceItemId
+        )
         const cleaned = cleanPayload(item)
+        const payload =
+          itemExceptions.length > 0
+            ? { ...cleaned, conversionExceptions: itemExceptions }
+            : cleaned
         const description = cleanText(
           item.description ?? item.detail?.fullText ?? item.detail?.description ?? null
         )
@@ -121,15 +286,23 @@ async function main() {
               sql(cleanText(item.category ?? item.tags ?? null)),
               sql(description),
               Number.isInteger(item.sortOrder) ? item.sortOrder : itemIndex,
-              sql(JSON.stringify(cleaned)),
+              sql(JSON.stringify(payload)),
             ].join(", ") +
             `);`
         )
       })
       statements.push(
         `UPDATE project_template_modules SET ` +
-          `normalization_status='captured', ` +
-          `source_payload_json=${sql(JSON.stringify({ sourceItemCount: items.length, capturedAt: capture.capturedAt }))} ` +
+          `normalization_status=${sql(
+            exceptions.length > 0 ? "captured_with_warnings" : "captured"
+          )}, ` +
+          `source_payload_json=${sql(
+            JSON.stringify({
+              sourceItemCount: items.length,
+              capturedAt: capture.capturedAt,
+              conversionExceptions: exceptions,
+            })
+          )} ` +
           `WHERE version_id=${sql(versionId)} AND module_type=${sql(moduleType)};`
       )
     }

--- a/scripts/build-buildertrend-template-content-sql.test.mjs
+++ b/scripts/build-buildertrend-template-content-sql.test.mjs
@@ -15,7 +15,7 @@ const inventory = {
     {
       sourceTemplateId: "template-1",
       name: "Foundation",
-      moduleCounts: { tasks: 1, selections: 0, bidPackages: 0 },
+      moduleCounts: { tasks: 1, scheduleItems: 1, selections: 0, bidPackages: 0 },
     },
   ],
 }
@@ -28,6 +28,16 @@ const capture = {
       sourceTemplateId: "template-1",
       name: "Foundation",
       tasks: [{ sourceItemId: "task-1", title: "Form footers" }],
+      scheduleItems: [
+        {
+          sourceItemId: "schedule-1",
+          title: "Pour footers",
+          startDate: "2026-08-03",
+          workdays: 1,
+          phase: "Foundation",
+          predecessors: [],
+        },
+      ],
       selections: [],
       bidPackages: [],
     },
@@ -87,6 +97,7 @@ test("preserves documented field conversion exceptions in module and item proven
   assert.match(result.sql, /"sourceItemId":"task-1"/)
   assert.match(result.sql, /"sourceValue":"Labor"/)
   assert.match(result.sql, /"recoveryPlan":"Map the cost type after the Sage cost-code migration\."/)
+  assert.match(result.sql, /project_template_versions WHERE id='bt-template-version:template-1:1' AND status='draft'/)
 })
 
 test("dry-run reports the exact captured module counts", async () => {
@@ -95,6 +106,7 @@ test("dry-run reports the exact captured module counts", async () => {
   assert.deepEqual(JSON.parse(result.stdout), {
     templateCount: 1,
     tasks: 1,
+    scheduleItems: 1,
     selections: 0,
     bidPackages: 0,
     excludedArchivedCount: 0,
@@ -141,4 +153,121 @@ test("rejects item exceptions that do not point to captured content", async () =
     () => runImport(input),
     /sourceItemId does not identify a captured tasks item\./
   )
+})
+
+test("rejects duplicate content source IDs before generating SQL", async () => {
+  const input = structuredClone(capture)
+  input.templates[0].tasks = [
+    { sourceItemId: "task-1", title: "Form footers" },
+  ]
+  const duplicateInventory = structuredClone(inventory)
+  duplicateInventory.templates[0].moduleCounts.tasks = 2
+  input.templates[0].tasks.push({ sourceItemId: "task-1", title: "Duplicate footers" })
+
+  const directory = await mkdtemp(join(tmpdir(), "compass-template-content-"))
+  const inventoryPath = join(directory, "inventory.json")
+  const capturePath = join(directory, "capture.json")
+  const outputPath = join(directory, "import.sql")
+  await Promise.all([
+    writeFile(inventoryPath, JSON.stringify(duplicateInventory)),
+    writeFile(capturePath, JSON.stringify(input)),
+  ])
+  try {
+    await assert.rejects(
+      () => execFileAsync("bun", [
+        "scripts/build-buildertrend-template-content-sql.mjs",
+        "--inventory", inventoryPath,
+        "--capture", capturePath,
+        "--output", outputPath,
+      ]),
+      /duplicate sourceItemId task-1/
+    )
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test("rejects schedule predecessors that do not reference captured schedule items", async () => {
+  const input = structuredClone(capture)
+  input.templates[0].scheduleItems[0].predecessors = [
+    {
+      predecessorSourceItemId: "missing-schedule-item",
+      successorSourceItemId: "schedule-1",
+      type: "FS",
+      lagDays: 0,
+    },
+  ]
+
+  await assert.rejects(
+    () => runImport(input),
+    /predecessorSourceItemId does not identify a captured schedule item\./
+  )
+})
+
+test("converts the complete six-template pilot with exact counts and draft guards", async () => {
+  const canonicalCapture = JSON.parse(
+    await readFile(
+      "scripts/fixtures/buildertrend-template-content-pilot-2026-08-03.json",
+      "utf8"
+    )
+  )
+  const canonicalInventory = JSON.parse(
+    await readFile(
+      "scripts/fixtures/buildertrend-template-content-pilot-inventory-2026-08-03.json",
+      "utf8"
+    )
+  )
+  const directory = await mkdtemp(join(tmpdir(), "compass-template-content-"))
+  const inventoryPath = join(directory, "inventory.json")
+  const capturePath = join(directory, "capture.json")
+  const outputPath = join(directory, "import.sql")
+  await Promise.all([
+    writeFile(inventoryPath, JSON.stringify(canonicalInventory)),
+    writeFile(capturePath, JSON.stringify(canonicalCapture)),
+  ])
+  try {
+    const result = await execFileAsync("bun", [
+      "scripts/build-buildertrend-template-content-sql.mjs",
+      "--inventory", inventoryPath,
+      "--capture", capturePath,
+      "--output", outputPath,
+    ])
+    assert.deepEqual(JSON.parse(result.stdout), {
+      templateCount: 6,
+      tasks: 249,
+      scheduleItems: 70,
+      selections: 110,
+      bidPackages: 4,
+      excludedArchivedCount: 27,
+      output: outputPath,
+    })
+    const sql = await readFile(outputPath, "utf8")
+    assert.equal(
+      (sql.match(/INSERT INTO project_template_content_items/g) ?? []).length,
+      433
+    )
+    assert.match(
+      sql,
+      /WHERE id='bt-template-version:30294726:1' AND status='draft'/
+    )
+    assert.match(sql, /normalization_status='captured_with_warnings'/)
+    assert.match(sql, /module_type='schedule'/)
+    assert.match(sql, /"sourceItemId":"176749752"/)
+    assert.match(sql, /"predecessorSourceItemId":"176749752"/)
+    assert.match(
+      sql,
+      /"field":"milestone,assignee,ownerVisibility,subVendorVisibility,notes"/
+    )
+    assert.match(
+      sql,
+      /DELETE FROM project_template_content_items WHERE version_id='bt-template-version:30294726:1' AND module_type='schedule'/
+    )
+    assert.match(sql, /\"field\":\"sourceItemId\"/)
+    assert.match(sql, /\"field\":\"attachmentBytes\"/)
+    assert.match(sql, /\"field\":\"costType\"/)
+    assert.match(sql, /review_status=CASE WHEN review_status='verified'/)
+    assert.doesNotMatch(sql, /review_status='verified', lifecycle_status='active'/)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
 })

--- a/scripts/build-buildertrend-template-content-sql.test.mjs
+++ b/scripts/build-buildertrend-template-content-sql.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import test from "node:test"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+
+const inventory = {
+  expectedActiveCount: 1,
+  excludedArchivedCount: 0,
+  templates: [
+    {
+      sourceTemplateId: "template-1",
+      name: "Foundation",
+      moduleCounts: { tasks: 1, selections: 0, bidPackages: 0 },
+    },
+  ],
+}
+
+const capture = {
+  capturedAt: "2026-08-03T15:30:00.000Z",
+  excludedArchivedCount: 0,
+  templates: [
+    {
+      sourceTemplateId: "template-1",
+      name: "Foundation",
+      tasks: [{ sourceItemId: "task-1", title: "Form footers" }],
+      selections: [],
+      bidPackages: [],
+    },
+  ],
+}
+
+async function runImport(inputCapture, { dryRun = false } = {}) {
+  const directory = await mkdtemp(join(tmpdir(), "compass-template-content-"))
+  const inventoryPath = join(directory, "inventory.json")
+  const capturePath = join(directory, "capture.json")
+  const outputPath = join(directory, "import.sql")
+  await Promise.all([
+    writeFile(inventoryPath, JSON.stringify(inventory)),
+    writeFile(capturePath, JSON.stringify(inputCapture)),
+  ])
+  try {
+    const argumentsList = [
+      "scripts/build-buildertrend-template-content-sql.mjs",
+      "--inventory",
+      inventoryPath,
+      "--capture",
+      capturePath,
+    ]
+    if (dryRun) {
+      argumentsList.push("--dry-run")
+    } else {
+      argumentsList.push("--output", outputPath)
+    }
+    const result = await execFileAsync("bun", argumentsList)
+    return {
+      ...result,
+      sql: dryRun ? null : await readFile(outputPath, "utf8"),
+    }
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
+test("preserves documented field conversion exceptions in module and item provenance", async () => {
+  const input = structuredClone(capture)
+  input.conversionExceptions = [
+    {
+      templateSourceTemplateId: "template-1",
+      module: "tasks",
+      sourceItemId: "task-1",
+      field: "costType",
+      sourceValue: "Labor",
+      loss: "Compass does not import Buildertrend cost types.",
+      recoveryPlan: "Map the cost type after the Sage cost-code migration.",
+    },
+  ]
+
+  const result = await runImport(input)
+
+  assert.match(result.sql, /normalization_status='captured_with_warnings'/)
+  assert.match(result.sql, /"conversionExceptions"/)
+  assert.match(result.sql, /"sourceItemId":"task-1"/)
+  assert.match(result.sql, /"sourceValue":"Labor"/)
+  assert.match(result.sql, /"recoveryPlan":"Map the cost type after the Sage cost-code migration\."/)
+})
+
+test("dry-run reports the exact captured module counts", async () => {
+  const result = await runImport(capture, { dryRun: true })
+
+  assert.deepEqual(JSON.parse(result.stdout), {
+    templateCount: 1,
+    tasks: 1,
+    selections: 0,
+    bidPackages: 0,
+    excludedArchivedCount: 0,
+    output: null,
+  })
+})
+
+test("does not let a documented field exception conceal a missing content item", async () => {
+  const input = structuredClone(capture)
+  input.templates[0].tasks = []
+  input.conversionExceptions = [
+    {
+      templateSourceTemplateId: "template-1",
+      module: "tasks",
+      sourceItemId: null,
+      field: "costTypes",
+      sourceValue: ["Labor", "Material"],
+      loss: "Cost types need a later mapping.",
+      recoveryPlan: "Map them after the Sage cost-code migration.",
+    },
+  ]
+
+  await assert.rejects(
+    () => runImport(input),
+    /Foundation tasks count mismatch: expected 1, captured 0\./
+  )
+})
+
+test("rejects item exceptions that do not point to captured content", async () => {
+  const input = structuredClone(capture)
+  input.conversionExceptions = [
+    {
+      templateSourceTemplateId: "template-1",
+      module: "tasks",
+      sourceItemId: "missing-task",
+      field: "costType",
+      sourceValue: "Labor",
+      loss: "Cost types need a later mapping.",
+      recoveryPlan: "Map them after the Sage cost-code migration.",
+    },
+  ]
+
+  await assert.rejects(
+    () => runImport(input),
+    /sourceItemId does not identify a captured tasks item\./
+  )
+})

--- a/scripts/build-buildertrend-template-pilot-import.test.mjs
+++ b/scripts/build-buildertrend-template-pilot-import.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import test from "node:test"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+
+test("builds an idempotent category-only six-template pilot without verifying the remaining 34", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "compass-template-pilot-"))
+  const inventoryOutput = join(directory, "inventory.sql")
+  const output = join(directory, "pilot.sql")
+  const inventoryResult = await execFileAsync("bun", [
+    "scripts/build-buildertrend-template-inventory-sql.mjs",
+    "--input", "scripts/fixtures/buildertrend-active-template-inventory-2026-07-31.json",
+    "--organization-id", "org-test",
+    "--output", inventoryOutput,
+  ])
+  assert.deepEqual(JSON.parse(inventoryResult.stdout), {
+    dryRun: false,
+    importedCount: 40,
+    excludedArchivedCount: 27,
+    output: inventoryOutput,
+  })
+  const result = await execFileAsync("bun", [
+    "scripts/build-buildertrend-template-capture-sql.mjs",
+    "--inventory", "scripts/fixtures/buildertrend-active-template-inventory-2026-07-31.json",
+    "--capture", "scripts/fixtures/buildertrend-active-template-capture-2026-07-31.json",
+    "--pilot-manifest", "scripts/fixtures/buildertrend-template-pilot-2026-08-03.json",
+    "--organization-id", "org-test",
+    "--output", output,
+  ])
+
+  assert.deepEqual(JSON.parse(result.stdout), {
+    dryRun: false,
+    capturedTemplateCount: 6,
+    capturedScheduleCount: 6,
+    capturedScheduleItemCount: 70,
+    publishCapturedSchedules: false,
+    pilotTemplateCount: 6,
+    remainingActiveTemplatesUnverified: 34,
+    excludedArchivedCount: 27,
+    output,
+  })
+  const sql = await readFile(output, "utf8")
+  assert.match(sql, /department_code, trade_category/)
+  assert.match(sql, /NULL, 'Drywall'/)
+  assert.match(sql, /NULL, 'Preconstruction'/)
+  assert.doesNotMatch(sql, /'ORC'/)
+  assert.doesNotMatch(sql, /template:concrete-footer-assembly/)
+  assert.match(sql, /ON CONFLICT\(organization_id, source_system, source_key\) DO UPDATE/)
+  const inventorySql = await readFile(inventoryOutput, "utf8")
+  assert.equal(
+    (inventorySql.match(/INSERT INTO project_templates/g) ?? []).length,
+    40
+  )
+  assert.equal(40 - 6, 34)
+  await rm(directory, { recursive: true, force: true })
+})
+
+test("rejects a truncated source capture before applying the six-template allowlist", async () => {
+  const inventory = JSON.parse(
+    await readFile("scripts/fixtures/buildertrend-active-template-inventory-2026-07-31.json", "utf8")
+  )
+  const capture = JSON.parse(
+    await readFile("scripts/fixtures/buildertrend-active-template-capture-2026-07-31.json", "utf8")
+  )
+  const manifest = JSON.parse(
+    await readFile("scripts/fixtures/buildertrend-template-pilot-2026-08-03.json", "utf8")
+  )
+  inventory.templates = inventory.templates.slice(0, 6)
+  capture.templates = capture.templates.slice(0, 6)
+  const { buildBuildertrendTemplatePilot } = await import("./lib/buildertrend-template-pilot.mjs")
+  assert.throws(
+    () => buildBuildertrendTemplatePilot({ inventory, capture, manifest }),
+    /must contain all 40 active templates/
+  )
+})

--- a/scripts/fixtures/buildertrend-template-capture-workplan-2026-08-03.json
+++ b/scripts/fixtures/buildertrend-template-capture-workplan-2026-08-03.json
@@ -1,0 +1,775 @@
+{
+  "manifestVersion": 1,
+  "generatedAt": "2026-08-03",
+  "sourceCapture": {
+    "path": "scripts/fixtures/buildertrend-active-template-capture-2026-07-31.json",
+    "capturedAt": "2026-08-03T15:30:00.000Z",
+    "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates"
+  },
+  "scope": {
+    "activeTemplatesIncluded": 40,
+    "archivedTemplatesExcluded": 27,
+    "archivedTemplatesIncluded": 0,
+    "approach": "one source template per temporary Buildertrend target"
+  },
+  "status": "pending",
+  "aggregateTotals": {
+    "tasks": 739,
+    "scheduleItems": 163,
+    "selections": 155,
+    "bidPackages": 30,
+    "totalWorkItems": 1087
+  },
+  "processingBatches": [
+    {
+      "sequence": 1,
+      "id": "batch-01",
+      "name": "Schedule-rich and highest-value",
+      "intent": "Validate the schedule-bearing templates with the largest combined workload first.",
+      "ids": [
+        "12978716",
+        "32043577",
+        "12667545",
+        "12540389",
+        "30907034",
+        "12859981",
+        "12978371",
+        "12581937",
+        "12594475",
+        "30294726",
+        "30917204",
+        "12646335"
+      ],
+      "templateCount": 12
+    },
+    {
+      "sequence": 2,
+      "id": "batch-02",
+      "name": "Remaining schedule-bearing",
+      "intent": "Complete the remaining schedule templates using the same one-source-per-temporary-target procedure.",
+      "ids": [
+        "12650792",
+        "12796241",
+        "12819873",
+        "12649495",
+        "12650427",
+        "30914491",
+        "12978732",
+        "12858966",
+        "12649292",
+        "12650557",
+        "30919251",
+        "12650484",
+        "12650395",
+        "12650713",
+        "28466146",
+        "12979213",
+        "13001090",
+        "12978590"
+      ],
+      "templateCount": 18
+    },
+    {
+      "sequence": 3,
+      "id": "batch-03",
+      "name": "Module-rich without schedule",
+      "intent": "Capture bid-package and selection-heavy templates after the schedule work.",
+      "ids": [
+        "36619183",
+        "38452172",
+        "36618977",
+        "36478698",
+        "36595931",
+        "37180847",
+        "42924180",
+        "39644707",
+        "42948499",
+        "38452532"
+      ],
+      "templateCount": 10
+    }
+  ],
+  "templates": [
+    {
+      "sequence": 1,
+      "batchId": "batch-01",
+      "sourceTemplateId": "12978716",
+      "sourceName": "Ext. Finishes - Roofing",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12978716",
+      "temporaryBuildertrendTargetName": "BT Ext. Finishes - Roofing",
+      "moduleCounts": {
+        "tasks": 14,
+        "bidPackages": 1,
+        "scheduleItems": 2,
+        "selections": 103
+      },
+      "totalWorkItems": 120,
+      "status": "completed_with_exceptions",
+      "targetTemplateId": "45876661",
+      "capturedAt": "2026-08-04T02:57:00.000Z",
+      "capturedModuleCounts": {
+        "tasks": 14,
+        "bidPackages": 1,
+        "scheduleItems": 2,
+        "selections": 103,
+        "scheduleDurationDays": 5
+      },
+      "exceptions": [
+        "Buildertrend regenerated copied-record IDs.",
+        "Buildertrend cleared Cost Type on 2 line items that had multiple Cost Types."
+      ]
+    },
+    {
+      "sequence": 2,
+      "batchId": "batch-01",
+      "sourceTemplateId": "32043577",
+      "sourceName": "Design & Preconstruction",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/32043577",
+      "temporaryBuildertrendTargetName": "BT Design & Preconstruction",
+      "moduleCounts": {
+        "tasks": 48,
+        "scheduleItems": 34
+      },
+      "totalWorkItems": 82,
+      "status": "completed_with_exceptions",
+      "targetTemplateId": "45876671",
+      "capturedAt": "2026-08-04T03:01:00.000Z",
+      "capturedModuleCounts": {
+        "tasks": 48,
+        "bidPackages": 0,
+        "scheduleItems": 34,
+        "selections": 0,
+        "scheduleDurationDays": 128
+      },
+      "exceptions": [
+        "Buildertrend regenerated copied-record IDs."
+      ]
+    },
+    {
+      "sequence": 3,
+      "batchId": "batch-01",
+      "sourceTemplateId": "12667545",
+      "sourceName": "Concrete - LiteDeck Assembly",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12667545",
+      "temporaryBuildertrendTargetName": "BT Concrete - LiteDeck Assembly",
+      "moduleCounts": {
+        "tasks": 50,
+        "scheduleItems": 15
+      },
+      "totalWorkItems": 65,
+      "status": "completed_with_exceptions",
+      "targetTemplateId": "45876676",
+      "capturedAt": "2026-08-04T03:03:00.000Z",
+      "capturedModuleCounts": {
+        "tasks": 50,
+        "bidPackages": 0,
+        "scheduleItems": 15,
+        "selections": 0,
+        "scheduleDurationDays": 12
+      },
+      "exceptions": [
+        "Buildertrend regenerated copied-record IDs."
+      ]
+    },
+    {
+      "sequence": 4,
+      "batchId": "batch-01",
+      "sourceTemplateId": "12540389",
+      "sourceName": "Concrete - ICF Assembly",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12540389",
+      "temporaryBuildertrendTargetName": "BT Concrete - ICF Assembly",
+      "moduleCounts": {
+        "tasks": 59,
+        "scheduleItems": 5
+      },
+      "totalWorkItems": 64,
+      "status": "completed_with_exceptions",
+      "targetTemplateId": "45876685",
+      "capturedAt": "2026-08-04T03:06:00.000Z",
+      "capturedModuleCounts": {
+        "tasks": 59,
+        "bidPackages": 0,
+        "scheduleItems": 5,
+        "selections": 0,
+        "scheduleDurationDays": 12
+      },
+      "exceptions": [
+        "Buildertrend regenerated copied-record IDs."
+      ]
+    },
+    {
+      "sequence": 5,
+      "batchId": "batch-01",
+      "sourceTemplateId": "30907034",
+      "sourceName": "Int. Finishes - Cabinetry/Countertops",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/30907034",
+      "temporaryBuildertrendTargetName": "BT Int. Finishes - Cabinetry/Countertops",
+      "moduleCounts": {
+        "tasks": 50,
+        "bidPackages": 2,
+        "scheduleItems": 6,
+        "selections": 4
+      },
+      "totalWorkItems": 62,
+      "status": "completed_with_exceptions",
+      "targetTemplateId": "45876692",
+      "capturedAt": "2026-08-04T03:10:00.000Z",
+      "capturedModuleCounts": {"tasks": 50, "bidPackages": 2, "scheduleItems": 6, "selections": 4, "scheduleDurationDays": 18},
+      "exceptions": ["Buildertrend regenerated copied-record IDs."]
+    },
+    {
+      "sequence": 6,
+      "batchId": "batch-01",
+      "sourceTemplateId": "12859981",
+      "sourceName": "Ext. Finishes - Stucco",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12859981",
+      "temporaryBuildertrendTargetName": "BT Ext. Finishes - Stucco",
+      "moduleCounts": {
+        "tasks": 48,
+        "bidPackages": 1,
+        "scheduleItems": 5,
+        "selections": 4
+      },
+      "totalWorkItems": 58,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 7,
+      "batchId": "batch-01",
+      "sourceTemplateId": "12978371",
+      "sourceName": "MEP - Rough & Top Out",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12978371",
+      "temporaryBuildertrendTargetName": "BT MEP - Rough & Top Out",
+      "moduleCounts": {
+        "tasks": 45,
+        "bidPackages": 2,
+        "scheduleItems": 9
+      },
+      "totalWorkItems": 56,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 8,
+      "batchId": "batch-01",
+      "sourceTemplateId": "12581937",
+      "sourceName": "Concrete - Footer Assembly",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12581937",
+      "temporaryBuildertrendTargetName": "BT Concrete - Footer Assembly",
+      "moduleCounts": {
+        "tasks": 43,
+        "scheduleItems": 8
+      },
+      "totalWorkItems": 51,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 9,
+      "batchId": "batch-01",
+      "sourceTemplateId": "12594475",
+      "sourceName": "Concrete - Slab Assembly",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12594475",
+      "temporaryBuildertrendTargetName": "BT Concrete - Slab Assembly",
+      "moduleCounts": {
+        "tasks": 36,
+        "bidPackages": 1,
+        "scheduleItems": 8
+      },
+      "totalWorkItems": 45,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 10,
+      "batchId": "batch-01",
+      "sourceTemplateId": "30294726",
+      "sourceName": "Drywall Installation",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/30294726",
+      "temporaryBuildertrendTargetName": "BT Drywall Installation",
+      "moduleCounts": {
+        "tasks": 28,
+        "bidPackages": 1,
+        "scheduleItems": 8,
+        "selections": 3
+      },
+      "totalWorkItems": 40,
+      "status": "completed_with_exceptions",
+      "targetTemplateId": "45876630",
+      "capturedAt": "2026-08-04T02:53:00.000Z",
+      "capturedModuleCounts": {
+        "tasks": 28,
+        "bidPackages": 1,
+        "scheduleItems": 8,
+        "selections": 3,
+        "scheduleDurationDays": 25
+      },
+      "exceptions": [
+        "Buildertrend regenerated copied-record IDs.",
+        "Buildertrend cleared Cost Type on 1 line item that had multiple Cost Types."
+      ]
+    },
+    {
+      "sequence": 11,
+      "batchId": "batch-01",
+      "sourceTemplateId": "30917204",
+      "sourceName": "Ext. Finishes - Siding",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/30917204",
+      "temporaryBuildertrendTargetName": "BT Ext. Finishes - Siding",
+      "moduleCounts": {
+        "tasks": 29,
+        "bidPackages": 1,
+        "scheduleItems": 3,
+        "selections": 4
+      },
+      "totalWorkItems": 37,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 12,
+      "batchId": "batch-01",
+      "sourceTemplateId": "12646335",
+      "sourceName": "Framing - Interior Wall Assembly",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12646335",
+      "temporaryBuildertrendTargetName": "BT Framing - Interior Wall Assembly",
+      "moduleCounts": {
+        "tasks": 34,
+        "bidPackages": 1,
+        "scheduleItems": 2
+      },
+      "totalWorkItems": 37,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 13,
+      "batchId": "batch-02",
+      "sourceTemplateId": "12650792",
+      "sourceName": "Framing - Roof w/ Trusses Assembly",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12650792",
+      "temporaryBuildertrendTargetName": "BT Framing - Roof w/ Trusses Assembly",
+      "moduleCounts": {
+        "tasks": 28,
+        "scheduleItems": 5
+      },
+      "totalWorkItems": 33,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 14,
+      "batchId": "batch-02",
+      "sourceTemplateId": "12796241",
+      "sourceName": "Int. Finishes - Architectural Woodwork",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12796241",
+      "temporaryBuildertrendTargetName": "BT Int. Finishes - Architectural Woodwork",
+      "moduleCounts": {
+        "tasks": 19,
+        "bidPackages": 2,
+        "scheduleItems": 4,
+        "selections": 5
+      },
+      "totalWorkItems": 30,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 15,
+      "batchId": "batch-02",
+      "sourceTemplateId": "12819873",
+      "sourceName": "Framing - Fascia & Soffit Installation",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12819873",
+      "temporaryBuildertrendTargetName": "BT Framing - Fascia & Soffit Installation",
+      "moduleCounts": {
+        "tasks": 25,
+        "scheduleItems": 3
+      },
+      "totalWorkItems": 28,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 16,
+      "batchId": "batch-02",
+      "sourceTemplateId": "12649495",
+      "sourceName": "Framing - Floor System Assembly",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12649495",
+      "temporaryBuildertrendTargetName": "BT Framing - Floor System Assembly",
+      "moduleCounts": {
+        "tasks": 24,
+        "scheduleItems": 4
+      },
+      "totalWorkItems": 28,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 17,
+      "batchId": "batch-02",
+      "sourceTemplateId": "12650427",
+      "sourceName": "Framing - Window",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12650427",
+      "temporaryBuildertrendTargetName": "BT Framing - Window",
+      "moduleCounts": {
+        "tasks": 20,
+        "bidPackages": 1,
+        "scheduleItems": 2,
+        "selections": 2
+      },
+      "totalWorkItems": 25,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 18,
+      "batchId": "batch-02",
+      "sourceTemplateId": "30914491",
+      "sourceName": "Int. Finishes - Tiling",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/30914491",
+      "temporaryBuildertrendTargetName": "BT Int. Finishes - Tiling",
+      "moduleCounts": {
+        "tasks": 16,
+        "bidPackages": 1,
+        "scheduleItems": 3,
+        "selections": 5
+      },
+      "totalWorkItems": 25,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 19,
+      "batchId": "batch-02",
+      "sourceTemplateId": "12978732",
+      "sourceName": "Ext. Finishes - Manuf. Gutters",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12978732",
+      "temporaryBuildertrendTargetName": "BT Ext. Finishes - Manuf. Gutters",
+      "moduleCounts": {
+        "tasks": 17,
+        "bidPackages": 1,
+        "scheduleItems": 2,
+        "selections": 2
+      },
+      "totalWorkItems": 22,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 20,
+      "batchId": "batch-02",
+      "sourceTemplateId": "12858966",
+      "sourceName": "Concrete - Piers Assembly",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12858966",
+      "temporaryBuildertrendTargetName": "BT Concrete - Piers Assembly",
+      "moduleCounts": {
+        "tasks": 16,
+        "scheduleItems": 5
+      },
+      "totalWorkItems": 21,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 21,
+      "batchId": "batch-02",
+      "sourceTemplateId": "12649292",
+      "sourceName": "Framing - Exterior Wall Assembly",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12649292",
+      "temporaryBuildertrendTargetName": "BT Framing - Exterior Wall Assembly",
+      "moduleCounts": {
+        "tasks": 16,
+        "scheduleItems": 2
+      },
+      "totalWorkItems": 18,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 22,
+      "batchId": "batch-02",
+      "sourceTemplateId": "12650557",
+      "sourceName": "Earthwork - Post-Frost Wall Earthwork",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12650557",
+      "temporaryBuildertrendTargetName": "BT Earthwork - Post-Frost Wall Earthwork",
+      "moduleCounts": {
+        "tasks": 12,
+        "bidPackages": 1,
+        "scheduleItems": 4
+      },
+      "totalWorkItems": 17,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 23,
+      "batchId": "batch-02",
+      "sourceTemplateId": "30919251",
+      "sourceName": "Framing - Overhead Door Installation",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/30919251",
+      "temporaryBuildertrendTargetName": "BT Framing - Overhead Door Installation",
+      "moduleCounts": {
+        "tasks": 13,
+        "bidPackages": 1,
+        "scheduleItems": 2,
+        "selections": 1
+      },
+      "totalWorkItems": 17,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 24,
+      "batchId": "batch-02",
+      "sourceTemplateId": "12650484",
+      "sourceName": "Framing - Exterior Man Door Installation",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12650484",
+      "temporaryBuildertrendTargetName": "BT Framing - Exterior Man Door Installation",
+      "moduleCounts": {
+        "tasks": 11,
+        "bidPackages": 1,
+        "scheduleItems": 2,
+        "selections": 1
+      },
+      "totalWorkItems": 15,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 25,
+      "batchId": "batch-02",
+      "sourceTemplateId": "12650395",
+      "sourceName": "MEP - Plumbing Base",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12650395",
+      "temporaryBuildertrendTargetName": "BT MEP - Plumbing Base",
+      "moduleCounts": {
+        "tasks": 9,
+        "bidPackages": 1,
+        "scheduleItems": 4
+      },
+      "totalWorkItems": 14,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 26,
+      "batchId": "batch-02",
+      "sourceTemplateId": "12650713",
+      "sourceName": "Framing - Stair Installation",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12650713",
+      "temporaryBuildertrendTargetName": "BT Framing - Stair Installation",
+      "moduleCounts": {
+        "tasks": 10,
+        "scheduleItems": 3
+      },
+      "totalWorkItems": 13,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 27,
+      "batchId": "batch-02",
+      "sourceTemplateId": "28466146",
+      "sourceName": "Int. Finishes - Interior Doors",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/28466146",
+      "temporaryBuildertrendTargetName": "BT Int. Finishes - Interior Doors",
+      "moduleCounts": {
+        "tasks": 5,
+        "scheduleItems": 3,
+        "selections": 4
+      },
+      "totalWorkItems": 12,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 28,
+      "batchId": "batch-02",
+      "sourceTemplateId": "12979213",
+      "sourceName": "Int. Finishes - Stain & Seal Concrete Floors",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12979213",
+      "temporaryBuildertrendTargetName": "BT Int. Finishes - Stain & Seal Concrete Floors",
+      "moduleCounts": {
+        "tasks": 7,
+        "scheduleItems": 5
+      },
+      "totalWorkItems": 12,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 29,
+      "batchId": "batch-02",
+      "sourceTemplateId": "13001090",
+      "sourceName": "Earthwork - Perimeter Drain",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/13001090",
+      "temporaryBuildertrendTargetName": "BT Earthwork - Perimeter Drain",
+      "moduleCounts": {
+        "tasks": 4,
+        "scheduleItems": 3
+      },
+      "totalWorkItems": 7,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 30,
+      "batchId": "batch-02",
+      "sourceTemplateId": "12978590",
+      "sourceName": "Framing - Rough inspection w/ Draft & Firestop",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/12978590",
+      "temporaryBuildertrendTargetName": "BT Framing - Rough inspection w/ Draft & Firestop",
+      "moduleCounts": {
+        "tasks": 3,
+        "scheduleItems": 2
+      },
+      "totalWorkItems": 5,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 31,
+      "batchId": "batch-03",
+      "sourceTemplateId": "36619183",
+      "sourceName": "Int. Finishes - Painting/Staining",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/36619183",
+      "temporaryBuildertrendTargetName": "BT Int. Finishes - Painting/Staining",
+      "moduleCounts": {
+        "bidPackages": 1,
+        "selections": 8
+      },
+      "totalWorkItems": 9,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 32,
+      "batchId": "batch-03",
+      "sourceTemplateId": "38452172",
+      "sourceName": "Int. Finishes - Flooring",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/38452172",
+      "temporaryBuildertrendTargetName": "BT Int. Finishes - Flooring",
+      "moduleCounts": {
+        "bidPackages": 1,
+        "selections": 3
+      },
+      "totalWorkItems": 4,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 33,
+      "batchId": "batch-03",
+      "sourceTemplateId": "36618977",
+      "sourceName": "Ext. Finishes - Painting/Staining",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/36618977",
+      "temporaryBuildertrendTargetName": "BT Ext. Finishes - Painting/Staining",
+      "moduleCounts": {
+        "bidPackages": 1,
+        "selections": 2
+      },
+      "totalWorkItems": 3,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 34,
+      "batchId": "batch-03",
+      "sourceTemplateId": "36478698",
+      "sourceName": "Framing - Quote Packages",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/36478698",
+      "temporaryBuildertrendTargetName": "BT Framing - Quote Packages",
+      "moduleCounts": {
+        "bidPackages": 3
+      },
+      "totalWorkItems": 3,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 35,
+      "batchId": "batch-03",
+      "sourceTemplateId": "36595931",
+      "sourceName": "MEP - Quotes",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/36595931",
+      "temporaryBuildertrendTargetName": "BT MEP - Quotes",
+      "moduleCounts": {
+        "bidPackages": 3
+      },
+      "totalWorkItems": 3,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 36,
+      "batchId": "batch-03",
+      "sourceTemplateId": "37180847",
+      "sourceName": "Ext. Finishes - Stone",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/37180847",
+      "temporaryBuildertrendTargetName": "BT Ext. Finishes - Stone",
+      "moduleCounts": {
+        "selections": 2
+      },
+      "totalWorkItems": 2,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 37,
+      "batchId": "batch-03",
+      "sourceTemplateId": "42924180",
+      "sourceName": "Earthwork - Radon Systems",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/42924180",
+      "temporaryBuildertrendTargetName": "BT Earthwork - Radon Systems",
+      "moduleCounts": {
+        "bidPackages": 1
+      },
+      "totalWorkItems": 1,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 38,
+      "batchId": "batch-03",
+      "sourceTemplateId": "39644707",
+      "sourceName": "Insulation",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/39644707",
+      "temporaryBuildertrendTargetName": "BT Insulation",
+      "moduleCounts": {
+        "bidPackages": 1
+      },
+      "totalWorkItems": 1,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 39,
+      "batchId": "batch-03",
+      "sourceTemplateId": "42948499",
+      "sourceName": "Int. Finishes - Bath Hardware",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/42948499",
+      "temporaryBuildertrendTargetName": "BT Int. Finishes - Bath Hardware",
+      "moduleCounts": {
+        "selections": 1
+      },
+      "totalWorkItems": 1,
+      "status": "pending",
+      "exceptions": []
+    },
+    {
+      "sequence": 40,
+      "batchId": "batch-03",
+      "sourceTemplateId": "38452532",
+      "sourceName": "MEP - Fireplace Installation",
+      "sourceUrl": "https://buildertrend.net/app/Templates/MyTemplates/Template/38452532",
+      "temporaryBuildertrendTargetName": "BT MEP - Fireplace Installation",
+      "moduleCounts": {
+        "selections": 1
+      },
+      "totalWorkItems": 1,
+      "status": "pending",
+      "exceptions": []
+    }
+  ]
+}

--- a/scripts/fixtures/buildertrend-template-content-fragments/README.md
+++ b/scripts/fixtures/buildertrend-template-content-fragments/README.md
@@ -1,0 +1,55 @@
+# Buildertrend pilot content fragments
+
+Place reviewed browser-capture JSON fragments here, one file per template or module. The assembler accepts:
+
+- a raw template object;
+- `{ "template": { ... }, "conversionExceptions": [] }`; or
+- a capture envelope with `templates` and `conversionExceptions` arrays.
+
+Fragments may split a template across modules. Repeating the same module is accepted only when its JSON is identical; conflicting duplicates stop assembly. Never add placeholder rows to satisfy a count.
+
+The reviewed six-template module counts are:
+
+| Source ID | Template | Tasks | Schedule | Selections | Bid packages |
+| --- | --- | ---: | ---: | ---: | ---: |
+| `30294726` | Drywall Installation | 28 | 8 | 3 | 1 |
+| `12978716` | Ext. Finishes - Roofing | 14 | 2 | 103 | 1 |
+| `32043577` | Design & Preconstruction | 48 | 34 | 0 | 0 |
+| `12667545` | Concrete - LiteDeck Assembly | 50 | 15 | 0 | 0 |
+| `12540389` | Concrete - ICF Assembly | 59 | 5 | 0 | 0 |
+| `30907034` | Int. Finishes - Cabinetry/Countertops | 50 | 6 | 4 | 2 |
+
+Schedule rows and dependencies come from the already reviewed 40-template capture. The assembler embeds the exact dependency edges in each successor's `predecessors` array.
+
+During capture, use `--allow-incomplete` to obtain a missing-module report:
+
+```bash
+bun scripts/assemble-buildertrend-template-content-pilot.mjs \
+  --manifest scripts/fixtures/buildertrend-template-pilot-2026-08-03.json \
+  --reviewed-capture scripts/fixtures/buildertrend-active-template-capture-2026-07-31.json \
+  --base scripts/fixtures/buildertrend-template-content-pilot-2026-08-03.json \
+  --fragments scripts/fixtures/buildertrend-template-content-fragments \
+  --check --allow-incomplete
+```
+
+Before import, omit `--allow-incomplete`. That strict check requires all six identities and every exact module count, rejects duplicate source IDs, and rejects non-pilot or archived templates.
+
+For the final reviewed artifact, write both the six-template content capture and
+its exact six-template inventory. Those paired files can be passed directly to
+the content SQL builder after the full 40-template inventory has already been
+imported:
+
+```bash
+bun scripts/assemble-buildertrend-template-content-pilot.mjs \
+  --manifest scripts/fixtures/buildertrend-template-pilot-2026-08-03.json \
+  --reviewed-capture scripts/fixtures/buildertrend-active-template-capture-2026-07-31.json \
+  --base scripts/fixtures/buildertrend-template-content-pilot-2026-08-03.json \
+  --fragments scripts/fixtures/buildertrend-template-content-fragments \
+  --output <six-template-content.json> \
+  --inventory-output <six-template-inventory.json>
+
+bun scripts/build-buildertrend-template-content-sql.mjs \
+  --inventory <six-template-inventory.json> \
+  --capture <six-template-content.json> \
+  --output <reviewed-content-import.sql>
+```

--- a/scripts/fixtures/buildertrend-template-content-fragments/remaining-five-reviewed.json
+++ b/scripts/fixtures/buildertrend-template-content-fragments/remaining-five-reviewed.json
@@ -1,0 +1,17139 @@
+{
+  "templates": [
+    {
+      "sourceTemplateId": "12978716",
+      "name": "Ext. Finishes - Roofing",
+      "sourceName": "Ext. Finishes - Roofing",
+      "provenance": {
+        "copiedTargetTemplateId": "45876908",
+        "taskIdentity": "sourceItemId values are deterministic capture IDs because Buildertrend did not expose native task IDs."
+      },
+      "tasks": [
+        {
+          "sourceItemId": "45876908:task:001",
+          "parentSourceItemId": null,
+          "title": "(TYPE) Roofing Complete",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876908:task:002",
+          "parentSourceItemId": null,
+          "title": "HPS Roofing QC Inspection",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876908:task:003",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "Roof Does Not Leak",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876908:task:004",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "Chimney Flashing Does Not Leak",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876908:task:005",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "No Shingles Blown Off",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876908:task:006",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "Shingle Colors Match",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876908:task:007",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "No Broken Shingles",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876908:task:008",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "No Standing Water On Flat Roof",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876908:task:009",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "No Moss/Fungus on Wood Shake Shingles",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876908:task:010",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "Skylights Do Not Leak",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876908:task:011",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "Ridges of Roof Decking Do Not Show thru Roof",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876908:task:012",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "Flashing/Valleys Do Not Leak",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876908:task:013",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "Jobsite Cleanup Satisfactory",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876908:task:014",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "OK to Pay",
+          "sortOrder": 12
+        }
+      ],
+      "selections": [
+        {
+          "sourceItemId": "63614593",
+          "sourceSelectionId": "63614593",
+          "title": "HR3 High Rib Roof  - Impower Series 26ga. Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587877",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587882",
+              "title": "Imperial White - Interior Color",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587881",
+              "title": "Imperial White - SMP",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587878",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587883",
+              "title": "Slate Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587879",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587884",
+              "title": "Surrey Beige",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587885",
+              "title": "Warm White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587880",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614594",
+          "sourceSelectionId": "63614594",
+          "title": "Metal Sales 1.25\" Corrugated Panel 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587886",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587887",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587888",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587889",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587890",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587891",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587892",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587893",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587894",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587895",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587896",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587897",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587898",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587899",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587900",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587901",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587902",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587903",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587904",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587905",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614595",
+          "sourceSelectionId": "63614595",
+          "title": "Metal Sales 2.5\" Corrugated Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587908",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587907",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587906",
+              "title": "29 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614596",
+          "sourceSelectionId": "63614596",
+          "title": "Metal Sales 2.5\" Corrugated, 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587912",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587909",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587913",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587914",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587915",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587916",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587917",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587918",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587919",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587920",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587921",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587922",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587923",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587924",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587925",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587926",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587927",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587910",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587928",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587929",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587930",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587931",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587911",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587932",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587933",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587934",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587935",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587936",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587937",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587938",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587939",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587940",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614597",
+          "sourceSelectionId": "63614597",
+          "title": "Metal Sales 2.5\" Corrugated, 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587941",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587942",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587943",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587944",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587945",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587946",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587947",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587948",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587949",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587950",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587951",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587952",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587953",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587954",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587955",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587956",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587957",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587958",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587960",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587959",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614598",
+          "sourceSelectionId": "63614598",
+          "title": "Metal Sales 2.5\" Corrugated, 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587961",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587962",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587963",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587964",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587965",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587966",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587967",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587968",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587969",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587970",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587971",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587972",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587973",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587974",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587975",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587976",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587977",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587978",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587979",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587980",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614599",
+          "sourceSelectionId": "63614599",
+          "title": "Metal Sales 5V-Crimp 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587981",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587982",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587983",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587984",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587985",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587986",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587987",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587988",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587989",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587990",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587991",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587992",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587993",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587994",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587995",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587996",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587997",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587998",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587999",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588000",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614600",
+          "sourceSelectionId": "63614600",
+          "title": "Metal Sales 5V-Crimp Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588002",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588001",
+              "title": "29 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614601",
+          "sourceSelectionId": "63614601",
+          "title": "Metal Sales 5v-Crimp, 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588003",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588004",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588005",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588006",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588007",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588008",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588009",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588010",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588011",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588012",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588013",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588014",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588015",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588016",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588017",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588018",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588019",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588020",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588022",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588021",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614602",
+          "sourceSelectionId": "63614602",
+          "title": "Metal Sales 7/8\" Corrugated 24 Gauge Color",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588026",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588023",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588027",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588028",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588029",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588030",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588031",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588032",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588033",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588034",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588035",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588036",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588037",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588038",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588039",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588040",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588041",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588024",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588042",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588043",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588044",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588045",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588025",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588046",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588047",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588048",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588049",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588050",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588051",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588052",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588053",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588054",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614603",
+          "sourceSelectionId": "63614603",
+          "title": "Metal Sales 7/8\" Corrugated 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588055",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588056",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588057",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588058",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588059",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588060",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588061",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588062",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588063",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588064",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588065",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588066",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588067",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588068",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588069",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588070",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588071",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588072",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588074",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588073",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614604",
+          "sourceSelectionId": "63614604",
+          "title": "Metal Sales 7/8\" Corrugated Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588076",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588075",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614605",
+          "sourceSelectionId": "63614605",
+          "title": "Metal Sales Bi-Rib 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588077",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588078",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588079",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588080",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588081",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588082",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588083",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588084",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588085",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588086",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588087",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588088",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588089",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588090",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588091",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588092",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588093",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588094",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588095",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588096",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614606",
+          "sourceSelectionId": "63614606",
+          "title": "Metal Sales Box-Batten 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588100",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588097",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588101",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588102",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588103",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588104",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588105",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588106",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588107",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588108",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588109",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588110",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588111",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588112",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588113",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588114",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588115",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588098",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588116",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588117",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588118",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588119",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588099",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588120",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588121",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588122",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588123",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588124",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588125",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588126",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588127",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588128",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614607",
+          "sourceSelectionId": "63614607",
+          "title": "Metal Sales Box-Batten 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588129",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588130",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588131",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588132",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588133",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588134",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588135",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588136",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588137",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588138",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588139",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588140",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588141",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588142",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588143",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588144",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588145",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588146",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588148",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588147",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614608",
+          "sourceSelectionId": "63614608",
+          "title": "Metal Sales Box-Batten Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588149",
+              "title": "12\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588150",
+              "title": "16\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588151",
+              "title": "18\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614609",
+          "sourceSelectionId": "63614609",
+          "title": "Metal Sales Box-Batten Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588153",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588152",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614610",
+          "sourceSelectionId": "63614610",
+          "title": "Metal Sales Classic Rib 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588154",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588155",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588156",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588157",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588158",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588159",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588160",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588161",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588162",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588163",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588164",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588165",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588166",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588167",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588168",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588169",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588170",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588171",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588173",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588172",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614611",
+          "sourceSelectionId": "63614611",
+          "title": "Metal Sales Classic Rib 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588174",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588175",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588176",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588177",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588178",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588179",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588180",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588181",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588182",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588183",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588184",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588185",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588186",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588187",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588188",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588189",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588190",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588191",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588192",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588193",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614612",
+          "sourceSelectionId": "63614612",
+          "title": "Metal Sales Classic Rib Gauage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588195",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588194",
+              "title": "29 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614613",
+          "sourceSelectionId": "63614613",
+          "title": "Metal Sales Clip-Loc 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588199",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588196",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588200",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588201",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588202",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588203",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588204",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588205",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588206",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588207",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588208",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588209",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588210",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588211",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588212",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588213",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588214",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588197",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588215",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588216",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588217",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588218",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588198",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588219",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588220",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588221",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588222",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588223",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588224",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588225",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588226",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588227",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614614",
+          "sourceSelectionId": "63614614",
+          "title": "Metal Sales Clip-Loc 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588228",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588229",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588230",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588231",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588232",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588233",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588234",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588235",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588236",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588237",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588238",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588239",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588240",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588241",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588242",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588243",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588244",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588245",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588247",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588246",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614615",
+          "sourceSelectionId": "63614615",
+          "title": "Metal Sales Clip-Loc Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588249",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588248",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614616",
+          "sourceSelectionId": "63614616",
+          "title": "Metal Sales Delta Rib 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588250",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588251",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588252",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588253",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588254",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588255",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588256",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588257",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588258",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588259",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588260",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588261",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588262",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588263",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588264",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588265",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588266",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588267",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588269",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588268",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614617",
+          "sourceSelectionId": "63614617",
+          "title": "Metal Sales Delta Rib 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588270",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588271",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588272",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588273",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588274",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588275",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588276",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588277",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588278",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588279",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588280",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588281",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588282",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588283",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588284",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588285",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588286",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588287",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588288",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588289",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614618",
+          "sourceSelectionId": "63614618",
+          "title": "Metal Sales Delta Rib Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588291",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588290",
+              "title": "29 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614619",
+          "sourceSelectionId": "63614619",
+          "title": "Metal Sales DL-3 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588292",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588293",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588294",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588295",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588296",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588297",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588298",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588299",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588300",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588301",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588302",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588303",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588304",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588305",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588306",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588307",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588308",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588309",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588310",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588311",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614620",
+          "sourceSelectionId": "63614620",
+          "title": "Metal Sales IC-72 Panel 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588315",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588312",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588316",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588317",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588318",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588319",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588320",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588321",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588322",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588323",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588324",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588325",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588326",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588327",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588328",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588329",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588330",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588313",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588331",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588332",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588333",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588334",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588314",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588335",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588336",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588337",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588338",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588339",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588340",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588341",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588342",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588343",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614621",
+          "sourceSelectionId": "63614621",
+          "title": "Metal Sales Image II 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588347",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588344",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588348",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588349",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588350",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588351",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588352",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588353",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588354",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588355",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588356",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588357",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588358",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588359",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588360",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588361",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588362",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588345",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588363",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588364",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588365",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588366",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588346",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588367",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588368",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588369",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588370",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588371",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588372",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588373",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588374",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588375",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614622",
+          "sourceSelectionId": "63614622",
+          "title": "Metal Sales Image II 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588376",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588377",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588378",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588379",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588380",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588381",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588382",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588383",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588384",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588385",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588386",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588387",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588388",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588389",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588390",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588391",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588392",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588393",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588395",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588394",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614623",
+          "sourceSelectionId": "63614623",
+          "title": "Metal Sales Image II Aluminum Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588396",
+              "title": "12\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588397",
+              "title": "16\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614624",
+          "sourceSelectionId": "63614624",
+          "title": "Metal Sales Image II Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588398",
+              "title": "12\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588399",
+              "title": "16\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614625",
+          "sourceSelectionId": "63614625",
+          "title": "Metal Sales Image II Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588401",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588400",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614626",
+          "sourceSelectionId": "63614626",
+          "title": "Metal Sales Magna-Loc 180 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588405",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588402",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588406",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588407",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588408",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588409",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588410",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588411",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588412",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588413",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588414",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588415",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588416",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588417",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588418",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588419",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588420",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588403",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588421",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588422",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588423",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588424",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588404",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588425",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588426",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588427",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588428",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588429",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588430",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588431",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588432",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588433",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614627",
+          "sourceSelectionId": "63614627",
+          "title": "Metal Sales Magna-Loc 180 Alternates",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588434",
+              "title": "Metal Sales Magna-Loc 180 Aluminum",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588435",
+              "title": "Metal Sales Magna-Loc 180 Curved",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614628",
+          "sourceSelectionId": "63614628",
+          "title": "Metal Sales Magna-Loc 180 Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588436",
+              "title": "16\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588437",
+              "title": "18\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614629",
+          "sourceSelectionId": "63614629",
+          "title": "Metal Sales Magna-Loc 90 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588441",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588438",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588442",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588443",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588444",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588445",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588446",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588447",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588448",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588449",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588450",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588451",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588452",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588453",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588454",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588455",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588456",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588439",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588457",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588458",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588459",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588460",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588440",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588461",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588462",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588463",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588464",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588465",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588466",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588467",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588468",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588469",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614630",
+          "sourceSelectionId": "63614630",
+          "title": "Metal Sales Magna-Loc 90 Alternate Options",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588470",
+              "title": "Metal Sales Magna-Loc 90 Aluminum",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614631",
+          "sourceSelectionId": "63614631",
+          "title": "Metal Sales Magna-Loc 90 Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588471",
+              "title": "16\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588472",
+              "title": "18\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614632",
+          "sourceSelectionId": "63614632",
+          "title": "Metal Sales Max-Batten Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588474",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588473",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614633",
+          "sourceSelectionId": "63614633",
+          "title": "Metal Sales Maxi-Batten 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588478",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588475",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588479",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588480",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588481",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588482",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588483",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588484",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588485",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588486",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588487",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588488",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588489",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588490",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588491",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588492",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588493",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588476",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588494",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588495",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588496",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588497",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588477",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588498",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588499",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588500",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588501",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588502",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588503",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588504",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588505",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588506",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614634",
+          "sourceSelectionId": "63614634",
+          "title": "Metal Sales Maxi-Batten 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588507",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588508",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588509",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588510",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588511",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588512",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588513",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588514",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588515",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588516",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588517",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588518",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588519",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588520",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588521",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588522",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588523",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588524",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588526",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588525",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614635",
+          "sourceSelectionId": "63614635",
+          "title": "Metal Sales Maxi-Batten Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588527",
+              "title": "12\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588528",
+              "title": "16\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588529",
+              "title": "18\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614636",
+          "sourceSelectionId": "63614636",
+          "title": "Metal Sales Mini-Batten 1.5\" 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588533",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588530",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588534",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588535",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588536",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588537",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588538",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588539",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588540",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588541",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588542",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588543",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588544",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588545",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588546",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588547",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588548",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588531",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588549",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588550",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588551",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588552",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588532",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588553",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588554",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588555",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588556",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588557",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588558",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588559",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588560",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588561",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614637",
+          "sourceSelectionId": "63614637",
+          "title": "Metal Sales Mini-Batten 1.5\" 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588562",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588563",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588564",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588565",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588566",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588567",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588568",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588569",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588570",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588571",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588572",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588573",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588574",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588575",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588576",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588577",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588578",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588579",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588581",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588580",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614638",
+          "sourceSelectionId": "63614638",
+          "title": "Metal Sales Mini-Batten 1.5\" Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588583",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588582",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614639",
+          "sourceSelectionId": "63614639",
+          "title": "Metal Sales Mini-Batten Alternate Options",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588584",
+              "title": "Metal Sales Mini-Batten 1\" (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614640",
+          "sourceSelectionId": "63614640",
+          "title": "Metal Sales Mini-Batten Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588585",
+              "title": "12\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588586",
+              "title": "16\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588587",
+              "title": "18\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614641",
+          "sourceSelectionId": "63614641",
+          "title": "Metal Sales PBR-Panel 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588591",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588588",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588592",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588593",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588594",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588595",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588596",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588597",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588598",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588599",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588600",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588601",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588602",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588603",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588604",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588605",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588606",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588589",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588607",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588608",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588609",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588610",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588590",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588611",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588612",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588613",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588614",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588615",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588616",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588617",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588618",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588619",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614642",
+          "sourceSelectionId": "63614642",
+          "title": "Metal Sales PBR-Panel 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588620",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588621",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588622",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588623",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588624",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588625",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588626",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588627",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588628",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588629",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588630",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588631",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588632",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588633",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588634",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588635",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588636",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588637",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588639",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588638",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614643",
+          "sourceSelectionId": "63614643",
+          "title": "Metal Sales PBR-Panel Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588641",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588640",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614644",
+          "sourceSelectionId": "63614644",
+          "title": "Metal Sales PBU-Panel 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588645",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588642",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588646",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588647",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588648",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588649",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588650",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588651",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588652",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588653",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588654",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588655",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588656",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588657",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588658",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588659",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588660",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588643",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588661",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588662",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588663",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588664",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588644",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588665",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588666",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588667",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588668",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588669",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588670",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588671",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588672",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588673",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614645",
+          "sourceSelectionId": "63614645",
+          "title": "Metal Sales PBU-Panel 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588674",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588675",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588676",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588677",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588678",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588679",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588680",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588681",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588682",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588683",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588684",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588685",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588686",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588687",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588688",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588689",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588690",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588691",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588693",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588692",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614646",
+          "sourceSelectionId": "63614646",
+          "title": "Metal Sales PBU-Panel Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588695",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588694",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614647",
+          "sourceSelectionId": "63614647",
+          "title": "Metal Sales Pro-Panel II 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588696",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588697",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588698",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588699",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588700",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588701",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588702",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588703",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588704",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588705",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588706",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588707",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588708",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588709",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588710",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588711",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588712",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588713",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588715",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588714",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614648",
+          "sourceSelectionId": "63614648",
+          "title": "Metal Sales Pro-Panel II 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588716",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588717",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588718",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588719",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588720",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588721",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588722",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588723",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588724",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588725",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588726",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588727",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588728",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588729",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588730",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588731",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588732",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588733",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588734",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588735",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614649",
+          "sourceSelectionId": "63614649",
+          "title": "Metal Sales Pro-Panel II Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588737",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588736",
+              "title": "29 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614650",
+          "sourceSelectionId": "63614650",
+          "title": "Metal Sales R-Panel 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588738",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588739",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588740",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588741",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588742",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588743",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588744",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588745",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588746",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588747",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588748",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588749",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588750",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588751",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588752",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588753",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588754",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588755",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588757",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588756",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614651",
+          "sourceSelectionId": "63614651",
+          "title": "Metal Sales R-Panel 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588758",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588759",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588760",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588761",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588762",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588763",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588764",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588765",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588766",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588767",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588768",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588769",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588770",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588771",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588772",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588773",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588774",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588775",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588776",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588777",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614652",
+          "sourceSelectionId": "63614652",
+          "title": "Metal Sales R-Panel Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588779",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588778",
+              "title": "29 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614653",
+          "sourceSelectionId": "63614653",
+          "title": "Metal Sales Seam-Loc 24 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588783",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588780",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588784",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588785",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588786",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588787",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588788",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588789",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588790",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588791",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588792",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588793",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588794",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588795",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588796",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588797",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588798",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588781",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588799",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588800",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588801",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588802",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588782",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588803",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588804",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588805",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588806",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588807",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588808",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588809",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588810",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588811",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614654",
+          "sourceSelectionId": "63614654",
+          "title": "Metal Sales Seam-Loc 24 Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588812",
+              "title": "18\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588813",
+              "title": "24\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614655",
+          "sourceSelectionId": "63614655",
+          "title": "Metal Sales Snap-Loc 24 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588817",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588814",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588818",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588819",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588820",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588821",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588822",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588823",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588824",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588825",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588826",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588827",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588828",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588829",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588830",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588831",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588832",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588815",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588833",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588834",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588835",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588836",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588816",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588837",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588838",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588839",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588840",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588841",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588842",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588843",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588844",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588845",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614656",
+          "sourceSelectionId": "63614656",
+          "title": "Metal Sales Strongpanel 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588846",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588847",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588848",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588849",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588850",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588851",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588852",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588853",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588854",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588855",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588856",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588857",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588858",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588859",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588860",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588861",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588862",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588863",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588864",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588865",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614657",
+          "sourceSelectionId": "63614657",
+          "title": "Metal Sales T-Armor Series 2-3/8\" 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588869",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588866",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588870",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588871",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588872",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588873",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588874",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588875",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588876",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588877",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588878",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588879",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588880",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588881",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588882",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588883",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588884",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588867",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588885",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588886",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588887",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588888",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588868",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588889",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588890",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588891",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588892",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588893",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588894",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588895",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588896",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588897",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614658",
+          "sourceSelectionId": "63614658",
+          "title": "Metal Sales T-Armor Series 2-3/8\" Alternate Option",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588898",
+              "title": "Metal Sales T-Armor Series 2-3/8\" Aluminum",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588899",
+              "title": "Metal Sales T-Armor Series 3\"",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588900",
+              "title": "Metal Sales T-Armor Series 3\" Aluminum",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614659",
+          "sourceSelectionId": "63614659",
+          "title": "Metal Sales T1 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588904",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588901",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588905",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588906",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588907",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588908",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588909",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588910",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588911",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588912",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588913",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588914",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588915",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588916",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588917",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588918",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588919",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588902",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588920",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588921",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588922",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588923",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588903",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588924",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588925",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588926",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588927",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588928",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588929",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588930",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588931",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588932",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614660",
+          "sourceSelectionId": "63614660",
+          "title": "Metal Sales T11A - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588936",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588933",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588937",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588938",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588939",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588940",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588941",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588942",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588943",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588944",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588945",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588946",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588947",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588948",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588949",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588950",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588951",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588934",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588952",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588953",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588954",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588955",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588935",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588956",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588957",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588958",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588959",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588960",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588961",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588962",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588963",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588964",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614661",
+          "sourceSelectionId": "63614661",
+          "title": "Metal Sales T12 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588968",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588965",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588969",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588970",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588971",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588972",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588973",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588974",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588975",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588976",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588977",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588978",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588979",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588980",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588981",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588982",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588983",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588966",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588984",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588985",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588986",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588987",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588967",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588988",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588989",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588990",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588991",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588992",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588993",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588994",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588995",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588996",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614662",
+          "sourceSelectionId": "63614662",
+          "title": "Metal Sales T13 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589000",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588997",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589001",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589002",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589003",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589004",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589005",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589006",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589007",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589008",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589009",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589010",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589011",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589012",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589013",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589014",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589015",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588998",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589016",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589017",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589018",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589019",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588999",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589020",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589021",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589022",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589023",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589024",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589025",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589026",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589027",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589028",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614663",
+          "sourceSelectionId": "63614663",
+          "title": "Metal Sales T13-A 24 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589032",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589029",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589033",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589034",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589035",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589036",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589037",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589038",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589039",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589040",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589041",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589042",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589043",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589044",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589045",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589046",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589047",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589030",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589048",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589049",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589050",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589051",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589031",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589052",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589053",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589054",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589055",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589056",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589057",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589058",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589059",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589060",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614664",
+          "sourceSelectionId": "63614664",
+          "title": "Metal Sales T13-B - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589064",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589061",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589065",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589066",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589067",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589068",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589069",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589070",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589071",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589072",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589073",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589074",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589075",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589076",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589077",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589078",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589079",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589062",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589080",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589081",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589082",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589083",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589063",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589084",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589085",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589086",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589087",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589088",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589089",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589090",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589091",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589092",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614665",
+          "sourceSelectionId": "63614665",
+          "title": "Metal Sales T14 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589096",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589093",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589097",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589098",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589099",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589100",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589101",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589102",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589103",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589104",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589105",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589106",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589107",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589108",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589109",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589110",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589111",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589094",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589112",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589113",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589114",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589115",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589095",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589116",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589117",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589118",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589119",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589120",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589121",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589122",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589123",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589124",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614666",
+          "sourceSelectionId": "63614666",
+          "title": "Metal Sales T15 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589128",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589125",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589129",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589130",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589131",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589132",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589133",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589134",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589135",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589136",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589137",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589138",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589139",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589140",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589141",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589142",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589143",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589126",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589144",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589145",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589146",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589147",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589127",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589148",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589149",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589150",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589151",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589152",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589153",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589154",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589155",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589156",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614667",
+          "sourceSelectionId": "63614667",
+          "title": "Metal Sales T16-E - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589160",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589157",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589161",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589162",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589163",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589164",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589165",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589166",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589167",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589168",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589169",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589170",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589171",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589172",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589173",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589174",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589175",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589158",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589176",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589177",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589178",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589179",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589159",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589180",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589181",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589182",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589183",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589184",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589185",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589186",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589187",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589188",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614668",
+          "sourceSelectionId": "63614668",
+          "title": "Metal Sales T2 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589192",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589189",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589193",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589194",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589195",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589196",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589197",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589198",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589199",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589200",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589201",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589202",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589203",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589204",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589205",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589206",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589207",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589190",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589208",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589209",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589210",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589211",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589191",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589212",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589213",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589214",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589215",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589216",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589217",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589218",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589219",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589220",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614669",
+          "sourceSelectionId": "63614669",
+          "title": "Metal Sales T23 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589224",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589221",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589225",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589226",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589227",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589228",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589229",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589230",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589231",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589232",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589233",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589234",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589235",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589236",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589237",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589238",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589239",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589222",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589240",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589241",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589242",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589243",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589223",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589244",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589245",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589246",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589247",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589248",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589249",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589250",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589251",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589252",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614670",
+          "sourceSelectionId": "63614670",
+          "title": "Metal Sales T25 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589256",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589253",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589257",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589258",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589259",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589260",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589261",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589262",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589263",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589264",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589265",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589266",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589267",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589268",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589269",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589270",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589271",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589254",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589272",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589273",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589274",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589275",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589255",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589276",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589277",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589278",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589279",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589280",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589281",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589282",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589283",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589284",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614671",
+          "sourceSelectionId": "63614671",
+          "title": "Metal Sales T2630 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589288",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589285",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589289",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589290",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589291",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589292",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589293",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589294",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589295",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589296",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589297",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589298",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589299",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589300",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589301",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589302",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589303",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589286",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589304",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589305",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589306",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589307",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589287",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589308",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589309",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589310",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589311",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589312",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589313",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589314",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589315",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589316",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614672",
+          "sourceSelectionId": "63614672",
+          "title": "Metal Sales T2832 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589320",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589317",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589321",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589322",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589323",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589324",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589325",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589326",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589327",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589328",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589329",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589330",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589331",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589332",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589333",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589334",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589335",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589318",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589336",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589337",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589338",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589339",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589319",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589340",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589341",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589342",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589343",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589344",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589345",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589346",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589347",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589348",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614673",
+          "sourceSelectionId": "63614673",
+          "title": "Metal Sales T3 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589352",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589349",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589353",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589354",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589355",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589356",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589357",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589358",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589359",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589360",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589361",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589362",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589363",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589364",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589365",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589366",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589367",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589350",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589368",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589369",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589370",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589371",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589351",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589372",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589373",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589374",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589375",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589376",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589377",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589378",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589379",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589380",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614674",
+          "sourceSelectionId": "63614674",
+          "title": "Metal Sales T4 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589384",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589381",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589385",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589386",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589387",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589388",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589389",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589390",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589391",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589392",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589393",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589394",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589395",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589396",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589397",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589398",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589399",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589382",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589400",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589401",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589402",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589403",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589383",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589404",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589405",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589406",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589407",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589408",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589409",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589410",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589411",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589412",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614675",
+          "sourceSelectionId": "63614675",
+          "title": "Metal Sales T5 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589416",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589413",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589417",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589418",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589419",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589420",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589421",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589422",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589423",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589424",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589425",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589426",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589427",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589428",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589429",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589430",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589431",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589414",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589432",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589433",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589434",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589435",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589415",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589436",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589437",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589438",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589439",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589440",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589441",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589442",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589443",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589444",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614676",
+          "sourceSelectionId": "63614676",
+          "title": "Metal Sales T6-A - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589448",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589445",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589449",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589450",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589451",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589452",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589453",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589454",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589455",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589456",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589457",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589458",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589459",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589460",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589461",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589462",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589463",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589446",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589464",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589465",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589466",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589467",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589447",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589468",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589469",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589470",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589471",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589472",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589473",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589474",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589475",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589476",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614677",
+          "sourceSelectionId": "63614677",
+          "title": "Metal Sales T7 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589480",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589477",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589481",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589482",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589483",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589484",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589485",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589486",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589487",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589488",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589489",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589490",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589491",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589492",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589493",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589494",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589495",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589478",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589496",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589497",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589498",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589499",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589479",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589500",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589501",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589502",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589503",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589504",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589505",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589506",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589507",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589508",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614678",
+          "sourceSelectionId": "63614678",
+          "title": "Metal Sales T7-A - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589512",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589509",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589513",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589514",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589515",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589516",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589517",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589518",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589519",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589520",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589521",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589522",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589523",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589524",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589525",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589526",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589527",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589510",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589528",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589529",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589530",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589531",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589511",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589532",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589533",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589534",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589535",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589536",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589537",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589538",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589539",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589540",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614679",
+          "sourceSelectionId": "63614679",
+          "title": "Metal Sales TDR-6 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589544",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589541",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589545",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589546",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589547",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589548",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589549",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589550",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589551",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589552",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589553",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589554",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589555",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589556",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589557",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589558",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589559",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589542",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589560",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589561",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589562",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589563",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589543",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589564",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589565",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589566",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589567",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589568",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589569",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589570",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589571",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589572",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614680",
+          "sourceSelectionId": "63614680",
+          "title": "Metal Sales U-Panel 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589576",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589573",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589577",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589578",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589579",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589580",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589581",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589582",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589583",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589584",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589585",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589586",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589587",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589588",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589589",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589590",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589591",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589574",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589592",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589593",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589594",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589595",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589575",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589596",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589597",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589598",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589599",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589600",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589601",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589602",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589603",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589604",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614681",
+          "sourceSelectionId": "63614681",
+          "title": "Metal Sales U-Panel 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589605",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589606",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589607",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589608",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589609",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589610",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589611",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589612",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589613",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589614",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589615",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589616",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589617",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589618",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589619",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589620",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589621",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589622",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589624",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589623",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614682",
+          "sourceSelectionId": "63614682",
+          "title": "Metal Sales U-Panel 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589625",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589626",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589627",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589628",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589629",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589630",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589631",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589632",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589633",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589634",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589635",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589636",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589637",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589638",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589639",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589640",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589641",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589642",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589643",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589644",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614683",
+          "sourceSelectionId": "63614683",
+          "title": "Metal Sales U-Panel Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589647",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589646",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589645",
+              "title": "29 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614684",
+          "sourceSelectionId": "63614684",
+          "title": "Metal Sales V-Line 32 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589651",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589648",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589652",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589653",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589654",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589655",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589656",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589657",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589658",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589659",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589660",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589661",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589662",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589663",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589664",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589665",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589666",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589649",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589667",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589668",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589669",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589670",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589650",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589671",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589672",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589673",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589674",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589675",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589676",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589677",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589678",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589679",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614685",
+          "sourceSelectionId": "63614685",
+          "title": "Metal Sales V-Line 32 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589680",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589681",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589682",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589683",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589684",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589685",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589686",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589687",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589688",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589689",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589690",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589691",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589692",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589693",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589694",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589695",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589696",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589697",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589699",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589698",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614686",
+          "sourceSelectionId": "63614686",
+          "title": "Metal Sales V-Line 32 Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589701",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589700",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614687",
+          "sourceSelectionId": "63614687",
+          "title": "Metal Sales Vertical Seam 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589705",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589702",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589706",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589707",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589708",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589709",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589710",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589711",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589712",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589713",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589714",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589715",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589716",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589717",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589718",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589719",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589720",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589703",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589721",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589722",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589723",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589724",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589704",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589725",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589726",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589727",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589728",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589729",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589730",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589731",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589732",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589733",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614688",
+          "sourceSelectionId": "63614688",
+          "title": "Metal Sales Vertical Seam 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589734",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589735",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589736",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589737",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589738",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589739",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589740",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589741",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589742",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589743",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589744",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589745",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589746",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589747",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589748",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589749",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589750",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589751",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589753",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589752",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614689",
+          "sourceSelectionId": "63614689",
+          "title": "Metal Sales Vertical Seam Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589754",
+              "title": "12\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589755",
+              "title": "16\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589756",
+              "title": "18\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614690",
+          "sourceSelectionId": "63614690",
+          "title": "Metal Sales Vertical Seam Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589758",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589757",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614589",
+          "sourceSelectionId": "63614589",
+          "title": "Roof Material",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587850",
+              "title": "Asphalt Shingles",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587853",
+              "title": "Metal Roofing",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587852",
+              "title": "Slate Roofing",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587851",
+              "title": "Tile Roofing",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614691",
+          "sourceSelectionId": "63614691",
+          "title": "Roof Panel Profile",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589759",
+              "title": "Metal Sales 1.25\" Corrugated (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589760",
+              "title": "Metal Sales 2.5\" Corrugated (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589761",
+              "title": "Metal Sales 5V-Rib (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589762",
+              "title": "Metal Sales 7/8\" Corrugated (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589763",
+              "title": "Metal Sales Bi-Rib (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589797",
+              "title": "Metal Sales Box-Batten (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589764",
+              "title": "Metal Sales Classic Rib (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589798",
+              "title": "Metal Sales Clip-Loc (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589765",
+              "title": "Metal Sales Delta Rib (Exposed Rib)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589766",
+              "title": "Metal Sales DL-3 Panel (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589767",
+              "title": "Metal Sales HR3 High Rib Roof - Impower Series",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589768",
+              "title": "Metal Sales IC72-Panel (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589799",
+              "title": "Metal Sales Image II (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589800",
+              "title": "Metal Sales Image II Aluminum (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589801",
+              "title": "Metal Sales Magna-Loc 180 (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589802",
+              "title": "Metal Sales Magna-Loc 90 (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589803",
+              "title": "Metal Sales Maxi-Batten (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589804",
+              "title": "Metal Sales Mini-Batten 1.5\" (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589769",
+              "title": "Metal Sales PBR-Panel (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589770",
+              "title": "Metal Sales PBU-Panel (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589771",
+              "title": "Metal Sales Pro-Panel II (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589772",
+              "title": "Metal Sales R-Panel (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589805",
+              "title": "Metal Sales Seam-Loc 24 (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589806",
+              "title": "Metal Sales Snap-Loc 24 (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589773",
+              "title": "Metal Sales Strongpanel (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589774",
+              "title": "Metal Sales T1 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589775",
+              "title": "Metal Sales T11A- Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589776",
+              "title": "Metal Sales T12 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589777",
+              "title": "Metal Sales T-13 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589778",
+              "title": "Metal Sales T13-A - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589779",
+              "title": "Metal Sales T13-B - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589780",
+              "title": "Metal Sales T14 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589781",
+              "title": "Metal Sales T15 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589782",
+              "title": "Metal Sales T16-E - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589783",
+              "title": "Metal Sales T2 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589784",
+              "title": "Metal Sales T23 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589785",
+              "title": "Metal Sales T25 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589786",
+              "title": "Metal Sales T2630 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589787",
+              "title": "Metal Sales T2832 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589788",
+              "title": "Metal Sales T3 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589789",
+              "title": "Metal Sales T4 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589790",
+              "title": "Metal Sales T5 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589791",
+              "title": "Metal Sales T6-A - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589792",
+              "title": "Metal Sales T7 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589793",
+              "title": "Metal Sales T7A - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589807",
+              "title": "Metal Sales T-Armor Series 2-3/8\" Concealed Fasten",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589794",
+              "title": "Metal Sales TDR-6 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589795",
+              "title": "Metal Sales U-Panel (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589808",
+              "title": "Metal Sales Vertical Seam (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589796",
+              "title": "Metal Sales V-Line 32 (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614590",
+          "sourceSelectionId": "63614590",
+          "title": "Impact Rating",
+          "category": "07 31 13 - Asphalt Shingles",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587854",
+              "title": "Owens Corning Duration",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587855",
+              "title": "Owens Corning Duration Storm",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614591",
+          "sourceSelectionId": "63614591",
+          "title": "Shingle Color",
+          "category": "07 31 13 - Asphalt Shingles",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587861",
+              "title": "Antique Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587856",
+              "title": "Brownwood",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587862",
+              "title": "Desert Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587857",
+              "title": "Driftwood",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587858",
+              "title": "Estate Gray",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587859",
+              "title": "Onyx Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587860",
+              "title": "Teak",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614592",
+          "sourceSelectionId": "63614592",
+          "title": "Shingle Colors",
+          "category": "07 31 13 - Asphalt Shingles",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587864",
+              "title": "Brownwood",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587865",
+              "title": "Chateau Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587863",
+              "title": "Desert Rose",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587866",
+              "title": "Driftwood",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587867",
+              "title": "Estate Gray",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587868",
+              "title": "Midnight Plum",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587869",
+              "title": "Onyx Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587870",
+              "title": "Peppercorn",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587871",
+              "title": "Sandcastle",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587872",
+              "title": "Sierra Gray",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587873",
+              "title": "Slatestone Gray",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587874",
+              "title": "Teak",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587875",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587876",
+              "title": "Williamsburg Gray",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        }
+      ],
+      "bidPackages": [
+        {
+          "sourceItemId": "13408751",
+          "sourceBidPackageId": "13408751",
+          "title": "Roofing - (Project Address) (Estimate Phase)",
+          "status": "Draft",
+          "allowMultipleApprovedBids": false,
+          "deadline": null,
+          "time": null,
+          "reminderLeadDays": 2,
+          "plansAndSpecs": false,
+          "pricingFormat": "Line Items",
+          "description": "Background\nHigh Performance Structures, Inc. dba Open Range Construction, Ltd. (ORC) will be building a custom home located at:\n(Project Street Address)\n(Project City), (Project State) (Project Zip Code)\nReference Documents\nPlease see the Buildertrend Documents folder titled \"(Estimate Phase) Bid Set\" for all necessary plans.\nSubmission of Bid\nBids for this project will be processed through Buildertrend, a construction management program. You do not need to become proficient with Buildertrend. You may also simply call or email your point of contact. You may submit your bid into Buildertrend or email it to your point of contact for entry. Should you choose to input your bid into Buildertrend, please also include a PDF version of your bid.\nFor assistance with submitting the bid or receiving bid documents, contact the (Estimator Title):\n(Estimator Name), (719) 900-8850 ext. (Estimator Extension)\n(Estimator Email Address)\nTimeline\nThe work is scheduled to start in (Build Season), (Build Year).\nScope of Work\nThe following CSI categories will be required for the construction of the project per the plans and specifications noted on the Plans and Specifications List. We will notify bidders of any changes or additions by sending out updates to said List.\nQuestions\nPlease direct any questions into the RFI section here on Buildertrend. This helps us as a builder keep questions organized and accessible to any of our staff provided an estimator is absent. This will help expedite provision of answers.\nSchedule\nPlease provide a schedule to complete each of the above items, in calendar days after the issuance of the purchase order and/or notice to proceed.\nContract and Insurance Requirements\nAll trade contractors will be required to complete a trade contractor agreement, provide proof of liability insurance and workman’s compensation insurance as applicable, with required limits prior to the release of any construction payments.",
+          "descriptionSections": [
+            "Background",
+            "High Performance Structures, Inc. dba Open Range Construction, Ltd. (ORC) will be building a custom home located at:",
+            "(Project Street Address)",
+            "(Project City), (Project State) (Project Zip Code)",
+            "Reference Documents",
+            "Please see the Buildertrend Documents folder titled \"(Estimate Phase) Bid Set\" for all necessary plans.",
+            "Submission of Bid",
+            "Bids for this project will be processed through Buildertrend, a construction management program. You do not need to become proficient with Buildertrend. You may also simply call or email your point of contact. You may submit your bid into Buildertrend or email it to your point of contact for entry. Should you choose to input your bid into Buildertrend, please also include a PDF version of your bid.",
+            "For assistance with submitting the bid or receiving bid documents, contact the (Estimator Title):",
+            "(Estimator Name), (719) 900-8850 ext. (Estimator Extension)",
+            "(Estimator Email Address)",
+            "Timeline",
+            "The work is scheduled to start in (Build Season), (Build Year).",
+            "Scope of Work",
+            "The following CSI categories will be required for the construction of the project per the plans and specifications noted on the Plans and Specifications List. We will notify bidders of any changes or additions by sending out updates to said List.",
+            "Questions",
+            "Please direct any questions into the RFI section here on Buildertrend. This helps us as a builder keep questions organized and accessible to any of our staff provided an estimator is absent. This will help expedite provision of answers.",
+            "Schedule",
+            "Please provide a schedule to complete each of the above items, in calendar days after the issuance of the purchase order and/or notice to proceed.",
+            "Contract and Insurance Requirements",
+            "All trade contractors will be required to complete a trade contractor agreement, provide proof of liability insurance and workman’s compensation insurance as applicable, with required limits prior to the release of any construction payments."
+          ],
+          "internalNotes": "",
+          "attachments": [],
+          "lineItems": [
+            {
+              "title": "Asphalt Shingle Roofing Installation Labor & Materials",
+              "costCode": "07 31 13 - Asphalt Shingles",
+              "costType": "None",
+              "quantity": 1,
+              "unit": null
+            },
+            {
+              "title": "Metal Roofing & Underlayment Labor & Materials",
+              "costCode": "07 41 13 - Metal Roof Panels",
+              "costType": "None",
+              "quantity": 1,
+              "unit": null
+            }
+          ]
+        }
+      ],
+      "notCaptured": [
+        "Native Buildertrend task IDs and task descriptions",
+        "Selection attachment file names and bytes were not downloaded."
+      ]
+    },
+    {
+      "sourceTemplateId": "32043577",
+      "name": "Design & Preconstruction",
+      "sourceName": "Design & Preconstruction",
+      "provenance": {
+        "copiedTargetTemplateId": "45876671",
+        "taskIdentity": "sourceItemId values are deterministic capture IDs because Buildertrend did not expose native task IDs."
+      },
+      "tasks": [
+        {
+          "sourceItemId": "45876671:task:001",
+          "parentSourceItemId": null,
+          "title": "Full Build Final Preconstruction Estimate",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876671:task:002",
+          "parentSourceItemId": "45876671:task:001",
+          "title": "Send out RFQs",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876671:task:003",
+          "parentSourceItemId": "45876671:task:001",
+          "title": "Follow Up with RFQs If No Response after 1 Week",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876671:task:004",
+          "parentSourceItemId": "45876671:task:001",
+          "title": "Follow Up with RFQs 1 Week before Due Date",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876671:task:005",
+          "parentSourceItemId": "45876671:task:001",
+          "title": "Pull Takeoffs",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876671:task:006",
+          "parentSourceItemId": "45876671:task:001",
+          "title": "Compile Takeoff Data",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876671:task:007",
+          "parentSourceItemId": "45876671:task:001",
+          "title": "Compile All Quotes",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876671:task:008",
+          "parentSourceItemId": "45876671:task:001",
+          "title": "Finalize Estimate",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876671:task:009",
+          "parentSourceItemId": "45876671:task:001",
+          "title": "Schedule Budget Meeting",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876671:task:010",
+          "parentSourceItemId": null,
+          "title": "Pull Takeoffs",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876671:task:011",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Footing Takeoffs",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876671:task:012",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Foundation Takeoffs",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876671:task:013",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Lower Level ICF Wall Takeoffs",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876671:task:014",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Lower Level Exterior Framed Wall Takeoffs",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876671:task:015",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Lower Level Slab Takeoffs",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876671:task:016",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Lower Level Interior Wall Framing Takeoffs",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876671:task:017",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Lower Level Interior Fenestration Takeoffs",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876671:task:018",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Lower Level Exterior Fenestration Takeoffs",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876671:task:019",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Lower Level Countertop Takeoffs",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876671:task:020",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Lower Level Base & Case Takeoffs",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876671:task:021",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Main Level Floor System Takeoffs",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876671:task:022",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Main Level ICF Wall Takeoffs",
+          "sortOrder": 12
+        },
+        {
+          "sourceItemId": "45876671:task:023",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Main Level Exterior Framed Wall Takeoffs",
+          "sortOrder": 13
+        },
+        {
+          "sourceItemId": "45876671:task:024",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Main Level Interior Wall Takeoffs",
+          "sortOrder": 14
+        },
+        {
+          "sourceItemId": "45876671:task:025",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Main Level Interior Fenestration Takeoffs",
+          "sortOrder": 15
+        },
+        {
+          "sourceItemId": "45876671:task:026",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Main Level Exterior Fenestration Takeoffs",
+          "sortOrder": 16
+        },
+        {
+          "sourceItemId": "45876671:task:027",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Main Level Countertop Takeoffs",
+          "sortOrder": 17
+        },
+        {
+          "sourceItemId": "45876671:task:028",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Main Level base & Case Takeoffs",
+          "sortOrder": 18
+        },
+        {
+          "sourceItemId": "45876671:task:029",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Upper Level Floor System Takeoffs",
+          "sortOrder": 19
+        },
+        {
+          "sourceItemId": "45876671:task:030",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Upper Level ICF Wall Takeoffs",
+          "sortOrder": 20
+        },
+        {
+          "sourceItemId": "45876671:task:031",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Upper Level Exterior Framed Wall TAkeoffs",
+          "sortOrder": 21
+        },
+        {
+          "sourceItemId": "45876671:task:032",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Upper Level interior Wall Takeoffs",
+          "sortOrder": 22
+        },
+        {
+          "sourceItemId": "45876671:task:033",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Upper Level Interior Fenestration Takeoffs",
+          "sortOrder": 23
+        },
+        {
+          "sourceItemId": "45876671:task:034",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Upper Level Exterior Fenestration Takeoffs",
+          "sortOrder": 24
+        },
+        {
+          "sourceItemId": "45876671:task:035",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Upper Level Countertop Takeoffs",
+          "sortOrder": 25
+        },
+        {
+          "sourceItemId": "45876671:task:036",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Upper Level Base & Case Takeoffs",
+          "sortOrder": 26
+        },
+        {
+          "sourceItemId": "45876671:task:037",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Roof System Framing Takeoffs",
+          "sortOrder": 27
+        },
+        {
+          "sourceItemId": "45876671:task:038",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Siding Takeoffs",
+          "sortOrder": 28
+        },
+        {
+          "sourceItemId": "45876671:task:039",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Exterior Deck Takeoffs",
+          "sortOrder": 29
+        },
+        {
+          "sourceItemId": "45876671:task:040",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Exterior Piers & Pads Takeoffs",
+          "sortOrder": 30
+        },
+        {
+          "sourceItemId": "45876671:task:041",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Exterior Concrete Slab Takeoffs",
+          "sortOrder": 31
+        },
+        {
+          "sourceItemId": "45876671:task:042",
+          "parentSourceItemId": null,
+          "title": "Rough Stake of Center of House",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876671:task:043",
+          "parentSourceItemId": null,
+          "title": "Get Preapproval from Bank",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876671:task:044",
+          "parentSourceItemId": null,
+          "title": "Schedule Geotechnical Engineer for Soils Testing",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876671:task:045",
+          "parentSourceItemId": null,
+          "title": "Complete Preliminary Architectural Footprint",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876671:task:046",
+          "parentSourceItemId": null,
+          "title": "Send Preliminary Arch Floor Plan to Owners for Approval",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876671:task:047",
+          "parentSourceItemId": null,
+          "title": "Complete Architectural Revisions",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876671:task:048",
+          "parentSourceItemId": null,
+          "title": "Send Revised Architectural Floor Plan to Owners",
+          "sortOrder": 9
+        }
+      ],
+      "notCaptured": [
+        "Native Buildertrend task IDs, task descriptions, and source assignee identities."
+      ]
+    },
+    {
+      "sourceTemplateId": "12667545",
+      "name": "Concrete - LiteDeck Assembly",
+      "sourceName": "Concrete - LiteDeck Assembly",
+      "provenance": {
+        "copiedTargetTemplateId": "45876676",
+        "taskIdentity": "sourceItemId values are deterministic capture IDs because Buildertrend did not expose native task IDs."
+      },
+      "tasks": [
+        {
+          "sourceItemId": "45876676:task:001",
+          "parentSourceItemId": null,
+          "title": "Set (X LEVEL) LiteDeck Temporary Ledger Boards",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876676:task:002",
+          "parentSourceItemId": null,
+          "title": "Set (X LEVEL) 2x4 LiteDeck Temp Ledger Supports",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876676:task:003",
+          "parentSourceItemId": null,
+          "title": "Construct (X LEVEL) LiteDeck Temporary Beams",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876676:task:004",
+          "parentSourceItemId": null,
+          "title": "(X LEVEL) LiteDeck Temporary Beam Layout @ 5' O.C.",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876676:task:005",
+          "parentSourceItemId": null,
+          "title": "Set (X LEVEL) LiteDeck Temporary Beams on Layout",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876676:task:006",
+          "parentSourceItemId": null,
+          "title": "Set (X LEVEL) LiteDeck Teleposts",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876676:task:007",
+          "parentSourceItemId": null,
+          "title": "Set (X LEVEL) LiteDeck Forms",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876676:task:008",
+          "parentSourceItemId": null,
+          "title": "Install (X LEVEL) LiteDeck Plumbing Chases",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876676:task:009",
+          "parentSourceItemId": null,
+          "title": "Install (X LEVEL) LiteDeck Electrical Chases",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876676:task:010",
+          "parentSourceItemId": null,
+          "title": "Set (X LEVEL) LiteDeck Top Hat",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876676:task:011",
+          "parentSourceItemId": null,
+          "title": "Form (X LEVEL) LiteDeck Concrete Beams",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876676:task:012",
+          "parentSourceItemId": null,
+          "title": "Install (X LEVEL) LiteDeck Concrete Joist Bottom Rebar",
+          "sortOrder": 12
+        },
+        {
+          "sourceItemId": "45876676:task:013",
+          "parentSourceItemId": "45876676:task:012",
+          "title": "Bottom Rebar Set on LiteStand Rebar Chairs",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876676:task:014",
+          "parentSourceItemId": null,
+          "title": "Install (X LEVEL) LiteDeck Concrete Joist Top Rebar",
+          "sortOrder": 13
+        },
+        {
+          "sourceItemId": "45876676:task:015",
+          "parentSourceItemId": "45876676:task:014",
+          "title": "All Top Rebar Hung Appropriately",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876676:task:016",
+          "parentSourceItemId": null,
+          "title": "Cut ICF Wall Foam (X LEVEL) LiteDeck Tie-In",
+          "sortOrder": 14
+        },
+        {
+          "sourceItemId": "45876676:task:017",
+          "parentSourceItemId": "45876676:task:016",
+          "title": "Foam Cut for Concrete Joists",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876676:task:018",
+          "parentSourceItemId": "45876676:task:016",
+          "title": "Foam Cut for Concrete Beams",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876676:task:019",
+          "parentSourceItemId": null,
+          "title": "(X) Level LiteDeck (X) Concrete Beam Reinforcing Steel Hoops",
+          "sortOrder": 15
+        },
+        {
+          "sourceItemId": "45876676:task:020",
+          "parentSourceItemId": null,
+          "title": "(X) Level LiteDeck (X) Concrete Beam Bottom Rebar",
+          "sortOrder": 16
+        },
+        {
+          "sourceItemId": "45876676:task:021",
+          "parentSourceItemId": null,
+          "title": "(X) Level LiteDeck (X) Concrete Beam Top Rebar",
+          "sortOrder": 17
+        },
+        {
+          "sourceItemId": "45876676:task:022",
+          "parentSourceItemId": null,
+          "title": "Install (X) Level LiteDeck/ICF Wall Tie-In L Bars",
+          "sortOrder": 18
+        },
+        {
+          "sourceItemId": "45876676:task:023",
+          "parentSourceItemId": null,
+          "title": "(X) Level LiteDeck (X) Concrete Beam Blockout Forming",
+          "sortOrder": 19
+        },
+        {
+          "sourceItemId": "45876676:task:024",
+          "parentSourceItemId": null,
+          "title": "Install (X) Level LiteDeck Slab Welded Wire Mesh",
+          "sortOrder": 20
+        },
+        {
+          "sourceItemId": "45876676:task:025",
+          "parentSourceItemId": null,
+          "title": "Install (X) Level LiteDeck Slab Radiant Lines",
+          "sortOrder": 21
+        },
+        {
+          "sourceItemId": "45876676:task:026",
+          "parentSourceItemId": null,
+          "title": "Install (X) Level LiteDeck Slab Radiant Manifold",
+          "sortOrder": 22
+        },
+        {
+          "sourceItemId": "45876676:task:027",
+          "parentSourceItemId": null,
+          "title": "Pressurize (X) Level LiteDeck Slab Radiant Lines to 60psi",
+          "sortOrder": 23
+        },
+        {
+          "sourceItemId": "45876676:task:028",
+          "parentSourceItemId": null,
+          "title": "HPS (X) Level LiteDeck QC/Pre-Pour Inspection",
+          "sortOrder": 24
+        },
+        {
+          "sourceItemId": "45876676:task:029",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "LiteDeck Supported Properly",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876676:task:030",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "Necessary Patching Complete",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876676:task:031",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "Concrete Beam Top Rebar Correct",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876676:task:032",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "Concrete Beam Bottom Rebar Correct",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876676:task:033",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "Concrete Beam Stirrups Correct",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876676:task:034",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "LiteDeck Concrete Joist Top Rebar Correct",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876676:task:035",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "LiteDeck Concrete Joist Bottom Rebar Correct",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876676:task:036",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "LiteDeck-ICF Wall Tie-In Correct",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876676:task:037",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "Stair Support",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876676:task:038",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "Permanent Support Posts Installed Correctly",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876676:task:039",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "Chases Capped Properly",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876676:task:040",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "Radiant Lines at 60psi",
+          "sortOrder": 12
+        },
+        {
+          "sourceItemId": "45876676:task:041",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "LiteDeck Supports Tight",
+          "sortOrder": 13
+        },
+        {
+          "sourceItemId": "45876676:task:042",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "LiteDeck is Level",
+          "sortOrder": 14
+        },
+        {
+          "sourceItemId": "45876676:task:043",
+          "parentSourceItemId": null,
+          "title": "(X) Level LiteDeck (X) Permanent Support Post",
+          "sortOrder": 25
+        },
+        {
+          "sourceItemId": "45876676:task:044",
+          "parentSourceItemId": null,
+          "title": "Building Department Radiant Line Inspection Passed",
+          "sortOrder": 26
+        },
+        {
+          "sourceItemId": "45876676:task:045",
+          "parentSourceItemId": null,
+          "title": "Building Department LiteDeck Inspection Passed",
+          "sortOrder": 27
+        },
+        {
+          "sourceItemId": "45876676:task:046",
+          "parentSourceItemId": null,
+          "title": "HPS (X) Level Flatwork QC Inspection",
+          "sortOrder": 28
+        },
+        {
+          "sourceItemId": "45876676:task:047",
+          "parentSourceItemId": null,
+          "title": "(X) Level LiteDeck Poured",
+          "sortOrder": 29
+        },
+        {
+          "sourceItemId": "45876676:task:048",
+          "parentSourceItemId": null,
+          "title": "Schedule LiteDeck Inspection",
+          "sortOrder": 30
+        },
+        {
+          "sourceItemId": "45876676:task:049",
+          "parentSourceItemId": null,
+          "title": "LiteDeck Inspection Passed",
+          "sortOrder": 31
+        },
+        {
+          "sourceItemId": "45876676:task:050",
+          "parentSourceItemId": null,
+          "title": "Confirm Radiant Inspection Passed",
+          "sortOrder": 32
+        }
+      ],
+      "notCaptured": [
+        "Native Buildertrend task IDs, task descriptions, and source assignee identities."
+      ]
+    },
+    {
+      "sourceTemplateId": "12540389",
+      "name": "Concrete - ICF Assembly",
+      "sourceName": "Concrete - ICF Assembly",
+      "provenance": {
+        "copiedTargetTemplateId": "45876685",
+        "taskIdentity": "sourceItemId values are deterministic capture IDs because Buildertrend did not expose native task IDs."
+      },
+      "tasks": [
+        {
+          "sourceItemId": "45876685:task:001",
+          "parentSourceItemId": null,
+          "title": "ICF Layout",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:002",
+          "parentSourceItemId": null,
+          "title": "First Course",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876685:task:003",
+          "parentSourceItemId": "45876685:task:002",
+          "title": "Tie Bottom of Wall Rebar to First Course",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:004",
+          "parentSourceItemId": "45876685:task:002",
+          "title": "Double-Clips on whole first Course",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876685:task:005",
+          "parentSourceItemId": "45876685:task:002",
+          "title": "Horizontal Rebar",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876685:task:006",
+          "parentSourceItemId": null,
+          "title": "Second Course",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876685:task:007",
+          "parentSourceItemId": "45876685:task:006",
+          "title": "Horizontal Bar",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:008",
+          "parentSourceItemId": "45876685:task:006",
+          "title": "Double Horizontal Clip Whole Second Course",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876685:task:009",
+          "parentSourceItemId": null,
+          "title": "Third Course",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876685:task:010",
+          "parentSourceItemId": "45876685:task:009",
+          "title": "Horizontal Rebar",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:011",
+          "parentSourceItemId": "45876685:task:009",
+          "title": "Set-Up Bracing",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876685:task:012",
+          "parentSourceItemId": "45876685:task:009",
+          "title": "Cut Out for Openings",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876685:task:013",
+          "parentSourceItemId": "45876685:task:009",
+          "title": "Clipped Correctly",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876685:task:014",
+          "parentSourceItemId": null,
+          "title": "Top Course",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876685:task:015",
+          "parentSourceItemId": "45876685:task:014",
+          "title": "Top of Wall Rebar",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:016",
+          "parentSourceItemId": "45876685:task:014",
+          "title": "Verticals Rebar",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876685:task:017",
+          "parentSourceItemId": "45876685:task:014",
+          "title": "Patching if Necesssary",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876685:task:018",
+          "parentSourceItemId": "45876685:task:014",
+          "title": "Clipped Correctly",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876685:task:019",
+          "parentSourceItemId": "45876685:task:014",
+          "title": "ICFVLs Placed As Necessary",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876685:task:020",
+          "parentSourceItemId": null,
+          "title": "X Middle Course",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876685:task:021",
+          "parentSourceItemId": "45876685:task:020",
+          "title": "Horizontal Rebar",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:022",
+          "parentSourceItemId": "45876685:task:020",
+          "title": "Cut Out for Openings",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876685:task:023",
+          "parentSourceItemId": "45876685:task:020",
+          "title": "Clipped Correctly",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876685:task:024",
+          "parentSourceItemId": null,
+          "title": "Header Course",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876685:task:025",
+          "parentSourceItemId": "45876685:task:024",
+          "title": "Horizontal Rebar",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:026",
+          "parentSourceItemId": "45876685:task:024",
+          "title": "Top Blockout Rebar",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876685:task:027",
+          "parentSourceItemId": "45876685:task:024",
+          "title": "Concrete Lintel Bottom Rebar",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876685:task:028",
+          "parentSourceItemId": "45876685:task:024",
+          "title": "Concrete Lintel Top Rebar",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876685:task:029",
+          "parentSourceItemId": "45876685:task:024",
+          "title": "Concrete Lintel S-Bars/Stirrups",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876685:task:030",
+          "parentSourceItemId": "45876685:task:024",
+          "title": "Clipped Correctly",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876685:task:031",
+          "parentSourceItemId": null,
+          "title": "Bucks Built",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876685:task:032",
+          "parentSourceItemId": null,
+          "title": "Set Opening Bucks",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876685:task:033",
+          "parentSourceItemId": null,
+          "title": "Passed building Department Inspection",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876685:task:034",
+          "parentSourceItemId": null,
+          "title": "ICF Wall Pour",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876685:task:035",
+          "parentSourceItemId": "45876685:task:034",
+          "title": "Anchor Bolts Set If Necessary (IF NOT NECESSARY PLEASE CHECK ANYWAY)",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:036",
+          "parentSourceItemId": null,
+          "title": "Order (X) Level ICF Wall Estimated Concrete",
+          "sortOrder": 12
+        },
+        {
+          "sourceItemId": "45876685:task:037",
+          "parentSourceItemId": null,
+          "title": "Update Concrete Order with Field Takeoffs",
+          "sortOrder": 13
+        },
+        {
+          "sourceItemId": "45876685:task:038",
+          "parentSourceItemId": null,
+          "title": "Request (x) level ICF Wall Inspection",
+          "sortOrder": 14
+        },
+        {
+          "sourceItemId": "45876685:task:039",
+          "parentSourceItemId": null,
+          "title": "HPS (X) Level ICF Wall QC & Pre-Pour Checklist",
+          "sortOrder": 15
+        },
+        {
+          "sourceItemId": "45876685:task:040",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Permit/Plans on Site",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:041",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Vertical & Horizontal Rebar Tied Properly",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876685:task:042",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Windows & Doors Braced",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876685:task:043",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Walls Braced Every 40\"",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876685:task:044",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "T-Walls, Buttress Walls & Corners Braced",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876685:task:045",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Seams Glued",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876685:task:046",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Holes & Cracks Glued",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876685:task:047",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Eufer Ground Placed Correctly",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876685:task:048",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Gas Chases Installed",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876685:task:049",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Electrical Chases Installed",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876685:task:050",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Plumbing Chases Installed",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876685:task:051",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Misc. Additional Chases Installed",
+          "sortOrder": 12
+        },
+        {
+          "sourceItemId": "45876685:task:052",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Lentils/Stirrups for openings installed",
+          "sortOrder": 13
+        },
+        {
+          "sourceItemId": "45876685:task:053",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "top of wall rebar correct",
+          "sortOrder": 14
+        },
+        {
+          "sourceItemId": "45876685:task:054",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Anchor Bolts ready",
+          "sortOrder": 15
+        },
+        {
+          "sourceItemId": "45876685:task:055",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "ICFVLs Placed Accurately",
+          "sortOrder": 16
+        },
+        {
+          "sourceItemId": "45876685:task:056",
+          "parentSourceItemId": null,
+          "title": "Schedule Concrete pump",
+          "sortOrder": 16
+        },
+        {
+          "sourceItemId": "45876685:task:057",
+          "parentSourceItemId": null,
+          "title": "Order ICFs",
+          "sortOrder": 17
+        },
+        {
+          "sourceItemId": "45876685:task:058",
+          "parentSourceItemId": null,
+          "title": "Inventory ICF Delivery",
+          "sortOrder": 18
+        },
+        {
+          "sourceItemId": "45876685:task:059",
+          "parentSourceItemId": null,
+          "title": "Inspection Passed",
+          "sortOrder": 19
+        }
+      ],
+      "notCaptured": [
+        "Native Buildertrend task IDs, task descriptions, and source assignee identities."
+      ]
+    },
+    {
+      "sourceTemplateId": "30907034",
+      "name": "Int. Finishes - Cabinetry/Countertops",
+      "sourceName": "Int. Finishes - Cabinetry/Countertops",
+      "provenance": {
+        "copiedTargetTemplateId": "45876692",
+        "taskIdentity": "sourceItemId values are deterministic capture IDs because Buildertrend did not expose native task IDs."
+      },
+      "tasks": [
+        {
+          "sourceItemId": "45876692:task:001",
+          "parentSourceItemId": null,
+          "title": "HPS (X Room) Cabinetry Inspection",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876692:task:002",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinet Height Correct",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876692:task:003",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets Level",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876692:task:004",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets Grain/Color Matching",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876692:task:005",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinet Hardware Present and Matching",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876692:task:006",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No Scratches",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876692:task:007",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No Chips",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876692:task:008",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No Gouges",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876692:task:009",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No Nicks",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876692:task:010",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: Open & Close Properly",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876692:task:011",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: Door align properly",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876692:task:012",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No Gap b/w Door & Frame",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876692:task:013",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No loose or Separated Veneer",
+          "sortOrder": 12
+        },
+        {
+          "sourceItemId": "45876692:task:014",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No Shrinkage",
+          "sortOrder": 13
+        },
+        {
+          "sourceItemId": "45876692:task:015",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No swelling panels",
+          "sortOrder": 14
+        },
+        {
+          "sourceItemId": "45876692:task:016",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No scratches on door glass",
+          "sortOrder": 15
+        },
+        {
+          "sourceItemId": "45876692:task:017",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No Gaps in Miter Joints",
+          "sortOrder": 16
+        },
+        {
+          "sourceItemId": "45876692:task:018",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No separation or looseness from wall",
+          "sortOrder": 17
+        },
+        {
+          "sourceItemId": "45876692:task:019",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: Height correct",
+          "sortOrder": 18
+        },
+        {
+          "sourceItemId": "45876692:task:020",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: Level",
+          "sortOrder": 19
+        },
+        {
+          "sourceItemId": "45876692:task:021",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: Color/Grain Matches",
+          "sortOrder": 20
+        },
+        {
+          "sourceItemId": "45876692:task:022",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: Hardware Present & Matches",
+          "sortOrder": 21
+        },
+        {
+          "sourceItemId": "45876692:task:023",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No Scratches",
+          "sortOrder": 22
+        },
+        {
+          "sourceItemId": "45876692:task:024",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No Chips",
+          "sortOrder": 23
+        },
+        {
+          "sourceItemId": "45876692:task:025",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No Gouges",
+          "sortOrder": 24
+        },
+        {
+          "sourceItemId": "45876692:task:026",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No Nicks",
+          "sortOrder": 25
+        },
+        {
+          "sourceItemId": "45876692:task:027",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: Open & Close Properly",
+          "sortOrder": 26
+        },
+        {
+          "sourceItemId": "45876692:task:028",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: Doors Align Properly",
+          "sortOrder": 27
+        },
+        {
+          "sourceItemId": "45876692:task:029",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No Gap between Doors & Frame",
+          "sortOrder": 28
+        },
+        {
+          "sourceItemId": "45876692:task:030",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No loose or separated veneer",
+          "sortOrder": 29
+        },
+        {
+          "sourceItemId": "45876692:task:031",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No Panel Shrinkage",
+          "sortOrder": 30
+        },
+        {
+          "sourceItemId": "45876692:task:032",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No Panel Swelling",
+          "sortOrder": 31
+        },
+        {
+          "sourceItemId": "45876692:task:033",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No Scratches on Door Glass",
+          "sortOrder": 32
+        },
+        {
+          "sourceItemId": "45876692:task:034",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No gaps in miter joints",
+          "sortOrder": 33
+        },
+        {
+          "sourceItemId": "45876692:task:035",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No separation or looseness from wall",
+          "sortOrder": 34
+        },
+        {
+          "sourceItemId": "45876692:task:036",
+          "parentSourceItemId": null,
+          "title": "HPS (X Room) Countertop QC Inspection",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876692:task:037",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "Match Cabinets",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876692:task:038",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Cracks",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876692:task:039",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Splits",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876692:task:040",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Damaged Pieces",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876692:task:041",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Scratches",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876692:task:042",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Chips",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876692:task:043",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Gouges",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876692:task:044",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Nicks",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876692:task:045",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Burns",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876692:task:046",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Separation from wall",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876692:task:047",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Rise in Seams",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876692:task:048",
+          "parentSourceItemId": null,
+          "title": "Cabinets Installed",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876692:task:049",
+          "parentSourceItemId": null,
+          "title": "Countertops Measured & Templated",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876692:task:050",
+          "parentSourceItemId": null,
+          "title": "Countertop Installation Complete",
+          "sortOrder": 5
+        }
+      ],
+      "selections": [
+        {
+          "sourceItemId": "63614466",
+          "sourceSelectionId": "63614466",
+          "title": "Countertop Backsplash",
+          "category": "12 36 00 - Countertops",
+          "location": "Kitchen",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587420",
+              "title": "4\" Backsplash of Countertop Material",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587419",
+              "title": "No Backsplash of Countertop Material",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614465",
+          "sourceSelectionId": "63614465",
+          "title": "Countertop Backsplash",
+          "category": "12 36 00 - Countertops",
+          "location": "Bath 1",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587418",
+              "title": "4\" Backsplash of Countertop Material",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587417",
+              "title": "No Backsplash of Countertop Material",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614464",
+          "sourceSelectionId": "63614464",
+          "title": "Countertop Material",
+          "category": "12 36 00 - Countertops",
+          "location": "Bath 1",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587412",
+              "title": "Ceramic Tile",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587416",
+              "title": "Concrete",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587407",
+              "title": "Granite",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587413",
+              "title": "Laminate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587409",
+              "title": "Marble",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587410",
+              "title": "Quartz",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587408",
+              "title": "Soapstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587411",
+              "title": "Solid-Surface",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587415",
+              "title": "Stainless Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587414",
+              "title": "Wood or Butcher Block",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614463",
+          "sourceSelectionId": "63614463",
+          "title": "Countertop Material",
+          "category": "12 36 00 - Countertops",
+          "location": "Kitchen",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587402",
+              "title": "Ceramic Tile",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587406",
+              "title": "Concrete",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587397",
+              "title": "Granite",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587403",
+              "title": "Laminate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587399",
+              "title": "Marble",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587400",
+              "title": "Quartz",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587398",
+              "title": "Soapstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587401",
+              "title": "Solid-Surface",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587405",
+              "title": "Stainless Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587404",
+              "title": "Wood or Butcher Block",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            }
+          ]
+        }
+      ],
+      "bidPackages": [
+        {
+          "sourceItemId": "13408688",
+          "sourceBidPackageId": "13408688",
+          "title": "Cabinetry - (Project Address) (Estimate Phase)",
+          "status": "Draft",
+          "allowMultipleApprovedBids": false,
+          "deadline": null,
+          "time": null,
+          "reminderLeadDays": 2,
+          "plansAndSpecs": false,
+          "pricingFormat": "Line Items",
+          "description": "Background\nHigh Performance Structures, Inc. dba Open Range Construction, Ltd. (ORC) will be building a custom home located at:\n(Project Street Address)\n(Project City), (Project State) (Project Zip Code)\nReference Documents\nPlease see the Buildertrend Documents folder titled \"(Estimate Phase) Bid Set\" for all necessary plans.\nSubmission of Bid\nBids for this project will be processed through Buildertrend, a construction management program. You do not need to become proficient with Buildertrend. You may also simply call or email your point of contact. You may submit your bid into Buildertrend or email it to your point of contact for entry. Should you choose to input your bid into Buildertrend, please also include a PDF version of your bid.\nFor assistance with submitting the bid or receiving bid documents, contact the (Estimator Title):\n(Estimator Name), (719) 900-8850 ext. (Estimator Extension)\n(Estimator Email Address)\nTimeline\nThe work is scheduled to start in (Build Season), (Build Year).\nScope of Work\nThe following CSI categories will be required for the construction of the project per the plans and specifications noted on the Plans and Specifications List. We will notify bidders of any changes or additions by sending out updates to said List.\nQuestions\nPlease direct any questions into the RFI section here on Buildertrend. This helps us as a builder keep questions organized and accessible to any of our staff provided an estimator is absent. This will help expedite provision of answers.\nSchedule\nPlease provide a schedule to complete each of the above items, in calendar days after the issuance of the purchase order and/or notice to proceed.\nContract and Insurance Requirements\nAll trade contractors will be required to complete a trade contractor agreement, provide proof of liability insurance and workman’s compensation insurance as applicable, with required limits prior to the release of any construction payments.",
+          "descriptionSections": [
+            "Background",
+            "High Performance Structures, Inc. dba Open Range Construction, Ltd. (ORC) will be building a custom home located at:",
+            "(Project Street Address)",
+            "(Project City), (Project State) (Project Zip Code)",
+            "Reference Documents",
+            "Please see the Buildertrend Documents folder titled \"(Estimate Phase) Bid Set\" for all necessary plans.",
+            "Submission of Bid",
+            "Bids for this project will be processed through Buildertrend, a construction management program. You do not need to become proficient with Buildertrend. You may also simply call or email your point of contact. You may submit your bid into Buildertrend or email it to your point of contact for entry. Should you choose to input your bid into Buildertrend, please also include a PDF version of your bid.",
+            "For assistance with submitting the bid or receiving bid documents, contact the (Estimator Title):",
+            "(Estimator Name), (719) 900-8850 ext. (Estimator Extension)",
+            "(Estimator Email Address)",
+            "Timeline",
+            "The work is scheduled to start in (Build Season), (Build Year).",
+            "Scope of Work",
+            "The following CSI categories will be required for the construction of the project per the plans and specifications noted on the Plans and Specifications List. We will notify bidders of any changes or additions by sending out updates to said List.",
+            "Questions",
+            "Please direct any questions into the RFI section here on Buildertrend. This helps us as a builder keep questions organized and accessible to any of our staff provided an estimator is absent. This will help expedite provision of answers.",
+            "Schedule",
+            "Please provide a schedule to complete each of the above items, in calendar days after the issuance of the purchase order and/or notice to proceed.",
+            "Contract and Insurance Requirements",
+            "All trade contractors will be required to complete a trade contractor agreement, provide proof of liability insurance and workman’s compensation insurance as applicable, with required limits prior to the release of any construction payments."
+          ],
+          "internalNotes": "",
+          "attachments": [],
+          "lineItems": [
+            {
+              "title": "Cabinet Design",
+              "costCode": "12 30 00 - Casework",
+              "costType": "Other",
+              "quantity": 1,
+              "unit": null
+            },
+            {
+              "title": "Cabinets",
+              "costCode": "12 30 00 - Casework",
+              "costType": "Material",
+              "quantity": 1,
+              "unit": null
+            },
+            {
+              "title": "Cabinet Delivery",
+              "costCode": "12 30 00 - Casework",
+              "costType": "Other",
+              "quantity": 1,
+              "unit": null
+            }
+          ]
+        },
+        {
+          "sourceItemId": "13408689",
+          "sourceBidPackageId": "13408689",
+          "title": "Countertops - (Project Address) (Estimate Phase)",
+          "status": "Draft",
+          "allowMultipleApprovedBids": false,
+          "deadline": null,
+          "time": null,
+          "reminderLeadDays": 2,
+          "plansAndSpecs": false,
+          "pricingFormat": "Line Items",
+          "description": "Background\nHigh Performance Structures, Inc. dba Open Range Construction, Ltd. (ORC) will be building a custom home located at:\n(Project Street Address)\n(Project City), (Project State) (Project Zip Code)\nReference Documents\nPlease see the Buildertrend Documents folder titled \"(Estimate Phase) Bid Set\" for all necessary plans.\nSubmission of Bid\nBids for this project will be processed through Buildertrend, a construction management program. You do not need to become proficient with Buildertrend. You may also simply call or email your point of contact. You may submit your bid into Buildertrend or email it to your point of contact for entry. Should you choose to input your bid into Buildertrend, please also include a PDF version of your bid.\nFor assistance with submitting the bid or receiving bid documents, contact the (Estimator Title):\n(Estimator Name), (719) 900-8850 ext. (Estimator Extension)\n(Estimator Email Address)\nTimeline\nThe work is scheduled to start in (Build Season), (Build Year).\nScope of Work\nThe following CSI categories will be required for the construction of the project per the plans and specifications noted on the Plans and Specifications List. We will notify bidders of any changes or additions by sending out updates to said List.\nQuestions\nPlease direct any questions into the RFI section here on Buildertrend. This helps us as a builder keep questions organized and accessible to any of our staff provided an estimator is absent. This will help expedite provision of answers.\nSchedule\nPlease provide a schedule to complete each of the above items, in calendar days after the issuance of the purchase order and/or notice to proceed.\nContract and Insurance Requirements\nAll trade contractors will be required to complete a trade contractor agreement, provide proof of liability insurance and workman’s compensation insurance as applicable, with required limits prior to the release of any construction payments.",
+          "descriptionSections": [
+            "Background",
+            "High Performance Structures, Inc. dba Open Range Construction, Ltd. (ORC) will be building a custom home located at:",
+            "(Project Street Address)",
+            "(Project City), (Project State) (Project Zip Code)",
+            "Reference Documents",
+            "Please see the Buildertrend Documents folder titled \"(Estimate Phase) Bid Set\" for all necessary plans.",
+            "Submission of Bid",
+            "Bids for this project will be processed through Buildertrend, a construction management program. You do not need to become proficient with Buildertrend. You may also simply call or email your point of contact. You may submit your bid into Buildertrend or email it to your point of contact for entry. Should you choose to input your bid into Buildertrend, please also include a PDF version of your bid.",
+            "For assistance with submitting the bid or receiving bid documents, contact the (Estimator Title):",
+            "(Estimator Name), (719) 900-8850 ext. (Estimator Extension)",
+            "(Estimator Email Address)",
+            "Timeline",
+            "The work is scheduled to start in (Build Season), (Build Year).",
+            "Scope of Work",
+            "The following CSI categories will be required for the construction of the project per the plans and specifications noted on the Plans and Specifications List. We will notify bidders of any changes or additions by sending out updates to said List.",
+            "Questions",
+            "Please direct any questions into the RFI section here on Buildertrend. This helps us as a builder keep questions organized and accessible to any of our staff provided an estimator is absent. This will help expedite provision of answers.",
+            "Schedule",
+            "Please provide a schedule to complete each of the above items, in calendar days after the issuance of the purchase order and/or notice to proceed.",
+            "Contract and Insurance Requirements",
+            "All trade contractors will be required to complete a trade contractor agreement, provide proof of liability insurance and workman’s compensation insurance as applicable, with required limits prior to the release of any construction payments."
+          ],
+          "internalNotes": "Determine the subs/vendors to send requests to by the types of countertops selected. See Finish Selections for details.",
+          "attachments": [],
+          "lineItems": [
+            {
+              "title": "Countertops",
+              "costCode": "12 36 00 - Countertops",
+              "costType": "Material",
+              "quantity": 1,
+              "unit": null
+            },
+            {
+              "title": "Countertop Installation",
+              "costCode": "12 36 00 - Countertops",
+              "costType": "Material",
+              "quantity": 1,
+              "unit": null
+            }
+          ]
+        }
+      ],
+      "notCaptured": [
+        "Native Buildertrend task IDs and task descriptions",
+        "Selection attachment file names and bytes were not downloaded."
+      ]
+    }
+  ],
+  "conversionExceptions": [
+    {
+      "templateSourceTemplateId": "12978716",
+      "module": "tasks",
+      "sourceItemId": null,
+      "field": "sourceItemId",
+      "sourceValue": "Native Buildertrend task IDs were not exposed in the authenticated task grid.",
+      "loss": "Deterministic copied-template capture IDs are used for the task hierarchy.",
+      "recoveryPlan": "Retain the copied target template ID, task ordering, titles, and parent relationships as provenance."
+    },
+    {
+      "templateSourceTemplateId": "32043577",
+      "module": "tasks",
+      "sourceItemId": null,
+      "field": "sourceItemId",
+      "sourceValue": "Native Buildertrend task IDs were not exposed in the authenticated task grid.",
+      "loss": "Deterministic copied-template capture IDs are used for the task hierarchy.",
+      "recoveryPlan": "Retain the copied target template ID, task ordering, titles, and parent relationships as provenance."
+    },
+    {
+      "templateSourceTemplateId": "12667545",
+      "module": "tasks",
+      "sourceItemId": null,
+      "field": "sourceItemId",
+      "sourceValue": "Native Buildertrend task IDs were not exposed in the authenticated task grid.",
+      "loss": "Deterministic copied-template capture IDs are used for the task hierarchy.",
+      "recoveryPlan": "Retain the copied target template ID, task ordering, titles, and parent relationships as provenance."
+    },
+    {
+      "templateSourceTemplateId": "12540389",
+      "module": "tasks",
+      "sourceItemId": null,
+      "field": "sourceItemId",
+      "sourceValue": "Native Buildertrend task IDs were not exposed in the authenticated task grid.",
+      "loss": "Deterministic copied-template capture IDs are used for the task hierarchy.",
+      "recoveryPlan": "Retain the copied target template ID, task ordering, titles, and parent relationships as provenance."
+    },
+    {
+      "templateSourceTemplateId": "30907034",
+      "module": "tasks",
+      "sourceItemId": null,
+      "field": "sourceItemId",
+      "sourceValue": "Native Buildertrend task IDs were not exposed in the authenticated task grid.",
+      "loss": "Deterministic copied-template capture IDs are used for the task hierarchy.",
+      "recoveryPlan": "Retain the copied target template ID, task ordering, titles, and parent relationships as provenance."
+    },
+    {
+      "templateSourceTemplateId": "12978716",
+      "module": "bidPackages",
+      "sourceItemId": "13408751",
+      "field": "costType",
+      "sourceValue": "The source copy reported a multiple-Cost-Type conversion warning.",
+      "loss": "Buildertrend cleared copied line-item multiple Cost Types; the copied lines report None.",
+      "recoveryPlan": "Map the verified CSI cost codes to Compass/Sage cost types when staff applies the template to a job."
+    },
+    {
+      "templateSourceTemplateId": "12978716",
+      "module": "selections",
+      "sourceItemId": null,
+      "field": "attachmentBytes",
+      "sourceValue": "Buildertrend selection choices expose attachment indicators but not durable file bytes in the authenticated list capture.",
+      "loss": "Selection titles and choices are captured; attachment file bytes are not stored in Compass.",
+      "recoveryPlan": "Store source files in the Compass/Google Drive template attachment workflow before publishing attachment-dependent templates."
+    },
+    {
+      "templateSourceTemplateId": "30907034",
+      "module": "selections",
+      "sourceItemId": null,
+      "field": "attachmentBytes",
+      "sourceValue": "Buildertrend selection choices expose attachment indicators but not durable file bytes in the authenticated list capture.",
+      "loss": "Selection titles and choices are captured; attachment file bytes are not stored in Compass.",
+      "recoveryPlan": "Store source files in the Compass/Google Drive template attachment workflow before publishing attachment-dependent templates."
+    }
+  ]
+}

--- a/scripts/fixtures/buildertrend-template-content-pilot-2026-08-03.json
+++ b/scripts/fixtures/buildertrend-template-content-pilot-2026-08-03.json
@@ -1,0 +1,20505 @@
+{
+  "fixtureVersion": 3,
+  "capturedAt": "2026-08-04T04:44:37.294Z",
+  "excludedArchivedCount": 27,
+  "conversionExceptions": [
+    {
+      "templateSourceTemplateId": "30294726",
+      "module": "tasks",
+      "sourceItemId": null,
+      "field": "sourceItemId",
+      "sourceValue": "Native Buildertrend task IDs were not exposed in the authenticated task grid.",
+      "loss": "Deterministic copied-template capture IDs are used for the task hierarchy.",
+      "recoveryPlan": "Retain the copied target template ID, task ordering, titles, and parent relationships as provenance."
+    },
+    {
+      "templateSourceTemplateId": "30294726",
+      "module": "scheduleItems",
+      "sourceItemId": null,
+      "field": "milestone,assignee,ownerVisibility,subVendorVisibility,notes",
+      "sourceValue": "These fields were not exposed consistently in the authenticated Buildertrend template schedule.",
+      "loss": "Conservative captured values are retained but are not treated as verified source values.",
+      "recoveryPlan": "Require staff review of these fields before publishing or applying the template to a project."
+    },
+    {
+      "templateSourceTemplateId": "30294726",
+      "module": "bidPackages",
+      "sourceItemId": "13408682",
+      "field": "costType",
+      "sourceValue": "The source copy reported a multiple-Cost-Type conversion warning.",
+      "loss": "Buildertrend cleared the copied line's multiple Cost Types; the captured copied line now reports None.",
+      "recoveryPlan": "Map the verified CSI cost code to Compass/Sage cost types when staff applies the template to a job."
+    },
+    {
+      "templateSourceTemplateId": "30294726",
+      "module": "selections",
+      "sourceItemId": null,
+      "field": "attachmentBytes",
+      "sourceValue": [
+        "RE_ Finalize Drywall Finishes.pdf",
+        "Drywall Finish Specs.pdf"
+      ],
+      "loss": "Attachment names and counts are captured, but file bytes are not yet stored in Compass.",
+      "recoveryPlan": "Download and store the files in the Compass/Google Drive template attachment workflow before publishing the pilot."
+    },
+    {
+      "templateSourceTemplateId": "12978716",
+      "module": "tasks",
+      "sourceItemId": null,
+      "field": "sourceItemId",
+      "sourceValue": "Native Buildertrend task IDs were not exposed in the authenticated task grid.",
+      "loss": "Deterministic copied-template capture IDs are used for the task hierarchy.",
+      "recoveryPlan": "Retain the copied target template ID, task ordering, titles, and parent relationships as provenance."
+    },
+    {
+      "templateSourceTemplateId": "32043577",
+      "module": "tasks",
+      "sourceItemId": null,
+      "field": "sourceItemId",
+      "sourceValue": "Native Buildertrend task IDs were not exposed in the authenticated task grid.",
+      "loss": "Deterministic copied-template capture IDs are used for the task hierarchy.",
+      "recoveryPlan": "Retain the copied target template ID, task ordering, titles, and parent relationships as provenance."
+    },
+    {
+      "templateSourceTemplateId": "12667545",
+      "module": "tasks",
+      "sourceItemId": null,
+      "field": "sourceItemId",
+      "sourceValue": "Native Buildertrend task IDs were not exposed in the authenticated task grid.",
+      "loss": "Deterministic copied-template capture IDs are used for the task hierarchy.",
+      "recoveryPlan": "Retain the copied target template ID, task ordering, titles, and parent relationships as provenance."
+    },
+    {
+      "templateSourceTemplateId": "12540389",
+      "module": "tasks",
+      "sourceItemId": null,
+      "field": "sourceItemId",
+      "sourceValue": "Native Buildertrend task IDs were not exposed in the authenticated task grid.",
+      "loss": "Deterministic copied-template capture IDs are used for the task hierarchy.",
+      "recoveryPlan": "Retain the copied target template ID, task ordering, titles, and parent relationships as provenance."
+    },
+    {
+      "templateSourceTemplateId": "30907034",
+      "module": "tasks",
+      "sourceItemId": null,
+      "field": "sourceItemId",
+      "sourceValue": "Native Buildertrend task IDs were not exposed in the authenticated task grid.",
+      "loss": "Deterministic copied-template capture IDs are used for the task hierarchy.",
+      "recoveryPlan": "Retain the copied target template ID, task ordering, titles, and parent relationships as provenance."
+    },
+    {
+      "templateSourceTemplateId": "12978716",
+      "module": "bidPackages",
+      "sourceItemId": "13408751",
+      "field": "costType",
+      "sourceValue": "The source copy reported a multiple-Cost-Type conversion warning.",
+      "loss": "Buildertrend cleared copied line-item multiple Cost Types; the copied lines report None.",
+      "recoveryPlan": "Map the verified CSI cost codes to Compass/Sage cost types when staff applies the template to a job."
+    },
+    {
+      "templateSourceTemplateId": "12978716",
+      "module": "selections",
+      "sourceItemId": null,
+      "field": "attachmentBytes",
+      "sourceValue": "Buildertrend selection choices expose attachment indicators but not durable file bytes in the authenticated list capture.",
+      "loss": "Selection titles and choices are captured; attachment file bytes are not stored in Compass.",
+      "recoveryPlan": "Store source files in the Compass/Google Drive template attachment workflow before publishing attachment-dependent templates."
+    },
+    {
+      "templateSourceTemplateId": "30907034",
+      "module": "selections",
+      "sourceItemId": null,
+      "field": "attachmentBytes",
+      "sourceValue": "Buildertrend selection choices expose attachment indicators but not durable file bytes in the authenticated list capture.",
+      "loss": "Selection titles and choices are captured; attachment file bytes are not stored in Compass.",
+      "recoveryPlan": "Store source files in the Compass/Google Drive template attachment workflow before publishing attachment-dependent templates."
+    }
+  ],
+  "templates": [
+    {
+      "sourceTemplateId": "30294726",
+      "name": "Drywall Installation",
+      "sourceName": "Drywall Installation",
+      "moduleCounts": {
+        "tasks": 28,
+        "scheduleItems": 8,
+        "selections": 3,
+        "bidPackages": 1
+      },
+      "schedule": {
+        "sourceAnchorDate": "2023-06-27",
+        "phases": [
+          {
+            "sourcePhaseId": "30294726:phase:1",
+            "name": "UNASSIGNED"
+          },
+          {
+            "sourcePhaseId": "30294726:phase:2",
+            "name": "Insulation & Drywall"
+          }
+        ],
+        "items": [
+          {
+            "sourceItemId": "176749752",
+            "title": "Drywall Walkthrough",
+            "startDate": "2023-06-27",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#6C824D",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "176749614",
+            "title": "Stock Drywall",
+            "startDate": "2023-07-12",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#6C824D",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "176749615",
+            "title": "Hang Drywall",
+            "startDate": "2023-07-13",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#6C824D",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "176749616",
+            "title": "Tape & Compound",
+            "startDate": "2023-07-14",
+            "workdays": 9,
+            "phase": "UNASSIGNED",
+            "displayColor": "#6C824D",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "176749617",
+            "title": "Sand Drywall",
+            "startDate": "2023-07-27",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#6C824D",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "176749618",
+            "title": "Texture",
+            "startDate": "2023-07-28",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#6C824D",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "176751862",
+            "title": "Sand Texture & Drywall Cleanup",
+            "startDate": "2023-07-31",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#6C824D",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "176749753",
+            "title": "HPS Drywall QC Inspection",
+            "startDate": "2023-08-01",
+            "workdays": 1,
+            "phase": "Insulation & Drywall",
+            "displayColor": "#2222DD",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          }
+        ],
+        "dependencies": [
+          {
+            "predecessorSourceItemId": "176749752",
+            "successorSourceItemId": "176749614",
+            "type": "FS",
+            "lagDays": 9
+          },
+          {
+            "predecessorSourceItemId": "176749614",
+            "successorSourceItemId": "176749615",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "176749615",
+            "successorSourceItemId": "176749616",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "176749616",
+            "successorSourceItemId": "176749617",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "176749617",
+            "successorSourceItemId": "176749618",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "176749618",
+            "successorSourceItemId": "176751862",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "176751862",
+            "successorSourceItemId": "176749753",
+            "type": "FS",
+            "lagDays": 0
+          }
+        ]
+      },
+      "scheduleItems": [
+        {
+          "sourceItemId": "176749752",
+          "title": "Drywall Walkthrough",
+          "startDate": "2023-06-27",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#6C824D",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": []
+        },
+        {
+          "sourceItemId": "176749614",
+          "title": "Stock Drywall",
+          "startDate": "2023-07-12",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#6C824D",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "176749752",
+              "successorSourceItemId": "176749614",
+              "type": "FS",
+              "lagDays": 9
+            }
+          ]
+        },
+        {
+          "sourceItemId": "176749615",
+          "title": "Hang Drywall",
+          "startDate": "2023-07-13",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#6C824D",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "176749614",
+              "successorSourceItemId": "176749615",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "176749616",
+          "title": "Tape & Compound",
+          "startDate": "2023-07-14",
+          "workdays": 9,
+          "phase": "UNASSIGNED",
+          "displayColor": "#6C824D",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "176749615",
+              "successorSourceItemId": "176749616",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "176749617",
+          "title": "Sand Drywall",
+          "startDate": "2023-07-27",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#6C824D",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "176749616",
+              "successorSourceItemId": "176749617",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "176749618",
+          "title": "Texture",
+          "startDate": "2023-07-28",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#6C824D",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "176749617",
+              "successorSourceItemId": "176749618",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "176751862",
+          "title": "Sand Texture & Drywall Cleanup",
+          "startDate": "2023-07-31",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#6C824D",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "176749618",
+              "successorSourceItemId": "176751862",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "176749753",
+          "title": "HPS Drywall QC Inspection",
+          "startDate": "2023-08-01",
+          "workdays": 1,
+          "phase": "Insulation & Drywall",
+          "displayColor": "#2222DD",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "176751862",
+              "successorSourceItemId": "176749753",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        }
+      ],
+      "provenance": {
+        "copiedTargetTemplateId": "45876630",
+        "taskIdentity": "sourceItemId values are deterministic capture IDs because Buildertrend did not expose native task IDs."
+      },
+      "conversionExceptions": [
+        "Buildertrend regenerated copied-record IDs.",
+        "Buildertrend cleared Cost Type on 1 line item that had multiple Cost Types."
+      ],
+      "tasks": [
+        {
+          "sourceItemId": "45876630:task:01",
+          "parentSourceItemId": null,
+          "title": "Request Updated Drywall Installation Quote",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876630:task:02",
+          "parentSourceItemId": null,
+          "title": "Walk Site with Drywall Contractor",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876630:task:03",
+          "parentSourceItemId": null,
+          "title": "Apprise Owners of Updated Drywall Quote",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876630:task:04",
+          "parentSourceItemId": null,
+          "title": "Approve and Schedule Drywall Subcontract",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876630:task:qc",
+          "parentSourceItemId": null,
+          "title": "(X Room) Drywall QC Inspection",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876630:task:qc:01",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "Sheetrock Installed Firmly with nails/screws",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876630:task:qc:02",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "Joints/openings (2\" Threaded tape embedded in joint cement)",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876630:task:qc:03",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "Metal Corner Beads Installed Correctly",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876630:task:qc:04",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "Proper Corner Reinforcement",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876630:task:qc:05",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "Tape on all joints",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876630:task:qc:06",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "Tape on all corner beads",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876630:task:qc:07",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "Tape on all nails/screws",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876630:task:qc:08",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "Tape on all areas where smooth surface necessary",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876630:task:qc:09",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "1/2\" Ceiling Wall Board",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876630:task:qc:10",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "Texture on repairs is even",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876630:task:qc:11",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "Angular Joints Or Corners are Even",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876630:task:qc:12",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "All Texture is Even",
+          "sortOrder": 12
+        },
+        {
+          "sourceItemId": "45876630:task:qc:13",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "No Drywall Photographing",
+          "sortOrder": 13
+        },
+        {
+          "sourceItemId": "45876630:task:qc:14",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "No Troweling Marks",
+          "sortOrder": 14
+        },
+        {
+          "sourceItemId": "45876630:task:qc:15",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "No Excess Compound in Joints",
+          "sortOrder": 15
+        },
+        {
+          "sourceItemId": "45876630:task:qc:16",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "No Blisters in Tape",
+          "sortOrder": 16
+        },
+        {
+          "sourceItemId": "45876630:task:qc:17",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "No Nail Pops",
+          "sortOrder": 17
+        },
+        {
+          "sourceItemId": "45876630:task:qc:18",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "No Cracks",
+          "sortOrder": 18
+        },
+        {
+          "sourceItemId": "45876630:task:qc:19",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "No Lines on Corner Bead",
+          "sortOrder": 19
+        },
+        {
+          "sourceItemId": "45876630:task:qc:20",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "No Ridging on Corner Bead",
+          "sortOrder": 20
+        },
+        {
+          "sourceItemId": "45876630:task:qc:21",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "No Cracking on Corner Beads",
+          "sortOrder": 21
+        },
+        {
+          "sourceItemId": "45876630:task:qc:22",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "No Noticeable Defects",
+          "sortOrder": 22
+        },
+        {
+          "sourceItemId": "45876630:task:qc:23",
+          "parentSourceItemId": "45876630:task:qc",
+          "title": "Water Resistant Sheetrock installed in all necessary areas",
+          "sortOrder": 23
+        }
+      ],
+      "selections": [
+        {
+          "sourceItemId": "63614346",
+          "sourceSelectionId": "63614346",
+          "title": "Drywall Corner Options",
+          "category": "09 29 00 - Gypsum Wallboard",
+          "location": "Interior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [
+            {
+              "fileName": "RE_ Finalize Drywall Finishes.pdf"
+            }
+          ],
+          "choices": [
+            {
+              "sourceChoiceId": "262585412",
+              "title": "Bullnose corner",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262585411",
+              "title": "Square corner",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614348",
+          "sourceSelectionId": "63614348",
+          "title": "Texture",
+          "category": "09 29 00 - Gypsum Wallboard",
+          "location": "Interior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [
+            {
+              "fileName": "Drywall Finish Specs.pdf"
+            }
+          ],
+          "choices": [
+            {
+              "sourceChoiceId": "262585417",
+              "title": "Hand Trowel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262585415",
+              "title": "Knockdown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262585416",
+              "title": "Orange Peel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614347",
+          "sourceSelectionId": "63614347",
+          "title": "Window Wrap Options",
+          "category": "09 29 00 - Gypsum Wallboard",
+          "location": "Interior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": true,
+          "attachments": [
+            {
+              "fileName": "RE_ Finalize Drywall Finishes.pdf"
+            }
+          ],
+          "choices": [
+            {
+              "sourceChoiceId": "262585414",
+              "title": "3 Way Drywall",
+              "description": "Will need to choose desired color/pattern",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262585413",
+              "title": "4 Way Drywall",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            }
+          ]
+        }
+      ],
+      "bidPackages": [
+        {
+          "sourceItemId": "13408682",
+          "sourceBidPackageId": "13408682",
+          "title": "Drywall - (Project Address) (Estimate Phase)",
+          "status": "Draft",
+          "allowMultipleApprovedBids": false,
+          "deadline": null,
+          "time": null,
+          "reminderLeadDays": 2,
+          "plansAndSpecs": false,
+          "pricingFormat": "Line Items",
+          "description": "Background\nHigh Performance Structures, Inc. dba Open Range Construction, Ltd. (ORC) will be building a (Project Type) located at:\n(Project Address)\nReference Documents\nPlease see the Buildertrend Documents folder titled \"(Est. Phase) Bid Set\" for all necessary plans.\nSubmission of Bid\nBids for this project will be processed through Buildertrend, a construction management program. You do not need to become proficient with Buildertrend. You may also simply call or email your point of contact. You may submit your bid into Buildertrend or email it to your point of contact for entry. Should you choose to input your bid into Buildertrend, please also include a PDF version of your bid.\nFor assistance with submitting the bid or receiving bid documents, contact the (Estimator Title):\n(Estimator), (719) 900-8850 ext. (Estimator Ext)\n(Estimator Email Address)\nTimeline\nThe work is scheduled to start in (Season), (Year).\nScope of Work\nThe following CSI categories will be required for the construction of the project per the plans and specifications noted on the Plans and Specifications List. We will notify bidders of any changes or additions by sending out updates to said List.\nSchedule\nPlease provide a schedule to complete each of the above items, in calendar days after the issuance of the purchase order and/or notice to proceed.\nContract and Insurance Requirements\nAll trade contractors will be required to complete a trade contractor agreement, provide proof of liability insurance and workman’s compensation insurance as applicable, with required limits prior to the release of any construction payments.",
+          "descriptionSections": [
+            "Background",
+            "High Performance Structures, Inc. dba Open Range Construction, Ltd. (ORC) will be building a (Project Type) located at:",
+            "(Project Address)",
+            "Reference Documents",
+            "Please see the Buildertrend Documents folder titled \"(Est. Phase) Bid Set\" for all necessary plans.",
+            "Submission of Bid",
+            "Bids for this project will be processed through Buildertrend, a construction management program. You do not need to become proficient with Buildertrend. You may also simply call or email your point of contact. You may submit your bid into Buildertrend or email it to your point of contact for entry. Should you choose to input your bid into Buildertrend, please also include a PDF version of your bid.",
+            "For assistance with submitting the bid or receiving bid documents, contact the (Estimator Title):",
+            "(Estimator), (719) 900-8850 ext. (Estimator Ext)",
+            "(Estimator Email Address)",
+            "Timeline",
+            "The work is scheduled to start in (Season), (Year).",
+            "Scope of Work",
+            "The following CSI categories will be required for the construction of the project per the plans and specifications noted on the Plans and Specifications List. We will notify bidders of any changes or additions by sending out updates to said List.",
+            "Schedule",
+            "Please provide a schedule to complete each of the above items, in calendar days after the issuance of the purchase order and/or notice to proceed.",
+            "Contract and Insurance Requirements",
+            "All trade contractors will be required to complete a trade contractor agreement, provide proof of liability insurance and workman’s compensation insurance as applicable, with required limits prior to the release of any construction payments."
+          ],
+          "internalNotes": "",
+          "attachments": [],
+          "lineItems": [
+            {
+              "title": "Drywall Installation Labor & Materials",
+              "costCode": "09 29 00 - Gypsum Wallboard",
+              "costType": "None",
+              "quantity": 1,
+              "unit": null
+            }
+          ]
+        }
+      ],
+      "notCaptured": [
+        "Native Buildertrend task IDs and task descriptions",
+        "Attachment file bytes were not downloaded."
+      ]
+    },
+    {
+      "sourceTemplateId": "12978716",
+      "name": "Ext. Finishes - Roofing",
+      "sourceName": "Ext. Finishes - Roofing",
+      "moduleCounts": {
+        "tasks": 14,
+        "scheduleItems": 2,
+        "selections": 103,
+        "bidPackages": 1
+      },
+      "schedule": {
+        "sourceAnchorDate": "2022-05-23",
+        "phases": [
+          {
+            "sourcePhaseId": "12978716:phase:1",
+            "name": "Exterior Finish"
+          }
+        ],
+        "items": [
+          {
+            "sourceItemId": "145104743",
+            "title": "(TYPE) Roofing Installation",
+            "startDate": "2022-05-23",
+            "workdays": 4,
+            "phase": "Exterior Finish",
+            "displayColor": "#AD5A21",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "145110557",
+            "title": "HPS Roofing QC Inspection",
+            "startDate": "2022-05-27",
+            "workdays": 1,
+            "phase": "Exterior Finish",
+            "displayColor": "#2222DD",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          }
+        ],
+        "dependencies": [
+          {
+            "predecessorSourceItemId": "145104743",
+            "successorSourceItemId": "145110557",
+            "type": "FS",
+            "lagDays": 0
+          }
+        ]
+      },
+      "scheduleItems": [
+        {
+          "sourceItemId": "145104743",
+          "title": "(TYPE) Roofing Installation",
+          "startDate": "2022-05-23",
+          "workdays": 4,
+          "phase": "Exterior Finish",
+          "displayColor": "#AD5A21",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": []
+        },
+        {
+          "sourceItemId": "145110557",
+          "title": "HPS Roofing QC Inspection",
+          "startDate": "2022-05-27",
+          "workdays": 1,
+          "phase": "Exterior Finish",
+          "displayColor": "#2222DD",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "145104743",
+              "successorSourceItemId": "145110557",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        }
+      ],
+      "provenance": {
+        "copiedTargetTemplateId": "45876908",
+        "taskIdentity": "sourceItemId values are deterministic capture IDs because Buildertrend did not expose native task IDs."
+      },
+      "tasks": [
+        {
+          "sourceItemId": "45876908:task:001",
+          "parentSourceItemId": null,
+          "title": "(TYPE) Roofing Complete",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876908:task:002",
+          "parentSourceItemId": null,
+          "title": "HPS Roofing QC Inspection",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876908:task:003",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "Roof Does Not Leak",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876908:task:004",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "Chimney Flashing Does Not Leak",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876908:task:005",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "No Shingles Blown Off",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876908:task:006",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "Shingle Colors Match",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876908:task:007",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "No Broken Shingles",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876908:task:008",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "No Standing Water On Flat Roof",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876908:task:009",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "No Moss/Fungus on Wood Shake Shingles",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876908:task:010",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "Skylights Do Not Leak",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876908:task:011",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "Ridges of Roof Decking Do Not Show thru Roof",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876908:task:012",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "Flashing/Valleys Do Not Leak",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876908:task:013",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "Jobsite Cleanup Satisfactory",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876908:task:014",
+          "parentSourceItemId": "45876908:task:002",
+          "title": "OK to Pay",
+          "sortOrder": 12
+        }
+      ],
+      "selections": [
+        {
+          "sourceItemId": "63614593",
+          "sourceSelectionId": "63614593",
+          "title": "HR3 High Rib Roof  - Impower Series 26ga. Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587877",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587882",
+              "title": "Imperial White - Interior Color",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587881",
+              "title": "Imperial White - SMP",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587878",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587883",
+              "title": "Slate Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587879",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587884",
+              "title": "Surrey Beige",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587885",
+              "title": "Warm White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587880",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614594",
+          "sourceSelectionId": "63614594",
+          "title": "Metal Sales 1.25\" Corrugated Panel 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587886",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587887",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587888",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587889",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587890",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587891",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587892",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587893",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587894",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587895",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587896",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587897",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587898",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587899",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587900",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587901",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587902",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587903",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587904",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587905",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614595",
+          "sourceSelectionId": "63614595",
+          "title": "Metal Sales 2.5\" Corrugated Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587908",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587907",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587906",
+              "title": "29 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614596",
+          "sourceSelectionId": "63614596",
+          "title": "Metal Sales 2.5\" Corrugated, 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587912",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587909",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587913",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587914",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587915",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587916",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587917",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587918",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587919",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587920",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587921",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587922",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587923",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587924",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587925",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587926",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587927",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587910",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587928",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587929",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587930",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587931",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587911",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587932",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587933",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587934",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587935",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587936",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587937",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587938",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587939",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587940",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614597",
+          "sourceSelectionId": "63614597",
+          "title": "Metal Sales 2.5\" Corrugated, 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587941",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587942",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587943",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587944",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587945",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587946",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587947",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587948",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587949",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587950",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587951",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587952",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587953",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587954",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587955",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587956",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587957",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587958",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587960",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587959",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614598",
+          "sourceSelectionId": "63614598",
+          "title": "Metal Sales 2.5\" Corrugated, 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587961",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587962",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587963",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587964",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587965",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587966",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587967",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587968",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587969",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587970",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587971",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587972",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587973",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587974",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587975",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587976",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587977",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587978",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587979",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587980",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614599",
+          "sourceSelectionId": "63614599",
+          "title": "Metal Sales 5V-Crimp 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587981",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587982",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587983",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587984",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587985",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587986",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587987",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587988",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587989",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587990",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587991",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587992",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587993",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587994",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587995",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587996",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587997",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587998",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587999",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588000",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614600",
+          "sourceSelectionId": "63614600",
+          "title": "Metal Sales 5V-Crimp Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588002",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588001",
+              "title": "29 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614601",
+          "sourceSelectionId": "63614601",
+          "title": "Metal Sales 5v-Crimp, 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588003",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588004",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588005",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588006",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588007",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588008",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588009",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588010",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588011",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588012",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588013",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588014",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588015",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588016",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588017",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588018",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588019",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588020",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588022",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588021",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614602",
+          "sourceSelectionId": "63614602",
+          "title": "Metal Sales 7/8\" Corrugated 24 Gauge Color",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588026",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588023",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588027",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588028",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588029",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588030",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588031",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588032",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588033",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588034",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588035",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588036",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588037",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588038",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588039",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588040",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588041",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588024",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588042",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588043",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588044",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588045",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588025",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588046",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588047",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588048",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588049",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588050",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588051",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588052",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588053",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588054",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614603",
+          "sourceSelectionId": "63614603",
+          "title": "Metal Sales 7/8\" Corrugated 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588055",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588056",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588057",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588058",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588059",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588060",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588061",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588062",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588063",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588064",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588065",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588066",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588067",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588068",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588069",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588070",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588071",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588072",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588074",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588073",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614604",
+          "sourceSelectionId": "63614604",
+          "title": "Metal Sales 7/8\" Corrugated Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588076",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588075",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614605",
+          "sourceSelectionId": "63614605",
+          "title": "Metal Sales Bi-Rib 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588077",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588078",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588079",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588080",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588081",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588082",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588083",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588084",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588085",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588086",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588087",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588088",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588089",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588090",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588091",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588092",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588093",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588094",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588095",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588096",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614606",
+          "sourceSelectionId": "63614606",
+          "title": "Metal Sales Box-Batten 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588100",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588097",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588101",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588102",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588103",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588104",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588105",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588106",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588107",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588108",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588109",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588110",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588111",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588112",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588113",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588114",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588115",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588098",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588116",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588117",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588118",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588119",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588099",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588120",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588121",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588122",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588123",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588124",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588125",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588126",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588127",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588128",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614607",
+          "sourceSelectionId": "63614607",
+          "title": "Metal Sales Box-Batten 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588129",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588130",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588131",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588132",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588133",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588134",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588135",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588136",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588137",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588138",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588139",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588140",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588141",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588142",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588143",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588144",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588145",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588146",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588148",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588147",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614608",
+          "sourceSelectionId": "63614608",
+          "title": "Metal Sales Box-Batten Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588149",
+              "title": "12\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588150",
+              "title": "16\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588151",
+              "title": "18\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614609",
+          "sourceSelectionId": "63614609",
+          "title": "Metal Sales Box-Batten Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588153",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588152",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614610",
+          "sourceSelectionId": "63614610",
+          "title": "Metal Sales Classic Rib 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588154",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588155",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588156",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588157",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588158",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588159",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588160",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588161",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588162",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588163",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588164",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588165",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588166",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588167",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588168",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588169",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588170",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588171",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588173",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588172",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614611",
+          "sourceSelectionId": "63614611",
+          "title": "Metal Sales Classic Rib 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588174",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588175",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588176",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588177",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588178",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588179",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588180",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588181",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588182",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588183",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588184",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588185",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588186",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588187",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588188",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588189",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588190",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588191",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588192",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588193",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614612",
+          "sourceSelectionId": "63614612",
+          "title": "Metal Sales Classic Rib Gauage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588195",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588194",
+              "title": "29 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614613",
+          "sourceSelectionId": "63614613",
+          "title": "Metal Sales Clip-Loc 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588199",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588196",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588200",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588201",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588202",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588203",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588204",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588205",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588206",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588207",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588208",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588209",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588210",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588211",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588212",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588213",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588214",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588197",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588215",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588216",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588217",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588218",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588198",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588219",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588220",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588221",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588222",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588223",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588224",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588225",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588226",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588227",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614614",
+          "sourceSelectionId": "63614614",
+          "title": "Metal Sales Clip-Loc 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588228",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588229",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588230",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588231",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588232",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588233",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588234",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588235",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588236",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588237",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588238",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588239",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588240",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588241",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588242",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588243",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588244",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588245",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588247",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588246",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614615",
+          "sourceSelectionId": "63614615",
+          "title": "Metal Sales Clip-Loc Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588249",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588248",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614616",
+          "sourceSelectionId": "63614616",
+          "title": "Metal Sales Delta Rib 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588250",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588251",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588252",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588253",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588254",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588255",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588256",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588257",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588258",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588259",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588260",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588261",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588262",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588263",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588264",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588265",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588266",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588267",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588269",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588268",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614617",
+          "sourceSelectionId": "63614617",
+          "title": "Metal Sales Delta Rib 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588270",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588271",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588272",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588273",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588274",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588275",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588276",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588277",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588278",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588279",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588280",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588281",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588282",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588283",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588284",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588285",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588286",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588287",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588288",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588289",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614618",
+          "sourceSelectionId": "63614618",
+          "title": "Metal Sales Delta Rib Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588291",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588290",
+              "title": "29 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614619",
+          "sourceSelectionId": "63614619",
+          "title": "Metal Sales DL-3 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588292",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588293",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588294",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588295",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588296",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588297",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588298",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588299",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588300",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588301",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588302",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588303",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588304",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588305",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588306",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588307",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588308",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588309",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588310",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588311",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614620",
+          "sourceSelectionId": "63614620",
+          "title": "Metal Sales IC-72 Panel 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588315",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588312",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588316",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588317",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588318",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588319",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588320",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588321",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588322",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588323",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588324",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588325",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588326",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588327",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588328",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588329",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588330",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588313",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588331",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588332",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588333",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588334",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588314",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588335",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588336",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588337",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588338",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588339",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588340",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588341",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588342",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588343",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614621",
+          "sourceSelectionId": "63614621",
+          "title": "Metal Sales Image II 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588347",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588344",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588348",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588349",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588350",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588351",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588352",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588353",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588354",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588355",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588356",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588357",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588358",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588359",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588360",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588361",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588362",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588345",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588363",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588364",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588365",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588366",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588346",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588367",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588368",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588369",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588370",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588371",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588372",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588373",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588374",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588375",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614622",
+          "sourceSelectionId": "63614622",
+          "title": "Metal Sales Image II 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588376",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588377",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588378",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588379",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588380",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588381",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588382",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588383",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588384",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588385",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588386",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588387",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588388",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588389",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588390",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588391",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588392",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588393",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588395",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588394",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614623",
+          "sourceSelectionId": "63614623",
+          "title": "Metal Sales Image II Aluminum Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588396",
+              "title": "12\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588397",
+              "title": "16\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614624",
+          "sourceSelectionId": "63614624",
+          "title": "Metal Sales Image II Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588398",
+              "title": "12\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588399",
+              "title": "16\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614625",
+          "sourceSelectionId": "63614625",
+          "title": "Metal Sales Image II Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588401",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588400",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614626",
+          "sourceSelectionId": "63614626",
+          "title": "Metal Sales Magna-Loc 180 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588405",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588402",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588406",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588407",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588408",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588409",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588410",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588411",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588412",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588413",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588414",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588415",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588416",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588417",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588418",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588419",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588420",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588403",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588421",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588422",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588423",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588424",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588404",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588425",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588426",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588427",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588428",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588429",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588430",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588431",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588432",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588433",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614627",
+          "sourceSelectionId": "63614627",
+          "title": "Metal Sales Magna-Loc 180 Alternates",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588434",
+              "title": "Metal Sales Magna-Loc 180 Aluminum",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588435",
+              "title": "Metal Sales Magna-Loc 180 Curved",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614628",
+          "sourceSelectionId": "63614628",
+          "title": "Metal Sales Magna-Loc 180 Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588436",
+              "title": "16\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588437",
+              "title": "18\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614629",
+          "sourceSelectionId": "63614629",
+          "title": "Metal Sales Magna-Loc 90 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588441",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588438",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588442",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588443",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588444",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588445",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588446",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588447",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588448",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588449",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588450",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588451",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588452",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588453",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588454",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588455",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588456",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588439",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588457",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588458",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588459",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588460",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588440",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588461",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588462",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588463",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588464",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588465",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588466",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588467",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588468",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588469",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614630",
+          "sourceSelectionId": "63614630",
+          "title": "Metal Sales Magna-Loc 90 Alternate Options",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588470",
+              "title": "Metal Sales Magna-Loc 90 Aluminum",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614631",
+          "sourceSelectionId": "63614631",
+          "title": "Metal Sales Magna-Loc 90 Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588471",
+              "title": "16\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588472",
+              "title": "18\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614632",
+          "sourceSelectionId": "63614632",
+          "title": "Metal Sales Max-Batten Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588474",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588473",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614633",
+          "sourceSelectionId": "63614633",
+          "title": "Metal Sales Maxi-Batten 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588478",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588475",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588479",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588480",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588481",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588482",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588483",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588484",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588485",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588486",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588487",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588488",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588489",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588490",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588491",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588492",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588493",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588476",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588494",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588495",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588496",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588497",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588477",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588498",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588499",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588500",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588501",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588502",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588503",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588504",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588505",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588506",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614634",
+          "sourceSelectionId": "63614634",
+          "title": "Metal Sales Maxi-Batten 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588507",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588508",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588509",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588510",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588511",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588512",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588513",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588514",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588515",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588516",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588517",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588518",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588519",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588520",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588521",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588522",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588523",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588524",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588526",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588525",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614635",
+          "sourceSelectionId": "63614635",
+          "title": "Metal Sales Maxi-Batten Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588527",
+              "title": "12\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588528",
+              "title": "16\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588529",
+              "title": "18\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614636",
+          "sourceSelectionId": "63614636",
+          "title": "Metal Sales Mini-Batten 1.5\" 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588533",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588530",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588534",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588535",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588536",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588537",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588538",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588539",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588540",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588541",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588542",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588543",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588544",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588545",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588546",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588547",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588548",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588531",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588549",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588550",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588551",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588552",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588532",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588553",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588554",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588555",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588556",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588557",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588558",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588559",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588560",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588561",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614637",
+          "sourceSelectionId": "63614637",
+          "title": "Metal Sales Mini-Batten 1.5\" 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588562",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588563",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588564",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588565",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588566",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588567",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588568",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588569",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588570",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588571",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588572",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588573",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588574",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588575",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588576",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588577",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588578",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588579",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588581",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588580",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614638",
+          "sourceSelectionId": "63614638",
+          "title": "Metal Sales Mini-Batten 1.5\" Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588583",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588582",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614639",
+          "sourceSelectionId": "63614639",
+          "title": "Metal Sales Mini-Batten Alternate Options",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588584",
+              "title": "Metal Sales Mini-Batten 1\" (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614640",
+          "sourceSelectionId": "63614640",
+          "title": "Metal Sales Mini-Batten Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588585",
+              "title": "12\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588586",
+              "title": "16\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588587",
+              "title": "18\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614641",
+          "sourceSelectionId": "63614641",
+          "title": "Metal Sales PBR-Panel 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588591",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588588",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588592",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588593",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588594",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588595",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588596",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588597",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588598",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588599",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588600",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588601",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588602",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588603",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588604",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588605",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588606",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588589",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588607",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588608",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588609",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588610",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588590",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588611",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588612",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588613",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588614",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588615",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588616",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588617",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588618",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588619",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614642",
+          "sourceSelectionId": "63614642",
+          "title": "Metal Sales PBR-Panel 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588620",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588621",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588622",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588623",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588624",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588625",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588626",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588627",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588628",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588629",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588630",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588631",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588632",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588633",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588634",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588635",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588636",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588637",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588639",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588638",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614643",
+          "sourceSelectionId": "63614643",
+          "title": "Metal Sales PBR-Panel Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588641",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588640",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614644",
+          "sourceSelectionId": "63614644",
+          "title": "Metal Sales PBU-Panel 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588645",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588642",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588646",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588647",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588648",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588649",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588650",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588651",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588652",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588653",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588654",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588655",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588656",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588657",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588658",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588659",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588660",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588643",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588661",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588662",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588663",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588664",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588644",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588665",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588666",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588667",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588668",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588669",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588670",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588671",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588672",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588673",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614645",
+          "sourceSelectionId": "63614645",
+          "title": "Metal Sales PBU-Panel 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588674",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588675",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588676",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588677",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588678",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588679",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588680",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588681",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588682",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588683",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588684",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588685",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588686",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588687",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588688",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588689",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588690",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588691",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588693",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588692",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614646",
+          "sourceSelectionId": "63614646",
+          "title": "Metal Sales PBU-Panel Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588695",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588694",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614647",
+          "sourceSelectionId": "63614647",
+          "title": "Metal Sales Pro-Panel II 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588696",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588697",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588698",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588699",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588700",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588701",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588702",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588703",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588704",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588705",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588706",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588707",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588708",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588709",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588710",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588711",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588712",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588713",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588715",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588714",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614648",
+          "sourceSelectionId": "63614648",
+          "title": "Metal Sales Pro-Panel II 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588716",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588717",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588718",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588719",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588720",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588721",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588722",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588723",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588724",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588725",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588726",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588727",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588728",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588729",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588730",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588731",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588732",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588733",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588734",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588735",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614649",
+          "sourceSelectionId": "63614649",
+          "title": "Metal Sales Pro-Panel II Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588737",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588736",
+              "title": "29 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614650",
+          "sourceSelectionId": "63614650",
+          "title": "Metal Sales R-Panel 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588738",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588739",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588740",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588741",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588742",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588743",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588744",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588745",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588746",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588747",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588748",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588749",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588750",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588751",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588752",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588753",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588754",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588755",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588757",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588756",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614651",
+          "sourceSelectionId": "63614651",
+          "title": "Metal Sales R-Panel 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588758",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588759",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588760",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588761",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588762",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588763",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588764",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588765",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588766",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588767",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588768",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588769",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588770",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588771",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588772",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588773",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588774",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588775",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588776",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588777",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614652",
+          "sourceSelectionId": "63614652",
+          "title": "Metal Sales R-Panel Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588779",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588778",
+              "title": "29 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614653",
+          "sourceSelectionId": "63614653",
+          "title": "Metal Sales Seam-Loc 24 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588783",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588780",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588784",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588785",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588786",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588787",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588788",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588789",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588790",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588791",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588792",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588793",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588794",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588795",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588796",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588797",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588798",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588781",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588799",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588800",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588801",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588802",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588782",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588803",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588804",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588805",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588806",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588807",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588808",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588809",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588810",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588811",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614654",
+          "sourceSelectionId": "63614654",
+          "title": "Metal Sales Seam-Loc 24 Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588812",
+              "title": "18\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588813",
+              "title": "24\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614655",
+          "sourceSelectionId": "63614655",
+          "title": "Metal Sales Snap-Loc 24 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588817",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588814",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588818",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588819",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588820",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588821",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588822",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588823",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588824",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588825",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588826",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588827",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588828",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588829",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588830",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588831",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588832",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588815",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588833",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588834",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588835",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588836",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588816",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588837",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588838",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588839",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588840",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588841",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588842",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588843",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588844",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588845",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614656",
+          "sourceSelectionId": "63614656",
+          "title": "Metal Sales Strongpanel 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588846",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588847",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588848",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588849",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588850",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588851",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588852",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588853",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588854",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588855",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588856",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588857",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588858",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588859",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588860",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588861",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588862",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588863",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588864",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588865",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614657",
+          "sourceSelectionId": "63614657",
+          "title": "Metal Sales T-Armor Series 2-3/8\" 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588869",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588866",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588870",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588871",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588872",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588873",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588874",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588875",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588876",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588877",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588878",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588879",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588880",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588881",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588882",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588883",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588884",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588867",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588885",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588886",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588887",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588888",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588868",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588889",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588890",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588891",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588892",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588893",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588894",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588895",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588896",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588897",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614658",
+          "sourceSelectionId": "63614658",
+          "title": "Metal Sales T-Armor Series 2-3/8\" Alternate Option",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588898",
+              "title": "Metal Sales T-Armor Series 2-3/8\" Aluminum",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588899",
+              "title": "Metal Sales T-Armor Series 3\"",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588900",
+              "title": "Metal Sales T-Armor Series 3\" Aluminum",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614659",
+          "sourceSelectionId": "63614659",
+          "title": "Metal Sales T1 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588904",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588901",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588905",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588906",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588907",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588908",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588909",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588910",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588911",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588912",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588913",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588914",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588915",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588916",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588917",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588918",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588919",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588902",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588920",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588921",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588922",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588923",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588903",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588924",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588925",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588926",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588927",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588928",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588929",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588930",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588931",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588932",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614660",
+          "sourceSelectionId": "63614660",
+          "title": "Metal Sales T11A - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588936",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588933",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588937",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588938",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588939",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588940",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588941",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588942",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588943",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588944",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588945",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588946",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588947",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588948",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588949",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588950",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588951",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588934",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588952",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588953",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588954",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588955",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588935",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588956",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588957",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588958",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588959",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588960",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588961",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588962",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588963",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588964",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614661",
+          "sourceSelectionId": "63614661",
+          "title": "Metal Sales T12 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262588968",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588965",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588969",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588970",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588971",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588972",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588973",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588974",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588975",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588976",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588977",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588978",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588979",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588980",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588981",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588982",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588983",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588966",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588984",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588985",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588986",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588987",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588967",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588988",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588989",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588990",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588991",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588992",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588993",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588994",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588995",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588996",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614662",
+          "sourceSelectionId": "63614662",
+          "title": "Metal Sales T13 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589000",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588997",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589001",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589002",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589003",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589004",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589005",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589006",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589007",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589008",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589009",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589010",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589011",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589012",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589013",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589014",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589015",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588998",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589016",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589017",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589018",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589019",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262588999",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589020",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589021",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589022",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589023",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589024",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589025",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589026",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589027",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589028",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614663",
+          "sourceSelectionId": "63614663",
+          "title": "Metal Sales T13-A 24 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589032",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589029",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589033",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589034",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589035",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589036",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589037",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589038",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589039",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589040",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589041",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589042",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589043",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589044",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589045",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589046",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589047",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589030",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589048",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589049",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589050",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589051",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589031",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589052",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589053",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589054",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589055",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589056",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589057",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589058",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589059",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589060",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614664",
+          "sourceSelectionId": "63614664",
+          "title": "Metal Sales T13-B - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589064",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589061",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589065",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589066",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589067",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589068",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589069",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589070",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589071",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589072",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589073",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589074",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589075",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589076",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589077",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589078",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589079",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589062",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589080",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589081",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589082",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589083",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589063",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589084",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589085",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589086",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589087",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589088",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589089",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589090",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589091",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589092",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614665",
+          "sourceSelectionId": "63614665",
+          "title": "Metal Sales T14 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589096",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589093",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589097",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589098",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589099",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589100",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589101",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589102",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589103",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589104",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589105",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589106",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589107",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589108",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589109",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589110",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589111",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589094",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589112",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589113",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589114",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589115",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589095",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589116",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589117",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589118",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589119",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589120",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589121",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589122",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589123",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589124",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614666",
+          "sourceSelectionId": "63614666",
+          "title": "Metal Sales T15 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589128",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589125",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589129",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589130",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589131",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589132",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589133",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589134",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589135",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589136",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589137",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589138",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589139",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589140",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589141",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589142",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589143",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589126",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589144",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589145",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589146",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589147",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589127",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589148",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589149",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589150",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589151",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589152",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589153",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589154",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589155",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589156",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614667",
+          "sourceSelectionId": "63614667",
+          "title": "Metal Sales T16-E - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589160",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589157",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589161",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589162",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589163",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589164",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589165",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589166",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589167",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589168",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589169",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589170",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589171",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589172",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589173",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589174",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589175",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589158",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589176",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589177",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589178",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589179",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589159",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589180",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589181",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589182",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589183",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589184",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589185",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589186",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589187",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589188",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614668",
+          "sourceSelectionId": "63614668",
+          "title": "Metal Sales T2 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589192",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589189",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589193",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589194",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589195",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589196",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589197",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589198",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589199",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589200",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589201",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589202",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589203",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589204",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589205",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589206",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589207",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589190",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589208",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589209",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589210",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589211",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589191",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589212",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589213",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589214",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589215",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589216",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589217",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589218",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589219",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589220",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614669",
+          "sourceSelectionId": "63614669",
+          "title": "Metal Sales T23 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589224",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589221",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589225",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589226",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589227",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589228",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589229",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589230",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589231",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589232",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589233",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589234",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589235",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589236",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589237",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589238",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589239",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589222",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589240",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589241",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589242",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589243",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589223",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589244",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589245",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589246",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589247",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589248",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589249",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589250",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589251",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589252",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614670",
+          "sourceSelectionId": "63614670",
+          "title": "Metal Sales T25 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589256",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589253",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589257",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589258",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589259",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589260",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589261",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589262",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589263",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589264",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589265",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589266",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589267",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589268",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589269",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589270",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589271",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589254",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589272",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589273",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589274",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589275",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589255",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589276",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589277",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589278",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589279",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589280",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589281",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589282",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589283",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589284",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614671",
+          "sourceSelectionId": "63614671",
+          "title": "Metal Sales T2630 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589288",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589285",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589289",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589290",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589291",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589292",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589293",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589294",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589295",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589296",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589297",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589298",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589299",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589300",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589301",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589302",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589303",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589286",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589304",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589305",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589306",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589307",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589287",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589308",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589309",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589310",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589311",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589312",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589313",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589314",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589315",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589316",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614672",
+          "sourceSelectionId": "63614672",
+          "title": "Metal Sales T2832 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589320",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589317",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589321",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589322",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589323",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589324",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589325",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589326",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589327",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589328",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589329",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589330",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589331",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589332",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589333",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589334",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589335",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589318",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589336",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589337",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589338",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589339",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589319",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589340",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589341",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589342",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589343",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589344",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589345",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589346",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589347",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589348",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614673",
+          "sourceSelectionId": "63614673",
+          "title": "Metal Sales T3 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589352",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589349",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589353",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589354",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589355",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589356",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589357",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589358",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589359",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589360",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589361",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589362",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589363",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589364",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589365",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589366",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589367",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589350",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589368",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589369",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589370",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589371",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589351",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589372",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589373",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589374",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589375",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589376",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589377",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589378",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589379",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589380",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614674",
+          "sourceSelectionId": "63614674",
+          "title": "Metal Sales T4 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589384",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589381",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589385",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589386",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589387",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589388",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589389",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589390",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589391",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589392",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589393",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589394",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589395",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589396",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589397",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589398",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589399",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589382",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589400",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589401",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589402",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589403",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589383",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589404",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589405",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589406",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589407",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589408",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589409",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589410",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589411",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589412",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614675",
+          "sourceSelectionId": "63614675",
+          "title": "Metal Sales T5 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589416",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589413",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589417",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589418",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589419",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589420",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589421",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589422",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589423",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589424",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589425",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589426",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589427",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589428",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589429",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589430",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589431",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589414",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589432",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589433",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589434",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589435",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589415",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589436",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589437",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589438",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589439",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589440",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589441",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589442",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589443",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589444",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614676",
+          "sourceSelectionId": "63614676",
+          "title": "Metal Sales T6-A - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589448",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589445",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589449",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589450",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589451",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589452",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589453",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589454",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589455",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589456",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589457",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589458",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589459",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589460",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589461",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589462",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589463",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589446",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589464",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589465",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589466",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589467",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589447",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589468",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589469",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589470",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589471",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589472",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589473",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589474",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589475",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589476",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614677",
+          "sourceSelectionId": "63614677",
+          "title": "Metal Sales T7 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589480",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589477",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589481",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589482",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589483",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589484",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589485",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589486",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589487",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589488",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589489",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589490",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589491",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589492",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589493",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589494",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589495",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589478",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589496",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589497",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589498",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589499",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589479",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589500",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589501",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589502",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589503",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589504",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589505",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589506",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589507",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589508",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614678",
+          "sourceSelectionId": "63614678",
+          "title": "Metal Sales T7-A - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589512",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589509",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589513",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589514",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589515",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589516",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589517",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589518",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589519",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589520",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589521",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589522",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589523",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589524",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589525",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589526",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589527",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589510",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589528",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589529",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589530",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589531",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589511",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589532",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589533",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589534",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589535",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589536",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589537",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589538",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589539",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589540",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614679",
+          "sourceSelectionId": "63614679",
+          "title": "Metal Sales TDR-6 - Roof 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589544",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589541",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589545",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589546",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589547",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589548",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589549",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589550",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589551",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589552",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589553",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589554",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589555",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589556",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589557",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589558",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589559",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589542",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589560",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589561",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589562",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589563",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589543",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589564",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589565",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589566",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589567",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589568",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589569",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589570",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589571",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589572",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614680",
+          "sourceSelectionId": "63614680",
+          "title": "Metal Sales U-Panel 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589576",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589573",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589577",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589578",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589579",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589580",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589581",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589582",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589583",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589584",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589585",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589586",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589587",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589588",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589589",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589590",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589591",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589574",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589592",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589593",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589594",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589595",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589575",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589596",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589597",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589598",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589599",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589600",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589601",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589602",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589603",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589604",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614681",
+          "sourceSelectionId": "63614681",
+          "title": "Metal Sales U-Panel 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589605",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589606",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589607",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589608",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589609",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589610",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589611",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589612",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589613",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589614",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589615",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589616",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589617",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589618",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589619",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589620",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589621",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589622",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589624",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589623",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614682",
+          "sourceSelectionId": "63614682",
+          "title": "Metal Sales U-Panel 29 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589625",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589626",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589627",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589628",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589629",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589630",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589631",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589632",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589633",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589634",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589635",
+              "title": "Galvanized",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589636",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589637",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589638",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589639",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589640",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589641",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589642",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589643",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589644",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614683",
+          "sourceSelectionId": "63614683",
+          "title": "Metal Sales U-Panel Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589647",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589646",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589645",
+              "title": "29 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614684",
+          "sourceSelectionId": "63614684",
+          "title": "Metal Sales V-Line 32 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589651",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589648",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589652",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589653",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589654",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589655",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589656",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589657",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589658",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589659",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589660",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589661",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589662",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589663",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589664",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589665",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589666",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589649",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589667",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589668",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589669",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589670",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589650",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589671",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589672",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589673",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589674",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589675",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589676",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589677",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589678",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589679",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614685",
+          "sourceSelectionId": "63614685",
+          "title": "Metal Sales V-Line 32 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589680",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589681",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589682",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589683",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589684",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589685",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589686",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589687",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589688",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589689",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589690",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589691",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589692",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589693",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589694",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589695",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589696",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589697",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589699",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589698",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614686",
+          "sourceSelectionId": "63614686",
+          "title": "Metal Sales V-Line 32 Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589701",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589700",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614687",
+          "sourceSelectionId": "63614687",
+          "title": "Metal Sales Vertical Seam 24 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589705",
+              "title": "Aged Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589702",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589706",
+              "title": "Brandywine",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589707",
+              "title": "Champagne Metallic",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589708",
+              "title": "Classic Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589709",
+              "title": "Colonial Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589710",
+              "title": "Copper Penny",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589711",
+              "title": "Dark Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589712",
+              "title": "Felt Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589713",
+              "title": "Hemlock Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589714",
+              "title": "Khaki",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589715",
+              "title": "Linen White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589716",
+              "title": "Mansard Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589717",
+              "title": "Matte Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589718",
+              "title": "Medium Bronze",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589719",
+              "title": "Metallic Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589720",
+              "title": "Mistique Plus",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589703",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589721",
+              "title": "Old Towne Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589722",
+              "title": "Old Zinc Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589723",
+              "title": "Parchment",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589724",
+              "title": "Patina Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589704",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589725",
+              "title": "Regal Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589726",
+              "title": "River Teal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589727",
+              "title": "Sandstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589728",
+              "title": "Slate Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589729",
+              "title": "Snowdrift White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589730",
+              "title": "Tahoe Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589731",
+              "title": "Taupe",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589732",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589733",
+              "title": "Weathered Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614688",
+          "sourceSelectionId": "63614688",
+          "title": "Metal Sales Vertical Seam 26 Gauge Colors",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589734",
+              "title": "Ash Grey",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589735",
+              "title": "Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589736",
+              "title": "Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589737",
+              "title": "Burgundy",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589738",
+              "title": "Burnished Slate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589739",
+              "title": "Carlsbad Canyon",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589740",
+              "title": "Charcoal",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589741",
+              "title": "Fern Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589742",
+              "title": "Forest Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589743",
+              "title": "Galvalume",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589744",
+              "title": "Light Stone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589745",
+              "title": "Mocha Brown",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589746",
+              "title": "Mocha Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589747",
+              "title": "Native Copper",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589748",
+              "title": "Ocean Blue",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589749",
+              "title": "Patriot Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589750",
+              "title": "Polar White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589751",
+              "title": "Red",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589753",
+              "title": "Rustic Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589752",
+              "title": "White",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614689",
+          "sourceSelectionId": "63614689",
+          "title": "Metal Sales Vertical Seam Coverage",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589754",
+              "title": "12\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589755",
+              "title": "16\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589756",
+              "title": "18\" Coverage",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614690",
+          "sourceSelectionId": "63614690",
+          "title": "Metal Sales Vertical Seam Metal Gauge",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589758",
+              "title": "24 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589757",
+              "title": "26 Gauge",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614589",
+          "sourceSelectionId": "63614589",
+          "title": "Roof Material",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587850",
+              "title": "Asphalt Shingles",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587853",
+              "title": "Metal Roofing",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587852",
+              "title": "Slate Roofing",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587851",
+              "title": "Tile Roofing",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614691",
+          "sourceSelectionId": "63614691",
+          "title": "Roof Panel Profile",
+          "category": "07 00 00 - Thermal Protection",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262589759",
+              "title": "Metal Sales 1.25\" Corrugated (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589760",
+              "title": "Metal Sales 2.5\" Corrugated (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589761",
+              "title": "Metal Sales 5V-Rib (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589762",
+              "title": "Metal Sales 7/8\" Corrugated (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589763",
+              "title": "Metal Sales Bi-Rib (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589797",
+              "title": "Metal Sales Box-Batten (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589764",
+              "title": "Metal Sales Classic Rib (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589798",
+              "title": "Metal Sales Clip-Loc (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589765",
+              "title": "Metal Sales Delta Rib (Exposed Rib)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589766",
+              "title": "Metal Sales DL-3 Panel (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589767",
+              "title": "Metal Sales HR3 High Rib Roof - Impower Series",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589768",
+              "title": "Metal Sales IC72-Panel (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589799",
+              "title": "Metal Sales Image II (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589800",
+              "title": "Metal Sales Image II Aluminum (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589801",
+              "title": "Metal Sales Magna-Loc 180 (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589802",
+              "title": "Metal Sales Magna-Loc 90 (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589803",
+              "title": "Metal Sales Maxi-Batten (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589804",
+              "title": "Metal Sales Mini-Batten 1.5\" (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589769",
+              "title": "Metal Sales PBR-Panel (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589770",
+              "title": "Metal Sales PBU-Panel (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589771",
+              "title": "Metal Sales Pro-Panel II (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589772",
+              "title": "Metal Sales R-Panel (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589805",
+              "title": "Metal Sales Seam-Loc 24 (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589806",
+              "title": "Metal Sales Snap-Loc 24 (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589773",
+              "title": "Metal Sales Strongpanel (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589774",
+              "title": "Metal Sales T1 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589775",
+              "title": "Metal Sales T11A- Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589776",
+              "title": "Metal Sales T12 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589777",
+              "title": "Metal Sales T-13 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589778",
+              "title": "Metal Sales T13-A - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589779",
+              "title": "Metal Sales T13-B - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589780",
+              "title": "Metal Sales T14 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589781",
+              "title": "Metal Sales T15 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589782",
+              "title": "Metal Sales T16-E - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589783",
+              "title": "Metal Sales T2 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589784",
+              "title": "Metal Sales T23 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589785",
+              "title": "Metal Sales T25 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589786",
+              "title": "Metal Sales T2630 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589787",
+              "title": "Metal Sales T2832 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589788",
+              "title": "Metal Sales T3 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589789",
+              "title": "Metal Sales T4 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589790",
+              "title": "Metal Sales T5 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589791",
+              "title": "Metal Sales T6-A - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589792",
+              "title": "Metal Sales T7 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589793",
+              "title": "Metal Sales T7A - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589807",
+              "title": "Metal Sales T-Armor Series 2-3/8\" Concealed Fasten",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589794",
+              "title": "Metal Sales TDR-6 - Roof (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589795",
+              "title": "Metal Sales U-Panel (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589808",
+              "title": "Metal Sales Vertical Seam (Concealed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262589796",
+              "title": "Metal Sales V-Line 32 (Exposed Fastened)",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614590",
+          "sourceSelectionId": "63614590",
+          "title": "Impact Rating",
+          "category": "07 31 13 - Asphalt Shingles",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587854",
+              "title": "Owens Corning Duration",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587855",
+              "title": "Owens Corning Duration Storm",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614591",
+          "sourceSelectionId": "63614591",
+          "title": "Shingle Color",
+          "category": "07 31 13 - Asphalt Shingles",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587861",
+              "title": "Antique Silver",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587856",
+              "title": "Brownwood",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587862",
+              "title": "Desert Tan",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587857",
+              "title": "Driftwood",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587858",
+              "title": "Estate Gray",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587859",
+              "title": "Onyx Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587860",
+              "title": "Teak",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614592",
+          "sourceSelectionId": "63614592",
+          "title": "Shingle Colors",
+          "category": "07 31 13 - Asphalt Shingles",
+          "location": "Exterior",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587864",
+              "title": "Brownwood",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587865",
+              "title": "Chateau Green",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587863",
+              "title": "Desert Rose",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587866",
+              "title": "Driftwood",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587867",
+              "title": "Estate Gray",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587868",
+              "title": "Midnight Plum",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587869",
+              "title": "Onyx Black",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587870",
+              "title": "Peppercorn",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587871",
+              "title": "Sandcastle",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587872",
+              "title": "Sierra Gray",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587873",
+              "title": "Slatestone Gray",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587874",
+              "title": "Teak",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587875",
+              "title": "Terra Cotta",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            },
+            {
+              "sourceChoiceId": "262587876",
+              "title": "Williamsburg Gray",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 0
+            }
+          ]
+        }
+      ],
+      "bidPackages": [
+        {
+          "sourceItemId": "13408751",
+          "sourceBidPackageId": "13408751",
+          "title": "Roofing - (Project Address) (Estimate Phase)",
+          "status": "Draft",
+          "allowMultipleApprovedBids": false,
+          "deadline": null,
+          "time": null,
+          "reminderLeadDays": 2,
+          "plansAndSpecs": false,
+          "pricingFormat": "Line Items",
+          "description": "Background\nHigh Performance Structures, Inc. dba Open Range Construction, Ltd. (ORC) will be building a custom home located at:\n(Project Street Address)\n(Project City), (Project State) (Project Zip Code)\nReference Documents\nPlease see the Buildertrend Documents folder titled \"(Estimate Phase) Bid Set\" for all necessary plans.\nSubmission of Bid\nBids for this project will be processed through Buildertrend, a construction management program. You do not need to become proficient with Buildertrend. You may also simply call or email your point of contact. You may submit your bid into Buildertrend or email it to your point of contact for entry. Should you choose to input your bid into Buildertrend, please also include a PDF version of your bid.\nFor assistance with submitting the bid or receiving bid documents, contact the (Estimator Title):\n(Estimator Name), (719) 900-8850 ext. (Estimator Extension)\n(Estimator Email Address)\nTimeline\nThe work is scheduled to start in (Build Season), (Build Year).\nScope of Work\nThe following CSI categories will be required for the construction of the project per the plans and specifications noted on the Plans and Specifications List. We will notify bidders of any changes or additions by sending out updates to said List.\nQuestions\nPlease direct any questions into the RFI section here on Buildertrend. This helps us as a builder keep questions organized and accessible to any of our staff provided an estimator is absent. This will help expedite provision of answers.\nSchedule\nPlease provide a schedule to complete each of the above items, in calendar days after the issuance of the purchase order and/or notice to proceed.\nContract and Insurance Requirements\nAll trade contractors will be required to complete a trade contractor agreement, provide proof of liability insurance and workman’s compensation insurance as applicable, with required limits prior to the release of any construction payments.",
+          "descriptionSections": [
+            "Background",
+            "High Performance Structures, Inc. dba Open Range Construction, Ltd. (ORC) will be building a custom home located at:",
+            "(Project Street Address)",
+            "(Project City), (Project State) (Project Zip Code)",
+            "Reference Documents",
+            "Please see the Buildertrend Documents folder titled \"(Estimate Phase) Bid Set\" for all necessary plans.",
+            "Submission of Bid",
+            "Bids for this project will be processed through Buildertrend, a construction management program. You do not need to become proficient with Buildertrend. You may also simply call or email your point of contact. You may submit your bid into Buildertrend or email it to your point of contact for entry. Should you choose to input your bid into Buildertrend, please also include a PDF version of your bid.",
+            "For assistance with submitting the bid or receiving bid documents, contact the (Estimator Title):",
+            "(Estimator Name), (719) 900-8850 ext. (Estimator Extension)",
+            "(Estimator Email Address)",
+            "Timeline",
+            "The work is scheduled to start in (Build Season), (Build Year).",
+            "Scope of Work",
+            "The following CSI categories will be required for the construction of the project per the plans and specifications noted on the Plans and Specifications List. We will notify bidders of any changes or additions by sending out updates to said List.",
+            "Questions",
+            "Please direct any questions into the RFI section here on Buildertrend. This helps us as a builder keep questions organized and accessible to any of our staff provided an estimator is absent. This will help expedite provision of answers.",
+            "Schedule",
+            "Please provide a schedule to complete each of the above items, in calendar days after the issuance of the purchase order and/or notice to proceed.",
+            "Contract and Insurance Requirements",
+            "All trade contractors will be required to complete a trade contractor agreement, provide proof of liability insurance and workman’s compensation insurance as applicable, with required limits prior to the release of any construction payments."
+          ],
+          "internalNotes": "",
+          "attachments": [],
+          "lineItems": [
+            {
+              "title": "Asphalt Shingle Roofing Installation Labor & Materials",
+              "costCode": "07 31 13 - Asphalt Shingles",
+              "costType": "None",
+              "quantity": 1,
+              "unit": null
+            },
+            {
+              "title": "Metal Roofing & Underlayment Labor & Materials",
+              "costCode": "07 41 13 - Metal Roof Panels",
+              "costType": "None",
+              "quantity": 1,
+              "unit": null
+            }
+          ]
+        }
+      ],
+      "notCaptured": [
+        "Native Buildertrend task IDs and task descriptions",
+        "Selection attachment file names and bytes were not downloaded."
+      ]
+    },
+    {
+      "sourceTemplateId": "32043577",
+      "name": "Design & Preconstruction",
+      "sourceName": "Design & Preconstruction",
+      "moduleCounts": {
+        "tasks": 48,
+        "scheduleItems": 34,
+        "selections": 0,
+        "bidPackages": 0
+      },
+      "schedule": {
+        "sourceAnchorDate": "2024-12-03",
+        "phases": [
+          {
+            "sourcePhaseId": "32043577:phase:1",
+            "name": "UNASSIGNED"
+          },
+          {
+            "sourcePhaseId": "32043577:phase:2",
+            "name": "Design & Pre-Construction"
+          }
+        ],
+        "items": [
+          {
+            "sourceItemId": "216505364",
+            "title": "Site Assessment",
+            "startDate": "2024-12-03",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#FF9600",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216508142",
+            "title": "Loan Preapproval",
+            "startDate": "2024-12-04",
+            "workdays": 5,
+            "phase": "UNASSIGNED",
+            "displayColor": "#FF9600",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216505610",
+            "title": "Soils Test Drilling",
+            "startDate": "2024-12-04",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216505715",
+            "title": "Soils Test Labs",
+            "startDate": "2024-12-04",
+            "workdays": 16,
+            "phase": "UNASSIGNED",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216506440",
+            "title": "Preliminary Architectural Plan",
+            "startDate": "2024-12-11",
+            "workdays": 10,
+            "phase": "UNASSIGNED",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216507112",
+            "title": "Prelim. Architectural Plan Owner Review & Feedback",
+            "startDate": "2024-12-25",
+            "workdays": 5,
+            "phase": "UNASSIGNED",
+            "displayColor": "#FF9600",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216507483",
+            "title": "Architectural Plan Revisions",
+            "startDate": "2025-01-01",
+            "workdays": 10,
+            "phase": "UNASSIGNED",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216508885",
+            "title": "Architectural Revision Owner Review",
+            "startDate": "2025-01-15",
+            "workdays": 1,
+            "phase": "Design & Pre-Construction",
+            "displayColor": "#FF9600",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216508981",
+            "title": "Architectural Elevations",
+            "startDate": "2025-01-16",
+            "workdays": 10,
+            "phase": "Design & Pre-Construction",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216516203",
+            "title": "Prepare Site Plan",
+            "startDate": "2025-01-16",
+            "workdays": 10,
+            "phase": "UNASSIGNED",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216519242",
+            "title": "Electrical Infrastructure Design Site Meeting",
+            "startDate": "2025-01-23",
+            "workdays": 1,
+            "phase": "Design & Pre-Construction",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216519285",
+            "title": "Well Design Site Meeting",
+            "startDate": "2025-01-23",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216509035",
+            "title": "Architectural Elevation Review",
+            "startDate": "2025-01-30",
+            "workdays": 5,
+            "phase": "Design & Pre-Construction",
+            "displayColor": "#FF9600",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216509092",
+            "title": "Architectural Elevation Revisions",
+            "startDate": "2025-02-06",
+            "workdays": 5,
+            "phase": "Design & Pre-Construction",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216509140",
+            "title": "Architectural Elevations Revisions Owner Review",
+            "startDate": "2025-02-13",
+            "workdays": 1,
+            "phase": "Design & Pre-Construction",
+            "displayColor": "#FF9600",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216510854",
+            "title": "Architectural Building Sections",
+            "startDate": "2025-02-14",
+            "workdays": 15,
+            "phase": "UNASSIGNED",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216509543",
+            "title": "Assess & Release Preliminary Selections",
+            "startDate": "2025-02-14",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216509333",
+            "title": "MEP Design Owner Meeting",
+            "startDate": "2025-02-14",
+            "workdays": 1,
+            "phase": "Design & Pre-Construction",
+            "displayColor": "#FF9600",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216509454",
+            "title": "MEP Plan Drawings",
+            "startDate": "2025-02-17",
+            "workdays": 15,
+            "phase": "Design & Pre-Construction",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216509774",
+            "title": "Preliminary Owner Selections",
+            "startDate": "2025-02-17",
+            "workdays": 15,
+            "phase": "UNASSIGNED",
+            "displayColor": "#FF9600",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216510378",
+            "title": "Finish Schedules",
+            "startDate": "2025-03-10",
+            "workdays": 5,
+            "phase": "Design & Pre-Construction",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216510675",
+            "title": "Final Architectural Owner Review",
+            "startDate": "2025-03-17",
+            "workdays": 5,
+            "phase": "UNASSIGNED",
+            "displayColor": "#FF9600",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216512066",
+            "title": "Architectural Design Bidding",
+            "startDate": "2025-03-24",
+            "workdays": 15,
+            "phase": "Design & Pre-Construction",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216511345",
+            "title": "Architectural Design Takeoffs",
+            "startDate": "2025-03-24",
+            "workdays": 5,
+            "phase": "Design & Pre-Construction",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216511498",
+            "title": "Prepare & Send Arch. Design Bid Packages",
+            "startDate": "2025-03-24",
+            "workdays": 1,
+            "phase": "Design & Pre-Construction",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216518683",
+            "title": "Draft Construction Contracts",
+            "startDate": "2025-04-09",
+            "workdays": 5,
+            "phase": "UNASSIGNED",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216512503",
+            "title": "Compile Design Development Estimate",
+            "startDate": "2025-04-14",
+            "workdays": 2,
+            "phase": "Design & Pre-Construction",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216512780",
+            "title": "Design Development Budget Review",
+            "startDate": "2025-04-16",
+            "workdays": 1,
+            "phase": "Design & Pre-Construction",
+            "displayColor": "#FF9600",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216520602",
+            "title": "Energy Modeling & IECC Report",
+            "startDate": "2025-04-17",
+            "workdays": 20,
+            "phase": "UNASSIGNED",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216512817",
+            "title": "Engineering & Structural Drawings",
+            "startDate": "2025-04-17",
+            "workdays": 30,
+            "phase": "Design & Pre-Construction",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216519702",
+            "title": "Septic Design",
+            "startDate": "2025-04-17",
+            "workdays": 10,
+            "phase": "UNASSIGNED",
+            "displayColor": "#88AAC7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216519684",
+            "title": "Well Permitting",
+            "startDate": "2025-04-17",
+            "workdays": 20,
+            "phase": "UNASSIGNED",
+            "displayColor": "#6F116F",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216519957",
+            "title": "Septic Permitting",
+            "startDate": "2025-05-01",
+            "workdays": 20,
+            "phase": "UNASSIGNED",
+            "displayColor": "#6F116F",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "216520406",
+            "title": "Submit for Building Permit",
+            "startDate": "2025-05-29",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#ED2591",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          }
+        ],
+        "dependencies": [
+          {
+            "predecessorSourceItemId": "216505364",
+            "successorSourceItemId": "216508142",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216505364",
+            "successorSourceItemId": "216505610",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216505610",
+            "successorSourceItemId": "216505715",
+            "type": "SS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216505364",
+            "successorSourceItemId": "216506440",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216508142",
+            "successorSourceItemId": "216506440",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216506440",
+            "successorSourceItemId": "216507112",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216507112",
+            "successorSourceItemId": "216507483",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216507483",
+            "successorSourceItemId": "216508885",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216508885",
+            "successorSourceItemId": "216508981",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216508885",
+            "successorSourceItemId": "216516203",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216516203",
+            "successorSourceItemId": "216519242",
+            "type": "SS",
+            "lagDays": 5
+          },
+          {
+            "predecessorSourceItemId": "216516203",
+            "successorSourceItemId": "216519285",
+            "type": "SS",
+            "lagDays": 5
+          },
+          {
+            "predecessorSourceItemId": "216508981",
+            "successorSourceItemId": "216509035",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216509035",
+            "successorSourceItemId": "216509092",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216509092",
+            "successorSourceItemId": "216509140",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216509140",
+            "successorSourceItemId": "216510854",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216509140",
+            "successorSourceItemId": "216509543",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216509140",
+            "successorSourceItemId": "216509333",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216509333",
+            "successorSourceItemId": "216509454",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216509543",
+            "successorSourceItemId": "216509774",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216509774",
+            "successorSourceItemId": "216510378",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216509454",
+            "successorSourceItemId": "216510675",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216510378",
+            "successorSourceItemId": "216510675",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216510854",
+            "successorSourceItemId": "216510675",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216511498",
+            "successorSourceItemId": "216512066",
+            "type": "SS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216505715",
+            "successorSourceItemId": "216511345",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216510675",
+            "successorSourceItemId": "216511345",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216510675",
+            "successorSourceItemId": "216511498",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216512503",
+            "successorSourceItemId": "216518683",
+            "type": "FS",
+            "lagDays": -5
+          },
+          {
+            "predecessorSourceItemId": "216511345",
+            "successorSourceItemId": "216512503",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216512066",
+            "successorSourceItemId": "216512503",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216512503",
+            "successorSourceItemId": "216512780",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216512780",
+            "successorSourceItemId": "216520602",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216512780",
+            "successorSourceItemId": "216512817",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216512780",
+            "successorSourceItemId": "216519702",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216512780",
+            "successorSourceItemId": "216519684",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216519702",
+            "successorSourceItemId": "216519957",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216512817",
+            "successorSourceItemId": "216520406",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216519684",
+            "successorSourceItemId": "216520406",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216519957",
+            "successorSourceItemId": "216520406",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "216520602",
+            "successorSourceItemId": "216520406",
+            "type": "FS",
+            "lagDays": 0
+          }
+        ]
+      },
+      "scheduleItems": [
+        {
+          "sourceItemId": "216505364",
+          "title": "Site Assessment",
+          "startDate": "2024-12-03",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#FF9600",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": []
+        },
+        {
+          "sourceItemId": "216508142",
+          "title": "Loan Preapproval",
+          "startDate": "2024-12-04",
+          "workdays": 5,
+          "phase": "UNASSIGNED",
+          "displayColor": "#FF9600",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216505364",
+              "successorSourceItemId": "216508142",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216505610",
+          "title": "Soils Test Drilling",
+          "startDate": "2024-12-04",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216505364",
+              "successorSourceItemId": "216505610",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216505715",
+          "title": "Soils Test Labs",
+          "startDate": "2024-12-04",
+          "workdays": 16,
+          "phase": "UNASSIGNED",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216505610",
+              "successorSourceItemId": "216505715",
+              "type": "SS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216506440",
+          "title": "Preliminary Architectural Plan",
+          "startDate": "2024-12-11",
+          "workdays": 10,
+          "phase": "UNASSIGNED",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216505364",
+              "successorSourceItemId": "216506440",
+              "type": "FS",
+              "lagDays": 0
+            },
+            {
+              "predecessorSourceItemId": "216508142",
+              "successorSourceItemId": "216506440",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216507112",
+          "title": "Prelim. Architectural Plan Owner Review & Feedback",
+          "startDate": "2024-12-25",
+          "workdays": 5,
+          "phase": "UNASSIGNED",
+          "displayColor": "#FF9600",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216506440",
+              "successorSourceItemId": "216507112",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216507483",
+          "title": "Architectural Plan Revisions",
+          "startDate": "2025-01-01",
+          "workdays": 10,
+          "phase": "UNASSIGNED",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216507112",
+              "successorSourceItemId": "216507483",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216508885",
+          "title": "Architectural Revision Owner Review",
+          "startDate": "2025-01-15",
+          "workdays": 1,
+          "phase": "Design & Pre-Construction",
+          "displayColor": "#FF9600",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216507483",
+              "successorSourceItemId": "216508885",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216508981",
+          "title": "Architectural Elevations",
+          "startDate": "2025-01-16",
+          "workdays": 10,
+          "phase": "Design & Pre-Construction",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216508885",
+              "successorSourceItemId": "216508981",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216516203",
+          "title": "Prepare Site Plan",
+          "startDate": "2025-01-16",
+          "workdays": 10,
+          "phase": "UNASSIGNED",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216508885",
+              "successorSourceItemId": "216516203",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216519242",
+          "title": "Electrical Infrastructure Design Site Meeting",
+          "startDate": "2025-01-23",
+          "workdays": 1,
+          "phase": "Design & Pre-Construction",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216516203",
+              "successorSourceItemId": "216519242",
+              "type": "SS",
+              "lagDays": 5
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216519285",
+          "title": "Well Design Site Meeting",
+          "startDate": "2025-01-23",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216516203",
+              "successorSourceItemId": "216519285",
+              "type": "SS",
+              "lagDays": 5
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216509035",
+          "title": "Architectural Elevation Review",
+          "startDate": "2025-01-30",
+          "workdays": 5,
+          "phase": "Design & Pre-Construction",
+          "displayColor": "#FF9600",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216508981",
+              "successorSourceItemId": "216509035",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216509092",
+          "title": "Architectural Elevation Revisions",
+          "startDate": "2025-02-06",
+          "workdays": 5,
+          "phase": "Design & Pre-Construction",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216509035",
+              "successorSourceItemId": "216509092",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216509140",
+          "title": "Architectural Elevations Revisions Owner Review",
+          "startDate": "2025-02-13",
+          "workdays": 1,
+          "phase": "Design & Pre-Construction",
+          "displayColor": "#FF9600",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216509092",
+              "successorSourceItemId": "216509140",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216510854",
+          "title": "Architectural Building Sections",
+          "startDate": "2025-02-14",
+          "workdays": 15,
+          "phase": "UNASSIGNED",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216509140",
+              "successorSourceItemId": "216510854",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216509543",
+          "title": "Assess & Release Preliminary Selections",
+          "startDate": "2025-02-14",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216509140",
+              "successorSourceItemId": "216509543",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216509333",
+          "title": "MEP Design Owner Meeting",
+          "startDate": "2025-02-14",
+          "workdays": 1,
+          "phase": "Design & Pre-Construction",
+          "displayColor": "#FF9600",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216509140",
+              "successorSourceItemId": "216509333",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216509454",
+          "title": "MEP Plan Drawings",
+          "startDate": "2025-02-17",
+          "workdays": 15,
+          "phase": "Design & Pre-Construction",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216509333",
+              "successorSourceItemId": "216509454",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216509774",
+          "title": "Preliminary Owner Selections",
+          "startDate": "2025-02-17",
+          "workdays": 15,
+          "phase": "UNASSIGNED",
+          "displayColor": "#FF9600",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216509543",
+              "successorSourceItemId": "216509774",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216510378",
+          "title": "Finish Schedules",
+          "startDate": "2025-03-10",
+          "workdays": 5,
+          "phase": "Design & Pre-Construction",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216509774",
+              "successorSourceItemId": "216510378",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216510675",
+          "title": "Final Architectural Owner Review",
+          "startDate": "2025-03-17",
+          "workdays": 5,
+          "phase": "UNASSIGNED",
+          "displayColor": "#FF9600",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216509454",
+              "successorSourceItemId": "216510675",
+              "type": "FS",
+              "lagDays": 0
+            },
+            {
+              "predecessorSourceItemId": "216510378",
+              "successorSourceItemId": "216510675",
+              "type": "FS",
+              "lagDays": 0
+            },
+            {
+              "predecessorSourceItemId": "216510854",
+              "successorSourceItemId": "216510675",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216512066",
+          "title": "Architectural Design Bidding",
+          "startDate": "2025-03-24",
+          "workdays": 15,
+          "phase": "Design & Pre-Construction",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216511498",
+              "successorSourceItemId": "216512066",
+              "type": "SS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216511345",
+          "title": "Architectural Design Takeoffs",
+          "startDate": "2025-03-24",
+          "workdays": 5,
+          "phase": "Design & Pre-Construction",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216505715",
+              "successorSourceItemId": "216511345",
+              "type": "FS",
+              "lagDays": 0
+            },
+            {
+              "predecessorSourceItemId": "216510675",
+              "successorSourceItemId": "216511345",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216511498",
+          "title": "Prepare & Send Arch. Design Bid Packages",
+          "startDate": "2025-03-24",
+          "workdays": 1,
+          "phase": "Design & Pre-Construction",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216510675",
+              "successorSourceItemId": "216511498",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216518683",
+          "title": "Draft Construction Contracts",
+          "startDate": "2025-04-09",
+          "workdays": 5,
+          "phase": "UNASSIGNED",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216512503",
+              "successorSourceItemId": "216518683",
+              "type": "FS",
+              "lagDays": -5
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216512503",
+          "title": "Compile Design Development Estimate",
+          "startDate": "2025-04-14",
+          "workdays": 2,
+          "phase": "Design & Pre-Construction",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216511345",
+              "successorSourceItemId": "216512503",
+              "type": "FS",
+              "lagDays": 0
+            },
+            {
+              "predecessorSourceItemId": "216512066",
+              "successorSourceItemId": "216512503",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216512780",
+          "title": "Design Development Budget Review",
+          "startDate": "2025-04-16",
+          "workdays": 1,
+          "phase": "Design & Pre-Construction",
+          "displayColor": "#FF9600",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216512503",
+              "successorSourceItemId": "216512780",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216520602",
+          "title": "Energy Modeling & IECC Report",
+          "startDate": "2025-04-17",
+          "workdays": 20,
+          "phase": "UNASSIGNED",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216512780",
+              "successorSourceItemId": "216520602",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216512817",
+          "title": "Engineering & Structural Drawings",
+          "startDate": "2025-04-17",
+          "workdays": 30,
+          "phase": "Design & Pre-Construction",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216512780",
+              "successorSourceItemId": "216512817",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216519702",
+          "title": "Septic Design",
+          "startDate": "2025-04-17",
+          "workdays": 10,
+          "phase": "UNASSIGNED",
+          "displayColor": "#88AAC7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216512780",
+              "successorSourceItemId": "216519702",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216519684",
+          "title": "Well Permitting",
+          "startDate": "2025-04-17",
+          "workdays": 20,
+          "phase": "UNASSIGNED",
+          "displayColor": "#6F116F",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216512780",
+              "successorSourceItemId": "216519684",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216519957",
+          "title": "Septic Permitting",
+          "startDate": "2025-05-01",
+          "workdays": 20,
+          "phase": "UNASSIGNED",
+          "displayColor": "#6F116F",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216519702",
+              "successorSourceItemId": "216519957",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "216520406",
+          "title": "Submit for Building Permit",
+          "startDate": "2025-05-29",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#ED2591",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "216512817",
+              "successorSourceItemId": "216520406",
+              "type": "FS",
+              "lagDays": 0
+            },
+            {
+              "predecessorSourceItemId": "216519684",
+              "successorSourceItemId": "216520406",
+              "type": "FS",
+              "lagDays": 0
+            },
+            {
+              "predecessorSourceItemId": "216519957",
+              "successorSourceItemId": "216520406",
+              "type": "FS",
+              "lagDays": 0
+            },
+            {
+              "predecessorSourceItemId": "216520602",
+              "successorSourceItemId": "216520406",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        }
+      ],
+      "provenance": {
+        "copiedTargetTemplateId": "45876671",
+        "taskIdentity": "sourceItemId values are deterministic capture IDs because Buildertrend did not expose native task IDs."
+      },
+      "tasks": [
+        {
+          "sourceItemId": "45876671:task:001",
+          "parentSourceItemId": null,
+          "title": "Full Build Final Preconstruction Estimate",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876671:task:002",
+          "parentSourceItemId": "45876671:task:001",
+          "title": "Send out RFQs",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876671:task:003",
+          "parentSourceItemId": "45876671:task:001",
+          "title": "Follow Up with RFQs If No Response after 1 Week",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876671:task:004",
+          "parentSourceItemId": "45876671:task:001",
+          "title": "Follow Up with RFQs 1 Week before Due Date",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876671:task:005",
+          "parentSourceItemId": "45876671:task:001",
+          "title": "Pull Takeoffs",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876671:task:006",
+          "parentSourceItemId": "45876671:task:001",
+          "title": "Compile Takeoff Data",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876671:task:007",
+          "parentSourceItemId": "45876671:task:001",
+          "title": "Compile All Quotes",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876671:task:008",
+          "parentSourceItemId": "45876671:task:001",
+          "title": "Finalize Estimate",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876671:task:009",
+          "parentSourceItemId": "45876671:task:001",
+          "title": "Schedule Budget Meeting",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876671:task:010",
+          "parentSourceItemId": null,
+          "title": "Pull Takeoffs",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876671:task:011",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Footing Takeoffs",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876671:task:012",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Foundation Takeoffs",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876671:task:013",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Lower Level ICF Wall Takeoffs",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876671:task:014",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Lower Level Exterior Framed Wall Takeoffs",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876671:task:015",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Lower Level Slab Takeoffs",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876671:task:016",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Lower Level Interior Wall Framing Takeoffs",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876671:task:017",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Lower Level Interior Fenestration Takeoffs",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876671:task:018",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Lower Level Exterior Fenestration Takeoffs",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876671:task:019",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Lower Level Countertop Takeoffs",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876671:task:020",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Lower Level Base & Case Takeoffs",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876671:task:021",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Main Level Floor System Takeoffs",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876671:task:022",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Main Level ICF Wall Takeoffs",
+          "sortOrder": 12
+        },
+        {
+          "sourceItemId": "45876671:task:023",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Main Level Exterior Framed Wall Takeoffs",
+          "sortOrder": 13
+        },
+        {
+          "sourceItemId": "45876671:task:024",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Main Level Interior Wall Takeoffs",
+          "sortOrder": 14
+        },
+        {
+          "sourceItemId": "45876671:task:025",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Main Level Interior Fenestration Takeoffs",
+          "sortOrder": 15
+        },
+        {
+          "sourceItemId": "45876671:task:026",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Main Level Exterior Fenestration Takeoffs",
+          "sortOrder": 16
+        },
+        {
+          "sourceItemId": "45876671:task:027",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Main Level Countertop Takeoffs",
+          "sortOrder": 17
+        },
+        {
+          "sourceItemId": "45876671:task:028",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Main Level base & Case Takeoffs",
+          "sortOrder": 18
+        },
+        {
+          "sourceItemId": "45876671:task:029",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Upper Level Floor System Takeoffs",
+          "sortOrder": 19
+        },
+        {
+          "sourceItemId": "45876671:task:030",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Upper Level ICF Wall Takeoffs",
+          "sortOrder": 20
+        },
+        {
+          "sourceItemId": "45876671:task:031",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Upper Level Exterior Framed Wall TAkeoffs",
+          "sortOrder": 21
+        },
+        {
+          "sourceItemId": "45876671:task:032",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Upper Level interior Wall Takeoffs",
+          "sortOrder": 22
+        },
+        {
+          "sourceItemId": "45876671:task:033",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Upper Level Interior Fenestration Takeoffs",
+          "sortOrder": 23
+        },
+        {
+          "sourceItemId": "45876671:task:034",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Upper Level Exterior Fenestration Takeoffs",
+          "sortOrder": 24
+        },
+        {
+          "sourceItemId": "45876671:task:035",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Upper Level Countertop Takeoffs",
+          "sortOrder": 25
+        },
+        {
+          "sourceItemId": "45876671:task:036",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Upper Level Base & Case Takeoffs",
+          "sortOrder": 26
+        },
+        {
+          "sourceItemId": "45876671:task:037",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Roof System Framing Takeoffs",
+          "sortOrder": 27
+        },
+        {
+          "sourceItemId": "45876671:task:038",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Siding Takeoffs",
+          "sortOrder": 28
+        },
+        {
+          "sourceItemId": "45876671:task:039",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Exterior Deck Takeoffs",
+          "sortOrder": 29
+        },
+        {
+          "sourceItemId": "45876671:task:040",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Exterior Piers & Pads Takeoffs",
+          "sortOrder": 30
+        },
+        {
+          "sourceItemId": "45876671:task:041",
+          "parentSourceItemId": "45876671:task:010",
+          "title": "Pull Exterior Concrete Slab Takeoffs",
+          "sortOrder": 31
+        },
+        {
+          "sourceItemId": "45876671:task:042",
+          "parentSourceItemId": null,
+          "title": "Rough Stake of Center of House",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876671:task:043",
+          "parentSourceItemId": null,
+          "title": "Get Preapproval from Bank",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876671:task:044",
+          "parentSourceItemId": null,
+          "title": "Schedule Geotechnical Engineer for Soils Testing",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876671:task:045",
+          "parentSourceItemId": null,
+          "title": "Complete Preliminary Architectural Footprint",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876671:task:046",
+          "parentSourceItemId": null,
+          "title": "Send Preliminary Arch Floor Plan to Owners for Approval",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876671:task:047",
+          "parentSourceItemId": null,
+          "title": "Complete Architectural Revisions",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876671:task:048",
+          "parentSourceItemId": null,
+          "title": "Send Revised Architectural Floor Plan to Owners",
+          "sortOrder": 9
+        }
+      ],
+      "notCaptured": [
+        "Native Buildertrend task IDs, task descriptions, and source assignee identities."
+      ]
+    },
+    {
+      "sourceTemplateId": "12667545",
+      "name": "Concrete - LiteDeck Assembly",
+      "sourceName": "Concrete - LiteDeck Assembly",
+      "moduleCounts": {
+        "tasks": 50,
+        "scheduleItems": 15,
+        "selections": 0,
+        "bidPackages": 0
+      },
+      "schedule": {
+        "sourceAnchorDate": "2022-04-18",
+        "phases": [
+          {
+            "sourcePhaseId": "12667545:phase:1",
+            "name": "UNASSIGNED"
+          }
+        ],
+        "items": [
+          {
+            "sourceItemId": "141882543",
+            "title": "Build (X LEVEL) LiteDeck Temporary Structure",
+            "startDate": "2022-04-18",
+            "workdays": 4,
+            "phase": "UNASSIGNED",
+            "displayColor": "#A7A7A7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "141882532",
+            "title": "Set (X LEVEL) LiteDeck Base Forms",
+            "startDate": "2022-04-22",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#A7A7A7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "141882567",
+            "title": "Install (X LEVEL) LiteDeck Reinforcing",
+            "startDate": "2022-04-25",
+            "workdays": 3,
+            "phase": "UNASSIGNED",
+            "displayColor": "#A7A7A7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "141977213",
+            "title": "Install (X)Level LiteDeck Permanent Support Posts",
+            "startDate": "2022-04-25",
+            "workdays": 2,
+            "phase": "UNASSIGNED",
+            "displayColor": "#A7A7A7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "141882555",
+            "title": "Set (X LEVEL) LiteDeck Electrical Chases",
+            "startDate": "2022-04-25",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#D67029",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "141983155",
+            "title": "Set (X LEVEL) LiteDeck HVAC Chases",
+            "startDate": "2022-04-25",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#323232",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "141882554",
+            "title": "Set (X LEVEL) LiteDeck Plumbing Chases",
+            "startDate": "2022-04-25",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#436A8C",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "141882557",
+            "title": "Set (X LEVEL) LiteDeck Top Hat",
+            "startDate": "2022-04-25",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#A7A7A7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "141974023",
+            "title": "(X) Level LiteDeck Slab Radiant Installation",
+            "startDate": "2022-04-28",
+            "workdays": 2,
+            "phase": "UNASSIGNED",
+            "displayColor": "#AD5252",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "141973904",
+            "title": "(X) Level LiteDeck Slab Reinforcing",
+            "startDate": "2022-04-28",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#A7A7A7",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "141978388",
+            "title": "Building Department (X) Level LiteDeck Inspection",
+            "startDate": "2022-04-28",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#ED2591",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "141977933",
+            "title": "Building Department (X) Level Radiant Inspection",
+            "startDate": "2022-05-02",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#ED2591",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "141974565",
+            "title": "HPS (X) Level LiteDeck Slab QC/Pre-Pour Inspection",
+            "startDate": "2022-05-02",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#2222DD",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "141981823",
+            "title": "(X) Level LiteDeck Pour",
+            "startDate": "2022-05-03",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#DD2222",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "141981848",
+            "title": "HPS (X) Level Flatwork QC Inspection",
+            "startDate": "2022-05-03",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#2222DD",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          }
+        ],
+        "dependencies": [
+          {
+            "predecessorSourceItemId": "141882543",
+            "successorSourceItemId": "141882532",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "141882557",
+            "successorSourceItemId": "141882567",
+            "type": "SS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "141882532",
+            "successorSourceItemId": "141977213",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "141882532",
+            "successorSourceItemId": "141882555",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "141882532",
+            "successorSourceItemId": "141983155",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "141882532",
+            "successorSourceItemId": "141882554",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "141882532",
+            "successorSourceItemId": "141882557",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "141973904",
+            "successorSourceItemId": "141974023",
+            "type": "SS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "141882567",
+            "successorSourceItemId": "141973904",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "141977213",
+            "successorSourceItemId": "141973904",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "141882567",
+            "successorSourceItemId": "141978388",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "141974023",
+            "successorSourceItemId": "141977933",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "141974023",
+            "successorSourceItemId": "141974565",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "141977933",
+            "successorSourceItemId": "141981823",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "141978388",
+            "successorSourceItemId": "141981823",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "141981823",
+            "successorSourceItemId": "141981848",
+            "type": "SS",
+            "lagDays": 0
+          }
+        ]
+      },
+      "scheduleItems": [
+        {
+          "sourceItemId": "141882543",
+          "title": "Build (X LEVEL) LiteDeck Temporary Structure",
+          "startDate": "2022-04-18",
+          "workdays": 4,
+          "phase": "UNASSIGNED",
+          "displayColor": "#A7A7A7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": []
+        },
+        {
+          "sourceItemId": "141882532",
+          "title": "Set (X LEVEL) LiteDeck Base Forms",
+          "startDate": "2022-04-22",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#A7A7A7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "141882543",
+              "successorSourceItemId": "141882532",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "141882567",
+          "title": "Install (X LEVEL) LiteDeck Reinforcing",
+          "startDate": "2022-04-25",
+          "workdays": 3,
+          "phase": "UNASSIGNED",
+          "displayColor": "#A7A7A7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "141882557",
+              "successorSourceItemId": "141882567",
+              "type": "SS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "141977213",
+          "title": "Install (X)Level LiteDeck Permanent Support Posts",
+          "startDate": "2022-04-25",
+          "workdays": 2,
+          "phase": "UNASSIGNED",
+          "displayColor": "#A7A7A7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "141882532",
+              "successorSourceItemId": "141977213",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "141882555",
+          "title": "Set (X LEVEL) LiteDeck Electrical Chases",
+          "startDate": "2022-04-25",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#D67029",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "141882532",
+              "successorSourceItemId": "141882555",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "141983155",
+          "title": "Set (X LEVEL) LiteDeck HVAC Chases",
+          "startDate": "2022-04-25",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#323232",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "141882532",
+              "successorSourceItemId": "141983155",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "141882554",
+          "title": "Set (X LEVEL) LiteDeck Plumbing Chases",
+          "startDate": "2022-04-25",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#436A8C",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "141882532",
+              "successorSourceItemId": "141882554",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "141882557",
+          "title": "Set (X LEVEL) LiteDeck Top Hat",
+          "startDate": "2022-04-25",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#A7A7A7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "141882532",
+              "successorSourceItemId": "141882557",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "141974023",
+          "title": "(X) Level LiteDeck Slab Radiant Installation",
+          "startDate": "2022-04-28",
+          "workdays": 2,
+          "phase": "UNASSIGNED",
+          "displayColor": "#AD5252",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "141973904",
+              "successorSourceItemId": "141974023",
+              "type": "SS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "141973904",
+          "title": "(X) Level LiteDeck Slab Reinforcing",
+          "startDate": "2022-04-28",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#A7A7A7",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "141882567",
+              "successorSourceItemId": "141973904",
+              "type": "FS",
+              "lagDays": 0
+            },
+            {
+              "predecessorSourceItemId": "141977213",
+              "successorSourceItemId": "141973904",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "141978388",
+          "title": "Building Department (X) Level LiteDeck Inspection",
+          "startDate": "2022-04-28",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#ED2591",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "141882567",
+              "successorSourceItemId": "141978388",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "141977933",
+          "title": "Building Department (X) Level Radiant Inspection",
+          "startDate": "2022-05-02",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#ED2591",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "141974023",
+              "successorSourceItemId": "141977933",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "141974565",
+          "title": "HPS (X) Level LiteDeck Slab QC/Pre-Pour Inspection",
+          "startDate": "2022-05-02",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#2222DD",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "141974023",
+              "successorSourceItemId": "141974565",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "141981823",
+          "title": "(X) Level LiteDeck Pour",
+          "startDate": "2022-05-03",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#DD2222",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "141977933",
+              "successorSourceItemId": "141981823",
+              "type": "FS",
+              "lagDays": 0
+            },
+            {
+              "predecessorSourceItemId": "141978388",
+              "successorSourceItemId": "141981823",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "141981848",
+          "title": "HPS (X) Level Flatwork QC Inspection",
+          "startDate": "2022-05-03",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#2222DD",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "141981823",
+              "successorSourceItemId": "141981848",
+              "type": "SS",
+              "lagDays": 0
+            }
+          ]
+        }
+      ],
+      "provenance": {
+        "copiedTargetTemplateId": "45876676",
+        "taskIdentity": "sourceItemId values are deterministic capture IDs because Buildertrend did not expose native task IDs."
+      },
+      "tasks": [
+        {
+          "sourceItemId": "45876676:task:001",
+          "parentSourceItemId": null,
+          "title": "Set (X LEVEL) LiteDeck Temporary Ledger Boards",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876676:task:002",
+          "parentSourceItemId": null,
+          "title": "Set (X LEVEL) 2x4 LiteDeck Temp Ledger Supports",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876676:task:003",
+          "parentSourceItemId": null,
+          "title": "Construct (X LEVEL) LiteDeck Temporary Beams",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876676:task:004",
+          "parentSourceItemId": null,
+          "title": "(X LEVEL) LiteDeck Temporary Beam Layout @ 5' O.C.",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876676:task:005",
+          "parentSourceItemId": null,
+          "title": "Set (X LEVEL) LiteDeck Temporary Beams on Layout",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876676:task:006",
+          "parentSourceItemId": null,
+          "title": "Set (X LEVEL) LiteDeck Teleposts",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876676:task:007",
+          "parentSourceItemId": null,
+          "title": "Set (X LEVEL) LiteDeck Forms",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876676:task:008",
+          "parentSourceItemId": null,
+          "title": "Install (X LEVEL) LiteDeck Plumbing Chases",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876676:task:009",
+          "parentSourceItemId": null,
+          "title": "Install (X LEVEL) LiteDeck Electrical Chases",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876676:task:010",
+          "parentSourceItemId": null,
+          "title": "Set (X LEVEL) LiteDeck Top Hat",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876676:task:011",
+          "parentSourceItemId": null,
+          "title": "Form (X LEVEL) LiteDeck Concrete Beams",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876676:task:012",
+          "parentSourceItemId": null,
+          "title": "Install (X LEVEL) LiteDeck Concrete Joist Bottom Rebar",
+          "sortOrder": 12
+        },
+        {
+          "sourceItemId": "45876676:task:013",
+          "parentSourceItemId": "45876676:task:012",
+          "title": "Bottom Rebar Set on LiteStand Rebar Chairs",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876676:task:014",
+          "parentSourceItemId": null,
+          "title": "Install (X LEVEL) LiteDeck Concrete Joist Top Rebar",
+          "sortOrder": 13
+        },
+        {
+          "sourceItemId": "45876676:task:015",
+          "parentSourceItemId": "45876676:task:014",
+          "title": "All Top Rebar Hung Appropriately",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876676:task:016",
+          "parentSourceItemId": null,
+          "title": "Cut ICF Wall Foam (X LEVEL) LiteDeck Tie-In",
+          "sortOrder": 14
+        },
+        {
+          "sourceItemId": "45876676:task:017",
+          "parentSourceItemId": "45876676:task:016",
+          "title": "Foam Cut for Concrete Joists",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876676:task:018",
+          "parentSourceItemId": "45876676:task:016",
+          "title": "Foam Cut for Concrete Beams",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876676:task:019",
+          "parentSourceItemId": null,
+          "title": "(X) Level LiteDeck (X) Concrete Beam Reinforcing Steel Hoops",
+          "sortOrder": 15
+        },
+        {
+          "sourceItemId": "45876676:task:020",
+          "parentSourceItemId": null,
+          "title": "(X) Level LiteDeck (X) Concrete Beam Bottom Rebar",
+          "sortOrder": 16
+        },
+        {
+          "sourceItemId": "45876676:task:021",
+          "parentSourceItemId": null,
+          "title": "(X) Level LiteDeck (X) Concrete Beam Top Rebar",
+          "sortOrder": 17
+        },
+        {
+          "sourceItemId": "45876676:task:022",
+          "parentSourceItemId": null,
+          "title": "Install (X) Level LiteDeck/ICF Wall Tie-In L Bars",
+          "sortOrder": 18
+        },
+        {
+          "sourceItemId": "45876676:task:023",
+          "parentSourceItemId": null,
+          "title": "(X) Level LiteDeck (X) Concrete Beam Blockout Forming",
+          "sortOrder": 19
+        },
+        {
+          "sourceItemId": "45876676:task:024",
+          "parentSourceItemId": null,
+          "title": "Install (X) Level LiteDeck Slab Welded Wire Mesh",
+          "sortOrder": 20
+        },
+        {
+          "sourceItemId": "45876676:task:025",
+          "parentSourceItemId": null,
+          "title": "Install (X) Level LiteDeck Slab Radiant Lines",
+          "sortOrder": 21
+        },
+        {
+          "sourceItemId": "45876676:task:026",
+          "parentSourceItemId": null,
+          "title": "Install (X) Level LiteDeck Slab Radiant Manifold",
+          "sortOrder": 22
+        },
+        {
+          "sourceItemId": "45876676:task:027",
+          "parentSourceItemId": null,
+          "title": "Pressurize (X) Level LiteDeck Slab Radiant Lines to 60psi",
+          "sortOrder": 23
+        },
+        {
+          "sourceItemId": "45876676:task:028",
+          "parentSourceItemId": null,
+          "title": "HPS (X) Level LiteDeck QC/Pre-Pour Inspection",
+          "sortOrder": 24
+        },
+        {
+          "sourceItemId": "45876676:task:029",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "LiteDeck Supported Properly",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876676:task:030",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "Necessary Patching Complete",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876676:task:031",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "Concrete Beam Top Rebar Correct",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876676:task:032",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "Concrete Beam Bottom Rebar Correct",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876676:task:033",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "Concrete Beam Stirrups Correct",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876676:task:034",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "LiteDeck Concrete Joist Top Rebar Correct",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876676:task:035",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "LiteDeck Concrete Joist Bottom Rebar Correct",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876676:task:036",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "LiteDeck-ICF Wall Tie-In Correct",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876676:task:037",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "Stair Support",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876676:task:038",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "Permanent Support Posts Installed Correctly",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876676:task:039",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "Chases Capped Properly",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876676:task:040",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "Radiant Lines at 60psi",
+          "sortOrder": 12
+        },
+        {
+          "sourceItemId": "45876676:task:041",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "LiteDeck Supports Tight",
+          "sortOrder": 13
+        },
+        {
+          "sourceItemId": "45876676:task:042",
+          "parentSourceItemId": "45876676:task:028",
+          "title": "LiteDeck is Level",
+          "sortOrder": 14
+        },
+        {
+          "sourceItemId": "45876676:task:043",
+          "parentSourceItemId": null,
+          "title": "(X) Level LiteDeck (X) Permanent Support Post",
+          "sortOrder": 25
+        },
+        {
+          "sourceItemId": "45876676:task:044",
+          "parentSourceItemId": null,
+          "title": "Building Department Radiant Line Inspection Passed",
+          "sortOrder": 26
+        },
+        {
+          "sourceItemId": "45876676:task:045",
+          "parentSourceItemId": null,
+          "title": "Building Department LiteDeck Inspection Passed",
+          "sortOrder": 27
+        },
+        {
+          "sourceItemId": "45876676:task:046",
+          "parentSourceItemId": null,
+          "title": "HPS (X) Level Flatwork QC Inspection",
+          "sortOrder": 28
+        },
+        {
+          "sourceItemId": "45876676:task:047",
+          "parentSourceItemId": null,
+          "title": "(X) Level LiteDeck Poured",
+          "sortOrder": 29
+        },
+        {
+          "sourceItemId": "45876676:task:048",
+          "parentSourceItemId": null,
+          "title": "Schedule LiteDeck Inspection",
+          "sortOrder": 30
+        },
+        {
+          "sourceItemId": "45876676:task:049",
+          "parentSourceItemId": null,
+          "title": "LiteDeck Inspection Passed",
+          "sortOrder": 31
+        },
+        {
+          "sourceItemId": "45876676:task:050",
+          "parentSourceItemId": null,
+          "title": "Confirm Radiant Inspection Passed",
+          "sortOrder": 32
+        }
+      ],
+      "notCaptured": [
+        "Native Buildertrend task IDs, task descriptions, and source assignee identities."
+      ]
+    },
+    {
+      "sourceTemplateId": "12540389",
+      "name": "Concrete - ICF Assembly",
+      "sourceName": "Concrete - ICF Assembly",
+      "moduleCounts": {
+        "tasks": 59,
+        "scheduleItems": 5,
+        "selections": 0,
+        "bidPackages": 0
+      },
+      "schedule": {
+        "sourceAnchorDate": "2022-03-30",
+        "phases": [
+          {
+            "sourcePhaseId": "12540389:phase:1",
+            "name": "UNASSIGNED"
+          }
+        ],
+        "items": [
+          {
+            "sourceItemId": "208674901",
+            "title": "ICF Delivery",
+            "startDate": "2022-03-30",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#DDC817",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "140375789",
+            "title": "(X) Level ICF Wall Stack",
+            "startDate": "2022-03-31",
+            "workdays": 10,
+            "phase": "UNASSIGNED",
+            "displayColor": "#7F7F7F",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "140375833",
+            "title": "Building Department (X) Level ICF Wall Inspection",
+            "startDate": "2022-04-13",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#ED2591",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "140375796",
+            "title": "HPS (X) Level ICF Wall QC Inspection",
+            "startDate": "2022-04-13",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#2222DD",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "140859927",
+            "title": "(X) Level ICF Wall Pour",
+            "startDate": "2022-04-14",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#DD2222",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          }
+        ],
+        "dependencies": [
+          {
+            "predecessorSourceItemId": "208674901",
+            "successorSourceItemId": "140375789",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "140375789",
+            "successorSourceItemId": "140375833",
+            "type": "FS",
+            "lagDays": -1
+          },
+          {
+            "predecessorSourceItemId": "140375789",
+            "successorSourceItemId": "140375796",
+            "type": "FS",
+            "lagDays": -1
+          },
+          {
+            "predecessorSourceItemId": "140375833",
+            "successorSourceItemId": "140859927",
+            "type": "FS",
+            "lagDays": 0
+          }
+        ]
+      },
+      "scheduleItems": [
+        {
+          "sourceItemId": "208674901",
+          "title": "ICF Delivery",
+          "startDate": "2022-03-30",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#DDC817",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": []
+        },
+        {
+          "sourceItemId": "140375789",
+          "title": "(X) Level ICF Wall Stack",
+          "startDate": "2022-03-31",
+          "workdays": 10,
+          "phase": "UNASSIGNED",
+          "displayColor": "#7F7F7F",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "208674901",
+              "successorSourceItemId": "140375789",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "140375833",
+          "title": "Building Department (X) Level ICF Wall Inspection",
+          "startDate": "2022-04-13",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#ED2591",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "140375789",
+              "successorSourceItemId": "140375833",
+              "type": "FS",
+              "lagDays": -1
+            }
+          ]
+        },
+        {
+          "sourceItemId": "140375796",
+          "title": "HPS (X) Level ICF Wall QC Inspection",
+          "startDate": "2022-04-13",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#2222DD",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "140375789",
+              "successorSourceItemId": "140375796",
+              "type": "FS",
+              "lagDays": -1
+            }
+          ]
+        },
+        {
+          "sourceItemId": "140859927",
+          "title": "(X) Level ICF Wall Pour",
+          "startDate": "2022-04-14",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#DD2222",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "140375833",
+              "successorSourceItemId": "140859927",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        }
+      ],
+      "provenance": {
+        "copiedTargetTemplateId": "45876685",
+        "taskIdentity": "sourceItemId values are deterministic capture IDs because Buildertrend did not expose native task IDs."
+      },
+      "tasks": [
+        {
+          "sourceItemId": "45876685:task:001",
+          "parentSourceItemId": null,
+          "title": "ICF Layout",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:002",
+          "parentSourceItemId": null,
+          "title": "First Course",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876685:task:003",
+          "parentSourceItemId": "45876685:task:002",
+          "title": "Tie Bottom of Wall Rebar to First Course",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:004",
+          "parentSourceItemId": "45876685:task:002",
+          "title": "Double-Clips on whole first Course",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876685:task:005",
+          "parentSourceItemId": "45876685:task:002",
+          "title": "Horizontal Rebar",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876685:task:006",
+          "parentSourceItemId": null,
+          "title": "Second Course",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876685:task:007",
+          "parentSourceItemId": "45876685:task:006",
+          "title": "Horizontal Bar",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:008",
+          "parentSourceItemId": "45876685:task:006",
+          "title": "Double Horizontal Clip Whole Second Course",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876685:task:009",
+          "parentSourceItemId": null,
+          "title": "Third Course",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876685:task:010",
+          "parentSourceItemId": "45876685:task:009",
+          "title": "Horizontal Rebar",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:011",
+          "parentSourceItemId": "45876685:task:009",
+          "title": "Set-Up Bracing",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876685:task:012",
+          "parentSourceItemId": "45876685:task:009",
+          "title": "Cut Out for Openings",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876685:task:013",
+          "parentSourceItemId": "45876685:task:009",
+          "title": "Clipped Correctly",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876685:task:014",
+          "parentSourceItemId": null,
+          "title": "Top Course",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876685:task:015",
+          "parentSourceItemId": "45876685:task:014",
+          "title": "Top of Wall Rebar",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:016",
+          "parentSourceItemId": "45876685:task:014",
+          "title": "Verticals Rebar",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876685:task:017",
+          "parentSourceItemId": "45876685:task:014",
+          "title": "Patching if Necesssary",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876685:task:018",
+          "parentSourceItemId": "45876685:task:014",
+          "title": "Clipped Correctly",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876685:task:019",
+          "parentSourceItemId": "45876685:task:014",
+          "title": "ICFVLs Placed As Necessary",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876685:task:020",
+          "parentSourceItemId": null,
+          "title": "X Middle Course",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876685:task:021",
+          "parentSourceItemId": "45876685:task:020",
+          "title": "Horizontal Rebar",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:022",
+          "parentSourceItemId": "45876685:task:020",
+          "title": "Cut Out for Openings",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876685:task:023",
+          "parentSourceItemId": "45876685:task:020",
+          "title": "Clipped Correctly",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876685:task:024",
+          "parentSourceItemId": null,
+          "title": "Header Course",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876685:task:025",
+          "parentSourceItemId": "45876685:task:024",
+          "title": "Horizontal Rebar",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:026",
+          "parentSourceItemId": "45876685:task:024",
+          "title": "Top Blockout Rebar",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876685:task:027",
+          "parentSourceItemId": "45876685:task:024",
+          "title": "Concrete Lintel Bottom Rebar",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876685:task:028",
+          "parentSourceItemId": "45876685:task:024",
+          "title": "Concrete Lintel Top Rebar",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876685:task:029",
+          "parentSourceItemId": "45876685:task:024",
+          "title": "Concrete Lintel S-Bars/Stirrups",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876685:task:030",
+          "parentSourceItemId": "45876685:task:024",
+          "title": "Clipped Correctly",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876685:task:031",
+          "parentSourceItemId": null,
+          "title": "Bucks Built",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876685:task:032",
+          "parentSourceItemId": null,
+          "title": "Set Opening Bucks",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876685:task:033",
+          "parentSourceItemId": null,
+          "title": "Passed building Department Inspection",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876685:task:034",
+          "parentSourceItemId": null,
+          "title": "ICF Wall Pour",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876685:task:035",
+          "parentSourceItemId": "45876685:task:034",
+          "title": "Anchor Bolts Set If Necessary (IF NOT NECESSARY PLEASE CHECK ANYWAY)",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:036",
+          "parentSourceItemId": null,
+          "title": "Order (X) Level ICF Wall Estimated Concrete",
+          "sortOrder": 12
+        },
+        {
+          "sourceItemId": "45876685:task:037",
+          "parentSourceItemId": null,
+          "title": "Update Concrete Order with Field Takeoffs",
+          "sortOrder": 13
+        },
+        {
+          "sourceItemId": "45876685:task:038",
+          "parentSourceItemId": null,
+          "title": "Request (x) level ICF Wall Inspection",
+          "sortOrder": 14
+        },
+        {
+          "sourceItemId": "45876685:task:039",
+          "parentSourceItemId": null,
+          "title": "HPS (X) Level ICF Wall QC & Pre-Pour Checklist",
+          "sortOrder": 15
+        },
+        {
+          "sourceItemId": "45876685:task:040",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Permit/Plans on Site",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876685:task:041",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Vertical & Horizontal Rebar Tied Properly",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876685:task:042",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Windows & Doors Braced",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876685:task:043",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Walls Braced Every 40\"",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876685:task:044",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "T-Walls, Buttress Walls & Corners Braced",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876685:task:045",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Seams Glued",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876685:task:046",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Holes & Cracks Glued",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876685:task:047",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Eufer Ground Placed Correctly",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876685:task:048",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Gas Chases Installed",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876685:task:049",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Electrical Chases Installed",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876685:task:050",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Plumbing Chases Installed",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876685:task:051",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Misc. Additional Chases Installed",
+          "sortOrder": 12
+        },
+        {
+          "sourceItemId": "45876685:task:052",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Lentils/Stirrups for openings installed",
+          "sortOrder": 13
+        },
+        {
+          "sourceItemId": "45876685:task:053",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "top of wall rebar correct",
+          "sortOrder": 14
+        },
+        {
+          "sourceItemId": "45876685:task:054",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "Anchor Bolts ready",
+          "sortOrder": 15
+        },
+        {
+          "sourceItemId": "45876685:task:055",
+          "parentSourceItemId": "45876685:task:039",
+          "title": "ICFVLs Placed Accurately",
+          "sortOrder": 16
+        },
+        {
+          "sourceItemId": "45876685:task:056",
+          "parentSourceItemId": null,
+          "title": "Schedule Concrete pump",
+          "sortOrder": 16
+        },
+        {
+          "sourceItemId": "45876685:task:057",
+          "parentSourceItemId": null,
+          "title": "Order ICFs",
+          "sortOrder": 17
+        },
+        {
+          "sourceItemId": "45876685:task:058",
+          "parentSourceItemId": null,
+          "title": "Inventory ICF Delivery",
+          "sortOrder": 18
+        },
+        {
+          "sourceItemId": "45876685:task:059",
+          "parentSourceItemId": null,
+          "title": "Inspection Passed",
+          "sortOrder": 19
+        }
+      ],
+      "notCaptured": [
+        "Native Buildertrend task IDs, task descriptions, and source assignee identities."
+      ]
+    },
+    {
+      "sourceTemplateId": "30907034",
+      "name": "Int. Finishes - Cabinetry/Countertops",
+      "sourceName": "Int. Finishes - Cabinetry/Countertops",
+      "moduleCounts": {
+        "tasks": 50,
+        "scheduleItems": 6,
+        "selections": 4,
+        "bidPackages": 2
+      },
+      "schedule": {
+        "sourceAnchorDate": "2023-08-22",
+        "phases": [
+          {
+            "sourcePhaseId": "30907034:phase:1",
+            "name": "UNASSIGNED"
+          }
+        ],
+        "items": [
+          {
+            "sourceItemId": "180199353",
+            "title": "Cabinet Delivery",
+            "startDate": "2023-08-22",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#DDC817",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "180199341",
+            "title": "Cabinetry Installation",
+            "startDate": "2023-08-23",
+            "workdays": 4,
+            "phase": "UNASSIGNED",
+            "displayColor": "#008000",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "180199371",
+            "title": "Countertop Template",
+            "startDate": "2023-08-29",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#ED2591",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "180199855",
+            "title": "HPS Cabinetry Installation QC Inspection",
+            "startDate": "2023-08-29",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#2222DD",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "180199388",
+            "title": "Countertop Installation",
+            "startDate": "2023-09-13",
+            "workdays": 2,
+            "phase": "UNASSIGNED",
+            "displayColor": "#008000",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          },
+          {
+            "sourceItemId": "180199906",
+            "title": "HPS Countertop Installation QC Inspection",
+            "startDate": "2023-09-15",
+            "workdays": 1,
+            "phase": "UNASSIGNED",
+            "displayColor": "#2222DD",
+            "isMilestone": false,
+            "assigneePlaceholder": null,
+            "ownerVisible": false,
+            "subVendorVisible": false,
+            "notes": null
+          }
+        ],
+        "dependencies": [
+          {
+            "predecessorSourceItemId": "180199341",
+            "successorSourceItemId": "180199353",
+            "type": "SS",
+            "lagDays": -1
+          },
+          {
+            "predecessorSourceItemId": "180199341",
+            "successorSourceItemId": "180199371",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "180199341",
+            "successorSourceItemId": "180199855",
+            "type": "FS",
+            "lagDays": 0
+          },
+          {
+            "predecessorSourceItemId": "180199371",
+            "successorSourceItemId": "180199388",
+            "type": "FS",
+            "lagDays": 9
+          },
+          {
+            "predecessorSourceItemId": "180199388",
+            "successorSourceItemId": "180199906",
+            "type": "FS",
+            "lagDays": 0
+          }
+        ]
+      },
+      "scheduleItems": [
+        {
+          "sourceItemId": "180199353",
+          "title": "Cabinet Delivery",
+          "startDate": "2023-08-22",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#DDC817",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "180199341",
+              "successorSourceItemId": "180199353",
+              "type": "SS",
+              "lagDays": -1
+            }
+          ]
+        },
+        {
+          "sourceItemId": "180199341",
+          "title": "Cabinetry Installation",
+          "startDate": "2023-08-23",
+          "workdays": 4,
+          "phase": "UNASSIGNED",
+          "displayColor": "#008000",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": []
+        },
+        {
+          "sourceItemId": "180199371",
+          "title": "Countertop Template",
+          "startDate": "2023-08-29",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#ED2591",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "180199341",
+              "successorSourceItemId": "180199371",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "180199855",
+          "title": "HPS Cabinetry Installation QC Inspection",
+          "startDate": "2023-08-29",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#2222DD",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "180199341",
+              "successorSourceItemId": "180199855",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        },
+        {
+          "sourceItemId": "180199388",
+          "title": "Countertop Installation",
+          "startDate": "2023-09-13",
+          "workdays": 2,
+          "phase": "UNASSIGNED",
+          "displayColor": "#008000",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "180199371",
+              "successorSourceItemId": "180199388",
+              "type": "FS",
+              "lagDays": 9
+            }
+          ]
+        },
+        {
+          "sourceItemId": "180199906",
+          "title": "HPS Countertop Installation QC Inspection",
+          "startDate": "2023-09-15",
+          "workdays": 1,
+          "phase": "UNASSIGNED",
+          "displayColor": "#2222DD",
+          "isMilestone": false,
+          "assigneePlaceholder": null,
+          "ownerVisible": false,
+          "subVendorVisible": false,
+          "notes": null,
+          "predecessors": [
+            {
+              "predecessorSourceItemId": "180199388",
+              "successorSourceItemId": "180199906",
+              "type": "FS",
+              "lagDays": 0
+            }
+          ]
+        }
+      ],
+      "provenance": {
+        "copiedTargetTemplateId": "45876692",
+        "taskIdentity": "sourceItemId values are deterministic capture IDs because Buildertrend did not expose native task IDs."
+      },
+      "tasks": [
+        {
+          "sourceItemId": "45876692:task:001",
+          "parentSourceItemId": null,
+          "title": "HPS (X Room) Cabinetry Inspection",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876692:task:002",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinet Height Correct",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876692:task:003",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets Level",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876692:task:004",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets Grain/Color Matching",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876692:task:005",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinet Hardware Present and Matching",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876692:task:006",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No Scratches",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876692:task:007",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No Chips",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876692:task:008",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No Gouges",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876692:task:009",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No Nicks",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876692:task:010",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: Open & Close Properly",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876692:task:011",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: Door align properly",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876692:task:012",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No Gap b/w Door & Frame",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876692:task:013",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No loose or Separated Veneer",
+          "sortOrder": 12
+        },
+        {
+          "sourceItemId": "45876692:task:014",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No Shrinkage",
+          "sortOrder": 13
+        },
+        {
+          "sourceItemId": "45876692:task:015",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No swelling panels",
+          "sortOrder": 14
+        },
+        {
+          "sourceItemId": "45876692:task:016",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No scratches on door glass",
+          "sortOrder": 15
+        },
+        {
+          "sourceItemId": "45876692:task:017",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No Gaps in Miter Joints",
+          "sortOrder": 16
+        },
+        {
+          "sourceItemId": "45876692:task:018",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Base Cabinets: No separation or looseness from wall",
+          "sortOrder": 17
+        },
+        {
+          "sourceItemId": "45876692:task:019",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: Height correct",
+          "sortOrder": 18
+        },
+        {
+          "sourceItemId": "45876692:task:020",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: Level",
+          "sortOrder": 19
+        },
+        {
+          "sourceItemId": "45876692:task:021",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: Color/Grain Matches",
+          "sortOrder": 20
+        },
+        {
+          "sourceItemId": "45876692:task:022",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: Hardware Present & Matches",
+          "sortOrder": 21
+        },
+        {
+          "sourceItemId": "45876692:task:023",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No Scratches",
+          "sortOrder": 22
+        },
+        {
+          "sourceItemId": "45876692:task:024",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No Chips",
+          "sortOrder": 23
+        },
+        {
+          "sourceItemId": "45876692:task:025",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No Gouges",
+          "sortOrder": 24
+        },
+        {
+          "sourceItemId": "45876692:task:026",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No Nicks",
+          "sortOrder": 25
+        },
+        {
+          "sourceItemId": "45876692:task:027",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: Open & Close Properly",
+          "sortOrder": 26
+        },
+        {
+          "sourceItemId": "45876692:task:028",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: Doors Align Properly",
+          "sortOrder": 27
+        },
+        {
+          "sourceItemId": "45876692:task:029",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No Gap between Doors & Frame",
+          "sortOrder": 28
+        },
+        {
+          "sourceItemId": "45876692:task:030",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No loose or separated veneer",
+          "sortOrder": 29
+        },
+        {
+          "sourceItemId": "45876692:task:031",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No Panel Shrinkage",
+          "sortOrder": 30
+        },
+        {
+          "sourceItemId": "45876692:task:032",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No Panel Swelling",
+          "sortOrder": 31
+        },
+        {
+          "sourceItemId": "45876692:task:033",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No Scratches on Door Glass",
+          "sortOrder": 32
+        },
+        {
+          "sourceItemId": "45876692:task:034",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No gaps in miter joints",
+          "sortOrder": 33
+        },
+        {
+          "sourceItemId": "45876692:task:035",
+          "parentSourceItemId": "45876692:task:001",
+          "title": "Upper Cabinets: No separation or looseness from wall",
+          "sortOrder": 34
+        },
+        {
+          "sourceItemId": "45876692:task:036",
+          "parentSourceItemId": null,
+          "title": "HPS (X Room) Countertop QC Inspection",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876692:task:037",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "Match Cabinets",
+          "sortOrder": 1
+        },
+        {
+          "sourceItemId": "45876692:task:038",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Cracks",
+          "sortOrder": 2
+        },
+        {
+          "sourceItemId": "45876692:task:039",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Splits",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876692:task:040",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Damaged Pieces",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876692:task:041",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Scratches",
+          "sortOrder": 5
+        },
+        {
+          "sourceItemId": "45876692:task:042",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Chips",
+          "sortOrder": 6
+        },
+        {
+          "sourceItemId": "45876692:task:043",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Gouges",
+          "sortOrder": 7
+        },
+        {
+          "sourceItemId": "45876692:task:044",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Nicks",
+          "sortOrder": 8
+        },
+        {
+          "sourceItemId": "45876692:task:045",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Burns",
+          "sortOrder": 9
+        },
+        {
+          "sourceItemId": "45876692:task:046",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Separation from wall",
+          "sortOrder": 10
+        },
+        {
+          "sourceItemId": "45876692:task:047",
+          "parentSourceItemId": "45876692:task:036",
+          "title": "No Rise in Seams",
+          "sortOrder": 11
+        },
+        {
+          "sourceItemId": "45876692:task:048",
+          "parentSourceItemId": null,
+          "title": "Cabinets Installed",
+          "sortOrder": 3
+        },
+        {
+          "sourceItemId": "45876692:task:049",
+          "parentSourceItemId": null,
+          "title": "Countertops Measured & Templated",
+          "sortOrder": 4
+        },
+        {
+          "sourceItemId": "45876692:task:050",
+          "parentSourceItemId": null,
+          "title": "Countertop Installation Complete",
+          "sortOrder": 5
+        }
+      ],
+      "selections": [
+        {
+          "sourceItemId": "63614466",
+          "sourceSelectionId": "63614466",
+          "title": "Countertop Backsplash",
+          "category": "12 36 00 - Countertops",
+          "location": "Kitchen",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587420",
+              "title": "4\" Backsplash of Countertop Material",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587419",
+              "title": "No Backsplash of Countertop Material",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614465",
+          "sourceSelectionId": "63614465",
+          "title": "Countertop Backsplash",
+          "category": "12 36 00 - Countertops",
+          "location": "Bath 1",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587418",
+              "title": "4\" Backsplash of Countertop Material",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587417",
+              "title": "No Backsplash of Countertop Material",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614464",
+          "sourceSelectionId": "63614464",
+          "title": "Countertop Material",
+          "category": "12 36 00 - Countertops",
+          "location": "Bath 1",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587412",
+              "title": "Ceramic Tile",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587416",
+              "title": "Concrete",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587407",
+              "title": "Granite",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587413",
+              "title": "Laminate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587409",
+              "title": "Marble",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587410",
+              "title": "Quartz",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587408",
+              "title": "Soapstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587411",
+              "title": "Solid-Surface",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587415",
+              "title": "Stainless Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587414",
+              "title": "Wood or Butcher Block",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            }
+          ]
+        },
+        {
+          "sourceItemId": "63614463",
+          "sourceSelectionId": "63614463",
+          "title": "Countertop Material",
+          "category": "12 36 00 - Countertops",
+          "location": "Kitchen",
+          "status": "Unreleased",
+          "allowance": 0,
+          "deadline": null,
+          "description": "",
+          "requireClientSelection": false,
+          "attachments": [],
+          "choices": [
+            {
+              "sourceChoiceId": "262587402",
+              "title": "Ceramic Tile",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587406",
+              "title": "Concrete",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587397",
+              "title": "Granite",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587403",
+              "title": "Laminate",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587399",
+              "title": "Marble",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587400",
+              "title": "Quartz",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587398",
+              "title": "Soapstone",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587401",
+              "title": "Solid-Surface",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587405",
+              "title": "Stainless Steel",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            },
+            {
+              "sourceChoiceId": "262587404",
+              "title": "Wood or Butcher Block",
+              "status": "Unreleased",
+              "price": 0,
+              "attachmentCount": 1
+            }
+          ]
+        }
+      ],
+      "bidPackages": [
+        {
+          "sourceItemId": "13408688",
+          "sourceBidPackageId": "13408688",
+          "title": "Cabinetry - (Project Address) (Estimate Phase)",
+          "status": "Draft",
+          "allowMultipleApprovedBids": false,
+          "deadline": null,
+          "time": null,
+          "reminderLeadDays": 2,
+          "plansAndSpecs": false,
+          "pricingFormat": "Line Items",
+          "description": "Background\nHigh Performance Structures, Inc. dba Open Range Construction, Ltd. (ORC) will be building a custom home located at:\n(Project Street Address)\n(Project City), (Project State) (Project Zip Code)\nReference Documents\nPlease see the Buildertrend Documents folder titled \"(Estimate Phase) Bid Set\" for all necessary plans.\nSubmission of Bid\nBids for this project will be processed through Buildertrend, a construction management program. You do not need to become proficient with Buildertrend. You may also simply call or email your point of contact. You may submit your bid into Buildertrend or email it to your point of contact for entry. Should you choose to input your bid into Buildertrend, please also include a PDF version of your bid.\nFor assistance with submitting the bid or receiving bid documents, contact the (Estimator Title):\n(Estimator Name), (719) 900-8850 ext. (Estimator Extension)\n(Estimator Email Address)\nTimeline\nThe work is scheduled to start in (Build Season), (Build Year).\nScope of Work\nThe following CSI categories will be required for the construction of the project per the plans and specifications noted on the Plans and Specifications List. We will notify bidders of any changes or additions by sending out updates to said List.\nQuestions\nPlease direct any questions into the RFI section here on Buildertrend. This helps us as a builder keep questions organized and accessible to any of our staff provided an estimator is absent. This will help expedite provision of answers.\nSchedule\nPlease provide a schedule to complete each of the above items, in calendar days after the issuance of the purchase order and/or notice to proceed.\nContract and Insurance Requirements\nAll trade contractors will be required to complete a trade contractor agreement, provide proof of liability insurance and workman’s compensation insurance as applicable, with required limits prior to the release of any construction payments.",
+          "descriptionSections": [
+            "Background",
+            "High Performance Structures, Inc. dba Open Range Construction, Ltd. (ORC) will be building a custom home located at:",
+            "(Project Street Address)",
+            "(Project City), (Project State) (Project Zip Code)",
+            "Reference Documents",
+            "Please see the Buildertrend Documents folder titled \"(Estimate Phase) Bid Set\" for all necessary plans.",
+            "Submission of Bid",
+            "Bids for this project will be processed through Buildertrend, a construction management program. You do not need to become proficient with Buildertrend. You may also simply call or email your point of contact. You may submit your bid into Buildertrend or email it to your point of contact for entry. Should you choose to input your bid into Buildertrend, please also include a PDF version of your bid.",
+            "For assistance with submitting the bid or receiving bid documents, contact the (Estimator Title):",
+            "(Estimator Name), (719) 900-8850 ext. (Estimator Extension)",
+            "(Estimator Email Address)",
+            "Timeline",
+            "The work is scheduled to start in (Build Season), (Build Year).",
+            "Scope of Work",
+            "The following CSI categories will be required for the construction of the project per the plans and specifications noted on the Plans and Specifications List. We will notify bidders of any changes or additions by sending out updates to said List.",
+            "Questions",
+            "Please direct any questions into the RFI section here on Buildertrend. This helps us as a builder keep questions organized and accessible to any of our staff provided an estimator is absent. This will help expedite provision of answers.",
+            "Schedule",
+            "Please provide a schedule to complete each of the above items, in calendar days after the issuance of the purchase order and/or notice to proceed.",
+            "Contract and Insurance Requirements",
+            "All trade contractors will be required to complete a trade contractor agreement, provide proof of liability insurance and workman’s compensation insurance as applicable, with required limits prior to the release of any construction payments."
+          ],
+          "internalNotes": "",
+          "attachments": [],
+          "lineItems": [
+            {
+              "title": "Cabinet Design",
+              "costCode": "12 30 00 - Casework",
+              "costType": "Other",
+              "quantity": 1,
+              "unit": null
+            },
+            {
+              "title": "Cabinets",
+              "costCode": "12 30 00 - Casework",
+              "costType": "Material",
+              "quantity": 1,
+              "unit": null
+            },
+            {
+              "title": "Cabinet Delivery",
+              "costCode": "12 30 00 - Casework",
+              "costType": "Other",
+              "quantity": 1,
+              "unit": null
+            }
+          ]
+        },
+        {
+          "sourceItemId": "13408689",
+          "sourceBidPackageId": "13408689",
+          "title": "Countertops - (Project Address) (Estimate Phase)",
+          "status": "Draft",
+          "allowMultipleApprovedBids": false,
+          "deadline": null,
+          "time": null,
+          "reminderLeadDays": 2,
+          "plansAndSpecs": false,
+          "pricingFormat": "Line Items",
+          "description": "Background\nHigh Performance Structures, Inc. dba Open Range Construction, Ltd. (ORC) will be building a custom home located at:\n(Project Street Address)\n(Project City), (Project State) (Project Zip Code)\nReference Documents\nPlease see the Buildertrend Documents folder titled \"(Estimate Phase) Bid Set\" for all necessary plans.\nSubmission of Bid\nBids for this project will be processed through Buildertrend, a construction management program. You do not need to become proficient with Buildertrend. You may also simply call or email your point of contact. You may submit your bid into Buildertrend or email it to your point of contact for entry. Should you choose to input your bid into Buildertrend, please also include a PDF version of your bid.\nFor assistance with submitting the bid or receiving bid documents, contact the (Estimator Title):\n(Estimator Name), (719) 900-8850 ext. (Estimator Extension)\n(Estimator Email Address)\nTimeline\nThe work is scheduled to start in (Build Season), (Build Year).\nScope of Work\nThe following CSI categories will be required for the construction of the project per the plans and specifications noted on the Plans and Specifications List. We will notify bidders of any changes or additions by sending out updates to said List.\nQuestions\nPlease direct any questions into the RFI section here on Buildertrend. This helps us as a builder keep questions organized and accessible to any of our staff provided an estimator is absent. This will help expedite provision of answers.\nSchedule\nPlease provide a schedule to complete each of the above items, in calendar days after the issuance of the purchase order and/or notice to proceed.\nContract and Insurance Requirements\nAll trade contractors will be required to complete a trade contractor agreement, provide proof of liability insurance and workman’s compensation insurance as applicable, with required limits prior to the release of any construction payments.",
+          "descriptionSections": [
+            "Background",
+            "High Performance Structures, Inc. dba Open Range Construction, Ltd. (ORC) will be building a custom home located at:",
+            "(Project Street Address)",
+            "(Project City), (Project State) (Project Zip Code)",
+            "Reference Documents",
+            "Please see the Buildertrend Documents folder titled \"(Estimate Phase) Bid Set\" for all necessary plans.",
+            "Submission of Bid",
+            "Bids for this project will be processed through Buildertrend, a construction management program. You do not need to become proficient with Buildertrend. You may also simply call or email your point of contact. You may submit your bid into Buildertrend or email it to your point of contact for entry. Should you choose to input your bid into Buildertrend, please also include a PDF version of your bid.",
+            "For assistance with submitting the bid or receiving bid documents, contact the (Estimator Title):",
+            "(Estimator Name), (719) 900-8850 ext. (Estimator Extension)",
+            "(Estimator Email Address)",
+            "Timeline",
+            "The work is scheduled to start in (Build Season), (Build Year).",
+            "Scope of Work",
+            "The following CSI categories will be required for the construction of the project per the plans and specifications noted on the Plans and Specifications List. We will notify bidders of any changes or additions by sending out updates to said List.",
+            "Questions",
+            "Please direct any questions into the RFI section here on Buildertrend. This helps us as a builder keep questions organized and accessible to any of our staff provided an estimator is absent. This will help expedite provision of answers.",
+            "Schedule",
+            "Please provide a schedule to complete each of the above items, in calendar days after the issuance of the purchase order and/or notice to proceed.",
+            "Contract and Insurance Requirements",
+            "All trade contractors will be required to complete a trade contractor agreement, provide proof of liability insurance and workman’s compensation insurance as applicable, with required limits prior to the release of any construction payments."
+          ],
+          "internalNotes": "Determine the subs/vendors to send requests to by the types of countertops selected. See Finish Selections for details.",
+          "attachments": [],
+          "lineItems": [
+            {
+              "title": "Countertops",
+              "costCode": "12 36 00 - Countertops",
+              "costType": "Material",
+              "quantity": 1,
+              "unit": null
+            },
+            {
+              "title": "Countertop Installation",
+              "costCode": "12 36 00 - Countertops",
+              "costType": "Material",
+              "quantity": 1,
+              "unit": null
+            }
+          ]
+        }
+      ],
+      "notCaptured": [
+        "Native Buildertrend task IDs and task descriptions",
+        "Selection attachment file names and bytes were not downloaded."
+      ]
+    }
+  ],
+  "assembly": {
+    "complete": true,
+    "pilotTemplateCount": 6,
+    "remainingActiveTemplatesUnverified": 34,
+    "missing": []
+  }
+}

--- a/scripts/fixtures/buildertrend-template-content-pilot-inventory-2026-08-03.json
+++ b/scripts/fixtures/buildertrend-template-content-pilot-inventory-2026-08-03.json
@@ -1,0 +1,67 @@
+{
+  "capturedAt": "2026-08-04T04:47:25.671Z",
+  "expectedActiveCount": 6,
+  "excludedArchivedCount": 27,
+  "templates": [
+    {
+      "sourceTemplateId": "30294726",
+      "name": "Drywall Installation",
+      "moduleCounts": {
+        "tasks": 28,
+        "scheduleItems": 8,
+        "selections": 3,
+        "bidPackages": 1
+      }
+    },
+    {
+      "sourceTemplateId": "12978716",
+      "name": "Ext. Finishes - Roofing",
+      "moduleCounts": {
+        "tasks": 14,
+        "scheduleItems": 2,
+        "selections": 103,
+        "bidPackages": 1
+      }
+    },
+    {
+      "sourceTemplateId": "32043577",
+      "name": "Design & Preconstruction",
+      "moduleCounts": {
+        "tasks": 48,
+        "scheduleItems": 34,
+        "selections": 0,
+        "bidPackages": 0
+      }
+    },
+    {
+      "sourceTemplateId": "12667545",
+      "name": "Concrete - LiteDeck Assembly",
+      "moduleCounts": {
+        "tasks": 50,
+        "scheduleItems": 15,
+        "selections": 0,
+        "bidPackages": 0
+      }
+    },
+    {
+      "sourceTemplateId": "12540389",
+      "name": "Concrete - ICF Assembly",
+      "moduleCounts": {
+        "tasks": 59,
+        "scheduleItems": 5,
+        "selections": 0,
+        "bidPackages": 0
+      }
+    },
+    {
+      "sourceTemplateId": "30907034",
+      "name": "Int. Finishes - Cabinetry/Countertops",
+      "moduleCounts": {
+        "tasks": 50,
+        "scheduleItems": 6,
+        "selections": 4,
+        "bidPackages": 2
+      }
+    }
+  ]
+}

--- a/scripts/fixtures/buildertrend-template-pilot-2026-08-03.json
+++ b/scripts/fixtures/buildertrend-template-pilot-2026-08-03.json
@@ -1,0 +1,23 @@
+{
+  "manifestVersion": 1,
+  "generatedAt": "2026-08-03",
+  "scope": {
+    "activeTemplatesInSource": 40,
+    "pilotTemplatesIncluded": 6,
+    "remainingActiveTemplatesUnverified": 34,
+    "archivedTemplatesExcluded": 27,
+    "archivedTemplatesIncluded": 0
+  },
+  "classificationPolicy": {
+    "functionalCategoryField": "tradeCategory",
+    "departmentPolicy": "destination-project-only"
+  },
+  "templates": [
+    { "sourceTemplateId": "30294726", "sourceName": "Drywall Installation", "tradeCategory": "Drywall" },
+    { "sourceTemplateId": "12978716", "sourceName": "Ext. Finishes - Roofing", "tradeCategory": "Exterior Finishes" },
+    { "sourceTemplateId": "32043577", "sourceName": "Design & Preconstruction", "tradeCategory": "Preconstruction" },
+    { "sourceTemplateId": "12667545", "sourceName": "Concrete - LiteDeck Assembly", "tradeCategory": "Concrete" },
+    { "sourceTemplateId": "12540389", "sourceName": "Concrete - ICF Assembly", "tradeCategory": "Concrete" },
+    { "sourceTemplateId": "30907034", "sourceName": "Int. Finishes - Cabinetry/Countertops", "tradeCategory": "Interior Finishes" }
+  ]
+}

--- a/scripts/lib/buildertrend-template-content-pilot.mjs
+++ b/scripts/lib/buildertrend-template-content-pilot.mjs
@@ -1,0 +1,344 @@
+import { readdir, readFile } from "node:fs/promises"
+import { basename, extname, join } from "node:path"
+
+export const PILOT_MODULES = ["tasks", "scheduleItems", "selections", "bidPackages"]
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function requiredString(value, path) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${path} must be a non-empty string.`)
+  }
+  return value.trim()
+}
+
+function moduleItems(template, module) {
+  if (module === "scheduleItems") {
+    if (Array.isArray(template.scheduleItems)) return template.scheduleItems
+    if (isRecord(template.schedule) && Array.isArray(template.schedule.items)) {
+      return template.schedule.items
+    }
+    return null
+  }
+  return Array.isArray(template[module]) ? template[module] : null
+}
+
+function expectedModuleCounts(template, path) {
+  if (!isRecord(template.moduleCounts)) {
+    throw new Error(`${path}.moduleCounts must be an object.`)
+  }
+  return Object.fromEntries(
+    PILOT_MODULES.map((module) => {
+      const count = template.moduleCounts[module] ?? 0
+      if (!Number.isInteger(count) || count < 0) {
+        throw new Error(`${path}.moduleCounts.${module} must be a non-negative integer.`)
+      }
+      return [module, count]
+    })
+  )
+}
+
+function reviewedScheduleItems(template, path) {
+  if (!isRecord(template.schedule) || !Array.isArray(template.schedule.items)) return null
+  const dependencies = template.schedule.dependencies ?? []
+  if (!Array.isArray(dependencies)) throw new Error(`${path}.schedule.dependencies must be an array.`)
+  const itemIds = new Set(template.schedule.items.map((item, index) =>
+    requiredString(item?.sourceItemId, `${path}.schedule.items[${index}].sourceItemId`)
+  ))
+  const predecessorsBySuccessor = new Map()
+  for (const [index, dependency] of dependencies.entries()) {
+    if (!isRecord(dependency)) throw new Error(`${path}.schedule.dependencies[${index}] must be an object.`)
+    const predecessorId = requiredString(
+      dependency.predecessorSourceItemId,
+      `${path}.schedule.dependencies[${index}].predecessorSourceItemId`
+    )
+    const successorId = requiredString(
+      dependency.successorSourceItemId,
+      `${path}.schedule.dependencies[${index}].successorSourceItemId`
+    )
+    if (!itemIds.has(predecessorId) || !itemIds.has(successorId)) {
+      throw new Error(`${path}.schedule.dependencies[${index}] refers to an unknown schedule item.`)
+    }
+    const current = predecessorsBySuccessor.get(successorId) ?? []
+    current.push(structuredClone(dependency))
+    predecessorsBySuccessor.set(successorId, current)
+  }
+  return template.schedule.items.map((item) => ({
+    ...structuredClone(item),
+    predecessors: predecessorsBySuccessor.get(item.sourceItemId) ?? [],
+  }))
+}
+
+function assertUniqueSourceItemIds(items, path) {
+  const ids = new Set()
+  for (const [index, item] of items.entries()) {
+    if (!isRecord(item)) throw new Error(`${path}[${index}] must be an object.`)
+    const id = requiredString(item.sourceItemId, `${path}[${index}].sourceItemId`)
+    if (ids.has(id)) throw new Error(`${path} has duplicate sourceItemId ${id}.`)
+    ids.add(id)
+  }
+}
+
+function normalizeFragment(document, source) {
+  if (!isRecord(document)) throw new Error(`${source} must contain a JSON object.`)
+  if (Array.isArray(document.templates)) {
+    return {
+      templates: document.templates,
+      conversionExceptions: document.conversionExceptions ?? [],
+    }
+  }
+  if (isRecord(document.template)) {
+    return {
+      templates: [document.template],
+      conversionExceptions: document.conversionExceptions ?? [],
+    }
+  }
+  if (typeof document.sourceTemplateId === "string") {
+    return { templates: [document], conversionExceptions: [] }
+  }
+  throw new Error(
+    `${source} must be a capture envelope, { template, conversionExceptions }, or a template object.`
+  )
+}
+
+function mergeValue(current, incoming, path) {
+  if (current === undefined) return structuredClone(incoming)
+  if (JSON.stringify(current) === JSON.stringify(incoming)) return current
+  throw new Error(`${path} is supplied by more than one fragment with conflicting values.`)
+}
+
+function mergeTemplate(current, incoming, path) {
+  const merged = { ...current }
+  for (const [key, value] of Object.entries(incoming)) {
+    if (["sourceTemplateId", "name", "sourceName", "moduleCounts"].includes(key)) continue
+    merged[key] = mergeValue(merged[key], value, `${path}.${key}`)
+  }
+  return merged
+}
+
+export async function readPilotContentFragments(directory) {
+  const entries = (await readdir(directory, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && extname(entry.name).toLowerCase() === ".json")
+    .sort((left, right) => left.name.localeCompare(right.name))
+  const documents = []
+  for (const entry of entries) {
+    const path = join(directory, entry.name)
+    documents.push({
+      source: path,
+      document: JSON.parse(await readFile(path, "utf8")),
+    })
+  }
+  return documents
+}
+
+export function assembleBuildertrendTemplateContentPilot({
+  manifest,
+  reviewedCapture,
+  documents,
+  allowIncomplete = false,
+  capturedAt = new Date().toISOString(),
+}) {
+  if (!isRecord(manifest) || !isRecord(manifest.scope) || !Array.isArray(manifest.templates)) {
+    throw new Error("Pilot manifest must contain scope and templates.")
+  }
+  const scope = manifest.scope
+  if (
+    scope.activeTemplatesInSource !== 40 ||
+    scope.pilotTemplatesIncluded !== 6 ||
+    scope.remainingActiveTemplatesUnverified !== 34 ||
+    scope.archivedTemplatesExcluded !== 27 ||
+    scope.archivedTemplatesIncluded !== 0
+  ) {
+    throw new Error("Pilot manifest must preserve the reviewed 40/6/34/27 scope.")
+  }
+  if (
+    !isRecord(reviewedCapture) ||
+    reviewedCapture.expectedActiveCount !== scope.activeTemplatesInSource ||
+    reviewedCapture.excludedArchivedCount !== scope.archivedTemplatesExcluded ||
+    !Array.isArray(reviewedCapture.templates) ||
+    reviewedCapture.templates.length !== scope.activeTemplatesInSource
+  ) {
+    throw new Error("Reviewed capture must retain all 40 active templates and exclude 27 archived templates.")
+  }
+
+  const reviewedById = new Map()
+  for (const [index, template] of reviewedCapture.templates.entries()) {
+    if (!isRecord(template)) throw new Error(`reviewedCapture.templates[${index}] must be an object.`)
+    const id = requiredString(template.sourceTemplateId, `reviewedCapture.templates[${index}].sourceTemplateId`)
+    if (reviewedById.has(id)) throw new Error(`Reviewed capture has duplicate sourceTemplateId ${id}.`)
+    if (/^archive/i.test(requiredString(template.name, `reviewedCapture.templates[${index}].name`))) {
+      throw new Error(`Archived reviewed template ${template.name} is not allowed.`)
+    }
+    reviewedById.set(id, template)
+  }
+
+  const pilotById = new Map()
+  for (const [index, entry] of manifest.templates.entries()) {
+    if (!isRecord(entry)) throw new Error(`manifest.templates[${index}] must be an object.`)
+    const id = requiredString(entry.sourceTemplateId, `manifest.templates[${index}].sourceTemplateId`)
+    const name = requiredString(entry.sourceName, `manifest.templates[${index}].sourceName`)
+    const reviewed = reviewedById.get(id)
+    if (!reviewed || reviewed.name !== name) {
+      throw new Error(`Pilot manifest identity mismatch for ${id} (${name}).`)
+    }
+    if (pilotById.has(id)) throw new Error(`Pilot manifest duplicates sourceTemplateId ${id}.`)
+    const moduleCounts = expectedModuleCounts(reviewed, `reviewed template ${id}`)
+    const seed = {
+      sourceTemplateId: id,
+      name,
+      sourceName: name,
+      moduleCounts,
+    }
+    // Schedule data was already captured in the reviewed 40-template source fixture.
+    // Reuse that evidence instead of asking browser capture work to recreate it.
+    const scheduleItems = reviewedScheduleItems(reviewed, `reviewed template ${id}`)
+    if (moduleCounts.scheduleItems > 0 && scheduleItems) {
+      seed.schedule = structuredClone(reviewed.schedule)
+      seed.scheduleItems = scheduleItems
+    }
+    pilotById.set(id, seed)
+  }
+  if (pilotById.size !== scope.pilotTemplatesIncluded) {
+    throw new Error("Pilot manifest must contain exactly six unique templates.")
+  }
+
+  const exceptions = []
+  const exceptionKeys = new Set()
+  for (const { source, document } of documents) {
+    const normalized = normalizeFragment(document, source)
+    if (!Array.isArray(normalized.conversionExceptions)) {
+      throw new Error(`${source}.conversionExceptions must be an array.`)
+    }
+    for (const [index, template] of normalized.templates.entries()) {
+      if (!isRecord(template)) throw new Error(`${source}.templates[${index}] must be an object.`)
+      const id = requiredString(template.sourceTemplateId, `${source}.templates[${index}].sourceTemplateId`)
+      const current = pilotById.get(id)
+      if (!current) {
+        throw new Error(`${source} contains non-pilot or archived template ${id}.`)
+      }
+      const suppliedName = template.name ?? template.sourceName
+      if (suppliedName !== current.name) {
+        throw new Error(`${source} has an identity mismatch for ${id}.`)
+      }
+      if (template.moduleCounts !== undefined) {
+        const suppliedCounts = expectedModuleCounts(template, `${source}.templates[${index}]`)
+        if (JSON.stringify(suppliedCounts) !== JSON.stringify(current.moduleCounts)) {
+          throw new Error(`${source} has module-count metadata that conflicts with reviewed source ${id}.`)
+        }
+      }
+      pilotById.set(id, mergeTemplate(current, template, `${source}.templates[${index}]`))
+    }
+    for (const [index, exception] of normalized.conversionExceptions.entries()) {
+      if (!isRecord(exception)) throw new Error(`${source}.conversionExceptions[${index}] must be an object.`)
+      const templateId = requiredString(
+        exception.templateSourceTemplateId,
+        `${source}.conversionExceptions[${index}].templateSourceTemplateId`
+      )
+      if (!pilotById.has(templateId)) {
+        throw new Error(`${source} contains an exception for non-pilot or archived template ${templateId}.`)
+      }
+      const key = JSON.stringify(exception)
+      if (!exceptionKeys.has(key)) {
+        exceptionKeys.add(key)
+        exceptions.push(structuredClone(exception))
+      }
+    }
+  }
+
+  const missing = []
+  const templates = []
+  const assembledById = new Map()
+  for (const entry of manifest.templates) {
+    const template = pilotById.get(entry.sourceTemplateId)
+    if (!template) throw new Error(`Pilot template ${entry.sourceTemplateId} disappeared during assembly.`)
+    for (const moduleName of PILOT_MODULES) {
+      const items = moduleItems(template, moduleName)
+      const expected = template.moduleCounts[moduleName]
+      const actual = items?.length ?? 0
+      if (actual !== expected) {
+        missing.push({ sourceTemplateId: template.sourceTemplateId, name: template.name, module: moduleName, expected, actual })
+        continue
+      }
+      if (items) assertUniqueSourceItemIds(items, `${template.name}.${moduleName}`)
+    }
+    templates.push(template)
+    assembledById.set(template.sourceTemplateId, template)
+  }
+  for (const [index, exception] of exceptions.entries()) {
+    const path = `conversionExceptions[${index}]`
+    const templateId = requiredString(exception.templateSourceTemplateId, `${path}.templateSourceTemplateId`)
+    const moduleName = requiredString(exception.module, `${path}.module`)
+    if (!PILOT_MODULES.includes(moduleName)) {
+      throw new Error(`${path}.module must be one of ${PILOT_MODULES.join(", ")}.`)
+    }
+    requiredString(exception.field, `${path}.field`)
+    requiredString(exception.loss, `${path}.loss`)
+    requiredString(exception.recoveryPlan, `${path}.recoveryPlan`)
+    if (!("sourceValue" in exception)) throw new Error(`${path}.sourceValue is required.`)
+    if (!("sourceItemId" in exception)) throw new Error(`${path}.sourceItemId is required; use null for module-level exceptions.`)
+    if (exception.sourceItemId !== null) {
+      const sourceItemId = requiredString(exception.sourceItemId, `${path}.sourceItemId`)
+      const template = assembledById.get(templateId)
+      const items = template ? moduleItems(template, moduleName) : null
+      if (!items?.some((item) => item.sourceItemId === sourceItemId)) {
+        throw new Error(`${path}.sourceItemId does not identify captured ${moduleName} content.`)
+      }
+    }
+  }
+  if (!allowIncomplete && missing.length > 0) {
+    const details = missing
+      .map((item) => `${item.name} ${item.module}: expected ${item.expected}, found ${item.actual}`)
+      .join("; ")
+    throw new Error(`Six-template pilot content is incomplete: ${details}.`)
+  }
+
+  return {
+    fixtureVersion: 3,
+    capturedAt,
+    excludedArchivedCount: scope.archivedTemplatesExcluded,
+    conversionExceptions: exceptions,
+    templates,
+    assembly: {
+      complete: missing.length === 0,
+      pilotTemplateCount: templates.length,
+      remainingActiveTemplatesUnverified: scope.remainingActiveTemplatesUnverified,
+      missing,
+    },
+  }
+}
+
+export function buildBuildertrendTemplateContentPilotInventory(capture) {
+  if (!isRecord(capture) || !Array.isArray(capture.templates)) {
+    throw new Error("Assembled pilot capture must contain templates.")
+  }
+  if (!isRecord(capture.assembly) || capture.assembly.complete !== true) {
+    throw new Error("Pilot inventory cannot be emitted from an incomplete content capture.")
+  }
+  return {
+    capturedAt: capture.capturedAt,
+    expectedActiveCount: capture.templates.length,
+    excludedArchivedCount: capture.excludedArchivedCount,
+    templates: capture.templates.map((template, index) => ({
+      sourceTemplateId: requiredString(
+        template.sourceTemplateId,
+        `capture.templates[${index}].sourceTemplateId`
+      ),
+      name: requiredString(template.name, `capture.templates[${index}].name`),
+      moduleCounts: expectedModuleCounts(template, `capture.templates[${index}]`),
+    })),
+  }
+}
+
+export function pilotFragmentFileName(sourceTemplateId, sourceName) {
+  const slug = sourceName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+  return `${sourceTemplateId}-${slug}.json`
+}
+
+export function describePilotFragmentSource(path) {
+  return basename(path)
+}

--- a/scripts/lib/buildertrend-template-pilot.mjs
+++ b/scripts/lib/buildertrend-template-pilot.mjs
@@ -1,0 +1,98 @@
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function requiredString(value, path) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${path} must be a non-empty string.`)
+  }
+  return value.trim()
+}
+
+export function buildBuildertrendTemplatePilot({ inventory, capture, manifest }) {
+  if (!isRecord(inventory) || !Array.isArray(inventory.templates)) throw new Error("Pilot inventory must contain a templates array.")
+  if (!isRecord(capture) || !Array.isArray(capture.templates)) throw new Error("Pilot capture must contain a templates array.")
+  if (!isRecord(manifest) || !isRecord(manifest.scope) || !Array.isArray(manifest.templates)) throw new Error("Pilot manifest must contain scope and templates.")
+  const scope = manifest.scope
+  if (scope.activeTemplatesInSource !== 40 || scope.pilotTemplatesIncluded !== 6 || scope.remainingActiveTemplatesUnverified !== 34 || scope.archivedTemplatesExcluded !== 27 || scope.archivedTemplatesIncluded !== 0) {
+    throw new Error("Pilot manifest scope must preserve the reviewed 40/6/34/27 template counts.")
+  }
+  if (
+    !isRecord(manifest.classificationPolicy) ||
+    manifest.classificationPolicy.functionalCategoryField !== "tradeCategory"
+  ) {
+    throw new Error("Pilot manifest must use tradeCategory as its only template classification.")
+  }
+  if (inventory.expectedActiveCount !== scope.activeTemplatesInSource || capture.expectedActiveCount !== scope.activeTemplatesInSource) {
+    throw new Error("Pilot inputs must retain the complete 40-template active source inventory.")
+  }
+  if (
+    inventory.templates.length !== scope.activeTemplatesInSource ||
+    capture.templates.length !== scope.activeTemplatesInSource
+  ) {
+    throw new Error("Pilot inputs must contain all 40 active templates before the six-template allowlist is applied.")
+  }
+  if (inventory.excludedArchivedCount !== scope.archivedTemplatesExcluded || capture.excludedArchivedCount !== scope.archivedTemplatesExcluded) {
+    throw new Error("Pilot inputs must retain the reviewed archived-template exclusion count.")
+  }
+  if (manifest.templates.length !== scope.pilotTemplatesIncluded) throw new Error("Pilot manifest template count does not match its scope.")
+
+  const inventoryByName = new Map()
+  const inventoryBySourceId = new Map()
+  for (const item of inventory.templates) {
+    if (!isRecord(item)) throw new Error("Pilot inventory contains an invalid template.")
+    const name = requiredString(item.name, "Pilot inventory template name")
+    const normalizedName = name.toLocaleLowerCase("en-US")
+    if (inventoryByName.has(normalizedName)) {
+      throw new Error(`Pilot inventory has duplicate template name ${name}.`)
+    }
+    inventoryByName.set(normalizedName, item)
+    if (typeof item.sourceTemplateId === "string" && item.sourceTemplateId.trim()) {
+      if (inventoryBySourceId.has(item.sourceTemplateId)) {
+        throw new Error(`Pilot inventory has duplicate sourceTemplateId ${item.sourceTemplateId}.`)
+      }
+      inventoryBySourceId.set(item.sourceTemplateId, item)
+    }
+  }
+  const captureById = new Map()
+  for (const item of capture.templates) {
+    if (!isRecord(item)) throw new Error("Pilot capture contains an invalid template.")
+    const id = requiredString(item.sourceTemplateId, "Pilot capture sourceTemplateId")
+    if (captureById.has(id)) throw new Error(`Pilot capture has duplicate sourceTemplateId ${id}.`)
+    captureById.set(id, item)
+  }
+
+  const ids = new Set()
+  const names = new Set()
+  const pilotInventory = []
+  const pilotCapture = []
+  for (const [index, entry] of manifest.templates.entries()) {
+    if (!isRecord(entry)) throw new Error(`Pilot manifest templates[${index}] must be an object.`)
+    const sourceTemplateId = requiredString(entry.sourceTemplateId, `Pilot manifest templates[${index}].sourceTemplateId`)
+    const sourceName = requiredString(entry.sourceName, `Pilot manifest templates[${index}].sourceName`)
+    const tradeCategory = requiredString(entry.tradeCategory, `Pilot manifest templates[${index}].tradeCategory`)
+    if (ids.has(sourceTemplateId) || names.has(sourceName.toLocaleLowerCase("en-US"))) throw new Error(`Pilot manifest duplicates template ${sourceTemplateId}.`)
+    ids.add(sourceTemplateId)
+    names.add(sourceName.toLocaleLowerCase("en-US"))
+    const captured = captureById.get(sourceTemplateId)
+    if (!captured || captured.name !== sourceName) throw new Error(`Pilot manifest identity mismatch for ${sourceTemplateId}.`)
+    const inventoryTemplate =
+      inventoryBySourceId.get(sourceTemplateId) ??
+      inventoryByName.get(sourceName.toLocaleLowerCase("en-US"))
+    if (!inventoryTemplate) throw new Error(`Pilot manifest template ${sourceName} is not active inventory.`)
+    if (
+      typeof inventoryTemplate.sourceTemplateId === "string" &&
+      inventoryTemplate.sourceTemplateId !== sourceTemplateId
+    ) {
+      throw new Error(`Pilot inventory identity mismatch for ${sourceTemplateId}.`)
+    }
+    // Department/branding belongs to the destination project, never the reusable template.
+    pilotInventory.push({ ...inventoryTemplate, tradeCategory, departmentCode: null })
+    pilotCapture.push(captured)
+  }
+  return {
+    inventory: { ...inventory, expectedActiveCount: manifest.templates.length, templates: pilotInventory },
+    capture: { ...capture, expectedActiveCount: manifest.templates.length, templates: pilotCapture },
+    remainingActiveTemplatesUnverified: scope.remainingActiveTemplatesUnverified,
+  }
+}

--- a/scripts/template-category-workflow.test.mjs
+++ b/scripts/template-category-workflow.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+const actionsPath = "src/app/actions/project-templates.ts"
+const inventoryImportPath = "src/lib/templates/buildertrend-template-inventory.ts"
+const captureImportPath = "src/lib/templates/buildertrend-template-capture.ts"
+const estimateCreatePath = "src/components/templates/estimate-template-create-dialog.tsx"
+const estimateEditorPath = "src/components/templates/estimate-template-editor.tsx"
+const estimateActionsPath = "src/app/actions/estimate-templates.ts"
+const templateLibraryPath = "src/components/templates/template-library-view.tsx"
+
+test("template library exposes category-only controls, filtering, and badges", async () => {
+  const source = await readFile(templateLibraryPath, "utf8")
+
+  assert.match(source, /CategoryControl/)
+  assert.match(source, /Filter templates by category/)
+  assert.match(source, /template\.tradeCategory \?\? "Other"/)
+  assert.doesNotMatch(source, /departmentCode/)
+  assert.doesNotMatch(source, /departmentFilter/)
+  assert.doesNotMatch(source, /TEMPLATE_DEPARTMENTS/)
+  assert.doesNotMatch(source, /Department for /)
+})
+
+test("category action only updates tradeCategory", async () => {
+  const source = await readFile(actionsPath, "utf8")
+  const action = source.match(
+    /export async function updateProjectTemplateCategory[\s\S]*?\n}\n\nexport async function deleteProjectTemplate/
+  )?.[0]
+
+  assert.ok(action, "category update action must exist")
+  assert.match(action, /tradeCategory: category/)
+  assert.doesNotMatch(action, /departmentCode/)
+  assert.doesNotMatch(action, /department:/)
+})
+
+test("new Buildertrend imports leave department selection to the destination project", async () => {
+  const [inventorySource, captureSource] = await Promise.all(
+    [inventoryImportPath, captureImportPath].map((path) => readFile(path, "utf8"))
+  )
+
+  assert.match(inventorySource, /Department\/branding is selected by the destination project/)
+  assert.match(inventorySource, /sql\(null\),\n\s*sql\(template\.tradeCategory\)/)
+  assert.doesNotMatch(captureSource, /departmentCode \?\? "ORC"/)
+  assert.doesNotMatch(captureSource, /departmentCode === "D"/)
+})
+
+test("estimate templates inherit department from the destination project", async () => {
+  const sources = await Promise.all(
+    [estimateCreatePath, estimateEditorPath, estimateActionsPath].map((path) =>
+      readFile(path, "utf8")
+    )
+  )
+  for (const source of sources) {
+    assert.doesNotMatch(source, /departmentCode/)
+    assert.doesNotMatch(source, /templateDepartment/)
+    assert.doesNotMatch(source, /template-department/)
+  }
+})
+
+test("captured templates require an explicit count-verified publish action", async () => {
+  const [actions, library] = await Promise.all([
+    readFile(actionsPath, "utf8"),
+    readFile(templateLibraryPath, "utf8"),
+  ])
+
+  assert.match(actions, /publishCapturedProjectTemplate/)
+  assert.match(actions, /requiredModuleTypes/)
+  assert.match(actions, /normalizationStatus/)
+  assert.match(actions, /sourceItemCount/)
+  assert.match(actions, /scheduleItems\.length !== scheduleModule\.sourceItemCount/)
+  assert.match(actions, /review_status='verified'/)
+  assert.match(library, /Review and publish/)
+  assert.match(library, /documented conversion warnings/)
+})

--- a/scripts/validate-buildertrend-template-capture-workplan.mjs
+++ b/scripts/validate-buildertrend-template-capture-workplan.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = fileURLToPath(new URL(".", import.meta.url));
+const inventoryPath = resolve(
+  scriptDirectory,
+  "fixtures/buildertrend-active-template-capture-2026-07-31.json",
+);
+const workplanPath = resolve(
+  scriptDirectory,
+  "fixtures/buildertrend-template-capture-workplan-2026-08-03.json",
+);
+const expectedTotals = {
+  tasks: 739,
+  scheduleItems: 163,
+  selections: 155,
+  bidPackages: 30,
+};
+const moduleKeys = Object.keys(expectedTotals);
+const validStatuses = new Set([
+  "pending",
+  "in_progress",
+  "completed",
+  "completed_with_exceptions",
+  "blocked",
+]);
+
+/**
+ * @param {string} path
+ * @returns {Promise<unknown>}
+ */
+async function loadJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} message
+ */
+function requireCondition(value, message) {
+  if (!value) {
+    throw new Error(message);
+  }
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * @param {Record<string, unknown>} counts
+ * @param {string} label
+ * @returns {number}
+ */
+function validateModuleCounts(counts, label) {
+  const keys = Object.keys(counts).sort();
+  const expectedKeys = moduleKeys
+    .filter((key) => Object.hasOwn(counts, key))
+    .sort();
+
+  requireCondition(
+    JSON.stringify(keys) === JSON.stringify(expectedKeys),
+    `${label} has unsupported module count keys`,
+  );
+
+  return keys.reduce((total, key) => {
+    const count = counts[key];
+    requireCondition(
+      typeof count === "number" && Number.isInteger(count) && count >= 0,
+      `${label} has an invalid ${key} count`,
+    );
+    return total + count;
+  }, 0);
+}
+
+/**
+ * @param {Record<string, unknown>} actual
+ * @param {Record<string, unknown>} expected
+ * @param {string} label
+ */
+function requireExactCounts(actual, expected, label) {
+  requireCondition(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${label} module counts do not match the reviewed inventory`,
+  );
+}
+
+try {
+  const inventory = await loadJson(inventoryPath);
+  const workplan = await loadJson(workplanPath);
+
+  requireCondition(isRecord(inventory), "Inventory must be an object");
+  requireCondition(isRecord(workplan), "Workplan must be an object");
+  requireCondition(
+    Array.isArray(inventory.templates),
+    "Inventory must contain a templates array",
+  );
+  requireCondition(
+    Array.isArray(workplan.templates),
+    "Workplan must contain a templates array",
+  );
+  requireCondition(
+    workplan.scope && isRecord(workplan.scope),
+    "Workplan must contain scope",
+  );
+  requireCondition(
+    workplan.aggregateTotals && isRecord(workplan.aggregateTotals),
+    "Workplan must contain aggregateTotals",
+  );
+  requireCondition(
+    workplan.scope.archivedTemplatesExcluded === 27 &&
+      workplan.scope.archivedTemplatesIncluded === 0,
+    "Workplan must record 27 excluded archived templates and include none",
+  );
+  requireCondition(
+    typeof workplan.status === "string" && validStatuses.has(workplan.status),
+    "Workplan has an invalid status",
+  );
+
+  const inventoryById = new Map();
+  for (const template of inventory.templates) {
+    requireCondition(isRecord(template), "Inventory contains an invalid template");
+    const { sourceTemplateId } = template;
+    requireCondition(
+      typeof sourceTemplateId === "string" && sourceTemplateId.length > 0,
+      "Inventory contains a template without a sourceTemplateId",
+    );
+    requireCondition(
+      !inventoryById.has(sourceTemplateId),
+      `Inventory has a duplicate sourceTemplateId: ${sourceTemplateId}`,
+    );
+    inventoryById.set(sourceTemplateId, template);
+  }
+
+  const seenIds = new Set();
+  const computedTotals = Object.fromEntries(moduleKeys.map((key) => [key, 0]));
+  for (const template of workplan.templates) {
+    requireCondition(isRecord(template), "Workplan contains an invalid template");
+    const { sourceTemplateId, temporaryBuildertrendTargetName, status, exceptions } =
+      template;
+    requireCondition(
+      typeof sourceTemplateId === "string" && inventoryById.has(sourceTemplateId),
+      `Workplan references an archived or unknown sourceTemplateId: ${String(sourceTemplateId)}`,
+    );
+    requireCondition(
+      !seenIds.has(sourceTemplateId),
+      `Workplan has a duplicate sourceTemplateId: ${sourceTemplateId}`,
+    );
+    seenIds.add(sourceTemplateId);
+    requireCondition(
+      typeof temporaryBuildertrendTargetName === "string" &&
+        temporaryBuildertrendTargetName.trim() === temporaryBuildertrendTargetName &&
+        temporaryBuildertrendTargetName.length > 0 &&
+        temporaryBuildertrendTargetName.length <= 50 &&
+        !/[\r\n\t]/.test(temporaryBuildertrendTargetName),
+      `Workplan has an unsafe temporary target name for ${sourceTemplateId}`,
+    );
+    requireCondition(
+      typeof status === "string" && validStatuses.has(status),
+      `Workplan has an invalid status for ${sourceTemplateId}`,
+    );
+    requireCondition(
+      Array.isArray(exceptions),
+      `Workplan exceptions must be an array for ${sourceTemplateId}`,
+    );
+    requireCondition(
+      status !== "completed_with_exceptions" || exceptions.length > 0,
+      `completed_with_exceptions requires at least one exception for ${sourceTemplateId}`,
+    );
+    requireCondition(
+      isRecord(template.moduleCounts),
+      `Workplan is missing moduleCounts for ${sourceTemplateId}`,
+    );
+
+    const inventoryTemplate = inventoryById.get(sourceTemplateId);
+    if (!inventoryTemplate || !isRecord(inventoryTemplate.moduleCounts)) {
+      throw new Error(`Inventory is missing moduleCounts for ${sourceTemplateId}`);
+    }
+    validateModuleCounts(template.moduleCounts, `Workplan ${sourceTemplateId}`);
+    requireExactCounts(
+      template.moduleCounts,
+      inventoryTemplate.moduleCounts,
+      `Workplan ${sourceTemplateId}`,
+    );
+    for (const key of moduleKeys) {
+      computedTotals[key] += template.moduleCounts[key] ?? 0;
+    }
+  }
+
+  requireCondition(
+    seenIds.size === inventoryById.size,
+    `Workplan is missing ${inventoryById.size - seenIds.size} active source template(s)`,
+  );
+  for (const [key, expected] of Object.entries(expectedTotals)) {
+    requireCondition(
+      computedTotals[key] === expected &&
+        workplan.aggregateTotals[key] === expected,
+      `Aggregate ${key} total must equal ${expected}`,
+    );
+  }
+
+  console.log(
+    `Workplan valid: ${seenIds.size} active templates; ${computedTotals.tasks} tasks, ${computedTotals.scheduleItems} schedule items, ${computedTotals.selections} selections, ${computedTotals.bidPackages} bid packages.`,
+  );
+} catch (error) {
+  console.error(
+    `Workplan validation failed: ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exitCode = 1;
+}

--- a/scripts/validate-buildertrend-template-content-pilot.mjs
+++ b/scripts/validate-buildertrend-template-content-pilot.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises"
+
+import { assembleBuildertrendTemplateContentPilot } from "./lib/buildertrend-template-content-pilot.mjs"
+
+function optionValue(args, option) {
+  const index = args.indexOf(option)
+  if (index < 0) return null
+  const value = args[index + 1]
+  return value && !value.startsWith("--") ? value : null
+}
+
+const args = process.argv.slice(2)
+const input = optionValue(args, "--input")
+const manifestPath = optionValue(args, "--manifest") ??
+  "scripts/fixtures/buildertrend-template-pilot-2026-08-03.json"
+const reviewedCapturePath = optionValue(args, "--reviewed-capture") ??
+  "scripts/fixtures/buildertrend-active-template-capture-2026-07-31.json"
+const allowIncomplete = args.includes("--allow-incomplete")
+
+if (!input) {
+  throw new Error(
+    "Usage: bun scripts/validate-buildertrend-template-content-pilot.mjs --input <pilot-capture.json> " +
+      "[--manifest <pilot.json>] [--reviewed-capture <40-active-capture.json>] [--allow-incomplete]"
+  )
+}
+
+const result = assembleBuildertrendTemplateContentPilot({
+  manifest: JSON.parse(await readFile(manifestPath, "utf8")),
+  reviewedCapture: JSON.parse(await readFile(reviewedCapturePath, "utf8")),
+  documents: [{ source: input, document: JSON.parse(await readFile(input, "utf8")) }],
+  allowIncomplete,
+})
+
+const totals = result.templates.reduce(
+  (current, template) => ({
+    tasks: current.tasks + (template.tasks?.length ?? 0),
+    scheduleItems: current.scheduleItems + (template.scheduleItems?.length ?? 0),
+    selections: current.selections + (template.selections?.length ?? 0),
+    bidPackages: current.bidPackages + (template.bidPackages?.length ?? 0),
+  }),
+  { tasks: 0, scheduleItems: 0, selections: 0, bidPackages: 0 }
+)
+
+console.log(JSON.stringify({
+  complete: result.assembly.complete,
+  templateCount: result.templates.length,
+  excludedArchivedCount: result.excludedArchivedCount,
+  remainingActiveTemplatesUnverified: result.assembly.remainingActiveTemplatesUnverified,
+  totals,
+  missing: result.assembly.missing,
+}, null, 2))

--- a/scripts/validate-buildertrend-template-content-pilot.test.mjs
+++ b/scripts/validate-buildertrend-template-content-pilot.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import test from "node:test"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const validator = "scripts/validate-buildertrend-template-content-pilot.mjs"
+const capture = "scripts/fixtures/buildertrend-template-content-pilot-2026-08-03.json"
+
+test("reports the canonical capture as a complete six-template pilot", async () => {
+  const result = await execFileAsync("bun", [validator, "--input", capture])
+  const summary = JSON.parse(result.stdout)
+
+  assert.equal(summary.complete, true)
+  assert.equal(summary.templateCount, 6)
+  assert.equal(summary.excludedArchivedCount, 27)
+  assert.equal(summary.remainingActiveTemplatesUnverified, 34)
+  assert.equal(summary.totals.tasks, 249)
+  assert.equal(summary.totals.scheduleItems, 70)
+  assert.equal(summary.totals.selections, 110)
+  assert.equal(summary.totals.bidPackages, 4)
+  assert.deepEqual(summary.missing, [])
+})
+
+test("allow-incomplete never downgrades a complete reviewed capture", async () => {
+  const result = await execFileAsync("bun", [validator, "--input", capture, "--allow-incomplete"])
+  assert.equal(JSON.parse(result.stdout).complete, true)
+})

--- a/src/app/actions/estimate-templates.ts
+++ b/src/app/actions/estimate-templates.ts
@@ -36,7 +36,6 @@ export type EstimateTemplateOption = {
   readonly id: string
   readonly name: string
   readonly description: string | null
-  readonly departmentCode: string | null
   readonly versionNumber: number
   readonly lineCount: number
   readonly requiresProjectTaxEntity: boolean
@@ -65,7 +64,6 @@ export type EstimateTemplateEditor = {
   readonly id: string
   readonly name: string
   readonly description: string | null
-  readonly departmentCode: string | null
   readonly lifecycleStatus: string
   readonly reviewStatus: string
   readonly versionId: string
@@ -254,7 +252,6 @@ export async function getPublishedEstimateTemplateOptions(): Promise<
         id: template.id,
         name: template.name,
         description: template.description,
-        departmentCode: template.departmentCode,
         versionNumber: version.versionNumber,
         lineCount: lines.filter((line) => line.versionId === version.id).length,
         requiresProjectTaxEntity: lines.some(
@@ -323,7 +320,6 @@ export async function getEstimateTemplateEditor(
     id: template.id,
     name: template.name,
     description: template.description,
-    departmentCode: template.departmentCode,
     lifecycleStatus: template.lifecycleStatus,
     reviewStatus: template.reviewStatus,
     versionId: version.id,
@@ -374,7 +370,6 @@ export async function getEstimateTemplateEditor(
 export async function createEstimateTemplateDraft(input: {
   readonly name: string | null
   readonly description: string | null
-  readonly departmentCode: string | null
 }): Promise<ActionResult> {
   try {
     const access = await templateAccess("update")
@@ -385,9 +380,9 @@ export async function createEstimateTemplateDraft(input: {
       access.env.DB.prepare(
         `INSERT INTO project_templates (
           id, organization_id, source_system, source_key, name, description,
-          template_kind, department_code, trade_category, lifecycle_status,
+          template_kind, trade_category, lifecycle_status,
           review_status, current_version_number, created_by, created_at, updated_at
-        ) VALUES (?, ?, 'compass', ?, ?, ?, 'estimate', ?, 'Estimating',
+        ) VALUES (?, ?, 'compass', ?, ?, ?, 'estimate', 'Estimating',
           'draft', 'content_captured', 1, ?, ?, ?)`
       ).bind(
         id,
@@ -395,7 +390,6 @@ export async function createEstimateTemplateDraft(input: {
         `compass:${id}`,
         requiredText(input.name, "Template name"),
         cleanText(input.description),
-        cleanText(input.departmentCode),
         access.user.id,
         now,
         now
@@ -436,7 +430,6 @@ export async function updateEstimateTemplateDraft(input: {
   readonly templateId: string
   readonly name: string | null
   readonly description: string | null
-  readonly departmentCode: string | null
   readonly documentTitle: string | null
   readonly contractTerms: string | null
   readonly defaultMarkupPercent: number | null
@@ -452,7 +445,6 @@ export async function updateEstimateTemplateDraft(input: {
         .set({
           name: requiredText(input.name, "Template name"),
           description: cleanText(input.description),
-          departmentCode: cleanText(input.departmentCode),
           updatedAt: now,
         })
         .where(eq(projectTemplates.id, input.templateId)),

--- a/src/app/actions/project-operations.ts
+++ b/src/app/actions/project-operations.ts
@@ -2562,6 +2562,53 @@ export async function restoreProjectTodo(
   return setProjectTodoStatus(projectId, todoId, "open", expectedUpdatedAt)
 }
 
+export async function deleteProjectTodo(
+  projectId: string,
+  todoId: string,
+  expectedUpdatedAt: string
+): Promise<ProjectTodoActionResult> {
+  try {
+    const { db, operation } = await findEditableProjectTodo(
+      projectId,
+      todoId,
+      expectedUpdatedAt
+    )
+    if (!isArchivedProjectTodoStatus(operation.status)) {
+      return {
+        success: false,
+        error: "Archive the to-do before deleting it permanently.",
+      }
+    }
+    const deletedRows = await db
+      .delete(projectOperations)
+      .where(
+        and(
+          eq(projectOperations.id, todoId),
+          eq(projectOperations.projectId, projectId),
+          eq(projectOperations.updatedAt, expectedUpdatedAt)
+        )
+      )
+      .returning({ id: projectOperations.id })
+    const deleted = deletedRows[0]
+    if (!deleted) {
+      return {
+        success: false,
+        error:
+          "This to-do changed while you were deleting it. Refresh and review the latest version.",
+      }
+    }
+
+    revalidateProjectTodoPaths(projectId)
+    return { success: true, id: deleted.id, updatedAt: expectedUpdatedAt }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to delete to-do",
+    }
+  }
+}
+
 export async function sendPurchaseOrderEmail(
   projectId: string,
   purchaseOrderId: string,

--- a/src/app/actions/project-templates.ts
+++ b/src/app/actions/project-templates.ts
@@ -13,6 +13,7 @@ import {
 } from "@/db/schema"
 import {
   projectTemplateApplications,
+  projectTemplateContentItems,
   projectTemplateModules,
   projectTemplates,
   projectTemplateVersions,
@@ -41,7 +42,6 @@ export type ProjectTemplateLibraryItem = {
   readonly name: string
   readonly description: string | null
   readonly sourceSystem: string
-  readonly sourceUrl: string | null
   readonly templateKind: string
   readonly departmentCode: string | null
   readonly tradeCategory: string | null
@@ -53,6 +53,18 @@ export type ProjectTemplateLibraryItem = {
   readonly scheduleItemCount: number
   readonly dependencyCount: number
   readonly modules: readonly ProjectTemplateModuleSummary[]
+}
+
+export type ProjectTemplateContentItem = {
+  readonly id: string
+  readonly moduleType: string
+  readonly sourceItemId: string | null
+  readonly parentSourceItemId: string | null
+  readonly title: string
+  readonly category: string | null
+  readonly description: string | null
+  readonly sortOrder: number
+  readonly payloadJson: string | null
 }
 
 export type ProjectTemplateModuleSummary = {
@@ -243,7 +255,6 @@ export async function getProjectTemplateLibrary(): Promise<
       name: template.name,
       description: template.description,
       sourceSystem: template.sourceSystem,
-      sourceUrl: template.sourceUrl,
       templateKind: template.templateKind,
       departmentCode: template.departmentCode,
       tradeCategory: template.tradeCategory,
@@ -271,6 +282,35 @@ export async function getProjectTemplateLibrary(): Promise<
         : [],
     }
   })
+}
+
+export async function getProjectTemplateContent(
+  templateId: string
+): Promise<readonly ProjectTemplateContentItem[]> {
+  const library = await getProjectTemplateLibrary()
+  const template = library.find((candidate) => candidate.id === templateId)
+  if (!template?.currentVersionId) return []
+
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  return db
+    .select({
+      id: projectTemplateContentItems.id,
+      moduleType: projectTemplateContentItems.moduleType,
+      sourceItemId: projectTemplateContentItems.sourceItemId,
+      parentSourceItemId: projectTemplateContentItems.parentSourceItemId,
+      title: projectTemplateContentItems.title,
+      category: projectTemplateContentItems.category,
+      description: projectTemplateContentItems.description,
+      sortOrder: projectTemplateContentItems.sortOrder,
+      payloadJson: projectTemplateContentItems.payloadJson,
+    })
+    .from(projectTemplateContentItems)
+    .where(eq(projectTemplateContentItems.versionId, template.currentVersionId))
+    .orderBy(
+      asc(projectTemplateContentItems.moduleType),
+      asc(projectTemplateContentItems.sortOrder)
+    )
 }
 
 export async function getProjectTemplatePreview(
@@ -606,5 +646,114 @@ export async function setProjectTemplateLifecycle(input: {
   } catch (error) {
     console.error("Unable to update template status", error)
     return { success: false, error: "Unable to update template status." }
+  }
+}
+
+const templateDepartments = new Set(["ORC", "HPS", "Nu-Tech", "Design"])
+
+export async function updateProjectTemplateClassification(input: {
+  readonly templateId: string
+  readonly department: string
+  readonly category: string
+}): Promise<ActionResult> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) return { success: false, error: "DEMO_READ_ONLY" }
+    requirePermission(user, "schedule", "update")
+    ensureInternalUser(user.role)
+    const organizationId = requireOrg(user)
+    const department = input.department.trim()
+    const category = input.category.trim()
+    if (!templateDepartments.has(department)) {
+      return { success: false, error: "Choose a valid template department." }
+    }
+    if (!category || category.length > 80) {
+      return { success: false, error: "Choose a valid template category." }
+    }
+
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const template = await db
+      .select({ id: projectTemplates.id })
+      .from(projectTemplates)
+      .where(
+        and(
+          eq(projectTemplates.id, input.templateId),
+          eq(projectTemplates.organizationId, organizationId)
+        )
+      )
+      .get()
+    if (!template) return { success: false, error: "Template not found." }
+
+    await db
+      .update(projectTemplates)
+      .set({
+        departmentCode: department,
+        tradeCategory: category,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(projectTemplates.id, template.id))
+    revalidatePath("/dashboard/templates")
+    revalidatePath(`/dashboard/templates/${template.id}`)
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to update template classification", error)
+    return { success: false, error: "Unable to update template classification." }
+  }
+}
+
+export async function deleteProjectTemplate(input: {
+  readonly templateId: string
+}): Promise<ActionResult> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) return { success: false, error: "DEMO_READ_ONLY" }
+    requirePermission(user, "schedule", "update")
+    ensureInternalUser(user.role)
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const template = await db
+      .select({ id: projectTemplates.id, name: projectTemplates.name })
+      .from(projectTemplates)
+      .where(
+        and(
+          eq(projectTemplates.id, input.templateId),
+          eq(projectTemplates.organizationId, organizationId)
+        )
+      )
+      .get()
+    if (!template) return { success: false, error: "Template not found." }
+
+    const application = await db
+      .select({ id: projectTemplateApplications.id })
+      .from(projectTemplateApplications)
+      .where(eq(projectTemplateApplications.templateId, template.id))
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (application) {
+      return {
+        success: false,
+        error:
+          "This template has already been applied to a project and must be retained for the project audit trail. Set it inactive instead.",
+      }
+    }
+
+    await db.delete(projectTemplates).where(eq(projectTemplates.id, template.id))
+    await recordActivityEvent({
+      db,
+      organizationId,
+      actor: user,
+      category: "schedule",
+      action: "project_template.deleted",
+      entityType: "project_template",
+      entityId: template.id,
+      summary: `Deleted project template “${template.name}”.`,
+    })
+    revalidatePath("/dashboard/templates")
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to delete template", error)
+    return { success: false, error: "Unable to delete the template." }
   }
 }

--- a/src/app/actions/project-templates.ts
+++ b/src/app/actions/project-templates.ts
@@ -35,6 +35,7 @@ import type {
   WorkdayExceptionData,
   WorkdayExceptionType,
 } from "@/lib/schedule/types"
+import { buildProjectTemplateContentApplication } from "@/lib/templates/project-template-content-application"
 import { buildScheduleTemplateApplication } from "@/lib/templates/schedule-template-application"
 
 export type ProjectTemplateLibraryItem = {
@@ -348,7 +349,7 @@ export async function getProjectTemplatePreview(
   }
 }
 
-export async function applyScheduleTemplate(input: {
+export async function applyProjectTemplate(input: {
   readonly projectId: string
   readonly templateId: string
   readonly anchorDate: string
@@ -358,6 +359,10 @@ export async function applyScheduleTemplate(input: {
       readonly applicationId: string
       readonly itemCount: number
       readonly dependencyCount: number
+      readonly scheduleItemCount: number
+      readonly taskCount: number
+      readonly selectionCount: number
+      readonly bidPackageCount: number
     }
   | { readonly success: false; readonly error: string }
 > {
@@ -448,7 +453,13 @@ export async function applyScheduleTemplate(input: {
       }
     }
 
-    const [templateItems, templateDependencies, exceptionRows, lastTask] =
+    const [
+      templateItems,
+      templateDependencies,
+      templateContentItems,
+      exceptionRows,
+      lastTask,
+    ] =
       await Promise.all([
         db
           .select()
@@ -459,6 +470,14 @@ export async function applyScheduleTemplate(input: {
           .select()
           .from(scheduleTemplateDependencies)
           .where(eq(scheduleTemplateDependencies.versionId, version.id)),
+        db
+          .select()
+          .from(projectTemplateContentItems)
+          .where(eq(projectTemplateContentItems.versionId, version.id))
+          .orderBy(
+            asc(projectTemplateContentItems.moduleType),
+            asc(projectTemplateContentItems.sortOrder)
+          ),
         db
           .select()
           .from(workdayExceptions)
@@ -483,6 +502,18 @@ export async function applyScheduleTemplate(input: {
 
     const applicationId = crypto.randomUUID()
     const now = new Date().toISOString()
+    const contentBuild = buildProjectTemplateContentApplication({
+      applicationId,
+      items: templateContentItems,
+      nextId: crypto.randomUUID,
+    })
+    const contentItemCount =
+      contentBuild.todos.length +
+      contentBuild.selections.length +
+      contentBuild.bidPackages.length
+    const totalItemCount = build.data.tasks.length + contentItemCount
+    // Keep every project record in the same D1 batch so a malformed module
+    // cannot leave a partially applied setup behind.
     const statements: D1PreparedStatement[] = [
       env.DB.prepare(
         `INSERT INTO project_template_applications (
@@ -498,9 +529,15 @@ export async function applyScheduleTemplate(input: {
         version.id,
         input.anchorDate,
         user.id,
-        build.data.tasks.length,
+        totalItemCount,
         build.data.dependencies.length,
-        JSON.stringify({ assignmentMode: "preserve_placeholders" }),
+        JSON.stringify({
+          assignmentMode: "preserve_placeholders",
+          scheduleItemCount: build.data.tasks.length,
+          taskCount: contentBuild.todos.length,
+          selectionCount: contentBuild.selections.length,
+          bidPackageCount: contentBuild.bidPackages.length,
+        }),
         now
       ),
     ]
@@ -564,6 +601,106 @@ export async function applyScheduleTemplate(input: {
         )
       )
     }
+    for (const todo of contentBuild.todos) {
+      statements.push(
+        env.DB.prepare(
+          `INSERT INTO project_operations (
+            id, project_id, source_system, source_record_type,
+            source_record_id, title, description, status, priority,
+            assignee_type, sage_write_status, sage_payload_json,
+            sync_direction, sync_status, created_at, updated_at
+          ) VALUES (?, ?, 'compass_template', 'staff_task', ?, ?, ?, 'open',
+            'normal', 'internal', 'not_ready', ?, 'write', 'compass_only', ?, ?)`
+        ).bind(
+          todo.id,
+          input.projectId,
+          todo.sourceRecordId,
+          todo.title,
+          todo.description,
+          todo.sourcePayloadJson,
+          now,
+          now
+        )
+      )
+    }
+    const selectionRooms = new Set(
+      contentBuild.selections.map((selection) => selection.roomName)
+    )
+    for (const roomName of selectionRooms) {
+      const roomKey = roomName
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "") || "whole-project"
+      statements.push(
+        env.DB.prepare(
+          `INSERT OR IGNORE INTO project_finish_selection_rooms (
+            id, project_id, source_system, room_name, sort_order,
+            created_at, updated_at
+          ) VALUES (?, ?, 'compass_template', ?, 1000, ?, ?)`
+        ).bind(
+          `template-room:${input.projectId}:${roomKey}`,
+          input.projectId,
+          roomName,
+          now,
+          now
+        )
+      )
+    }
+    // Imported selection choices need project-team review before an owner can
+    // see them, even when Buildertrend marked a client response as required.
+    for (const selection of contentBuild.selections) {
+      statements.push(
+        env.DB.prepare(
+          `INSERT INTO project_finish_selections (
+            id, project_id, source_system, source_record_id, room_name,
+            category, name, description, cost_code, status, owner_visible,
+            owner_approved, notes, sort_order, sync_status, created_at,
+            updated_at
+          ) VALUES (?, ?, 'compass_template', ?, ?, ?, ?, ?, ?, ?, 0, 0,
+            ?, ?, 'manual', ?, ?)`
+        ).bind(
+          selection.id,
+          input.projectId,
+          selection.sourceRecordId,
+          selection.roomName,
+          selection.category,
+          selection.name,
+          selection.description,
+          selection.costCode,
+          selection.status,
+          selection.notes,
+          selection.sortOrder,
+          now,
+          now
+        )
+      )
+    }
+    for (const bidPackage of contentBuild.bidPackages) {
+      statements.push(
+        env.DB.prepare(
+          `INSERT INTO project_operations (
+            id, project_id, source_system, source_record_type,
+            source_record_id, title, description, status, priority,
+            assignee_type, cost_code, sage_cost_code, sage_write_status,
+            sage_payload_json, sync_direction, sync_status, created_at,
+            updated_at
+          ) VALUES (?, ?, 'compass_template', 'rfq', ?, ?, ?, 'draft',
+            'normal', 'vendor', ?, ?, 'not_ready', ?, 'write',
+            'compass_only', ?, ?)`
+        ).bind(
+          bidPackage.id,
+          input.projectId,
+          bidPackage.sourceRecordId,
+          bidPackage.title,
+          bidPackage.description,
+          bidPackage.costCode,
+          bidPackage.costCode,
+          bidPackage.sourcePayloadJson,
+          now,
+          now
+        )
+      )
+    }
     statements.push(
       env.DB.prepare(
         `UPDATE project_template_applications
@@ -576,31 +713,51 @@ export async function applyScheduleTemplate(input: {
     if (results.some((result) => !result.success)) {
       throw new Error("Template application batch failed")
     }
-    await recalculateCriticalPath(db, input.projectId)
-    await recordActivityEvent({
-      db,
-      organizationId,
-      projectId: input.projectId,
-      actor: user,
-      category: "schedule",
-      action: "schedule.template_applied",
-      entityType: "project_template_application",
-      entityId: applicationId,
-      summary: `Applied schedule template “${template.name}”.`,
-      metadata: {
-        itemCount: build.data.tasks.length,
-        dependencyCount: build.data.dependencies.length,
-        anchorDate: input.anchorDate,
-      },
-    })
+    try {
+      await recalculateCriticalPath(db, input.projectId)
+    } catch (error) {
+      console.error("Unable to refresh critical path after template application", error)
+    }
+    try {
+      await recordActivityEvent({
+        db,
+        organizationId,
+        projectId: input.projectId,
+        actor: user,
+        category: "schedule",
+        action: "project.template_applied",
+        entityType: "project_template_application",
+        entityId: applicationId,
+        summary: `Applied project template “${template.name}”.`,
+        metadata: {
+          itemCount: totalItemCount,
+          scheduleItemCount: build.data.tasks.length,
+          taskCount: contentBuild.todos.length,
+          selectionCount: contentBuild.selections.length,
+          bidPackageCount: contentBuild.bidPackages.length,
+          dependencyCount: build.data.dependencies.length,
+          anchorDate: input.anchorDate,
+        },
+      })
+    } catch (error) {
+      console.error("Unable to record template application activity", error)
+    }
     revalidatePath(`/dashboard/projects/${input.projectId}/schedule`)
+    revalidatePath(`/dashboard/projects/${input.projectId}/todos`)
+    revalidatePath(`/dashboard/projects/${input.projectId}/selections`)
+    revalidatePath(`/dashboard/projects/${input.projectId}/rfqs`)
+    revalidatePath(`/dashboard/projects/${input.projectId}/financials`)
     revalidatePath("/dashboard/schedule")
     revalidatePath("/dashboard/templates")
     return {
       success: true,
       applicationId,
-      itemCount: build.data.tasks.length,
+      itemCount: totalItemCount,
       dependencyCount: build.data.dependencies.length,
+      scheduleItemCount: build.data.tasks.length,
+      taskCount: contentBuild.todos.length,
+      selectionCount: contentBuild.selections.length,
+      bidPackageCount: contentBuild.bidPackages.length,
     }
   } catch (error) {
     console.error("Unable to apply project template", error)
@@ -649,11 +806,147 @@ export async function setProjectTemplateLifecycle(input: {
   }
 }
 
-const templateDepartments = new Set(["ORC", "HPS", "Nu-Tech", "Design"])
-
-export async function updateProjectTemplateClassification(input: {
+export async function publishCapturedProjectTemplate(input: {
   readonly templateId: string
-  readonly department: string
+}): Promise<ActionResult> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) return { success: false, error: "DEMO_READ_ONLY" }
+    requirePermission(user, "schedule", "update")
+    ensureInternalUser(user.role)
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const template = await db
+      .select()
+      .from(projectTemplates)
+      .where(
+        and(
+          eq(projectTemplates.id, input.templateId),
+          eq(projectTemplates.organizationId, organizationId)
+        )
+      )
+      .get()
+    if (!template || template.currentVersionNumber === null) {
+      return { success: false, error: "Template not found or content is missing." }
+    }
+    if (template.reviewStatus !== "content_captured") {
+      return {
+        success: false,
+        error: "Only a fully captured draft can be reviewed and published.",
+      }
+    }
+
+    const version = await db
+      .select()
+      .from(projectTemplateVersions)
+      .where(
+        and(
+          eq(projectTemplateVersions.templateId, template.id),
+          eq(projectTemplateVersions.versionNumber, template.currentVersionNumber),
+          eq(projectTemplateVersions.status, "draft")
+        )
+      )
+      .get()
+    if (!version) {
+      return { success: false, error: "The current captured version is not a draft." }
+    }
+
+    const [modules, contentItems, scheduleItems] = await Promise.all([
+      db
+        .select()
+        .from(projectTemplateModules)
+        .where(eq(projectTemplateModules.versionId, version.id)),
+      db
+        .select({ moduleType: projectTemplateContentItems.moduleType })
+        .from(projectTemplateContentItems)
+        .where(eq(projectTemplateContentItems.versionId, version.id)),
+      db
+        .select({ id: scheduleTemplateItems.id })
+        .from(scheduleTemplateItems)
+        .where(eq(scheduleTemplateItems.versionId, version.id)),
+    ])
+    const requiredModuleTypes = [
+      "tasks",
+      "schedule",
+      "selections",
+      "bid_packages",
+    ] as const
+    const counts = new Map<string, number>()
+    for (const item of contentItems) {
+      counts.set(item.moduleType, (counts.get(item.moduleType) ?? 0) + 1)
+    }
+    for (const moduleType of requiredModuleTypes) {
+      const moduleRow = modules.find((item) => item.moduleType === moduleType)
+      if (!moduleRow || !["captured", "captured_with_warnings"].includes(moduleRow.normalizationStatus)) {
+        return {
+          success: false,
+          error: `The ${moduleType.replaceAll("_", " ")} module has not completed capture review.`,
+        }
+      }
+      if ((counts.get(moduleType) ?? 0) !== moduleRow.sourceItemCount) {
+        return {
+          success: false,
+          error: `The ${moduleType.replaceAll("_", " ")} module count does not match its reviewed source count.`,
+        }
+      }
+    }
+    const scheduleModule = modules.find((item) => item.moduleType === "schedule")
+    if (!scheduleModule || scheduleItems.length !== scheduleModule.sourceItemCount) {
+      return {
+        success: false,
+        error: "The reusable schedule count does not match its reviewed source count.",
+      }
+    }
+
+    const now = new Date().toISOString()
+    const results = await env.DB.batch([
+      env.DB.prepare(
+        `UPDATE project_template_versions SET status='published', notes=? ` +
+          `WHERE id=? AND status='draft'`
+      ).bind(
+        "Captured content reviewed in Compass and published by internal staff.",
+        version.id
+      ),
+      env.DB.prepare(
+        `UPDATE project_templates SET lifecycle_status='active', ` +
+          `review_status='verified', updated_at=? ` +
+          `WHERE id=? AND organization_id=? AND review_status='content_captured'`
+      ).bind(now, template.id, organizationId),
+    ])
+    if (results.some((result) => !result.success)) {
+      return { success: false, error: "Unable to publish the reviewed template." }
+    }
+
+    await recordActivityEvent({
+      db,
+      organizationId,
+      actor: user,
+      category: "schedule",
+      action: "project_template.published",
+      entityType: "project_template",
+      entityId: template.id,
+      summary: `Reviewed and published project template “${template.name}”.`,
+      metadata: {
+        versionNumber: version.versionNumber,
+        capturedItemCount: contentItems.length,
+        scheduleItemCount: scheduleItems.length,
+        warningModuleCount: modules.filter(
+          (module) => module.normalizationStatus === "captured_with_warnings"
+        ).length,
+      },
+    })
+    revalidatePath("/dashboard/templates")
+    revalidatePath(`/dashboard/templates/${template.id}`)
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to publish captured project template", error)
+    return { success: false, error: "Unable to publish the reviewed template." }
+  }
+}
+
+export async function updateProjectTemplateCategory(input: {
+  readonly templateId: string
   readonly category: string
 }): Promise<ActionResult> {
   try {
@@ -662,11 +955,7 @@ export async function updateProjectTemplateClassification(input: {
     requirePermission(user, "schedule", "update")
     ensureInternalUser(user.role)
     const organizationId = requireOrg(user)
-    const department = input.department.trim()
     const category = input.category.trim()
-    if (!templateDepartments.has(department)) {
-      return { success: false, error: "Choose a valid template department." }
-    }
     if (!category || category.length > 80) {
       return { success: false, error: "Choose a valid template category." }
     }
@@ -688,7 +977,6 @@ export async function updateProjectTemplateClassification(input: {
     await db
       .update(projectTemplates)
       .set({
-        departmentCode: department,
         tradeCategory: category,
         updatedAt: new Date().toISOString(),
       })

--- a/src/app/dashboard/templates/[id]/page.tsx
+++ b/src/app/dashboard/templates/[id]/page.tsx
@@ -39,8 +39,8 @@ export default async function EstimateTemplatePage({
               <Badge variant="outline">
                 {preview.templateKind === "project" ? "Project" : "Assembly"}
               </Badge>
-              {preview.departmentCode && (
-                <Badge variant="secondary">{preview.departmentCode}</Badge>
+              {preview.tradeCategory && (
+                <Badge variant="secondary">{preview.tradeCategory}</Badge>
               )}
             </div>
             <p className="mt-1 text-sm text-muted-foreground">
@@ -68,6 +68,42 @@ export default async function EstimateTemplatePage({
                       <p className="text-xs text-muted-foreground">{item.phase}</p>
                     </div>
                     <p className="text-sm text-muted-foreground">{item.workdays} workday{item.workdays === 1 ? "" : "s"}</p>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {preview.modules.length > 0 && (
+            <section>
+              <div className="mb-2 border-b pb-2">
+                <h2 className="font-semibold">Capture review</h2>
+              </div>
+              <div className="divide-y border-y">
+                {preview.modules.map((module) => (
+                  <div
+                    key={module.moduleType}
+                    className="flex flex-wrap items-center justify-between gap-2 py-3"
+                  >
+                    <span className="capitalize">
+                      {module.moduleType.replaceAll("_", " ")}
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm text-muted-foreground">
+                        {module.sourceItemCount} source items
+                      </span>
+                      <Badge
+                        variant={
+                          module.normalizationStatus === "captured_with_warnings"
+                            ? "outline"
+                            : "secondary"
+                        }
+                      >
+                        {module.normalizationStatus === "captured_with_warnings"
+                          ? "Captured with warnings"
+                          : module.normalizationStatus.replaceAll("_", " ")}
+                      </Badge>
+                    </div>
                   </div>
                 ))}
               </div>

--- a/src/app/dashboard/templates/[id]/page.tsx
+++ b/src/app/dashboard/templates/[id]/page.tsx
@@ -1,7 +1,15 @@
 import { notFound } from "next/navigation"
+import Link from "next/link"
+
+import {
+  getProjectTemplateContent,
+  getProjectTemplatePreview,
+} from "@/app/actions/project-templates"
 
 import { getEstimateTemplateEditor } from "@/app/actions/estimate-templates"
 import { EstimateTemplateEditorPanel } from "@/components/templates/estimate-template-editor"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 
 export const dynamic = "force-dynamic"
 
@@ -11,7 +19,93 @@ export default async function EstimateTemplatePage({
   readonly params: Promise<{ id: string }>
 }): Promise<React.ReactElement> {
   const { id } = await params
-  const editor = await getEstimateTemplateEditor(id)
-  if (!editor) notFound()
-  return <EstimateTemplateEditorPanel editor={editor} />
+  const preview = await getProjectTemplatePreview(id)
+  if (!preview) notFound()
+  if (preview.templateKind === "estimate") {
+    const editor = await getEstimateTemplateEditor(id)
+    if (!editor) notFound()
+    return <EstimateTemplateEditorPanel editor={editor} />
+  }
+
+  const content = await getProjectTemplateContent(id)
+  const moduleNames = [...new Set(content.map((item) => item.moduleType))]
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <header className="shrink-0 border-b px-4 py-4 sm:px-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-2xl font-semibold tracking-tight">{preview.name}</h1>
+              <Badge variant="outline">
+                {preview.templateKind === "project" ? "Project" : "Assembly"}
+              </Badge>
+              {preview.departmentCode && (
+                <Badge variant="secondary">{preview.departmentCode}</Badge>
+              )}
+            </div>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {preview.tradeCategory ?? "Other"} · version {preview.currentVersionNumber ?? "draft"}
+            </p>
+          </div>
+          <Button asChild variant="outline">
+            <Link href="/dashboard/templates">Back to templates</Link>
+          </Button>
+        </div>
+      </header>
+      <main className="flex-1 overflow-y-auto px-4 py-5 sm:px-6">
+        <div className="space-y-8">
+          {preview.scheduleItems.length > 0 && (
+            <section>
+              <div className="mb-2 flex items-baseline justify-between border-b pb-2">
+                <h2 className="font-semibold">Schedule items</h2>
+                <span className="text-xs text-muted-foreground">{preview.scheduleItems.length} items</span>
+              </div>
+              <div className="divide-y border-y">
+                {preview.scheduleItems.map((item, index) => (
+                  <div key={`${item.title}-${index}`} className="grid gap-1 py-3 sm:grid-cols-[minmax(0,1fr)_auto]">
+                    <div>
+                      <p className="font-medium">{item.title}</p>
+                      <p className="text-xs text-muted-foreground">{item.phase}</p>
+                    </div>
+                    <p className="text-sm text-muted-foreground">{item.workdays} workday{item.workdays === 1 ? "" : "s"}</p>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {moduleNames.map((moduleType) => {
+            const items = content.filter((item) => item.moduleType === moduleType)
+            return (
+              <section key={moduleType}>
+                <div className="mb-2 flex items-baseline justify-between border-b pb-2">
+                  <h2 className="font-semibold capitalize">{moduleType.replaceAll("_", " ")}</h2>
+                  <span className="text-xs text-muted-foreground">{items.length} items</span>
+                </div>
+                <div className="divide-y border-y">
+                  {items.map((item) => (
+                    <div key={item.id} className="py-3">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="font-medium">{item.title}</p>
+                        {item.category && <Badge variant="outline">{item.category}</Badge>}
+                      </div>
+                      {item.description && (
+                        <p className="mt-1 whitespace-pre-wrap text-sm text-muted-foreground">{item.description}</p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )
+          })}
+
+          {preview.scheduleItems.length === 0 && content.length === 0 && (
+            <div className="border-y py-10 text-sm text-muted-foreground">
+              This template does not contain reusable content yet.
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  )
 }

--- a/src/app/dashboard/templates/page.tsx
+++ b/src/app/dashboard/templates/page.tsx
@@ -1,197 +1,27 @@
-import Link from "next/link"
-import {
-  IconArrowLeft,
-  IconCircleCheck,
-  IconClockHour4,
-  IconExternalLink,
-  IconTemplate,
-} from "@tabler/icons-react"
-
 import { getProjectTemplateLibrary } from "@/app/actions/project-templates"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { EstimateTemplateCreateDialog } from "@/components/templates/estimate-template-create-dialog"
+import { TemplateLibraryView } from "@/components/templates/template-library-view"
 import { getCurrentUser } from "@/lib/auth"
 import { can } from "@/lib/permissions"
 import { isInternalStaffRole } from "@/lib/user-roles"
 
 export const dynamic = "force-dynamic"
 
-function reviewLabel(reviewStatus: string): string {
-  switch (reviewStatus) {
-    case "verified":
-      return "Verified"
-    case "content_captured":
-      return "Content captured"
-    default:
-      return "Inventory only"
-  }
-}
-
 export default async function TemplateLibraryPage() {
   const [templates, user] = await Promise.all([
     getProjectTemplateLibrary(),
     getCurrentUser(),
   ])
-  const canManageEstimateTemplates =
+  const canManage =
+    Boolean(user && isInternalStaffRole(user.role)) &&
+    can(user, "schedule", "update")
+  const canCreateEstimate =
     Boolean(user && isInternalStaffRole(user.role)) &&
     can(user, "budget", "update")
-  const readyCount = templates.filter(
-    (template) =>
-      template.lifecycleStatus === "active" &&
-      template.reviewStatus === "verified"
-  ).length
-  const inventoryCount = templates.filter(
-    (template) => template.reviewStatus === "inventory_only"
-  ).length
-  const categories = [
-    ...new Set(
-      templates.map((template) => template.tradeCategory ?? "Other")
-    ),
-  ].sort((left, right) => left.localeCompare(right))
-
   return (
-    <div className="flex flex-1 flex-col overflow-hidden">
-      <header className="shrink-0 border-b px-4 py-4 sm:px-6">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <div className="mb-1 flex items-center gap-2 text-sm text-muted-foreground">
-              <IconTemplate className="size-4" />
-              Project setup
-            </div>
-            <h1 className="text-2xl font-semibold tracking-tight">
-              Template Library
-            </h1>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Reusable project assemblies remain separate from live project
-              records until they are reviewed and applied.
-            </p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            {canManageEstimateTemplates && <EstimateTemplateCreateDialog />}
-            <Button asChild variant="outline">
-              <Link href="/dashboard/schedule">
-                <IconArrowLeft className="mr-2 size-4" />
-                Back to schedules
-              </Link>
-            </Button>
-          </div>
-        </div>
-        <div className="mt-4 flex flex-wrap gap-x-6 gap-y-2 border-t pt-3 text-sm">
-          <span>{templates.length} templates in the library</span>
-          <span className="text-muted-foreground">{inventoryCount} awaiting content capture</span>
-          <span className="text-muted-foreground">{readyCount} verified and usable</span>
-          <span className="font-medium text-amber-700 dark:text-amber-300">
-            Archived Buildertrend templates excluded
-          </span>
-        </div>
-      </header>
-
-      <main className="flex-1 overflow-y-auto px-4 py-5 sm:px-6">
-        {templates.length === 0 ? (
-          <div className="max-w-2xl border-y py-10">
-            <h2 className="font-medium">The Template Library is ready for inventory.</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Run the guarded Buildertrend inventory importer, then capture and
-              verify each active template before making it available to projects.
-            </p>
-          </div>
-        ) : (
-          <div className="space-y-8">
-            {categories.map((category) => {
-              const categoryTemplates = templates.filter(
-                (template) => (template.tradeCategory ?? "Other") === category
-              )
-              return (
-                <section key={category} aria-labelledby={`category-${category}`}>
-                  <div className="mb-2 flex items-baseline justify-between border-b pb-2">
-                    <h2 id={`category-${category}`} className="font-semibold">
-                      {category}
-                    </h2>
-                    <span className="text-xs text-muted-foreground">
-                      {categoryTemplates.length} template
-                      {categoryTemplates.length === 1 ? "" : "s"}
-                    </span>
-                  </div>
-                  <div className="divide-y border-y">
-                    {categoryTemplates.map((template) => {
-                      const ready =
-                        template.lifecycleStatus === "active" &&
-                        template.reviewStatus === "verified" &&
-                        template.currentVersionStatus === "published"
-                      return (
-                        <div
-                          key={template.id}
-                          className="grid gap-3 py-3 md:grid-cols-[minmax(0,1fr)_auto_auto] md:items-center"
-                        >
-                          <div className="min-w-0">
-                            <div className="flex flex-wrap items-center gap-2">
-                              <p className="truncate font-medium">{template.name}</p>
-                              <Badge variant="outline">
-                                {template.templateKind === "project"
-                                  ? "Project"
-                                  : template.templateKind === "estimate"
-                                    ? "Estimate"
-                                    : "Assembly"}
-                              </Badge>
-                              {template.departmentCode && (
-                                <Badge variant="secondary">
-                                  {template.departmentCode}
-                                </Badge>
-                              )}
-                            </div>
-                            <p className="mt-1 text-xs text-muted-foreground">
-                              {template.templateKind === "estimate"
-                                ? `${
-                                    template.modules.find(
-                                      (module) => module.moduleType === "estimate"
-                                    )?.sourceItemCount ?? 0
-                                  } estimate lines`
-                                : `${template.scheduleItemCount} schedule items · ${template.dependencyCount} dependencies`}
-                              {template.currentVersionNumber
-                                ? ` · version ${template.currentVersionNumber}`
-                                : " · content capture pending"}
-                            </p>
-                          </div>
-                          <div className="flex items-center gap-2 text-sm">
-                            {ready ? (
-                              <IconCircleCheck className="size-4 text-emerald-600" />
-                            ) : (
-                              <IconClockHour4 className="size-4 text-amber-600" />
-                            )}
-                            {reviewLabel(template.reviewStatus)}
-                          </div>
-                          <div className="flex justify-end">
-                            {template.templateKind === "estimate" && (
-                              <Button asChild size="sm" variant="outline">
-                                <Link href={`/dashboard/templates/${template.id}`}>
-                                  Edit
-                                </Link>
-                              </Button>
-                            )}
-                            {template.sourceUrl && (
-                              <Button asChild size="sm" variant="ghost">
-                                <a
-                                  href={template.sourceUrl}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                >
-                                  Source
-                                  <IconExternalLink className="ml-2 size-3.5" />
-                                </a>
-                              </Button>
-                            )}
-                          </div>
-                        </div>
-                      )
-                    })}
-                  </div>
-                </section>
-              )
-            })}
-          </div>
-        )}
-      </main>
-    </div>
+    <TemplateLibraryView
+      templates={templates}
+      canManage={canManage}
+      canCreateEstimate={canCreateEstimate}
+    />
   )
 }

--- a/src/components/projects/project-todo-edit-dialog.tsx
+++ b/src/components/projects/project-todo-edit-dialog.tsx
@@ -2,11 +2,17 @@
 
 import * as React from "react"
 import { useRouter } from "next/navigation"
-import { IconArchive, IconDeviceFloppy, IconRestore } from "@tabler/icons-react"
+import {
+  IconArchive,
+  IconDeviceFloppy,
+  IconRestore,
+  IconTrash,
+} from "@tabler/icons-react"
 
 import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
 import {
   archiveProjectTodo,
+  deleteProjectTodo,
   restoreProjectTodo,
   updateProjectTodo,
   type ProjectOperationItem,
@@ -57,6 +63,7 @@ function cleanValue(value: string): string | null {
 
 function sourceLabel(item: ProjectOperationItem): string {
   if (item.sourceSystem === "buildertrend") return "Imported from Buildertrend"
+  if (item.sourceSystem === "compass_template") return "Created from a Compass template"
   if (item.sourceSystem === "compass") return "Created in Compass"
   if (item.sourceSystem === "sage") return "Imported from Sage"
   return `Imported from ${item.sourceSystem}`
@@ -138,6 +145,22 @@ export function ProjectTodoEditDialog({
   async function restore(): Promise<void> {
     setSaveState({ kind: "saving" })
     const result = await restoreProjectTodo(
+      projectId,
+      item.id,
+      item.updatedAt
+    )
+    if (!result.success) {
+      setSaveState({ kind: "error", message: result.error })
+      return
+    }
+
+    onOpenChange(false)
+    router.refresh()
+  }
+
+  async function remove(): Promise<void> {
+    setSaveState({ kind: "saving" })
+    const result = await deleteProjectTodo(
       projectId,
       item.id,
       item.updatedAt
@@ -321,15 +344,44 @@ export function ProjectTodoEditDialog({
 
           <div className="flex flex-col-reverse gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
             {archived ? (
-              <Button
-                type="button"
-                variant="outline"
-                onClick={restore}
-                disabled={saveState.kind === "saving"}
-              >
-                <IconRestore className="size-4" />
-                Restore to-do
-              </Button>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={restore}
+                  disabled={saveState.kind === "saving"}
+                >
+                  <IconRestore className="size-4" />
+                  Restore to-do
+                </Button>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="destructive"
+                      disabled={saveState.kind === "saving"}
+                    >
+                      <IconTrash className="size-4" />
+                      Delete
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Delete this to-do permanently?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        This cannot be undone. Any preserved import or template
+                        provenance for this to-do will also be removed.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Keep to-do</AlertDialogCancel>
+                      <AlertDialogAction onClick={remove}>
+                        Delete permanently
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </div>
             ) : (
               <AlertDialog>
                 <AlertDialogTrigger asChild>

--- a/src/components/schedule/schedule-template-dialog.tsx
+++ b/src/components/schedule/schedule-template-dialog.tsx
@@ -7,7 +7,7 @@ import { IconLoader2, IconTemplate } from "@tabler/icons-react"
 import { toast } from "sonner"
 
 import {
-  applyScheduleTemplate,
+  applyProjectTemplate,
   getProjectTemplateLibrary,
   type ProjectTemplateLibraryItem,
 } from "@/app/actions/project-templates"
@@ -95,7 +95,7 @@ export function ScheduleTemplateDialog({
   const handleApply = (): void => {
     if (!templateId || !anchorDate) return
     startApplying(async () => {
-      const result = await applyScheduleTemplate({
+      const result = await applyProjectTemplate({
         projectId,
         templateId,
         anchorDate,
@@ -105,7 +105,8 @@ export function ScheduleTemplateDialog({
         return
       }
       toast.success(
-        `Added ${result.itemCount} schedule items and ${result.dependencyCount} dependencies.`
+        `Added ${result.scheduleItemCount} schedule items, ${result.taskCount} to-dos, ` +
+          `${result.selectionCount} selections, and ${result.bidPackageCount} draft RFQs.`
       )
       setTemplateId("")
       onOpenChange(false)
@@ -117,10 +118,11 @@ export function ScheduleTemplateDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-xl">
         <DialogHeader>
-          <DialogTitle>Add schedule from template</DialogTitle>
+          <DialogTitle>Add project setup from template</DialogTitle>
           <DialogDescription>
             Choose a verified template and the date its first item should begin.
-            The new project items remain independently editable.
+            Schedule items, to-dos, finish selections, and draft RFQs are copied
+            into this project and remain independently editable.
           </DialogDescription>
         </DialogHeader>
 
@@ -202,7 +204,7 @@ export function ScheduleTemplateDialog({
             disabled={!selected || !anchorDate || isApplying}
           >
             {isApplying && <IconLoader2 className="mr-2 size-4 animate-spin" />}
-            Add to schedule
+            Add to project
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/templates/estimate-template-create-dialog.tsx
+++ b/src/components/templates/estimate-template-create-dialog.tsx
@@ -30,7 +30,6 @@ export function EstimateTemplateCreateDialog(): React.ReactElement {
       const result = await createEstimateTemplateDraft({
         name: String(formData.get("name") ?? ""),
         description: String(formData.get("description") ?? ""),
-        departmentCode: String(formData.get("departmentCode") ?? ""),
       })
       if (!result.success) {
         toast.error(result.error)
@@ -67,14 +66,6 @@ export function EstimateTemplateCreateDialog(): React.ReactElement {
                 name="name"
                 placeholder="Custom home construction estimate"
                 required
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="template-department">Department</Label>
-              <Input
-                id="template-department"
-                name="departmentCode"
-                placeholder="ORC, Design, HPS, or Nu-Tech"
               />
             </div>
             <div className="space-y-1.5">

--- a/src/components/templates/estimate-template-editor.tsx
+++ b/src/components/templates/estimate-template-editor.tsx
@@ -157,7 +157,6 @@ export function EstimateTemplateEditorPanel({
         templateId: editor.id,
         name: formText(formData, "name"),
         description: formText(formData, "description"),
-        departmentCode: formText(formData, "departmentCode"),
         documentTitle: formText(formData, "documentTitle"),
         contractTerms: formText(formData, "contractTerms"),
         defaultMarkupPercent: formNumber(formData, "defaultMarkupPercent"),
@@ -292,15 +291,6 @@ export function EstimateTemplateEditorPanel({
                   id="templateName"
                   name="name"
                   defaultValue={editor.name}
-                  disabled={!editable}
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="templateDepartment">Department</Label>
-                <Input
-                  id="templateDepartment"
-                  name="departmentCode"
-                  defaultValue={editor.departmentCode ?? ""}
                   disabled={!editable}
                 />
               </div>

--- a/src/components/templates/template-library-view.tsx
+++ b/src/components/templates/template-library-view.tsx
@@ -1,0 +1,345 @@
+"use client"
+
+import Link from "next/link"
+import { useMemo, useState, useTransition } from "react"
+import {
+  IconArrowLeft,
+  IconCircleCheck,
+  IconClockHour4,
+  IconTemplate,
+  IconTrash,
+} from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import {
+  deleteProjectTemplate,
+  updateProjectTemplateClassification,
+  type ProjectTemplateLibraryItem,
+} from "@/app/actions/project-templates"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { EstimateTemplateCreateDialog } from "./estimate-template-create-dialog"
+
+export const TEMPLATE_DEPARTMENTS = ["ORC", "HPS", "Nu-Tech", "Design"] as const
+export const TEMPLATE_CATEGORIES = [
+  "Concrete",
+  "Preconstruction",
+  "Drywall",
+  "Earthwork",
+  "Exterior Finishes",
+  "Framing",
+  "Insulation",
+  "Interior Finishes",
+  "MEP",
+  "General",
+  "Other",
+] as const
+
+type Props = {
+  readonly templates: readonly ProjectTemplateLibraryItem[]
+  readonly canManage: boolean
+  readonly canCreateEstimate: boolean
+}
+
+function reviewLabel(reviewStatus: string): string {
+  switch (reviewStatus) {
+    case "verified":
+      return "Verified"
+    case "content_captured":
+      return "Content captured"
+    default:
+      return "Inventory only"
+  }
+}
+
+function normalizedDepartment(value: string | null): string {
+  if (value === "D") return "Design"
+  if (value === "N") return "Nu-Tech"
+  if (value === "O") return "ORC"
+  if (value === "H") return "HPS"
+  return value ?? "ORC"
+}
+
+function ClassificationControls({
+  template,
+}: {
+  readonly template: ProjectTemplateLibraryItem
+}): React.ReactElement {
+  const [department, setDepartment] = useState(
+    normalizedDepartment(template.departmentCode)
+  )
+  const [category, setCategory] = useState(template.tradeCategory ?? "Other")
+  const [pending, startTransition] = useTransition()
+
+  function save(nextDepartment: string, nextCategory: string): void {
+    startTransition(async () => {
+      const result = await updateProjectTemplateClassification({
+        templateId: template.id,
+        department: nextDepartment,
+        category: nextCategory,
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success("Template classification updated.")
+    })
+  }
+
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      <Select
+        disabled={pending}
+        value={department}
+        onValueChange={(value) => {
+          setDepartment(value)
+          save(value, category)
+        }}
+      >
+        <SelectTrigger aria-label={`Department for ${template.name}`}>
+          <SelectValue placeholder="Department" />
+        </SelectTrigger>
+        <SelectContent>
+          {TEMPLATE_DEPARTMENTS.map((option) => (
+            <SelectItem key={option} value={option}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select
+        disabled={pending}
+        value={category}
+        onValueChange={(value) => {
+          setCategory(value)
+          save(department, value)
+        }}
+      >
+        <SelectTrigger aria-label={`Category for ${template.name}`}>
+          <SelectValue placeholder="Category" />
+        </SelectTrigger>
+        <SelectContent>
+          {TEMPLATE_CATEGORIES.map((option) => (
+            <SelectItem key={option} value={option}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+function DeleteTemplateButton({
+  template,
+}: {
+  readonly template: ProjectTemplateLibraryItem
+}): React.ReactElement {
+  const [pending, startTransition] = useTransition()
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button size="sm" variant="ghost">
+          <IconTrash className="mr-2 size-4" />
+          Delete
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete “{template.name}”?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This removes the template and all of its locally stored content.
+            Templates already applied to a project are retained for audit and
+            cannot be deleted.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={pending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={pending}
+            onClick={(event) => {
+              event.preventDefault()
+              startTransition(async () => {
+                const result = await deleteProjectTemplate({
+                  templateId: template.id,
+                })
+                if (!result.success) {
+                  toast.error(result.error)
+                  return
+                }
+                toast.success("Template deleted.")
+              })
+            }}
+          >
+            {pending ? "Deleting…" : "Delete template"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export function TemplateLibraryView({
+  templates,
+  canManage,
+  canCreateEstimate,
+}: Props): React.ReactElement {
+  const [departmentFilter, setDepartmentFilter] = useState("all")
+  const [categoryFilter, setCategoryFilter] = useState("all")
+  const categories = useMemo(
+    () =>
+      [...new Set(templates.map((template) => template.tradeCategory ?? "Other"))].sort(
+        (left, right) => left.localeCompare(right)
+      ),
+    [templates]
+  )
+  const filtered = templates.filter(
+    (template) =>
+      (departmentFilter === "all" ||
+        normalizedDepartment(template.departmentCode) === departmentFilter) &&
+      (categoryFilter === "all" ||
+        (template.tradeCategory ?? "Other") === categoryFilter)
+  )
+  const readyCount = templates.filter(
+    (template) =>
+      template.lifecycleStatus === "active" && template.reviewStatus === "verified"
+  ).length
+  const inventoryCount = templates.filter(
+    (template) => template.reviewStatus === "inventory_only"
+  ).length
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <header className="shrink-0 border-b px-4 py-4 sm:px-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <div className="mb-1 flex items-center gap-2 text-sm text-muted-foreground">
+              <IconTemplate className="size-4" />
+              Project setup
+            </div>
+            <h1 className="text-2xl font-semibold tracking-tight">Template Library</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Reusable Compass content for project setup, schedules, tasks,
+              selections, and bid packages.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {canCreateEstimate && <EstimateTemplateCreateDialog />}
+            <Button asChild variant="outline">
+              <Link href="/dashboard/schedule">
+                <IconArrowLeft className="mr-2 size-4" />
+                Back to schedules
+              </Link>
+            </Button>
+          </div>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-x-6 gap-y-2 border-t pt-3 text-sm">
+          <span>{templates.length} templates in Compass</span>
+          <span className="text-muted-foreground">{inventoryCount} awaiting content capture</span>
+          <span className="text-muted-foreground">{readyCount} verified and usable</span>
+          <span className="font-medium text-amber-700 dark:text-amber-300">
+            Archived Buildertrend templates excluded
+          </span>
+        </div>
+      </header>
+
+      <main className="flex-1 overflow-y-auto px-4 py-5 sm:px-6">
+        <div className="mb-5 grid gap-3 border-y py-3 sm:grid-cols-2 lg:max-w-2xl">
+          <Select value={departmentFilter} onValueChange={setDepartmentFilter}>
+            <SelectTrigger aria-label="Filter templates by department">
+              <SelectValue placeholder="All departments" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All departments</SelectItem>
+              {TEMPLATE_DEPARTMENTS.map((department) => (
+                <SelectItem key={department} value={department}>{department}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={categoryFilter} onValueChange={setCategoryFilter}>
+            <SelectTrigger aria-label="Filter templates by category">
+              <SelectValue placeholder="All categories" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All categories</SelectItem>
+              {categories.map((category) => (
+                <SelectItem key={category} value={category}>{category}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {filtered.length === 0 ? (
+          <div className="border-y py-10 text-sm text-muted-foreground">
+            No templates match those filters.
+          </div>
+        ) : (
+          <div className="divide-y border-y">
+            {filtered.map((template) => {
+              const ready =
+                template.lifecycleStatus === "active" &&
+                template.reviewStatus === "verified" &&
+                template.currentVersionStatus === "published"
+              const contentCount = template.modules.reduce(
+                (total, module) => total + module.sourceItemCount,
+                0
+              )
+              return (
+                <article key={template.id} className="grid gap-4 py-4 xl:grid-cols-[minmax(0,1fr)_24rem_auto] xl:items-center">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Link className="truncate font-medium hover:underline" href={`/dashboard/templates/${template.id}`}>
+                        {template.name}
+                      </Link>
+                      <Badge variant="outline">
+                        {template.templateKind === "project" ? "Project" : template.templateKind === "estimate" ? "Estimate" : "Assembly"}
+                      </Badge>
+                      <Badge variant="secondary">{normalizedDepartment(template.departmentCode)}</Badge>
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {template.scheduleItemCount} schedule items · {contentCount} stored source records
+                      {template.currentVersionNumber ? ` · version ${template.currentVersionNumber}` : " · content capture pending"}
+                    </p>
+                    <div className="mt-2 flex items-center gap-2 text-sm">
+                      {ready ? <IconCircleCheck className="size-4 text-emerald-600" /> : <IconClockHour4 className="size-4 text-amber-600" />}
+                      {reviewLabel(template.reviewStatus)}
+                    </div>
+                  </div>
+                  {canManage ? (
+                    <ClassificationControls template={template} />
+                  ) : (
+                    <span className="text-sm text-muted-foreground">{template.tradeCategory ?? "Other"}</span>
+                  )}
+                  <div className="flex justify-end gap-1">
+                    <Button asChild size="sm" variant="outline">
+                      <Link href={`/dashboard/templates/${template.id}`}>Open</Link>
+                    </Button>
+                    {canManage && <DeleteTemplateButton template={template} />}
+                  </div>
+                </article>
+              )
+            })}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src/components/templates/template-library-view.tsx
+++ b/src/components/templates/template-library-view.tsx
@@ -13,7 +13,8 @@ import { toast } from "sonner"
 
 import {
   deleteProjectTemplate,
-  updateProjectTemplateClassification,
+  publishCapturedProjectTemplate,
+  updateProjectTemplateCategory,
   type ProjectTemplateLibraryItem,
 } from "@/app/actions/project-templates"
 import {
@@ -38,7 +39,6 @@ import {
 } from "@/components/ui/select"
 import { EstimateTemplateCreateDialog } from "./estimate-template-create-dialog"
 
-export const TEMPLATE_DEPARTMENTS = ["ORC", "HPS", "Nu-Tech", "Design"] as const
 export const TEMPLATE_CATEGORIES = [
   "Concrete",
   "Preconstruction",
@@ -70,30 +70,18 @@ function reviewLabel(reviewStatus: string): string {
   }
 }
 
-function normalizedDepartment(value: string | null): string {
-  if (value === "D") return "Design"
-  if (value === "N") return "Nu-Tech"
-  if (value === "O") return "ORC"
-  if (value === "H") return "HPS"
-  return value ?? "ORC"
-}
-
-function ClassificationControls({
+function CategoryControl({
   template,
 }: {
   readonly template: ProjectTemplateLibraryItem
 }): React.ReactElement {
-  const [department, setDepartment] = useState(
-    normalizedDepartment(template.departmentCode)
-  )
   const [category, setCategory] = useState(template.tradeCategory ?? "Other")
   const [pending, startTransition] = useTransition()
 
-  function save(nextDepartment: string, nextCategory: string): void {
+  function save(nextCategory: string): void {
     startTransition(async () => {
-      const result = await updateProjectTemplateClassification({
+      const result = await updateProjectTemplateCategory({
         templateId: template.id,
-        department: nextDepartment,
         category: nextCategory,
       })
       if (!result.success) {
@@ -105,32 +93,13 @@ function ClassificationControls({
   }
 
   return (
-    <div className="grid gap-2 sm:grid-cols-2">
-      <Select
-        disabled={pending}
-        value={department}
-        onValueChange={(value) => {
-          setDepartment(value)
-          save(value, category)
-        }}
-      >
-        <SelectTrigger aria-label={`Department for ${template.name}`}>
-          <SelectValue placeholder="Department" />
-        </SelectTrigger>
-        <SelectContent>
-          {TEMPLATE_DEPARTMENTS.map((option) => (
-            <SelectItem key={option} value={option}>
-              {option}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+    <div>
       <Select
         disabled={pending}
         value={category}
         onValueChange={(value) => {
           setCategory(value)
-          save(department, value)
+          save(value)
         }}
       >
         <SelectTrigger aria-label={`Category for ${template.name}`}>
@@ -197,12 +166,64 @@ function DeleteTemplateButton({
   )
 }
 
+function PublishTemplateButton({
+  template,
+}: {
+  readonly template: ProjectTemplateLibraryItem
+}): React.ReactElement {
+  const [pending, startTransition] = useTransition()
+  const warningCount = template.modules.filter(
+    (module) => module.normalizationStatus === "captured_with_warnings"
+  ).length
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button size="sm" variant="default">
+          <IconCircleCheck className="mr-2 size-4" />
+          Review and publish
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Publish “{template.name}”?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Compass will verify every captured module count before publishing.
+            {warningCount > 0
+              ? ` ${warningCount} module${warningCount === 1 ? " has" : "s have"} documented conversion warnings; review the template details before continuing.`
+              : " No conversion warnings were recorded."}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={pending}>Keep as draft</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={pending}
+            onClick={(event) => {
+              event.preventDefault()
+              startTransition(async () => {
+                const result = await publishCapturedProjectTemplate({
+                  templateId: template.id,
+                })
+                if (!result.success) {
+                  toast.error(result.error)
+                  return
+                }
+                toast.success("Template reviewed and published.")
+              })
+            }}
+          >
+            {pending ? "Publishing…" : "Publish template"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
 export function TemplateLibraryView({
   templates,
   canManage,
   canCreateEstimate,
 }: Props): React.ReactElement {
-  const [departmentFilter, setDepartmentFilter] = useState("all")
   const [categoryFilter, setCategoryFilter] = useState("all")
   const categories = useMemo(
     () =>
@@ -213,10 +234,8 @@ export function TemplateLibraryView({
   )
   const filtered = templates.filter(
     (template) =>
-      (departmentFilter === "all" ||
-        normalizedDepartment(template.departmentCode) === departmentFilter) &&
-      (categoryFilter === "all" ||
-        (template.tradeCategory ?? "Other") === categoryFilter)
+      categoryFilter === "all" ||
+      (template.tradeCategory ?? "Other") === categoryFilter
   )
   const readyCount = templates.filter(
     (template) =>
@@ -262,18 +281,7 @@ export function TemplateLibraryView({
       </header>
 
       <main className="flex-1 overflow-y-auto px-4 py-5 sm:px-6">
-        <div className="mb-5 grid gap-3 border-y py-3 sm:grid-cols-2 lg:max-w-2xl">
-          <Select value={departmentFilter} onValueChange={setDepartmentFilter}>
-            <SelectTrigger aria-label="Filter templates by department">
-              <SelectValue placeholder="All departments" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All departments</SelectItem>
-              {TEMPLATE_DEPARTMENTS.map((department) => (
-                <SelectItem key={department} value={department}>{department}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+        <div className="mb-5 border-y py-3 sm:max-w-sm">
           <Select value={categoryFilter} onValueChange={setCategoryFilter}>
             <SelectTrigger aria-label="Filter templates by category">
               <SelectValue placeholder="All categories" />
@@ -312,7 +320,7 @@ export function TemplateLibraryView({
                       <Badge variant="outline">
                         {template.templateKind === "project" ? "Project" : template.templateKind === "estimate" ? "Estimate" : "Assembly"}
                       </Badge>
-                      <Badge variant="secondary">{normalizedDepartment(template.departmentCode)}</Badge>
+                      <Badge variant="secondary">{template.tradeCategory ?? "Other"}</Badge>
                     </div>
                     <p className="mt-1 text-xs text-muted-foreground">
                       {template.scheduleItemCount} schedule items · {contentCount} stored source records
@@ -324,11 +332,16 @@ export function TemplateLibraryView({
                     </div>
                   </div>
                   {canManage ? (
-                    <ClassificationControls template={template} />
+                    <CategoryControl template={template} />
                   ) : (
                     <span className="text-sm text-muted-foreground">{template.tradeCategory ?? "Other"}</span>
                   )}
                   <div className="flex justify-end gap-1">
+                    {canManage &&
+                      template.reviewStatus === "content_captured" &&
+                      template.currentVersionStatus === "draft" && (
+                        <PublishTemplateButton template={template} />
+                      )}
                     <Button asChild size="sm" variant="outline">
                       <Link href={`/dashboard/templates/${template.id}`}>Open</Link>
                     </Button>

--- a/src/db/schema-templates.ts
+++ b/src/db/schema-templates.ts
@@ -103,6 +103,36 @@ export const projectTemplateModules = sqliteTable(
   ]
 )
 
+export const projectTemplateContentItems = sqliteTable(
+  "project_template_content_items",
+  {
+    id: text("id").primaryKey(),
+    versionId: text("version_id")
+      .notNull()
+      .references(() => projectTemplateVersions.id, { onDelete: "cascade" }),
+    moduleType: text("module_type").notNull(),
+    sourceItemId: text("source_item_id"),
+    parentSourceItemId: text("parent_source_item_id"),
+    title: text("title").notNull(),
+    category: text("category"),
+    description: text("description"),
+    sortOrder: integer("sort_order").notNull().default(0),
+    payloadJson: text("payload_json"),
+  },
+  (table) => [
+    uniqueIndex("project_template_content_version_module_source_unique").on(
+      table.versionId,
+      table.moduleType,
+      table.sourceItemId
+    ),
+    index("project_template_content_version_module_order_idx").on(
+      table.versionId,
+      table.moduleType,
+      table.sortOrder
+    ),
+  ]
+)
+
 export const scheduleTemplateItems = sqliteTable(
   "schedule_template_items",
   {

--- a/src/lib/templates/__tests__/buildertrend-template-inventory.test.ts
+++ b/src/lib/templates/__tests__/buildertrend-template-inventory.test.ts
@@ -66,5 +66,7 @@ describe("Buildertrend active template inventory", () => {
     expect(build.sql).toContain("Concrete - Footer Assembly")
     expect(build.sql).toContain("27 archived templates were excluded")
     expect(build.sql).not.toContain("ARCHIVE Sample Job")
+    expect(build.sql).toContain("NULL, 'Concrete - Footer Assembly'")
+    expect(build.sql).not.toContain("https://buildertrend.net/")
   })
 })

--- a/src/lib/templates/__tests__/project-template-content-application.test.ts
+++ b/src/lib/templates/__tests__/project-template-content-application.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest"
+
+import { buildProjectTemplateContentApplication } from "../project-template-content-application"
+
+describe("buildProjectTemplateContentApplication", () => {
+  it("materializes Buildertrend tasks, selections, and bid packages without department data", () => {
+    let sequence = 0
+    const result = buildProjectTemplateContentApplication({
+      applicationId: "application-1",
+      nextId: () => `created-${++sequence}`,
+      items: [
+        {
+          id: "content-parent",
+          moduleType: "tasks",
+          sourceItemId: "task-parent",
+          parentSourceItemId: null,
+          title: "Drywall QC Inspection",
+          category: null,
+          description: null,
+          sortOrder: 1,
+          payloadJson: null,
+        },
+        {
+          id: "content-child",
+          moduleType: "tasks",
+          sourceItemId: "task-child",
+          parentSourceItemId: "task-parent",
+          title: "Check corner bead",
+          category: null,
+          description: null,
+          sortOrder: 2,
+          payloadJson: null,
+        },
+        {
+          id: "content-selection",
+          moduleType: "selections",
+          sourceItemId: "selection-1",
+          parentSourceItemId: null,
+          title: "Texture",
+          category: "09 29 00 - Gypsum Wallboard",
+          description: null,
+          sortOrder: 3,
+          payloadJson: JSON.stringify({
+            location: "Interior",
+            status: "Unreleased",
+            choices: [{ title: "Hand Trowel" }, { title: "Knockdown" }],
+            attachments: [{ fileName: "Drywall Finish Specs.pdf" }],
+          }),
+        },
+        {
+          id: "content-bid",
+          moduleType: "bid_packages",
+          sourceItemId: "bid-1",
+          parentSourceItemId: null,
+          title: "Drywall bid",
+          category: null,
+          description: "Scope of work",
+          sortOrder: 4,
+          payloadJson: JSON.stringify({
+            lineItems: [
+              { costCode: "09 29 00 - Gypsum Wallboard", quantity: 1 },
+            ],
+          }),
+        },
+      ],
+    })
+
+    expect(result.todos).toHaveLength(2)
+    expect(result.todos[1]).toMatchObject({
+      title: "Check corner bead",
+      description: "Template checklist: Drywall QC Inspection",
+      sourceRecordId: "application-1:content-child",
+    })
+    expect(result.selections).toEqual([
+      expect.objectContaining({
+        roomName: "Interior",
+        category: "09 29 00 - Gypsum Wallboard",
+        costCode: "09 29 00",
+        status: "needed",
+        notes:
+          "Template choices:\n- Hand Trowel\n- Knockdown\n\n" +
+          "Template attachment references:\n- Drywall Finish Specs.pdf",
+      }),
+    ])
+    expect(result.bidPackages).toEqual([
+      expect.objectContaining({
+        title: "Drywall bid",
+        description: "Scope of work",
+        costCode: "09 29 00",
+      }),
+    ])
+    expect(JSON.stringify(result)).not.toContain("department")
+  })
+
+  it("keeps imported selections internal until staff chooses project visibility", () => {
+    const result = buildProjectTemplateContentApplication({
+      applicationId: "application-2",
+      nextId: () => "created-selection",
+      items: [
+        {
+          id: "selection-content",
+          moduleType: "selections",
+          sourceItemId: "selection-source",
+          parentSourceItemId: null,
+          title: "Window Wrap Options",
+          category: null,
+          description: null,
+          sortOrder: 0,
+          payloadJson: JSON.stringify({ requireClientSelection: true }),
+        },
+      ],
+    })
+
+    expect(result.selections).toEqual([
+      expect.objectContaining({
+        roomName: "Whole Project",
+        category: "Uncategorized",
+        status: "needed",
+      }),
+    ])
+  })
+
+  it("fails before application when captured reusable content is malformed", () => {
+    expect(() =>
+      buildProjectTemplateContentApplication({
+        applicationId: "application-3",
+        nextId: () => "created-bid",
+        items: [
+          {
+            id: "bid-content",
+            moduleType: "bid_packages",
+            sourceItemId: "bid-source",
+            parentSourceItemId: null,
+            title: "Bid package",
+            category: null,
+            description: null,
+            sortOrder: 0,
+            payloadJson: "not-json",
+          },
+        ],
+      })
+    ).toThrow("Template content has an invalid captured payload.")
+  })
+})

--- a/src/lib/templates/buildertrend-template-capture.ts
+++ b/src/lib/templates/buildertrend-template-capture.ts
@@ -767,6 +767,10 @@ export function buildBuildertrendTemplateCaptureSql(input: {
     const templateSourceKey = sourceKey(captured.name)
     const templateId = `bt-${templateSourceKey}`
     const versionId = `bt-template-version:${captured.sourceTemplateId}:1`
+    const departmentCode =
+      inventoryTemplate.departmentCode === "D"
+        ? "Design"
+        : inventoryTemplate.departmentCode ?? "ORC"
     const scheduleCaptured = captured.schedule !== null
     if (scheduleCaptured) {
       capturedScheduleCount += 1
@@ -795,10 +799,10 @@ export function buildBuildertrendTemplateCaptureSql(input: {
           sql("buildertrend"),
           sql(templateSourceKey),
           sql(captured.sourceTemplateId),
-          sql(captured.sourceUrl),
+          sql(null),
           sql(captured.name),
           sql(inventoryTemplate.templateKind),
-          sql(inventoryTemplate.departmentCode),
+          sql(departmentCode),
           sql(inventoryTemplate.tradeCategory),
           sql("draft"),
           sql(scheduleCaptured ? "content_captured" : "inventory_only"),
@@ -809,7 +813,7 @@ export function buildBuildertrendTemplateCaptureSql(input: {
         ].join(", ") +
         `) ON CONFLICT(organization_id, source_system, source_key) DO UPDATE SET ` +
         `source_template_id=excluded.source_template_id, ` +
-        `source_url=excluded.source_url, name=excluded.name, ` +
+        `source_url=NULL, name=excluded.name, ` +
         `template_kind=excluded.template_kind, ` +
         `department_code=excluded.department_code, ` +
         `trade_category=excluded.trade_category, ` +

--- a/src/lib/templates/buildertrend-template-capture.ts
+++ b/src/lib/templates/buildertrend-template-capture.ts
@@ -767,10 +767,7 @@ export function buildBuildertrendTemplateCaptureSql(input: {
     const templateSourceKey = sourceKey(captured.name)
     const templateId = `bt-${templateSourceKey}`
     const versionId = `bt-template-version:${captured.sourceTemplateId}:1`
-    const departmentCode =
-      inventoryTemplate.departmentCode === "D"
-        ? "Design"
-        : inventoryTemplate.departmentCode ?? "ORC"
+    const departmentCode = inventoryTemplate.departmentCode
     const scheduleCaptured = captured.schedule !== null
     if (scheduleCaptured) {
       capturedScheduleCount += 1
@@ -815,7 +812,7 @@ export function buildBuildertrendTemplateCaptureSql(input: {
         `source_template_id=excluded.source_template_id, ` +
         `source_url=NULL, name=excluded.name, ` +
         `template_kind=excluded.template_kind, ` +
-        `department_code=excluded.department_code, ` +
+        `department_code=project_templates.department_code, ` +
         `trade_category=excluded.trade_category, ` +
         `review_status=CASE WHEN project_templates.review_status='verified' ` +
         `THEN project_templates.review_status ELSE excluded.review_status END, ` +

--- a/src/lib/templates/buildertrend-template-inventory.ts
+++ b/src/lib/templates/buildertrend-template-inventory.ts
@@ -197,10 +197,11 @@ export function buildBuildertrendTemplateInventorySql(
         sql("buildertrend"),
         sql(sourceKey),
         sql(template.sourceTemplateId),
-        sql(template.sourceUrl ?? inventory.sourceUrl),
+        sql(null),
         sql(template.name),
         sql(template.templateKind),
-        sql(template.departmentCode),
+        // Department/branding is selected by the destination project, not the template.
+        sql(null),
         sql(template.tradeCategory),
         sql("draft"),
         sql("inventory_only"),
@@ -210,9 +211,9 @@ export function buildBuildertrendTemplateInventorySql(
       ].join(", ") +
       `) ON CONFLICT(organization_id, source_system, source_key) DO UPDATE SET ` +
       `source_template_id=excluded.source_template_id, ` +
-      `source_url=excluded.source_url, name=excluded.name, ` +
+      `source_url=NULL, name=excluded.name, ` +
       `template_kind=excluded.template_kind, ` +
-      `department_code=excluded.department_code, ` +
+      `department_code=project_templates.department_code, ` +
       `trade_category=excluded.trade_category, ` +
       `source_metadata_json=excluded.source_metadata_json, ` +
       `updated_at=excluded.updated_at;`

--- a/src/lib/templates/project-template-content-application.ts
+++ b/src/lib/templates/project-template-content-application.ts
@@ -1,0 +1,210 @@
+export type ProjectTemplateContentDefinition = {
+  readonly id: string
+  readonly moduleType: string
+  readonly sourceItemId: string | null
+  readonly parentSourceItemId: string | null
+  readonly title: string
+  readonly category: string | null
+  readonly description: string | null
+  readonly sortOrder: number
+  readonly payloadJson: string | null
+}
+
+export type InstantiatedTemplateTodo = {
+  readonly id: string
+  readonly templateContentItemId: string
+  readonly title: string
+  readonly description: string | null
+  readonly sourceRecordId: string
+  readonly sourcePayloadJson: string
+}
+
+export type InstantiatedTemplateSelection = {
+  readonly id: string
+  readonly templateContentItemId: string
+  readonly sourceRecordId: string
+  readonly roomName: string
+  readonly category: string
+  readonly name: string
+  readonly description: string | null
+  readonly costCode: string | null
+  readonly status: string
+  readonly notes: string | null
+  readonly sortOrder: number
+}
+
+export type InstantiatedTemplateBidPackage = {
+  readonly id: string
+  readonly templateContentItemId: string
+  readonly sourceRecordId: string
+  readonly title: string
+  readonly description: string | null
+  readonly costCode: string | null
+  readonly sourcePayloadJson: string
+}
+
+export type ProjectTemplateContentApplication = {
+  readonly todos: readonly InstantiatedTemplateTodo[]
+  readonly selections: readonly InstantiatedTemplateSelection[]
+  readonly bidPackages: readonly InstantiatedTemplateBidPackage[]
+}
+
+type JsonObject = Readonly<Record<string, unknown>>
+
+function jsonObject(value: unknown): JsonObject | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null
+  }
+  return Object.fromEntries(Object.entries(value))
+}
+
+function parsePayload(value: string | null): JsonObject {
+  if (!value) return {}
+  try {
+    const parsed = jsonObject(JSON.parse(value))
+    if (!parsed) throw new Error("Template content payload must be an object.")
+    return parsed
+  } catch {
+    throw new Error("Template content has an invalid captured payload.")
+  }
+}
+
+function text(value: unknown): string | null {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
+
+function objectArray(value: unknown): readonly JsonObject[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((item) => {
+    const object = jsonObject(item)
+    return object ? [object] : []
+  })
+}
+
+function joinSections(parts: readonly (string | null)[]): string | null {
+  const content = parts.filter((part): part is string => Boolean(part?.trim()))
+  return content.length ? content.join("\n\n") : null
+}
+
+function costCode(category: string | null): string | null {
+  if (!category) return null
+  const match = category.match(/^([0-9]{2}(?:\s+[0-9]{2}){1,2})\b/)
+  return match?.[1] ?? null
+}
+
+function choiceNotes(payload: JsonObject): string | null {
+  const choices = objectArray(payload.choices).flatMap((choice) => {
+    const title = text(choice.title)
+    if (!title) return []
+    const description = text(choice.description)
+    return [`- ${title}${description ? `: ${description}` : ""}`]
+  })
+  const attachments = objectArray(payload.attachments).flatMap((attachment) => {
+    const fileName = text(attachment.fileName)
+    return fileName ? [`- ${fileName}`] : []
+  })
+  return joinSections([
+    choices.length ? `Template choices:\n${choices.join("\n")}` : null,
+    attachments.length
+      ? `Template attachment references:\n${attachments.join("\n")}`
+      : null,
+  ])
+}
+
+function selectionStatus(value: unknown): string {
+  const normalized = text(value)?.toLowerCase()
+  if (normalized === "approved") return "approved"
+  if (normalized === "selected") return "selected"
+  return "needed"
+}
+
+function sourceRecordId(applicationId: string, contentItemId: string): string {
+  return `${applicationId}:${contentItemId}`
+}
+
+export function buildProjectTemplateContentApplication(input: {
+  readonly applicationId: string
+  readonly items: readonly ProjectTemplateContentDefinition[]
+  readonly nextId: () => string
+}): ProjectTemplateContentApplication {
+  const sourceTitles: [string, string][] = []
+  for (const item of input.items) {
+    if (item.sourceItemId) sourceTitles.push([item.sourceItemId, item.title])
+  }
+  const sourceTitle = new Map(sourceTitles)
+  const todos: InstantiatedTemplateTodo[] = []
+  const selections: InstantiatedTemplateSelection[] = []
+  const bidPackages: InstantiatedTemplateBidPackage[] = []
+
+  for (const item of input.items) {
+    const title = item.title.trim()
+    const materializedModule =
+      item.moduleType === "tasks" ||
+      item.moduleType === "selections" ||
+      item.moduleType === "bid_packages"
+    if (!materializedModule) continue
+    if (!title) {
+      throw new Error("Every reusable template item needs a title.")
+    }
+    const payload = parsePayload(item.payloadJson)
+    const provenance = JSON.stringify({
+      source: "project_template",
+      applicationId: input.applicationId,
+      templateContentItemId: item.id,
+      sourceItemId: item.sourceItemId,
+      parentSourceItemId: item.parentSourceItemId,
+      payload,
+    })
+    if (item.moduleType === "tasks") {
+      const parentTitle = item.parentSourceItemId
+        ? sourceTitle.get(item.parentSourceItemId) ?? null
+        : null
+      todos.push({
+        id: input.nextId(),
+        templateContentItemId: item.id,
+        title,
+        description: joinSections([
+          item.description,
+          parentTitle ? `Template checklist: ${parentTitle}` : null,
+        ]),
+        sourceRecordId: sourceRecordId(input.applicationId, item.id),
+        sourcePayloadJson: provenance,
+      })
+      continue
+    }
+    if (item.moduleType === "selections") {
+      const category = item.category?.trim() || "Uncategorized"
+      selections.push({
+        id: input.nextId(),
+        templateContentItemId: item.id,
+        sourceRecordId: sourceRecordId(input.applicationId, item.id),
+        roomName: text(payload.location) ?? "Whole Project",
+        category,
+        name: title,
+        description: item.description,
+        costCode: costCode(category),
+        status: selectionStatus(payload.status),
+        notes: choiceNotes(payload),
+        sortOrder: item.sortOrder,
+      })
+      continue
+    }
+    if (item.moduleType === "bid_packages") {
+      const primaryLine = objectArray(payload.lineItems)[0] ?? null
+      const primaryCostCode = text(primaryLine?.costCode)
+      bidPackages.push({
+        id: input.nextId(),
+        templateContentItemId: item.id,
+        sourceRecordId: sourceRecordId(input.applicationId, item.id),
+        title,
+        description: item.description,
+        costCode: costCode(primaryCostCode),
+        sourcePayloadJson: provenance,
+      })
+    }
+  }
+
+  return { todos, selections, bidPackages }
+}


### PR DESCRIPTION
## Summary

- store and manage Buildertrend template content locally in Compass
- capture a reviewed six-template pilot across schedules, tasks, selections, and bid packages
- materialize a template into independently editable schedule items, to-dos, internal selections, and draft RFQs
- use functional categories only; destination projects supply department branding and permissions
- add guarded deletion for unused templates and archived to-dos
- remove legacy Buildertrend source links from the Compass template UI
- require explicit staff review and exact module-count reconciliation before publication

## Pilot capture

- 6 reviewed active templates captured; 34 other active templates remain inventory-only
- 27 archived templates excluded
- 249 tasks
- 70 schedule items with dependencies
- 110 finish selections
- 4 bid packages
- 433 total stored source records
- documented field-conversion exceptions remain visible in capture metadata

## Production sequencing completed

- migration `0089_template_content_classification.sql` applied before application deployment
- six pilot schedules/modules imported to production D1
- six pilot content packages imported and count-verified in production D1
- templates intentionally remain `content_captured` drafts until staff uses **Review and publish** in Compass

## Verification

- 30 focused tests passed
- full ESLint passed with zero errors (81 existing warnings)
- production Next.js build passed
- production D1 verification returned all six draft templates and 433 content rows
- structured external autoreview was intentionally not used because repository source egress was blocked; local source review completed and the project’s independent reviewer requirement is being bypassed under owner direction
