### PR TITLE
fix(schedule): create template todos within D1 limits

### DIFF
--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -631,9 +631,12 @@ export async function createTask(
       })) ?? []
 
     if (linkedTodoRows.length > 0) {
+      // Keep each to-do in its own prepared statement. D1 limits the number of
+      // bound values in one statement, so a multi-row insert fails for larger
+      // templates even though the surrounding batch is otherwise valid.
       await db.batch([
         db.insert(scheduleTasks).values(scheduleTaskRow),
-        db.insert(projectOperations).values(linkedTodoRows)
+        ...linkedTodoRows.map((todoRow) => db.insert(projectOperations).values(todoRow))
       ])
     } else {
       await db.insert(scheduleTasks).values(scheduleTaskRow)


### PR DESCRIPTION
## Summary
- keep schedule item and linked template to-dos in one atomic D1 batch
- insert each linked to-do with its own prepared statement
- avoid D1 bound-parameter failures on templates with larger task/checklist payloads

## Production diagnosis
- O-210-33 had no partial schedule item after the failed submission
- production schema is current
- the failure occurs in the atomic schedule/template-to-do write
- published templates can contain up to 32 root to-dos, which made the prior multi-row insert exceed D1 statement limits

## Verification
- `bunx tsc --noEmit`
- focused template/checklist tests: 6 passed
- `bunx eslint src/app/actions/schedule.ts`
- `git diff --check`
- `bun run build`
- pre-commit full ESLint: 0 errors (existing warnings only)
