### PR TITLE
fix(contacts): restore project contact management

### DIFF
--- a/__tests__/google-project-intake-tracker.test.ts
+++ b/__tests__/google-project-intake-tracker.test.ts
@@ -138,6 +138,7 @@ describe("Google Developer-folder project tracking intake", () => {
         "Contact Person",
         "Estimator",
         "Quote Status",
+        "Update Status",
         "Folder Link",
         "Project Address",
       ],
@@ -176,11 +177,41 @@ describe("Google Developer-folder project tracking intake", () => {
       "H-432-3295",
       "Scott and Farrell Thompson",
       "Scott and Farrell Thompson",
-      "Martine Vogel",
+      "Martine",
       "I - Intake",
+      "Current",
       "https://drive.google.com/drive/folders/folder-id",
       "3295 Little Turkey Creek Rd., Colorado Springs, CO 80926",
     ])
+  })
+
+  it("uses each live tracker staff and update-status validation value", () => {
+    const hpsLayout = locateProjectTrackerLayout([
+      ["Project ID", "Estimator", "Update Status"],
+    ])
+    const orcLayout = locateProjectTrackerLayout([
+      ["Project ID", "Assigned To", "Update Status"],
+    ])
+    expect(hpsLayout).not.toBeNull()
+    expect(orcLayout).not.toBeNull()
+    if (!hpsLayout || !orcLayout) return
+
+    expect(
+      buildDepartmentTrackerRow({
+        layout: hpsLayout,
+        project: { ...PROJECT, department: "H", assignedTo: "Martine Vogel" },
+        projectNumber: "H-432-3295",
+        driveFolderUrl: null,
+      })
+    ).toEqual(["H-432-3295", "Martine", "Current"])
+    expect(
+      buildDepartmentTrackerRow({
+        layout: orcLayout,
+        project: { ...PROJECT, department: "O", assignedTo: "Wesley Jones" },
+        projectNumber: "O-211-33A",
+        driveFolderUrl: null,
+      })
+    ).toEqual(["O-211-33A", "Wes", "Weekly"])
   })
 
   it("keeps Project Number header compatibility without dropping the identifier", () => {

--- a/src/app/actions/project-contacts.ts
+++ b/src/app/actions/project-contacts.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
 import {
+  customers,
   organizationMembers,
   projectAccessInvitations,
   projectContacts,
@@ -162,6 +163,44 @@ export type AddTaskAssigneeContactResult =
   | { readonly success: true; readonly contact: ProjectTaskAssigneeOption }
   | { readonly success: false; readonly error: string }
 
+export type ProjectContactDirectorySource = "customer" | "vendor" | "team"
+
+export type ProjectContactDirectoryOption = {
+  readonly id: string
+  readonly sourceType: ProjectContactDirectorySource
+  readonly displayName: string
+  readonly companyName: string | null
+  readonly email: string | null
+  readonly phone: string | null
+  readonly suggestedContactType: ProjectContactType
+}
+
+export type ProjectContactMutationInput = {
+  readonly projectId: string
+  readonly contactId: string | null
+  readonly directorySourceType: ProjectContactDirectorySource | null
+  readonly directorySourceId: string | null
+  readonly contactType: ProjectContactType
+  readonly displayName: string
+  readonly companyName: string
+  readonly role: string
+  readonly trade: string
+  readonly csiDivision: string
+  readonly csiDivisionName: string
+  readonly primaryCostCode: string
+  readonly email: string
+  readonly phone: string
+  readonly notes: string
+  readonly ownerPortalVisible: boolean
+  readonly subVendorPortalVisible: boolean
+  readonly internalVisible: boolean
+  readonly primaryContact: boolean
+}
+
+export type ProjectContactMutationResult =
+  | { readonly success: true; readonly contactId: string }
+  | { readonly success: false; readonly error: string }
+
 const CONTACT_TYPES: readonly ProjectContactType[] = [
   "owner",
   "supplier",
@@ -194,6 +233,15 @@ function toWritableContactType(value: string): ProjectContactType {
   if (value === "supplier") return "supplier"
   if (value === "internal") return "internal"
   return "subcontractor"
+}
+
+function nullableInput(value: string): string | null {
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function validContactType(value: string): value is ProjectContactType {
+  return CONTACT_TYPES.some((contactType) => contactType === value)
 }
 
 function vendorCategoryToContactType(category: string): ProjectContactType {
@@ -613,6 +661,560 @@ export async function getProjectContactsSummary(
     groups: buildGroups(allContacts),
     csiGroups: buildCsiGroups(allContacts),
     allContacts,
+  }
+}
+
+export async function getProjectContactDirectoryOptions(
+  projectId: string
+): Promise<readonly ProjectContactDirectoryOption[]> {
+  const user = await requireAuth()
+  await requireFeaturePermission(user, "project-contacts", "update")
+  const orgId = requireOrg(user)
+  // The picker exposes organization-wide customer, vendor, and staff details,
+  // so project read access alone is intentionally insufficient.
+  const db = await verifyProjectAccess(projectId, "update")
+
+  const existingRows = await db
+    .select({
+      sourceEntityType: projectContacts.sourceEntityType,
+      sourceEntityId: projectContacts.sourceEntityId,
+    })
+    .from(projectContacts)
+    .where(
+      and(eq(projectContacts.projectId, projectId), eq(projectContacts.active, true))
+    )
+  const existingSources = new Set(
+    existingRows
+      .filter(
+        (row) => row.sourceEntityId !== null && row.sourceEntityId.length > 0
+      )
+      .map((row) => `${row.sourceEntityType}:${row.sourceEntityId}`)
+  )
+
+  const [customerRows, vendorRows, teamRows] = await Promise.all([
+    db
+      .select({
+        id: customers.id,
+        name: customers.name,
+        company: customers.company,
+        email: customers.email,
+        phone: customers.phone,
+      })
+      .from(customers)
+      .where(eq(customers.organizationId, orgId)),
+    db
+      .select({
+        id: vendors.id,
+        name: vendors.name,
+        category: vendors.category,
+        email: vendors.email,
+        phone: vendors.phone,
+      })
+      .from(vendors)
+      .where(
+        and(
+          eq(vendors.organizationId, orgId),
+          eq(vendors.directoryStatus, "active")
+        )
+      ),
+    db
+      .select({
+        id: users.id,
+        email: users.email,
+        displayName: users.displayName,
+        firstName: users.firstName,
+        lastName: users.lastName,
+      })
+      .from(organizationMembers)
+      .innerJoin(users, eq(users.id, organizationMembers.userId))
+      .where(
+        and(
+          eq(organizationMembers.organizationId, orgId),
+          eq(users.isActive, true)
+        )
+      ),
+  ])
+
+  const customerOptions: ProjectContactDirectoryOption[] = customerRows
+    .filter((row) => !existingSources.has(`customer:${row.id}`))
+    .map((row) => ({
+      id: row.id,
+      sourceType: "customer",
+      displayName: row.name,
+      companyName: row.company,
+      email: row.email,
+      phone: row.phone,
+      suggestedContactType: "owner",
+    }))
+  const vendorOptions: ProjectContactDirectoryOption[] = vendorRows
+    .filter(
+      (row) =>
+        isDirectoryAssignable(row.category) &&
+        !existingSources.has(`vendor:${row.id}`)
+    )
+    .map((row) => ({
+      id: row.id,
+      sourceType: "vendor",
+      displayName: row.name,
+      companyName: row.name,
+      email: row.email,
+      phone: row.phone,
+      suggestedContactType: vendorCategoryToContactType(row.category),
+    }))
+  const teamOptions: ProjectContactDirectoryOption[] = teamRows
+    .filter((row) => !existingSources.has(`user:${row.id}`))
+    .map((row) => {
+      const fullName = [row.firstName, row.lastName]
+        .filter((part): part is string => part !== null && part.trim().length > 0)
+        .join(" ")
+      return {
+        id: row.id,
+        sourceType: "team",
+        displayName: row.displayName?.trim() || fullName || row.email,
+        companyName: null,
+        email: row.email,
+        phone: null,
+        suggestedContactType: "internal",
+      }
+    })
+
+  return [...customerOptions, ...vendorOptions, ...teamOptions].sort((left, right) =>
+    left.displayName.localeCompare(right.displayName)
+  )
+}
+
+export async function saveProjectContact(
+  input: ProjectContactMutationInput
+): Promise<ProjectContactMutationResult> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) return { success: false, error: "DEMO_READ_ONLY" }
+    await requireFeaturePermission(user, "project-contacts", "update")
+    if (!input.projectId.trim()) {
+      return { success: false, error: "Project is required" }
+    }
+    if (!input.displayName.trim()) {
+      return { success: false, error: "Contact name is required" }
+    }
+    if (!validContactType(input.contactType)) {
+      return { success: false, error: "Choose a valid contact type" }
+    }
+
+    const orgId = requireOrg(user)
+    const db = await verifyProjectAccess(input.projectId, "update")
+    const now = new Date().toISOString()
+    let contactId = input.contactId
+    let sourceSystem = "compass"
+    let sourceRecordId: string | null = null
+    let sourceEntityType = "manual"
+    let sourceEntityId: string | null = null
+    let syncStatus = "manual"
+
+    if (!contactId && input.directorySourceType && input.directorySourceId) {
+      sourceRecordId = input.directorySourceId
+      sourceEntityId = input.directorySourceId
+
+      if (input.directorySourceType === "customer") {
+        const [directoryRecord] = await db
+          .select({ id: customers.id })
+          .from(customers)
+          .where(
+            and(
+              eq(customers.id, input.directorySourceId),
+              eq(customers.organizationId, orgId)
+            )
+          )
+          .limit(1)
+        if (!directoryRecord) {
+          return { success: false, error: "Customer directory record not found" }
+        }
+        sourceSystem = "customer_directory"
+        sourceEntityType = "customer"
+      } else if (input.directorySourceType === "vendor") {
+        const [directoryRecord] = await db
+          .select({ id: vendors.id, syncStatus: vendors.syncStatus })
+          .from(vendors)
+          .where(
+            and(
+              eq(vendors.id, input.directorySourceId),
+              eq(vendors.organizationId, orgId),
+              eq(vendors.directoryStatus, "active")
+            )
+          )
+          .limit(1)
+        if (!directoryRecord) {
+          return { success: false, error: "Vendor directory record not found" }
+        }
+        sourceSystem = "global_directory"
+        sourceEntityType = "vendor"
+        syncStatus = directoryRecord.syncStatus
+      } else {
+        const [directoryRecord] = await db
+          .select({ id: users.id })
+          .from(organizationMembers)
+          .innerJoin(users, eq(users.id, organizationMembers.userId))
+          .where(
+            and(
+              eq(organizationMembers.organizationId, orgId),
+              eq(users.id, input.directorySourceId),
+              eq(users.isActive, true)
+            )
+          )
+          .limit(1)
+        if (!directoryRecord) {
+          return { success: false, error: "Team directory record not found" }
+        }
+        sourceSystem = "organization_directory"
+        sourceEntityType = "user"
+      }
+
+      const [existingContact] = await db
+        .select({ id: projectContacts.id, active: projectContacts.active })
+        .from(projectContacts)
+        .where(
+          and(
+            eq(projectContacts.projectId, input.projectId),
+            eq(projectContacts.sourceEntityType, sourceEntityType),
+            eq(projectContacts.sourceEntityId, input.directorySourceId)
+          )
+        )
+        .limit(1)
+      if (existingContact?.active) {
+        return { success: false, error: "This contact is already on the project" }
+      }
+      if (existingContact) contactId = existingContact.id
+    }
+
+    const contactValues = {
+      contactType: input.contactType,
+      displayName: input.displayName.trim(),
+      companyName: nullableInput(input.companyName),
+      role: nullableInput(input.role),
+      trade: nullableInput(input.trade),
+      csiDivision: nullableInput(input.csiDivision),
+      csiDivisionName: nullableInput(input.csiDivisionName),
+      primaryCostCode: nullableInput(input.primaryCostCode),
+      email: nullableInput(input.email),
+      phone: nullableInput(input.phone),
+      notes: nullableInput(input.notes),
+      ownerPortalVisible: input.ownerPortalVisible,
+      subVendorPortalVisible: input.subVendorPortalVisible,
+      internalVisible: input.internalVisible,
+      primaryContact: input.primaryContact,
+      active: true,
+      updatedAt: now,
+    }
+
+    if (contactId) {
+      const [existingContact] = await db
+        .select({
+          id: projectContacts.id,
+          email: projectContacts.email,
+          sourceEntityType: projectContacts.sourceEntityType,
+          sourceEntityId: projectContacts.sourceEntityId,
+        })
+        .from(projectContacts)
+        .where(
+          and(
+            eq(projectContacts.id, contactId),
+            eq(projectContacts.projectId, input.projectId)
+          )
+        )
+        .limit(1)
+      if (!existingContact) {
+        return { success: false, error: "Project contact not found" }
+      }
+      const existingEmail = existingContact.email?.trim().toLowerCase() ?? ""
+      const updatedEmail = nullableInput(input.email)?.toLowerCase() ?? ""
+      if (existingEmail !== updatedEmail) {
+        const [invitationRows, organizationUserRows] = await Promise.all([
+          db
+            .select({ status: projectAccessInvitations.status })
+            .from(projectAccessInvitations)
+            .where(
+              and(
+                eq(projectAccessInvitations.projectId, input.projectId),
+                eq(projectAccessInvitations.projectContactId, contactId)
+              )
+            ),
+          db
+            .select({ id: users.id, email: users.email })
+            .from(organizationMembers)
+            .innerJoin(users, eq(users.id, organizationMembers.userId))
+            .where(eq(organizationMembers.organizationId, orgId)),
+        ])
+        const linkedUserIds = new Set<string>()
+        if (
+          existingContact.sourceEntityType === "user" &&
+          existingContact.sourceEntityId
+        ) {
+          linkedUserIds.add(existingContact.sourceEntityId)
+        }
+        if (existingEmail) {
+          for (const organizationUser of organizationUserRows) {
+            if (organizationUser.email.trim().toLowerCase() === existingEmail) {
+              linkedUserIds.add(organizationUser.id)
+            }
+          }
+        }
+        const linkedUserIdList = Array.from(linkedUserIds)
+        const linkedMembership =
+          linkedUserIdList.length > 0
+            ? await db
+                .select({ id: projectMembers.id })
+                .from(projectMembers)
+                .where(
+                  and(
+                    eq(projectMembers.projectId, input.projectId),
+                    inArray(projectMembers.userId, linkedUserIdList)
+                  )
+                )
+                .limit(1)
+            : []
+        const hasActiveInvitation = invitationRows.some((invitation) =>
+          ["sent", "accepted"].includes(invitation.status)
+        )
+        if (hasActiveInvitation || linkedMembership.length > 0) {
+          return {
+            success: false,
+            error:
+              "This contact has Compass access. Remove the contact from the project, then add the correct person so access is revoked safely.",
+          }
+        }
+      }
+      if (input.primaryContact) {
+        await db
+          .update(projectContacts)
+          .set({ primaryContact: false, updatedAt: now })
+          .where(
+            and(
+              eq(projectContacts.projectId, input.projectId),
+              eq(projectContacts.contactType, input.contactType)
+            )
+          )
+      }
+      await db
+        .update(projectContacts)
+        .set(contactValues)
+        .where(
+          and(
+            eq(projectContacts.id, contactId),
+            eq(projectContacts.projectId, input.projectId)
+          )
+        )
+    } else {
+      contactId = crypto.randomUUID()
+      if (input.primaryContact) {
+        await db
+          .update(projectContacts)
+          .set({ primaryContact: false, updatedAt: now })
+          .where(
+            and(
+              eq(projectContacts.projectId, input.projectId),
+              eq(projectContacts.contactType, input.contactType)
+            )
+          )
+      }
+      await db.insert(projectContacts).values({
+        id: contactId,
+        projectId: input.projectId,
+        sourceSystem,
+        sourceRecordId,
+        sourceEntityType,
+        sourceEntityId,
+        sortOrder: 800,
+        syncStatus,
+        lastSyncedAt: null,
+        createdAt: now,
+        ...contactValues,
+      })
+    }
+
+    revalidateContactPaths(input.projectId)
+    return { success: true, contactId }
+  } catch (error) {
+    console.error("Failed to save project contact", error)
+    return { success: false, error: "Failed to save project contact" }
+  }
+}
+
+export async function removeProjectContact(
+  projectId: string,
+  contactId: string
+): Promise<ProjectContactMutationResult> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) return { success: false, error: "DEMO_READ_ONLY" }
+    await requireFeaturePermission(user, "project-contacts", "update")
+    const orgId = requireOrg(user)
+    const db = await verifyProjectAccess(projectId, "update")
+    const [contact] = await db
+      .select({
+        id: projectContacts.id,
+        sourceEntityType: projectContacts.sourceEntityType,
+        sourceEntityId: projectContacts.sourceEntityId,
+        email: projectContacts.email,
+      })
+      .from(projectContacts)
+      .where(
+        and(
+          eq(projectContacts.id, contactId),
+          eq(projectContacts.projectId, projectId),
+          eq(projectContacts.active, true)
+        )
+      )
+      .limit(1)
+    if (!contact) return { success: false, error: "Project contact not found" }
+
+    const invitationRows = await db
+      .select({ acceptedBy: projectAccessInvitations.acceptedBy })
+      .from(projectAccessInvitations)
+      .where(
+        and(
+          eq(projectAccessInvitations.projectId, projectId),
+          eq(projectAccessInvitations.projectContactId, contactId)
+        )
+      )
+    const memberUserIds = new Set(
+      invitationRows
+        .map((invitation) => invitation.acceptedBy)
+        .filter((acceptedBy): acceptedBy is string => acceptedBy !== null)
+    )
+    if (contact.sourceEntityType === "user" && contact.sourceEntityId) {
+      memberUserIds.add(contact.sourceEntityId)
+    }
+    const organizationUsers = await db
+      .select({ id: users.id, email: users.email })
+      .from(organizationMembers)
+      .innerJoin(users, eq(users.id, organizationMembers.userId))
+      .where(eq(organizationMembers.organizationId, orgId))
+    if (contact.email) {
+      const contactEmail = contact.email.trim().toLowerCase()
+      for (const organizationUser of organizationUsers) {
+        if (organizationUser.email.trim().toLowerCase() === contactEmail) {
+          memberUserIds.add(organizationUser.id)
+        }
+      }
+    }
+
+    const now = new Date().toISOString()
+    await db
+      .update(projectContacts)
+      .set({
+        active: false,
+        ownerPortalVisible: false,
+        subVendorPortalVisible: false,
+        internalVisible: false,
+        primaryContact: false,
+        updatedAt: now,
+      })
+      .where(
+        and(eq(projectContacts.id, contactId), eq(projectContacts.projectId, projectId))
+      )
+    await db
+      .update(projectContactSourceLinks)
+      .set({
+        projectContactId: null,
+        matchStatus: "review",
+        matchConfidence: 0,
+        matchReason: "Project contact was removed in Compass and needs reassignment.",
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(projectContactSourceLinks.projectId, projectId),
+          eq(projectContactSourceLinks.projectContactId, contactId)
+        )
+      )
+    await db
+      .update(projectAccessInvitations)
+      .set({ status: "revoked", updatedAt: now })
+      .where(
+        and(
+          eq(projectAccessInvitations.projectId, projectId),
+          eq(projectAccessInvitations.projectContactId, contactId)
+        )
+      )
+    const projectMemberIds = Array.from(memberUserIds)
+    if (projectMemberIds.length > 0) {
+      // One person can have multiple project-contact roles. Preserve access
+      // whenever another active contact or invitation still grants it.
+      const [remainingContacts, remainingInvitations] = await Promise.all([
+        db
+          .select({
+            sourceEntityType: projectContacts.sourceEntityType,
+            sourceEntityId: projectContacts.sourceEntityId,
+            email: projectContacts.email,
+          })
+          .from(projectContacts)
+          .where(
+            and(
+              eq(projectContacts.projectId, projectId),
+              eq(projectContacts.active, true)
+            )
+          ),
+        db
+          .select({
+            acceptedBy: projectAccessInvitations.acceptedBy,
+            email: projectAccessInvitations.email,
+            status: projectAccessInvitations.status,
+          })
+          .from(projectAccessInvitations)
+          .where(eq(projectAccessInvitations.projectId, projectId)),
+      ])
+      const remainingUserIds = new Set(
+        remainingContacts
+          .filter(
+            (remainingContact) =>
+              remainingContact.sourceEntityType === "user" &&
+              remainingContact.sourceEntityId !== null
+          )
+          .map((remainingContact) => remainingContact.sourceEntityId)
+          .filter((userId): userId is string => userId !== null)
+      )
+      const remainingEmails = new Set(
+        remainingContacts
+          .map((remainingContact) =>
+            remainingContact.email?.trim().toLowerCase() ?? ""
+          )
+          .filter((email) => email.length > 0)
+      )
+      for (const invitation of remainingInvitations) {
+        if (invitation.status !== "accepted") continue
+        if (invitation.acceptedBy) remainingUserIds.add(invitation.acceptedBy)
+        const invitationEmail = invitation.email.trim().toLowerCase()
+        if (invitationEmail) remainingEmails.add(invitationEmail)
+      }
+      const organizationEmailByUserId = new Map(
+        organizationUsers.map((organizationUser) => [
+          organizationUser.id,
+          organizationUser.email.trim().toLowerCase(),
+        ])
+      )
+      const removableMemberIds = projectMemberIds.filter((userId) => {
+        const email = organizationEmailByUserId.get(userId)
+        return (
+          !remainingUserIds.has(userId) &&
+          (!email || !remainingEmails.has(email))
+        )
+      })
+      if (removableMemberIds.length > 0) {
+        await db
+          .delete(projectMembers)
+          .where(
+            and(
+              eq(projectMembers.projectId, projectId),
+              inArray(projectMembers.userId, removableMemberIds)
+            )
+          )
+      }
+    }
+
+    revalidateContactPaths(projectId)
+    return { success: true, contactId }
+  } catch (error) {
+    console.error("Failed to remove project contact", error)
+    return { success: false, error: "Failed to remove project contact" }
   }
 }
 

--- a/src/app/dashboard/projects/[id]/contacts/page.tsx
+++ b/src/app/dashboard/projects/[id]/contacts/page.tsx
@@ -9,7 +9,9 @@ import {
 import Link from "next/link"
 
 import {
+  getProjectContactDirectoryOptions,
   getProjectContactsSummary,
+  type ProjectContactDirectoryOption,
   type ProjectContactsSummary,
 } from "@/app/actions/project-contacts"
 import { getProjects } from "@/app/actions/projects"
@@ -28,6 +30,8 @@ export default async function ProjectContactsPage({
   const { id } = await params
 
   let contacts: ProjectContactsSummary | null = null
+  let directoryOptions: readonly ProjectContactDirectoryOption[] = []
+  let canManageContacts = false
   let projectLabel = "This project"
 
   try {
@@ -44,6 +48,14 @@ export default async function ProjectContactsPage({
     }
   } catch (error) {
     console.warn("Project contacts unavailable", error)
+  }
+
+  try {
+    directoryOptions = await getProjectContactDirectoryOptions(id)
+    canManageContacts = true
+  } catch {
+    // Read-only project users may view allowed contacts without receiving the
+    // organization-wide directory or any editing controls.
   }
 
   return (
@@ -93,6 +105,7 @@ export default async function ProjectContactsPage({
           projectLabel={projectLabel}
           summary={contacts}
           showOpenLink={false}
+          directoryOptions={canManageContacts ? directoryOptions : undefined}
         />
       </div>
 
@@ -101,6 +114,7 @@ export default async function ProjectContactsPage({
           projectId={id}
           projectLabel={projectLabel}
           summary={contacts}
+          directoryOptions={canManageContacts ? directoryOptions : undefined}
         />
       )}
     </div>

--- a/src/components/projects/project-contact-management.tsx
+++ b/src/components/projects/project-contact-management.tsx
@@ -1,0 +1,546 @@
+"use client"
+
+import {
+  IconCheck,
+  IconChevronDown,
+  IconPencil,
+  IconPlus,
+  IconTrash,
+} from "@tabler/icons-react"
+import { useRouter } from "next/navigation"
+import { useState, useTransition } from "react"
+import { toast } from "sonner"
+
+import {
+  removeProjectContact,
+  saveProjectContact,
+  type ProjectContactDirectoryOption,
+  type ProjectContactItem,
+  type ProjectContactMutationInput,
+  type ProjectContactType,
+} from "@/app/actions/project-contacts"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+
+function contactTypeLabel(type: ProjectContactType): string {
+  switch (type) {
+    case "owner":
+      return "Owner / customer"
+    case "supplier":
+      return "Supplier"
+    case "subcontractor":
+      return "Subcontractor"
+    case "internal":
+      return "Internal team"
+  }
+}
+
+function directorySourceLabel(
+  sourceType: ProjectContactDirectoryOption["sourceType"]
+): string {
+  switch (sourceType) {
+    case "customer":
+      return "Customers"
+    case "vendor":
+      return "Vendors and subcontractors"
+    case "team":
+      return "Internal team"
+  }
+}
+
+function initialInput(
+  projectId: string,
+  contact: ProjectContactItem | null
+): ProjectContactMutationInput {
+  return {
+    projectId,
+    contactId: contact?.id ?? null,
+    directorySourceType: null,
+    directorySourceId: null,
+    contactType: contact?.contactType ?? "owner",
+    displayName: contact?.displayName ?? "",
+    companyName: contact?.companyName ?? "",
+    role: contact?.role ?? "",
+    trade: contact?.trade ?? "",
+    csiDivision: contact?.csiDivision ?? "",
+    csiDivisionName: contact?.csiDivisionName ?? "",
+    primaryCostCode: contact?.primaryCostCode ?? "",
+    email: contact?.email ?? "",
+    phone: contact?.phone ?? "",
+    notes: contact?.notes ?? "",
+    ownerPortalVisible: contact?.ownerPortalVisible ?? false,
+    subVendorPortalVisible: contact?.subVendorPortalVisible ?? false,
+    internalVisible: contact?.internalVisible ?? true,
+    primaryContact: contact?.primaryContact ?? false,
+  }
+}
+
+function groupedDirectoryOptions(
+  options: readonly ProjectContactDirectoryOption[]
+): readonly {
+  readonly sourceType: ProjectContactDirectoryOption["sourceType"]
+  readonly options: readonly ProjectContactDirectoryOption[]
+}[] {
+  return (["customer", "vendor", "team"] satisfies readonly ProjectContactDirectoryOption["sourceType"][])
+    .map((sourceType) => ({
+      sourceType,
+      options: options.filter((option) => option.sourceType === sourceType),
+    }))
+    .filter((group) => group.options.length > 0)
+}
+
+function DirectoryPicker({
+  options,
+  selected,
+  onSelect,
+}: {
+  readonly options: readonly ProjectContactDirectoryOption[]
+  readonly selected: ProjectContactDirectoryOption | null
+  readonly onSelect: (option: ProjectContactDirectoryOption) => void
+}): React.ReactElement {
+  const [open, setOpen] = useState(false)
+  const groups = groupedDirectoryOptions(options)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full justify-between font-normal"
+        >
+          <span className="truncate">
+            {selected ? selected.displayName : "Choose a contact or enter one manually..."}
+          </span>
+          <IconChevronDown className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search customers, vendors, or staff..." />
+          <CommandList>
+            <CommandEmpty>No matching directory contact.</CommandEmpty>
+            {groups.map((group) => (
+              <CommandGroup
+                key={group.sourceType}
+                heading={directorySourceLabel(group.sourceType)}
+              >
+                {group.options.map((option) => (
+                  <CommandItem
+                    key={`${option.sourceType}:${option.id}`}
+                    value={`${option.displayName} ${option.companyName ?? ""} ${option.email ?? ""}`}
+                    onSelect={() => {
+                      onSelect(option)
+                      setOpen(false)
+                    }}
+                  >
+                    <IconCheck
+                      className={cn(
+                        "mr-2 size-4",
+                        selected?.id === option.id &&
+                          selected.sourceType === option.sourceType
+                          ? "opacity-100"
+                          : "opacity-0"
+                      )}
+                    />
+                    <div className="min-w-0">
+                      <p className="truncate">{option.displayName}</p>
+                      {(option.companyName || option.email) && (
+                        <p className="truncate text-xs text-muted-foreground">
+                          {[option.companyName, option.email].filter(Boolean).join(" · ")}
+                        </p>
+                      )}
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function VisibilityCheckbox({
+  id,
+  checked,
+  label,
+  description,
+  onCheckedChange,
+}: {
+  readonly id: string
+  readonly checked: boolean
+  readonly label: string
+  readonly description: string
+  readonly onCheckedChange: (checked: boolean) => void
+}): React.ReactElement {
+  return (
+    <div className="flex items-start gap-3 rounded-md border p-3">
+      <Checkbox
+        id={id}
+        checked={checked}
+        onCheckedChange={(value) => onCheckedChange(value === true)}
+      />
+      <div className="grid gap-1 leading-none">
+        <Label htmlFor={id}>{label}</Label>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  )
+}
+
+export function ProjectContactEditor({
+  projectId,
+  contact = null,
+  directoryOptions,
+}: {
+  readonly projectId: string
+  readonly contact?: ProjectContactItem | null
+  readonly directoryOptions: readonly ProjectContactDirectoryOption[]
+}): React.ReactElement {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [directoryOpenKey, setDirectoryOpenKey] = useState<string | null>(null)
+  const [input, setInput] = useState(() => initialInput(projectId, contact))
+  const [isPending, startTransition] = useTransition()
+  const isEditing = contact !== null
+  const selectedDirectory = directoryOptions.find(
+    (option) =>
+      option.id === input.directorySourceId &&
+      option.sourceType === input.directorySourceType
+  ) ?? null
+
+  function updateInput<Key extends keyof ProjectContactMutationInput>(
+    key: Key,
+    value: ProjectContactMutationInput[Key]
+  ): void {
+    setInput((current) => ({ ...current, [key]: value }))
+  }
+
+  function resetEditor(nextOpen: boolean): void {
+    setOpen(nextOpen)
+    if (nextOpen) {
+      setInput(initialInput(projectId, contact))
+      setDirectoryOpenKey(null)
+    }
+  }
+
+  function applyDirectoryOption(option: ProjectContactDirectoryOption): void {
+    setDirectoryOpenKey(`${option.sourceType}:${option.id}`)
+    setInput((current) => ({
+      ...current,
+      directorySourceType: option.sourceType,
+      directorySourceId: option.id,
+      contactType: option.suggestedContactType,
+      displayName: option.displayName,
+      companyName: option.companyName ?? "",
+      email: option.email ?? "",
+      phone: option.phone ?? "",
+      role: contactTypeLabel(option.suggestedContactType),
+      ownerPortalVisible:
+        option.suggestedContactType === "internal" || current.ownerPortalVisible,
+      subVendorPortalVisible:
+        option.suggestedContactType === "subcontractor" ||
+        option.suggestedContactType === "supplier" ||
+        current.subVendorPortalVisible,
+    }))
+  }
+
+  function submit(event: React.FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    startTransition(async () => {
+      const result = await saveProjectContact(input)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(isEditing ? "Project contact updated." : "Project contact added.")
+      setOpen(false)
+      router.refresh()
+    })
+  }
+
+  function remove(): void {
+    if (!contact) return
+    startTransition(async () => {
+      const result = await removeProjectContact(projectId, contact.id)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success("Contact removed from this project.")
+      setOpen(false)
+      router.refresh()
+    })
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={resetEditor}>
+      <SheetTrigger asChild>
+        <Button type="button" size={isEditing ? "icon-sm" : "sm"} variant={isEditing ? "outline" : "default"}>
+          {isEditing ? <IconPencil className="size-4" /> : <IconPlus className="size-4" />}
+          {!isEditing && "Add contact"}
+          {isEditing && <span className="sr-only">Edit {contact.displayName}</span>}
+        </Button>
+      </SheetTrigger>
+      <SheetContent className="w-full overflow-y-auto sm:max-w-2xl">
+        <form onSubmit={submit} className="flex min-h-full flex-col">
+          <SheetHeader>
+            <SheetTitle>{isEditing ? "Edit project contact" : "Add project contact"}</SheetTitle>
+            <SheetDescription>
+              Changes apply to this project. The company-wide directory record remains intact.
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="grid flex-1 gap-5 px-4 py-5 sm:px-6">
+            {!isEditing && directoryOptions.length > 0 && (
+              <div className="grid gap-2">
+                <Label>Company directory</Label>
+                <DirectoryPicker
+                  key={directoryOpenKey ?? "manual"}
+                  options={directoryOptions}
+                  selected={selectedDirectory}
+                  onSelect={applyDirectoryOption}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Select an existing record to prefill the form, or enter a new contact below.
+                </p>
+              </div>
+            )}
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="grid gap-2">
+                <Label htmlFor="project-contact-type">Contact type</Label>
+                <Select
+                  value={input.contactType}
+                  onValueChange={(value) => {
+                    if (
+                      value === "owner" ||
+                      value === "supplier" ||
+                      value === "subcontractor" ||
+                      value === "internal"
+                    ) {
+                      updateInput("contactType", value)
+                    }
+                  }}
+                >
+                  <SelectTrigger id="project-contact-type">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="owner">Owner / customer</SelectItem>
+                    <SelectItem value="supplier">Supplier</SelectItem>
+                    <SelectItem value="subcontractor">Subcontractor</SelectItem>
+                    <SelectItem value="internal">Internal team</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="project-contact-name">Contact name</Label>
+                <Input
+                  id="project-contact-name"
+                  required
+                  value={input.displayName}
+                  onChange={(event) => updateInput("displayName", event.target.value)}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="project-contact-company">Company</Label>
+                <Input
+                  id="project-contact-company"
+                  value={input.companyName}
+                  onChange={(event) => updateInput("companyName", event.target.value)}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="project-contact-role">Project role</Label>
+                <Input
+                  id="project-contact-role"
+                  value={input.role}
+                  onChange={(event) => updateInput("role", event.target.value)}
+                  placeholder="Owner, Project Administrator, Electrician..."
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="project-contact-trade">Trade / scope</Label>
+                <Input
+                  id="project-contact-trade"
+                  value={input.trade}
+                  onChange={(event) => updateInput("trade", event.target.value)}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="project-contact-email">Email</Label>
+                <Input
+                  id="project-contact-email"
+                  type="email"
+                  value={input.email}
+                  onChange={(event) => updateInput("email", event.target.value)}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="project-contact-phone">Phone</Label>
+                <Input
+                  id="project-contact-phone"
+                  type="tel"
+                  value={input.phone}
+                  onChange={(event) => updateInput("phone", event.target.value)}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="project-contact-cost-code">Primary cost code</Label>
+                <Input
+                  id="project-contact-cost-code"
+                  value={input.primaryCostCode}
+                  onChange={(event) => updateInput("primaryCostCode", event.target.value)}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="project-contact-csi">CSI division</Label>
+                <Input
+                  id="project-contact-csi"
+                  value={input.csiDivision}
+                  onChange={(event) => updateInput("csiDivision", event.target.value)}
+                  placeholder="09"
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="project-contact-csi-name">CSI division name</Label>
+                <Input
+                  id="project-contact-csi-name"
+                  value={input.csiDivisionName}
+                  onChange={(event) => updateInput("csiDivisionName", event.target.value)}
+                  placeholder="Finishes"
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="project-contact-notes">Notes</Label>
+              <Textarea
+                id="project-contact-notes"
+                value={input.notes}
+                onChange={(event) => updateInput("notes", event.target.value)}
+                rows={4}
+              />
+            </div>
+
+            <div className="grid gap-3">
+              <Label>Visibility and responsibility</Label>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <VisibilityCheckbox
+                  id={`project-contact-internal-${contact?.id ?? "new"}`}
+                  checked={input.internalVisible}
+                  label="Internal visibility"
+                  description="Show this contact to authorized staff."
+                  onCheckedChange={(checked) => updateInput("internalVisible", checked)}
+                />
+                <VisibilityCheckbox
+                  id={`project-contact-owner-${contact?.id ?? "new"}`}
+                  checked={input.ownerPortalVisible}
+                  label="Owner workspace"
+                  description="Allow owners to see this contact."
+                  onCheckedChange={(checked) => updateInput("ownerPortalVisible", checked)}
+                />
+                <VisibilityCheckbox
+                  id={`project-contact-sub-${contact?.id ?? "new"}`}
+                  checked={input.subVendorPortalVisible}
+                  label="Sub/vendor workspace"
+                  description="Allow approved subs and vendors to see this contact."
+                  onCheckedChange={(checked) => updateInput("subVendorPortalVisible", checked)}
+                />
+                <VisibilityCheckbox
+                  id={`project-contact-primary-${contact?.id ?? "new"}`}
+                  checked={input.primaryContact}
+                  label="Primary contact"
+                  description="Make this the primary contact for its type."
+                  onCheckedChange={(checked) => updateInput("primaryContact", checked)}
+                />
+              </div>
+            </div>
+          </div>
+
+          <SheetFooter className="border-t px-4 py-4 sm:px-6">
+            {isEditing && (
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button type="button" variant="destructive" className="sm:mr-auto">
+                    <IconTrash className="size-4" />
+                    Remove from project
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Remove {contact.displayName}?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      This removes the contact and any Compass access to this project. It does not delete the customer, vendor, or staff directory record, and imported source history is preserved for review.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      disabled={isPending}
+                      onClick={remove}
+                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    >
+                      Remove contact
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            )}
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending || !input.displayName.trim()}>
+              {isPending ? "Saving..." : "Save contact"}
+            </Button>
+          </SheetFooter>
+        </form>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/components/projects/project-contacts-panel.tsx
+++ b/src/components/projects/project-contacts-panel.tsx
@@ -12,9 +12,11 @@ import {
 import Link from "next/link"
 
 import type {
+  ProjectContactDirectoryOption,
   ProjectContactItem,
   ProjectContactsSummary,
 } from "@/app/actions/project-contacts"
+import { ProjectContactEditor } from "@/components/projects/project-contact-management"
 import { ProjectContactInviteButton } from "@/components/projects/project-contact-invite-button"
 import { ProjectContactInviteLauncher } from "@/components/projects/project-contact-invite-launcher"
 import { Badge } from "@/components/ui/badge"
@@ -122,11 +124,13 @@ function ContactCard({
   projectId,
   projectLabel,
   compact = false,
+  directoryOptions,
 }: {
   readonly contact: ProjectContactItem
   readonly projectId: string
   readonly projectLabel: string
   readonly compact?: boolean
+  readonly directoryOptions?: readonly ProjectContactDirectoryOption[]
 }): React.ReactElement {
   return (
     <article className="rounded-md border bg-background p-3">
@@ -150,7 +154,16 @@ function ContactCard({
             </p>
           )}
         </div>
-        <Badge variant="outline">{visibilityLabel(contact)}</Badge>
+        <div className="flex items-center gap-2">
+          <Badge variant="outline">{visibilityLabel(contact)}</Badge>
+          {directoryOptions && (
+            <ProjectContactEditor
+              projectId={projectId}
+              contact={contact}
+              directoryOptions={directoryOptions}
+            />
+          )}
+        </div>
       </div>
 
       {!compact && (
@@ -197,11 +210,13 @@ export function ProjectContactsPanel({
   projectLabel = "This project",
   summary,
   showOpenLink = true,
+  directoryOptions,
 }: {
   readonly projectId: string
   readonly projectLabel?: string
   readonly summary: ProjectContactsSummary | null
   readonly showOpenLink?: boolean
+  readonly directoryOptions?: readonly ProjectContactDirectoryOption[]
 }): React.ReactElement {
   if (!summary) {
     return (
@@ -234,6 +249,12 @@ export function ProjectContactsPanel({
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          {directoryOptions && (
+            <ProjectContactEditor
+              projectId={projectId}
+              directoryOptions={directoryOptions}
+            />
+          )}
           {!showOpenLink && (
             <ProjectContactInviteLauncher
               projectId={projectId}
@@ -318,6 +339,7 @@ export function ProjectContactsPanel({
               projectId={projectId}
               projectLabel={projectLabel}
               compact
+              directoryOptions={directoryOptions}
             />
           ))}
         </div>
@@ -342,10 +364,12 @@ export function ProjectContactsDirectory({
   projectId,
   projectLabel,
   summary,
+  directoryOptions,
 }: {
   readonly projectId: string
   readonly projectLabel: string
   readonly summary: ProjectContactsSummary
+  readonly directoryOptions?: readonly ProjectContactDirectoryOption[]
 }): React.ReactElement {
   const displayGroups = buildDisplayGroups(summary.allContacts)
 
@@ -368,6 +392,7 @@ export function ProjectContactsDirectory({
                   contact={contact}
                   projectId={projectId}
                   projectLabel={projectLabel}
+                  directoryOptions={directoryOptions}
                 />
               ))}
             </div>

--- a/src/lib/google/project-intake-tracker.ts
+++ b/src/lib/google/project-intake-tracker.ts
@@ -175,6 +175,36 @@ function sequenceFromProjectNumber(projectNumber: string): string {
   return projectNumber.match(/^[A-Z]-(\d+)-/i)?.[1] ?? ""
 }
 
+const TRACKER_STAFF_LABELS: Readonly<Record<string, string>> = {
+  "martine vogel": "Martine",
+  martine: "Martine",
+  "daniel vogel": "Dan",
+  "dan vogel": "Dan",
+  daniel: "Dan",
+  dan: "Dan",
+  "sarah cowman": "Sarah",
+  sarah: "Sarah",
+  "stanley platt": "Stanley",
+  stanley: "Stanley",
+  "sylvi vogel": "Sylvi",
+  sylvi: "Sylvi",
+  "cassandra rodriguez-v": "Cassandra",
+  cassandra: "Cassandra",
+  "wesley jones": "Wes",
+  "wes jones": "Wes",
+  wesley: "Wes",
+  wes: "Wes",
+  "rebekah jones": "Rebekah",
+  rebekah: "Rebekah",
+  "isabel araguz": "Isabel",
+  isabel: "Isabel",
+}
+
+function trackerStaffName(value: string | null): string {
+  const staffName = cellText(value)
+  return TRACKER_STAFF_LABELS[staffName.toLowerCase()] ?? staffName
+}
+
 export function buildProjectRegistryRow(input: {
   readonly layout: ProjectTrackerLayout
   readonly project: ProjectIntakeTrackerInput
@@ -227,31 +257,31 @@ export function buildDepartmentTrackerRow(input: {
     "billing address": cellText(project.billingAddress),
     "client id": "",
     "project address": address,
-    "update status": "Weekly",
+    "update status": project.department === "O" ? "Weekly" : "Current",
   }
   const departmentValues: Readonly<Record<ProjectIntakeDepartment, Record<string, string>>> = {
     H: {
       "builder gc": company || client || "Homeowner",
       "contact person": client,
-      estimator: cellText(project.assignedTo),
+      estimator: trackerStaffName(project.assignedTo),
       "quote status": "I - Intake",
     },
     O: {
       client,
       address,
-      "assigned to": cellText(project.assignedTo),
+      "assigned to": trackerStaffName(project.assignedTo),
       "lead status": "I - Intake",
     },
     N: {
       customer: client || company,
-      "assigned to": cellText(project.assignedTo),
+      "assigned to": trackerStaffName(project.assignedTo),
       "quote status": "I - Intake",
       "order status": "I - Intake",
     },
     D: {
       client,
       address,
-      "assigned designer": cellText(project.assignedTo),
+      "assigned designer": trackerStaffName(project.assignedTo),
       "proposal status": "I - Intake",
     },
   }


### PR DESCRIPTION
## Summary

- restore add, edit, and project-only removal controls on the Project Contacts page
- add a searchable picker for existing customers, vendors/subcontractors, and internal staff while preserving manual entry
- preserve company-wide directory records and imported history when a contact is removed from a project
- enforce Project Contacts feature permissions and prevent stale access when contacts are edited or removed
- align new-project Developer tracker writes with live staff and update-status validation values

## Verification

- `bun test __tests__/google-project-intake-tracker.test.ts` (7 passed)
- `bunx tsc --noEmit`
- `bun lint` (0 errors; 81 existing warnings)
- `bun run build`
- `autoreview --mode local` (clean; no actionable findings)

## Notes

- Removal is intentionally scoped to the project. It does not delete the customer, vendor, subcontractor, or staff directory record.
- Contacts with active Compass access cannot have their email identity silently changed; the UI instructs staff to remove and re-add the correct person so access is revoked safely.
