### PR TITLE
fix(projects): route intake to Developer trackers

### DIFF
--- a/__tests__/google-project-intake-tracker.test.ts
+++ b/__tests__/google-project-intake-tracker.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from "vitest"
 
 import {
   allocateProjectNumber,
-  buildProjectTrackerRow,
-  findProjectTrackerSheetTitle,
+  buildDepartmentTrackerRow,
+  buildProjectRegistryRow,
+  departmentTrackingDestination,
   locateProjectTrackerLayout,
   type ProjectIntakeTrackerInput,
 } from "@/lib/google/project-intake-tracker"
@@ -27,16 +28,7 @@ const PROJECT: ProjectIntakeTrackerInput = {
   intakeDate: "2026-08-05",
 }
 
-describe("Google Project Lead Tracking intake", () => {
-  it("uses the current Master List tab and keeps the former tab name compatible", () => {
-    expect(
-      findProjectTrackerSheetTitle(["Stats", "Master List", "Parameters"])
-    ).toBe("Master List")
-    expect(findProjectTrackerSheetTitle(["Highlight Project"])).toBe(
-      "Highlight Project"
-    )
-  })
-
+describe("Google Developer-folder project tracking intake", () => {
   it("locates a shifted tracker header and allocates the next department number", () => {
     const rows = [
       ["Project Lead Tracking"],
@@ -59,38 +51,6 @@ describe("Google Project Lead Tracking intake", () => {
         layout,
       })
     ).toBe("O-211-33A")
-  })
-
-  it("maps values by header name so tracker column moves remain safe", () => {
-    const layout = locateProjectTrackerLayout([
-      [
-        "Notes",
-        "CLIENT FIRST NAME",
-        "ACTIVE PROJECTS",
-        "PROJECT NUMBER",
-        "CONTACT EMAIL",
-        "ASSIGNED TO",
-        "INTAKE DATE",
-      ],
-    ])
-    expect(layout).not.toBeNull()
-    if (!layout) return
-
-    expect(
-      buildProjectTrackerRow({
-        layout,
-        project: PROJECT,
-        projectNumber: "O-211-33A",
-      })
-    ).toEqual([
-      "Call before site visit",
-      "Dan",
-      "Mitchell Residence",
-      "O-211-33A",
-      "dan@example.com",
-      "Wes Jones",
-      "2026-08-05",
-    ])
   })
 
   it("uses a safe street placeholder when a lead has no street number yet", () => {
@@ -124,5 +84,133 @@ describe("Google Project Lead Tracking intake", () => {
         reservedProjectNumbers: ["O-211-33", "H-995-20"],
       })
     ).toBe("O-212-55")
+  })
+
+  it("allocates from the Developer Project Registry Project ID column", () => {
+    const rows = [
+      ["Project ID", "Division", "Sequence"],
+      ["H-430-1900", "HPS", 430],
+      ["H-431-00", "HPS", 431],
+    ]
+    const layout = locateProjectTrackerLayout(rows)
+    expect(layout).not.toBeNull()
+    if (!layout) return
+
+    expect(
+      allocateProjectNumber({
+        department: "H",
+        streetNumber: "3295",
+        rows,
+        layout,
+      })
+    ).toBe("H-432-3295")
+  })
+
+  it("maps the Project Registry and HPS Tracker live headers", () => {
+    const hpsProject: ProjectIntakeTrackerInput = {
+      ...PROJECT,
+      department: "H",
+      projectName: "Thompson Residence",
+      clientName: "Scott and Farrell Thompson",
+      companyName: null,
+      clientFirstName: "Scott",
+      clientLastName: "Thompson",
+      streetNumber: "3295",
+      streetName: "Little Turkey Creek Rd.",
+      cityStateZip: "Colorado Springs, CO 80926",
+      assignedTo: "Martine Vogel",
+    }
+    const registryLayout = locateProjectTrackerLayout([
+      [
+        "Project ID",
+        "Division",
+        "Sequence",
+        "Street Number / Code",
+        "Folder Link",
+        "Lead Tracker Link",
+        "Status",
+      ],
+    ])
+    const trackerLayout = locateProjectTrackerLayout([
+      [
+        "Project ID",
+        "Builder / GC",
+        "Contact Person",
+        "Estimator",
+        "Quote Status",
+        "Folder Link",
+        "Project Address",
+      ],
+    ])
+    expect(registryLayout).not.toBeNull()
+    expect(trackerLayout).not.toBeNull()
+    if (!registryLayout || !trackerLayout) return
+
+    const destination = departmentTrackingDestination("H")
+    expect(
+      buildProjectRegistryRow({
+        layout: registryLayout,
+        project: hpsProject,
+        projectNumber: "H-432-3295",
+        driveFolderUrl: "https://drive.google.com/drive/folders/folder-id",
+        departmentTrackerUrl: `https://docs.google.com/spreadsheets/d/${destination.spreadsheetId}`,
+        createdBy: "Martine Vogel",
+      })
+    ).toEqual([
+      "H-432-3295",
+      "HPS",
+      "432",
+      "3295",
+      "https://drive.google.com/drive/folders/folder-id",
+      `https://docs.google.com/spreadsheets/d/${destination.spreadsheetId}`,
+      "I - Intake",
+    ])
+    expect(
+      buildDepartmentTrackerRow({
+        layout: trackerLayout,
+        project: hpsProject,
+        projectNumber: "H-432-3295",
+        driveFolderUrl: "https://drive.google.com/drive/folders/folder-id",
+      })
+    ).toEqual([
+      "H-432-3295",
+      "Scott and Farrell Thompson",
+      "Scott and Farrell Thompson",
+      "Martine Vogel",
+      "I - Intake",
+      "https://drive.google.com/drive/folders/folder-id",
+      "3295 Little Turkey Creek Rd., Colorado Springs, CO 80926",
+    ])
+  })
+
+  it("keeps Project Number header compatibility without dropping the identifier", () => {
+    const registryLayout = locateProjectTrackerLayout([
+      ["Project Number", "Division"],
+    ])
+    const trackerLayout = locateProjectTrackerLayout([
+      ["Project Number", "Client"],
+    ])
+    expect(registryLayout).not.toBeNull()
+    expect(trackerLayout).not.toBeNull()
+    if (!registryLayout || !trackerLayout) return
+
+    expect(
+      buildProjectRegistryRow({
+        layout: registryLayout,
+        project: PROJECT,
+        projectNumber: "O-211-33A",
+        driveFolderUrl: null,
+        departmentTrackerUrl: "https://example.invalid/tracker",
+        createdBy: "Martine Vogel",
+      })[0]
+    ).toBe("O-211-33A")
+    expect(
+      buildDepartmentTrackerRow({
+        layout: trackerLayout,
+        project: PROJECT,
+        projectNumber: "O-211-33A",
+        driveFolderUrl: null,
+      })[0]
+    ).toBe("O-211-33A")
   })
 })

--- a/docs/wip/compass-google-sage-integration-plan.md
+++ b/docs/wip/compass-google-sage-integration-plan.md
@@ -168,7 +168,7 @@ Initial behavior:
 The prior Google Site plan called for Apps Script around:
 
 - project intake form to folder creation
-- automatic numbering from Project Lead Tracking
+- automatic numbering from the Developer-folder Project Registry
 - tracker updates on submit
 - installable form-submit triggers
 - insurance expiration alerts
@@ -188,7 +188,9 @@ Apps Script access still depends on Google Admin OAuth scopes. The known require
 Current Compass bridge endpoints:
 
 - `/api/google/project-manager-handoff` is the dedicated HPS Project Manager receiver. It creates or updates the Compass project, maps the Drive folder, and stages Sage job review.
+- Compass-native project intake must dual-write the `________Developer` Project Registry and the matching department tracker. The legacy `Project Lead Tracking` workbook is prohibited as a destination for new records.
 - Project Manager handoffs should use the active tracker spreadsheets in the `________Developer` Google Drive folder: ORC Tracker, HPS Tracker, Nu-Tech Tracker, and Design Tracker. ORC and Design currently expose a full `Address` column; HPS and Nu-Tech expose `Project Address`. Compass accepts those raw tracker headers directly, plus normalized names such as `address`, `projectAddress`, and `jobsiteAddress`.
+- The Developer folder also contains the protected `Copy of Contract Package Template`, `Finish Schedule Form Responses`, and `Finish Schedule Generator` workflow assets. Generated finish schedules must carry a project number and remain discoverable from the matching Compass project; reconciliation should report response rows or generated workbooks without a Compass mapping.
 - When a tracker or script sends split address fields, Compass also accepts `streetAddress`, `addressLine1`, `city`, `state`, `zip`, the Project Manager form names `streetNum`, `streetName`, and `cityState`, and raw sheet headers such as `PROJECT STREET NUMBER`, `PROJECT STREET NAME`, and `City, State Zip`. Zip code is captured when it is included in `Address`/`Project Address`/`City, State Zip` or sent separately as `zip`/`zipCode`; older rows that only contain city should be cleaned up or flagged as incomplete address data. Compass composes those fields into `projects.address` and will not erase an existing address when a later handoff omits address data.
 - `/api/google/script-handoff` is the generic receiver for the remaining Google scripts. The first target scripts are HPS Project Intake Automation, Nu-Tech PO Order Manager, and the Design-owned Finish Schedule Generator. Each request must include a bearer token and a project number so Compass can attach the handoff to the correct project.
 

--- a/src/app/actions/projects.ts
+++ b/src/app/actions/projects.ts
@@ -30,11 +30,15 @@ import {
 } from "@/lib/google/project-drive-provisioning"
 import {
   allocateProjectNumber,
-  buildProjectTrackerRow,
-  findProjectTrackerSheetTitle,
+  buildDepartmentTrackerRow,
+  buildProjectRegistryRow,
+  departmentTrackingDestination,
   locateProjectTrackerLayout,
+  PROJECT_REGISTRY_DESTINATION,
+  projectRowNumber,
   type ProjectIntakeDepartment,
   type ProjectIntakeTrackerInput,
+  type ProjectTrackerLayout,
 } from "@/lib/google/project-intake-tracker"
 import { requireOrg } from "@/lib/org-scope"
 import {
@@ -110,9 +114,6 @@ export type CreateProjectIntakeResult =
     }
   | { readonly success: false; readonly error: string }
 
-const PROJECT_LEAD_TRACKING_SPREADSHEET_ID =
-  "15DPCjDK9a4b3pkNB7ZdSFtJsSN1q2CyajNUBb40aRkE"
-
 function cleanText(value: string | null): string | null {
   const trimmed = value?.trim() ?? ""
   return trimmed.length > 0 ? trimmed : null
@@ -183,6 +184,49 @@ function isProjectStatusValue(value: string): value is ProjectStatusValue {
 
 function quotedSheetRange(sheetTitle: string, range: string): string {
   return `'${sheetTitle.replace(/'/g, "''")}'!${range}`
+}
+
+function spreadsheetUrl(spreadsheetId: string): string {
+  return `https://docs.google.com/spreadsheets/d/${spreadsheetId}`
+}
+
+async function appendProjectRowIfMissing(input: {
+  readonly sheets: SheetsClient
+  readonly googleEmail: string
+  readonly spreadsheetId: string
+  readonly sheetTitle: string
+  readonly rows: ReadonlyArray<ReadonlyArray<unknown>>
+  readonly layout: ProjectTrackerLayout
+  readonly projectNumber: string
+  readonly row: readonly string[]
+}): Promise<{ readonly updatedRange: string; readonly alreadyPresent: boolean }> {
+  const existingRow = projectRowNumber(
+    input.rows,
+    input.layout,
+    input.projectNumber
+  )
+  if (existingRow !== null) {
+    return {
+      updatedRange: quotedSheetRange(
+        input.sheetTitle,
+        `A${existingRow}:${String.fromCharCode(64 + Math.min(input.layout.headers.length, 26))}${existingRow}`
+      ),
+      alreadyPresent: true,
+    }
+  }
+  const appended = await input.sheets.appendValues(input.googleEmail, {
+    spreadsheetId: input.spreadsheetId,
+    range: quotedSheetRange(
+      input.sheetTitle,
+      `A${input.layout.headerRowNumber}:AZ`
+    ),
+    values: [input.row],
+  })
+  return {
+    updatedRange:
+      appended.updatedRange ?? quotedSheetRange(input.sheetTitle, "A:AZ"),
+    alreadyPresent: false,
+  }
 }
 
 function joinedAddress(input: CreateProjectIntakeInput): string | null {
@@ -324,29 +368,24 @@ export async function createProjectIntake(
       organizationId,
     })
     const googleEmail = user.googleEmail ?? user.email
-    const metadata = await googleClients.sheets.getSpreadsheetMetadata(
-      googleEmail,
-      PROJECT_LEAD_TRACKING_SPREADSHEET_ID
-    )
-    const trackerSheet = findProjectTrackerSheetTitle(
-      metadata.sheets.map((sheet) => sheet.title)
-    )
-    if (!trackerSheet) {
+    const departmentDestination = departmentTrackingDestination(department)
+    const [registryRows, departmentRows] = await Promise.all([
+      googleClients.sheets.getValues(googleEmail, {
+        spreadsheetId: PROJECT_REGISTRY_DESTINATION.spreadsheetId,
+        range: quotedSheetRange(PROJECT_REGISTRY_DESTINATION.sheetTitle, "A:Z"),
+      }),
+      googleClients.sheets.getValues(googleEmail, {
+        spreadsheetId: departmentDestination.spreadsheetId,
+        range: quotedSheetRange(departmentDestination.sheetTitle, "A:AZ"),
+      }),
+    ])
+    const registryLayout = locateProjectTrackerLayout(registryRows)
+    const departmentLayout = locateProjectTrackerLayout(departmentRows)
+    if (!registryLayout || !departmentLayout) {
       return {
         success: false,
         error:
-          "Project Lead Tracking is missing its Master List sheet. No project was created.",
-      }
-    }
-    const trackerRows = await googleClients.sheets.getValues(googleEmail, {
-      spreadsheetId: PROJECT_LEAD_TRACKING_SPREADSHEET_ID,
-      range: quotedSheetRange(trackerSheet, "A:AZ"),
-    })
-    const layout = locateProjectTrackerLayout(trackerRows)
-    if (!layout) {
-      return {
-        success: false,
-        error: "The Project Lead Tracking header row could not be identified.",
+          "The Developer Project Registry or department Tracker headers could not be identified. No project was created.",
       }
     }
     const reservations = await db
@@ -365,11 +404,15 @@ export async function createProjectIntake(
     const projectNumber = allocateProjectNumber({
       department,
       streetNumber: input.streetNumber,
-      rows: trackerRows,
-      layout,
+      rows: registryRows,
+      layout: registryLayout,
       reservedProjectNumbers: reservations.map(
         (reservation) => reservation.projectNumber
       ).concat(
+        departmentRows.slice(departmentLayout.headerRowNumber).flatMap((row) => {
+          const value = row[departmentLayout.projectNumberColumn]
+          return typeof value === "string" && value.trim() ? [value] : []
+        }),
         compassProjectNumbers.flatMap((project) =>
           project.projectNumber ? [project.projectNumber] : []
         )
@@ -396,7 +439,8 @@ export async function createProjectIntake(
     const now = new Date().toISOString()
     const projectId = `proj-${slugPart(projectNumber)}-${crypto.randomUUID().slice(0, 8)}`
     const operationId = crypto.randomUUID()
-    const trackerLinkId = crypto.randomUUID()
+    const registryLinkId = crypto.randomUUID()
+    const departmentTrackerLinkId = crypto.randomUUID()
     const driveLinkId = crypto.randomUUID()
     const sageLinkId = crypto.randomUUID()
     const sageOperationId = crypto.randomUUID()
@@ -406,11 +450,6 @@ export async function createProjectIntake(
       projectName,
       intakeDate,
     }
-    const trackerRow = buildProjectTrackerRow({
-      layout,
-      project: trackerProject,
-      projectNumber,
-    })
     const driveFolderName = buildProjectDriveFolderName({
       projectNumber,
       projectName,
@@ -503,21 +542,38 @@ export async function createProjectIntake(
           updatedAt: now,
         }),
         db.insert(projectExternalLinks).values({
-          id: trackerLinkId,
+          id: registryLinkId,
           projectId,
-          system: "google_project_lead_tracking",
-          label: "Project Lead Tracking",
-          externalId: PROJECT_LEAD_TRACKING_SPREADSHEET_ID,
+          system: "google_project_registry",
+          label: PROJECT_REGISTRY_DESTINATION.workbookTitle,
+          externalId: PROJECT_REGISTRY_DESTINATION.spreadsheetId,
           externalNumber: projectNumber,
-          externalUrl: `https://docs.google.com/spreadsheets/d/${PROJECT_LEAD_TRACKING_SPREADSHEET_ID}`,
+          externalUrl: spreadsheetUrl(
+            PROJECT_REGISTRY_DESTINATION.spreadsheetId
+          ),
           syncDirection: "bidirectional",
           syncStatus: "pending",
-          // Retain the exact row only while the handoff is pending so a later
-          // reconciliation does not need to reconstruct discarded form fields.
           metadata: JSON.stringify({
-            sheet: trackerSheet,
-            headers: layout.headers,
-            row: trackerRow,
+            sheet: PROJECT_REGISTRY_DESTINATION.sheetTitle,
+            projectNumber,
+          }),
+          createdAt: now,
+          updatedAt: now,
+        }),
+        db.insert(projectExternalLinks).values({
+          id: departmentTrackerLinkId,
+          projectId,
+          system: "google_department_tracker",
+          label: departmentDestination.workbookTitle,
+          externalId: departmentDestination.spreadsheetId,
+          externalNumber: projectNumber,
+          externalUrl: spreadsheetUrl(departmentDestination.spreadsheetId),
+          syncDirection: "bidirectional",
+          syncStatus: "pending",
+          metadata: JSON.stringify({
+            sheet: departmentDestination.sheetTitle,
+            department,
+            projectNumber,
           }),
           createdAt: now,
           updatedAt: now,
@@ -525,18 +581,20 @@ export async function createProjectIntake(
         db.insert(projectOperations).values({
           id: operationId,
           projectId,
-          sourceSystem: "google_project_lead_tracking",
+          sourceSystem: "google_developer_project_tracking",
           sourceRecordType: "project_intake",
-          sourceRecordId: PROJECT_LEAD_TRACKING_SPREADSHEET_ID,
+          sourceRecordId: PROJECT_REGISTRY_DESTINATION.spreadsheetId,
           sourceRecordNumber: projectNumber,
-          title: `Write ${projectNumber} to Project Lead Tracking`,
+          title: `Write ${projectNumber} to Developer project trackers`,
           description:
-            "Compass project intake and its Project Lead Tracking handoff.",
+            `Write Compass intake to Project Registry and ${departmentDestination.workbookTitle}.`,
           status: "open",
           priority: "high",
           assigneeName: cleanText(input.assignedTo),
           companyName: cleanText(input.companyName),
-          externalUrl: `https://docs.google.com/spreadsheets/d/${PROJECT_LEAD_TRACKING_SPREADSHEET_ID}`,
+          externalUrl: spreadsheetUrl(
+            PROJECT_REGISTRY_DESTINATION.spreadsheetId
+          ),
           sageWriteStatus: "not_ready",
           syncDirection: "bidirectional",
           syncStatus: "pending",
@@ -578,67 +636,16 @@ export async function createProjectIntake(
       throw error
     }
 
-    let trackerStatus: "written" | "pending" = "written"
     let warning: string | null = null
-    try {
-      const appended = await googleClients.sheets.appendValues(googleEmail, {
-        spreadsheetId: PROJECT_LEAD_TRACKING_SPREADSHEET_ID,
-        range: quotedSheetRange(
-          trackerSheet,
-          `A${layout.headerRowNumber}:AZ`
-        ),
-        values: [trackerRow],
-      })
-      const syncedAt = new Date().toISOString()
-      try {
-        await db.batch([
-          db
-            .update(projectExternalLinks)
-            .set({
-              syncStatus: "mapped",
-              lastSyncedAt: syncedAt,
-              metadata: JSON.stringify({
-                sheet: trackerSheet,
-                updatedRange: appended.updatedRange,
-              }),
-              updatedAt: syncedAt,
-            })
-            .where(eq(projectExternalLinks.id, trackerLinkId)),
-          db
-            .update(projectOperations)
-            .set({
-              status: "completed",
-              syncStatus: "mapped",
-              lastSyncedAt: syncedAt,
-              updatedAt: syncedAt,
-            })
-            .where(eq(projectOperations.id, operationId)),
-        ])
-      } catch (error) {
-        // The Google write already succeeded. Preserve that truth so a retry
-        // can reconcile by project number instead of appending a duplicate row.
-        warning = appendWarning(
-          warning,
-          "Project Lead Tracking was updated, but Compass could not save its sync receipt. The project is safe to use; do not resend the intake."
-        )
-        console.error("Unable to save the Project Lead Tracking receipt", error)
-      }
-    } catch (error) {
-      trackerStatus = "pending"
-      warning = appendWarning(
-        warning,
-        "The Compass project and number were saved, but Project Lead Tracking is pending and recorded for follow-up. Do not recreate the project."
-      )
-      console.error("Unable to append the new project to Project Lead Tracking", error)
-    }
-
     let driveStatus: "provisioned" | "pending" = "provisioned"
+    let projectDriveUrl: string | null = null
     try {
       const drive = await provisionGoogleProjectDriveFolder(
         googleClients.drive,
         googleEmail,
         { department, folderName: driveFolderName }
       )
+      projectDriveUrl = drive.folderUrl
       const syncedAt = new Date().toISOString()
       try {
         await db.batch([
@@ -685,6 +692,116 @@ export async function createProjectIntake(
         "Google Drive setup is pending. The Compass project is safe to use; retry Drive setup from the Project Registry."
       )
       console.error("Unable to provision the project Drive folder", error)
+    }
+
+    const registryRow = buildProjectRegistryRow({
+      layout: registryLayout,
+      project: trackerProject,
+      projectNumber,
+      driveFolderUrl: projectDriveUrl,
+      departmentTrackerUrl: spreadsheetUrl(
+        departmentDestination.spreadsheetId
+      ),
+      createdBy: user.displayName ?? user.email,
+    })
+    const departmentRow = buildDepartmentTrackerRow({
+      layout: departmentLayout,
+      project: trackerProject,
+      projectNumber,
+      driveFolderUrl: projectDriveUrl,
+    })
+    let registryWrite: Awaited<ReturnType<typeof appendProjectRowIfMissing>> | null =
+      null
+    let departmentWrite: Awaited<ReturnType<typeof appendProjectRowIfMissing>> | null =
+      null
+    try {
+      registryWrite = await appendProjectRowIfMissing({
+        sheets: googleClients.sheets,
+        googleEmail,
+        spreadsheetId: PROJECT_REGISTRY_DESTINATION.spreadsheetId,
+        sheetTitle: PROJECT_REGISTRY_DESTINATION.sheetTitle,
+        rows: registryRows,
+        layout: registryLayout,
+        projectNumber,
+        row: registryRow,
+      })
+    } catch (error) {
+      warning = appendWarning(
+        warning,
+        "The Compass project is safe, but the Developer Project Registry write is pending. Do not recreate the project."
+      )
+      console.error("Unable to write the Developer Project Registry", error)
+    }
+    try {
+      departmentWrite = await appendProjectRowIfMissing({
+        sheets: googleClients.sheets,
+        googleEmail,
+        spreadsheetId: departmentDestination.spreadsheetId,
+        sheetTitle: departmentDestination.sheetTitle,
+        rows: departmentRows,
+        layout: departmentLayout,
+        projectNumber,
+        row: departmentRow,
+      })
+    } catch (error) {
+      warning = appendWarning(
+        warning,
+        `The Compass project is safe, but the ${departmentDestination.workbookTitle} write is pending. Do not recreate the project.`
+      )
+      console.error(
+        `Unable to write ${departmentDestination.workbookTitle}`,
+        error
+      )
+    }
+    const trackerStatus: "written" | "pending" =
+      registryWrite && departmentWrite ? "written" : "pending"
+    const trackingSyncedAt = new Date().toISOString()
+    try {
+      await db.batch([
+        db
+          .update(projectExternalLinks)
+          .set({
+            syncStatus: registryWrite ? "mapped" : "pending",
+            lastSyncedAt: registryWrite ? trackingSyncedAt : null,
+            metadata: JSON.stringify({
+              sheet: PROJECT_REGISTRY_DESTINATION.sheetTitle,
+              updatedRange: registryWrite?.updatedRange ?? null,
+              alreadyPresent: registryWrite?.alreadyPresent ?? false,
+            }),
+            updatedAt: trackingSyncedAt,
+          })
+          .where(eq(projectExternalLinks.id, registryLinkId)),
+        db
+          .update(projectExternalLinks)
+          .set({
+            syncStatus: departmentWrite ? "mapped" : "pending",
+            lastSyncedAt: departmentWrite ? trackingSyncedAt : null,
+            metadata: JSON.stringify({
+              sheet: departmentDestination.sheetTitle,
+              department,
+              updatedRange: departmentWrite?.updatedRange ?? null,
+              alreadyPresent: departmentWrite?.alreadyPresent ?? false,
+            }),
+            updatedAt: trackingSyncedAt,
+          })
+          .where(eq(projectExternalLinks.id, departmentTrackerLinkId)),
+        db
+          .update(projectOperations)
+          .set({
+            status: trackerStatus === "written" ? "completed" : "open",
+            syncStatus: trackerStatus === "written" ? "mapped" : "pending",
+            lastSyncedAt:
+              trackerStatus === "written" ? trackingSyncedAt : null,
+            updatedAt: trackingSyncedAt,
+          })
+          .where(eq(projectOperations.id, operationId)),
+      ])
+    } catch (error) {
+      warning = appendWarning(
+        warning,
+        "Google tracking rows were handled, but Compass could not save every sync receipt. Reconcile by project number; do not resend the intake."
+      )
+      console.error("Unable to save Developer tracker receipts", error)
     }
 
     await recordActivityEvent({

--- a/src/components/projects/project-intake-drawer.tsx
+++ b/src/components/projects/project-intake-drawer.tsx
@@ -118,7 +118,7 @@ export function ProjectIntakeDrawer({
         if (result.warning) toast.warning(result.warning)
         else {
           toast.success(
-            `${result.projectNumber} created with Project Lead Tracking, Drive, and Sage review staged.`
+            `${result.projectNumber} created in Compass, Project Registry, the department tracker, Drive, and Sage review.`
           )
         }
         formRef.current?.reset()
@@ -146,7 +146,7 @@ export function ProjectIntakeDrawer({
         <SheetHeader className="border-b px-5 py-4 text-left">
           <SheetTitle>New Project</SheetTitle>
           <SheetDescription>
-            Create the Compass project and update the existing Project Lead Tracking register in one step.
+            Create the Compass project and update the Developer Project Registry and department tracker in one step.
           </SheetDescription>
         </SheetHeader>
 
@@ -270,7 +270,7 @@ export function ProjectIntakeDrawer({
 
           <div className="grid gap-2 border-y py-4 text-sm sm:grid-cols-3">
             <span className="flex items-center gap-2"><IconCheck className="size-4 text-emerald-700" /> Compass registry</span>
-            <span className="flex items-center gap-2"><IconCheck className="size-4 text-emerald-700" /> Project Lead Tracking</span>
+            <span className="flex items-center gap-2"><IconCheck className="size-4 text-emerald-700" /> Project Registry + department tracker</span>
             <span className="flex items-center gap-2"><IconCheck className="size-4 text-emerald-700" /> Drive folder + Sage review</span>
           </div>
 

--- a/src/lib/google/project-intake-tracker.ts
+++ b/src/lib/google/project-intake-tracker.ts
@@ -25,18 +25,52 @@ export type ProjectTrackerLayout = {
   readonly projectNumberColumn: number
 }
 
-const PROJECT_TRACKER_SHEET_NAMES = ["Master List", "Highlight Project"] as const
+export type ProjectTrackingDestination = {
+  readonly spreadsheetId: string
+  readonly workbookTitle: string
+  readonly sheetTitle: "Tracker"
+  readonly divisionLabel: "ORC" | "HPS" | "NuTech" | "Design"
+}
 
-export function findProjectTrackerSheetTitle(
-  sheetTitles: readonly string[]
-): string | null {
-  for (const preferred of PROJECT_TRACKER_SHEET_NAMES) {
-    const match = sheetTitles.find(
-      (title) => title.trim().toLowerCase() === preferred.toLowerCase()
-    )
-    if (match) return match
-  }
-  return null
+export const PROJECT_REGISTRY_DESTINATION = {
+  spreadsheetId: "1Gwmxfm2wzVgrmov9qSxnFxyX_WJDa5gPbk6VgoZI46I",
+  workbookTitle: "Project Registry",
+  sheetTitle: "Registry",
+} as const
+
+const DEPARTMENT_TRACKING_DESTINATIONS: Readonly<
+  Record<ProjectIntakeDepartment, ProjectTrackingDestination>
+> = {
+  O: {
+    spreadsheetId: "1A2vaXdNdhv_J5XX1iFCiNCH5c1Lm-YaHJ8fqWIJevIg",
+    workbookTitle: "ORC Tracker",
+    sheetTitle: "Tracker",
+    divisionLabel: "ORC",
+  },
+  H: {
+    spreadsheetId: "1t-RRoL5iE8ZFIxEr2KtlrTHSbx_HqmM_DHzjRjL5jIc",
+    workbookTitle: "HPS Tracker",
+    sheetTitle: "Tracker",
+    divisionLabel: "HPS",
+  },
+  N: {
+    spreadsheetId: "1ySa3VgHB-6gZHvJY4DKskPTJX8LdnwB6PhAE-D3JVxE",
+    workbookTitle: "Nu-Tech Tracker",
+    sheetTitle: "Tracker",
+    divisionLabel: "NuTech",
+  },
+  D: {
+    spreadsheetId: "1reeTLmijIxZ-xeegidJcZoW3vbYkfSXHBw24-veu7-w",
+    workbookTitle: "Design Tracker",
+    sheetTitle: "Tracker",
+    divisionLabel: "Design",
+  },
+}
+
+export function departmentTrackingDestination(
+  department: ProjectIntakeDepartment
+): ProjectTrackingDestination {
+  return DEPARTMENT_TRACKING_DESTINATIONS[department]
 }
 
 function cellText(value: unknown): string {
@@ -54,9 +88,10 @@ export function locateProjectTrackerLayout(
 ): ProjectTrackerLayout | null {
   for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
     const headers = (rows[rowIndex] ?? []).map(cellText)
-    const projectNumberColumn = headers.findIndex(
-      (header) => normalizedHeader(header) === "project number"
-    )
+    const projectNumberColumn = headers.findIndex((header) => {
+      const normalized = normalizedHeader(header)
+      return normalized === "project number" || normalized === "project id"
+    })
     if (projectNumberColumn >= 0) {
       return {
         headerRowNumber: rowIndex + 1,
@@ -64,6 +99,23 @@ export function locateProjectTrackerLayout(
         projectNumberColumn,
       }
     }
+  }
+  return null
+}
+
+export function projectRowNumber(
+  rows: ReadonlyArray<ReadonlyArray<unknown>>,
+  layout: ProjectTrackerLayout,
+  projectNumber: string
+): number | null {
+  const normalizedProjectNumber = projectNumber.trim().toUpperCase()
+  for (
+    let rowIndex = layout.headerRowNumber;
+    rowIndex < rows.length;
+    rowIndex += 1
+  ) {
+    const value = cellText(rows[rowIndex]?.[layout.projectNumberColumn])
+    if (value.toUpperCase() === normalizedProjectNumber) return rowIndex + 1
   }
   return null
 }
@@ -76,7 +128,7 @@ export function allocateProjectNumber(input: {
   readonly reservedProjectNumbers?: readonly string[]
 }): string {
   let maximumSequence = 0
-  const pattern = new RegExp(`^${input.department}-(\\d+)-`, "i")
+  const pattern = new RegExp(`^${input.department}-(\\d+)(?:-|$)`, "i")
   for (const row of input.rows.slice(input.layout.headerRowNumber)) {
     const value = cellText(row[input.layout.projectNumberColumn])
     const match = pattern.exec(value)
@@ -98,41 +150,113 @@ export function allocateProjectNumber(input: {
   return `${input.department}-${String(maximumSequence + 1).padStart(2, "0")}-${streetNumber}`
 }
 
-function valueForHeader(
-  header: string,
-  input: ProjectIntakeTrackerInput,
-  projectNumber: string
-): string {
-  const normalized = normalizedHeader(header)
-  const values: Readonly<Record<string, string | null>> = {
-    "project number": projectNumber,
-    type: input.department,
-    "intake date": input.intakeDate,
-    "assigned to": input.assignedTo,
-    status: "OPEN",
-    "company name": input.companyName,
-    "client last name": input.clientLastName,
-    "client first name": input.clientFirstName,
-    "contact phone": input.contactPhone,
-    "contact email": input.contactEmail,
-    "project street number": input.streetNumber,
-    "project street name": input.streetName,
-    "city state zip": input.cityStateZip,
-    "billing address": input.billingAddress,
-    "referred by": input.referredBy,
-    notes: input.notes,
-  }
-  if (normalized === "active projects") return input.projectName
-  if (normalized === "client name") return input.clientName ?? ""
-  return values[normalized] ?? ""
+function joinedName(input: ProjectIntakeTrackerInput): string {
+  return [cellText(input.clientFirstName), cellText(input.clientLastName)]
+    .filter(Boolean)
+    .join(" ")
 }
 
-export function buildProjectTrackerRow(input: {
+function joinedAddress(input: ProjectIntakeTrackerInput): string {
+  const street = [cellText(input.streetNumber), cellText(input.streetName)]
+    .filter(Boolean)
+    .join(" ")
+  return [street, cellText(input.cityStateZip)].filter(Boolean).join(", ")
+}
+
+function intakeNotes(input: ProjectIntakeTrackerInput): string {
+  const notes = cellText(input.notes)
+  const referredBy = cellText(input.referredBy)
+  return [notes, referredBy ? `Referred by ${referredBy}` : ""]
+    .filter(Boolean)
+    .join(" · ")
+}
+
+function sequenceFromProjectNumber(projectNumber: string): string {
+  return projectNumber.match(/^[A-Z]-(\d+)-/i)?.[1] ?? ""
+}
+
+export function buildProjectRegistryRow(input: {
   readonly layout: ProjectTrackerLayout
   readonly project: ProjectIntakeTrackerInput
   readonly projectNumber: string
+  readonly driveFolderUrl: string | null
+  readonly departmentTrackerUrl: string
+  readonly createdBy: string
 }): readonly string[] {
-  return input.layout.headers.map((header) =>
-    valueForHeader(header, input.project, input.projectNumber)
+  const destination = departmentTrackingDestination(input.project.department)
+  const values: Readonly<Record<string, string>> = {
+    "project id": input.projectNumber,
+    "project number": input.projectNumber,
+    division: destination.divisionLabel,
+    sequence: sequenceFromProjectNumber(input.projectNumber),
+    "street number code": cellText(input.project.streetNumber),
+    "street name label": cellText(input.project.streetName) || input.project.projectName,
+    "client last name": cellText(input.project.clientLastName),
+    "client first name": cellText(input.project.clientFirstName),
+    "company name": cellText(input.project.companyName),
+    "city state zip": cellText(input.project.cityStateZip),
+    "folder link": input.driveFolderUrl ?? "",
+    "lead tracker link": input.departmentTrackerUrl,
+    "created date": input.project.intakeDate,
+    "created by": input.createdBy,
+    status: "I - Intake",
+    notes: intakeNotes(input.project),
+  }
+  return input.layout.headers.map(
+    (header) => values[normalizedHeader(header)] ?? ""
+  )
+}
+
+export function buildDepartmentTrackerRow(input: {
+  readonly layout: ProjectTrackerLayout
+  readonly project: ProjectIntakeTrackerInput
+  readonly projectNumber: string
+  readonly driveFolderUrl: string | null
+}): readonly string[] {
+  const project = input.project
+  const client = cellText(project.clientName) || joinedName(project)
+  const company = cellText(project.companyName)
+  const address = joinedAddress(project)
+  const common: Record<string, string> = {
+    "project id": input.projectNumber,
+    "project number": input.projectNumber,
+    "folder link": input.driveFolderUrl ?? "",
+    notes: intakeNotes(project),
+    phone: cellText(project.contactPhone),
+    email: cellText(project.contactEmail),
+    "billing address": cellText(project.billingAddress),
+    "client id": "",
+    "project address": address,
+    "update status": "Weekly",
+  }
+  const departmentValues: Readonly<Record<ProjectIntakeDepartment, Record<string, string>>> = {
+    H: {
+      "builder gc": company || client || "Homeowner",
+      "contact person": client,
+      estimator: cellText(project.assignedTo),
+      "quote status": "I - Intake",
+    },
+    O: {
+      client,
+      address,
+      "assigned to": cellText(project.assignedTo),
+      "lead status": "I - Intake",
+    },
+    N: {
+      customer: client || company,
+      "assigned to": cellText(project.assignedTo),
+      "quote status": "I - Intake",
+      "order status": "I - Intake",
+    },
+    D: {
+      client,
+      address,
+      "assigned designer": cellText(project.assignedTo),
+      "proposal status": "I - Intake",
+    },
+  }
+  const values = { ...common, ...departmentValues[project.department] }
+  return input.layout.headers.map(
+    (header) => values[normalizedHeader(header)] ?? ""
   )
 }


### PR DESCRIPTION
## Outcome

- routes native Compass project creation to the active `________Developer` Project Registry
- also writes each project to its matching HPS, ORC, Nu-Tech, or Design tracker
- removes all runtime dependency on the obsolete Project Lead Tracking workbook
- preserves idempotent receipts and partial-write recovery so staff should not recreate a project after a transient Sheet error
- records the protected contract-template and finish-schedule assets in the integration plan

## Verification

- focused project-intake tests: 9 passed
- TypeScript: passed
- lint: 0 errors (existing warnings only)
- production build: passed
- pre-ship review: no actionable findings
