### PR TITLE
feat(projects): add native project intake

### DIFF
--- a/__tests__/google-project-intake-tracker.test.ts
+++ b/__tests__/google-project-intake-tracker.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  allocateProjectNumber,
+  buildProjectTrackerRow,
+  locateProjectTrackerLayout,
+  type ProjectIntakeTrackerInput,
+} from "@/lib/google/project-intake-tracker"
+
+const PROJECT: ProjectIntakeTrackerInput = {
+  department: "O",
+  projectName: "Mitchell Residence",
+  clientName: "Dan and Jane Mitchell",
+  companyName: null,
+  clientFirstName: "Dan",
+  clientLastName: "Mitchell",
+  contactPhone: "970-555-0100",
+  contactEmail: "dan@example.com",
+  streetNumber: "33 A",
+  streetName: "Mitchell Lane",
+  cityStateZip: "Durango, CO 81301",
+  billingAddress: "PO Box 22",
+  assignedTo: "Wes Jones",
+  referredBy: "Existing client",
+  notes: "Call before site visit",
+  intakeDate: "2026-08-05",
+}
+
+describe("Google Project Lead Tracking intake", () => {
+  it("locates a shifted tracker header and allocates the next department number", () => {
+    const rows = [
+      ["Project Lead Tracking"],
+      [],
+      ["PROJECT NUMBER", "Type", "ACTIVE PROJECTS"],
+      ["O-208-14", "O", "Prior project"],
+      ["H-994-82", "H", "HPS project"],
+      ["O-210-17", "O", "Latest ORC project"],
+    ]
+    const layout = locateProjectTrackerLayout(rows)
+
+    expect(layout).not.toBeNull()
+    if (!layout) return
+    expect(layout.headerRowNumber).toBe(3)
+    expect(
+      allocateProjectNumber({
+        department: "O",
+        streetNumber: PROJECT.streetNumber,
+        rows,
+        layout,
+      })
+    ).toBe("O-211-33A")
+  })
+
+  it("maps values by header name so tracker column moves remain safe", () => {
+    const layout = locateProjectTrackerLayout([
+      [
+        "Notes",
+        "CLIENT FIRST NAME",
+        "ACTIVE PROJECTS",
+        "PROJECT NUMBER",
+        "CONTACT EMAIL",
+        "ASSIGNED TO",
+        "INTAKE DATE",
+      ],
+    ])
+    expect(layout).not.toBeNull()
+    if (!layout) return
+
+    expect(
+      buildProjectTrackerRow({
+        layout,
+        project: PROJECT,
+        projectNumber: "O-211-33A",
+      })
+    ).toEqual([
+      "Call before site visit",
+      "Dan",
+      "Mitchell Residence",
+      "O-211-33A",
+      "dan@example.com",
+      "Wes Jones",
+      "2026-08-05",
+    ])
+  })
+
+  it("uses a safe street placeholder when a lead has no street number yet", () => {
+    const rows = [["PROJECT NUMBER"], ["D-27-45"]]
+    const layout = locateProjectTrackerLayout(rows)
+    expect(layout).not.toBeNull()
+    if (!layout) return
+
+    expect(
+      allocateProjectNumber({
+        department: "D",
+        streetNumber: null,
+        rows,
+        layout,
+      })
+    ).toBe("D-28-00")
+  })
+
+  it("advances past a Compass reservation that is not in Google yet", () => {
+    const rows = [["PROJECT NUMBER"], ["O-210-17"]]
+    const layout = locateProjectTrackerLayout(rows)
+    expect(layout).not.toBeNull()
+    if (!layout) return
+
+    expect(
+      allocateProjectNumber({
+        department: "O",
+        streetNumber: "55",
+        rows,
+        layout,
+        reservedProjectNumbers: ["O-211-33", "H-995-20"],
+      })
+    ).toBe("O-212-55")
+  })
+})

--- a/drizzle/0091_project_number_reservations.sql
+++ b/drizzle/0091_project_number_reservations.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `project_number_reservations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`project_id` text NOT NULL,
+	`department` text NOT NULL,
+	`sequence` integer NOT NULL,
+	`project_number` text NOT NULL,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `project_number_reservations_org_department_sequence_unique` ON `project_number_reservations` (`organization_id`,`department`,`sequence`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `project_number_reservations_org_number_unique` ON `project_number_reservations` (`organization_id`,`project_number`);

--- a/src/app/actions/projects.ts
+++ b/src/app/actions/projects.ts
@@ -2,10 +2,34 @@
 
 import { getCloudflareContext } from "@/lib/db"
 import { getDb } from "@/db"
-import { projectExternalLinks, projectMembers, projects } from "@/db/schema"
+import {
+  organizationMembers,
+  projectExternalLinks,
+  projectMembers,
+  projectNumberReservations,
+  projectOperations,
+  projects,
+  users,
+} from "@/db/schema"
+import { googleAuth } from "@/db/schema-google"
 import { and, asc, eq } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { requireAuth } from "@/lib/auth"
+import { decrypt } from "@/lib/crypto"
+import { recordActivityEvent } from "@/lib/activity-log"
+import { SheetsClient } from "@/lib/google/client/sheets-client"
+import {
+  getGoogleConfig,
+  getGoogleCryptoSalt,
+  parseServiceAccountKey,
+} from "@/lib/google/config"
+import {
+  allocateProjectNumber,
+  buildProjectTrackerRow,
+  locateProjectTrackerLayout,
+  type ProjectIntakeDepartment,
+  type ProjectIntakeTrackerInput,
+} from "@/lib/google/project-intake-tracker"
 import { requireOrg } from "@/lib/org-scope"
 import { requirePermission } from "@/lib/permissions"
 import { canUseOrganizationProjectScopeRole } from "@/lib/user-roles"
@@ -54,6 +78,31 @@ type UpdateProjectStatusResult =
   | { readonly success: true }
   | { readonly success: false; readonly error: string }
 
+export type ProjectIntakeAssignee = {
+  readonly id: string
+  readonly name: string
+  readonly email: string
+}
+
+export type CreateProjectIntakeInput = Omit<
+  ProjectIntakeTrackerInput,
+  "intakeDate"
+>
+
+export type CreateProjectIntakeResult =
+  | {
+      readonly success: true
+      readonly id: string
+      readonly projectNumber: string
+      readonly trackerStatus: "written" | "pending"
+      readonly warning: string | null
+    }
+  | { readonly success: false; readonly error: string }
+
+const PROJECT_LEAD_TRACKING_SPREADSHEET_ID =
+  "15DPCjDK9a4b3pkNB7ZdSFtJsSN1q2CyajNUBb40aRkE"
+const PROJECT_LEAD_TRACKING_SHEET = "Highlight Project"
+
 function cleanText(value: string | null): string | null {
   const trimmed = value?.trim() ?? ""
   return trimmed.length > 0 ? trimmed : null
@@ -84,8 +133,399 @@ function departmentPrefix(
   return "unassigned"
 }
 
+function projectSequence(projectNumber: string): number {
+  const match = /^[A-Z]-(\d+)-/i.exec(projectNumber)
+  if (!match) throw new Error("Compass could not reserve the project sequence.")
+  const sequence = Number(match[1])
+  if (!Number.isInteger(sequence)) {
+    throw new Error("Compass could not reserve the project sequence.")
+  }
+  return sequence
+}
+
+function isProjectSequenceConflict(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message.includes("project_number_reservations") ||
+      error.message.toLowerCase().includes("unique constraint"))
+  )
+}
+
+function normalizedIntakeDepartment(
+  value: unknown
+): ProjectIntakeDepartment | null {
+  if (typeof value !== "string") return null
+  const normalized = value.trim().toUpperCase()
+  if (
+    normalized === "O" ||
+    normalized === "H" ||
+    normalized === "N" ||
+    normalized === "D"
+  ) {
+    return normalized
+  }
+  return null
+}
+
 function isProjectStatusValue(value: string): value is ProjectStatusValue {
   return PROJECT_STATUS_VALUES.some((status) => status === value)
+}
+
+function quotedSheetRange(sheetTitle: string, range: string): string {
+  return `'${sheetTitle.replace(/'/g, "''")}'!${range}`
+}
+
+function joinedAddress(input: CreateProjectIntakeInput): string | null {
+  const street = [cleanText(input.streetNumber), cleanText(input.streetName)]
+    .filter((value) => value !== null)
+    .join(" ")
+  return [street || null, cleanText(input.cityStateZip)]
+    .filter((value) => value !== null)
+    .join(", ") || null
+}
+
+function intakeClientName(input: CreateProjectIntakeInput): string | null {
+  const explicit = cleanText(input.clientName)
+  if (explicit) return explicit
+  const contact = [cleanText(input.clientFirstName), cleanText(input.clientLastName)]
+    .filter((value) => value !== null)
+    .join(" ")
+  return contact || cleanText(input.companyName)
+}
+
+async function projectTrackerClient(input: {
+  readonly environment: CloudflareEnv
+  readonly organizationId: string
+  readonly googleEmail: string
+}): Promise<SheetsClient> {
+  const db = getDb(input.environment.DB)
+  const authRows = await db
+    .select()
+    .from(googleAuth)
+    .where(eq(googleAuth.organizationId, input.organizationId))
+    .limit(1)
+  const auth = authRows[0]
+  if (!auth) throw new Error("Google Workspace service account is not connected.")
+
+  const config = getGoogleConfig(input.environment)
+  const keyJson = await decrypt(
+    auth.serviceAccountKeyEncrypted,
+    config.encryptionKey,
+    getGoogleCryptoSalt()
+  )
+  return new SheetsClient(parseServiceAccountKey(keyJson))
+}
+
+export async function getProjectIntakeAssignees(): Promise<
+  readonly ProjectIntakeAssignee[]
+> {
+  try {
+    const user = await requireAuth()
+    requirePermission(user, "project", "create")
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    if (!env?.DB) return []
+    const db = getDb(env.DB)
+    const rows = await db
+      .select({
+        id: users.id,
+        displayName: users.displayName,
+        firstName: users.firstName,
+        lastName: users.lastName,
+        email: users.email,
+      })
+      .from(organizationMembers)
+      .innerJoin(users, eq(users.id, organizationMembers.userId))
+      .where(
+        and(
+          eq(organizationMembers.organizationId, organizationId),
+          eq(users.isActive, true)
+        )
+      )
+      .orderBy(asc(users.displayName), asc(users.email))
+
+    return rows.map((row) => ({
+      id: row.id,
+      name:
+        cleanText(row.displayName) ??
+        ([cleanText(row.firstName), cleanText(row.lastName)]
+          .filter((value) => value !== null)
+          .join(" ") || row.email),
+      email: row.email,
+    }))
+  } catch {
+    return []
+  }
+}
+
+export async function createProjectIntake(
+  input: CreateProjectIntakeInput
+): Promise<CreateProjectIntakeResult> {
+  try {
+    const user = await requireAuth()
+    requirePermission(user, "project", "create")
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    if (!env?.DB) return { success: false, error: "D1 not available" }
+    const db = getDb(env.DB)
+
+    const projectName = requireText(input.projectName, "Project name")
+    const department = normalizedIntakeDepartment(input.department)
+    if (!department) {
+      return { success: false, error: "Choose ORC, HPS, Nu-Tech, or Design." }
+    }
+    const intakeDate = new Date().toISOString().slice(0, 10)
+    const client = await projectTrackerClient({
+      environment: env,
+      organizationId,
+      googleEmail: user.googleEmail ?? user.email,
+    })
+    const metadata = await client.getSpreadsheetMetadata(
+      user.googleEmail ?? user.email,
+      PROJECT_LEAD_TRACKING_SPREADSHEET_ID
+    )
+    if (!metadata.sheets.some((sheet) => sheet.title === PROJECT_LEAD_TRACKING_SHEET)) {
+      return {
+        success: false,
+        error: `The ${PROJECT_LEAD_TRACKING_SHEET} sheet is missing from Project Lead Tracking.`,
+      }
+    }
+    const trackerRows = await client.getValues(user.googleEmail ?? user.email, {
+      spreadsheetId: PROJECT_LEAD_TRACKING_SPREADSHEET_ID,
+      range: quotedSheetRange(PROJECT_LEAD_TRACKING_SHEET, "A:AZ"),
+    })
+    const layout = locateProjectTrackerLayout(trackerRows)
+    if (!layout) {
+      return {
+        success: false,
+        error: "The Project Lead Tracking header row could not be identified.",
+      }
+    }
+    const reservations = await db
+      .select({ projectNumber: projectNumberReservations.projectNumber })
+      .from(projectNumberReservations)
+      .where(
+        and(
+          eq(projectNumberReservations.organizationId, organizationId),
+          eq(projectNumberReservations.department, department)
+        )
+      )
+    const compassProjectNumbers = await db
+      .select({ projectNumber: projects.projectNumber })
+      .from(projects)
+      .where(eq(projects.organizationId, organizationId))
+    const projectNumber = allocateProjectNumber({
+      department,
+      streetNumber: input.streetNumber,
+      rows: trackerRows,
+      layout,
+      reservedProjectNumbers: reservations.map(
+        (reservation) => reservation.projectNumber
+      ).concat(
+        compassProjectNumbers.flatMap((project) =>
+          project.projectNumber ? [project.projectNumber] : []
+        )
+      ),
+    })
+    const sequence = projectSequence(projectNumber)
+    const duplicate = await db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(
+        and(
+          eq(projects.organizationId, organizationId),
+          eq(projects.projectNumber, projectNumber)
+        )
+      )
+      .limit(1)
+    if (duplicate[0]) {
+      return {
+        success: false,
+        error: `Compass project ${projectNumber} already exists. Refresh and try again.`,
+      }
+    }
+
+    const now = new Date().toISOString()
+    const projectId = `proj-${slugPart(projectNumber)}-${crypto.randomUUID().slice(0, 8)}`
+    const operationId = crypto.randomUUID()
+    const trackerLinkId = crypto.randomUUID()
+    const trackerProject: ProjectIntakeTrackerInput = {
+      ...input,
+      department,
+      projectName,
+      intakeDate,
+    }
+    const trackerRow = buildProjectTrackerRow({
+      layout,
+      project: trackerProject,
+      projectNumber,
+    })
+
+    try {
+      await db.batch([
+        db.insert(projects).values({
+          id: projectId,
+          organizationId,
+          projectNumber,
+          name: projectName,
+          status: "OPEN",
+          address: joinedAddress(input),
+          clientName: intakeClientName(input),
+          projectManager: cleanText(input.assignedTo),
+          ownerUpdatesEnabled: true,
+          ownerUpdateChannel: "compass",
+          ownerUpdateCadence: "weekly",
+          createdAt: now,
+          updatedAt: now,
+        }),
+        db.insert(projectNumberReservations).values({
+          id: crypto.randomUUID(),
+          organizationId,
+          projectId,
+          department,
+          sequence,
+          projectNumber,
+          createdAt: now,
+        }),
+        db.insert(projectExternalLinks).values({
+          id: crypto.randomUUID(),
+          projectId,
+          system: "compass",
+          label: "Compass project",
+          externalId: projectId,
+          externalNumber: projectNumber,
+          externalUrl: `/dashboard/projects/${projectId}`,
+          syncDirection: "bidirectional",
+          syncStatus: "mapped",
+          metadata: JSON.stringify({ department }),
+          createdAt: now,
+          updatedAt: now,
+        }),
+        db.insert(projectExternalLinks).values({
+          id: trackerLinkId,
+          projectId,
+          system: "google_project_lead_tracking",
+          label: "Project Lead Tracking",
+          externalId: PROJECT_LEAD_TRACKING_SPREADSHEET_ID,
+          externalNumber: projectNumber,
+          externalUrl: `https://docs.google.com/spreadsheets/d/${PROJECT_LEAD_TRACKING_SPREADSHEET_ID}`,
+          syncDirection: "bidirectional",
+          syncStatus: "pending",
+          // Retain the exact row only while the handoff is pending so a later
+          // reconciliation does not need to reconstruct discarded form fields.
+          metadata: JSON.stringify({
+            sheet: PROJECT_LEAD_TRACKING_SHEET,
+            headers: layout.headers,
+            row: trackerRow,
+          }),
+          createdAt: now,
+          updatedAt: now,
+        }),
+        db.insert(projectOperations).values({
+          id: operationId,
+          projectId,
+          sourceSystem: "google_project_lead_tracking",
+          sourceRecordType: "project_intake",
+          sourceRecordId: PROJECT_LEAD_TRACKING_SPREADSHEET_ID,
+          sourceRecordNumber: projectNumber,
+          title: `Write ${projectNumber} to Project Lead Tracking`,
+          description:
+            "Compass project intake and its Project Lead Tracking handoff.",
+          status: "open",
+          priority: "high",
+          assigneeName: cleanText(input.assignedTo),
+          companyName: cleanText(input.companyName),
+          externalUrl: `https://docs.google.com/spreadsheets/d/${PROJECT_LEAD_TRACKING_SPREADSHEET_ID}`,
+          sageWriteStatus: "not_ready",
+          syncDirection: "bidirectional",
+          syncStatus: "pending",
+          createdAt: now,
+          updatedAt: now,
+        }),
+      ])
+    } catch (error) {
+      if (isProjectSequenceConflict(error)) {
+        return {
+          success: false,
+          error:
+            "Another intake claimed that department number. Your entries are still here; submit again to receive the next number.",
+        }
+      }
+      throw error
+    }
+
+    let trackerStatus: "written" | "pending" = "written"
+    let warning: string | null = null
+    try {
+      const appended = await client.appendValues(user.googleEmail ?? user.email, {
+        spreadsheetId: PROJECT_LEAD_TRACKING_SPREADSHEET_ID,
+        range: quotedSheetRange(
+          PROJECT_LEAD_TRACKING_SHEET,
+          `A${layout.headerRowNumber}:AZ`
+        ),
+        values: [trackerRow],
+      })
+      const syncedAt = new Date().toISOString()
+      try {
+        await db.batch([
+          db
+            .update(projectExternalLinks)
+            .set({
+              syncStatus: "mapped",
+              lastSyncedAt: syncedAt,
+              metadata: JSON.stringify({
+                sheet: PROJECT_LEAD_TRACKING_SHEET,
+                updatedRange: appended.updatedRange,
+              }),
+              updatedAt: syncedAt,
+            })
+            .where(eq(projectExternalLinks.id, trackerLinkId)),
+          db
+            .update(projectOperations)
+            .set({
+              status: "completed",
+              syncStatus: "mapped",
+              lastSyncedAt: syncedAt,
+              updatedAt: syncedAt,
+            })
+            .where(eq(projectOperations.id, operationId)),
+        ])
+      } catch (error) {
+        // The Google write already succeeded. Preserve that truth so a retry
+        // can reconcile by project number instead of appending a duplicate row.
+        warning =
+          "Project Lead Tracking was updated, but Compass could not save its sync receipt. The project is safe to use; do not resend the intake."
+        console.error("Unable to save the Project Lead Tracking receipt", error)
+      }
+    } catch (error) {
+      trackerStatus = "pending"
+      warning =
+        "The Compass project and number were saved, but Project Lead Tracking is pending and recorded for follow-up. Do not recreate the project."
+      console.error("Unable to append the new project to Project Lead Tracking", error)
+    }
+
+    await recordActivityEvent({
+      db,
+      organizationId,
+      projectId,
+      actor: user,
+      category: "account",
+      action: "project.created",
+      entityType: "project",
+      entityId: projectId,
+      summary: `Created ${projectNumber} — ${projectName}.`,
+      metadata: { department, trackerStatus },
+    })
+    revalidatePath("/dashboard/projects")
+    revalidatePath(`/dashboard/projects/${projectId}`)
+    revalidatePath("/dashboard")
+    return { success: true, id: projectId, projectNumber, trackerStatus, warning }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to create project",
+    }
+  }
 }
 
 export async function getProjects(): Promise<ProjectListItem[]> {

--- a/src/app/dashboard/projects/page.tsx
+++ b/src/app/dashboard/projects/page.tsx
@@ -3,7 +3,10 @@ export const dynamic = "force-dynamic"
 import { and, asc, eq, inArray } from "drizzle-orm"
 
 import { getDashboardOverview } from "@/app/actions/dashboard-overview"
-import { getProjects } from "@/app/actions/projects"
+import {
+  getProjectIntakeAssignees,
+  getProjects,
+} from "@/app/actions/projects"
 import { getDb } from "@/db"
 import { projectExternalLinks, projects } from "@/db/schema"
 import { ProjectsHub } from "@/components/projects/projects-hub"
@@ -48,10 +51,11 @@ export default async function ProjectsPage({
     params.status !== undefined
 
   if (!showRegistry) {
-    const [projectList, overview, currentUser] = await Promise.all([
+    const [projectList, overview, currentUser, intakeAssignees] = await Promise.all([
       getProjects(),
       getDashboardOverview(),
       getCurrentUser(),
+      getProjectIntakeAssignees(),
     ])
 
     return (
@@ -59,6 +63,7 @@ export default async function ProjectsPage({
         projects={projectList}
         overview={overview}
         canManageProjects={canManageProjectRegistry(currentUser)}
+        intakeAssignees={intakeAssignees}
       />
     )
   }

--- a/src/components/projects/project-hub-launchpad.tsx
+++ b/src/components/projects/project-hub-launchpad.tsx
@@ -11,19 +11,21 @@ import {
   IconLayoutCards,
   IconList,
   IconPaint,
-  IconPlus,
   IconSettings,
   IconTool,
 } from "@tabler/icons-react"
 
 import type { DashboardOverview } from "@/app/actions/dashboard-overview"
-import type { ProjectListItem } from "@/app/actions/projects"
+import type {
+  ProjectIntakeAssignee,
+  ProjectListItem,
+} from "@/app/actions/projects"
 import { useActiveProject } from "@/components/project-list-provider"
+import { ProjectIntakeDrawer } from "@/components/projects/project-intake-drawer"
 import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { OfficeMaintenanceDrawer } from "@/components/projects/office-maintenance-drawer"
-import { openHpsProjectManagerWorkWindow } from "@/lib/google/project-manager-app"
 import { cn } from "@/lib/utils"
 
 type DepartmentFilter = "ALL" | "O" | "H" | "N" | "D" | "OTHER"
@@ -252,27 +254,16 @@ function ProjectCard({
   )
 }
 
-function NewProjectButton(): React.ReactElement {
-  return (
-    <Button
-      type="button"
-      size="sm"
-      onClick={() => openHpsProjectManagerWorkWindow()}
-    >
-      <IconPlus className="size-4" />
-      New project
-    </Button>
-  )
-}
-
 export function ProjectHubLaunchpad({
   projects,
   overview,
   canManageProjects,
+  intakeAssignees,
 }: {
   readonly projects: readonly ProjectListItem[]
   readonly overview: DashboardOverview
   readonly canManageProjects: boolean
+  readonly intakeAssignees: readonly ProjectIntakeAssignee[]
 }): React.ReactElement {
   const { activeProjectId } = useActiveProject()
   const [department, setDepartment] = useState<DepartmentFilter>("ALL")
@@ -329,7 +320,7 @@ export function ProjectHubLaunchpad({
             <OfficeMaintenanceDrawer projects={projects} />
           ) : null}
           {canManageProjects ? (
-            <NewProjectButton />
+            <ProjectIntakeDrawer assignees={intakeAssignees} />
           ) : null}
         </div>
       </header>

--- a/src/components/projects/project-intake-drawer.tsx
+++ b/src/components/projects/project-intake-drawer.tsx
@@ -1,0 +1,281 @@
+"use client"
+
+import { useRef, useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import {
+  IconArrowRight,
+  IconBuilding,
+  IconCheck,
+  IconDatabase,
+  IconPlus,
+} from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import {
+  createProjectIntake,
+  type ProjectIntakeAssignee,
+} from "@/app/actions/projects"
+import { ProjectSelectionComboboxInput } from "@/components/projects/project-selection-combobox-input"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
+import { Textarea } from "@/components/ui/textarea"
+import type { ProjectIntakeDepartment } from "@/lib/google/project-intake-tracker"
+
+const DEPARTMENTS: readonly {
+  readonly value: ProjectIntakeDepartment
+  readonly label: string
+}[] = [
+  { value: "O", label: "ORC" },
+  { value: "H", label: "HPS" },
+  { value: "N", label: "Nu-Tech" },
+  { value: "D", label: "Design" },
+]
+
+function fieldValue(formData: FormData, name: string): string | null {
+  const value = formData.get(name)
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function isDepartment(value: string): value is ProjectIntakeDepartment {
+  return DEPARTMENTS.some((department) => department.value === value)
+}
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  readonly label: string
+  readonly htmlFor?: string
+  readonly children: React.ReactNode
+}): React.ReactElement {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={htmlFor} className="text-xs text-muted-foreground">
+        {label}
+      </Label>
+      {children}
+    </div>
+  )
+}
+
+export function ProjectIntakeDrawer({
+  assignees,
+}: {
+  readonly assignees: readonly ProjectIntakeAssignee[]
+}): React.ReactElement {
+  const router = useRouter()
+  const formRef = useRef<HTMLFormElement>(null)
+  const [open, setOpen] = useState(false)
+  const [department, setDepartment] = useState<ProjectIntakeDepartment>("O")
+  const [isPending, startTransition] = useTransition()
+
+  function submitProject(event: React.FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    startTransition(async () => {
+      const result = await createProjectIntake({
+        department,
+        projectName: fieldValue(formData, "projectName") ?? "",
+        clientName: fieldValue(formData, "clientName"),
+        companyName: fieldValue(formData, "companyName"),
+        clientFirstName: fieldValue(formData, "clientFirstName"),
+        clientLastName: fieldValue(formData, "clientLastName"),
+        contactPhone: fieldValue(formData, "contactPhone"),
+        contactEmail: fieldValue(formData, "contactEmail"),
+        streetNumber: fieldValue(formData, "streetNumber"),
+        streetName: fieldValue(formData, "streetName"),
+        cityStateZip: fieldValue(formData, "cityStateZip"),
+        billingAddress: fieldValue(formData, "billingAddress"),
+        assignedTo: fieldValue(formData, "assignedTo"),
+        referredBy: fieldValue(formData, "referredBy"),
+        notes: fieldValue(formData, "notes"),
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      if (result.warning) toast.warning(result.warning)
+      else toast.success(`${result.projectNumber} created in Compass and Project Lead Tracking.`)
+      formRef.current?.reset()
+      setOpen(false)
+      router.push(`/dashboard/projects/${result.id}`)
+      router.refresh()
+    })
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button type="button" size="sm">
+          <IconPlus className="size-4" />
+          New project
+        </Button>
+      </SheetTrigger>
+      <SheetContent className="w-[min(96vw,840px)] overflow-y-auto sm:max-w-none">
+        <SheetHeader className="border-b px-5 py-4 text-left">
+          <SheetTitle>New Project</SheetTitle>
+          <SheetDescription>
+            Create the Compass project and update the existing Project Lead Tracking register in one step.
+          </SheetDescription>
+        </SheetHeader>
+
+        <form ref={formRef} onSubmit={submitProject} className="space-y-6 px-5 pb-6">
+          <Alert className="rounded-none border-x-0 border-t-0">
+            <IconDatabase className="size-4" />
+            <AlertTitle>One intake, both systems</AlertTitle>
+            <AlertDescription>
+              Compass assigns the next department project number. Drive and Sage setup remain visibly staged until their integrations finish.
+            </AlertDescription>
+          </Alert>
+
+          <section className="space-y-3">
+            <div className="flex items-center gap-2 border-b pb-2">
+              <IconBuilding className="size-4" />
+              <h3 className="text-sm font-semibold">Project identity</h3>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-[12rem_minmax(0,1fr)]">
+              <Field label="Department">
+                <Select
+                  value={department}
+                  onValueChange={(value) => {
+                    if (isDepartment(value)) setDepartment(value)
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {DEPARTMENTS.map((item) => (
+                      <SelectItem key={item.value} value={item.value}>
+                        {item.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Field>
+              <Field label="Project name" htmlFor="project-intake-name">
+                <Input
+                  id="project-intake-name"
+                  name="projectName"
+                  placeholder="Mitchell Residence"
+                  required
+                />
+              </Field>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              The official number is assigned from the live department sequence when you submit.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="border-b pb-2 text-sm font-semibold">Client and contact</h3>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <Field label="Client display name" htmlFor="project-intake-client">
+                <Input id="project-intake-client" name="clientName" placeholder="Dan and Jane Mitchell" />
+              </Field>
+              <Field label="Company" htmlFor="project-intake-company">
+                <Input id="project-intake-company" name="companyName" />
+              </Field>
+              <Field label="First name" htmlFor="project-intake-first-name">
+                <Input id="project-intake-first-name" name="clientFirstName" />
+              </Field>
+              <Field label="Last name" htmlFor="project-intake-last-name">
+                <Input id="project-intake-last-name" name="clientLastName" />
+              </Field>
+              <Field label="Phone" htmlFor="project-intake-phone">
+                <Input id="project-intake-phone" name="contactPhone" type="tel" />
+              </Field>
+              <Field label="Email" htmlFor="project-intake-email">
+                <Input id="project-intake-email" name="contactEmail" type="email" />
+              </Field>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="border-b pb-2 text-sm font-semibold">Project location</h3>
+            <div className="grid gap-4 sm:grid-cols-[10rem_minmax(0,1fr)]">
+              <Field label="Street number" htmlFor="project-intake-street-number">
+                <Input id="project-intake-street-number" name="streetNumber" placeholder="33" />
+              </Field>
+              <Field label="Street name" htmlFor="project-intake-street-name">
+                <Input id="project-intake-street-name" name="streetName" placeholder="Mitchell Lane" />
+              </Field>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <Field label="City, state, ZIP" htmlFor="project-intake-city">
+                <Input id="project-intake-city" name="cityStateZip" placeholder="Durango, CO 81301" />
+              </Field>
+              <Field label="Billing address" htmlFor="project-intake-billing">
+                <Input id="project-intake-billing" name="billingAddress" />
+              </Field>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="border-b pb-2 text-sm font-semibold">Assignment and notes</h3>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <Field label="Assigned to">
+                <ProjectSelectionComboboxInput
+                  id="project-intake-assignee"
+                  name="assignedTo"
+                  options={assignees.map((assignee) => ({
+                    value: assignee.name,
+                    label: assignee.name,
+                    description: assignee.email,
+                  }))}
+                  placeholder="Choose staff or type a name..."
+                  emptyMessage="No matching staff member."
+                  manualInputLabel="Use typed name"
+                />
+              </Field>
+              <Field label="Referred by" htmlFor="project-intake-referral">
+                <Input id="project-intake-referral" name="referredBy" />
+              </Field>
+            </div>
+            <Field label="Notes" htmlFor="project-intake-notes">
+              <Textarea id="project-intake-notes" name="notes" rows={4} />
+            </Field>
+          </section>
+
+          <div className="grid gap-2 border-y py-4 text-sm sm:grid-cols-3">
+            <span className="flex items-center gap-2"><IconCheck className="size-4 text-emerald-700" /> Compass registry</span>
+            <span className="flex items-center gap-2"><IconCheck className="size-4 text-emerald-700" /> Project Lead Tracking</span>
+            <span className="flex items-center gap-2 text-muted-foreground"><IconArrowRight className="size-4" /> Drive and Sage staging</span>
+          </div>
+
+          <SheetFooter className="px-0">
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="outline" onClick={() => setOpen(false)} disabled={isPending}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending ? "Creating project…" : "Create project"}
+              </Button>
+            </div>
+          </SheetFooter>
+        </form>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -396,6 +396,34 @@ export const projects = sqliteTable("projects", {
   updatedAt: text("updated_at"),
 })
 
+export const projectNumberReservations = sqliteTable(
+  "project_number_reservations",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    department: text("department").notNull(),
+    sequence: integer("sequence").notNull(),
+    projectNumber: text("project_number").notNull(),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("project_number_reservations_org_department_sequence_unique").on(
+      table.organizationId,
+      table.department,
+      table.sequence
+    ),
+    uniqueIndex("project_number_reservations_org_number_unique").on(
+      table.organizationId,
+      table.projectNumber
+    ),
+  ]
+)
+
 export const activityEvents = sqliteTable(
   "activity_events",
   {

--- a/src/lib/google/client/sheets-client.ts
+++ b/src/lib/google/client/sheets-client.ts
@@ -22,6 +22,10 @@ export type GoogleSpreadsheetMetadata = {
   readonly sheets: readonly GoogleSheetMetadata[]
 }
 
+export type GoogleSheetAppendResult = {
+  readonly updatedRange: string | null
+}
+
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
@@ -127,5 +131,44 @@ export class SheetsClient {
       return []
     }
     return payload.values.filter(Array.isArray)
+  }
+
+  async appendValues(
+    userEmail: string,
+    input: {
+      readonly spreadsheetId: string
+      readonly range: string
+      readonly values: ReadonlyArray<ReadonlyArray<unknown>>
+    }
+  ): Promise<GoogleSheetAppendResult> {
+    const token = await getAccessToken(this.serviceAccountKey, userEmail)
+    const params = new URLSearchParams({
+      // Intake text is browser supplied. RAW prevents spreadsheet formula
+      // execution while preserving the visible strings staff entered.
+      valueInputOption: "RAW",
+      insertDataOption: "INSERT_ROWS",
+    })
+    const range = encodeURIComponent(input.range)
+    const response = await fetch(
+      `${GOOGLE_SHEETS_API}/${input.spreadsheetId}/values/${range}:append?${params.toString()}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ values: input.values }),
+      }
+    )
+
+    if (!response.ok) {
+      const body = await response.text()
+      throw new Error(
+        `Google Sheets API error (${response.status}): ${body.slice(0, 500)}`
+      )
+    }
+    const payload = objectValue(await response.json())
+    const updates = objectValue(payload?.updates)
+    return { updatedRange: stringValue(updates?.updatedRange) }
   }
 }

--- a/src/lib/google/project-intake-tracker.ts
+++ b/src/lib/google/project-intake-tracker.ts
@@ -1,0 +1,124 @@
+export type ProjectIntakeDepartment = "O" | "H" | "N" | "D"
+
+export type ProjectIntakeTrackerInput = {
+  readonly department: ProjectIntakeDepartment
+  readonly projectName: string
+  readonly clientName: string | null
+  readonly companyName: string | null
+  readonly clientFirstName: string | null
+  readonly clientLastName: string | null
+  readonly contactPhone: string | null
+  readonly contactEmail: string | null
+  readonly streetNumber: string | null
+  readonly streetName: string | null
+  readonly cityStateZip: string | null
+  readonly billingAddress: string | null
+  readonly assignedTo: string | null
+  readonly referredBy: string | null
+  readonly notes: string | null
+  readonly intakeDate: string
+}
+
+export type ProjectTrackerLayout = {
+  readonly headerRowNumber: number
+  readonly headers: readonly string[]
+  readonly projectNumberColumn: number
+}
+
+function cellText(value: unknown): string {
+  if (typeof value === "string") return value.trim()
+  if (typeof value === "number" && Number.isFinite(value)) return String(value)
+  return ""
+}
+
+function normalizedHeader(value: unknown): string {
+  return cellText(value).toLowerCase().replace(/[^a-z0-9]+/g, " ").trim()
+}
+
+export function locateProjectTrackerLayout(
+  rows: ReadonlyArray<ReadonlyArray<unknown>>
+): ProjectTrackerLayout | null {
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+    const headers = (rows[rowIndex] ?? []).map(cellText)
+    const projectNumberColumn = headers.findIndex(
+      (header) => normalizedHeader(header) === "project number"
+    )
+    if (projectNumberColumn >= 0) {
+      return {
+        headerRowNumber: rowIndex + 1,
+        headers,
+        projectNumberColumn,
+      }
+    }
+  }
+  return null
+}
+
+export function allocateProjectNumber(input: {
+  readonly department: ProjectIntakeDepartment
+  readonly streetNumber: string | null
+  readonly rows: ReadonlyArray<ReadonlyArray<unknown>>
+  readonly layout: ProjectTrackerLayout
+  readonly reservedProjectNumbers?: readonly string[]
+}): string {
+  let maximumSequence = 0
+  const pattern = new RegExp(`^${input.department}-(\\d+)-`, "i")
+  for (const row of input.rows.slice(input.layout.headerRowNumber)) {
+    const value = cellText(row[input.layout.projectNumberColumn])
+    const match = pattern.exec(value)
+    if (!match) continue
+    const sequence = Number(match[1])
+    if (Number.isInteger(sequence) && sequence > maximumSequence) {
+      maximumSequence = sequence
+    }
+  }
+  for (const value of input.reservedProjectNumbers ?? []) {
+    const match = pattern.exec(cellText(value))
+    if (!match) continue
+    const sequence = Number(match[1])
+    if (Number.isInteger(sequence) && sequence > maximumSequence) {
+      maximumSequence = sequence
+    }
+  }
+  const streetNumber = cellText(input.streetNumber).replace(/[^a-z0-9]+/gi, "") || "00"
+  return `${input.department}-${String(maximumSequence + 1).padStart(2, "0")}-${streetNumber}`
+}
+
+function valueForHeader(
+  header: string,
+  input: ProjectIntakeTrackerInput,
+  projectNumber: string
+): string {
+  const normalized = normalizedHeader(header)
+  const values: Readonly<Record<string, string | null>> = {
+    "project number": projectNumber,
+    type: input.department,
+    "intake date": input.intakeDate,
+    "assigned to": input.assignedTo,
+    status: "OPEN",
+    "company name": input.companyName,
+    "client last name": input.clientLastName,
+    "client first name": input.clientFirstName,
+    "contact phone": input.contactPhone,
+    "contact email": input.contactEmail,
+    "project street number": input.streetNumber,
+    "project street name": input.streetName,
+    "city state zip": input.cityStateZip,
+    "billing address": input.billingAddress,
+    "referred by": input.referredBy,
+    notes: input.notes,
+  }
+  if (normalized === "active projects") return input.projectName
+  if (normalized === "client name") return input.clientName ?? ""
+  return values[normalized] ?? ""
+}
+
+export function buildProjectTrackerRow(input: {
+  readonly layout: ProjectTrackerLayout
+  readonly project: ProjectIntakeTrackerInput
+  readonly projectNumber: string
+}): readonly string[] {
+  return input.layout.headers.map((header) =>
+    valueForHeader(header, input.project, input.projectNumber)
+  )
+}


### PR DESCRIPTION
## Summary

- replace the Project Hub `New project` launch with a native Compass drawer
- allocate official O/H/N/D numbers against live Project Lead Tracking and existing Compass records
- write new projects to Compass and the Google tracker while preserving the legacy Google Form during cutover
- reserve department sequences in D1 to prevent concurrent duplicates
- retain recoverable pending handoffs and stage project setup follow-up

## Verification

- `bunx vitest run __tests__/google-project-intake-tracker.test.ts` (4 passed)
- `bunx tsc --noEmit`
- targeted ESLint (clean)
- `bun run scripts/run-with-deployment-id.mjs next build --webpack`
- autoreview clean: no accepted/actionable findings

## Deployment order

Production D1 migration `0091_project_number_reservations.sql` was applied successfully before this application change.
