### PR TITLE
fix(templates): preserve task checklists

### DIFF
--- a/src/app/dashboard/templates/[id]/page.tsx
+++ b/src/app/dashboard/templates/[id]/page.tsx
@@ -10,6 +10,7 @@ import { getEstimateTemplateEditor } from "@/app/actions/estimate-templates"
 import { EstimateTemplateEditorPanel } from "@/components/templates/estimate-template-editor"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { groupTemplateChecklistItems } from "@/lib/templates/template-checklist-hierarchy"
 import { resolveTemplateDetailId } from "@/lib/templates/template-detail-route"
 
 export const dynamic = "force-dynamic"
@@ -119,6 +120,62 @@ export default async function EstimateTemplatePage({
 
           {moduleNames.map((moduleType) => {
             const items = content.filter((item) => item.moduleType === moduleType)
+            if (moduleType === "tasks") {
+              const taskGroups = groupTemplateChecklistItems(items)
+              const checklistItemCount = items.length - taskGroups.length
+              return (
+                <section key={moduleType}>
+                  <div className="mb-2 flex flex-wrap items-baseline justify-between gap-2 border-b pb-2">
+                    <h2 className="font-semibold">Tasks and checklists</h2>
+                    <span className="text-xs text-muted-foreground">
+                      {taskGroups.length} tasks · {checklistItemCount} checklist items
+                    </span>
+                  </div>
+                  <div className="divide-y border-y">
+                    {taskGroups.map(({ task, checklistItems }) => (
+                      <article key={task.id} className="py-4">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h3 className="font-medium">{task.title}</h3>
+                          {task.category && (
+                            <Badge variant="outline">{task.category}</Badge>
+                          )}
+                        </div>
+                        {task.description && (
+                          <p className="mt-1 whitespace-pre-wrap text-sm text-muted-foreground">
+                            {task.description}
+                          </p>
+                        )}
+                        {checklistItems.length > 0 && (
+                          <div className="mt-3 border-l-2 border-primary/40 pl-4">
+                            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                              Checklist · {checklistItems.length}
+                            </p>
+                            <ul className="mt-2 space-y-2">
+                              {checklistItems.map((checklistItem) => (
+                                <li
+                                  key={checklistItem.id}
+                                  className="grid grid-cols-[1rem_minmax(0,1fr)] gap-2 text-sm"
+                                >
+                                  <span aria-hidden="true">☐</span>
+                                  <div>
+                                    <p>{checklistItem.title}</p>
+                                    {checklistItem.description && (
+                                      <p className="mt-0.5 whitespace-pre-wrap text-xs text-muted-foreground">
+                                        {checklistItem.description}
+                                      </p>
+                                    )}
+                                  </div>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                      </article>
+                    ))}
+                  </div>
+                </section>
+              )
+            }
             return (
               <section key={moduleType}>
                 <div className="mb-2 flex items-baseline justify-between border-b pb-2">

--- a/src/lib/templates/__tests__/project-template-content-application.test.ts
+++ b/src/lib/templates/__tests__/project-template-content-application.test.ts
@@ -65,11 +65,20 @@ describe("buildProjectTemplateContentApplication", () => {
       ],
     })
 
-    expect(result.todos).toHaveLength(2)
-    expect(result.todos[1]).toMatchObject({
-      title: "Check corner bead",
-      description: "Template checklist: Drywall QC Inspection",
-      sourceRecordId: "application-1:content-child",
+    expect(result.todos).toHaveLength(1)
+    expect(result.todos[0]).toMatchObject({
+      title: "Drywall QC Inspection",
+      description: "Checklist:\n☐ Check corner bead",
+      sourceRecordId: "application-1:content-parent",
+    })
+    expect(JSON.parse(result.todos[0]?.sourcePayloadJson ?? "{}")).toMatchObject({
+      checklistItems: [
+        {
+          templateContentItemId: "content-child",
+          sourceItemId: "task-child",
+          title: "Check corner bead",
+        },
+      ],
     })
     expect(result.selections).toEqual([
       expect.objectContaining({
@@ -140,5 +149,27 @@ describe("buildProjectTemplateContentApplication", () => {
         ],
       })
     ).toThrow("Template content has an invalid captured payload.")
+  })
+
+  it("fails instead of materializing a checklist item without its task", () => {
+    expect(() =>
+      buildProjectTemplateContentApplication({
+        applicationId: "application-4",
+        nextId: () => "created-task",
+        items: [
+          {
+            id: "orphan-content",
+            moduleType: "tasks",
+            sourceItemId: "orphan-source",
+            parentSourceItemId: "missing-parent",
+            title: "Orphan checklist item",
+            category: null,
+            description: null,
+            sortOrder: 0,
+            payloadJson: null,
+          },
+        ],
+      })
+    ).toThrow("Template checklist item references a missing parent task.")
   })
 })

--- a/src/lib/templates/__tests__/template-checklist-hierarchy.test.ts
+++ b/src/lib/templates/__tests__/template-checklist-hierarchy.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  formatTemplateChecklist,
+  groupTemplateChecklistItems,
+} from "@/lib/templates/template-checklist-hierarchy"
+
+const parent = {
+  id: "parent-content",
+  sourceItemId: "task-qc",
+  parentSourceItemId: null,
+  title: "Drywall QC Inspection",
+  description: null,
+  sortOrder: 2,
+}
+
+const child = {
+  id: "child-content",
+  sourceItemId: "task-qc-1",
+  parentSourceItemId: "task-qc",
+  title: "Tape on all joints",
+  description: "Confirm full coverage.",
+  sortOrder: 1,
+}
+
+describe("template checklist hierarchy", () => {
+  it("groups captured checklist items under their parent task", () => {
+    expect(groupTemplateChecklistItems([child, parent])).toEqual([
+      { task: parent, checklistItems: [child] },
+    ])
+  })
+
+  it("formats checklist content inside the parent task", () => {
+    expect(formatTemplateChecklist([child])).toBe(
+      "Checklist:\n☐ Tape on all joints\n  Confirm full coverage."
+    )
+  })
+
+  it("fails instead of flattening an orphan checklist item", () => {
+    expect(() => groupTemplateChecklistItems([child])).toThrow(
+      "Template checklist item references a missing parent task."
+    )
+  })
+})

--- a/src/lib/templates/project-template-content-application.ts
+++ b/src/lib/templates/project-template-content-application.ts
@@ -1,3 +1,8 @@
+import {
+  formatTemplateChecklist,
+  groupTemplateChecklistItems,
+} from "@/lib/templates/template-checklist-hierarchy"
+
 export type ProjectTemplateContentDefinition = {
   readonly id: string
   readonly moduleType: string
@@ -129,11 +134,12 @@ export function buildProjectTemplateContentApplication(input: {
   readonly items: readonly ProjectTemplateContentDefinition[]
   readonly nextId: () => string
 }): ProjectTemplateContentApplication {
-  const sourceTitles: [string, string][] = []
-  for (const item of input.items) {
-    if (item.sourceItemId) sourceTitles.push([item.sourceItemId, item.title])
-  }
-  const sourceTitle = new Map(sourceTitles)
+  const taskGroups = groupTemplateChecklistItems(
+    input.items.filter((item) => item.moduleType === "tasks")
+  )
+  const taskGroupById = new Map(
+    taskGroups.map((group) => [group.task.id, group])
+  )
   const todos: InstantiatedTemplateTodo[] = []
   const selections: InstantiatedTemplateSelection[] = []
   const bidPackages: InstantiatedTemplateBidPackage[] = []
@@ -149,6 +155,38 @@ export function buildProjectTemplateContentApplication(input: {
       throw new Error("Every reusable template item needs a title.")
     }
     const payload = parsePayload(item.payloadJson)
+    if (item.moduleType === "tasks") {
+      if (item.parentSourceItemId) continue
+      const checklistItems = taskGroupById.get(item.id)?.checklistItems ?? []
+      const checklistProvenance = checklistItems.map((checklistItem) => ({
+        templateContentItemId: checklistItem.id,
+        sourceItemId: checklistItem.sourceItemId,
+        title: checklistItem.title,
+        description: checklistItem.description,
+        sortOrder: checklistItem.sortOrder,
+        payload: parsePayload(checklistItem.payloadJson),
+      }))
+      todos.push({
+        id: input.nextId(),
+        templateContentItemId: item.id,
+        title,
+        description: joinSections([
+          item.description,
+          formatTemplateChecklist(checklistItems),
+        ]),
+        sourceRecordId: sourceRecordId(input.applicationId, item.id),
+        sourcePayloadJson: JSON.stringify({
+          source: "project_template",
+          applicationId: input.applicationId,
+          templateContentItemId: item.id,
+          sourceItemId: item.sourceItemId,
+          parentSourceItemId: null,
+          payload,
+          checklistItems: checklistProvenance,
+        }),
+      })
+      continue
+    }
     const provenance = JSON.stringify({
       source: "project_template",
       applicationId: input.applicationId,
@@ -157,23 +195,6 @@ export function buildProjectTemplateContentApplication(input: {
       parentSourceItemId: item.parentSourceItemId,
       payload,
     })
-    if (item.moduleType === "tasks") {
-      const parentTitle = item.parentSourceItemId
-        ? sourceTitle.get(item.parentSourceItemId) ?? null
-        : null
-      todos.push({
-        id: input.nextId(),
-        templateContentItemId: item.id,
-        title,
-        description: joinSections([
-          item.description,
-          parentTitle ? `Template checklist: ${parentTitle}` : null,
-        ]),
-        sourceRecordId: sourceRecordId(input.applicationId, item.id),
-        sourcePayloadJson: provenance,
-      })
-      continue
-    }
     if (item.moduleType === "selections") {
       const category = item.category?.trim() || "Uncategorized"
       selections.push({

--- a/src/lib/templates/template-checklist-hierarchy.ts
+++ b/src/lib/templates/template-checklist-hierarchy.ts
@@ -1,0 +1,75 @@
+export type TemplateChecklistItemLike = {
+  readonly id: string
+  readonly sourceItemId: string | null
+  readonly parentSourceItemId: string | null
+  readonly title: string
+  readonly description: string | null
+  readonly sortOrder: number
+}
+
+export type TemplateChecklistGroup<T extends TemplateChecklistItemLike> = {
+  readonly task: T
+  readonly checklistItems: readonly T[]
+}
+
+function orderedItems<T extends TemplateChecklistItemLike>(
+  items: readonly T[]
+): readonly T[] {
+  return items
+    .map((item, index) => ({ item, index }))
+    .sort(
+      (left, right) =>
+        left.item.sortOrder - right.item.sortOrder || left.index - right.index
+    )
+    .map(({ item }) => item)
+}
+
+export function groupTemplateChecklistItems<
+  T extends TemplateChecklistItemLike,
+>(items: readonly T[]): readonly TemplateChecklistGroup<T>[] {
+  const bySourceId = new Map<string, T>()
+  for (const item of items) {
+    if (!item.sourceItemId) continue
+    if (bySourceId.has(item.sourceItemId)) {
+      throw new Error("Template tasks contain duplicate source identifiers.")
+    }
+    bySourceId.set(item.sourceItemId, item)
+  }
+
+  const childrenByParent = new Map<string, T[]>()
+  for (const item of items) {
+    if (!item.parentSourceItemId) continue
+    const parent = bySourceId.get(item.parentSourceItemId)
+    if (!parent) {
+      throw new Error("Template checklist item references a missing parent task.")
+    }
+    if (parent.id === item.id) {
+      throw new Error("Template checklist item cannot reference itself.")
+    }
+    if (parent.parentSourceItemId) {
+      throw new Error("Nested template checklists are not supported.")
+    }
+    const children = childrenByParent.get(parent.id) ?? []
+    children.push(item)
+    childrenByParent.set(parent.id, children)
+  }
+
+  return orderedItems(items)
+    .filter((item) => !item.parentSourceItemId)
+    .map((task) => ({
+      task,
+      checklistItems: orderedItems(childrenByParent.get(task.id) ?? []),
+    }))
+}
+
+export function formatTemplateChecklist(
+  items: readonly TemplateChecklistItemLike[]
+): string | null {
+  if (items.length === 0) return null
+  const lines = items.map((item) => {
+    const detail = item.description?.trim()
+    if (!detail) return `☐ ${item.title.trim()}`
+    return `☐ ${item.title.trim()}\n  ${detail.replaceAll("\n", "\n  ")}`
+  })
+  return `Checklist:\n${lines.join("\n")}`
+}


### PR DESCRIPTION
## What changed

- preserve Buildertrend checklist rows under their captured parent task
- show nested checklists in the Compass template detail preview
- materialize one Compass to-do per parent task instead of unrelated child to-dos
- retain structured checklist provenance while also placing readable checklist text in the task notes
- reject malformed orphaned or nested checklist relationships instead of silently flattening them

## Why

Buildertrend exports checklist items as task content records with a parent source identifier. Compass captured that relationship but the preview and application layer flattened every row into an unrelated task.

## User impact

Drywall Installation now displays 5 tasks with 23 nested checklist items. For example, `Tape on all joints` stays inside `(X Room) Drywall QC Inspection`. The same hierarchy handling applies to all six pilot templates.

## Validation

- `bun test src/lib/templates/__tests__/template-checklist-hierarchy.test.ts src/lib/templates/__tests__/project-template-content-application.test.ts src/lib/templates/__tests__/buildertrend-template-capture.test.ts` — 12 passed
- `bun lint` — 0 errors (81 existing warnings)
- `bun run build` — passed, including TypeScript and static generation
- validated captured hierarchy counts across all six pilot Buildertrend fixtures
- local source review completed; external reviewer bypassed because the environment blocked repository-source egress
