### PR TITLE
feat(selections): import Google finish schedules

### DIFF
--- a/__tests__/google-finish-schedule-import.test.ts
+++ b/__tests__/google-finish-schedule-import.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  normalizeProjectNumber,
+  parseFinishScheduleWorkbook,
+} from "@/lib/selections/google-finish-schedule-import"
+
+describe("Google finish schedule import", () => {
+  it("preserves room groupings and category headings", () => {
+    const parsed = parseFinishScheduleWorkbook({
+      coverPageRows: [
+        ["Project", "Mitchell Residence"],
+        ["Project Number", "O-210-33"],
+        ["Room", "Room Type"],
+        ["Living", "Living Area"],
+      ],
+      roomSheets: [
+        {
+          sheetId: 17,
+          title: "Living",
+          index: 2,
+          values: [
+            [
+              "Name",
+              "Description",
+              "Qty",
+              "Manufacturer",
+              "Type/Model",
+              "Color/Finish",
+              "Additional Notes",
+            ],
+            ["WALL FINISH"],
+            ["Main wall paint", "Eggshell", 12, "Sherwin-Williams", "Emerald", "Alabaster", "Confirm sample"],
+            [],
+            ["FLOOR FINISH"],
+            ["Oak floor", "Wide plank", "430 SF", "Local Mill", "Select", "Natural", ""],
+          ],
+        },
+      ],
+    })
+
+    expect(parsed.projectNumber).toBe("O-210-33")
+    expect(parsed.rooms).toEqual([
+      {
+        sheetId: 17,
+        sheetName: "Living",
+        roomName: "Living",
+        roomType: "Living Area",
+        sortOrder: 2,
+      },
+    ])
+    expect(parsed.selections).toHaveLength(2)
+    expect(parsed.selections[0]).toMatchObject({
+      sourceRowNumber: 3,
+      category: "WALL FINISH",
+      name: "Main wall paint",
+      quantity: 12,
+      model: "Emerald",
+      colorFinish: "Alabaster",
+    })
+    expect(parsed.selections[1]).toMatchObject({
+      sourceRowNumber: 6,
+      category: "FLOOR FINISH",
+      name: "Oak floor",
+      quantity: 430,
+    })
+  })
+
+  it("warns when a workbook cannot be tied to a project", () => {
+    const parsed = parseFinishScheduleWorkbook({
+      coverPageRows: [],
+      roomSheets: [],
+    })
+
+    expect(parsed.projectNumber).toBeNull()
+    expect(parsed.warnings).toEqual([
+      "The workbook cover page has no project number.",
+      "The workbook has no visible room sheets.",
+    ])
+  })
+
+  it("normalizes harmless project-number formatting differences", () => {
+    expect(normalizeProjectNumber(" o-210-33 ")).toBe("O21033")
+    expect(normalizeProjectNumber("O 210 / 33")).toBe("O21033")
+    expect(normalizeProjectNumber(null)).toBeNull()
+  })
+})

--- a/src/app/actions/project-selections.ts
+++ b/src/app/actions/project-selections.ts
@@ -13,10 +13,24 @@ import {
   projects,
   sageCostCodes,
 } from "@/db/schema"
+import { googleAuth } from "@/db/schema-google"
 import { requireAuth } from "@/lib/auth"
+import { decrypt } from "@/lib/crypto"
 import { getCloudflareContext } from "@/lib/db"
+import { spreadsheetIdFromUrl } from "@/lib/financials/project-totals-import"
+import { SheetsClient } from "@/lib/google/client/sheets-client"
+import {
+  getGoogleConfig,
+  getGoogleCryptoSalt,
+  parseServiceAccountKey,
+} from "@/lib/google/config"
 import { requireOrg } from "@/lib/org-scope"
 import { requireFeaturePermission } from "@/lib/permission-enforcement"
+import {
+  normalizeProjectNumber,
+  parseFinishScheduleWorkbook,
+  type ParsedFinishSchedule,
+} from "@/lib/selections/google-finish-schedule-import"
 
 export type ProjectSelectionStatus =
   | "needed"
@@ -137,6 +151,36 @@ type ActionResult =
   | { readonly success: true; readonly id?: string }
   | { readonly success: false; readonly error: string }
 
+export type ProjectFinishScheduleImportPreview = {
+  readonly workbookId: string
+  readonly workbookTitle: string
+  readonly workbookProjectNumber: string | null
+  readonly compassProjectNumber: string | null
+  readonly projectMatch: "match" | "mismatch" | "unknown"
+  readonly roomCount: number
+  readonly selectionCount: number
+  readonly warnings: readonly string[]
+}
+
+export type ProjectFinishScheduleImportResult =
+  | {
+      readonly success: true
+      readonly preview: ProjectFinishScheduleImportPreview
+    }
+  | { readonly success: false; readonly error: string }
+
+export type ApplyProjectFinishScheduleImportResult =
+  | {
+      readonly success: true
+      readonly createdCount: number
+      readonly updatedCount: number
+      readonly removedCount: number
+      readonly conflictCount: number
+      readonly staleCount: number
+      readonly roomCount: number
+    }
+  | { readonly success: false; readonly error: string }
+
 const PROJECT_SELECTION_STATUSES: readonly ProjectSelectionStatus[] = [
   "needed",
   "proposed",
@@ -227,6 +271,193 @@ async function verifyProjectAccess(
   }
 
   return db
+}
+
+type FinishScheduleImportAccess = {
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string
+  readonly projectNumber: string | null
+  readonly googleEmail: string
+  readonly client: SheetsClient
+}
+
+async function finishScheduleImportAccess(
+  projectId: string
+): Promise<FinishScheduleImportAccess> {
+  const user = await requireAuth()
+  await requireFeaturePermission(user, "finish-selections", "update")
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const projectRows = await db
+    .select({ projectNumber: projects.projectNumber })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.id, projectId),
+        eq(projects.organizationId, organizationId)
+      )
+    )
+    .limit(1)
+  const project = projectRows[0]
+  if (!project) throw new Error("Project not found")
+
+  const authRows = await db
+    .select()
+    .from(googleAuth)
+    .where(eq(googleAuth.organizationId, organizationId))
+    .limit(1)
+  const auth = authRows[0]
+  if (!auth) throw new Error("Google Workspace service account is not connected.")
+
+  const config = getGoogleConfig(env)
+  const keyJson = await decrypt(
+    auth.serviceAccountKeyEncrypted,
+    config.encryptionKey,
+    getGoogleCryptoSalt()
+  )
+  return {
+    db,
+    organizationId,
+    projectNumber: project.projectNumber,
+    googleEmail: user.googleEmail ?? user.email,
+    client: new SheetsClient(parseServiceAccountKey(keyJson)),
+  }
+}
+
+type LoadedFinishSchedule = {
+  readonly workbookId: string
+  readonly workbookTitle: string
+  readonly parsed: ParsedFinishSchedule
+}
+
+function quotedSheetRange(sheetTitle: string, range: string): string {
+  return `'${sheetTitle.replace(/'/g, "''")}'!${range}`
+}
+
+async function loadFinishSchedule(
+  access: FinishScheduleImportAccess,
+  workbookUrl: string
+): Promise<LoadedFinishSchedule> {
+  const workbookId = spreadsheetIdFromUrl(workbookUrl)
+  if (!workbookId) throw new Error("Enter a valid Google Sheets workbook URL.")
+  const metadata = await access.client.getSpreadsheetMetadata(
+    access.googleEmail,
+    workbookId
+  )
+  const coverSheet = metadata.sheets.find(
+    (sheet) => sheet.title.trim().toLowerCase() === "cover page"
+  )
+  const roomMetadata = metadata.sheets.filter((sheet) => {
+    const title = sheet.title.trim().toLowerCase()
+    return !sheet.hidden && title !== "cover page" && title !== "_validation"
+  })
+  const coverPageRows = coverSheet
+    ? await access.client.getValues(access.googleEmail, {
+        spreadsheetId: workbookId,
+        range: quotedSheetRange(coverSheet.title, "A:K"),
+        valueRenderOption: "UNFORMATTED_VALUE",
+      })
+    : []
+  const roomSheets = []
+  for (const sheet of roomMetadata) {
+    const values = await access.client.getValues(access.googleEmail, {
+      spreadsheetId: workbookId,
+      range: quotedSheetRange(sheet.title, "A:G"),
+      valueRenderOption: "UNFORMATTED_VALUE",
+    })
+    roomSheets.push({
+      sheetId: sheet.sheetId,
+      title: sheet.title,
+      index: sheet.index,
+      values,
+    })
+  }
+
+  return {
+    workbookId,
+    workbookTitle: metadata.title,
+    parsed: parseFinishScheduleWorkbook({ coverPageRows, roomSheets }),
+  }
+}
+
+function finishSchedulePreview(
+  loaded: LoadedFinishSchedule,
+  compassProjectNumber: string | null
+): ProjectFinishScheduleImportPreview {
+  const workbookProjectNumber = loaded.parsed.projectNumber
+  const normalizedWorkbook = normalizeProjectNumber(workbookProjectNumber)
+  const normalizedCompass = normalizeProjectNumber(compassProjectNumber)
+  const projectMatch =
+    !normalizedWorkbook || !normalizedCompass
+      ? "unknown"
+      : normalizedWorkbook === normalizedCompass
+        ? "match"
+        : "mismatch"
+  const warnings = [...loaded.parsed.warnings]
+  if (projectMatch === "mismatch") {
+    warnings.push(
+      `Workbook project ${workbookProjectNumber ?? "unknown"} does not match Compass project ${compassProjectNumber ?? "unknown"}.`
+    )
+  }
+  if (projectMatch === "unknown") {
+    warnings.push("The workbook and Compass project numbers could not both be verified.")
+  }
+  return {
+    workbookId: loaded.workbookId,
+    workbookTitle: loaded.workbookTitle,
+    workbookProjectNumber,
+    compassProjectNumber,
+    projectMatch,
+    roomCount: loaded.parsed.rooms.length,
+    selectionCount: loaded.parsed.selections.length,
+    warnings,
+  }
+}
+
+type ImportedSelectionSourceValues = {
+  readonly sourceSheetName: string
+  readonly roomName: string
+  readonly roomType: string | null
+  readonly category: string
+  readonly name: string
+  readonly description: string | null
+  readonly quantity: number | null
+  readonly manufacturer: string | null
+  readonly model: string | null
+  readonly colorFinish: string | null
+  readonly notes: string | null
+  readonly sortOrder: number
+  readonly lastSyncedAt: string
+  readonly updatedAt: string
+}
+
+function importedSelectionIdentity(input: {
+  readonly sourceSheetName: string | null
+  readonly category: string
+  readonly name: string
+}): string {
+  return [input.sourceSheetName ?? "", input.category, input.name]
+    .map((value) => value.trim().toLowerCase().replace(/[^a-z0-9]+/g, " "))
+    .join("|")
+}
+
+function importedSourceChanged(
+  existing: typeof projectFinishSelections.$inferSelect,
+  incoming: ImportedSelectionSourceValues
+): boolean {
+  return (
+    existing.roomName !== incoming.roomName ||
+    existing.roomType !== incoming.roomType ||
+    existing.category !== incoming.category ||
+    existing.name !== incoming.name ||
+    existing.description !== incoming.description ||
+    existing.quantity !== incoming.quantity ||
+    existing.manufacturer !== incoming.manufacturer ||
+    existing.model !== incoming.model ||
+    existing.colorFinish !== incoming.colorFinish ||
+    existing.notes !== incoming.notes
+  )
 }
 
 function cleanText(value: string | null): string | null {
@@ -456,6 +687,278 @@ export async function getProjectSelections(
   ])
 
   return summarizeSelections(roomRows, selectionRows.map(toSelectionItem))
+}
+
+export async function previewProjectFinishScheduleImport(
+  projectId: string,
+  workbookUrl: string
+): Promise<ProjectFinishScheduleImportResult> {
+  try {
+    const access = await finishScheduleImportAccess(projectId)
+    const loaded = await loadFinishSchedule(access, workbookUrl)
+    return {
+      success: true,
+      preview: finishSchedulePreview(loaded, access.projectNumber),
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to preview the finish schedule workbook.",
+    }
+  }
+}
+
+export async function importProjectFinishSchedule(
+  projectId: string,
+  workbookUrl: string
+): Promise<ApplyProjectFinishScheduleImportResult> {
+  try {
+    const access = await finishScheduleImportAccess(projectId)
+    const loaded = await loadFinishSchedule(access, workbookUrl)
+    const preview = finishSchedulePreview(loaded, access.projectNumber)
+    if (preview.projectMatch !== "match") {
+      throw new Error(
+        preview.projectMatch === "mismatch"
+          ? `This workbook belongs to ${preview.workbookProjectNumber ?? "another project"}, not ${preview.compassProjectNumber ?? "this Compass project"}.`
+          : "Add matching project numbers to the workbook and Compass before importing."
+      )
+    }
+    if (loaded.parsed.selections.length === 0) {
+      throw new Error("The workbook contains no finish selections to import.")
+    }
+
+    const now = new Date().toISOString()
+    const existingRooms = await access.db
+      .select()
+      .from(projectFinishSelectionRooms)
+      .where(
+        and(
+          eq(projectFinishSelectionRooms.projectId, projectId),
+          eq(projectFinishSelectionRooms.sourceSystem, "google_sheets"),
+          eq(projectFinishSelectionRooms.sourceWorkbookId, loaded.workbookId)
+        )
+      )
+    const roomsBySheetId = new Map(
+      existingRooms
+        .filter((room) => room.sourceSheetId !== null)
+        .map((room) => [room.sourceSheetId, room])
+    )
+    const importedSheetIds = new Set(
+      loaded.parsed.rooms.map((room) => String(room.sheetId))
+    )
+    for (const room of loaded.parsed.rooms) {
+      const sourceSheetId = String(room.sheetId)
+      const existing = roomsBySheetId.get(sourceSheetId)
+      if (existing) {
+        await access.db
+          .update(projectFinishSelectionRooms)
+          .set({
+            sourceSheetName: room.sheetName,
+            roomName: room.roomName,
+            roomType: room.roomType,
+            sortOrder: room.sortOrder,
+            active: true,
+            updatedAt: now,
+          })
+          .where(eq(projectFinishSelectionRooms.id, existing.id))
+      } else {
+        await access.db.insert(projectFinishSelectionRooms).values({
+          id: crypto.randomUUID(),
+          projectId,
+          sourceSystem: "google_sheets",
+          sourceWorkbookId: loaded.workbookId,
+          sourceSheetId,
+          sourceSheetName: room.sheetName,
+          roomName: room.roomName,
+          roomType: room.roomType,
+          sortOrder: room.sortOrder,
+          active: true,
+          createdAt: now,
+          updatedAt: now,
+        })
+      }
+    }
+    for (const staleRoom of existingRooms) {
+      if (
+        staleRoom.sourceSheetId !== null &&
+        importedSheetIds.has(staleRoom.sourceSheetId)
+      ) {
+        continue
+      }
+      await access.db
+        .update(projectFinishSelectionRooms)
+        .set({ active: false, updatedAt: now })
+        .where(eq(projectFinishSelectionRooms.id, staleRoom.id))
+    }
+
+    const existingSelections = await access.db
+      .select()
+      .from(projectFinishSelections)
+      .where(
+        and(
+          eq(projectFinishSelections.projectId, projectId),
+          eq(projectFinishSelections.sourceSystem, "google_sheets"),
+          eq(projectFinishSelections.sourceWorkbookId, loaded.workbookId)
+        )
+      )
+    const selectionsBySourceRecordId = new Map(
+      existingSelections
+        .filter((selection) => selection.sourceRecordId !== null)
+        .map((selection) => [selection.sourceRecordId, selection])
+    )
+    const selectionsByIdentity = new Map<
+      string,
+      (typeof projectFinishSelections.$inferSelect)[]
+    >()
+    for (const selection of existingSelections) {
+      const identity = importedSelectionIdentity(selection)
+      const matches = selectionsByIdentity.get(identity) ?? []
+      matches.push(selection)
+      selectionsByIdentity.set(identity, matches)
+    }
+    const incomingSelectionIdentities = new Set(
+      loaded.parsed.selections.map((selection) =>
+        importedSelectionIdentity({
+          sourceSheetName: selection.sheetName,
+          category: selection.category,
+          name: selection.name,
+        })
+      )
+    )
+    const usedSelectionIds = new Set<string>()
+    let createdCount = 0
+    let updatedCount = 0
+    let removedCount = 0
+    let conflictCount = 0
+
+    for (const selection of loaded.parsed.selections) {
+      const sourceRecordId = `${loaded.workbookId}:${selection.sheetId}:${selection.sourceRowNumber}`
+      const identity = importedSelectionIdentity({
+        sourceSheetName: selection.sheetName,
+        category: selection.category,
+        name: selection.name,
+      })
+      const exactMatch = selectionsBySourceRecordId.get(sourceRecordId)
+      const exactIdentity = exactMatch
+        ? importedSelectionIdentity(exactMatch)
+        : null
+      const stableMatch = (selectionsByIdentity.get(identity) ?? []).find(
+        (candidate) => !usedSelectionIds.has(candidate.id)
+      )
+      const unusedExactMatch =
+        exactMatch && !usedSelectionIds.has(exactMatch.id) ? exactMatch : null
+      // A semantic match at another row indicates an insertion/deletion/reorder.
+      // If no such match exists and the old identity disappeared, this row was renamed in place.
+      const existing =
+        unusedExactMatch && exactIdentity === identity
+          ? unusedExactMatch
+          : stableMatch ??
+            (unusedExactMatch &&
+            exactIdentity !== null &&
+            !incomingSelectionIdentities.has(exactIdentity)
+              ? unusedExactMatch
+              : null)
+      const sourceValues: ImportedSelectionSourceValues = {
+        sourceSheetName: selection.sheetName,
+        roomName: selection.roomName,
+        roomType: selection.roomType,
+        category: selection.category,
+        name: selection.name,
+        description: selection.description,
+        quantity: selection.quantity,
+        manufacturer: selection.manufacturer,
+        model: selection.model,
+        colorFinish: selection.colorFinish,
+        notes: selection.notes,
+        sortOrder: selection.sortOrder,
+        lastSyncedAt: now,
+        updatedAt: now,
+      }
+      if (!existing) {
+        await access.db.insert(projectFinishSelections).values({
+          id: crypto.randomUUID(),
+          projectId,
+          sourceSystem: "google_sheets",
+          sourceRecordId,
+          sourceWorkbookId: loaded.workbookId,
+          ...sourceValues,
+          status: "needed",
+          ownerVisible: false,
+          ownerApproved: false,
+          syncStatus: "imported",
+          createdAt: now,
+        })
+        createdCount += 1
+        continue
+      }
+      usedSelectionIds.add(existing.id)
+      if (existing.syncStatus !== "imported") {
+        conflictCount += 1
+        continue
+      }
+      const approvalNeedsReview =
+        (existing.ownerApproved || existing.status === "approved") &&
+        importedSourceChanged(existing, sourceValues)
+      await access.db
+        .update(projectFinishSelections)
+        .set({
+          ...sourceValues,
+          sourceRecordId,
+          status: approvalNeedsReview ? "owner_review" : existing.status,
+          ownerApproved: approvalNeedsReview ? false : existing.ownerApproved,
+          approvedBy: approvalNeedsReview ? null : existing.approvedBy,
+          approvedAt: approvalNeedsReview ? null : existing.approvedAt,
+          syncStatus: approvalNeedsReview
+            ? "selection_change_review"
+            : "imported",
+        })
+        .where(eq(projectFinishSelections.id, existing.id))
+      updatedCount += 1
+      if (approvalNeedsReview) conflictCount += 1
+    }
+
+    const staleSelections = existingSelections.filter(
+      (selection) => !usedSelectionIds.has(selection.id)
+    )
+    for (const stale of staleSelections) {
+      const canRemoveUntouchedSourceRow =
+        stale.syncStatus === "imported" &&
+        !stale.ownerApproved &&
+        stale.status === "needed"
+      if (!canRemoveUntouchedSourceRow) {
+        conflictCount += 1
+        continue
+      }
+      await access.db
+        .delete(projectFinishSelections)
+        .where(eq(projectFinishSelections.id, stale.id))
+      removedCount += 1
+    }
+    const staleCount = staleSelections.length - removedCount
+
+    revalidatePath(`/dashboard/projects/${projectId}/selections`)
+    revalidatePath(`/dashboard/projects/${projectId}`)
+    return {
+      success: true,
+      createdCount,
+      updatedCount,
+      removedCount,
+      conflictCount,
+      staleCount,
+      roomCount: loaded.parsed.rooms.length,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to import the finish schedule workbook.",
+    }
+  }
 }
 
 function optionFromLabel(label: string): ProjectSelectionOption {
@@ -895,7 +1398,9 @@ export async function updateProjectSelection(
         syncStatus:
           existing.status === "approved" && changes.length > 0
             ? "selection_change_review"
-            : existing.syncStatus,
+            : existing.sourceSystem === "google_sheets" && changes.length > 0
+              ? "manual_edit"
+              : existing.syncStatus,
         updatedAt: now,
       })
       .where(

--- a/src/components/projects/project-finish-schedule-import-sheet.tsx
+++ b/src/components/projects/project-finish-schedule-import-sheet.tsx
@@ -1,0 +1,203 @@
+"use client"
+
+import * as React from "react"
+import { useRouter } from "next/navigation"
+import { IconFileImport, IconRefresh } from "@tabler/icons-react"
+
+import {
+  importProjectFinishSchedule,
+  previewProjectFinishScheduleImport,
+  type ProjectFinishScheduleImportPreview,
+} from "@/app/actions/project-selections"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
+
+type ImportState =
+  | { readonly kind: "idle" }
+  | { readonly kind: "previewing" }
+  | { readonly kind: "ready"; readonly preview: ProjectFinishScheduleImportPreview }
+  | { readonly kind: "importing"; readonly preview: ProjectFinishScheduleImportPreview }
+  | {
+      readonly kind: "complete"
+      readonly message: string
+      readonly preview: ProjectFinishScheduleImportPreview
+    }
+  | { readonly kind: "error"; readonly message: string }
+
+export function ProjectFinishScheduleImportSheet({
+  projectId,
+}: {
+  readonly projectId: string
+}): React.ReactElement {
+  const router = useRouter()
+  const [open, setOpen] = React.useState(false)
+  const [workbookUrl, setWorkbookUrl] = React.useState("")
+  const [state, setState] = React.useState<ImportState>({ kind: "idle" })
+
+  function changeWorkbookUrl(value: string): void {
+    setWorkbookUrl(value)
+    setState({ kind: "idle" })
+  }
+
+  async function preview(): Promise<void> {
+    setState({ kind: "previewing" })
+    const result = await previewProjectFinishScheduleImport(projectId, workbookUrl)
+    if (!result.success) {
+      setState({ kind: "error", message: result.error })
+      return
+    }
+    setState({ kind: "ready", preview: result.preview })
+  }
+
+  async function applyImport(previewValue: ProjectFinishScheduleImportPreview): Promise<void> {
+    setState({ kind: "importing", preview: previewValue })
+    const result = await importProjectFinishSchedule(projectId, workbookUrl)
+    if (!result.success) {
+      setState({ kind: "error", message: result.error })
+      return
+    }
+    const details = [
+      `${result.createdCount} added`,
+      `${result.updatedCount} refreshed`,
+      result.removedCount > 0 ? `${result.removedCount} removed from source` : null,
+      result.conflictCount > 0 ? `${result.conflictCount} preserved for review` : null,
+      result.staleCount > 0 ? `${result.staleCount} stale source rows retained` : null,
+    ].filter((value) => value !== null)
+    setState({
+      kind: "complete",
+      message: details.join(" · "),
+      preview: previewValue,
+    })
+    router.refresh()
+  }
+
+  const activePreview =
+    state.kind === "ready" ||
+    state.kind === "importing" ||
+    state.kind === "complete"
+      ? state.preview
+      : null
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button type="button" variant="outline">
+          <IconFileImport className="size-4" />
+          Import workbook
+        </Button>
+      </SheetTrigger>
+      <SheetContent className="w-full overflow-y-auto sm:max-w-xl">
+        <SheetHeader>
+          <SheetTitle>Import finish schedule</SheetTitle>
+          <SheetDescription>
+            Preview a project workbook, verify its project number, then bring its
+            room selections into Compass.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="space-y-6 px-4 pb-6">
+          <label className="block space-y-2">
+            <span className="text-xs font-medium text-muted-foreground">
+              Google Sheets workbook
+            </span>
+            <Input
+              type="url"
+              value={workbookUrl}
+              placeholder="https://docs.google.com/spreadsheets/d/..."
+              className="rounded-none border-x-0 border-t-0 px-0 shadow-none"
+              onChange={(event) => changeWorkbookUrl(event.target.value)}
+            />
+          </label>
+
+          <Button
+            type="button"
+            variant="outline"
+            disabled={!workbookUrl.trim() || state.kind === "previewing" || state.kind === "importing"}
+            onClick={preview}
+          >
+            {state.kind === "previewing" ? (
+              <IconRefresh className="size-4 animate-spin" />
+            ) : (
+              <IconFileImport className="size-4" />
+            )}
+            Preview workbook
+          </Button>
+
+          {activePreview && (
+            <section className="border-y py-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="font-semibold">{activePreview.workbookTitle}</p>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {activePreview.roomCount} rooms · {activePreview.selectionCount} selections
+                  </p>
+                </div>
+                <Badge
+                  variant={activePreview.projectMatch === "match" ? "secondary" : "destructive"}
+                >
+                  {activePreview.projectMatch === "match"
+                    ? "Project verified"
+                    : activePreview.projectMatch === "mismatch"
+                      ? "Project mismatch"
+                      : "Project unverified"}
+                </Badge>
+              </div>
+              <dl className="mt-4 grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+                <dt className="text-muted-foreground">Workbook</dt>
+                <dd>{activePreview.workbookProjectNumber ?? "Not found"}</dd>
+                <dt className="text-muted-foreground">Compass</dt>
+                <dd>{activePreview.compassProjectNumber ?? "Not found"}</dd>
+              </dl>
+              {activePreview.warnings.length > 0 && (
+                <ul className="mt-4 list-disc space-y-1 pl-5 text-sm text-amber-800 dark:text-amber-300">
+                  {activePreview.warnings.map((warning) => (
+                    <li key={warning}>{warning}</li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          )}
+
+          {state.kind === "error" && (
+            <p className="text-sm text-destructive" role="alert">
+              {state.message}
+            </p>
+          )}
+          {state.kind === "complete" && (
+            <p className="text-sm text-emerald-700 dark:text-emerald-300" role="status">
+              Import complete: {state.message}
+            </p>
+          )}
+
+          {activePreview && (
+            <Button
+              type="button"
+              disabled={
+                activePreview.projectMatch !== "match" ||
+                activePreview.selectionCount === 0 ||
+                state.kind === "importing"
+              }
+              onClick={() => applyImport(activePreview)}
+            >
+              {state.kind === "importing" ? (
+                <IconRefresh className="size-4 animate-spin" />
+              ) : (
+                <IconFileImport className="size-4" />
+              )}
+              Import into Compass
+            </Button>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/components/projects/project-selections-workspace.tsx
+++ b/src/components/projects/project-selections-workspace.tsx
@@ -16,6 +16,7 @@ import {
   type ProjectSelectionsSummary,
 } from "@/app/actions/project-selections"
 import { ProjectSelectionCreateForm } from "@/components/projects/project-selection-create-form"
+import { ProjectFinishScheduleImportSheet } from "@/components/projects/project-finish-schedule-import-sheet"
 import { ProjectSelectionDeleteButton } from "@/components/projects/project-selection-delete-button"
 import { ProjectSelectionEditForm } from "@/components/projects/project-selection-edit-form"
 import { ProjectSelectionShareActions } from "@/components/projects/project-selection-share-actions"
@@ -507,8 +508,9 @@ function EmptySelectionsState({
       <p className="mt-1 text-sm text-muted-foreground">
         Add the first room-based selection or import a finish schedule workbook.
       </p>
-      <div className="mt-5 flex justify-center">
+      <div className="mt-5 flex flex-wrap justify-center gap-2">
         <ProjectSelectionCreateForm projectId={projectId} options={options} />
+        <ProjectFinishScheduleImportSheet projectId={projectId} />
       </div>
     </div>
   )
@@ -710,7 +712,10 @@ export function ProjectSelectionsWorkspace({
           projectLabel={projectLabel}
           summary={filteredSummary}
         />
-        <ProjectSelectionCreateForm projectId={projectId} options={options} />
+        <div className="flex flex-wrap gap-2">
+          <ProjectFinishScheduleImportSheet projectId={projectId} />
+          <ProjectSelectionCreateForm projectId={projectId} options={options} />
+        </div>
       </div>
 
       {filteredSummary.rooms.length === 0 ? (

--- a/src/lib/google/client/sheets-client.ts
+++ b/src/lib/google/client/sheets-client.ts
@@ -9,10 +9,88 @@ type SheetsValueRenderOption =
   | "UNFORMATTED_VALUE"
   | "FORMULA"
 
+export type GoogleSheetMetadata = {
+  readonly sheetId: number
+  readonly title: string
+  readonly index: number
+  readonly hidden: boolean
+  readonly rowCount: number | null
+}
+
+export type GoogleSpreadsheetMetadata = {
+  readonly title: string
+  readonly sheets: readonly GoogleSheetMetadata[]
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return isObjectRecord(value) ? value : null
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" ? value : null
+}
+
 export class SheetsClient {
   constructor(
     private readonly serviceAccountKey: ServiceAccountKey
   ) {}
+
+  async getSpreadsheetMetadata(
+    userEmail: string,
+    spreadsheetId: string
+  ): Promise<GoogleSpreadsheetMetadata> {
+    const token = await getAccessToken(this.serviceAccountKey, userEmail)
+    const params = new URLSearchParams({
+      fields:
+        "properties.title,sheets.properties(sheetId,title,index,hidden,gridProperties.rowCount)",
+    })
+    const response = await fetch(
+      `${GOOGLE_SHEETS_API}/${spreadsheetId}?${params.toString()}`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    )
+
+    if (!response.ok) {
+      const body = await response.text()
+      throw new Error(
+        `Google Sheets API error (${response.status}): ${body.slice(0, 500)}`
+      )
+    }
+
+    const payload = objectValue(await response.json())
+    const spreadsheetProperties = objectValue(payload?.properties)
+    const sheetValues = Array.isArray(payload?.sheets) ? payload.sheets : []
+    const sheets = sheetValues.flatMap((value) => {
+      const sheet = objectValue(value)
+      const properties = objectValue(sheet?.properties)
+      const gridProperties = objectValue(properties?.gridProperties)
+      const sheetId = numberValue(properties?.sheetId)
+      const title = stringValue(properties?.title)
+      const index = numberValue(properties?.index)
+      if (sheetId === null || title === null || index === null) return []
+      return [
+        {
+          sheetId,
+          title,
+          index,
+          hidden: properties?.hidden === true,
+          rowCount: numberValue(gridProperties?.rowCount),
+        },
+      ]
+    })
+
+    return {
+      title: stringValue(spreadsheetProperties?.title) ?? "Untitled workbook",
+      sheets,
+    }
+  }
 
   async getValues(
     userEmail: string,

--- a/src/lib/selections/google-finish-schedule-import.ts
+++ b/src/lib/selections/google-finish-schedule-import.ts
@@ -1,0 +1,197 @@
+export type FinishScheduleSheet = {
+  readonly sheetId: number
+  readonly title: string
+  readonly index: number
+  readonly values: ReadonlyArray<ReadonlyArray<unknown>>
+}
+
+export type FinishScheduleRoom = {
+  readonly sheetId: number
+  readonly sheetName: string
+  readonly roomName: string
+  readonly roomType: string | null
+  readonly sortOrder: number
+}
+
+export type FinishScheduleSelection = {
+  readonly sourceRowNumber: number
+  readonly sheetId: number
+  readonly sheetName: string
+  readonly roomName: string
+  readonly roomType: string | null
+  readonly category: string
+  readonly name: string
+  readonly description: string | null
+  readonly quantity: number | null
+  readonly manufacturer: string | null
+  readonly model: string | null
+  readonly colorFinish: string | null
+  readonly notes: string | null
+  readonly sortOrder: number
+}
+
+export type ParsedFinishSchedule = {
+  readonly projectNumber: string | null
+  readonly rooms: readonly FinishScheduleRoom[]
+  readonly selections: readonly FinishScheduleSelection[]
+  readonly warnings: readonly string[]
+}
+
+function text(value: unknown): string | null {
+  if (typeof value === "string") {
+    const cleaned = value.trim()
+    return cleaned.length > 0 ? cleaned : null
+  }
+  if (typeof value === "number" && Number.isFinite(value)) return String(value)
+  return null
+}
+
+function normalizedLabel(value: unknown): string {
+  return text(value)?.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim() ?? ""
+}
+
+function quantity(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  const cleaned = text(value)?.replace(/,/g, "")
+  if (!cleaned) return null
+  const match = /^-?\d+(?:\.\d+)?/.exec(cleaned)
+  if (!match) return null
+  const parsed = Number(match[0])
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function isHeaderRow(row: ReadonlyArray<unknown>): boolean {
+  return normalizedLabel(row[0]) === "name" &&
+    normalizedLabel(row[1]).includes("description")
+}
+
+function isCategoryRow(row: ReadonlyArray<unknown>): boolean {
+  const first = text(row[0])
+  if (!first || first.length > 100) return false
+  if (row.slice(1).some((value) => text(value) !== null)) return false
+  if (!/[A-Z]/.test(first)) return false
+  return first === first.toUpperCase()
+}
+
+function projectNumberFromCoverPage(
+  rows: ReadonlyArray<ReadonlyArray<unknown>>
+): string | null {
+  for (const row of rows) {
+    for (let index = 0; index < row.length; index += 1) {
+      const label = normalizedLabel(row[index])
+      if (!["project number", "project no", "job number", "job no"].includes(label)) {
+        continue
+      }
+      const adjacent = text(row[index + 1])
+      if (adjacent) return adjacent
+    }
+  }
+
+  for (const row of rows.slice(0, 20)) {
+    for (const value of row) {
+      const candidate = text(value)
+      if (candidate && /^[A-Z]-\d{2,4}(?:-\d{1,6})?$/i.test(candidate)) {
+        return candidate
+      }
+    }
+  }
+  return null
+}
+
+function roomTypesFromCoverPage(
+  rows: ReadonlyArray<ReadonlyArray<unknown>>
+): ReadonlyMap<string, string> {
+  const result = new Map<string, string>()
+  let roomColumn = -1
+  let typeColumn = -1
+  let headerRow = -1
+
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+    const row = rows[rowIndex] ?? []
+    for (let column = 0; column < row.length; column += 1) {
+      const label = normalizedLabel(row[column])
+      if (["room", "room name", "area"].includes(label)) roomColumn = column
+      if (["type", "room type", "area type"].includes(label)) typeColumn = column
+    }
+    if (roomColumn >= 0 && typeColumn >= 0) {
+      headerRow = rowIndex
+      break
+    }
+    roomColumn = -1
+    typeColumn = -1
+  }
+
+  if (headerRow < 0) return result
+  for (const row of rows.slice(headerRow + 1)) {
+    const roomName = text(row[roomColumn])
+    const roomType = text(row[typeColumn])
+    if (roomName && roomType) result.set(roomName.toLowerCase(), roomType)
+  }
+  return result
+}
+
+export function normalizeProjectNumber(value: string | null): string | null {
+  const normalized = value?.toUpperCase().replace(/[^A-Z0-9]/g, "") ?? ""
+  return normalized.length > 0 ? normalized : null
+}
+
+export function parseFinishScheduleWorkbook(input: {
+  readonly coverPageRows: ReadonlyArray<ReadonlyArray<unknown>>
+  readonly roomSheets: readonly FinishScheduleSheet[]
+}): ParsedFinishSchedule {
+  const warnings: string[] = []
+  const projectNumber = projectNumberFromCoverPage(input.coverPageRows)
+  const roomTypes = roomTypesFromCoverPage(input.coverPageRows)
+  const rooms: FinishScheduleRoom[] = []
+  const selections: FinishScheduleSelection[] = []
+
+  for (const sheet of [...input.roomSheets].sort((left, right) => left.index - right.index)) {
+    const roomName = sheet.title.trim()
+    if (!roomName) continue
+    const roomType = roomTypes.get(roomName.toLowerCase()) ?? null
+    rooms.push({
+      sheetId: sheet.sheetId,
+      sheetName: sheet.title,
+      roomName,
+      roomType,
+      sortOrder: sheet.index,
+    })
+
+    let category = "Uncategorized"
+    let selectionSortOrder = 0
+    for (let rowIndex = 0; rowIndex < sheet.values.length; rowIndex += 1) {
+      const row = sheet.values[rowIndex] ?? []
+      if (isHeaderRow(row)) continue
+      if (isCategoryRow(row)) {
+        category = text(row[0]) ?? category
+        continue
+      }
+      const name = text(row[0])
+      if (!name) continue
+      selectionSortOrder += 1
+      selections.push({
+        sourceRowNumber: rowIndex + 1,
+        sheetId: sheet.sheetId,
+        sheetName: sheet.title,
+        roomName,
+        roomType,
+        category,
+        name,
+        description: text(row[1]),
+        quantity: quantity(row[2]),
+        manufacturer: text(row[3]),
+        model: text(row[4]),
+        colorFinish: text(row[5]),
+        notes: text(row[6]),
+        sortOrder: selectionSortOrder,
+      })
+    }
+    if (selectionSortOrder === 0) {
+      warnings.push(`${sheet.title} contains no importable selection rows.`)
+    }
+  }
+
+  if (!projectNumber) warnings.push("The workbook cover page has no project number.")
+  if (rooms.length === 0) warnings.push("The workbook has no visible room sheets.")
+  return { projectNumber, rooms, selections, warnings }
+}


### PR DESCRIPTION
## What changed

- adds a Compass drawer to preview and import Google finish-schedule workbooks
- verifies the workbook project number before writing any records
- imports visible room tabs as editable Compass rooms and selections
- reconciles row moves, insertions, deletions, and in-place renames idempotently
- preserves manual/workflow changes and resets changed approved selections to owner review
- extends the Google Sheets client with bounded metadata discovery

## Why

Existing Google-generated finish schedules were only partially connected to Compass. Litten had a one-time import, while Mitchell and future projects had no reliable path from the workbook into editable Compass selections.

## Validation

- `bun test __tests__/google-finish-schedule-import.test.ts`
- targeted ESLint
- `tsc --noEmit`
- `bun run build`
- autoreview clean: no accepted/actionable findings
