### PR TITLE
fix(projects): restore HPS Project Manager entry

### DIFF
--- a/src/components/projects/project-hub-launchpad.tsx
+++ b/src/components/projects/project-hub-launchpad.tsx
@@ -1,9 +1,8 @@
 "use client"
 
-import { useMemo, useState, useTransition } from "react"
+import { useMemo, useState } from "react"
 import Image from "next/image"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
 import {
   IconAlertTriangle,
   IconBuilding,
@@ -18,35 +17,16 @@ import {
 } from "@tabler/icons-react"
 
 import type { DashboardOverview } from "@/app/actions/dashboard-overview"
-import {
-  createProjectShell,
-  type ProjectListItem,
-} from "@/app/actions/projects"
+import type { ProjectListItem } from "@/app/actions/projects"
 import { useActiveProject } from "@/components/project-list-provider"
 import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import { OfficeMaintenanceDrawer } from "@/components/projects/office-maintenance-drawer"
+import { openHpsProjectManagerWorkWindow } from "@/lib/google/project-manager-app"
 import { cn } from "@/lib/utils"
 
 type DepartmentFilter = "ALL" | "O" | "H" | "N" | "D" | "OTHER"
-type NewProjectDepartment = "O" | "H" | "N" | "D" | "UNASSIGNED"
 type StatusFilter = "active" | "warranty" | "complete" | "all"
 type ProjectLayout = "cards" | "list"
 
@@ -81,23 +61,6 @@ function departmentForProject(project: ProjectListItem): DepartmentFilter {
     return prefix
   }
   return "OTHER"
-}
-
-function isNewProjectDepartment(value: string): value is NewProjectDepartment {
-  return (
-    value === "O" ||
-    value === "H" ||
-    value === "N" ||
-    value === "D" ||
-    value === "UNASSIGNED"
-  )
-}
-
-function formText(formData: FormData, name: string): string | null {
-  const value = formData.get(name)
-  if (typeof value !== "string") return null
-  const trimmed = value.trim()
-  return trimmed.length > 0 ? trimmed : null
 }
 
 function statusForProject(project: ProjectListItem): StatusFilter {
@@ -289,146 +252,16 @@ function ProjectCard({
   )
 }
 
-function NewProjectDialog({
-  activeDepartment,
-}: {
-  readonly activeDepartment: DepartmentFilter
-}): React.ReactElement {
-  const router = useRouter()
-  const [open, setOpen] = useState(false)
-  const [department, setDepartment] = useState<NewProjectDepartment>(
-    isNewProjectDepartment(activeDepartment) ? activeDepartment : "O"
-  )
-  const [status, setStatus] = useState("OPEN")
-  const [message, setMessage] = useState<string | null>(null)
-  const [isPending, startTransition] = useTransition()
-
-  function handleOpenChange(nextOpen: boolean): void {
-    if (nextOpen && isNewProjectDepartment(activeDepartment)) {
-      setDepartment(activeDepartment)
-    }
-    setMessage(null)
-    setOpen(nextOpen)
-  }
-
-  function handleSubmit(event: React.FormEvent<HTMLFormElement>): void {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    const name = formText(formData, "name")
-    if (!name) {
-      setMessage("Project name is required.")
-      return
-    }
-
-    startTransition(async () => {
-      setMessage(null)
-      const result = await createProjectShell({
-        projectNumber: formText(formData, "projectNumber"),
-        name,
-        department,
-        clientName: formText(formData, "clientName"),
-        address: formText(formData, "address"),
-        status,
-      })
-
-      if (!result.success) {
-        setMessage(result.error)
-        return
-      }
-
-      setOpen(false)
-      router.push(`/dashboard/projects/${result.id}`)
-      router.refresh()
-    })
-  }
-
+function NewProjectButton(): React.ReactElement {
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogTrigger asChild>
-        <Button size="sm">
-          <IconPlus className="size-4" />
-          New project
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="sm:max-w-xl">
-        <DialogHeader>
-          <DialogTitle>Create project</DialogTitle>
-          <DialogDescription>
-            Start the Compass project shell. Integration IDs can be added later
-            in advanced registry tools.
-          </DialogDescription>
-        </DialogHeader>
-        <form className="space-y-4" onSubmit={handleSubmit}>
-          <div className="grid gap-3 sm:grid-cols-2">
-            <label className="space-y-1.5 text-sm font-medium">
-              Project name
-              <Input name="name" required placeholder="Loeffler Residence" />
-            </label>
-            <label className="space-y-1.5 text-sm font-medium">
-              Project number
-              <Input name="projectNumber" placeholder="O-202-595" />
-            </label>
-            <label className="space-y-1.5 text-sm font-medium">
-              Department
-              <Select
-                value={department}
-                onValueChange={(value) => {
-                  if (isNewProjectDepartment(value)) setDepartment(value)
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="O">ORC</SelectItem>
-                  <SelectItem value="H">HPS</SelectItem>
-                  <SelectItem value="N">Nu-Tech</SelectItem>
-                  <SelectItem value="D">Design</SelectItem>
-                  <SelectItem value="UNASSIGNED">Unassigned</SelectItem>
-                </SelectContent>
-              </Select>
-            </label>
-            <label className="space-y-1.5 text-sm font-medium">
-              Status
-              <Select value={status} onValueChange={setStatus}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="OPEN">Active</SelectItem>
-                  <SelectItem value="LEAD">Lead</SelectItem>
-                  <SelectItem value="WARRANTY">Warranty</SelectItem>
-                </SelectContent>
-              </Select>
-            </label>
-            <label className="space-y-1.5 text-sm font-medium">
-              Client
-              <Input name="clientName" placeholder="Client name" />
-            </label>
-            <label className="space-y-1.5 text-sm font-medium">
-              Address
-              <Input name="address" placeholder="Job site address" />
-            </label>
-          </div>
-          {message ? (
-            <p className="text-sm text-destructive">{message}</p>
-          ) : null}
-          <div className="flex justify-end gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setOpen(false)}
-              disabled={isPending}
-            >
-              Cancel
-            </Button>
-            <Button type="submit" disabled={isPending}>
-              {isPending ? "Creating..." : "Create project"}
-            </Button>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
+    <Button
+      type="button"
+      size="sm"
+      onClick={() => openHpsProjectManagerWorkWindow()}
+    >
+      <IconPlus className="size-4" />
+      New project
+    </Button>
   )
 }
 
@@ -496,7 +329,7 @@ export function ProjectHubLaunchpad({
             <OfficeMaintenanceDrawer projects={projects} />
           ) : null}
           {canManageProjects ? (
-            <NewProjectDialog activeDepartment={department} />
+            <NewProjectButton />
           ) : null}
         </div>
       </header>

--- a/src/components/projects/projects-hub.tsx
+++ b/src/components/projects/projects-hub.tsx
@@ -45,6 +45,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import {
+  CONFIGURED_HPS_PROJECT_MANAGER_WEB_APP_URL,
+  HPS_PROJECT_MANAGER_WEB_APP_URL,
+  openHpsProjectManagerWorkWindow,
+} from "@/lib/google/project-manager-app"
 import { cn } from "@/lib/utils"
 
 type DepartmentId = "O" | "H" | "N" | "D" | "UNASSIGNED"
@@ -183,15 +188,6 @@ const PROJECT_STATUS_OPTIONS: readonly ProjectStatusOption[] = [
 const HPS_PROJECT_MANAGER_EDITOR_URL =
   "https://script.google.com/d/1NzKjO6r_WS5optIHxwGxB5mby3PX0TSHhctU73xZIFtWXXgLueksPN-s/edit"
 
-const DEFAULT_HPS_PROJECT_MANAGER_WEB_APP_URL =
-  "https://script.google.com/a/macros/hps-colorado.com/s/AKfycbyeCqsdObrPp91LRmpEHSLZ8xdGerw7ExF2mFSSzYkxGnTrliv9OvHsYOFXicnVC5nQ/exec"
-
-const CONFIGURED_HPS_PROJECT_MANAGER_WEB_APP_URL =
-  process.env.NEXT_PUBLIC_HPS_PROJECT_MANAGER_WEB_APP_URL ?? ""
-
-const HPS_PROJECT_MANAGER_WEB_APP_URL =
-  CONFIGURED_HPS_PROJECT_MANAGER_WEB_APP_URL ||
-  DEFAULT_HPS_PROJECT_MANAGER_WEB_APP_URL
 const DASHBOARD_MODE_STORAGE_KEY = "compass-dashboard-workspace-mode"
 
 const DEPARTMENT_TOOLS: readonly (DepartmentTool & {
@@ -226,18 +222,6 @@ const DEPARTMENT_TOOLS: readonly (DepartmentTool & {
     href: "/dashboard/automations",
   },
 ]
-
-function openProjectManagerWorkWindow(appUrl: string): void {
-  const projectManagerWindow = window.open(
-    appUrl,
-    "hps-project-manager",
-    "popup=yes,width=1180,height=860,menubar=no,toolbar=yes,location=yes,status=no,scrollbars=yes,resizable=yes"
-  )
-
-  if (projectManagerWindow) {
-    projectManagerWindow.focus()
-  }
-}
 
 function storedDashboardDeveloperMode(canUseDeveloperMode: boolean): boolean {
   if (!canUseDeveloperMode) return false
@@ -1022,7 +1006,7 @@ function ProjectManagerEmbedDialog({
   readonly onUrlInputChange: (value: string) => void
 }): React.ReactElement {
   const handleOpenDetachedWindow = React.useCallback(() => {
-    openProjectManagerWorkWindow(appUrl)
+    openHpsProjectManagerWorkWindow(window, appUrl)
   }, [appUrl])
 
   return (
@@ -1363,7 +1347,7 @@ export function ProjectsHub({
       : groups.find((group) => group.id === activeDepartment) ?? null
 
   function openProjectManager(): void {
-    openProjectManagerWorkWindow(projectManagerAppUrl)
+    openHpsProjectManagerWorkWindow(window, projectManagerAppUrl)
   }
 
   function openProjectManagerDetails(): void {

--- a/src/lib/__tests__/project-manager-app.test.ts
+++ b/src/lib/__tests__/project-manager-app.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  openHpsProjectManagerWorkWindow,
+  resolveHpsProjectManagerWebAppUrl,
+} from "@/lib/google/project-manager-app"
+
+describe("HPS Project Manager app", () => {
+  it("uses the configured web app URL when present", () => {
+    expect(resolveHpsProjectManagerWebAppUrl(" https://example.com/manager ")).toBe(
+      "https://example.com/manager"
+    )
+  })
+
+  it("falls back to the deployed HPS web app URL", () => {
+    expect(resolveHpsProjectManagerWebAppUrl(" ")).toContain(
+      "script.google.com/a/macros/hps-colorado.com/"
+    )
+  })
+
+  it("focuses the Project Manager popup", () => {
+    const focus = vi.fn()
+    const assign = vi.fn()
+    const open = vi.fn(() => ({ focus }))
+
+    openHpsProjectManagerWorkWindow({ location: { assign }, open }, "https://example.com")
+
+    expect(open).toHaveBeenCalledWith(
+      "https://example.com",
+      "hps-project-manager",
+      expect.stringContaining("scrollbars=yes")
+    )
+    expect(focus).toHaveBeenCalledOnce()
+    expect(assign).not.toHaveBeenCalled()
+  })
+
+  it("navigates directly when the popup is blocked", () => {
+    const assign = vi.fn()
+    const open = vi.fn(() => null)
+
+    openHpsProjectManagerWorkWindow({ location: { assign }, open }, "https://example.com")
+
+    expect(assign).toHaveBeenCalledWith("https://example.com")
+  })
+})

--- a/src/lib/google/project-manager-app.ts
+++ b/src/lib/google/project-manager-app.ts
@@ -1,0 +1,52 @@
+const DEFAULT_HPS_PROJECT_MANAGER_WEB_APP_URL =
+  "https://script.google.com/a/macros/hps-colorado.com/s/AKfycbyeCqsdObrPp91LRmpEHSLZ8xdGerw7ExF2mFSSzYkxGnTrliv9OvHsYOFXicnVC5nQ/exec"
+
+const PROJECT_MANAGER_WINDOW_FEATURES =
+  "popup=yes,width=1180,height=860,menubar=no,toolbar=yes,location=yes,status=no,scrollbars=yes,resizable=yes"
+
+type ProjectManagerPopup = {
+  focus(): void
+}
+
+type ProjectManagerBrowser = {
+  readonly location: {
+    assign(url: string): void
+  }
+  open(
+    url: string,
+    target: string,
+    features: string
+  ): ProjectManagerPopup | null
+}
+
+export function resolveHpsProjectManagerWebAppUrl(
+  configuredUrl: string | null | undefined
+): string {
+  const trimmed = configuredUrl?.trim() ?? ""
+  return trimmed.length > 0 ? trimmed : DEFAULT_HPS_PROJECT_MANAGER_WEB_APP_URL
+}
+
+export const CONFIGURED_HPS_PROJECT_MANAGER_WEB_APP_URL =
+  process.env.NEXT_PUBLIC_HPS_PROJECT_MANAGER_WEB_APP_URL?.trim() ?? ""
+
+export const HPS_PROJECT_MANAGER_WEB_APP_URL =
+  resolveHpsProjectManagerWebAppUrl(CONFIGURED_HPS_PROJECT_MANAGER_WEB_APP_URL)
+
+export function openHpsProjectManagerWorkWindow(
+  browser: ProjectManagerBrowser = window,
+  appUrl: string = HPS_PROJECT_MANAGER_WEB_APP_URL
+): void {
+  const projectManagerWindow = browser.open(
+    appUrl,
+    "hps-project-manager",
+    PROJECT_MANAGER_WINDOW_FEATURES
+  )
+
+  if (projectManagerWindow) {
+    projectManagerWindow.focus()
+    return
+  }
+
+  // A direct navigation keeps project creation available when a browser blocks popups.
+  browser.location.assign(appUrl)
+}


### PR DESCRIPTION
## What changed

- Restores the Project Hub **New project** button to the HPS Project Manager workflow.
- Shares one deployed Project Manager URL between the launchpad and registry views.
- Falls back to direct navigation when a browser blocks the popup.
- Adds focused coverage for configured URLs, fallback URLs, popup focus, and popup-blocked navigation.

## Why

The replacement Project Hub dialog created only a Compass shell and bypassed the HPS workflow that assigns project numbers, creates Drive folders, updates the department tracker and central Project Registry, and hands the record back to Compass. That left staff unable to create registry-safe projects.

## Validation

- `bun test src/lib/__tests__/project-manager-app.test.ts` — 4 passing
- `bun lint` — 0 errors (existing warnings only)
- `tsc --noEmit` — passing
- `bun run build` — passing
- Autoreview branch review — clean, no actionable findings
