### PR TITLE
feat(templates): import guarded next-batch content

### DIFF
--- a/scripts/assemble-buildertrend-template-next-batch-content.mjs
+++ b/scripts/assemble-buildertrend-template-next-batch-content.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises"
+
+import { assembleBuildertrendTemplateNextBatchContent } from "./lib/buildertrend-template-next-batch-content.mjs"
+
+function optionValue(args, option) {
+  const index = args.indexOf(option)
+  if (index < 0) return null
+  const value = args[index + 1]
+  return value && !value.startsWith("--") ? value : null
+}
+
+const args = process.argv.slice(2)
+if (args.some((argument) => argument.startsWith("--publish"))) {
+  throw new Error("Next-batch template content is draft-only; publication requests are prohibited.")
+}
+const releasePath = optionValue(args, "--release") ??
+  "scripts/fixtures/buildertrend-template-content-next-batch-release-2026-08-04.json"
+const manifestPath = optionValue(args, "--manifest") ??
+  "scripts/fixtures/buildertrend-template-next-batch-2026-08-04.json"
+const reviewedCapturePath = optionValue(args, "--reviewed-capture") ??
+  "scripts/fixtures/buildertrend-active-template-capture-2026-07-31.json"
+const captureOutputPath = optionValue(args, "--capture-output")
+const inventoryOutputPath = optionValue(args, "--inventory-output")
+const check = args.includes("--check")
+
+if (!check && (!captureOutputPath || !inventoryOutputPath)) {
+  throw new Error(
+    "Usage: bun scripts/assemble-buildertrend-template-next-batch-content.mjs " +
+      "[--release <release.json>] [--manifest <manifest.json>] " +
+      "[--reviewed-capture <capture.json>] " +
+      "[--capture-output <capture.json> --inventory-output <inventory.json> | --check]"
+  )
+}
+
+const [release, nextBatchManifest, reviewedCapture] = await Promise.all(
+  [releasePath, manifestPath, reviewedCapturePath].map(async (path) =>
+    JSON.parse(await readFile(path, "utf8"))
+  )
+)
+const documents = await Promise.all(release.templates.map(async (template) => ({
+  source: template.fragmentPath,
+  document: JSON.parse(await readFile(template.fragmentPath, "utf8")),
+})))
+const result = assembleBuildertrendTemplateNextBatchContent({
+  release,
+  nextBatchManifest,
+  reviewedCapture,
+  documents,
+})
+
+if (captureOutputPath) {
+  await writeFile(captureOutputPath, `${JSON.stringify(result.capture, null, 2)}\n`)
+}
+if (inventoryOutputPath) {
+  await writeFile(inventoryOutputPath, `${JSON.stringify(result.inventory, null, 2)}\n`)
+}
+console.log(JSON.stringify({
+  draftOnly: result.capture.assembly.draftOnly,
+  publish: result.capture.assembly.publish,
+  templateCount: result.capture.templates.length,
+  sourceTemplateIds: result.capture.assembly.sourceTemplateIds,
+  browserCaptureGateCount: result.capture.assembly.browserCaptureGateCount,
+  scheduleItemCount: result.capture.templates.reduce(
+    (total, template) => total + template.scheduleItems.length,
+    0
+  ),
+  captureOutput: captureOutputPath,
+  inventoryOutput: inventoryOutputPath,
+}, null, 2))

--- a/scripts/build-buildertrend-template-content-sql.mjs
+++ b/scripts/build-buildertrend-template-content-sql.mjs
@@ -189,11 +189,13 @@ async function main() {
   const outputPath = optionValue(args, "--output")
   const pilotManifestPath = optionValue(args, "--pilot-manifest")
   const dryRun = args.includes("--dry-run")
+  const strictDraftOnly = args.includes("--strict-draft-only")
   if (!capturePath || !inventoryPath || (!dryRun && !outputPath)) {
     throw new Error(
       "Usage: bun scripts/build-buildertrend-template-content-sql.mjs " +
         "--inventory <reviewed-inventory.json> --capture <content.json> " +
-        "[--output <import.sql>] [--dry-run] [--pilot-manifest <reviewed-pilot.json>]"
+        "[--output <import.sql>] [--dry-run] [--pilot-manifest <reviewed-pilot.json>] " +
+        "[--strict-draft-only]"
     )
   }
   let capture = JSON.parse(await readFile(capturePath, "utf8"))
@@ -391,8 +393,10 @@ async function main() {
     }
     statements.push(
       `UPDATE project_templates SET ` +
-        `review_status=CASE WHEN review_status='verified' THEN review_status ELSE 'content_captured' END, ` +
-        `lifecycle_status=CASE WHEN review_status='verified' THEN lifecycle_status ELSE 'draft' END, ` +
+        (strictDraftOnly
+          ? `review_status='content_captured', lifecycle_status='draft', `
+          : `review_status=CASE WHEN review_status='verified' THEN review_status ELSE 'content_captured' END, ` +
+            `lifecycle_status=CASE WHEN review_status='verified' THEN lifecycle_status ELSE 'draft' END, `) +
         `source_url=NULL, updated_at=${sql(capture.capturedAt)} ` +
       `WHERE source_system='buildertrend' AND source_template_id=${sql(template.sourceTemplateId)} ` +
         `AND EXISTS (SELECT 1 FROM project_template_versions ` +
@@ -408,6 +412,7 @@ async function main() {
         templateCount: capture.templates.length,
         ...totals,
         excludedArchivedCount: capture.excludedArchivedCount ?? null,
+        ...(strictDraftOnly ? { draftOnly: true } : {}),
         ...(pilot
           ? {
               pilotTemplateCount: pilot.capture.templates.length,

--- a/scripts/build-buildertrend-template-next-batch-content-sql.mjs
+++ b/scripts/build-buildertrend-template-next-batch-content-sql.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process"
+import { readFile } from "node:fs/promises"
+import { promisify } from "node:util"
+
+import { NEXT_BATCH_CONTENT_IDS } from "./lib/buildertrend-template-next-batch-content.mjs"
+
+const execFileAsync = promisify(execFile)
+
+function optionValue(args, option) {
+  const index = args.indexOf(option)
+  if (index < 0) return null
+  const value = args[index + 1]
+  return value && !value.startsWith("--") ? value : null
+}
+
+const args = process.argv.slice(2)
+if (args.some((argument) => argument.startsWith("--publish"))) {
+  throw new Error("Next-batch template content is draft-only; publication requests are prohibited.")
+}
+const capturePath = optionValue(args, "--capture")
+const inventoryPath = optionValue(args, "--inventory")
+const outputPath = optionValue(args, "--output")
+const dryRun = args.includes("--dry-run")
+if (!capturePath || !inventoryPath || (!dryRun && !outputPath)) {
+  throw new Error(
+    "Usage: bun scripts/build-buildertrend-template-next-batch-content-sql.mjs " +
+      "--capture <capture.json> --inventory <inventory.json> " +
+      "[--output <import.sql> | --dry-run]"
+  )
+}
+
+const [capture, inventory] = await Promise.all(
+  [capturePath, inventoryPath].map(async (path) => JSON.parse(await readFile(path, "utf8")))
+)
+if (
+  capture.assembly?.complete !== true ||
+  capture.assembly?.draftOnly !== true ||
+  capture.assembly?.publish !== false
+) {
+  throw new Error("Next-batch SQL requires a complete, draft-only assembled capture.")
+}
+const capturedIds = capture.templates?.map((template) => template.sourceTemplateId)
+const inventoryIds = inventory.templates?.map((template) => template.sourceTemplateId)
+if (
+  JSON.stringify(capturedIds) !== JSON.stringify(NEXT_BATCH_CONTENT_IDS) ||
+  JSON.stringify(inventoryIds) !== JSON.stringify(NEXT_BATCH_CONTENT_IDS)
+) {
+  throw new Error("Next-batch SQL may import only the approved Stucco and MEP templates.")
+}
+
+const command = [
+  "scripts/build-buildertrend-template-content-sql.mjs",
+  "--capture", capturePath,
+  "--inventory", inventoryPath,
+  "--strict-draft-only",
+]
+if (dryRun) command.push("--dry-run")
+if (outputPath) command.push("--output", outputPath)
+const result = await execFileAsync("bun", command)
+process.stdout.write(result.stdout)

--- a/scripts/buildertrend-template-next-batch-content.test.mjs
+++ b/scripts/buildertrend-template-next-batch-content.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import test from "node:test"
+import { promisify } from "node:util"
+
+import { assembleBuildertrendTemplateNextBatchContent } from "./lib/buildertrend-template-next-batch-content.mjs"
+
+const execFileAsync = promisify(execFile)
+const paths = {
+  release: "scripts/fixtures/buildertrend-template-content-next-batch-release-2026-08-04.json",
+  manifest: "scripts/fixtures/buildertrend-template-next-batch-2026-08-04.json",
+  reviewed: "scripts/fixtures/buildertrend-active-template-capture-2026-07-31.json",
+}
+
+async function inputs() {
+  const [release, nextBatchManifest, reviewedCapture] = await Promise.all(
+    Object.values(paths).map(async (path) => JSON.parse(await readFile(path, "utf8")))
+  )
+  const documents = await Promise.all(release.templates.map(async (template) => ({
+    source: template.fragmentPath,
+    document: JSON.parse(await readFile(template.fragmentPath, "utf8")),
+  })))
+  return { release, nextBatchManifest, reviewedCapture, documents }
+}
+
+test("assembles only the two gate-complete templates with reviewed schedules", async () => {
+  const result = assembleBuildertrendTemplateNextBatchContent(await inputs())
+
+  assert.deepEqual(result.capture.assembly.sourceTemplateIds, ["12859981", "12978371"])
+  assert.equal(result.capture.assembly.draftOnly, true)
+  assert.equal(result.capture.assembly.publish, false)
+  assert.equal(result.capture.templates.reduce((sum, item) => sum + item.scheduleItems.length, 0), 14)
+  assert.equal(result.capture.templates.reduce(
+    (sum, item) => sum + item.scheduleItems.flatMap((row) => row.predecessors).length,
+    0
+  ), 10)
+  assert.deepEqual(
+    result.inventory.templates.map((template) => template.sourceTemplateId),
+    ["12859981", "12978371"]
+  )
+})
+
+test("rejects partial capture, Concrete Footer, and publication requests", async () => {
+  const partial = await inputs()
+  partial.documents[0].document.tasks = partial.documents[0].document.tasks.slice(1)
+  assert.throws(
+    () => assembleBuildertrendTemplateNextBatchContent(partial),
+    /tasks expected 48, found 47/
+  )
+
+  const concrete = await inputs()
+  concrete.release.templates.push({
+    sourceTemplateId: "12581937",
+    sourceName: "Concrete - Footer Assembly",
+    fragmentPath: "scripts/fixtures/buildertrend-template-content-next-batch/fragments/08-12581937.capture.json",
+    browserCaptureGates: "complete",
+  })
+  assert.throws(
+    () => assembleBuildertrendTemplateNextBatchContent(concrete),
+    /Concrete - Footer Assembly is partially captured/
+  )
+
+  const publish = await inputs()
+  publish.publishRequested = true
+  assert.throws(
+    () => assembleBuildertrendTemplateNextBatchContent(publish),
+    /publication requests are prohibited/
+  )
+})
+
+test("builds SQL that remains draft-only and excludes Concrete Footer", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "compass-next-batch-content-"))
+  const capture = join(directory, "capture.json")
+  const inventory = join(directory, "inventory.json")
+  const output = join(directory, "import.sql")
+  try {
+    await execFileAsync("bun", [
+      "scripts/assemble-buildertrend-template-next-batch-content.mjs",
+      "--capture-output", capture,
+      "--inventory-output", inventory,
+    ])
+    const result = await execFileAsync("bun", [
+      "scripts/build-buildertrend-template-next-batch-content-sql.mjs",
+      "--capture", capture,
+      "--inventory", inventory,
+      "--output", output,
+    ])
+    assert.deepEqual(JSON.parse(result.stdout), {
+      templateCount: 2,
+      tasks: 93,
+      scheduleItems: 14,
+      selections: 4,
+      bidPackages: 3,
+      excludedArchivedCount: 27,
+      draftOnly: true,
+      output,
+    })
+    const sql = await readFile(output, "utf8")
+    assert.match(sql, /bt-template-version:12859981:1/)
+    assert.match(sql, /bt-template-version:12978371:1/)
+    assert.match(sql, /review_status='content_captured', lifecycle_status='draft'/)
+    assert.doesNotMatch(sql, /12581937|status='published'|lifecycle_status='active'|review_status='verified'/)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test("SQL command rejects publish flags before generating output", async () => {
+  await assert.rejects(
+    () => execFileAsync("bun", [
+      "scripts/build-buildertrend-template-next-batch-content-sql.mjs",
+      "--publish-captured-schedules",
+    ]),
+    /publication requests are prohibited/
+  )
+})

--- a/scripts/fixtures/buildertrend-template-content-next-batch-release-2026-08-04.json
+++ b/scripts/fixtures/buildertrend-template-content-next-batch-release-2026-08-04.json
@@ -1,0 +1,29 @@
+{
+  "releaseVersion": 1,
+  "generatedAt": "2026-08-04T19:00:00.000Z",
+  "sourceNextBatchManifest": "scripts/fixtures/buildertrend-template-next-batch-2026-08-04.json",
+  "sourceReviewedCapture": "scripts/fixtures/buildertrend-active-template-capture-2026-07-31.json",
+  "draftOnly": true,
+  "publish": false,
+  "templates": [
+    {
+      "sourceTemplateId": "12859981",
+      "sourceName": "Ext. Finishes - Stucco",
+      "fragmentPath": "scripts/fixtures/buildertrend-template-content-next-batch/fragments/06-12859981.capture.json",
+      "browserCaptureGates": "complete"
+    },
+    {
+      "sourceTemplateId": "12978371",
+      "sourceName": "MEP - Rough & Top Out",
+      "fragmentPath": "scripts/fixtures/buildertrend-template-content-next-batch/fragments/07-12978371.capture.json",
+      "browserCaptureGates": "complete"
+    }
+  ],
+  "excludedTemplates": [
+    {
+      "sourceTemplateId": "12581937",
+      "sourceName": "Concrete - Footer Assembly",
+      "reason": "Browser task capture is incomplete; reviewed schedule rows alone do not satisfy the release gate."
+    }
+  ]
+}

--- a/scripts/fixtures/buildertrend-template-content-next-batch/README.md
+++ b/scripts/fixtures/buildertrend-template-content-next-batch/README.md
@@ -37,3 +37,27 @@ browser-capture modules are present:
 bun scripts/validate-buildertrend-template-next-batch.mjs --require-priority-complete
 bun scripts/validate-buildertrend-template-next-batch.mjs --require-all-complete
 ```
+
+## First guarded content release
+
+The release allowlist currently contains only Stucco (`12859981`) and MEP Rough
+& Top Out (`12978371`). Their browser gates are complete, and the assembler
+combines those fragments with the already-reviewed schedule rows and
+dependencies. Concrete Footer (`12581937`) remains explicitly excluded until
+its browser task capture is complete.
+
+```bash
+bun scripts/assemble-buildertrend-template-next-batch-content.mjs \
+  --capture-output <reviewed-capture.json> \
+  --inventory-output <reviewed-inventory.json>
+
+bun scripts/build-buildertrend-template-next-batch-content-sql.mjs \
+  --capture <reviewed-capture.json> \
+  --inventory <reviewed-inventory.json> \
+  --output <reviewed-import.sql>
+```
+
+Both commands reject publish flags. The generated content SQL is guarded by
+draft version checks and leaves the two Compass templates in
+`content_captured` / `draft` state for staff review and later publication from
+the Template Library.

--- a/scripts/lib/buildertrend-template-content-pilot.mjs
+++ b/scripts/lib/buildertrend-template-content-pilot.mjs
@@ -133,6 +133,156 @@ export async function readPilotContentFragments(directory) {
   return documents
 }
 
+export function assembleBuildertrendTemplateContentSubset({
+  templateEntries,
+  reviewedCapture,
+  documents,
+  excludedArchivedCount,
+  allowIncomplete = false,
+  capturedAt = new Date().toISOString(),
+  incompleteLabel = "Template content",
+  assemblyMetadata = {},
+}) {
+  if (!Array.isArray(templateEntries) || templateEntries.length === 0) {
+    throw new Error("Template content subset must contain at least one template.")
+  }
+  if (!isRecord(reviewedCapture) || !Array.isArray(reviewedCapture.templates)) {
+    throw new Error("Reviewed capture must contain templates.")
+  }
+
+  const reviewedById = new Map()
+  for (const [index, template] of reviewedCapture.templates.entries()) {
+    if (!isRecord(template)) throw new Error(`reviewedCapture.templates[${index}] must be an object.`)
+    const id = requiredString(template.sourceTemplateId, `reviewedCapture.templates[${index}].sourceTemplateId`)
+    if (reviewedById.has(id)) throw new Error(`Reviewed capture has duplicate sourceTemplateId ${id}.`)
+    if (/^archive/i.test(requiredString(template.name, `reviewedCapture.templates[${index}].name`))) {
+      throw new Error(`Archived reviewed template ${template.name} is not allowed.`)
+    }
+    reviewedById.set(id, template)
+  }
+
+  const contentById = new Map()
+  for (const [index, entry] of templateEntries.entries()) {
+    if (!isRecord(entry)) throw new Error(`templateEntries[${index}] must be an object.`)
+    const id = requiredString(entry.sourceTemplateId, `templateEntries[${index}].sourceTemplateId`)
+    const name = requiredString(entry.sourceName, `templateEntries[${index}].sourceName`)
+    const reviewed = reviewedById.get(id)
+    if (!reviewed || reviewed.name !== name) {
+      throw new Error(`Template content identity mismatch for ${id} (${name}).`)
+    }
+    if (contentById.has(id)) throw new Error(`Template content duplicates sourceTemplateId ${id}.`)
+    const moduleCounts = expectedModuleCounts(reviewed, `reviewed template ${id}`)
+    const seed = { sourceTemplateId: id, name, sourceName: name, moduleCounts }
+    // Browser fragments never recreate schedule data; the reviewed 40-template
+    // capture remains the sole source for schedule rows and dependencies.
+    const scheduleItems = reviewedScheduleItems(reviewed, `reviewed template ${id}`)
+    if (moduleCounts.scheduleItems > 0 && scheduleItems) {
+      seed.schedule = structuredClone(reviewed.schedule)
+      seed.scheduleItems = scheduleItems
+    }
+    contentById.set(id, seed)
+  }
+
+  const exceptions = []
+  const exceptionKeys = new Set()
+  for (const { source, document } of documents) {
+    const normalized = normalizeFragment(document, source)
+    if (!Array.isArray(normalized.conversionExceptions)) {
+      throw new Error(`${source}.conversionExceptions must be an array.`)
+    }
+    for (const [index, template] of normalized.templates.entries()) {
+      if (!isRecord(template)) throw new Error(`${source}.templates[${index}] must be an object.`)
+      const id = requiredString(template.sourceTemplateId, `${source}.templates[${index}].sourceTemplateId`)
+      const current = contentById.get(id)
+      if (!current) {
+        throw new Error(
+          `${source} contains non-pilot or archived template ${id} outside the approved content subset.`
+        )
+      }
+      const suppliedName = template.name ?? template.sourceName
+      if (suppliedName !== current.name) throw new Error(`${source} has an identity mismatch for ${id}.`)
+      if (template.moduleCounts !== undefined) {
+        const suppliedCounts = expectedModuleCounts(template, `${source}.templates[${index}]`)
+        if (JSON.stringify(suppliedCounts) !== JSON.stringify(current.moduleCounts)) {
+          throw new Error(`${source} has module-count metadata that conflicts with reviewed source ${id}.`)
+        }
+      }
+      contentById.set(id, mergeTemplate(current, template, `${source}.templates[${index}]`))
+    }
+    for (const [index, exception] of normalized.conversionExceptions.entries()) {
+      if (!isRecord(exception)) throw new Error(`${source}.conversionExceptions[${index}] must be an object.`)
+      const templateId = requiredString(
+        exception.templateSourceTemplateId,
+        `${source}.conversionExceptions[${index}].templateSourceTemplateId`
+      )
+      if (!contentById.has(templateId)) {
+        throw new Error(`${source} contains an exception outside the approved content subset: ${templateId}.`)
+      }
+      const key = JSON.stringify(exception)
+      if (!exceptionKeys.has(key)) {
+        exceptionKeys.add(key)
+        exceptions.push(structuredClone(exception))
+      }
+    }
+  }
+
+  const missing = []
+  const templates = []
+  const assembledById = new Map()
+  for (const entry of templateEntries) {
+    const template = contentById.get(entry.sourceTemplateId)
+    if (!template) throw new Error(`Template ${entry.sourceTemplateId} disappeared during assembly.`)
+    for (const moduleName of PILOT_MODULES) {
+      const items = moduleItems(template, moduleName)
+      const expected = template.moduleCounts[moduleName]
+      const actual = items?.length ?? 0
+      if (actual !== expected) {
+        missing.push({ sourceTemplateId: template.sourceTemplateId, name: template.name, module: moduleName, expected, actual })
+      } else if (items) {
+        assertUniqueSourceItemIds(items, `${template.name}.${moduleName}`)
+      }
+    }
+    templates.push(template)
+    assembledById.set(template.sourceTemplateId, template)
+  }
+  for (const [index, exception] of exceptions.entries()) {
+    const path = `conversionExceptions[${index}]`
+    const templateId = requiredString(exception.templateSourceTemplateId, `${path}.templateSourceTemplateId`)
+    const moduleName = requiredString(exception.module, `${path}.module`)
+    if (!PILOT_MODULES.includes(moduleName)) {
+      throw new Error(`${path}.module must be one of ${PILOT_MODULES.join(", ")}.`)
+    }
+    requiredString(exception.field, `${path}.field`)
+    requiredString(exception.loss, `${path}.loss`)
+    requiredString(exception.recoveryPlan, `${path}.recoveryPlan`)
+    if (!("sourceValue" in exception)) throw new Error(`${path}.sourceValue is required.`)
+    if (!("sourceItemId" in exception)) throw new Error(`${path}.sourceItemId is required; use null for module-level exceptions.`)
+    if (exception.sourceItemId !== null) {
+      const sourceItemId = requiredString(exception.sourceItemId, `${path}.sourceItemId`)
+      const template = assembledById.get(templateId)
+      const items = template ? moduleItems(template, moduleName) : null
+      if (!items?.some((item) => item.sourceItemId === sourceItemId)) {
+        throw new Error(`${path}.sourceItemId does not identify captured ${moduleName} content.`)
+      }
+    }
+  }
+  if (!allowIncomplete && missing.length > 0) {
+    const details = missing
+      .map((item) => `${item.name} ${item.module}: expected ${item.expected}, found ${item.actual}`)
+      .join("; ")
+    throw new Error(`${incompleteLabel} is incomplete: ${details}.`)
+  }
+
+  return {
+    fixtureVersion: 3,
+    capturedAt,
+    excludedArchivedCount,
+    conversionExceptions: exceptions,
+    templates,
+    assembly: { complete: missing.length === 0, ...assemblyMetadata, missing },
+  }
+}
+
 export function assembleBuildertrendTemplateContentPilot({
   manifest,
   reviewedCapture,
@@ -163,158 +313,27 @@ export function assembleBuildertrendTemplateContentPilot({
     throw new Error("Reviewed capture must retain all 40 active templates and exclude 27 archived templates.")
   }
 
-  const reviewedById = new Map()
-  for (const [index, template] of reviewedCapture.templates.entries()) {
-    if (!isRecord(template)) throw new Error(`reviewedCapture.templates[${index}] must be an object.`)
-    const id = requiredString(template.sourceTemplateId, `reviewedCapture.templates[${index}].sourceTemplateId`)
-    if (reviewedById.has(id)) throw new Error(`Reviewed capture has duplicate sourceTemplateId ${id}.`)
-    if (/^archive/i.test(requiredString(template.name, `reviewedCapture.templates[${index}].name`))) {
-      throw new Error(`Archived reviewed template ${template.name} is not allowed.`)
-    }
-    reviewedById.set(id, template)
-  }
-
-  const pilotById = new Map()
-  for (const [index, entry] of manifest.templates.entries()) {
-    if (!isRecord(entry)) throw new Error(`manifest.templates[${index}] must be an object.`)
-    const id = requiredString(entry.sourceTemplateId, `manifest.templates[${index}].sourceTemplateId`)
-    const name = requiredString(entry.sourceName, `manifest.templates[${index}].sourceName`)
-    const reviewed = reviewedById.get(id)
-    if (!reviewed || reviewed.name !== name) {
-      throw new Error(`Pilot manifest identity mismatch for ${id} (${name}).`)
-    }
-    if (pilotById.has(id)) throw new Error(`Pilot manifest duplicates sourceTemplateId ${id}.`)
-    const moduleCounts = expectedModuleCounts(reviewed, `reviewed template ${id}`)
-    const seed = {
-      sourceTemplateId: id,
-      name,
-      sourceName: name,
-      moduleCounts,
-    }
-    // Schedule data was already captured in the reviewed 40-template source fixture.
-    // Reuse that evidence instead of asking browser capture work to recreate it.
-    const scheduleItems = reviewedScheduleItems(reviewed, `reviewed template ${id}`)
-    if (moduleCounts.scheduleItems > 0 && scheduleItems) {
-      seed.schedule = structuredClone(reviewed.schedule)
-      seed.scheduleItems = scheduleItems
-    }
-    pilotById.set(id, seed)
-  }
-  if (pilotById.size !== scope.pilotTemplatesIncluded) {
-    throw new Error("Pilot manifest must contain exactly six unique templates.")
-  }
-
-  const exceptions = []
-  const exceptionKeys = new Set()
-  for (const { source, document } of documents) {
-    const normalized = normalizeFragment(document, source)
-    if (!Array.isArray(normalized.conversionExceptions)) {
-      throw new Error(`${source}.conversionExceptions must be an array.`)
-    }
-    for (const [index, template] of normalized.templates.entries()) {
-      if (!isRecord(template)) throw new Error(`${source}.templates[${index}] must be an object.`)
-      const id = requiredString(template.sourceTemplateId, `${source}.templates[${index}].sourceTemplateId`)
-      const current = pilotById.get(id)
-      if (!current) {
-        throw new Error(`${source} contains non-pilot or archived template ${id}.`)
-      }
-      const suppliedName = template.name ?? template.sourceName
-      if (suppliedName !== current.name) {
-        throw new Error(`${source} has an identity mismatch for ${id}.`)
-      }
-      if (template.moduleCounts !== undefined) {
-        const suppliedCounts = expectedModuleCounts(template, `${source}.templates[${index}]`)
-        if (JSON.stringify(suppliedCounts) !== JSON.stringify(current.moduleCounts)) {
-          throw new Error(`${source} has module-count metadata that conflicts with reviewed source ${id}.`)
-        }
-      }
-      pilotById.set(id, mergeTemplate(current, template, `${source}.templates[${index}]`))
-    }
-    for (const [index, exception] of normalized.conversionExceptions.entries()) {
-      if (!isRecord(exception)) throw new Error(`${source}.conversionExceptions[${index}] must be an object.`)
-      const templateId = requiredString(
-        exception.templateSourceTemplateId,
-        `${source}.conversionExceptions[${index}].templateSourceTemplateId`
-      )
-      if (!pilotById.has(templateId)) {
-        throw new Error(`${source} contains an exception for non-pilot or archived template ${templateId}.`)
-      }
-      const key = JSON.stringify(exception)
-      if (!exceptionKeys.has(key)) {
-        exceptionKeys.add(key)
-        exceptions.push(structuredClone(exception))
-      }
-    }
-  }
-
-  const missing = []
-  const templates = []
-  const assembledById = new Map()
-  for (const entry of manifest.templates) {
-    const template = pilotById.get(entry.sourceTemplateId)
-    if (!template) throw new Error(`Pilot template ${entry.sourceTemplateId} disappeared during assembly.`)
-    for (const moduleName of PILOT_MODULES) {
-      const items = moduleItems(template, moduleName)
-      const expected = template.moduleCounts[moduleName]
-      const actual = items?.length ?? 0
-      if (actual !== expected) {
-        missing.push({ sourceTemplateId: template.sourceTemplateId, name: template.name, module: moduleName, expected, actual })
-        continue
-      }
-      if (items) assertUniqueSourceItemIds(items, `${template.name}.${moduleName}`)
-    }
-    templates.push(template)
-    assembledById.set(template.sourceTemplateId, template)
-  }
-  for (const [index, exception] of exceptions.entries()) {
-    const path = `conversionExceptions[${index}]`
-    const templateId = requiredString(exception.templateSourceTemplateId, `${path}.templateSourceTemplateId`)
-    const moduleName = requiredString(exception.module, `${path}.module`)
-    if (!PILOT_MODULES.includes(moduleName)) {
-      throw new Error(`${path}.module must be one of ${PILOT_MODULES.join(", ")}.`)
-    }
-    requiredString(exception.field, `${path}.field`)
-    requiredString(exception.loss, `${path}.loss`)
-    requiredString(exception.recoveryPlan, `${path}.recoveryPlan`)
-    if (!("sourceValue" in exception)) throw new Error(`${path}.sourceValue is required.`)
-    if (!("sourceItemId" in exception)) throw new Error(`${path}.sourceItemId is required; use null for module-level exceptions.`)
-    if (exception.sourceItemId !== null) {
-      const sourceItemId = requiredString(exception.sourceItemId, `${path}.sourceItemId`)
-      const template = assembledById.get(templateId)
-      const items = template ? moduleItems(template, moduleName) : null
-      if (!items?.some((item) => item.sourceItemId === sourceItemId)) {
-        throw new Error(`${path}.sourceItemId does not identify captured ${moduleName} content.`)
-      }
-    }
-  }
-  if (!allowIncomplete && missing.length > 0) {
-    const details = missing
-      .map((item) => `${item.name} ${item.module}: expected ${item.expected}, found ${item.actual}`)
-      .join("; ")
-    throw new Error(`Six-template pilot content is incomplete: ${details}.`)
-  }
-
-  return {
-    fixtureVersion: 3,
-    capturedAt,
+  return assembleBuildertrendTemplateContentSubset({
+    templateEntries: manifest.templates,
+    reviewedCapture,
+    documents,
     excludedArchivedCount: scope.archivedTemplatesExcluded,
-    conversionExceptions: exceptions,
-    templates,
-    assembly: {
-      complete: missing.length === 0,
-      pilotTemplateCount: templates.length,
+    allowIncomplete,
+    capturedAt,
+    incompleteLabel: "Six-template pilot content",
+    assemblyMetadata: {
+      pilotTemplateCount: manifest.templates.length,
       remainingActiveTemplatesUnverified: scope.remainingActiveTemplatesUnverified,
-      missing,
     },
-  }
+  })
 }
 
-export function buildBuildertrendTemplateContentPilotInventory(capture) {
+export function buildBuildertrendTemplateContentInventory(capture, label = "Content") {
   if (!isRecord(capture) || !Array.isArray(capture.templates)) {
-    throw new Error("Assembled pilot capture must contain templates.")
+    throw new Error(`Assembled ${label.toLowerCase()} capture must contain templates.`)
   }
   if (!isRecord(capture.assembly) || capture.assembly.complete !== true) {
-    throw new Error("Pilot inventory cannot be emitted from an incomplete content capture.")
+    throw new Error(`${label} inventory cannot be emitted from an incomplete content capture.`)
   }
   return {
     capturedAt: capture.capturedAt,
@@ -329,6 +348,10 @@ export function buildBuildertrendTemplateContentPilotInventory(capture) {
       moduleCounts: expectedModuleCounts(template, `capture.templates[${index}]`),
     })),
   }
+}
+
+export function buildBuildertrendTemplateContentPilotInventory(capture) {
+  return buildBuildertrendTemplateContentInventory(capture, "Pilot")
 }
 
 export function pilotFragmentFileName(sourceTemplateId, sourceName) {

--- a/scripts/lib/buildertrend-template-next-batch-content.mjs
+++ b/scripts/lib/buildertrend-template-next-batch-content.mjs
@@ -1,0 +1,136 @@
+import {
+  assembleBuildertrendTemplateContentSubset,
+  buildBuildertrendTemplateContentInventory,
+} from "./buildertrend-template-content-pilot.mjs"
+import {
+  BROWSER_CAPTURE_MODULES,
+  validateBuildertrendNextBatchFragments,
+} from "./buildertrend-template-next-batch.mjs"
+
+export const NEXT_BATCH_CONTENT_IDS = ["12859981", "12978371"]
+export const INCOMPLETE_CONCRETE_FOOTER_ID = "12581937"
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function requiredString(value, path) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${path} must be a non-empty string.`)
+  }
+  return value.trim()
+}
+
+function browserCaptureGateCount(templates) {
+  return templates.reduce(
+    (total, template) => total + BROWSER_CAPTURE_MODULES.filter(
+      (moduleName) => (template.moduleCounts[moduleName] ?? 0) > 0
+    ).length,
+    0
+  )
+}
+
+export function assembleBuildertrendTemplateNextBatchContent({
+  release,
+  nextBatchManifest,
+  reviewedCapture,
+  documents,
+  publishRequested = false,
+  capturedAt,
+}) {
+  if (publishRequested || release?.publish !== false || release?.draftOnly !== true) {
+    throw new Error("Next-batch template content is draft-only; publication requests are prohibited.")
+  }
+  if (!isRecord(release) || release.releaseVersion !== 1 || !Array.isArray(release.templates)) {
+    throw new Error("Next-batch content release must contain a versioned template allowlist.")
+  }
+  if (
+    !isRecord(nextBatchManifest) ||
+    nextBatchManifest.scope?.remainingActiveTemplatesIncluded !== 34 ||
+    !Array.isArray(nextBatchManifest.templates)
+  ) {
+    throw new Error("Next-batch manifest must retain all 34 reviewed non-pilot templates.")
+  }
+  if (
+    !isRecord(reviewedCapture) ||
+    reviewedCapture.expectedActiveCount !== 40 ||
+    reviewedCapture.excludedArchivedCount !== 27 ||
+    !Array.isArray(reviewedCapture.templates) ||
+    reviewedCapture.templates.length !== 40
+  ) {
+    throw new Error("Reviewed capture must retain all 40 active templates and exclude 27 archived templates.")
+  }
+
+  const requestedIds = release.templates.map((template, index) =>
+    requiredString(template?.sourceTemplateId, `release.templates[${index}].sourceTemplateId`)
+  )
+  if (new Set(requestedIds).size !== requestedIds.length) {
+    throw new Error("Next-batch content release contains duplicate template IDs.")
+  }
+  if (JSON.stringify(requestedIds) !== JSON.stringify(NEXT_BATCH_CONTENT_IDS)) {
+    if (requestedIds.includes(INCOMPLETE_CONCRETE_FOOTER_ID)) {
+      throw new Error("Concrete - Footer Assembly is partially captured and cannot be released.")
+    }
+    throw new Error(
+      `Next-batch content release must contain only ${NEXT_BATCH_CONTENT_IDS.join(" and ")}.`
+    )
+  }
+  const concreteExclusion = release.excludedTemplates?.find(
+    (template) => template?.sourceTemplateId === INCOMPLETE_CONCRETE_FOOTER_ID
+  )
+  if (!concreteExclusion) {
+    throw new Error("Next-batch content release must explicitly exclude incomplete Concrete - Footer Assembly.")
+  }
+
+  const manifestById = new Map(
+    nextBatchManifest.templates.map((template) => [template.sourceTemplateId, template])
+  )
+  const selected = release.templates.map((entry) => {
+    if (entry.browserCaptureGates !== "complete") {
+      throw new Error(`${entry.sourceName ?? entry.sourceTemplateId} is partially captured and cannot be released.`)
+    }
+    const reviewed = manifestById.get(entry.sourceTemplateId)
+    if (!reviewed || reviewed.sourceName !== entry.sourceName) {
+      throw new Error(`Next-batch identity mismatch for ${entry.sourceTemplateId}.`)
+    }
+    if (reviewed.fragmentPath !== entry.fragmentPath) {
+      throw new Error(`Next-batch fragment path mismatch for ${entry.sourceTemplateId}.`)
+    }
+    return reviewed
+  })
+  const scopedManifest = {
+    browserCaptureGateCount: browserCaptureGateCount(selected),
+    templates: selected,
+  }
+  const status = validateBuildertrendNextBatchFragments({
+    manifest: scopedManifest,
+    documents,
+  })
+  if (!status.complete) {
+    const missing = status.missing
+      .map((item) => `${item.sourceName} ${item.module}`)
+      .join(", ")
+    throw new Error(`Next-batch template content is partially captured: ${missing}.`)
+  }
+
+  const capture = assembleBuildertrendTemplateContentSubset({
+    templateEntries: selected,
+    reviewedCapture,
+    documents,
+    excludedArchivedCount: 27,
+    capturedAt: capturedAt ?? release.generatedAt,
+    incompleteLabel: "Next-batch template content",
+    assemblyMetadata: {
+      releaseVersion: release.releaseVersion,
+      draftOnly: true,
+      publish: false,
+      templateCount: selected.length,
+      sourceTemplateIds: requestedIds,
+      browserCaptureGateCount: status.capturedGateCount,
+    },
+  })
+  return {
+    capture,
+    inventory: buildBuildertrendTemplateContentInventory(capture, "Next-batch"),
+  }
+}


### PR DESCRIPTION
## What changed

- adds a guarded assembler for the fully captured Stucco and MEP Rough & Top Out Buildertrend templates
- merges their 93 task rows, 14 reviewed schedule items, 10 dependencies, four selections, and three bid packages into a count-matched import envelope
- adds a draft-only SQL wrapper that rejects all publication flags
- excludes partial templates, including the in-progress Concrete Footer capture
- shares the reviewed pilot conversion logic so hierarchy, provenance, and conversion safeguards stay consistent

## Why

The complete next-batch templates need a safe bridge into Compass without waiting for every remaining Buildertrend template and without weakening the human Review and Publish gate.

## Impact

- only Stucco `12859981` and MEP `12978371` are eligible
- imported templates remain draft and unpublished
- partial captures and publication requests fail closed

## Validation

- 28 focused assembler, SQL, manifest, and regression tests pass
- `git diff --check`
