### PR TITLE
fix(templates): open Buildertrend template details

### DIFF
--- a/src/app/dashboard/templates/[id]/page.tsx
+++ b/src/app/dashboard/templates/[id]/page.tsx
@@ -10,15 +10,22 @@ import { getEstimateTemplateEditor } from "@/app/actions/estimate-templates"
 import { EstimateTemplateEditorPanel } from "@/components/templates/estimate-template-editor"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { resolveTemplateDetailId } from "@/lib/templates/template-detail-route"
 
 export const dynamic = "force-dynamic"
 
 export default async function EstimateTemplatePage({
   params,
+  searchParams,
 }: {
   readonly params: Promise<{ id: string }>
+  readonly searchParams: Promise<{
+    readonly templateId?: string | readonly string[]
+  }>
 }): Promise<React.ReactElement> {
-  const { id } = await params
+  const [{ id: routeId }, query] = await Promise.all([params, searchParams])
+  const id = resolveTemplateDetailId(routeId, query.templateId)
+  if (!id) notFound()
   const preview = await getProjectTemplatePreview(id)
   if (!preview) notFound()
   if (preview.templateKind === "estimate") {

--- a/src/components/templates/template-library-view.tsx
+++ b/src/components/templates/template-library-view.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/ui/alert-dialog"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { templateDetailHref } from "@/lib/templates/template-detail-route"
 import {
   Select,
   SelectContent,
@@ -314,7 +315,7 @@ export function TemplateLibraryView({
                 <article key={template.id} className="grid gap-4 py-4 xl:grid-cols-[minmax(0,1fr)_24rem_auto] xl:items-center">
                   <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-2">
-                      <Link className="truncate font-medium hover:underline" href={`/dashboard/templates/${template.id}`}>
+                      <Link className="truncate font-medium hover:underline" href={templateDetailHref(template.id)}>
                         {template.name}
                       </Link>
                       <Badge variant="outline">
@@ -343,7 +344,7 @@ export function TemplateLibraryView({
                         <PublishTemplateButton template={template} />
                       )}
                     <Button asChild size="sm" variant="outline">
-                      <Link href={`/dashboard/templates/${template.id}`}>Open</Link>
+                      <Link href={templateDetailHref(template.id)}>Open</Link>
                     </Button>
                     {canManage && <DeleteTemplateButton template={template} />}
                   </div>

--- a/src/lib/templates/__tests__/template-detail-route.test.ts
+++ b/src/lib/templates/__tests__/template-detail-route.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  resolveTemplateDetailId,
+  templateDetailHref,
+} from "@/lib/templates/template-detail-route"
+
+describe("template detail routing", () => {
+  it("keeps punctuation-heavy template IDs out of the path segment", () => {
+    expect(
+      templateDetailHref("bt-template:drywall-installation:ec8558d35e")
+    ).toBe(
+      "/dashboard/templates/open?templateId=bt-template%3Adrywall-installation%3Aec8558d35e"
+    )
+  })
+
+  it("resolves the query-backed template alias", () => {
+    expect(
+      resolveTemplateDetailId(
+        "open",
+        "bt-template:drywall-installation:ec8558d35e"
+      )
+    ).toBe("bt-template:drywall-installation:ec8558d35e")
+  })
+
+  it("preserves existing UUID detail routes", () => {
+    expect(resolveTemplateDetailId("template-uuid", undefined)).toBe(
+      "template-uuid"
+    )
+  })
+
+  it("rejects missing or ambiguous alias query values", () => {
+    expect(resolveTemplateDetailId("open", undefined)).toBeNull()
+    expect(resolveTemplateDetailId("open", ["one", "two"])).toBeNull()
+    expect(resolveTemplateDetailId("open", "   ")).toBeNull()
+  })
+})

--- a/src/lib/templates/template-detail-route.ts
+++ b/src/lib/templates/template-detail-route.ts
@@ -1,0 +1,17 @@
+const TEMPLATE_DETAIL_ALIAS = "open"
+
+export function templateDetailHref(templateId: string): string {
+  const query = new URLSearchParams({ templateId })
+  return `/dashboard/templates/${TEMPLATE_DETAIL_ALIAS}?${query.toString()}`
+}
+
+export function resolveTemplateDetailId(
+  routeId: string,
+  queryTemplateId: string | readonly string[] | undefined
+): string | null {
+  if (routeId !== TEMPLATE_DETAIL_ALIAS) return routeId
+  if (typeof queryTemplateId !== "string") return null
+
+  const normalized = queryTemplateId.trim()
+  return normalized.length > 0 ? normalized : null
+}


### PR DESCRIPTION
## What changed

- route template-library detail links through a query-backed alias so punctuation-heavy Buildertrend IDs do not occupy a dynamic path segment
- keep existing UUID detail routes supported
- reject missing, blank, or ambiguous template identifiers
- add focused route construction and resolution tests

## Why

Buildertrend templates use colon-delimited internal IDs. The production Cloudflare/OpenNext route returned a 404 when those IDs were placed directly in `/dashboard/templates/[id]`, even though UUID-based estimate templates opened correctly.

## User impact

Staff can open and review captured Buildertrend templates from the Compass Template Library without a 404. Existing authentication, organization scoping, and template permissions remain unchanged.

## Validation

- reproduced the 404 against the live Drywall template
- confirmed an existing UUID estimate-template route still opens
- `bun test src/lib/templates/__tests__/template-detail-route.test.ts src/lib/templates/__tests__/project-template-content-application.test.ts` (7 passed)
- `bun lint` (0 errors; 81 existing warnings)
- `bun run build` (passed)
- manual source review completed; the external review helper was blocked by repository-source egress policy, consistent with the authorized independent-review bypass
