### PR TITLE
feat(templates): import items into project workflows

### DIFF
--- a/src/app/actions/project-selections.ts
+++ b/src/app/actions/project-selections.ts
@@ -11,26 +11,29 @@ import {
   projectFinishSelections,
   projectOperations,
   projects,
-  sageCostCodes,
+  sageCostCodes
 } from "@/db/schema"
 import { googleAuth } from "@/db/schema-google"
+import {
+  projectTemplateContentItems,
+  projectTemplates,
+  projectTemplateVersions
+} from "@/db/schema-templates"
 import { requireAuth } from "@/lib/auth"
 import { decrypt } from "@/lib/crypto"
 import { getCloudflareContext } from "@/lib/db"
 import { spreadsheetIdFromUrl } from "@/lib/financials/project-totals-import"
 import { SheetsClient } from "@/lib/google/client/sheets-client"
-import {
-  getGoogleConfig,
-  getGoogleCryptoSalt,
-  parseServiceAccountKey,
-} from "@/lib/google/config"
+import { getGoogleConfig, getGoogleCryptoSalt, parseServiceAccountKey } from "@/lib/google/config"
 import { requireOrg } from "@/lib/org-scope"
 import { requireFeaturePermission } from "@/lib/permission-enforcement"
 import {
   normalizeProjectNumber,
   parseFinishScheduleWorkbook,
-  type ParsedFinishSchedule,
+  type ParsedFinishSchedule
 } from "@/lib/selections/google-finish-schedule-import"
+import { buildProjectTemplateContentApplication } from "@/lib/templates/project-template-content-application"
+import { parseTemplateChoiceOptions } from "@/lib/templates/template-creation-import"
 
 export type ProjectSelectionStatus =
   | "needed"
@@ -141,6 +144,9 @@ export type CreateProjectSelectionInput = {
   readonly phaseCode: string | null
   readonly status: string | null
   readonly notes: string | null
+  readonly templateId?: string | null
+  readonly templateContentItemId?: string | null
+  readonly choiceOptions?: readonly string[]
 }
 
 export type UpdateProjectSelectionInput = CreateProjectSelectionInput & {
@@ -191,7 +197,7 @@ const PROJECT_SELECTION_STATUSES: readonly ProjectSelectionStatus[] = [
   "ordered",
   "installed",
   "unavailable",
-  "deferred",
+  "deferred"
 ]
 
 const ROOM_TYPE_OPTIONS: readonly string[] = [
@@ -222,7 +228,7 @@ const ROOM_TYPE_OPTIONS: readonly string[] = [
   "Pool / Spa",
   "Sauna / Wellness",
   "Outdoor Kitchen",
-  "Other",
+  "Other"
 ]
 
 const MANUFACTURER_OPTIONS: readonly string[] = [
@@ -245,7 +251,7 @@ const MANUFACTURER_OPTIONS: readonly string[] = [
   "Andersen Windows",
   "Marvin Windows",
   "James Hardie",
-  "Custom (see notes)",
+  "Custom (see notes)"
 ]
 
 const EXCLUDED_SELECTION_COST_DIVISIONS = new Set(["00", "01", "02"])
@@ -281,9 +287,7 @@ type FinishScheduleImportAccess = {
   readonly client: SheetsClient
 }
 
-async function finishScheduleImportAccess(
-  projectId: string
-): Promise<FinishScheduleImportAccess> {
+async function finishScheduleImportAccess(projectId: string): Promise<FinishScheduleImportAccess> {
   const user = await requireAuth()
   await requireFeaturePermission(user, "finish-selections", "update")
   const organizationId = requireOrg(user)
@@ -292,12 +296,7 @@ async function finishScheduleImportAccess(
   const projectRows = await db
     .select({ projectNumber: projects.projectNumber })
     .from(projects)
-    .where(
-      and(
-        eq(projects.id, projectId),
-        eq(projects.organizationId, organizationId)
-      )
-    )
+    .where(and(eq(projects.id, projectId), eq(projects.organizationId, organizationId)))
     .limit(1)
   const project = projectRows[0]
   if (!project) throw new Error("Project not found")
@@ -321,7 +320,7 @@ async function finishScheduleImportAccess(
     organizationId,
     projectNumber: project.projectNumber,
     googleEmail: user.googleEmail ?? user.email,
-    client: new SheetsClient(parseServiceAccountKey(keyJson)),
+    client: new SheetsClient(parseServiceAccountKey(keyJson))
   }
 }
 
@@ -341,10 +340,7 @@ async function loadFinishSchedule(
 ): Promise<LoadedFinishSchedule> {
   const workbookId = spreadsheetIdFromUrl(workbookUrl)
   if (!workbookId) throw new Error("Enter a valid Google Sheets workbook URL.")
-  const metadata = await access.client.getSpreadsheetMetadata(
-    access.googleEmail,
-    workbookId
-  )
+  const metadata = await access.client.getSpreadsheetMetadata(access.googleEmail, workbookId)
   const coverSheet = metadata.sheets.find(
     (sheet) => sheet.title.trim().toLowerCase() === "cover page"
   )
@@ -356,7 +352,7 @@ async function loadFinishSchedule(
     ? await access.client.getValues(access.googleEmail, {
         spreadsheetId: workbookId,
         range: quotedSheetRange(coverSheet.title, "A:K"),
-        valueRenderOption: "UNFORMATTED_VALUE",
+        valueRenderOption: "UNFORMATTED_VALUE"
       })
     : []
   const roomSheets = []
@@ -364,20 +360,20 @@ async function loadFinishSchedule(
     const values = await access.client.getValues(access.googleEmail, {
       spreadsheetId: workbookId,
       range: quotedSheetRange(sheet.title, "A:G"),
-      valueRenderOption: "UNFORMATTED_VALUE",
+      valueRenderOption: "UNFORMATTED_VALUE"
     })
     roomSheets.push({
       sheetId: sheet.sheetId,
       title: sheet.title,
       index: sheet.index,
-      values,
+      values
     })
   }
 
   return {
     workbookId,
     workbookTitle: metadata.title,
-    parsed: parseFinishScheduleWorkbook({ coverPageRows, roomSheets }),
+    parsed: parseFinishScheduleWorkbook({ coverPageRows, roomSheets })
   }
 }
 
@@ -411,7 +407,7 @@ function finishSchedulePreview(
     projectMatch,
     roomCount: loaded.parsed.rooms.length,
     selectionCount: loaded.parsed.selections.length,
-    warnings,
+    warnings
   }
 }
 
@@ -438,7 +434,12 @@ function importedSelectionIdentity(input: {
   readonly name: string
 }): string {
   return [input.sourceSheetName ?? "", input.category, input.name]
-    .map((value) => value.trim().toLowerCase().replace(/[^a-z0-9]+/g, " "))
+    .map((value) =>
+      value
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, " ")
+    )
     .join("|")
 }
 
@@ -491,6 +492,91 @@ function parseQuantity(value: string | null): number | null {
   return parsed
 }
 
+function normalizedChoiceOptions(values: readonly string[] | undefined): readonly string[] {
+  if (!values) return []
+  const unique = new Set<string>()
+  for (const value of values) {
+    const cleaned = value.trim()
+    if (!cleaned) continue
+    if (cleaned.length > 200) {
+      throw new Error("Template selection choices must be 200 characters or less.")
+    }
+    unique.add(cleaned)
+  }
+  if (unique.size > 200) {
+    throw new Error("A finish selection may have no more than 200 choices.")
+  }
+  return [...unique]
+}
+
+type PublishedTemplateSelection = {
+  readonly templateId: string
+  readonly templateContentItemId: string
+  readonly choiceOptions: readonly string[]
+}
+
+async function loadPublishedTemplateSelection(
+  db: ReturnType<typeof getDb>,
+  organizationId: string,
+  templateId: string,
+  templateContentItemId: string
+): Promise<PublishedTemplateSelection | null> {
+  const matches = await db
+    .select({
+      templateId: projectTemplates.id,
+      versionId: projectTemplateVersions.id,
+      templateContentItemId: projectTemplateContentItems.id
+    })
+    .from(projectTemplateContentItems)
+    .innerJoin(
+      projectTemplateVersions,
+      eq(projectTemplateVersions.id, projectTemplateContentItems.versionId)
+    )
+    .innerJoin(projectTemplates, eq(projectTemplates.id, projectTemplateVersions.templateId))
+    .where(
+      and(
+        eq(projectTemplates.id, templateId),
+        eq(projectTemplates.organizationId, organizationId),
+        eq(projectTemplates.lifecycleStatus, "active"),
+        eq(projectTemplates.reviewStatus, "verified"),
+        eq(projectTemplateVersions.status, "published"),
+        eq(projectTemplateVersions.versionNumber, projectTemplates.currentVersionNumber),
+        eq(projectTemplateContentItems.id, templateContentItemId),
+        eq(projectTemplateContentItems.moduleType, "selections")
+      )
+    )
+    .limit(1)
+  const match = matches[0]
+  if (!match) return null
+
+  const versionItems = await db
+    .select()
+    .from(projectTemplateContentItems)
+    .where(
+      and(
+        eq(projectTemplateContentItems.versionId, match.versionId),
+        eq(projectTemplateContentItems.moduleType, "selections")
+      )
+    )
+    .orderBy(asc(projectTemplateContentItems.sortOrder))
+  let nextId = 0
+  const build = buildProjectTemplateContentApplication({
+    applicationId: `selection-create:${templateContentItemId}`,
+    items: versionItems,
+    nextId: () => `selection-create:${nextId++}`
+  })
+  const selection = build.selections.find(
+    (candidate) => candidate.templateContentItemId === templateContentItemId
+  )
+  if (!selection) return null
+
+  return {
+    templateId: match.templateId,
+    templateContentItemId: match.templateContentItemId,
+    choiceOptions: parseTemplateChoiceOptions(selection.choiceOptionsJson)
+  }
+}
+
 function normalizedNumberText(value: number | null): string {
   return value === null ? "" : String(value)
 }
@@ -503,7 +589,11 @@ function changedTextField(
   label: string,
   before: string | null,
   after: string | null
-): { readonly field: string; readonly before: string; readonly after: string } | null {
+): {
+  readonly field: string
+  readonly before: string
+  readonly after: string
+} | null {
   const normalizedBefore = normalizedText(before)
   const normalizedAfter = normalizedText(after)
   if (normalizedBefore === normalizedAfter) return null
@@ -514,7 +604,11 @@ function changedNumberField(
   label: string,
   before: number | null,
   after: number | null
-): { readonly field: string; readonly before: string; readonly after: string } | null {
+): {
+  readonly field: string
+  readonly before: string
+  readonly after: string
+} | null {
   const normalizedBefore = normalizedNumberText(before)
   const normalizedAfter = normalizedNumberText(after)
   if (normalizedBefore === normalizedAfter) return null
@@ -534,9 +628,7 @@ function parseChoiceOptions(value: string | null): readonly string[] {
   }
 }
 
-function toSelectionItem(
-  row: typeof projectFinishSelections.$inferSelect
-): ProjectSelectionItem {
+function toSelectionItem(row: typeof projectFinishSelections.$inferSelect): ProjectSelectionItem {
   const status = isSelectionStatus(row.status) ? row.status : "needed"
   return {
     id: row.id,
@@ -569,7 +661,7 @@ function toSelectionItem(
     purchaseOrderOperationId: row.purchaseOrderOperationId,
     notes: row.notes,
     syncStatus: row.syncStatus,
-    updatedAt: row.updatedAt,
+    updatedAt: row.updatedAt
   }
 }
 
@@ -577,9 +669,12 @@ function summarizeSelections(
   roomRows: readonly (typeof projectFinishSelectionRooms.$inferSelect)[],
   selections: readonly ProjectSelectionItem[]
 ): ProjectSelectionsSummary {
-  const roomMap = new Map<string, ProjectSelectionRoom & {
-    readonly selections: ProjectSelectionItem[]
-  }>()
+  const roomMap = new Map<
+    string,
+    ProjectSelectionRoom & {
+      readonly selections: ProjectSelectionItem[]
+    }
+  >()
 
   for (const room of roomRows) {
     roomMap.set(room.roomName, {
@@ -593,7 +688,7 @@ function summarizeSelections(
       roomType: room.roomType,
       sortOrder: room.sortOrder,
       selectionCount: 0,
-      selections: [],
+      selections: []
     })
   }
 
@@ -615,14 +710,14 @@ function summarizeSelections(
       roomType: selection.roomType,
       sortOrder: roomMap.size + 1_000,
       selectionCount: 0,
-      selections: [selection],
+      selections: [selection]
     })
   }
 
   const rooms = Array.from(roomMap.values())
     .map((room) => ({
       ...room,
-      selectionCount: room.selections.length,
+      selectionCount: room.selections.length
     }))
     .sort((left, right) => {
       if (left.sortOrder !== right.sortOrder) {
@@ -635,30 +730,23 @@ function summarizeSelections(
     totalCount: selections.length,
     roomCount: rooms.length,
     sourceWorkbookCount: new Set(
-      rooms
-        .map((room) => room.sourceWorkbookId)
-        .filter((value): value is string => Boolean(value))
+      rooms.map((room) => room.sourceWorkbookId).filter((value): value is string => Boolean(value))
     ).size,
     needsDecisionCount: selections.filter((selection) =>
-      ["needed", "proposed", "owner_review", "unavailable"].includes(
-        selection.status
-      )
+      ["needed", "proposed", "owner_review", "unavailable"].includes(selection.status)
     ).length,
-    approvedCount: selections.filter((selection) => selection.status === "approved")
-      .length,
+    approvedCount: selections.filter((selection) => selection.status === "approved").length,
     pricingCount: selections.filter((selection) =>
       ["pricing", "rfq_sent"].includes(selection.status)
     ).length,
     orderedCount: selections.filter((selection) =>
       ["ordered", "installed"].includes(selection.status)
     ).length,
-    rooms,
+    rooms
   }
 }
 
-export async function getProjectSelections(
-  projectId: string
-): Promise<ProjectSelectionsSummary> {
+export async function getProjectSelections(projectId: string): Promise<ProjectSelectionsSummary> {
   const db = await verifyProjectAccess(projectId, "read")
   const [roomRows, selectionRows] = await Promise.all([
     db
@@ -683,7 +771,7 @@ export async function getProjectSelections(
         asc(projectFinishSelections.category),
         asc(projectFinishSelections.sortOrder),
         asc(projectFinishSelections.name)
-      ),
+      )
   ])
 
   return summarizeSelections(roomRows, selectionRows.map(toSelectionItem))
@@ -698,15 +786,13 @@ export async function previewProjectFinishScheduleImport(
     const loaded = await loadFinishSchedule(access, workbookUrl)
     return {
       success: true,
-      preview: finishSchedulePreview(loaded, access.projectNumber),
+      preview: finishSchedulePreview(loaded, access.projectNumber)
     }
   } catch (error) {
     return {
       success: false,
       error:
-        error instanceof Error
-          ? error.message
-          : "Unable to preview the finish schedule workbook.",
+        error instanceof Error ? error.message : "Unable to preview the finish schedule workbook."
     }
   }
 }
@@ -746,9 +832,7 @@ export async function importProjectFinishSchedule(
         .filter((room) => room.sourceSheetId !== null)
         .map((room) => [room.sourceSheetId, room])
     )
-    const importedSheetIds = new Set(
-      loaded.parsed.rooms.map((room) => String(room.sheetId))
-    )
+    const importedSheetIds = new Set(loaded.parsed.rooms.map((room) => String(room.sheetId)))
     for (const room of loaded.parsed.rooms) {
       const sourceSheetId = String(room.sheetId)
       const existing = roomsBySheetId.get(sourceSheetId)
@@ -761,7 +845,7 @@ export async function importProjectFinishSchedule(
             roomType: room.roomType,
             sortOrder: room.sortOrder,
             active: true,
-            updatedAt: now,
+            updatedAt: now
           })
           .where(eq(projectFinishSelectionRooms.id, existing.id))
       } else {
@@ -777,15 +861,12 @@ export async function importProjectFinishSchedule(
           sortOrder: room.sortOrder,
           active: true,
           createdAt: now,
-          updatedAt: now,
+          updatedAt: now
         })
       }
     }
     for (const staleRoom of existingRooms) {
-      if (
-        staleRoom.sourceSheetId !== null &&
-        importedSheetIds.has(staleRoom.sourceSheetId)
-      ) {
+      if (staleRoom.sourceSheetId !== null && importedSheetIds.has(staleRoom.sourceSheetId)) {
         continue
       }
       await access.db
@@ -809,10 +890,7 @@ export async function importProjectFinishSchedule(
         .filter((selection) => selection.sourceRecordId !== null)
         .map((selection) => [selection.sourceRecordId, selection])
     )
-    const selectionsByIdentity = new Map<
-      string,
-      (typeof projectFinishSelections.$inferSelect)[]
-    >()
+    const selectionsByIdentity = new Map<string, (typeof projectFinishSelections.$inferSelect)[]>()
     for (const selection of existingSelections) {
       const identity = importedSelectionIdentity(selection)
       const matches = selectionsByIdentity.get(identity) ?? []
@@ -824,7 +902,7 @@ export async function importProjectFinishSchedule(
         importedSelectionIdentity({
           sourceSheetName: selection.sheetName,
           category: selection.category,
-          name: selection.name,
+          name: selection.name
         })
       )
     )
@@ -839,12 +917,10 @@ export async function importProjectFinishSchedule(
       const identity = importedSelectionIdentity({
         sourceSheetName: selection.sheetName,
         category: selection.category,
-        name: selection.name,
+        name: selection.name
       })
       const exactMatch = selectionsBySourceRecordId.get(sourceRecordId)
-      const exactIdentity = exactMatch
-        ? importedSelectionIdentity(exactMatch)
-        : null
+      const exactIdentity = exactMatch ? importedSelectionIdentity(exactMatch) : null
       const stableMatch = (selectionsByIdentity.get(identity) ?? []).find(
         (candidate) => !usedSelectionIds.has(candidate.id)
       )
@@ -855,12 +931,12 @@ export async function importProjectFinishSchedule(
       const existing =
         unusedExactMatch && exactIdentity === identity
           ? unusedExactMatch
-          : stableMatch ??
+          : (stableMatch ??
             (unusedExactMatch &&
             exactIdentity !== null &&
             !incomingSelectionIdentities.has(exactIdentity)
               ? unusedExactMatch
-              : null)
+              : null))
       const sourceValues: ImportedSelectionSourceValues = {
         sourceSheetName: selection.sheetName,
         roomName: selection.roomName,
@@ -875,7 +951,7 @@ export async function importProjectFinishSchedule(
         notes: selection.notes,
         sortOrder: selection.sortOrder,
         lastSyncedAt: now,
-        updatedAt: now,
+        updatedAt: now
       }
       if (!existing) {
         await access.db.insert(projectFinishSelections).values({
@@ -889,7 +965,7 @@ export async function importProjectFinishSchedule(
           ownerVisible: false,
           ownerApproved: false,
           syncStatus: "imported",
-          createdAt: now,
+          createdAt: now
         })
         createdCount += 1
         continue
@@ -911,9 +987,7 @@ export async function importProjectFinishSchedule(
           ownerApproved: approvalNeedsReview ? false : existing.ownerApproved,
           approvedBy: approvalNeedsReview ? null : existing.approvedBy,
           approvedAt: approvalNeedsReview ? null : existing.approvedAt,
-          syncStatus: approvalNeedsReview
-            ? "selection_change_review"
-            : "imported",
+          syncStatus: approvalNeedsReview ? "selection_change_review" : "imported"
         })
         .where(eq(projectFinishSelections.id, existing.id))
       updatedCount += 1
@@ -925,9 +999,7 @@ export async function importProjectFinishSchedule(
     )
     for (const stale of staleSelections) {
       const canRemoveUntouchedSourceRow =
-        stale.syncStatus === "imported" &&
-        !stale.ownerApproved &&
-        stale.status === "needed"
+        stale.syncStatus === "imported" && !stale.ownerApproved && stale.status === "needed"
       if (!canRemoveUntouchedSourceRow) {
         conflictCount += 1
         continue
@@ -948,15 +1020,13 @@ export async function importProjectFinishSchedule(
       removedCount,
       conflictCount,
       staleCount,
-      roomCount: loaded.parsed.rooms.length,
+      roomCount: loaded.parsed.rooms.length
     }
   } catch (error) {
     return {
       success: false,
       error:
-        error instanceof Error
-          ? error.message
-          : "Unable to import the finish schedule workbook.",
+        error instanceof Error ? error.message : "Unable to import the finish schedule workbook."
     }
   }
 }
@@ -1008,7 +1078,7 @@ export async function getProjectSelectionOptions(
         description: sageCostCodes.description,
         displayLabel: sageCostCodes.displayLabel,
         divisionCode: sageCostCodes.divisionCode,
-        divisionDisplayLabel: sageCostCodes.divisionDisplayLabel,
+        divisionDisplayLabel: sageCostCodes.divisionDisplayLabel
       })
       .from(sageCostCodes)
       .where(eq(sageCostCodes.active, true))
@@ -1018,7 +1088,7 @@ export async function getProjectSelectionOptions(
         costCode: projectBudgetLines.costCode,
         description: projectBudgetLines.description,
         csiDivision: projectBudgetLines.csiDivision,
-        csiDivisionName: projectBudgetLines.csiDivisionName,
+        csiDivisionName: projectBudgetLines.csiDivisionName
       })
       .from(projectBudgetLines)
       .where(eq(projectBudgetLines.projectId, projectId))
@@ -1030,7 +1100,7 @@ export async function getProjectSelectionOptions(
         contactType: projectContacts.contactType,
         csiDivision: projectContacts.csiDivision,
         csiDivisionName: projectContacts.csiDivisionName,
-        primaryCostCode: projectContacts.primaryCostCode,
+        primaryCostCode: projectContacts.primaryCostCode
       })
       .from(projectContacts)
       .where(and(eq(projectContacts.projectId, projectId), eq(projectContacts.active, true)))
@@ -1040,10 +1110,10 @@ export async function getProjectSelectionOptions(
         manufacturer: projectFinishSelections.manufacturer,
         supplierName: projectFinishSelections.supplierName,
         costCode: projectFinishSelections.costCode,
-        category: projectFinishSelections.category,
+        category: projectFinishSelections.category
       })
       .from(projectFinishSelections)
-      .where(eq(projectFinishSelections.projectId, projectId)),
+      .where(eq(projectFinishSelections.projectId, projectId))
   ])
 
   const divisionMap = new Map<string, ProjectSelectionOption>()
@@ -1055,7 +1125,7 @@ export async function getProjectSelectionOptions(
     if (row.divisionCode && row.divisionDisplayLabel) {
       divisionMap.set(row.divisionCode, {
         value: row.divisionCode,
-        label: row.divisionDisplayLabel,
+        label: row.divisionDisplayLabel
       })
     }
 
@@ -1066,7 +1136,7 @@ export async function getProjectSelectionOptions(
       divisionCode: row.divisionCode,
       divisionLabel: row.divisionDisplayLabel,
       source: "sage",
-      needsSageReview: false,
+      needsSageReview: false
     })
   }
 
@@ -1076,7 +1146,7 @@ export async function getProjectSelectionOptions(
     if (row.csiDivision && row.csiDivisionName) {
       divisionMap.set(row.csiDivision, {
         value: row.csiDivision,
-        label: divisionLabel(row.csiDivision, row.csiDivisionName),
+        label: divisionLabel(row.csiDivision, row.csiDivisionName)
       })
     }
     if (!costCodeMap.has(row.costCode)) {
@@ -1087,23 +1157,20 @@ export async function getProjectSelectionOptions(
         divisionCode: row.csiDivision,
         divisionLabel: divisionLabel(row.csiDivision, row.csiDivisionName),
         source: "project_budget",
-        needsSageReview: true,
+        needsSageReview: true
       })
     }
   }
 
   for (const row of contactRows) {
-    if (
-      row.csiDivision &&
-      EXCLUDED_SELECTION_COST_DIVISIONS.has(row.csiDivision)
-    ) {
+    if (row.csiDivision && EXCLUDED_SELECTION_COST_DIVISIONS.has(row.csiDivision)) {
       continue
     }
 
     if (row.csiDivision && row.csiDivisionName) {
       divisionMap.set(row.csiDivision, {
         value: row.csiDivision,
-        label: divisionLabel(row.csiDivision, row.csiDivisionName),
+        label: divisionLabel(row.csiDivision, row.csiDivisionName)
       })
     }
   }
@@ -1118,7 +1185,7 @@ export async function getProjectSelectionOptions(
     if (!divisionMap.has(divisionCode)) {
       divisionMap.set(divisionCode, {
         value: divisionCode,
-        label: existingDivisionLabel,
+        label: existingDivisionLabel
       })
     }
 
@@ -1134,7 +1201,7 @@ export async function getProjectSelectionOptions(
         divisionCode,
         divisionLabel: existingDivisionLabel,
         source: "selection",
-        needsSageReview: true,
+        needsSageReview: true
       })
     }
   }
@@ -1144,7 +1211,7 @@ export async function getProjectSelectionOptions(
     ...contactRows
       .filter((row) => row.contactType === "supplier")
       .flatMap((row) => [row.companyName, row.displayName]),
-    ...selectionRows.flatMap((row) => [row.manufacturer, row.supplierName]),
+    ...selectionRows.flatMap((row) => [row.manufacturer, row.supplierName])
   ].filter((value): value is string => Boolean(value))
 
   return {
@@ -1155,7 +1222,7 @@ export async function getProjectSelectionOptions(
     ),
     costCodes: Array.from(costCodeMap.values()).sort((left, right) =>
       left.label.localeCompare(right.label)
-    ),
+    )
   }
 }
 
@@ -1200,12 +1267,12 @@ export async function requestSelectionCostCodeSageReview(
         sageWriteStatus: "needs_review",
         sagePayloadJson: JSON.stringify({
           source: "compass_finish_selection",
-          requestedCostCode: cleanedCostCode,
+          requestedCostCode: cleanedCostCode
         }),
         syncDirection: "write",
         syncStatus: "needs_review",
         createdAt: now,
-        updatedAt: now,
+        updatedAt: now
       })
     }
 
@@ -1213,7 +1280,7 @@ export async function requestSelectionCostCodeSageReview(
       .update(projectFinishSelections)
       .set({
         syncStatus: "needs_sage_review",
-        updatedAt: now,
+        updatedAt: now
       })
       .where(
         and(
@@ -1228,10 +1295,7 @@ export async function requestSelectionCostCodeSageReview(
   } catch (error) {
     return {
       success: false,
-      error:
-        error instanceof Error
-          ? error.message
-          : "Failed to request Sage cost code review",
+      error: error instanceof Error ? error.message : "Failed to request Sage cost code review"
     }
   }
 }
@@ -1241,11 +1305,33 @@ export async function createProjectSelection(
   input: CreateProjectSelectionInput
 ): Promise<ActionResult> {
   try {
+    const user = await requireAuth()
+    const organizationId = requireOrg(user)
     const db = await verifyProjectAccess(projectId, "update")
     const now = new Date().toISOString()
     const id = crypto.randomUUID()
     const roomName = requiredText(input.roomName, "Room")
     const roomType = cleanText(input.roomType)
+    const templateId = cleanText(input.templateId ?? null)
+    const templateContentItemId = cleanText(input.templateContentItemId ?? null)
+    if (Boolean(templateId) !== Boolean(templateContentItemId)) {
+      throw new Error("Choose both a template and one of its finish selections.")
+    }
+    const templateSelection =
+      templateId && templateContentItemId
+        ? await loadPublishedTemplateSelection(
+            db,
+            organizationId,
+            templateId,
+            templateContentItemId
+          )
+        : null
+    if (templateId && templateContentItemId && !templateSelection) {
+      throw new Error("That published template finish selection is no longer available.")
+    }
+    const choiceOptions = normalizedChoiceOptions(
+      templateSelection?.choiceOptions ?? input.choiceOptions
+    )
 
     await db
       .insert(projectFinishSelectionRooms)
@@ -1260,14 +1346,17 @@ export async function createProjectSelection(
         roomType,
         sortOrder: 1_000,
         createdAt: now,
-        updatedAt: now,
+        updatedAt: now
       })
       .onConflictDoNothing()
 
     await db.insert(projectFinishSelections).values({
       id,
       projectId,
-      sourceSystem: "compass",
+      sourceSystem: templateSelection ? "compass_template" : "compass",
+      sourceRecordId: templateSelection
+        ? `${templateSelection.templateId}:${templateSelection.templateContentItemId}`
+        : null,
       roomName,
       roomType,
       category: cleanText(input.category) ?? "Uncategorized",
@@ -1277,6 +1366,7 @@ export async function createProjectSelection(
       manufacturer: cleanText(input.manufacturer),
       model: cleanText(input.model),
       colorFinish: cleanText(input.colorFinish),
+      choiceOptionsJson: choiceOptions.length > 0 ? JSON.stringify(choiceOptions) : null,
       supplierName: cleanText(input.supplierName),
       productUrl: cleanText(input.productUrl),
       costCode: cleanText(input.costCode),
@@ -1285,7 +1375,7 @@ export async function createProjectSelection(
       notes: cleanText(input.notes),
       syncStatus: "manual",
       createdAt: now,
-      updatedAt: now,
+      updatedAt: now
     })
 
     revalidatePath(`/dashboard/projects/${projectId}/selections`)
@@ -1294,8 +1384,7 @@ export async function createProjectSelection(
   } catch (error) {
     return {
       success: false,
-      error:
-        error instanceof Error ? error.message : "Failed to create selection",
+      error: error instanceof Error ? error.message : "Failed to create selection"
     }
   }
 }
@@ -1355,7 +1444,7 @@ export async function updateProjectSelection(
       changedTextField("Cost code", existing.costCode, costCode),
       changedTextField("Phase", existing.phaseCode, phaseCode),
       changedTextField("Status", existing.status, status),
-      changedTextField("Notes", existing.notes, notes),
+      changedTextField("Notes", existing.notes, notes)
     ].filter((change) => change !== null)
 
     await db
@@ -1371,7 +1460,7 @@ export async function updateProjectSelection(
         roomType,
         sortOrder: 1_000,
         createdAt: now,
-        updatedAt: now,
+        updatedAt: now
       })
       .onConflictDoNothing()
 
@@ -1401,7 +1490,7 @@ export async function updateProjectSelection(
             : existing.sourceSystem === "google_sheets" && changes.length > 0
               ? "manual_edit"
               : existing.syncStatus,
-        updatedAt: now,
+        updatedAt: now
       })
       .where(
         and(
@@ -1419,7 +1508,7 @@ export async function updateProjectSelection(
         .select({
           projectManager: projects.projectManager,
           sageJobId: projects.sageJobId,
-          sageJobNumber: projects.sageJobNumber,
+          sageJobNumber: projects.sageJobNumber
         })
         .from(projects)
         .where(eq(projects.id, projectId))
@@ -1434,7 +1523,7 @@ export async function updateProjectSelection(
               "staff_task",
               "subcontractor_task",
               "supplier_task",
-              "schedule_task",
+              "schedule_task"
             ])
           )
         )
@@ -1443,7 +1532,7 @@ export async function updateProjectSelection(
         selectionId,
         selectionName: existing.name,
         changeReason,
-        changes,
+        changes
       }
 
       await db.insert(projectOperations).values({
@@ -1465,7 +1554,7 @@ export async function updateProjectSelection(
         syncDirection: "write",
         syncStatus: "compass_only",
         createdAt: now,
-        updatedAt: now,
+        updatedAt: now
       })
 
       await db.insert(projectOperations).values({
@@ -1486,7 +1575,7 @@ export async function updateProjectSelection(
         syncDirection: "write",
         syncStatus: "needs_review",
         createdAt: now,
-        updatedAt: now,
+        updatedAt: now
       })
 
       await db.insert(projectOperations).values({
@@ -1511,12 +1600,12 @@ export async function updateProjectSelection(
         sagePayloadJson: JSON.stringify({
           ...payload,
           taskRole: "project_manager",
-          linkedChangeOrderReviewId: changeOrderReviewId,
+          linkedChangeOrderReviewId: changeOrderReviewId
         }),
         syncDirection: "write",
         syncStatus: "compass_only",
         createdAt: now,
-        updatedAt: now,
+        updatedAt: now
       })
 
       await db.insert(projectOperations).values({
@@ -1541,12 +1630,12 @@ export async function updateProjectSelection(
         sagePayloadJson: JSON.stringify({
           ...payload,
           taskRole: "project_administrator",
-          linkedChangeLogId: logId,
+          linkedChangeLogId: logId
         }),
         syncDirection: "write",
         syncStatus: "compass_only",
         createdAt: now,
-        updatedAt: now,
+        updatedAt: now
       })
     }
 
@@ -1556,8 +1645,7 @@ export async function updateProjectSelection(
   } catch (error) {
     return {
       success: false,
-      error:
-        error instanceof Error ? error.message : "Failed to update selection",
+      error: error instanceof Error ? error.message : "Failed to update selection"
     }
   }
 }
@@ -1599,7 +1687,7 @@ export async function updateProjectSelectionStatus(
           status === "unavailable" && existing.status !== "unavailable"
             ? "selection_change_review"
             : existing.syncStatus,
-        updatedAt: now,
+        updatedAt: now
       })
       .where(
         and(
@@ -1616,7 +1704,7 @@ export async function updateProjectSelectionStatus(
         .select({
           projectManager: projects.projectManager,
           sageJobId: projects.sageJobId,
-          sageJobNumber: projects.sageJobNumber,
+          sageJobNumber: projects.sageJobNumber
         })
         .from(projects)
         .where(eq(projects.id, projectId))
@@ -1631,7 +1719,7 @@ export async function updateProjectSelectionStatus(
               "staff_task",
               "subcontractor_task",
               "supplier_task",
-              "schedule_task",
+              "schedule_task"
             ])
           )
         )
@@ -1644,8 +1732,8 @@ export async function updateProjectSelectionStatus(
         requiredFollowUp: [
           "Confirm product availability issue.",
           "Ask owner to select an alternate.",
-          "Review RFQ, PO, schedule, and change-order impact.",
-        ],
+          "Review RFQ, PO, schedule, and change-order impact."
+        ]
       }
 
       await db.insert(projectOperations).values({
@@ -1666,7 +1754,7 @@ export async function updateProjectSelectionStatus(
         syncDirection: "write",
         syncStatus: "needs_review",
         createdAt: now,
-        updatedAt: now,
+        updatedAt: now
       })
 
       await db.insert(projectOperations).values({
@@ -1691,12 +1779,12 @@ export async function updateProjectSelectionStatus(
         sagePayloadJson: JSON.stringify({
           ...payload,
           taskRole: "project_manager",
-          linkedUnavailableReviewId: reviewId,
+          linkedUnavailableReviewId: reviewId
         }),
         syncDirection: "write",
         syncStatus: "compass_only",
         createdAt: now,
-        updatedAt: now,
+        updatedAt: now
       })
 
       await db.insert(projectOperations).values({
@@ -1721,12 +1809,12 @@ export async function updateProjectSelectionStatus(
         sagePayloadJson: JSON.stringify({
           ...payload,
           taskRole: "project_administrator",
-          linkedUnavailableReviewId: reviewId,
+          linkedUnavailableReviewId: reviewId
         }),
         syncDirection: "write",
         syncStatus: "compass_only",
         createdAt: now,
-        updatedAt: now,
+        updatedAt: now
       })
     }
 
@@ -1736,8 +1824,7 @@ export async function updateProjectSelectionStatus(
   } catch (error) {
     return {
       success: false,
-      error:
-        error instanceof Error ? error.message : "Failed to update selection",
+      error: error instanceof Error ? error.message : "Failed to update selection"
     }
   }
 }
@@ -1752,7 +1839,7 @@ export async function deleteProjectSelection(
       .select({
         id: projectFinishSelections.id,
         status: projectFinishSelections.status,
-        ownerApproved: projectFinishSelections.ownerApproved,
+        ownerApproved: projectFinishSelections.ownerApproved
       })
       .from(projectFinishSelections)
       .where(
@@ -1771,7 +1858,7 @@ export async function deleteProjectSelection(
       return {
         success: false,
         error:
-          "Approved selections cannot be deleted. Change the selection status or create a change review instead.",
+          "Approved selections cannot be deleted. Change the selection status or create a change review instead."
       }
     }
 
@@ -1791,8 +1878,7 @@ export async function deleteProjectSelection(
   } catch (error) {
     return {
       success: false,
-      error:
-        error instanceof Error ? error.message : "Failed to delete selection",
+      error: error instanceof Error ? error.message : "Failed to delete selection"
     }
   }
 }

--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -7,23 +7,27 @@ import {
   taskDependencies,
   workdayExceptions,
   projects,
+  projectOperations,
   organizationMembers,
   projectAccessInvitations,
-  users,
+  users
 } from "@/db/schema"
+import {
+  projectTemplateContentItems,
+  projectTemplates,
+  projectTemplateVersions,
+  scheduleTemplateItems
+} from "@/db/schema-templates"
 import { eq, asc, and, inArray } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { calculateEndDate } from "@/lib/schedule/business-days"
 import { findCriticalPath } from "@/lib/schedule/critical-path"
 import {
   wouldCreateCycle,
-  wouldDependencyUpdateCreateCycle,
+  wouldDependencyUpdateCreateCycle
 } from "@/lib/schedule/dependency-validation"
 import { propagateDates } from "@/lib/schedule/propagate-dates"
-import {
-  effectivePercentComplete,
-  normalizeScheduleProgress,
-} from "@/lib/schedule/progress"
+import { effectivePercentComplete, normalizeScheduleProgress } from "@/lib/schedule/progress"
 import { newScheduleConfirmationState } from "@/lib/schedule/confirmation"
 import { requireAuth } from "@/lib/auth"
 import { requireOrg } from "@/lib/org-scope"
@@ -35,9 +39,10 @@ import { requirePermission } from "@/lib/permissions"
 import { isInternalStaffRole } from "@/lib/user-roles"
 import { recordActivityEvent } from "@/lib/activity-log"
 import {
-  isOwnerScheduleView,
-  type OwnerScheduleView,
-} from "@/lib/schedule/owner-visibility"
+  formatTemplateChecklist,
+  groupTemplateChecklistItems
+} from "@/lib/templates/template-checklist-hierarchy"
+import { isOwnerScheduleView, type OwnerScheduleView } from "@/lib/schedule/owner-visibility"
 import type {
   TaskStatus,
   DependencyType,
@@ -46,7 +51,7 @@ import type {
   ScheduleData,
   ScopedScheduleData,
   WorkdayExceptionData,
-  WorkdayExceptionType,
+  WorkdayExceptionType
 } from "@/lib/schedule/types"
 
 function revalidateSchedulePaths(projectId: string): void {
@@ -81,8 +86,100 @@ async function fetchExceptions(
     ...r,
     type: r.type as WorkdayExceptionType,
     category: r.category as ExceptionCategory,
-    recurrence: r.recurrence as ExceptionRecurrence,
+    recurrence: r.recurrence as ExceptionRecurrence
   }))
+}
+
+type ScheduleTemplateLinkedTodo = {
+  readonly templateContentItemId: string
+  readonly sourceItemId: string | null
+  readonly title: string
+  readonly description: string | null
+  readonly checklistItems: readonly {
+    readonly templateContentItemId: string
+    readonly sourceItemId: string | null
+    readonly title: string
+    readonly description: string | null
+    readonly sortOrder: number
+  }[]
+}
+
+type ScheduleTemplateItemImport = {
+  readonly templateId: string
+  readonly templateName: string
+  readonly versionId: string
+  readonly scheduleTemplateItemId: string
+  readonly linkedTodos: readonly ScheduleTemplateLinkedTodo[]
+}
+
+function joinedDescription(parts: readonly (string | null)[]): string | null {
+  const content = parts.flatMap((part) => {
+    const cleaned = part?.trim()
+    return cleaned ? [cleaned] : []
+  })
+  return content.length > 0 ? content.join("\n\n") : null
+}
+
+async function loadScheduleTemplateItemImport(
+  db: ReturnType<typeof getDb>,
+  organizationId: string,
+  templateItemId: string
+): Promise<ScheduleTemplateItemImport | null> {
+  const rows = await db
+    .select({
+      templateId: projectTemplates.id,
+      templateName: projectTemplates.name,
+      versionId: projectTemplateVersions.id,
+      scheduleTemplateItemId: scheduleTemplateItems.id
+    })
+    .from(scheduleTemplateItems)
+    .innerJoin(
+      projectTemplateVersions,
+      eq(projectTemplateVersions.id, scheduleTemplateItems.versionId)
+    )
+    .innerJoin(projectTemplates, eq(projectTemplates.id, projectTemplateVersions.templateId))
+    .where(
+      and(
+        eq(scheduleTemplateItems.id, templateItemId),
+        eq(projectTemplates.organizationId, organizationId),
+        eq(projectTemplates.lifecycleStatus, "active"),
+        eq(projectTemplates.reviewStatus, "verified"),
+        eq(projectTemplateVersions.status, "published"),
+        eq(projectTemplateVersions.versionNumber, projectTemplates.currentVersionNumber)
+      )
+    )
+    .limit(1)
+  const selected = rows[0]
+  if (!selected) return null
+
+  const taskItems = await db
+    .select()
+    .from(projectTemplateContentItems)
+    .where(
+      and(
+        eq(projectTemplateContentItems.versionId, selected.versionId),
+        eq(projectTemplateContentItems.moduleType, "tasks")
+      )
+    )
+    .orderBy(asc(projectTemplateContentItems.sortOrder))
+  const linkedTodos = groupTemplateChecklistItems(taskItems).map((group) => ({
+    templateContentItemId: group.task.id,
+    sourceItemId: group.task.sourceItemId,
+    title: group.task.title.trim(),
+    description: joinedDescription([
+      group.task.description,
+      formatTemplateChecklist(group.checklistItems)
+    ]),
+    checklistItems: group.checklistItems.map((item) => ({
+      templateContentItemId: item.id,
+      sourceItemId: item.sourceItemId,
+      title: item.title,
+      description: item.description,
+      sortOrder: item.sortOrder
+    }))
+  }))
+
+  return { ...selected, linkedTodos }
 }
 
 async function resolveAssignedUserId(
@@ -98,10 +195,7 @@ async function resolveAssignedUserId(
     const member = await db
       .select({ userId: users.id })
       .from(users)
-      .innerJoin(
-        organizationMembers,
-        eq(organizationMembers.userId, users.id)
-      )
+      .innerJoin(organizationMembers, eq(organizationMembers.userId, users.id))
       .where(
         and(
           eq(users.id, userId),
@@ -133,9 +227,7 @@ async function resolveAssignedUserId(
   return null
 }
 
-export async function getSchedule(
-  projectId: string
-): Promise<ScheduleData> {
+export async function getSchedule(projectId: string): Promise<ScheduleData> {
   const user = await requireAuth()
   requirePermission(user, "schedule", "read")
   const orgId = requireOrg(user)
@@ -168,9 +260,7 @@ export async function getSchedule(
   const exceptions = await fetchExceptions(db, projectId)
 
   const taskIds = new Set(tasks.map((t) => t.id))
-  const projectDeps = deps.filter(
-    (d) => taskIds.has(d.predecessorId) && taskIds.has(d.successorId)
-  )
+  const projectDeps = deps.filter((d) => taskIds.has(d.predecessorId) && taskIds.has(d.successorId))
 
   return {
     tasks: tasks.map((t) => {
@@ -179,20 +269,18 @@ export async function getSchedule(
         ...t,
         status,
         phase: t.phase,
-        percentComplete: effectivePercentComplete(status, t.percentComplete),
+        percentComplete: effectivePercentComplete(status, t.percentComplete)
       }
     }),
     dependencies: projectDeps.map((d) => ({
       ...d,
-      type: d.type as DependencyType,
+      type: d.type as DependencyType
     })),
-    exceptions,
+    exceptions
   }
 }
 
-export async function getOwnerScheduleView(
-  projectId: string
-): Promise<OwnerScheduleView> {
+export async function getOwnerScheduleView(projectId: string): Promise<OwnerScheduleView> {
   const user = await requireAuth()
   requirePermission(user, "schedule", "read")
   const orgId = requireOrg(user)
@@ -206,24 +294,17 @@ export async function getOwnerScheduleView(
   const project = await db
     .select({ ownerScheduleView: projects.ownerScheduleView })
     .from(projects)
-    .where(
-      and(eq(projects.id, projectId), eq(projects.organizationId, orgId))
-    )
+    .where(and(eq(projects.id, projectId), eq(projects.organizationId, orgId)))
     .get()
 
   if (!project) throw new Error("Project not found or access denied")
-  return isOwnerScheduleView(project.ownerScheduleView)
-    ? project.ownerScheduleView
-    : "items"
+  return isOwnerScheduleView(project.ownerScheduleView) ? project.ownerScheduleView : "items"
 }
 
 export async function updateOwnerScheduleView(
   projectId: string,
   ownerScheduleView: string
-): Promise<
-  | { readonly success: true }
-  | { readonly success: false; readonly error: string }
-> {
+): Promise<{ readonly success: true } | { readonly success: false; readonly error: string }> {
   try {
     const user = await requireAuth()
     if (isDemoUser(user.id)) {
@@ -233,7 +314,7 @@ export async function updateOwnerScheduleView(
     if (!isInternalStaffRole(user.role)) {
       return {
         success: false,
-        error: "Only internal project staff can change owner schedule access.",
+        error: "Only internal project staff can change owner schedule access."
       }
     }
     if (!isOwnerScheduleView(ownerScheduleView)) {
@@ -246,9 +327,7 @@ export async function updateOwnerScheduleView(
     const existing = await db
       .select({ id: projects.id })
       .from(projects)
-      .where(
-        and(eq(projects.id, projectId), eq(projects.organizationId, orgId))
-      )
+      .where(and(eq(projects.id, projectId), eq(projects.organizationId, orgId)))
       .get()
 
     if (!existing) {
@@ -259,7 +338,7 @@ export async function updateOwnerScheduleView(
       .update(projects)
       .set({
         ownerScheduleView,
-        updatedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
       })
       .where(eq(projects.id, projectId))
 
@@ -275,17 +354,14 @@ export async function updateOwnerScheduleView(
       summary:
         ownerScheduleView === "phases"
           ? "Changed the owner schedule to phase-only visibility."
-          : "Changed the owner schedule to item-level visibility.",
+          : "Changed the owner schedule to item-level visibility."
     })
     revalidateOwnerSchedulePaths(projectId)
     return { success: true }
   } catch (error) {
     return {
       success: false,
-      error:
-        error instanceof Error
-          ? error.message
-          : "Unable to update the owner schedule view.",
+      error: error instanceof Error ? error.message : "Unable to update the owner schedule view."
     }
   }
 }
@@ -298,9 +374,7 @@ export async function getScopedSchedule(
   const orgId = requireOrg(user)
   const accessibleProjects = await getProjects()
   const requestedIds = new Set(
-    requestedProjectIds
-      ?.map((projectId) => projectId.trim())
-      .filter(Boolean) ?? []
+    requestedProjectIds?.map((projectId) => projectId.trim()).filter(Boolean) ?? []
   )
   const selectedProjects =
     requestedIds.size === 0
@@ -313,9 +387,9 @@ export async function getScopedSchedule(
     projectNumber: project.projectNumber,
     department: projectDepartment({
       projectId: project.id,
-      projectNumber: project.projectNumber,
+      projectNumber: project.projectNumber
     }),
-    color: projectScheduleColor(project.id),
+    color: projectScheduleColor(project.id)
   }))
 
   if (scopedProjects.length === 0) {
@@ -323,7 +397,7 @@ export async function getScopedSchedule(
       projects: [],
       tasks: [],
       dependencies: [],
-      exceptions: [],
+      exceptions: []
     }
   }
 
@@ -336,28 +410,19 @@ export async function getScopedSchedule(
         db
           .select({ id: projects.id })
           .from(projects)
-          .where(
-            and(
-              eq(projects.organizationId, orgId),
-              inArray(projects.id, projectIdChunk)
-            )
-          )
+          .where(and(eq(projects.organizationId, orgId), inArray(projects.id, projectIdChunk)))
       )
     )
   ).flat()
-  const verifiedProjectIds = new Set(
-    verifiedProjects.map((project) => project.id)
-  )
-  const safeProjectIds = projectIds.filter((projectId) =>
-    verifiedProjectIds.has(projectId)
-  )
+  const verifiedProjectIds = new Set(verifiedProjects.map((project) => project.id))
+  const safeProjectIds = projectIds.filter((projectId) => verifiedProjectIds.has(projectId))
 
   if (safeProjectIds.length === 0) {
     return {
       projects: [],
       tasks: [],
       dependencies: [],
-      exceptions: [],
+      exceptions: []
     }
   }
 
@@ -382,7 +447,7 @@ export async function getScopedSchedule(
           .from(workdayExceptions)
           .where(inArray(workdayExceptions.projectId, projectIdChunk))
       )
-    ),
+    )
   ])
   const tasks = taskChunks
     .flat()
@@ -397,46 +462,37 @@ export async function getScopedSchedule(
   const dependencies = (
     await Promise.all(
       chunkValues(taskIds, 50).map((taskIdChunk) =>
-        db
-          .select()
-          .from(taskDependencies)
-          .where(inArray(taskDependencies.successorId, taskIdChunk))
+        db.select().from(taskDependencies).where(inArray(taskDependencies.successorId, taskIdChunk))
       )
     )
   ).flat()
   const taskIdSet = new Set(taskIds)
 
   return {
-    projects: scopedProjects.filter((project) =>
-      verifiedProjectIds.has(project.id)
-    ),
+    projects: scopedProjects.filter((project) => verifiedProjectIds.has(project.id)),
     tasks: tasks.map((task) => {
       const status = task.status as TaskStatus
       return {
         ...task,
         status,
-        percentComplete: effectivePercentComplete(
-          status,
-          task.percentComplete
-        ),
+        percentComplete: effectivePercentComplete(status, task.percentComplete)
       }
     }),
     dependencies: dependencies
       .filter(
         (dependency) =>
-          taskIdSet.has(dependency.predecessorId) &&
-          taskIdSet.has(dependency.successorId)
+          taskIdSet.has(dependency.predecessorId) && taskIdSet.has(dependency.successorId)
       )
       .map((dependency) => ({
         ...dependency,
-        type: dependency.type as DependencyType,
+        type: dependency.type as DependencyType
       })),
     exceptions: exceptions.map((exception) => ({
       ...exception,
       type: exception.type as WorkdayExceptionType,
       category: exception.category as ExceptionCategory,
-      recurrence: exception.recurrence as ExceptionRecurrence,
-    })),
+      recurrence: exception.recurrence as ExceptionRecurrence
+    }))
   }
 }
 
@@ -456,9 +512,14 @@ export async function createTask(
     ownerVisible?: boolean
     subVendorVisible?: boolean
     confirmationRequired?: boolean
+    templateScheduleItemId?: string | null
   }
 ): Promise<
-  | { readonly success: true; readonly taskId: string }
+  | {
+      readonly success: true
+      readonly taskId: string
+      readonly linkedTodoCount: number
+    }
   | { readonly success: false; readonly error: string }
 > {
   try {
@@ -483,10 +544,18 @@ export async function createTask(
       return { success: false, error: "Project not found or access denied" }
     }
 
+    const templateImport = data.templateScheduleItemId
+      ? await loadScheduleTemplateItemImport(db, orgId, data.templateScheduleItemId)
+      : null
+    if (data.templateScheduleItemId && !templateImport) {
+      return {
+        success: false,
+        error: "That published template schedule item is no longer available."
+      }
+    }
+
     const exceptions = await fetchExceptions(db, projectId)
-    const endDate = calculateEndDate(
-      data.startDate, data.workdays, exceptions
-    )
+    const endDate = calculateEndDate(data.startDate, data.workdays, exceptions)
     const now = new Date().toISOString()
 
     const existing = await db
@@ -495,28 +564,18 @@ export async function createTask(
       .where(eq(scheduleTasks.projectId, projectId))
       .orderBy(asc(scheduleTasks.sortOrder))
 
-    const nextOrder = existing.length > 0
-      ? existing[existing.length - 1].sortOrder + 1
-      : 0
+    const nextOrder = existing.length > 0 ? existing[existing.length - 1].sortOrder + 1 : 0
 
     const id = crypto.randomUUID()
-    const assignedUserId = await resolveAssignedUserId(
-      db,
-      orgId,
-      projectId,
-      data.assignedOptionId
-    )
+    const assignedUserId = await resolveAssignedUserId(db, orgId, projectId, data.assignedOptionId)
     const confirmationRequired = data.confirmationRequired ?? false
     const confirmation = newScheduleConfirmationState({
       required: confirmationRequired,
       assignedUserId,
-      now,
+      now
     })
-    const progress = normalizeScheduleProgress(
-      data.status ?? "PENDING",
-      data.percentComplete ?? 0
-    )
-    await db.insert(scheduleTasks).values({
+    const progress = normalizeScheduleProgress(data.status ?? "PENDING", data.percentComplete ?? 0)
+    const scheduleTaskRow: typeof scheduleTasks.$inferInsert = {
       id,
       projectId,
       title: data.title,
@@ -538,8 +597,47 @@ export async function createTask(
       confirmationRequestedAt: confirmation.requestedAt,
       sortOrder: nextOrder,
       createdAt: now,
-      updatedAt: now,
-    })
+      updatedAt: now
+    }
+    const linkedTodoRows: (typeof projectOperations.$inferInsert)[] =
+      templateImport?.linkedTodos.map((todo) => ({
+        id: crypto.randomUUID(),
+        projectId,
+        sourceSystem: "compass_template",
+        sourceRecordType: "schedule_task",
+        sourceRecordId: id,
+        title: todo.title,
+        description: todo.description,
+        status: "open",
+        priority: "normal",
+        assigneeType: "internal",
+        startDate: data.startDate,
+        dueDate: endDate,
+        sageWriteStatus: "not_ready",
+        sagePayloadJson: JSON.stringify({
+          source: "project_template_schedule_item",
+          templateId: templateImport.templateId,
+          templateName: templateImport.templateName,
+          versionId: templateImport.versionId,
+          scheduleTemplateItemId: templateImport.scheduleTemplateItemId,
+          templateContentItemId: todo.templateContentItemId,
+          sourceItemId: todo.sourceItemId,
+          checklistItems: todo.checklistItems
+        }),
+        syncDirection: "write",
+        syncStatus: "compass_only",
+        createdAt: now,
+        updatedAt: now
+      })) ?? []
+
+    if (linkedTodoRows.length > 0) {
+      await db.batch([
+        db.insert(scheduleTasks).values(scheduleTaskRow),
+        db.insert(projectOperations).values(linkedTodoRows)
+      ])
+    } else {
+      await db.insert(scheduleTasks).values(scheduleTaskRow)
+    }
 
     await recordActivityEvent({
       db,
@@ -551,11 +649,27 @@ export async function createTask(
       entityType: "schedule_item",
       entityId: id,
       summary: `Created schedule item “${data.title}”.`,
+      metadata: templateImport
+        ? {
+            templateId: templateImport.templateId,
+            templateName: templateImport.templateName,
+            scheduleTemplateItemId: templateImport.scheduleTemplateItemId,
+            linkedTodoCount: linkedTodoRows.length
+          }
+        : undefined
     })
 
     await recalcCriticalPath(db, projectId)
     revalidateSchedulePaths(projectId)
-    return { success: true, taskId: id }
+    if (linkedTodoRows.length > 0) {
+      revalidatePath(`/dashboard/projects/${projectId}/todos`)
+      revalidatePath("/dashboard")
+    }
+    return {
+      success: true,
+      taskId: id,
+      linkedTodoCount: linkedTodoRows.length
+    }
   } catch (error) {
     console.error("Failed to create task:", error)
     return { success: false, error: "Failed to create schedule item" }
@@ -620,22 +734,14 @@ export async function updateTask(
     )
     const assignedUserId =
       data.assignedOptionId !== undefined
-        ? await resolveAssignedUserId(
-            db,
-            orgId,
-            task.projectId,
-            data.assignedOptionId
-          )
+        ? await resolveAssignedUserId(db, orgId, task.projectId, data.assignedOptionId)
         : data.assignedTo === null
           ? null
           : task.assignedUserId
     const assignmentChanged =
-      (data.assignedTo !== undefined &&
-        data.assignedTo !== task.assignedTo) ||
-      (data.assignedOptionId !== undefined &&
-        assignedUserId !== task.assignedUserId)
-    const confirmationRequired =
-      data.confirmationRequired ?? task.confirmationRequired
+      (data.assignedTo !== undefined && data.assignedTo !== task.assignedTo) ||
+      (data.assignedOptionId !== undefined && assignedUserId !== task.assignedUserId)
+    const confirmationRequired = data.confirmationRequired ?? task.confirmationRequired
     const resetConfirmation =
       assignmentChanged ||
       (data.confirmationRequired !== undefined &&
@@ -644,7 +750,7 @@ export async function updateTask(
     const confirmation = newScheduleConfirmationState({
       required: confirmationRequired,
       assignedUserId,
-      now,
+      now
     })
 
     await db
@@ -658,33 +764,33 @@ export async function updateTask(
         ...(data.displayColor && { displayColor: data.displayColor }),
         status: progress.status,
         ...(data.isMilestone !== undefined && {
-          isMilestone: data.isMilestone,
+          isMilestone: data.isMilestone
         }),
         percentComplete: progress.percentComplete,
         ...(data.assignedTo !== undefined && {
-          assignedTo: data.assignedTo,
+          assignedTo: data.assignedTo
         }),
         ...(data.assignedOptionId !== undefined || data.assignedTo === null
           ? { assignedUserId }
           : {}),
         ...(data.ownerVisible !== undefined && {
-          ownerVisible: data.ownerVisible,
+          ownerVisible: data.ownerVisible
         }),
         ...(data.subVendorVisible !== undefined && {
-          subVendorVisible: data.subVendorVisible,
+          subVendorVisible: data.subVendorVisible
         }),
         ...(data.confirmationRequired !== undefined && {
-          confirmationRequired,
+          confirmationRequired
         }),
         ...(resetConfirmation
           ? {
               confirmationStatus: confirmation.status,
               confirmationRequestedAt: confirmation.requestedAt,
               confirmationRespondedAt: null,
-              reminderSentAt: null,
+              reminderSentAt: null
             }
           : {}),
-        updatedAt: now,
+        updatedAt: now
       })
       .where(eq(scheduleTasks.id, taskId))
 
@@ -697,7 +803,7 @@ export async function updateTask(
       action: "schedule.item_updated",
       entityType: "schedule_item",
       entityId: taskId,
-      summary: `Updated schedule item “${data.title ?? task.title}”.`,
+      summary: `Updated schedule item “${data.title ?? task.title}”.`
     })
 
     // propagate date changes to downstream tasks
@@ -708,14 +814,10 @@ export async function updateTask(
       percentComplete: progress.percentComplete,
       startDate,
       workdays,
-      endDateCalculated: endDate,
+      endDateCalculated: endDate
     }
-    const allTasks = schedule.tasks.map((t) =>
-      t.id === taskId ? updatedTask : t
-    )
-    const { updatedTasks } = propagateDates(
-      taskId, allTasks, schedule.dependencies, exceptions
-    )
+    const allTasks = schedule.tasks.map((t) => (t.id === taskId ? updatedTask : t))
+    const { updatedTasks } = propagateDates(taskId, allTasks, schedule.dependencies, exceptions)
 
     for (const [id, dates] of updatedTasks) {
       await db
@@ -723,7 +825,7 @@ export async function updateTask(
         .set({
           startDate: dates.startDate,
           endDateCalculated: dates.endDateCalculated,
-          updatedAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString()
         })
         .where(eq(scheduleTasks.id, id))
     }
@@ -737,9 +839,7 @@ export async function updateTask(
   }
 }
 
-export async function deleteTask(
-  taskId: string
-): Promise<{ success: boolean; error?: string }> {
+export async function deleteTask(taskId: string): Promise<{ success: boolean; error?: string }> {
   try {
     const user = await requireAuth()
     if (isDemoUser(user.id)) {
@@ -780,7 +880,7 @@ export async function deleteTask(
       action: "schedule.item_deleted",
       entityType: "schedule_item",
       entityId: taskId,
-      summary: `Deleted schedule item “${task.title}”.`,
+      summary: `Deleted schedule item “${task.title}”.`
     })
     await recalcCriticalPath(db, task.projectId)
     revalidateSchedulePaths(task.projectId)
@@ -810,7 +910,7 @@ export async function completeScheduleTasks(
     if (ids.length > 200) {
       return {
         success: false,
-        error: "Update no more than 200 schedule items at a time",
+        error: "Update no more than 200 schedule items at a time"
       }
     }
 
@@ -829,17 +929,12 @@ export async function completeScheduleTasks(
     const matchingTasks = await db
       .select({ id: scheduleTasks.id })
       .from(scheduleTasks)
-      .where(
-        and(
-          eq(scheduleTasks.projectId, projectId),
-          inArray(scheduleTasks.id, ids)
-        )
-      )
+      .where(and(eq(scheduleTasks.projectId, projectId), inArray(scheduleTasks.id, ids)))
 
     if (matchingTasks.length !== ids.length) {
       return {
         success: false,
-        error: "One or more schedule items could not be found",
+        error: "One or more schedule items could not be found"
       }
     }
 
@@ -848,14 +943,9 @@ export async function completeScheduleTasks(
       .set({
         status: "COMPLETE",
         percentComplete: 100,
-        updatedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
       })
-      .where(
-        and(
-          eq(scheduleTasks.projectId, projectId),
-          inArray(scheduleTasks.id, ids)
-        )
-      )
+      .where(and(eq(scheduleTasks.projectId, projectId), inArray(scheduleTasks.id, ids)))
 
     await recordActivityEvent({
       db,
@@ -866,7 +956,7 @@ export async function completeScheduleTasks(
       action: "schedule.items_completed",
       entityType: "schedule_item_batch",
       summary: `Marked ${ids.length} schedule ${ids.length === 1 ? "item" : "items"} complete.`,
-      metadata: { itemCount: ids.length },
+      metadata: { itemCount: ids.length }
     })
     await recalcCriticalPath(db, projectId)
     revalidateSchedulePaths(projectId)
@@ -881,10 +971,7 @@ export async function assignScheduleTasks(
   projectId: string,
   taskIds: readonly string[],
   assignedTo: string | null
-): Promise<
-  | { readonly success: true }
-  | { readonly success: false; readonly error: string }
-> {
+): Promise<{ readonly success: true } | { readonly success: false; readonly error: string }> {
   try {
     const user = await requireAuth()
     if (isDemoUser(user.id)) {
@@ -900,7 +987,7 @@ export async function assignScheduleTasks(
     if (ids.length > 200) {
       return {
         success: false,
-        error: "Update no more than 200 schedule items at a time",
+        error: "Update no more than 200 schedule items at a time"
       }
     }
 
@@ -919,20 +1006,15 @@ export async function assignScheduleTasks(
     const matchingTasks = await db
       .select({
         id: scheduleTasks.id,
-        confirmationRequired: scheduleTasks.confirmationRequired,
+        confirmationRequired: scheduleTasks.confirmationRequired
       })
       .from(scheduleTasks)
-      .where(
-        and(
-          eq(scheduleTasks.projectId, projectId),
-          inArray(scheduleTasks.id, ids)
-        )
-      )
+      .where(and(eq(scheduleTasks.projectId, projectId), inArray(scheduleTasks.id, ids)))
 
     if (matchingTasks.length !== ids.length) {
       return {
         success: false,
-        error: "One or more schedule items could not be found",
+        error: "One or more schedule items could not be found"
       }
     }
 
@@ -943,20 +1025,13 @@ export async function assignScheduleTasks(
         .set({
           assignedTo: assignedTo?.trim() || null,
           assignedUserId: null,
-          confirmationStatus: task.confirmationRequired
-            ? "unavailable"
-            : "not_requested",
+          confirmationStatus: task.confirmationRequired ? "unavailable" : "not_requested",
           confirmationRequestedAt: task.confirmationRequired ? now : null,
           confirmationRespondedAt: null,
           reminderSentAt: null,
-          updatedAt: now,
+          updatedAt: now
         })
-        .where(
-          and(
-            eq(scheduleTasks.id, task.id),
-            eq(scheduleTasks.projectId, projectId)
-          )
-        )
+        .where(and(eq(scheduleTasks.id, task.id), eq(scheduleTasks.projectId, projectId)))
     }
 
     await recordActivityEvent({
@@ -970,7 +1045,7 @@ export async function assignScheduleTasks(
       summary: assignedTo?.trim()
         ? `Assigned ${ids.length} schedule ${ids.length === 1 ? "item" : "items"} to ${assignedTo.trim()}.`
         : `Cleared the assignee from ${ids.length} schedule ${ids.length === 1 ? "item" : "items"}.`,
-      metadata: { itemCount: ids.length },
+      metadata: { itemCount: ids.length }
     })
     revalidateSchedulePaths(projectId)
     return { success: true }
@@ -999,7 +1074,7 @@ export async function deleteScheduleTasks(
     if (ids.length > 200) {
       return {
         success: false,
-        error: "Delete no more than 200 schedule items at a time",
+        error: "Delete no more than 200 schedule items at a time"
       }
     }
 
@@ -1018,28 +1093,18 @@ export async function deleteScheduleTasks(
     const matchingTasks = await db
       .select({ id: scheduleTasks.id })
       .from(scheduleTasks)
-      .where(
-        and(
-          eq(scheduleTasks.projectId, projectId),
-          inArray(scheduleTasks.id, ids)
-        )
-      )
+      .where(and(eq(scheduleTasks.projectId, projectId), inArray(scheduleTasks.id, ids)))
 
     if (matchingTasks.length !== ids.length) {
       return {
         success: false,
-        error: "One or more schedule items could not be found",
+        error: "One or more schedule items could not be found"
       }
     }
 
     await db
       .delete(scheduleTasks)
-      .where(
-        and(
-          eq(scheduleTasks.projectId, projectId),
-          inArray(scheduleTasks.id, ids)
-        )
-      )
+      .where(and(eq(scheduleTasks.projectId, projectId), inArray(scheduleTasks.id, ids)))
 
     await recordActivityEvent({
       db,
@@ -1050,7 +1115,7 @@ export async function deleteScheduleTasks(
       action: "schedule.items_deleted",
       entityType: "schedule_item_batch",
       summary: `Deleted ${ids.length} schedule ${ids.length === 1 ? "item" : "items"}.`,
-      metadata: { itemCount: ids.length },
+      metadata: { itemCount: ids.length }
     })
     await recalcCriticalPath(db, projectId)
     revalidateSchedulePaths(projectId)
@@ -1087,18 +1152,18 @@ export async function reorderTasks(
       return { success: false, error: "Project not found or access denied" }
     }
 
-    const uniqueItems = [...new Map(
-      items
-        .filter((item) => item.id.trim().length > 0)
-        .map((item) => [item.id, item])
-    ).values()]
+    const uniqueItems = [
+      ...new Map(
+        items.filter((item) => item.id.trim().length > 0).map((item) => [item.id, item])
+      ).values()
+    ]
     if (uniqueItems.length === 0) {
       return { success: false, error: "Select schedule items to reorder" }
     }
     if (uniqueItems.length > 500) {
       return {
         success: false,
-        error: "Reorder no more than 500 schedule items at a time",
+        error: "Reorder no more than 500 schedule items at a time"
       }
     }
     const matchingTasks = await db
@@ -1116,7 +1181,7 @@ export async function reorderTasks(
     if (matchingTasks.length !== uniqueItems.length) {
       return {
         success: false,
-        error: "One or more schedule items do not belong to this project",
+        error: "One or more schedule items do not belong to this project"
       }
     }
 
@@ -1124,12 +1189,7 @@ export async function reorderTasks(
       await db
         .update(scheduleTasks)
         .set({ sortOrder: item.sortOrder })
-        .where(
-          and(
-            eq(scheduleTasks.id, item.id),
-            eq(scheduleTasks.projectId, projectId)
-          )
-        )
+        .where(and(eq(scheduleTasks.id, item.id), eq(scheduleTasks.projectId, projectId)))
     }
 
     await recordActivityEvent({
@@ -1142,7 +1202,7 @@ export async function reorderTasks(
       entityType: "project_schedule",
       entityId: projectId,
       summary: `Reordered ${uniqueItems.length} schedule ${uniqueItems.length === 1 ? "item" : "items"}.`,
-      metadata: { itemCount: uniqueItems.length },
+      metadata: { itemCount: uniqueItems.length }
     })
     revalidateSchedulePaths(projectId)
     return { success: true }
@@ -1158,10 +1218,7 @@ export async function createDependency(data: {
   type: DependencyType
   lagDays: number
   projectId: string
-}): Promise<
-  | { readonly success: true }
-  | { readonly success: false; readonly error: string }
-> {
+}): Promise<{ readonly success: true } | { readonly success: false; readonly error: string }> {
   try {
     const user = await requireAuth()
     if (isDemoUser(user.id)) {
@@ -1187,7 +1244,7 @@ export async function createDependency(data: {
     if (data.predecessorId === data.successorId) {
       return {
         success: false,
-        error: "A schedule item cannot depend on itself",
+        error: "A schedule item cannot depend on itself"
       }
     }
 
@@ -1210,7 +1267,7 @@ export async function createDependency(data: {
     ) {
       return {
         success: false,
-        error: "Both schedule items must belong to this project",
+        error: "Both schedule items must belong to this project"
       }
     }
 
@@ -1228,7 +1285,7 @@ export async function createDependency(data: {
     if (duplicate) {
       return {
         success: false,
-        error: "That dependency already exists",
+        error: "That dependency already exists"
       }
     }
 
@@ -1244,7 +1301,7 @@ export async function createDependency(data: {
       predecessorId: data.predecessorId,
       successorId: data.successorId,
       type: data.type,
-      lagDays: data.lagDays,
+      lagDays: data.lagDays
     })
 
     // propagate dates from predecessor
@@ -1262,7 +1319,7 @@ export async function createDependency(data: {
         .set({
           startDate: dates.startDate,
           endDateCalculated: dates.endDateCalculated,
-          updatedAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString()
         })
         .where(eq(scheduleTasks.id, id))
     }
@@ -1279,8 +1336,8 @@ export async function createDependency(data: {
       metadata: {
         affectedItemCount: updatedTasks.size,
         relationship: data.type,
-        lagDays: data.lagDays,
-      },
+        lagDays: data.lagDays
+      }
     })
     await recalcCriticalPath(db, data.projectId)
     revalidateSchedulePaths(data.projectId)
@@ -1298,10 +1355,7 @@ export async function updateDependency(data: {
   type: DependencyType
   lagDays: number
   projectId: string
-}): Promise<
-  | { readonly success: true }
-  | { readonly success: false; readonly error: string }
-> {
+}): Promise<{ readonly success: true } | { readonly success: false; readonly error: string }> {
   try {
     const user = await requireAuth()
     if (isDemoUser(user.id)) {
@@ -1315,12 +1369,7 @@ export async function updateDependency(data: {
     const [project] = await db
       .select({ id: projects.id })
       .from(projects)
-      .where(
-        and(
-          eq(projects.id, data.projectId),
-          eq(projects.organizationId, orgId)
-        )
-      )
+      .where(and(eq(projects.id, data.projectId), eq(projects.organizationId, orgId)))
       .limit(1)
 
     if (!project) {
@@ -1329,7 +1378,7 @@ export async function updateDependency(data: {
     if (data.predecessorId === data.successorId) {
       return {
         success: false,
-        error: "A schedule item cannot depend on itself",
+        error: "A schedule item cannot depend on itself"
       }
     }
 
@@ -1342,13 +1391,10 @@ export async function updateDependency(data: {
     if (!currentDependency) {
       return { success: false, error: "Dependency not found" }
     }
-    if (
-      !taskIds.has(data.predecessorId) ||
-      !taskIds.has(data.successorId)
-    ) {
+    if (!taskIds.has(data.predecessorId) || !taskIds.has(data.successorId)) {
       return {
         success: false,
-        error: "Both schedule items must belong to this project",
+        error: "Both schedule items must belong to this project"
       }
     }
 
@@ -1380,7 +1426,7 @@ export async function updateDependency(data: {
       predecessorId: data.predecessorId,
       successorId: data.successorId,
       type: data.type,
-      lagDays: data.lagDays,
+      lagDays: data.lagDays
     }
     const recalculated = propagateDates(
       data.predecessorId,
@@ -1394,13 +1440,7 @@ export async function updateDependency(data: {
         `UPDATE task_dependencies
          SET predecessor_id = ?, successor_id = ?, type = ?, lag_days = ?
          WHERE id = ?`
-      ).bind(
-        data.predecessorId,
-        data.successorId,
-        data.type,
-        data.lagDays,
-        data.dependencyId
-      ),
+      ).bind(data.predecessorId, data.successorId, data.type, data.lagDays, data.dependencyId)
     ]
 
     for (const [taskId, dates] of recalculated.updatedTasks) {
@@ -1409,13 +1449,7 @@ export async function updateDependency(data: {
           `UPDATE schedule_tasks
            SET start_date = ?, end_date_calculated = ?, updated_at = ?
            WHERE id = ? AND project_id = ?`
-        ).bind(
-          dates.startDate,
-          dates.endDateCalculated,
-          updatedAt,
-          taskId,
-          data.projectId
-        )
+        ).bind(dates.startDate, dates.endDateCalculated, updatedAt, taskId, data.projectId)
       )
     }
 
@@ -1437,8 +1471,8 @@ export async function updateDependency(data: {
       metadata: {
         affectedItemCount: recalculated.updatedTasks.size,
         relationship: data.type,
-        lagDays: data.lagDays,
-      },
+        lagDays: data.lagDays
+      }
     })
     await recalcCriticalPath(db, data.projectId)
     revalidateSchedulePaths(data.projectId)
@@ -1493,13 +1527,10 @@ export async function deleteDependency(
           .where(eq(scheduleTasks.projectId, projectId))
       ).map((task) => task.id)
     )
-    if (
-      !taskIds.has(dependency.predecessorId) ||
-      !taskIds.has(dependency.successorId)
-    ) {
+    if (!taskIds.has(dependency.predecessorId) || !taskIds.has(dependency.successorId)) {
       return {
         success: false,
-        error: "Dependency does not belong to this project",
+        error: "Dependency does not belong to this project"
       }
     }
 
@@ -1513,7 +1544,7 @@ export async function deleteDependency(
       action: "schedule.dependency_deleted",
       entityType: "schedule_dependency",
       entityId: depId,
-      summary: "Removed a schedule dependency.",
+      summary: "Removed a schedule dependency."
     })
     await recalcCriticalPath(db, projectId)
     revalidateSchedulePaths(projectId)
@@ -1563,7 +1594,7 @@ export async function updateTaskStatus(
       .set({
         status,
         percentComplete: effectivePercentComplete(status, task.percentComplete),
-        updatedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
       })
       .where(eq(scheduleTasks.id, taskId))
 
@@ -1577,7 +1608,7 @@ export async function updateTaskStatus(
       entityType: "schedule_item",
       entityId: taskId,
       summary: `Changed “${task.title}” to ${status.toLowerCase().replace("_", " ")}.`,
-      metadata: { status },
+      metadata: { status }
     })
     revalidateSchedulePaths(task.projectId)
     return { success: true }
@@ -1588,20 +1619,12 @@ export async function updateTaskStatus(
 }
 
 // recalculates critical path and updates all tasks
-async function recalcCriticalPath(
-  db: ReturnType<typeof getDb>,
-  projectId: string
-) {
-  const tasks = await db
-    .select()
-    .from(scheduleTasks)
-    .where(eq(scheduleTasks.projectId, projectId))
+async function recalcCriticalPath(db: ReturnType<typeof getDb>, projectId: string) {
+  const tasks = await db.select().from(scheduleTasks).where(eq(scheduleTasks.projectId, projectId))
 
   const deps = await db.select().from(taskDependencies)
   const taskIds = new Set(tasks.map((t) => t.id))
-  const projectDeps = deps.filter(
-    (d) => taskIds.has(d.predecessorId) && taskIds.has(d.successorId)
-  )
+  const projectDeps = deps.filter((d) => taskIds.has(d.predecessorId) && taskIds.has(d.successorId))
 
   const criticalSet = findCriticalPath(
     tasks.map((t) => ({ ...t, status: t.status as TaskStatus })),

--- a/src/app/actions/template-import-options.ts
+++ b/src/app/actions/template-import-options.ts
@@ -1,0 +1,233 @@
+"use server"
+
+import { and, asc, eq, inArray } from "drizzle-orm"
+
+import { getDb } from "@/db"
+import {
+  projectTemplateContentItems,
+  projectTemplates,
+  projectTemplateVersions,
+  scheduleTemplateItems
+} from "@/db/schema-templates"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { requireOrg } from "@/lib/org-scope"
+import { requireFeaturePermission } from "@/lib/permission-enforcement"
+import { requirePermission } from "@/lib/permissions"
+import { isInternalStaffRole } from "@/lib/user-roles"
+import { buildProjectTemplateContentApplication } from "@/lib/templates/project-template-content-application"
+import { groupTemplateChecklistItems } from "@/lib/templates/template-checklist-hierarchy"
+import {
+  parseTemplateChoiceOptions,
+  resolveTemplateSchedulePhase
+} from "@/lib/templates/template-creation-import"
+
+export type ScheduleTemplateImportTodo = {
+  readonly id: string
+  readonly title: string
+  readonly checklistItemCount: number
+}
+
+export type ScheduleTemplateImportItem = {
+  readonly id: string
+  readonly title: string
+  readonly workdays: number
+  readonly phase: string
+  readonly displayColor: string
+  readonly isMilestone: boolean
+  readonly assignedTo: string | null
+  readonly ownerVisible: boolean
+  readonly subVendorVisible: boolean
+}
+
+export type ScheduleTemplateImportGroup = {
+  readonly templateId: string
+  readonly templateName: string
+  readonly tradeCategory: string
+  readonly scheduleItems: readonly ScheduleTemplateImportItem[]
+  readonly linkedTodos: readonly ScheduleTemplateImportTodo[]
+}
+
+export type FinishSelectionTemplateImportItem = {
+  readonly id: string
+  readonly title: string
+  readonly roomName: string
+  readonly category: string
+  readonly description: string | null
+  readonly costCode: string | null
+  readonly notes: string | null
+  readonly choiceOptions: readonly string[]
+}
+
+export type FinishSelectionTemplateImportGroup = {
+  readonly templateId: string
+  readonly templateName: string
+  readonly tradeCategory: string
+  readonly selections: readonly FinishSelectionTemplateImportItem[]
+}
+
+type PublishedTemplateVersion = {
+  readonly templateId: string
+  readonly templateName: string
+  readonly tradeCategory: string | null
+  readonly versionId: string
+}
+
+function ensureInternalUser(role: string): void {
+  if (!isInternalStaffRole(role)) {
+    throw new Error("Template imports are limited to internal staff.")
+  }
+}
+
+async function publishedTemplateVersions(
+  organizationId: string
+): Promise<readonly PublishedTemplateVersion[]> {
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  return db
+    .select({
+      templateId: projectTemplates.id,
+      templateName: projectTemplates.name,
+      tradeCategory: projectTemplates.tradeCategory,
+      versionId: projectTemplateVersions.id
+    })
+    .from(projectTemplates)
+    .innerJoin(projectTemplateVersions, eq(projectTemplateVersions.templateId, projectTemplates.id))
+    .where(
+      and(
+        eq(projectTemplates.organizationId, organizationId),
+        eq(projectTemplates.lifecycleStatus, "active"),
+        eq(projectTemplates.reviewStatus, "verified"),
+        eq(projectTemplateVersions.status, "published"),
+        eq(projectTemplateVersions.versionNumber, projectTemplates.currentVersionNumber)
+      )
+    )
+    .orderBy(asc(projectTemplates.tradeCategory), asc(projectTemplates.name))
+}
+
+export async function getScheduleTemplateImportOptions(): Promise<
+  readonly ScheduleTemplateImportGroup[]
+> {
+  const user = await requireAuth()
+  requirePermission(user, "schedule", "read")
+  ensureInternalUser(user.role)
+  const organizationId = requireOrg(user)
+  const versions = await publishedTemplateVersions(organizationId)
+  if (versions.length === 0) return []
+
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const versionIds = versions.map((version) => version.versionId)
+  const [scheduleItems, taskItems] = await Promise.all([
+    db
+      .select()
+      .from(scheduleTemplateItems)
+      .where(inArray(scheduleTemplateItems.versionId, versionIds))
+      .orderBy(asc(scheduleTemplateItems.sortOrder)),
+    db
+      .select()
+      .from(projectTemplateContentItems)
+      .where(
+        and(
+          inArray(projectTemplateContentItems.versionId, versionIds),
+          eq(projectTemplateContentItems.moduleType, "tasks")
+        )
+      )
+      .orderBy(asc(projectTemplateContentItems.sortOrder))
+  ])
+
+  return versions.flatMap((version) => {
+    const items = scheduleItems.filter((item) => item.versionId === version.versionId)
+    if (items.length === 0) return []
+    const todoGroups = groupTemplateChecklistItems(
+      taskItems.filter((item) => item.versionId === version.versionId)
+    )
+    return [
+      {
+        templateId: version.templateId,
+        templateName: version.templateName,
+        tradeCategory: version.tradeCategory ?? "Other",
+        scheduleItems: items.map((item) => ({
+          id: item.id,
+          title: item.title,
+          workdays: item.workdays,
+          phase: resolveTemplateSchedulePhase({
+            capturedPhase: item.phase,
+            tradeCategory: version.tradeCategory
+          }),
+          displayColor: item.displayColor,
+          isMilestone: item.isMilestone,
+          assignedTo: item.assigneePlaceholder,
+          ownerVisible: item.ownerVisible,
+          subVendorVisible: item.subVendorVisible
+        })),
+        linkedTodos: todoGroups.map((group) => ({
+          id: group.task.id,
+          title: group.task.title,
+          checklistItemCount: group.checklistItems.length
+        }))
+      }
+    ]
+  })
+}
+
+export async function getFinishSelectionTemplateImportOptions(): Promise<
+  readonly FinishSelectionTemplateImportGroup[]
+> {
+  const user = await requireAuth()
+  await requireFeaturePermission(user, "finish-selections", "read")
+  ensureInternalUser(user.role)
+  const organizationId = requireOrg(user)
+  const versions = await publishedTemplateVersions(organizationId)
+  if (versions.length === 0) return []
+
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const contentItems = await db
+    .select()
+    .from(projectTemplateContentItems)
+    .where(
+      and(
+        inArray(
+          projectTemplateContentItems.versionId,
+          versions.map((version) => version.versionId)
+        ),
+        eq(projectTemplateContentItems.moduleType, "selections")
+      )
+    )
+    .orderBy(asc(projectTemplateContentItems.sortOrder))
+
+  return versions.flatMap((version) => {
+    let nextId = 0
+    const build = buildProjectTemplateContentApplication({
+      applicationId: `selection-import-preview:${version.templateId}`,
+      items: contentItems.filter((item) => item.versionId === version.versionId),
+      nextId: () => `selection-import-preview:${nextId++}`
+    })
+    const selections = build.selections.flatMap((selection) => {
+      const choiceOptions = parseTemplateChoiceOptions(selection.choiceOptionsJson)
+      if (choiceOptions.length === 0) return []
+      return [
+        {
+          id: selection.templateContentItemId,
+          title: selection.name,
+          roomName: selection.roomName,
+          category: selection.category,
+          description: selection.description,
+          costCode: selection.costCode,
+          notes: selection.notes,
+          choiceOptions
+        }
+      ]
+    })
+    if (selections.length === 0) return []
+    return [
+      {
+        templateId: version.templateId,
+        templateName: version.templateName,
+        tradeCategory: version.tradeCategory ?? "Other",
+        selections
+      }
+    ]
+  })
+}

--- a/src/components/projects/project-selection-create-form.tsx
+++ b/src/components/projects/project-selection-create-form.tsx
@@ -2,12 +2,12 @@
 
 import * as React from "react"
 import { useRouter } from "next/navigation"
-import { IconCheck, IconPalette, IconPlus } from "@tabler/icons-react"
+import { IconCheck, IconLoader2, IconPalette, IconPlus, IconTemplate } from "@tabler/icons-react"
 
 import {
   createProjectSelection,
   type ProjectSelectionOptions,
-  type ProjectSelectionStatus,
+  type ProjectSelectionStatus
 } from "@/app/actions/project-selections"
 import { ProjectSelectionComboboxInput } from "@/components/projects/project-selection-combobox-input"
 import { Button } from "@/components/ui/button"
@@ -17,7 +17,7 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue,
+  SelectValue
 } from "@/components/ui/select"
 import {
   Sheet,
@@ -25,9 +25,13 @@ import {
   SheetDescription,
   SheetHeader,
   SheetTitle,
-  SheetTrigger,
+  SheetTrigger
 } from "@/components/ui/sheet"
 import { Textarea } from "@/components/ui/textarea"
+import {
+  getFinishSelectionTemplateImportOptions,
+  type FinishSelectionTemplateImportGroup
+} from "@/app/actions/template-import-options"
 
 type FormState =
   | { readonly kind: "idle" }
@@ -48,13 +52,12 @@ const STATUS_OPTIONS: readonly {
   { value: "ordered", label: "Ordered" },
   { value: "installed", label: "Installed" },
   { value: "unavailable", label: "Unavailable" },
-  { value: "deferred", label: "Deferred" },
+  { value: "deferred", label: "Deferred" }
 ]
 
 const DOCUMENT_INPUT_CLASS =
   "rounded-none border-x-0 border-t-0 px-0 shadow-none focus-visible:border-foreground focus-visible:ring-0"
-const DOCUMENT_SELECT_CLASS =
-  "w-full rounded-none border-x-0 border-t-0 px-0 shadow-none"
+const DOCUMENT_SELECT_CLASS = "w-full rounded-none border-x-0 border-t-0 px-0 shadow-none"
 const DOCUMENT_TEXTAREA_CLASS =
   "rounded-none border-x-0 border-t-0 px-0 shadow-none focus-visible:border-foreground focus-visible:ring-0"
 
@@ -65,7 +68,7 @@ function fieldValue(formData: FormData, name: string): string | null {
 
 function Field({
   label,
-  children,
+  children
 }: {
   readonly label: string
   readonly children: React.ReactNode
@@ -84,7 +87,7 @@ export function ProjectSelectionCreateForm({
   roomName = "",
   roomType = "",
   triggerLabel = "New Selection",
-  triggerVariant = "default",
+  triggerVariant = "default"
 }: {
   readonly projectId: string
   readonly options: ProjectSelectionOptions
@@ -96,10 +99,16 @@ export function ProjectSelectionCreateForm({
   const router = useRouter()
   const [open, setOpen] = React.useState(false)
   const [status, setStatus] = React.useState<FormState>({ kind: "idle" })
-  const [selectionStatus, setSelectionStatus] =
-    React.useState<ProjectSelectionStatus>("needed")
+  const [selectionStatus, setSelectionStatus] = React.useState<ProjectSelectionStatus>("needed")
   const [selectedRoomType, setSelectedRoomType] = React.useState(roomType)
   const [division, setDivision] = React.useState("all")
+  const [templateGroups, setTemplateGroups] = React.useState<
+    readonly FinishSelectionTemplateImportGroup[] | null
+  >(null)
+  const [templateLoading, setTemplateLoading] = React.useState(false)
+  const [selectedTemplateId, setSelectedTemplateId] = React.useState("")
+  const [selectedTemplateSelectionId, setSelectedTemplateSelectionId] = React.useState("")
+  const [templateCostCode, setTemplateCostCode] = React.useState("")
   const formRef = React.useRef<HTMLFormElement | null>(null)
   const costCodeOptions = React.useMemo(
     () =>
@@ -108,17 +117,81 @@ export function ProjectSelectionCreateForm({
         : options.costCodes,
     [division, options.costCodes]
   )
+  const selectedTemplateGroup = React.useMemo(
+    () => templateGroups?.find((group) => group.templateId === selectedTemplateId) ?? null,
+    [selectedTemplateId, templateGroups]
+  )
+  const selectedTemplateSelection = React.useMemo(
+    () =>
+      selectedTemplateGroup?.selections.find(
+        (selection) => selection.id === selectedTemplateSelectionId
+      ) ?? null,
+    [selectedTemplateGroup, selectedTemplateSelectionId]
+  )
+
+  React.useEffect(() => {
+    if (!open || templateGroups !== null) return
+    let cancelled = false
+    setTemplateLoading(true)
+    void getFinishSelectionTemplateImportOptions()
+      .then((groups) => {
+        if (!cancelled) setTemplateGroups(groups)
+      })
+      .catch((error: unknown) => {
+        console.error("Unable to load finish selection templates", error)
+        if (!cancelled) {
+          setTemplateGroups([])
+          setStatus({
+            kind: "error",
+            message: "Unable to load published finish selection templates."
+          })
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setTemplateLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open, templateGroups])
+
+  function setFormFieldValue(name: string, value: string): void {
+    const field = formRef.current?.elements.namedItem(name)
+    if (field instanceof HTMLInputElement || field instanceof HTMLTextAreaElement) {
+      field.value = value
+    }
+  }
+
+  function applyTemplateSelection(selectionId: string): void {
+    setSelectedTemplateSelectionId(selectionId)
+    const selection = selectedTemplateGroup?.selections.find(
+      (candidate) => candidate.id === selectionId
+    )
+    if (!selection) return
+    if (!roomName) {
+      const roomField = formRef.current?.elements.namedItem("roomName")
+      if (roomField instanceof HTMLInputElement && !roomField.value.trim()) {
+        roomField.value = selection.roomName
+      }
+    }
+    setFormFieldValue("category", selection.category)
+    setFormFieldValue("name", selection.title)
+    setFormFieldValue("description", selection.description ?? "")
+    setFormFieldValue("notes", selection.notes ?? "")
+    setTemplateCostCode(selection.costCode ?? "")
+  }
 
   function resetDraft(): void {
     formRef.current?.reset()
     setSelectionStatus("needed")
     setSelectedRoomType(roomType)
     setDivision("all")
+    setSelectedTemplateId("")
+    setSelectedTemplateSelectionId("")
+    setTemplateCostCode("")
   }
 
-  async function submitSelection(
-    event: React.FormEvent<HTMLFormElement>
-  ): Promise<void> {
+  async function submitSelection(event: React.FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault()
     setStatus({ kind: "saving" })
     const formData = new FormData(event.currentTarget)
@@ -138,6 +211,9 @@ export function ProjectSelectionCreateForm({
       phaseCode: fieldValue(formData, "phaseCode"),
       status: selectionStatus,
       notes: fieldValue(formData, "notes"),
+      templateId: selectedTemplateGroup?.templateId ?? null,
+      templateContentItemId: selectedTemplateSelection?.id ?? null,
+      choiceOptions: selectedTemplateSelection?.choiceOptions ?? []
     })
 
     if (!result.success) {
@@ -169,16 +245,81 @@ export function ProjectSelectionCreateForm({
         <SheetHeader className="border-b px-5 py-4">
           <SheetTitle>Add Finish Selection</SheetTitle>
           <SheetDescription>
-            Capture one selection with room context, product detail, and
-            Sage-ready cost coding.
+            Capture one selection with room context, product detail, and Sage-ready cost coding.
           </SheetDescription>
         </SheetHeader>
 
-        <form
-          ref={formRef}
-          onSubmit={submitSelection}
-          className="space-y-4 px-5 pb-6"
-        >
+        <form ref={formRef} onSubmit={submitSelection} className="space-y-4 px-5 pb-6">
+          <section className="border-y bg-muted/20 py-3">
+            <div className="mb-2 flex items-center gap-2 text-xs font-medium">
+              <IconTemplate className="size-4" />
+              Import choices from a published template
+            </div>
+            {templateLoading ? (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <IconLoader2 className="size-3.5 animate-spin" />
+                Loading finish selection choices…
+              </div>
+            ) : templateGroups?.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                No published templates contain reusable finish choices.
+              </p>
+            ) : (
+              <div className="grid gap-2 sm:grid-cols-2">
+                <Select
+                  value={selectedTemplateId}
+                  onValueChange={(value) => {
+                    setSelectedTemplateId(value)
+                    setSelectedTemplateSelectionId("")
+                    setTemplateCostCode("")
+                  }}
+                >
+                  <SelectTrigger aria-label="Choose finish selection template">
+                    <SelectValue placeholder="Choose template" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(templateGroups ?? []).map((group) => (
+                      <SelectItem key={group.templateId} value={group.templateId}>
+                        {group.templateName}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Select
+                  value={selectedTemplateSelectionId}
+                  onValueChange={applyTemplateSelection}
+                  disabled={!selectedTemplateGroup}
+                >
+                  <SelectTrigger aria-label="Choose template finish selection">
+                    <SelectValue placeholder="Choose selection" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(selectedTemplateGroup?.selections ?? []).map((selection) => (
+                      <SelectItem key={selection.id} value={selection.id}>
+                        {selection.title}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            {selectedTemplateSelection && (
+              <div className="mt-3">
+                <p className="text-xs text-muted-foreground">
+                  These choices will be available to the client after the selection is made
+                  owner-visible.
+                </p>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {selectedTemplateSelection.choiceOptions.map((choice) => (
+                    <span key={choice} className="border px-2 py-1 text-xs text-muted-foreground">
+                      {choice}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </section>
+
           <div className="flex flex-wrap items-center justify-between gap-3 border-b py-3 text-sm">
             <span className="font-medium">
               {roomName ? `${roomName} selection` : "Selection draft"}
@@ -201,10 +342,7 @@ export function ProjectSelectionCreateForm({
                 />
               </Field>
               <Field label="Room type">
-                <Select
-                  value={selectedRoomType}
-                  onValueChange={setSelectedRoomType}
-                >
+                <Select value={selectedRoomType} onValueChange={setSelectedRoomType}>
                   <SelectTrigger className={DOCUMENT_SELECT_CLASS}>
                     <SelectValue placeholder="Select room type" />
                   </SelectTrigger>
@@ -216,19 +354,13 @@ export function ProjectSelectionCreateForm({
                     ))}
                   </SelectContent>
                 </Select>
-                <input
-                  type="hidden"
-                  name="roomType"
-                  value={selectedRoomType}
-                />
+                <input type="hidden" name="roomType" value={selectedRoomType} />
               </Field>
               <Field label="Status">
                 <Select
                   value={selectionStatus}
                   onValueChange={(value) => {
-                    const next = STATUS_OPTIONS.find(
-                      (option) => option.value === value
-                    )
+                    const next = STATUS_OPTIONS.find((option) => option.value === value)
                     if (next) setSelectionStatus(next.value)
                   }}
                 >
@@ -257,11 +389,7 @@ export function ProjectSelectionCreateForm({
 
             <div className="grid gap-3 sm:grid-cols-[minmax(0,.65fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)]">
               <Field label="Qty">
-                <Input
-                  name="quantity"
-                  inputMode="decimal"
-                  className={DOCUMENT_INPUT_CLASS}
-                />
+                <Input name="quantity" inputMode="decimal" className={DOCUMENT_INPUT_CLASS} />
               </Field>
               <Field label="Manufacturer">
                 <ProjectSelectionComboboxInput
@@ -314,11 +442,13 @@ export function ProjectSelectionCreateForm({
               </Field>
               <Field label="Cost code">
                 <ProjectSelectionComboboxInput
+                  key={`selection-cost-code-${templateCostCode}`}
                   id="selection-cost-code"
                   name="costCode"
                   options={costCodeOptions}
                   placeholder="Search cost code"
                   emptyMessage="No cost codes in this division."
+                  defaultValue={templateCostCode}
                 />
               </Field>
               <Field label="Phase">
@@ -339,10 +469,7 @@ export function ProjectSelectionCreateForm({
               <Input name="description" className={DOCUMENT_INPUT_CLASS} />
             </Field>
             <Field label="Notes">
-              <Textarea
-                name="notes"
-                className={`min-h-24 ${DOCUMENT_TEXTAREA_CLASS}`}
-              />
+              <Textarea name="notes" className={`min-h-24 ${DOCUMENT_TEXTAREA_CLASS}`} />
             </Field>
           </div>
 

--- a/src/components/schedule/schedule-item-form-dialog.tsx
+++ b/src/components/schedule/schedule-item-form-dialog.tsx
@@ -5,39 +5,28 @@ import { useEffect, useMemo, useState } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 import { zodResolver } from "@hookform/resolvers/zod"
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import {
   Form,
   FormControl,
   FormField,
   FormItem,
   FormLabel,
-  FormMessage,
+  FormMessage
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Calendar } from "@/components/ui/calendar"
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover"
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import {
   IconCalendar,
   IconPlus,
   IconTrash,
   IconChevronDown,
   IconChevronRight,
+  IconLoader2,
+  IconTemplate
 } from "@tabler/icons-react"
 import { format, parseISO } from "date-fns"
 import { Slider } from "@/components/ui/slider"
@@ -46,7 +35,7 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue,
+  SelectValue
 } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import { Button } from "@/components/ui/button"
@@ -55,7 +44,7 @@ import {
   updateTask,
   createDependency,
   updateDependency,
-  deleteDependency,
+  deleteDependency
 } from "@/app/actions/schedule"
 import { sendScheduleTaskReminder } from "@/app/actions/schedule-confirmations"
 import { calculateEndDate } from "@/lib/schedule/business-days"
@@ -63,13 +52,10 @@ import type {
   ScheduleTaskData,
   TaskDependencyData,
   DependencyType,
-  WorkdayExceptionData,
+  WorkdayExceptionData
 } from "@/lib/schedule/types"
 import { PHASE_ORDER, PHASE_LABELS, getPhaseColor } from "@/lib/schedule/phase-colors"
-import {
-  DEFAULT_DISPLAY_COLOR,
-  DISPLAY_COLOR_OPTIONS,
-} from "@/lib/schedule/appearance"
+import { DEFAULT_DISPLAY_COLOR, DISPLAY_COLOR_OPTIONS } from "@/lib/schedule/appearance"
 import { STATUS_OPTIONS } from "@/lib/schedule/types"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
@@ -77,17 +63,21 @@ import { cn } from "@/lib/utils"
 import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
 import { ProjectAssigneePicker } from "@/components/projects/project-assignee-picker"
 import { ScheduleItemLinks } from "@/components/schedule/schedule-item-links"
+import {
+  getScheduleTemplateImportOptions,
+  type ScheduleTemplateImportGroup
+} from "@/app/actions/template-import-options"
 
 const phases = PHASE_ORDER.map((value) => ({
   value,
-  label: PHASE_LABELS[value],
+  label: PHASE_LABELS[value]
 }))
 
 const DEPENDENCY_TYPES: readonly { value: DependencyType; label: string }[] = [
   { value: "FS", label: "Finish-to-Start" },
   { value: "SS", label: "Start-to-Start" },
   { value: "FF", label: "Finish-to-Finish" },
-  { value: "SF", label: "Start-to-Finish" },
+  { value: "SF", label: "Start-to-Finish" }
 ]
 
 const scheduleItemSchema = z.object({
@@ -103,7 +93,7 @@ const scheduleItemSchema = z.object({
   ownerVisible: z.boolean(),
   subVendorVisible: z.boolean(),
   confirmationRequired: z.boolean(),
-  notes: z.string(),
+  notes: z.string()
 })
 
 type ScheduleItemFormValues = z.infer<typeof scheduleItemSchema>
@@ -133,19 +123,23 @@ export function ScheduleItemFormDialog({
   allTasks = [],
   dependencies = [],
   exceptions = [],
-  assigneeOptions = [],
+  assigneeOptions = []
 }: ScheduleItemFormDialogProps) {
   const router = useRouter()
   const isEditing = !!editingTask
   const [detailsOpen, setDetailsOpen] = useState(false)
-  const [pendingPredecessors, setPendingPredecessors] = useState<
-    PendingPredecessor[]
-  >([])
+  const [pendingPredecessors, setPendingPredecessors] = useState<PendingPredecessor[]>([])
   const [existingPredecessorEdits, setExistingPredecessorEdits] = useState<
     Record<string, PendingPredecessor>
   >({})
   const [assignedOptionId, setAssignedOptionId] = useState<string | null>(null)
   const [sendingReminder, setSendingReminder] = useState(false)
+  const [templateGroups, setTemplateGroups] = useState<
+    readonly ScheduleTemplateImportGroup[] | null
+  >(null)
+  const [templateLoading, setTemplateLoading] = useState(false)
+  const [selectedTemplateId, setSelectedTemplateId] = useState("")
+  const [selectedTemplateItemId, setSelectedTemplateItemId] = useState("")
 
   const existingPredecessors = useMemo(() => {
     if (!editingTask) return []
@@ -171,11 +165,35 @@ export function ScheduleItemFormDialog({
       ownerVisible: true,
       subVendorVisible: false,
       confirmationRequired: false,
-      notes: "",
-    },
+      notes: ""
+    }
   })
 
   useEffect(() => {
+    if (!open || isEditing || templateGroups !== null) return
+    let cancelled = false
+    setTemplateLoading(true)
+    void getScheduleTemplateImportOptions()
+      .then((groups) => {
+        if (!cancelled) setTemplateGroups(groups)
+      })
+      .catch((error: unknown) => {
+        console.error("Unable to load schedule template options", error)
+        if (!cancelled) {
+          setTemplateGroups([])
+          toast.error("Unable to load published schedule templates.")
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setTemplateLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [isEditing, open, templateGroups])
+
+  useEffect(() => {
+    if (!open) return
     if (editingTask) {
       form.reset({
         title: editingTask.title,
@@ -190,13 +208,12 @@ export function ScheduleItemFormDialog({
         ownerVisible: editingTask.ownerVisible ?? true,
         subVendorVisible: editingTask.subVendorVisible ?? false,
         confirmationRequired: editingTask.confirmationRequired ?? false,
-        notes: "",
+        notes: ""
       })
       setAssignedOptionId(
         assigneeOptions.find(
           (option) =>
-            option.name.trim().toLowerCase() ===
-            (editingTask.assignedTo ?? "").trim().toLowerCase()
+            option.name.trim().toLowerCase() === (editingTask.assignedTo ?? "").trim().toLowerCase()
         )?.id ?? null
       )
       // expand details when editing since they likely want to see everything
@@ -215,13 +232,15 @@ export function ScheduleItemFormDialog({
         ownerVisible: true,
         subVendorVisible: false,
         confirmationRequired: false,
-        notes: "",
+        notes: ""
       })
       setAssignedOptionId(null)
       setDetailsOpen(false)
+      setSelectedTemplateId("")
+      setSelectedTemplateItemId("")
     }
     setPendingPredecessors([])
-  }, [assigneeOptions, editingTask, form])
+  }, [assigneeOptions, editingTask, form, open])
 
   useEffect(() => {
     if (!editingTask) {
@@ -238,8 +257,8 @@ export function ScheduleItemFormDialog({
             {
               taskId: dependency.predecessorId,
               type: dependency.type,
-              lagDays: dependency.lagDays,
-            },
+              lagDays: dependency.lagDays
+            }
           ])
       )
     )
@@ -251,6 +270,45 @@ export function ScheduleItemFormDialog({
   const watchedDisplayColor = form.watch("displayColor")
   const watchedStatus = form.watch("status")
   const watchedPercent = form.watch("percentComplete")
+  const selectedTemplateGroup = useMemo(
+    () => templateGroups?.find((group) => group.templateId === selectedTemplateId) ?? null,
+    [selectedTemplateId, templateGroups]
+  )
+
+  function applyTemplateScheduleItem(templateItemId: string): void {
+    setSelectedTemplateItemId(templateItemId)
+    const item = selectedTemplateGroup?.scheduleItems.find(
+      (candidate) => candidate.id === templateItemId
+    )
+    if (!item) return
+    form.setValue("title", item.title, { shouldDirty: true })
+    form.setValue("workdays", item.workdays, { shouldDirty: true })
+    form.setValue("phase", item.phase, { shouldDirty: true })
+    form.setValue("displayColor", item.displayColor, { shouldDirty: true })
+    form.setValue("isMilestone", item.isMilestone, { shouldDirty: true })
+    form.setValue("assignedTo", item.assignedTo ?? "", { shouldDirty: true })
+    form.setValue("ownerVisible", item.ownerVisible, { shouldDirty: true })
+    form.setValue("subVendorVisible", item.subVendorVisible, {
+      shouldDirty: true
+    })
+    setAssignedOptionId(null)
+  }
+
+  function chooseTemplate(templateId: string): void {
+    setSelectedTemplateId(templateId)
+    setSelectedTemplateItemId("")
+    form.setValue("title", "", { shouldDirty: true })
+    form.setValue("workdays", 5, { shouldDirty: true })
+    form.setValue("phase", "preconstruction", { shouldDirty: true })
+    form.setValue("displayColor", DEFAULT_DISPLAY_COLOR, {
+      shouldDirty: true
+    })
+    form.setValue("isMilestone", false, { shouldDirty: true })
+    form.setValue("assignedTo", "", { shouldDirty: true })
+    form.setValue("ownerVisible", true, { shouldDirty: true })
+    form.setValue("subVendorVisible", false, { shouldDirty: true })
+    setAssignedOptionId(null)
+  }
 
   const calculatedEnd = useMemo(() => {
     if (!watchedStart || !watchedWorkdays || watchedWorkdays < 1) return ""
@@ -261,11 +319,12 @@ export function ScheduleItemFormDialog({
     const { notes, ...taskValues } = values
     void notes
     let savedTaskId: string
+    let linkedTodoCount = 0
     if (isEditing) {
       const result = await updateTask(editingTask.id, {
         ...taskValues,
         assignedTo: taskValues.assignedTo || null,
-        assignedOptionId,
+        assignedOptionId
       })
       if (!result.success) {
         toast.error(result.error)
@@ -277,12 +336,14 @@ export function ScheduleItemFormDialog({
         ...taskValues,
         assignedTo: taskValues.assignedTo || undefined,
         assignedOptionId,
+        templateScheduleItemId: selectedTemplateItemId || null
       })
       if (!result.success) {
         toast.error(result.error)
         return
       }
       savedTaskId = result.taskId
+      linkedTodoCount = result.linkedTodoCount
     }
 
     const dependencyErrors: string[] = []
@@ -303,7 +364,7 @@ export function ScheduleItemFormDialog({
         successorId: savedTaskId,
         type: edit.type,
         lagDays: edit.lagDays,
-        projectId,
+        projectId
       })
       if (!dependencyResult.success) {
         dependencyErrors.push(dependencyResult.error)
@@ -317,7 +378,7 @@ export function ScheduleItemFormDialog({
           successorId: savedTaskId,
           type: predecessor.type,
           lagDays: predecessor.lagDays,
-          projectId,
+          projectId
         })
         if (!dependencyResult.success) {
           dependencyErrors.push(dependencyResult.error)
@@ -334,14 +395,18 @@ export function ScheduleItemFormDialog({
       )
       return
     }
+    if (linkedTodoCount > 0) {
+      toast.success(
+        `Schedule item created with ${linkedTodoCount} linked to-do${
+          linkedTodoCount === 1 ? "" : "s"
+        }.`
+      )
+    }
     onOpenChange(false)
   }
 
   const addPendingPredecessor = () => {
-    setPendingPredecessors((prev) => [
-      ...prev,
-      { taskId: "", type: "FS", lagDays: 0 },
-    ])
+    setPendingPredecessors((prev) => [...prev, { taskId: "", type: "FS", lagDays: 0 }])
   }
 
   const removePendingPredecessor = (index: number) => {
@@ -377,13 +442,12 @@ export function ScheduleItemFormDialog({
       if (!existing) return current
       return {
         ...current,
-        [dependencyId]: { ...existing, [field]: value },
+        [dependencyId]: { ...existing, [field]: value }
       }
     })
   }
 
-  const hasPredecessors =
-    existingPredecessors.length > 0 || pendingPredecessors.length > 0
+  const hasPredecessors = existingPredecessors.length > 0 || pendingPredecessors.length > 0
 
   async function handleSendReminder(): Promise<void> {
     if (!editingTask) return
@@ -408,12 +472,77 @@ export function ScheduleItemFormDialog({
         </DialogHeader>
 
         <Form {...form}>
-          <form
-            onSubmit={form.handleSubmit(onSubmit)}
-            className="flex flex-col flex-1 min-h-0"
-          >
+          <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col flex-1 min-h-0">
             <div className="overflow-y-auto flex-1 min-h-0 px-5 pb-4 space-y-4">
               {/* === ESSENTIAL FIELDS === */}
+
+              {!isEditing && (
+                <section className="border-y bg-muted/20 py-3">
+                  <div className="mb-2 flex items-center gap-2 text-xs font-medium">
+                    <IconTemplate className="size-4" />
+                    Import from a published template
+                  </div>
+                  {templateLoading ? (
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <IconLoader2 className="size-3.5 animate-spin" />
+                      Loading template schedule items…
+                    </div>
+                  ) : templateGroups?.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">
+                      No published templates contain reusable schedule items.
+                    </p>
+                  ) : (
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      <Select value={selectedTemplateId} onValueChange={chooseTemplate}>
+                        <SelectTrigger aria-label="Choose schedule template">
+                          <SelectValue placeholder="Choose template" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {(templateGroups ?? []).map((group) => (
+                            <SelectItem key={group.templateId} value={group.templateId}>
+                              {group.templateName}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Select
+                        value={selectedTemplateItemId}
+                        onValueChange={applyTemplateScheduleItem}
+                        disabled={!selectedTemplateGroup}
+                      >
+                        <SelectTrigger aria-label="Choose template schedule item">
+                          <SelectValue placeholder="Choose schedule item" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {(selectedTemplateGroup?.scheduleItems ?? []).map((item) => (
+                            <SelectItem key={item.id} value={item.id}>
+                              {item.title}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+                  {selectedTemplateGroup && selectedTemplateItemId && (
+                    <div className="mt-2 text-xs text-muted-foreground">
+                      {selectedTemplateGroup.linkedTodos.length > 0 ? (
+                        <>
+                          This will also create and link {selectedTemplateGroup.linkedTodos.length}{" "}
+                          template to-do
+                          {selectedTemplateGroup.linkedTodos.length === 1 ? "" : "s"}
+                          {selectedTemplateGroup.linkedTodos.some(
+                            (todo) => todo.checklistItemCount > 0
+                          )
+                            ? ", preserving their checklists."
+                            : "."}
+                        </>
+                      ) : (
+                        "This template does not include any to-dos to link."
+                      )}
+                    </div>
+                  )}
+                </section>
+              )}
 
               {/* Title */}
               <FormField
@@ -458,9 +587,7 @@ export function ScheduleItemFormDialog({
               </div>
 
               <div className="flex items-center gap-2">
-                <span className="text-[11px] text-muted-foreground font-medium">
-                  Display color
-                </span>
+                <span className="text-[11px] text-muted-foreground font-medium">Display color</span>
                 <div className="flex items-center gap-1.5" aria-label="Display color">
                   {DISPLAY_COLOR_OPTIONS.map((color) => {
                     const selected = watchedDisplayColor === color.value
@@ -512,9 +639,7 @@ export function ScheduleItemFormDialog({
                         <PopoverContent className="w-auto p-0" align="start">
                           <Calendar
                             mode="single"
-                            selected={
-                              field.value ? parseISO(field.value) : undefined
-                            }
+                            selected={field.value ? parseISO(field.value) : undefined}
                             onSelect={(date) => {
                               if (date) {
                                 field.onChange(format(date, "yyyy-MM-dd"))
@@ -543,17 +668,13 @@ export function ScheduleItemFormDialog({
                             min={1}
                             className="h-9 text-center"
                             value={field.value}
-                            onChange={(e) =>
-                              field.onChange(Number(e.target.value) || 0)
-                            }
+                            onChange={(e) => field.onChange(Number(e.target.value) || 0)}
                             onBlur={field.onBlur}
                             ref={field.ref}
                             name={field.name}
                           />
                         </FormControl>
-                        <span className="text-[11px] text-muted-foreground shrink-0">
-                          d
-                        </span>
+                        <span className="text-[11px] text-muted-foreground shrink-0">d</span>
                       </div>
                       <FormMessage />
                     </FormItem>
@@ -565,9 +686,7 @@ export function ScheduleItemFormDialog({
                     End
                   </FormLabel>
                   <div className="flex items-center h-9 px-3 rounded-md bg-muted/40 text-sm text-muted-foreground tabular-nums">
-                    {calculatedEnd
-                      ? format(parseISO(calculatedEnd), "MMM d, yyyy")
-                      : "\u2014"}
+                    {calculatedEnd ? format(parseISO(calculatedEnd), "MMM d, yyyy") : "\u2014"}
                   </div>
                 </FormItem>
               </div>
@@ -586,9 +705,7 @@ export function ScheduleItemFormDialog({
                     )}
                     Details
                     {!detailsOpen && (isEditing || hasPredecessors) && (
-                      <span className="text-[10px] text-primary ml-1">
-                        (has data)
-                      </span>
+                      <span className="text-[10px] text-primary ml-1">(has data)</span>
                     )}
                   </button>
                 </CollapsibleTrigger>
@@ -609,7 +726,7 @@ export function ScheduleItemFormDialog({
                               field.onChange(status)
                               if (status === "COMPLETE") {
                                 form.setValue("percentComplete", 100, {
-                                  shouldDirty: true,
+                                  shouldDirty: true
                                 })
                               } else if (watchedPercent >= 100) {
                                 form.setValue(
@@ -654,7 +771,7 @@ export function ScheduleItemFormDialog({
                               setAssignedOptionId(option?.id ?? null)
                               if (option?.contactType === "owner") {
                                 form.setValue("ownerVisible", true, {
-                                  shouldDirty: true,
+                                  shouldDirty: true
                                 })
                               }
                               if (
@@ -662,7 +779,7 @@ export function ScheduleItemFormDialog({
                                 option?.contactType === "supplier"
                               ) {
                                 form.setValue("subVendorVisible", true, {
-                                  shouldDirty: true,
+                                  shouldDirty: true
                                 })
                               }
                             }}
@@ -678,10 +795,7 @@ export function ScheduleItemFormDialog({
                       render={({ field }) => (
                         <FormItem className="flex items-center gap-2 pb-0.5">
                           <FormControl>
-                            <Switch
-                              checked={field.value}
-                              onCheckedChange={field.onChange}
-                            />
+                            <Switch checked={field.value} onCheckedChange={field.onChange} />
                           </FormControl>
                           <FormLabel className="!mt-0 text-[11px] text-muted-foreground font-medium">
                             Milestone
@@ -711,17 +825,12 @@ export function ScheduleItemFormDialog({
                                 field.onChange(value)
                                 if (value === 100 && watchedStatus !== "COMPLETE") {
                                   form.setValue("status", "COMPLETE", {
-                                    shouldDirty: true,
+                                    shouldDirty: true
                                   })
-                                } else if (
-                                  value < 100 &&
-                                  watchedStatus === "COMPLETE"
-                                ) {
-                                  form.setValue(
-                                    "status",
-                                    value > 0 ? "IN_PROGRESS" : "PENDING",
-                                    { shouldDirty: true }
-                                  )
+                                } else if (value < 100 && watchedStatus === "COMPLETE") {
+                                  form.setValue("status", value > 0 ? "IN_PROGRESS" : "PENDING", {
+                                    shouldDirty: true
+                                  })
                                 }
                               }}
                               className="flex-1"
@@ -736,12 +845,10 @@ export function ScheduleItemFormDialog({
                   />
 
                   <div className="border-t pt-4">
-                    <p className="text-xs font-medium">
-                      Audience &amp; commitment
-                    </p>
+                    <p className="text-xs font-medium">Audience &amp; commitment</p>
                     <p className="mt-1 text-[11px] text-muted-foreground">
-                      Visibility changes reach project workspaces only after the
-                      schedule is published.
+                      Visibility changes reach project workspaces only after the schedule is
+                      published.
                     </p>
                     <div className="mt-3 grid gap-3 sm:grid-cols-3">
                       <FormField
@@ -749,14 +856,9 @@ export function ScheduleItemFormDialog({
                         name="ownerVisible"
                         render={({ field }) => (
                           <FormItem className="flex items-center justify-between gap-3 border px-3 py-2">
-                            <FormLabel className="!mt-0 text-xs">
-                              Owner can view
-                            </FormLabel>
+                            <FormLabel className="!mt-0 text-xs">Owner can view</FormLabel>
                             <FormControl>
-                              <Switch
-                                checked={field.value}
-                                onCheckedChange={field.onChange}
-                              />
+                              <Switch checked={field.value} onCheckedChange={field.onChange} />
                             </FormControl>
                           </FormItem>
                         )}
@@ -766,14 +868,9 @@ export function ScheduleItemFormDialog({
                         name="subVendorVisible"
                         render={({ field }) => (
                           <FormItem className="flex items-center justify-between gap-3 border px-3 py-2">
-                            <FormLabel className="!mt-0 text-xs">
-                              Subs can view
-                            </FormLabel>
+                            <FormLabel className="!mt-0 text-xs">Subs can view</FormLabel>
                             <FormControl>
-                              <Switch
-                                checked={field.value}
-                                onCheckedChange={field.onChange}
-                              />
+                              <Switch checked={field.value} onCheckedChange={field.onChange} />
                             </FormControl>
                           </FormItem>
                         )}
@@ -783,14 +880,9 @@ export function ScheduleItemFormDialog({
                         name="confirmationRequired"
                         render={({ field }) => (
                           <FormItem className="flex items-center justify-between gap-3 border px-3 py-2">
-                            <FormLabel className="!mt-0 text-xs">
-                              Require confirmation
-                            </FormLabel>
+                            <FormLabel className="!mt-0 text-xs">Require confirmation</FormLabel>
                             <FormControl>
-                              <Switch
-                                checked={field.value}
-                                onCheckedChange={field.onChange}
-                              />
+                              <Switch checked={field.value} onCheckedChange={field.onChange} />
                             </FormControl>
                           </FormItem>
                         )}
@@ -831,7 +923,7 @@ export function ScheduleItemFormDialog({
                       const edit = existingPredecessorEdits[dep.id] ?? {
                         taskId: dep.predecessorId,
                         type: dep.type,
-                        lagDays: dep.lagDays,
+                        lagDays: dep.lagDays
                       }
                       return (
                         <div
@@ -841,11 +933,7 @@ export function ScheduleItemFormDialog({
                           <Select
                             value={edit.taskId}
                             onValueChange={(value) =>
-                              updateExistingPredecessor(
-                                dep.id,
-                                "taskId",
-                                value
-                              )
+                              updateExistingPredecessor(dep.id, "taskId", value)
                             }
                           >
                             <SelectTrigger
@@ -870,11 +958,7 @@ export function ScheduleItemFormDialog({
                               <Select
                                 value={edit.type}
                                 onValueChange={(value) =>
-                                  updateExistingPredecessor(
-                                    dep.id,
-                                    "type",
-                                    value
-                                  )
+                                  updateExistingPredecessor(dep.id, "type", value)
                                 }
                               >
                                 <SelectTrigger
@@ -936,9 +1020,7 @@ export function ScheduleItemFormDialog({
                       >
                         <Select
                           value={pred.taskId}
-                          onValueChange={(val) =>
-                            updatePendingPredecessor(idx, "taskId", val)
-                          }
+                          onValueChange={(val) => updatePendingPredecessor(idx, "taskId", val)}
                         >
                           <SelectTrigger
                             className="h-9 w-full min-w-0 text-xs [&_[data-slot=select-value]]:truncate"
@@ -961,9 +1043,7 @@ export function ScheduleItemFormDialog({
                             </span>
                             <Select
                               value={pred.type}
-                              onValueChange={(val) =>
-                                updatePendingPredecessor(idx, "type", val)
-                              }
+                              onValueChange={(val) => updatePendingPredecessor(idx, "type", val)}
                             >
                               <SelectTrigger
                                 className="h-9 w-full min-w-0 text-xs [&_[data-slot=select-value]]:truncate"
@@ -1026,12 +1106,11 @@ export function ScheduleItemFormDialog({
                       </Button>
                     )}
 
-                    {availableTasks.length === 0 &&
-                      existingPredecessors.length === 0 && (
-                        <p className="text-[11px] text-muted-foreground/60">
-                          No other schedule items to link as predecessors.
-                        </p>
-                      )}
+                    {availableTasks.length === 0 && existingPredecessors.length === 0 && (
+                      <p className="text-[11px] text-muted-foreground/60">
+                        No other schedule items to link as predecessors.
+                      </p>
+                    )}
                   </div>
 
                   {/* Notes */}
@@ -1059,12 +1138,7 @@ export function ScheduleItemFormDialog({
 
             {/* Footer */}
             <div className="flex justify-end gap-2 px-5 py-3 border-t shrink-0">
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => onOpenChange(false)}
-              >
+              <Button type="button" variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
                 Cancel
               </Button>
               <Button type="submit" size="sm">

--- a/src/lib/templates/__tests__/template-creation-import.test.ts
+++ b/src/lib/templates/__tests__/template-creation-import.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  parseTemplateChoiceOptions,
+  resolveTemplateSchedulePhase
+} from "@/lib/templates/template-creation-import"
+
+describe("template creation imports", () => {
+  it("uses the captured construction phase when Compass recognizes it", () => {
+    expect(
+      resolveTemplateSchedulePhase({
+        capturedPhase: "Insulation & Drywall",
+        tradeCategory: "Drywall"
+      })
+    ).toBe("drywall")
+  })
+
+  it("falls back to the template trade when Buildertrend left the phase unassigned", () => {
+    expect(
+      resolveTemplateSchedulePhase({
+        capturedPhase: "UNASSIGNED",
+        tradeCategory: "Drywall"
+      })
+    ).toBe("drywall")
+  })
+
+  it("reads the preserved finish choices without accepting malformed values", () => {
+    expect(
+      parseTemplateChoiceOptions(JSON.stringify(["Hand Trowel", "Knockdown", "Orange Peel"]))
+    ).toEqual(["Hand Trowel", "Knockdown", "Orange Peel"])
+    expect(parseTemplateChoiceOptions('{"choice":"Hand Trowel"}')).toEqual([])
+    expect(parseTemplateChoiceOptions("not-json")).toEqual([])
+  })
+})

--- a/src/lib/templates/template-creation-import.ts
+++ b/src/lib/templates/template-creation-import.ts
@@ -1,0 +1,55 @@
+import { PHASE_LABELS, PHASE_ORDER } from "@/lib/schedule/phase-colors"
+import type { ConstructionPhase } from "@/lib/schedule/types"
+
+const GENERIC_PHASES = new Set(["", "general", "none", "unassigned", "unassigned general"])
+
+function normalizedWords(value: string | null): string {
+  return (value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+}
+
+function phaseFromText(value: string | null): ConstructionPhase | null {
+  const normalized = normalizedWords(value)
+  if (!normalized || GENERIC_PHASES.has(normalized)) return null
+
+  const exact = PHASE_ORDER.find(
+    (phase) =>
+      normalizedWords(phase) === normalized || normalizedWords(PHASE_LABELS[phase]) === normalized
+  )
+  if (exact) return exact
+
+  // Later construction phases win when a captured Buildertrend label combines
+  // phases, such as "Insulation & Drywall".
+  return (
+    [...PHASE_ORDER]
+      .reverse()
+      .find((phase) => normalized.includes(normalizedWords(PHASE_LABELS[phase]))) ?? null
+  )
+}
+
+export function resolveTemplateSchedulePhase(input: {
+  readonly capturedPhase: string | null
+  readonly tradeCategory: string | null
+}): ConstructionPhase {
+  return (
+    phaseFromText(input.capturedPhase) ?? phaseFromText(input.tradeCategory) ?? "preconstruction"
+  )
+}
+
+export function parseTemplateChoiceOptions(value: string | null): readonly string[] {
+  if (!value) return []
+  try {
+    const parsed: unknown = JSON.parse(value)
+    if (!Array.isArray(parsed)) return []
+    return parsed.flatMap((option) => {
+      if (typeof option !== "string") return []
+      const cleaned = option.trim()
+      return cleaned ? [cleaned] : []
+    })
+  } catch {
+    return []
+  }
+}


### PR DESCRIPTION
## Summary
- add published-template pickers to New Schedule Item and New Finish Selection
- create template to-dos in the same database batch as the new schedule item and preserve checklist hierarchy inside each to-do
- import and preview finish-selection choice lists such as Hand Trowel, Knockdown, and Orange Peel
- validate all template IDs and choice data server-side against the current verified published version

## Verification
- `bunx tsc --noEmit`
- focused ESLint on all changed files
- `bun test src/lib/templates/__tests__` (33 passing)
- `bun run build`
- pre-commit full lint (0 errors; existing warnings only)
- pre-push production build

## Review note
The structured autoreview helper was attempted but execution policy rejected exporting the source diff to its external model service. I completed a local source review plus the checks above instead.
