### PR TITLE
feat(projects): provision Drive and stage Sage intake

### DIFF
--- a/__tests__/google-project-drive-provisioning.test.ts
+++ b/__tests__/google-project-drive-provisioning.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest"
+
+import type {
+  DriveFile,
+  DriveFileList,
+  ListFilesOptions,
+} from "@/lib/google/client/types"
+import {
+  buildProjectDriveFolderName,
+  projectDriveChildFolders,
+  provisionProjectDriveFolder,
+} from "@/lib/google/project-drive-provisioning"
+
+const FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
+
+class MemoryDriveClient {
+  readonly files = new Map<string, DriveFile>()
+  readonly createdNames: string[] = []
+  private nextId = 1
+
+  async listFiles(
+    _userEmail: string,
+    options: ListFilesOptions = {}
+  ): Promise<DriveFileList> {
+    const exactName = options.query?.match(/name = '(.+)'/)?.[1]
+    return {
+      files: [...this.files.values()].filter((file) => {
+        const inParent = options.folderId
+          ? file.parents?.includes(options.folderId) === true
+          : true
+        return inParent && (!exactName || file.name === exactName)
+      }),
+    }
+  }
+
+  async getFile(_userEmail: string, fileId: string): Promise<DriveFile> {
+    const file = this.files.get(fileId)
+    if (!file) throw new Error("Missing test file")
+    return file
+  }
+
+  async createFolder(
+    _userEmail: string,
+    options: { readonly name: string; readonly parentId?: string }
+  ): Promise<DriveFile> {
+    const id = `folder-${this.nextId}`
+    this.nextId += 1
+    const file: DriveFile = {
+      id,
+      name: options.name,
+      mimeType: FOLDER_MIME_TYPE,
+      parents: options.parentId ? [options.parentId] : [],
+    }
+    this.files.set(id, file)
+    this.createdNames.push(options.name)
+    return file
+  }
+}
+
+describe("project Drive provisioning", () => {
+  it("builds a filesystem-safe project folder name", () => {
+    expect(
+      buildProjectDriveFolderName({
+        projectNumber: "O-214-55",
+        projectName: "Smith / Jones Residence",
+        streetNumber: "55",
+        streetName: "County Rd: 7",
+      })
+    ).toBe("O-214-55 - 55 County Rd- 7 - Smith - Jones Residence")
+  })
+
+  it("creates and verifies the ORC folder set under the canonical department root", async () => {
+    const client = new MemoryDriveClient()
+    const result = await provisionProjectDriveFolder(
+      client,
+      "martine@hps-colorado.com",
+      { department: "O", folderName: "O-214-55 - Smith Residence" }
+    )
+
+    expect(result.createdRoot).toBe(true)
+    expect(result.createdChildCount).toBe(projectDriveChildFolders("O").length)
+    expect(client.createdNames).toContain("03_PayRequests")
+    expect(client.createdNames).toContain("11_ChangeOrders")
+    expect(result.parentFolderId).toBe("0Bzi_pskoDROqd3RCemxpT3Flanc")
+  })
+
+  it("reuses a previously created root and only fills missing children", async () => {
+    const client = new MemoryDriveClient()
+    await client.createFolder("test@example.com", {
+      name: "H-432-10 - Example",
+      parentId: "0Bzi_pskoDROqcEZZRHhIQ01RMmc",
+    })
+
+    const first = await provisionProjectDriveFolder(client, "test@example.com", {
+      department: "H",
+      folderName: "H-432-10 - Example",
+    })
+    const createdAfterFirstRun = client.createdNames.length
+    const second = await provisionProjectDriveFolder(client, "test@example.com", {
+      department: "H",
+      folderName: "H-432-10 - Example",
+    })
+
+    expect(first.createdRoot).toBe(false)
+    expect(second.createdRoot).toBe(false)
+    expect(second.createdChildCount).toBe(0)
+    expect(client.createdNames).toHaveLength(createdAfterFirstRun)
+  })
+})

--- a/__tests__/google-project-intake-tracker.test.ts
+++ b/__tests__/google-project-intake-tracker.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   allocateProjectNumber,
   buildProjectTrackerRow,
+  findProjectTrackerSheetTitle,
   locateProjectTrackerLayout,
   type ProjectIntakeTrackerInput,
 } from "@/lib/google/project-intake-tracker"
@@ -27,6 +28,15 @@ const PROJECT: ProjectIntakeTrackerInput = {
 }
 
 describe("Google Project Lead Tracking intake", () => {
+  it("uses the current Master List tab and keeps the former tab name compatible", () => {
+    expect(
+      findProjectTrackerSheetTitle(["Stats", "Master List", "Parameters"])
+    ).toBe("Master List")
+    expect(findProjectTrackerSheetTitle(["Highlight Project"])).toBe(
+      "Highlight Project"
+    )
+  })
+
   it("locates a shifted tracker header and allocates the next department number", () => {
     const rows = [
       ["Project Lead Tracking"],

--- a/src/app/actions/projects.ts
+++ b/src/app/actions/projects.ts
@@ -18,20 +18,29 @@ import { requireAuth } from "@/lib/auth"
 import { decrypt } from "@/lib/crypto"
 import { recordActivityEvent } from "@/lib/activity-log"
 import { SheetsClient } from "@/lib/google/client/sheets-client"
+import { DriveClient } from "@/lib/google/client/drive-client"
 import {
   getGoogleConfig,
   getGoogleCryptoSalt,
   parseServiceAccountKey,
 } from "@/lib/google/config"
 import {
+  buildProjectDriveFolderName,
+  provisionProjectDriveFolder as provisionGoogleProjectDriveFolder,
+} from "@/lib/google/project-drive-provisioning"
+import {
   allocateProjectNumber,
   buildProjectTrackerRow,
+  findProjectTrackerSheetTitle,
   locateProjectTrackerLayout,
   type ProjectIntakeDepartment,
   type ProjectIntakeTrackerInput,
 } from "@/lib/google/project-intake-tracker"
 import { requireOrg } from "@/lib/org-scope"
-import { requirePermission } from "@/lib/permissions"
+import {
+  canManageProjectRegistry,
+  requirePermission,
+} from "@/lib/permissions"
 import { canUseOrganizationProjectScopeRole } from "@/lib/user-roles"
 
 export type ProjectStatusValue =
@@ -95,13 +104,14 @@ export type CreateProjectIntakeResult =
       readonly id: string
       readonly projectNumber: string
       readonly trackerStatus: "written" | "pending"
+      readonly driveStatus: "provisioned" | "pending"
+      readonly sageStatus: "staged"
       readonly warning: string | null
     }
   | { readonly success: false; readonly error: string }
 
 const PROJECT_LEAD_TRACKING_SPREADSHEET_ID =
   "15DPCjDK9a4b3pkNB7ZdSFtJsSN1q2CyajNUBb40aRkE"
-const PROJECT_LEAD_TRACKING_SHEET = "Highlight Project"
 
 function cleanText(value: string | null): string | null {
   const trimmed = value?.trim() ?? ""
@@ -193,11 +203,15 @@ function intakeClientName(input: CreateProjectIntakeInput): string | null {
   return contact || cleanText(input.companyName)
 }
 
-async function projectTrackerClient(input: {
+type ProjectWorkspaceClients = {
+  readonly sheets: SheetsClient
+  readonly drive: DriveClient
+}
+
+async function projectWorkspaceClients(input: {
   readonly environment: CloudflareEnv
   readonly organizationId: string
-  readonly googleEmail: string
-}): Promise<SheetsClient> {
+}): Promise<ProjectWorkspaceClients> {
   const db = getDb(input.environment.DB)
   const authRows = await db
     .select()
@@ -213,7 +227,37 @@ async function projectTrackerClient(input: {
     config.encryptionKey,
     getGoogleCryptoSalt()
   )
-  return new SheetsClient(parseServiceAccountKey(keyJson))
+  const serviceAccountKey = parseServiceAccountKey(keyJson)
+  return {
+    sheets: new SheetsClient(serviceAccountKey),
+    drive: new DriveClient({ serviceAccountKey }),
+  }
+}
+
+function appendWarning(current: string | null, next: string): string {
+  return current ? `${current} ${next}` : next
+}
+
+function projectDepartment(projectNumber: string | null): ProjectIntakeDepartment | null {
+  return normalizedIntakeDepartment(projectNumber?.slice(0, 1) ?? null)
+}
+
+function metadataFolderName(metadata: string | null): string | null {
+  if (!metadata) return null
+  try {
+    const parsed: unknown = JSON.parse(metadata)
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "folderName" in parsed &&
+      typeof parsed.folderName === "string"
+    ) {
+      return cleanText(parsed.folderName)
+    }
+  } catch {
+    return null
+  }
+  return null
 }
 
 export async function getProjectIntakeAssignees(): Promise<
@@ -275,24 +319,28 @@ export async function createProjectIntake(
       return { success: false, error: "Choose ORC, HPS, Nu-Tech, or Design." }
     }
     const intakeDate = new Date().toISOString().slice(0, 10)
-    const client = await projectTrackerClient({
+    const googleClients = await projectWorkspaceClients({
       environment: env,
       organizationId,
-      googleEmail: user.googleEmail ?? user.email,
     })
-    const metadata = await client.getSpreadsheetMetadata(
-      user.googleEmail ?? user.email,
+    const googleEmail = user.googleEmail ?? user.email
+    const metadata = await googleClients.sheets.getSpreadsheetMetadata(
+      googleEmail,
       PROJECT_LEAD_TRACKING_SPREADSHEET_ID
     )
-    if (!metadata.sheets.some((sheet) => sheet.title === PROJECT_LEAD_TRACKING_SHEET)) {
+    const trackerSheet = findProjectTrackerSheetTitle(
+      metadata.sheets.map((sheet) => sheet.title)
+    )
+    if (!trackerSheet) {
       return {
         success: false,
-        error: `The ${PROJECT_LEAD_TRACKING_SHEET} sheet is missing from Project Lead Tracking.`,
+        error:
+          "Project Lead Tracking is missing its Master List sheet. No project was created.",
       }
     }
-    const trackerRows = await client.getValues(user.googleEmail ?? user.email, {
+    const trackerRows = await googleClients.sheets.getValues(googleEmail, {
       spreadsheetId: PROJECT_LEAD_TRACKING_SPREADSHEET_ID,
-      range: quotedSheetRange(PROJECT_LEAD_TRACKING_SHEET, "A:AZ"),
+      range: quotedSheetRange(trackerSheet, "A:AZ"),
     })
     const layout = locateProjectTrackerLayout(trackerRows)
     if (!layout) {
@@ -349,6 +397,9 @@ export async function createProjectIntake(
     const projectId = `proj-${slugPart(projectNumber)}-${crypto.randomUUID().slice(0, 8)}`
     const operationId = crypto.randomUUID()
     const trackerLinkId = crypto.randomUUID()
+    const driveLinkId = crypto.randomUUID()
+    const sageLinkId = crypto.randomUUID()
+    const sageOperationId = crypto.randomUUID()
     const trackerProject: ProjectIntakeTrackerInput = {
       ...input,
       department,
@@ -359,6 +410,22 @@ export async function createProjectIntake(
       layout,
       project: trackerProject,
       projectNumber,
+    })
+    const driveFolderName = buildProjectDriveFolderName({
+      projectNumber,
+      projectName,
+      streetNumber: input.streetNumber,
+      streetName: input.streetName,
+    })
+    const sagePayload = JSON.stringify({
+      source: "compass_project_intake",
+      projectId,
+      projectNumber,
+      department,
+      projectName,
+      clientName: intakeClientName(input),
+      address: joinedAddress(input),
+      assignedTo: cleanText(input.assignedTo),
     })
 
     try {
@@ -402,6 +469,40 @@ export async function createProjectIntake(
           updatedAt: now,
         }),
         db.insert(projectExternalLinks).values({
+          id: driveLinkId,
+          projectId,
+          system: "google_drive",
+          label: "Project Drive folder",
+          externalId: null,
+          externalNumber: null,
+          externalUrl: null,
+          syncDirection: "read_write",
+          syncStatus: "pending",
+          metadata: JSON.stringify({
+            department,
+            folderName: driveFolderName,
+          }),
+          createdAt: now,
+          updatedAt: now,
+        }),
+        db.insert(projectExternalLinks).values({
+          id: sageLinkId,
+          projectId,
+          system: "sage",
+          label: "Sage job",
+          externalId: null,
+          externalNumber: projectNumber,
+          externalUrl: null,
+          syncDirection: "bidirectional",
+          syncStatus: "unmapped",
+          metadata: JSON.stringify({
+            pendingProjectNumber: projectNumber,
+            source: "compass_project_intake",
+          }),
+          createdAt: now,
+          updatedAt: now,
+        }),
+        db.insert(projectExternalLinks).values({
           id: trackerLinkId,
           projectId,
           system: "google_project_lead_tracking",
@@ -414,7 +515,7 @@ export async function createProjectIntake(
           // Retain the exact row only while the handoff is pending so a later
           // reconciliation does not need to reconstruct discarded form fields.
           metadata: JSON.stringify({
-            sheet: PROJECT_LEAD_TRACKING_SHEET,
+            sheet: trackerSheet,
             headers: layout.headers,
             row: trackerRow,
           }),
@@ -442,6 +543,29 @@ export async function createProjectIntake(
           createdAt: now,
           updatedAt: now,
         }),
+        db.insert(projectOperations).values({
+          id: sageOperationId,
+          projectId,
+          sourceSystem: "compass_project_intake",
+          sourceRecordType: "sage_project_handoff",
+          sourceRecordId: projectNumber,
+          sourceRecordNumber: projectNumber,
+          title: `${projectNumber} Sage project handoff`,
+          description:
+            "Review this Compass project intake, then create or match the Sage job.",
+          status: "needs_review",
+          priority: "high",
+          assigneeType: "internal",
+          assigneeName: cleanText(input.assignedTo),
+          companyName: intakeClientName(input),
+          externalUrl: null,
+          sageWriteStatus: "needs_review",
+          sagePayloadJson: sagePayload,
+          syncDirection: "write",
+          syncStatus: "pending_sage",
+          createdAt: now,
+          updatedAt: now,
+        }),
       ])
     } catch (error) {
       if (isProjectSequenceConflict(error)) {
@@ -457,10 +581,10 @@ export async function createProjectIntake(
     let trackerStatus: "written" | "pending" = "written"
     let warning: string | null = null
     try {
-      const appended = await client.appendValues(user.googleEmail ?? user.email, {
+      const appended = await googleClients.sheets.appendValues(googleEmail, {
         spreadsheetId: PROJECT_LEAD_TRACKING_SPREADSHEET_ID,
         range: quotedSheetRange(
-          PROJECT_LEAD_TRACKING_SHEET,
+          trackerSheet,
           `A${layout.headerRowNumber}:AZ`
         ),
         values: [trackerRow],
@@ -474,7 +598,7 @@ export async function createProjectIntake(
               syncStatus: "mapped",
               lastSyncedAt: syncedAt,
               metadata: JSON.stringify({
-                sheet: PROJECT_LEAD_TRACKING_SHEET,
+                sheet: trackerSheet,
                 updatedRange: appended.updatedRange,
               }),
               updatedAt: syncedAt,
@@ -493,15 +617,74 @@ export async function createProjectIntake(
       } catch (error) {
         // The Google write already succeeded. Preserve that truth so a retry
         // can reconcile by project number instead of appending a duplicate row.
-        warning =
+        warning = appendWarning(
+          warning,
           "Project Lead Tracking was updated, but Compass could not save its sync receipt. The project is safe to use; do not resend the intake."
+        )
         console.error("Unable to save the Project Lead Tracking receipt", error)
       }
     } catch (error) {
       trackerStatus = "pending"
-      warning =
+      warning = appendWarning(
+        warning,
         "The Compass project and number were saved, but Project Lead Tracking is pending and recorded for follow-up. Do not recreate the project."
+      )
       console.error("Unable to append the new project to Project Lead Tracking", error)
+    }
+
+    let driveStatus: "provisioned" | "pending" = "provisioned"
+    try {
+      const drive = await provisionGoogleProjectDriveFolder(
+        googleClients.drive,
+        googleEmail,
+        { department, folderName: driveFolderName }
+      )
+      const syncedAt = new Date().toISOString()
+      try {
+        await db.batch([
+          db
+            .update(projects)
+            .set({
+              googleDriveFolderId: drive.folderId,
+              updatedAt: syncedAt,
+            })
+            .where(eq(projects.id, projectId)),
+          db
+            .update(projectExternalLinks)
+            .set({
+              externalId: drive.folderId,
+              externalUrl: drive.folderUrl,
+              syncStatus: "mapped",
+              lastSyncedAt: syncedAt,
+              metadata: JSON.stringify({
+                department,
+                folderName: drive.folderName,
+                parentFolderId: drive.parentFolderId,
+                childFolderNames: drive.childFolderNames,
+              }),
+              updatedAt: syncedAt,
+            })
+            .where(eq(projectExternalLinks.id, driveLinkId)),
+          db
+            .update(projectOperations)
+            .set({ externalUrl: drive.folderUrl, updatedAt: syncedAt })
+            .where(eq(projectOperations.id, sageOperationId)),
+        ])
+      } catch (error) {
+        driveStatus = "pending"
+        warning = appendWarning(
+          warning,
+          "The Drive folder was created, but Compass could not save its link. Use Retry Drive setup in the Project Registry; it will reuse the folder."
+        )
+        console.error("Unable to save the project Drive receipt", error)
+      }
+    } catch (error) {
+      driveStatus = "pending"
+      warning = appendWarning(
+        warning,
+        "Google Drive setup is pending. The Compass project is safe to use; retry Drive setup from the Project Registry."
+      )
+      console.error("Unable to provision the project Drive folder", error)
     }
 
     await recordActivityEvent({
@@ -514,16 +697,201 @@ export async function createProjectIntake(
       entityType: "project",
       entityId: projectId,
       summary: `Created ${projectNumber} — ${projectName}.`,
-      metadata: { department, trackerStatus },
+      metadata: { department, trackerStatus, driveStatus, sageStatus: "staged" },
     })
     revalidatePath("/dashboard/projects")
     revalidatePath(`/dashboard/projects/${projectId}`)
     revalidatePath("/dashboard")
-    return { success: true, id: projectId, projectNumber, trackerStatus, warning }
+    return {
+      success: true,
+      id: projectId,
+      projectNumber,
+      trackerStatus,
+      driveStatus,
+      sageStatus: "staged",
+      warning,
+    }
   } catch (error) {
     return {
       success: false,
       error: error instanceof Error ? error.message : "Failed to create project",
+    }
+  }
+}
+
+export type ProvisionProjectDriveResult =
+  | {
+      readonly success: true
+      readonly folderId: string
+      readonly folderUrl: string
+      readonly createdRoot: boolean
+      readonly createdChildCount: number
+    }
+  | { readonly success: false; readonly error: string }
+
+export async function provisionProjectDriveFolder(
+  projectId: string
+): Promise<ProvisionProjectDriveResult> {
+  try {
+    const user = await requireAuth()
+    requirePermission(user, "project", "update")
+    requirePermission(user, "document", "create")
+    if (!canManageProjectRegistry(user)) {
+      return {
+        success: false,
+        error: "Permission denied: project registry is admin-only",
+      }
+    }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    if (!env?.DB) return { success: false, error: "D1 not available" }
+    const db = getDb(env.DB)
+    const [project] = await db
+      .select({
+        id: projects.id,
+        projectNumber: projects.projectNumber,
+        name: projects.name,
+        googleDriveFolderId: projects.googleDriveFolderId,
+      })
+      .from(projects)
+      .where(
+        and(
+          eq(projects.id, projectId),
+          eq(projects.organizationId, organizationId)
+        )
+      )
+      .limit(1)
+    if (!project) return { success: false, error: "Project not found" }
+    if (project.googleDriveFolderId) {
+      return {
+        success: true,
+        folderId: project.googleDriveFolderId,
+        folderUrl: `https://drive.google.com/drive/folders/${project.googleDriveFolderId}`,
+        createdRoot: false,
+        createdChildCount: 0,
+      }
+    }
+
+    const department = projectDepartment(project.projectNumber)
+    if (!department || !project.projectNumber) {
+      return {
+        success: false,
+        error: "Set an O, H, N, or D project number before provisioning Drive.",
+      }
+    }
+    const [driveLink] = await db
+      .select({
+        id: projectExternalLinks.id,
+        metadata: projectExternalLinks.metadata,
+      })
+      .from(projectExternalLinks)
+      .where(
+        and(
+          eq(projectExternalLinks.projectId, projectId),
+          eq(projectExternalLinks.system, "google_drive")
+        )
+      )
+      .limit(1)
+    const folderName =
+      metadataFolderName(driveLink?.metadata ?? null) ??
+      buildProjectDriveFolderName({
+        projectNumber: project.projectNumber,
+        projectName: project.name,
+        streetNumber: null,
+        streetName: null,
+      })
+    const googleClients = await projectWorkspaceClients({
+      environment: env,
+      organizationId,
+    })
+    const drive = await provisionGoogleProjectDriveFolder(
+      googleClients.drive,
+      user.googleEmail ?? user.email,
+      { department, folderName }
+    )
+    const now = new Date().toISOString()
+    const linkValues = {
+      label: "Project Drive folder",
+      externalId: drive.folderId,
+      externalNumber: null,
+      externalUrl: drive.folderUrl,
+      syncDirection: "read_write",
+      syncStatus: "mapped",
+      lastSyncedAt: now,
+      metadata: JSON.stringify({
+        department,
+        folderName: drive.folderName,
+        parentFolderId: drive.parentFolderId,
+        childFolderNames: drive.childFolderNames,
+      }),
+      updatedAt: now,
+    }
+    const projectUpdate = db
+      .update(projects)
+      .set({ googleDriveFolderId: drive.folderId, updatedAt: now })
+      .where(eq(projects.id, projectId))
+    const sageOperationUpdate = db
+      .update(projectOperations)
+      .set({ externalUrl: drive.folderUrl, updatedAt: now })
+      .where(
+        and(
+          eq(projectOperations.projectId, projectId),
+          eq(projectOperations.sourceRecordType, "sage_project_handoff")
+        )
+      )
+    if (driveLink) {
+      await db.batch([
+        projectUpdate,
+        sageOperationUpdate,
+        db
+          .update(projectExternalLinks)
+          .set(linkValues)
+          .where(eq(projectExternalLinks.id, driveLink.id)),
+      ])
+    } else {
+      await db.batch([
+        projectUpdate,
+        sageOperationUpdate,
+        db.insert(projectExternalLinks).values({
+          id: crypto.randomUUID(),
+          projectId,
+          system: "google_drive",
+          createdAt: now,
+          ...linkValues,
+        }),
+      ])
+    }
+    await recordActivityEvent({
+      db,
+      organizationId,
+      projectId,
+      actor: user,
+      category: "file",
+      action: "project.drive_provisioned",
+      entityType: "project",
+      entityId: projectId,
+      summary: `Provisioned the Drive folder for ${project.projectNumber}.`,
+      metadata: {
+        folderId: drive.folderId,
+        createdRoot: drive.createdRoot,
+        createdChildCount: drive.createdChildCount,
+      },
+    })
+    revalidatePath(`/dashboard/projects/${projectId}`)
+    revalidatePath("/dashboard/projects")
+    revalidatePath("/dashboard/files")
+    return {
+      success: true,
+      folderId: drive.folderId,
+      folderUrl: drive.folderUrl,
+      createdRoot: drive.createdRoot,
+      createdChildCount: drive.createdChildCount,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to provision Drive",
     }
   }
 }

--- a/src/components/projects/project-intake-drawer.tsx
+++ b/src/components/projects/project-intake-drawer.tsx
@@ -3,7 +3,6 @@
 import { useRef, useState, useTransition } from "react"
 import { useRouter } from "next/navigation"
 import {
-  IconArrowRight,
   IconBuilding,
   IconCheck,
   IconDatabase,
@@ -94,33 +93,44 @@ export function ProjectIntakeDrawer({
     event.preventDefault()
     const formData = new FormData(event.currentTarget)
     startTransition(async () => {
-      const result = await createProjectIntake({
-        department,
-        projectName: fieldValue(formData, "projectName") ?? "",
-        clientName: fieldValue(formData, "clientName"),
-        companyName: fieldValue(formData, "companyName"),
-        clientFirstName: fieldValue(formData, "clientFirstName"),
-        clientLastName: fieldValue(formData, "clientLastName"),
-        contactPhone: fieldValue(formData, "contactPhone"),
-        contactEmail: fieldValue(formData, "contactEmail"),
-        streetNumber: fieldValue(formData, "streetNumber"),
-        streetName: fieldValue(formData, "streetName"),
-        cityStateZip: fieldValue(formData, "cityStateZip"),
-        billingAddress: fieldValue(formData, "billingAddress"),
-        assignedTo: fieldValue(formData, "assignedTo"),
-        referredBy: fieldValue(formData, "referredBy"),
-        notes: fieldValue(formData, "notes"),
-      })
-      if (!result.success) {
-        toast.error(result.error)
-        return
+      try {
+        const result = await createProjectIntake({
+          department,
+          projectName: fieldValue(formData, "projectName") ?? "",
+          clientName: fieldValue(formData, "clientName"),
+          companyName: fieldValue(formData, "companyName"),
+          clientFirstName: fieldValue(formData, "clientFirstName"),
+          clientLastName: fieldValue(formData, "clientLastName"),
+          contactPhone: fieldValue(formData, "contactPhone"),
+          contactEmail: fieldValue(formData, "contactEmail"),
+          streetNumber: fieldValue(formData, "streetNumber"),
+          streetName: fieldValue(formData, "streetName"),
+          cityStateZip: fieldValue(formData, "cityStateZip"),
+          billingAddress: fieldValue(formData, "billingAddress"),
+          assignedTo: fieldValue(formData, "assignedTo"),
+          referredBy: fieldValue(formData, "referredBy"),
+          notes: fieldValue(formData, "notes"),
+        })
+        if (!result.success) {
+          toast.error(result.error)
+          return
+        }
+        if (result.warning) toast.warning(result.warning)
+        else {
+          toast.success(
+            `${result.projectNumber} created with Project Lead Tracking, Drive, and Sage review staged.`
+          )
+        }
+        formRef.current?.reset()
+        setOpen(false)
+        router.push(`/dashboard/projects/${result.id}`)
+        router.refresh()
+      } catch (error) {
+        console.error("Project intake request failed", error)
+        toast.error(
+          "Compass could not submit this project. Your entries are still here; refresh Compass before trying again."
+        )
       }
-      if (result.warning) toast.warning(result.warning)
-      else toast.success(`${result.projectNumber} created in Compass and Project Lead Tracking.`)
-      formRef.current?.reset()
-      setOpen(false)
-      router.push(`/dashboard/projects/${result.id}`)
-      router.refresh()
     })
   }
 
@@ -145,7 +155,7 @@ export function ProjectIntakeDrawer({
             <IconDatabase className="size-4" />
             <AlertTitle>One intake, both systems</AlertTitle>
             <AlertDescription>
-              Compass assigns the next department project number. Drive and Sage setup remain visibly staged until their integrations finish.
+              Compass assigns the next department project number, provisions the department Drive folder, and stages Sage review.
             </AlertDescription>
           </Alert>
 
@@ -261,7 +271,7 @@ export function ProjectIntakeDrawer({
           <div className="grid gap-2 border-y py-4 text-sm sm:grid-cols-3">
             <span className="flex items-center gap-2"><IconCheck className="size-4 text-emerald-700" /> Compass registry</span>
             <span className="flex items-center gap-2"><IconCheck className="size-4 text-emerald-700" /> Project Lead Tracking</span>
-            <span className="flex items-center gap-2 text-muted-foreground"><IconArrowRight className="size-4" /> Drive and Sage staging</span>
+            <span className="flex items-center gap-2"><IconCheck className="size-4 text-emerald-700" /> Drive folder + Sage review</span>
           </div>
 
           <SheetFooter className="px-0">

--- a/src/components/projects/project-registry-panel.tsx
+++ b/src/components/projects/project-registry-panel.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import { useRouter } from "next/navigation"
 import {
   IconBrandTelegram,
   IconCalendar,
@@ -17,6 +18,7 @@ import {
   updateProjectRegistry,
   type ProjectRegistry,
 } from "@/app/actions/project-registry"
+import { provisionProjectDriveFolder } from "@/app/actions/projects"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -151,8 +153,10 @@ export function ProjectRegistryPanel({
   readonly projectId: string
   readonly registry: ProjectRegistry | null
 }): React.ReactElement {
+  const router = useRouter()
   const [message, setMessage] = React.useState<string | null>(null)
   const [isSaving, setIsSaving] = React.useState(false)
+  const [isProvisioningDrive, setIsProvisioningDrive] = React.useState(false)
   const [isEditing, setIsEditing] = React.useState(false)
 
   if (!registry) {
@@ -181,6 +185,23 @@ export function ProjectRegistryPanel({
     )
   }
 
+  async function retryDriveSetup(): Promise<void> {
+    setIsProvisioningDrive(true)
+    setMessage(null)
+    const result = await provisionProjectDriveFolder(projectId)
+    setIsProvisioningDrive(false)
+    if (!result.success) {
+      setMessage(`Could not provision Drive: ${result.error}`)
+      return
+    }
+    setMessage(
+      result.createdRoot
+        ? "Project Drive folder created and linked."
+        : "Existing project Drive folder found and linked."
+    )
+    router.refresh()
+  }
+
   const mappedCount = connectionCount(registry)
   const telegramId = telegramChatId(registry)
   const links = mappedLinks(registry)
@@ -203,6 +224,22 @@ export function ProjectRegistryPanel({
             <Badge variant={mappedCount > 0 ? "secondary" : "outline"}>
               {mappedCount} mapped
             </Badge>
+            {!registry.project.googleDriveFolderId && (
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={retryDriveSetup}
+                disabled={isProvisioningDrive}
+              >
+                {isProvisioningDrive ? (
+                  <IconRefresh className="size-4 animate-spin" />
+                ) : (
+                  <IconFolder className="size-4" />
+                )}
+                Retry Drive setup
+              </Button>
+            )}
             <Button
               type="button"
               size="sm"
@@ -214,6 +251,11 @@ export function ProjectRegistryPanel({
             </Button>
           </div>
         </div>
+        {message && (
+          <p className="mt-3 rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">
+            {message}
+          </p>
+        )}
       </section>
     )
   }

--- a/src/lib/google/project-drive-provisioning.ts
+++ b/src/lib/google/project-drive-provisioning.ts
@@ -1,0 +1,246 @@
+import type {
+  DriveFile,
+  DriveFileList,
+  ListFilesOptions,
+} from "@/lib/google/client/types"
+import {
+  PROJECT_FILE_SOURCES,
+  type ProjectFileSource,
+} from "@/lib/project-files"
+import type { ProjectIntakeDepartment } from "./project-intake-tracker"
+
+const GOOGLE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
+
+type ProjectDriveClient = {
+  readonly listFiles: (
+    userEmail: string,
+    options?: ListFilesOptions
+  ) => Promise<DriveFileList>
+  readonly getFile: (userEmail: string, fileId: string) => Promise<DriveFile>
+  readonly createFolder: (
+    userEmail: string,
+    options: {
+      readonly name: string
+      readonly parentId?: string
+      readonly driveId?: string
+    }
+  ) => Promise<DriveFile>
+}
+
+export type ProjectDriveProvisioningInput = {
+  readonly department: ProjectIntakeDepartment
+  readonly folderName: string
+}
+
+export type ProjectDriveProvisioningResult = {
+  readonly folderId: string
+  readonly folderName: string
+  readonly folderUrl: string
+  readonly parentFolderId: string
+  readonly childFolderNames: readonly string[]
+  readonly createdRoot: boolean
+  readonly createdChildCount: number
+}
+
+const DEPARTMENT_CHILD_FOLDERS: Readonly<
+  Record<ProjectIntakeDepartment, readonly string[]>
+> = {
+  O: [
+    "00_CustomerInfo",
+    "01_ActiveContractDocuments",
+    "02_WorkingEstimate",
+    "03_PayRequests",
+    "04_PermittedPlansSpecifications",
+    "05_SelectionsFinishes",
+    "06_Communications",
+    "07_ConstructionLog",
+    "08_Inspections",
+    "09_Financing",
+    "10_Preconstruction",
+    "11_ConstructionSchedule",
+    "11_ChangeOrders",
+    "12_Purchasing",
+    "Pictures",
+    "99_Archive",
+  ],
+  H: [
+    "00_Contracts",
+    "01_Takeoffs",
+    "02_Estimates",
+    "03_BidDocs",
+    "04_PermittedPlans",
+    "05_PropertyInfo",
+    "06_PayRequests",
+    "07_Inspections-Tests",
+    "08_Submittals",
+    "Correspondence",
+    "Photos",
+    "Schedules",
+  ],
+  D: [
+    "00_Contracts",
+    "01_ProgramDocs",
+    "02_Schematics",
+    "03_DesignDevelopment",
+    "04_ConstructionDocs",
+    "05_PermitSet",
+    "06_Engineering",
+    "Correspondence",
+    "Photos",
+    "99_Archive",
+  ],
+  N: ["00_OrderDocs", "01_Quotes", "02_Invoices", "03_DeliveryDocs", "Photos"],
+}
+
+function cleanFolderPart(value: string | null): string | null {
+  const cleaned = value?.replace(/[/:\\]/g, "-").replace(/\s+/g, " ").trim() ?? ""
+  return cleaned.length > 0 ? cleaned : null
+}
+
+function driveQueryValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")
+}
+
+function sourceForDepartment(
+  department: ProjectIntakeDepartment
+): ProjectFileSource {
+  const source = PROJECT_FILE_SOURCES.find(
+    (candidate) => candidate.projectPrefix === department
+  )
+  if (!source) {
+    throw new Error(`No Google Drive project root is configured for ${department}.`)
+  }
+  return source
+}
+
+function folderQuery(name: string): string {
+  return (
+    `mimeType = '${GOOGLE_FOLDER_MIME_TYPE}' and ` +
+    `name = '${driveQueryValue(name)}'`
+  )
+}
+
+async function findFolder(
+  client: ProjectDriveClient,
+  userEmail: string,
+  parentId: string,
+  name: string
+): Promise<DriveFile | null> {
+  const result = await client.listFiles(userEmail, {
+    folderId: parentId,
+    query: folderQuery(name),
+    pageSize: 10,
+    orderBy: "createdTime",
+  })
+  return result.files[0] ?? null
+}
+
+function verifyFolder(
+  folder: DriveFile,
+  expectedName: string,
+  expectedParentId: string
+): void {
+  if (folder.mimeType !== GOOGLE_FOLDER_MIME_TYPE) {
+    throw new Error(`Google created ${expectedName}, but it is not a folder.`)
+  }
+  if (folder.name !== expectedName) {
+    throw new Error(`Google returned the wrong folder for ${expectedName}.`)
+  }
+  if (!folder.parents?.includes(expectedParentId)) {
+    throw new Error(`Google created ${expectedName} outside the expected project location.`)
+  }
+}
+
+export function buildProjectDriveFolderName(input: {
+  readonly projectNumber: string
+  readonly projectName: string
+  readonly streetNumber: string | null
+  readonly streetName: string | null
+}): string {
+  const projectNumber = cleanFolderPart(input.projectNumber)
+  const projectName = cleanFolderPart(input.projectName)
+  if (!projectNumber || !projectName) {
+    throw new Error("Project number and name are required for Drive provisioning.")
+  }
+  const address = [
+    cleanFolderPart(input.streetNumber),
+    cleanFolderPart(input.streetName),
+  ]
+    .filter((value) => value !== null)
+    .join(" ")
+  return [projectNumber, address || null, projectName]
+    .filter((value) => value !== null)
+    .join(" - ")
+}
+
+export function projectDriveChildFolders(
+  department: ProjectIntakeDepartment
+): readonly string[] {
+  return DEPARTMENT_CHILD_FOLDERS[department]
+}
+
+export async function provisionProjectDriveFolder(
+  client: ProjectDriveClient,
+  userEmail: string,
+  input: ProjectDriveProvisioningInput
+): Promise<ProjectDriveProvisioningResult> {
+  const source = sourceForDepartment(input.department)
+  const folderName = cleanFolderPart(input.folderName)
+  if (!folderName) throw new Error("Project folder name is required.")
+
+  const existingRoot = await findFolder(
+    client,
+    userEmail,
+    source.folderId,
+    folderName
+  )
+  const root =
+    existingRoot ??
+    (await client.createFolder(userEmail, {
+      name: folderName,
+      parentId: source.folderId,
+    }))
+  const verifiedRoot = await client.getFile(userEmail, root.id)
+  verifyFolder(verifiedRoot, folderName, source.folderId)
+
+  const childFolderNames = projectDriveChildFolders(input.department)
+  const existingChildren = await client.listFiles(userEmail, {
+    folderId: verifiedRoot.id,
+    query: `mimeType = '${GOOGLE_FOLDER_MIME_TYPE}'`,
+    pageSize: 200,
+  })
+  const existingNames = new Set(existingChildren.files.map((folder) => folder.name))
+  const missingNames = childFolderNames.filter((name) => !existingNames.has(name))
+  await Promise.all(
+    missingNames.map((name) =>
+      client.createFolder(userEmail, { name, parentId: verifiedRoot.id })
+    )
+  )
+
+  // Read the project folder again after writes so Compass only records a link
+  // once every required child landed in the intended parent.
+  const verifiedChildren = await client.listFiles(userEmail, {
+    folderId: verifiedRoot.id,
+    query: `mimeType = '${GOOGLE_FOLDER_MIME_TYPE}'`,
+    pageSize: 200,
+  })
+  const verifiedNames = new Set(verifiedChildren.files.map((folder) => folder.name))
+  const missingAfterWrite = childFolderNames.filter(
+    (name) => !verifiedNames.has(name)
+  )
+  if (missingAfterWrite.length > 0) {
+    throw new Error(
+      `Google Drive did not confirm ${missingAfterWrite.join(", ")}.`
+    )
+  }
+
+  return {
+    folderId: verifiedRoot.id,
+    folderName,
+    folderUrl: `https://drive.google.com/drive/folders/${verifiedRoot.id}`,
+    parentFolderId: source.folderId,
+    childFolderNames,
+    createdRoot: existingRoot === null,
+    createdChildCount: missingNames.length,
+  }
+}

--- a/src/lib/google/project-intake-tracker.ts
+++ b/src/lib/google/project-intake-tracker.ts
@@ -25,6 +25,20 @@ export type ProjectTrackerLayout = {
   readonly projectNumberColumn: number
 }
 
+const PROJECT_TRACKER_SHEET_NAMES = ["Master List", "Highlight Project"] as const
+
+export function findProjectTrackerSheetTitle(
+  sheetTitles: readonly string[]
+): string | null {
+  for (const preferred of PROJECT_TRACKER_SHEET_NAMES) {
+    const match = sheetTitles.find(
+      (title) => title.trim().toLowerCase() === preferred.toLowerCase()
+    )
+    if (match) return match
+  }
+  return null
+}
+
 function cellText(value: unknown): string {
   if (typeof value === "string") return value.trim()
   if (typeof value === "number" && Number.isFinite(value)) return String(value)


### PR DESCRIPTION
## What changed

- use the live `Master List` tab in Project Lead Tracking while preserving the former `Highlight Project` tab name as a fallback
- provision a verified department-specific Google Drive project folder and standard child folders during native project intake
- record a pending Drive mapping before external work and provide an idempotent Project Registry retry when Google or the receipt write fails
- stage a reviewable Sage project handoff without automatically writing to Sage
- surface unexpected server-action failures without clearing the user's intake form

## Why

The native intake was blocked because `Highlight Project` is a heading inside the workbook, while the actual sheet tab is `Master List`. New projects also needed their document home and Sage review lane created as part of the same durable workflow.

## Validation

- `bun test __tests__/google-project-drive-provisioning.test.ts __tests__/google-project-intake-tracker.test.ts`
- `bunx tsc --noEmit`
- `bun lint` (zero errors; existing warnings only)
- `bun run build`
- structured autoreview: clean, no accepted/actionable findings

The repository-wide `bun test` run reached 678 passing tests before known harness failures from loading Playwright specs under Bun and the existing `better-sqlite3`/Bun incompatibility.
