### PR TITLE
Operationalize Compass feedback request lifecycle

### DIFF
--- a/custom-worker.ts
+++ b/custom-worker.ts
@@ -1,0 +1,47 @@
+// OpenNext creates this module before Wrangler bundles this custom entrypoint.
+// @ts-expect-error Generated build output is intentionally absent in source checkouts.
+import worker from "./.open-next/worker.js"
+import {
+  createJarvisSignature,
+  getJarvisEnvValue,
+} from "./src/lib/jarvis/auth"
+
+const RECONCILE_TARGET = "/api/operations/feedback/reconcile"
+
+async function reconcile(env: CloudflareEnv): Promise<void> {
+  const body = JSON.stringify({ source: "cron" })
+  const timestamp = String(Math.floor(Date.now() / 1_000))
+  const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
+  if (!secret) throw new Error("JARVIS_BRIDGE_SECRET is required")
+  const signature = await createJarvisSignature(
+    secret,
+    timestamp,
+    "POST",
+    RECONCILE_TARGET,
+    body,
+  )
+  const worker = env.WORKER_SELF_REFERENCE
+  if (!worker) throw new Error("WORKER_SELF_REFERENCE is required")
+  const response = await worker.fetch(
+    `https://compass.internal${RECONCILE_TARGET}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Compass-Timestamp": timestamp,
+        "X-Compass-Signature": signature,
+      },
+      body,
+    },
+  )
+  if (!response.ok) {
+    throw new Error(`Feedback reconciliation failed with ${response.status}`)
+  }
+}
+
+export default {
+  fetch: worker.fetch,
+  async scheduled(_controller, env, ctx): Promise<void> {
+    ctx.waitUntil(reconcile(env))
+  },
+} satisfies ExportedHandler<CloudflareEnv>

--- a/docs/architecture/jarvis-feedback-bridge.md
+++ b/docs/architecture/jarvis-feedback-bridge.md
@@ -136,15 +136,15 @@ The corresponding request content, source provenance, requester identity,
 and reply target stay in Compass D1 and the signed private bridge. Configure
 `GITHUB_FEEDBACK_PROJECT_ID` with the node ID of the `Compass Development &
 Feedback` Project for deterministic project insertion. When it is absent,
-Compass attempts a title lookup among the token owner's projects and logs a
+Compass attempts a title lookup among the repository organization's projects and logs a
 configuration error rather than exporting private data.
 
 The prior feedback-widget issue formatter included the optional reporter name
 and email in GitHub issue bodies. It has been removed: new widget submissions
 now use the same sanitized export as Telegram, Jarvis email, and Compass
-conversation feedback. Any historical issue created by the former formatter
-must be edited in GitHub to remove the reporter line before the issue is
-shared further.
+conversation feedback. Scheduled reconciliation rewrites linked legacy widget
+issues to the private-correlation format and records `privacy_scrubbed_at`; it
+never copies private request content back to GitHub.
 
 Guest policy
 ---
@@ -221,6 +221,12 @@ through the signed reply endpoint, and acknowledges Ask Jarvis/widget events
 after their Compass-native receipt or notification is available. Its local
 delivery ledger prevents a service restart from sending the same external
 update twice before acknowledgement.
+
+Both private relay services post a signed heartbeat to
+`POST /api/integrations/jarvis/health` at least once per minute. The protected
+Feedback Desk shows heartbeat age, last failure, and pending/processing/failed
+bridge counts. A missing heartbeat is an operational failure even when the
+process manager still reports the service as running.
 
 ### Acknowledge an event
 
@@ -345,9 +351,33 @@ updates only through email, and Compass updates only to the stored Compass
 thread/request. Cross-channel delivery requires a separate product decision.
 
 The notification links to `/dashboard/requests`, where authenticated users
-see only requests matching their organization and account email. GitHub
-remains the developer record and is not required for staff to follow a
-request.
+see only requests matching their organization and account email. Users in the
+`developer`, `admin`, and `secondary_admin` roles also receive a protected
+My requests / All requests filter for organization-wide investigation. Only
+administrators can mutate the organization-wide desk at
+`/dashboard/requests/manage`.
+
+Scheduled reconciliation and administration
+---
+
+Cloudflare invokes the custom OpenNext worker every ten minutes. Its scheduled
+handler signs a service-binding request to
+`POST /api/operations/feedback/reconcile`; the endpoint accepts no public or
+cookie-based authentication. Each run:
+
+1. recovers legacy feedback-widget rows and confirmed Ask Jarvis reports;
+2. creates or repairs opaque GitHub issue links and project membership;
+3. imports GitHub Project status and closing pull-request links;
+4. emits the normal private requester notifications for meaningful changes;
+5. backfills SLA targets and scrubs linked legacy widget issues; and
+6. stores run counts and reconciler health for the administrative dashboard.
+
+Administrators can run the same idempotent operation with **Reconcile now**.
+They can assign an active internal organization member, set priority and
+status, attach issue/PR links, and add a requester-facing explanation. SLA
+targets are four hours for urgent, 24 hours for high, 72 hours for normal, and
+seven days for low priority. Existing requests are measured from their
+original submission time; resolved requests are never reported overdue.
 
 ### Reply to a Compass assistance request
 
@@ -410,7 +440,7 @@ other channel members when a message is stored.
 Rollout checklist
 ---
 
-1. Apply migration `0065_jarvis_feedback_bridge.sql`.
+1. Apply migrations through `0092_feedback_lifecycle_operations.sql`.
 2. Create an active Jarvis service user in Compass.
 3. Add that user to the organization and `compass-feedback` channel.
 4. Configure the three `JARVIS_*` secrets/variables in Cloudflare.
@@ -428,6 +458,10 @@ Rollout checklist
 13. Start the requester lifecycle notifier, submit one test request per
     enabled source, and confirm each receipt returns only through its original
     source.
+14. Deploy the custom worker and confirm the `*/10 * * * *` trigger is listed.
+15. Run **Reconcile now**, verify the maintenance summary and three healthy
+    service cards, and inspect a legacy GitHub issue to confirm that its body
+    contains only the opaque `CFD-<UUID>` reference.
 
 The bundled bridge helper includes a `configure` command for step 5. It
 generates the HMAC key on the private runtime and returns only RSA-encrypted

--- a/docs/architecture/jarvis-feedback-bridge.md
+++ b/docs/architecture/jarvis-feedback-bridge.md
@@ -124,8 +124,11 @@ Feedback Desk's protected record and bridge payloads.
 GitHub issue and privacy boundary
 ---
 
-Every Feedback Desk item is mirrored to a GitHub issue and added to the
-`Compass Development & Feedback` GitHub Project. GitHub is deliberately a
+New Feedback Desk submissions are mirrored to a GitHub issue and added to the
+`Compass Development & Feedback` GitHub Project. Recovered historical requests
+without an existing link remain in an administrative preview until an
+administrator either maps existing work or explicitly approves creation of a
+new issue. GitHub is deliberately a
 minimal engineering tracker, not the system of record for a request. Its
 title and body contain only the request kind and an opaque `CFD-<UUID>`
 correlation reference. They never contain the submitted title or message,
@@ -366,15 +369,18 @@ handler signs a service-binding request to
 cookie-based authentication. Each run:
 
 1. recovers legacy feedback-widget rows and confirmed Ask Jarvis reports;
-2. creates or repairs opaque GitHub issue links and project membership;
+2. repairs existing GitHub links and creates missing issues only after
+   administrative approval;
 3. imports GitHub Project status and closing pull-request links;
 4. emits the normal private requester notifications for meaningful changes;
 5. backfills SLA targets and scrubs linked legacy widget issues; and
 6. stores run counts and reconciler health for the administrative dashboard.
 
 Administrators can run the same idempotent operation with **Reconcile now**.
-They can assign an active internal organization member, set priority and
-status, attach issue/PR links, and add a requester-facing explanation. SLA
+The GitHub link preview shows recovered requests that need review. Administrators
+can map an existing issue or pull request, or approve a new issue before the next
+reconciliation. They can also assign an active internal organization member,
+set priority and status, and add a requester-facing explanation. SLA
 targets are four hours for urgent, 24 hours for high, 72 hours for normal, and
 seven days for low priority. Existing requests are measured from their
 original submission time; resolved requests are never reported overdue.
@@ -440,7 +446,7 @@ other channel members when a message is stored.
 Rollout checklist
 ---
 
-1. Apply migrations through `0092_feedback_lifecycle_operations.sql`.
+1. Apply migrations through `0093_feedback_github_creation_approval.sql`.
 2. Create an active Jarvis service user in Compass.
 3. Add that user to the organization and `compass-feedback` channel.
 4. Configure the three `JARVIS_*` secrets/variables in Cloudflare.
@@ -459,9 +465,13 @@ Rollout checklist
     enabled source, and confirm each receipt returns only through its original
     source.
 14. Deploy the custom worker and confirm the `*/10 * * * *` trigger is listed.
-15. Run **Reconcile now**, verify the maintenance summary and three healthy
-    service cards, and inspect a legacy GitHub issue to confirm that its body
-    contains only the opaque `CFD-<UUID>` reference.
+15. Run **Reconcile now** and confirm missing historical links appear in the
+    GitHub review preview without creating issues.
+16. Map known existing work, approve one genuinely untracked request, run
+    **Reconcile now** again, and verify only that approved issue was created.
+17. Verify the maintenance summary and three healthy service cards, and inspect
+    a legacy GitHub issue to confirm that its body contains only the opaque
+    `CFD-<UUID>` reference.
 
 The bundled bridge helper includes a `configure` command for step 5. It
 generates the HMAC key on the private runtime and returns only RSA-encrypted

--- a/drizzle/0092_feedback_lifecycle_operations.sql
+++ b/drizzle/0092_feedback_lifecycle_operations.sql
@@ -1,0 +1,48 @@
+ALTER TABLE `feedback_desk_items` ADD `assigned_to_user_id` text;
+--> statement-breakpoint
+ALTER TABLE `feedback_desk_items` ADD `assigned_to_name` text;
+--> statement-breakpoint
+ALTER TABLE `feedback_desk_items` ADD `sla_target_at` text;
+--> statement-breakpoint
+ALTER TABLE `feedback_desk_items` ADD `triaged_at` text;
+--> statement-breakpoint
+ALTER TABLE `feedback_desk_items` ADD `resolved_at` text;
+--> statement-breakpoint
+ALTER TABLE `feedback_desk_items` ADD `last_requester_update_at` text;
+--> statement-breakpoint
+ALTER TABLE `feedback_desk_items` ADD `last_github_sync_at` text;
+--> statement-breakpoint
+ALTER TABLE `feedback_desk_items` ADD `privacy_scrubbed_at` text;
+--> statement-breakpoint
+CREATE INDEX `feedback_desk_owner_sla_idx` ON `feedback_desk_items` (`organization_id`,`assigned_to_user_id`,`sla_target_at`);
+--> statement-breakpoint
+CREATE TABLE `feedback_service_health` (
+	`service_name` text PRIMARY KEY NOT NULL,
+	`organization_id` text,
+	`status` text NOT NULL,
+	`last_heartbeat_at` text NOT NULL,
+	`last_success_at` text,
+	`last_failure_at` text,
+	`consecutive_failures` integer DEFAULT 0 NOT NULL,
+	`last_error` text,
+	`metadata` text,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `feedback_service_health_org_idx` ON `feedback_service_health` (`organization_id`,`updated_at`);
+--> statement-breakpoint
+CREATE TABLE `feedback_maintenance_runs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text,
+	`operation` text NOT NULL,
+	`source` text NOT NULL,
+	`status` text NOT NULL,
+	`processed_count` integer DEFAULT 0 NOT NULL,
+	`updated_count` integer DEFAULT 0 NOT NULL,
+	`failed_count` integer DEFAULT 0 NOT NULL,
+	`summary` text,
+	`started_at` text NOT NULL,
+	`completed_at` text
+);
+--> statement-breakpoint
+CREATE INDEX `feedback_maintenance_runs_org_idx` ON `feedback_maintenance_runs` (`organization_id`,`started_at`);

--- a/drizzle/0093_feedback_github_creation_approval.sql
+++ b/drizzle/0093_feedback_github_creation_approval.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `feedback_desk_items` ADD `github_issue_creation_approved_at` text;
+--> statement-breakpoint
+ALTER TABLE `feedback_desk_items` ADD `github_issue_creation_approved_by` text;
+--> statement-breakpoint
+CREATE INDEX `feedback_desk_github_review_idx` ON `feedback_desk_items` (`organization_id`,`github_issue_url`,`github_issue_creation_approved_at`);

--- a/scripts/jarvis-agent-poller.py
+++ b/scripts/jarvis-agent-poller.py
@@ -20,11 +20,13 @@ from typing import Any
 MAX_RESPONSE_BYTES = 64 * 1024
 MAX_COMPASS_CONTEXT_CHARACTERS = 14_000
 PULL_TARGET = "/api/integrations/jarvis/events?limit=1&eventType=agent.prompt"
+HEALTH_TARGET = "/api/integrations/jarvis/health"
 FEEDBACK_CONFIRMATION_QUESTION = (
     "Would you like me to file this with the Compass Feedback Desk?"
 )
 LOGGER = logging.getLogger("compass-jarvis-agent-poller")
 RUNNING = True
+LAST_HEARTBEAT_AT = 0.0
 
 BASE_SYSTEM_PROMPT = """
 You are Jarvis inside HPS Compass. Provide concise, practical basic assistance
@@ -167,6 +169,26 @@ def compass_request(
         ) from error
     except (TimeoutError, urllib.error.URLError) as error:
         raise RetryableError("Compass request failed") from error
+
+
+def heartbeat(status: str, error: str | None = None) -> None:
+    global LAST_HEARTBEAT_AT
+    now = time.time()
+    if status == "healthy" and now - LAST_HEARTBEAT_AT < 60:
+        return
+    try:
+        compass_request(
+            "POST",
+            HEALTH_TARGET,
+            {
+                "serviceName": "jarvis-agent-poller",
+                "status": status,
+                "error": error[:2_000] if error else None,
+            },
+        )
+        LAST_HEARTBEAT_AT = now
+    except Exception:
+        LOGGER.debug("Could not record poller heartbeat", exc_info=True)
 
 
 def load_compass_skill() -> str:
@@ -780,6 +802,7 @@ def run() -> None:
             )
             if not isinstance(events, list):
                 raise RuntimeError("Compass pull response has no events")
+            heartbeat("healthy")
             if not events:
                 time.sleep(poll_seconds)
                 continue
@@ -819,10 +842,12 @@ def run() -> None:
                         "Agent event failed: %s",
                         event_id,
                     )
-        except RetryableError:
+        except RetryableError as error:
+            heartbeat("failed", str(error))
             LOGGER.warning("Bridge temporarily unavailable")
             time.sleep(5)
-        except Exception:
+        except Exception as error:
+            heartbeat("failed", str(error))
             LOGGER.exception("Agent poll cycle failed")
             time.sleep(5)
 

--- a/scripts/jarvis-feedback-notifier.py
+++ b/scripts/jarvis-feedback-notifier.py
@@ -24,8 +24,10 @@ PULL_TARGET = (
     "/api/integrations/jarvis/events"
     "?limit=20&eventType=feedback.status_changed"
 )
+HEALTH_TARGET = "/api/integrations/jarvis/health"
 LOGGER = logging.getLogger("compass-jarvis-feedback-notifier")
 RUNNING = True
+LAST_HEARTBEAT_AT = 0.0
 
 
 class RetryableError(RuntimeError):
@@ -121,6 +123,26 @@ def compass_request(
         return json.loads(raw)
     except json.JSONDecodeError as error:
         raise RuntimeError("Compass returned invalid JSON") from error
+
+
+def heartbeat(status: str, error: str | None = None) -> None:
+    global LAST_HEARTBEAT_AT
+    now = time.time()
+    if status == "healthy" and now - LAST_HEARTBEAT_AT < 60:
+        return
+    try:
+        compass_request(
+            "POST",
+            HEALTH_TARGET,
+            {
+                "serviceName": "jarvis-feedback-notifier",
+                "status": status,
+                "error": error[:2_000] if error else None,
+            },
+        )
+        LAST_HEARTBEAT_AT = now
+    except Exception:
+        LOGGER.debug("Could not record notifier heartbeat", exc_info=True)
 
 
 def acknowledge(
@@ -330,6 +352,7 @@ def run() -> None:
             )
             if not isinstance(events, list):
                 raise RuntimeError("Compass pull response has no events")
+            heartbeat("healthy")
             if not events:
                 time.sleep(poll_seconds)
                 continue
@@ -370,10 +393,12 @@ def run() -> None:
                         "Feedback delivery failed: %s",
                         event_id,
                     )
-        except RetryableError:
+        except RetryableError as error:
+            heartbeat("failed", str(error))
             LOGGER.warning("Bridge temporarily unavailable")
             time.sleep(5)
-        except Exception:
+        except Exception as error:
+            heartbeat("failed", str(error))
             LOGGER.exception("Feedback poll cycle failed")
             time.sleep(5)
 

--- a/src/app/actions/feedback-admin.ts
+++ b/src/app/actions/feedback-admin.ts
@@ -1,0 +1,309 @@
+"use server"
+
+import { and, desc, eq } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+import { z } from "zod/v4"
+
+import { getDb } from "@/db"
+import { organizationMembers, users } from "@/db/schema"
+import {
+  feedbackDeskItems,
+  feedbackMaintenanceRuns,
+  feedbackServiceHealth,
+  jarvisBridgeEvents,
+} from "@/db/schema-jarvis"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import {
+  FEEDBACK_DESK_STATUSES,
+  feedbackIsOverdue,
+} from "@/lib/jarvis/feedback-lifecycle"
+import { runFeedbackMaintenance } from "@/lib/jarvis/feedback-maintenance"
+import { applyFeedbackLifecycleUpdate } from "@/lib/jarvis/feedback-status-update"
+import { canManageUserAccess } from "@/lib/permissions"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+const updateSchema = z.object({
+  id: z.string().min(1),
+  status: z.enum(FEEDBACK_DESK_STATUSES),
+  priority: z.enum(["low", "normal", "high", "urgent"]),
+  assignedToUserId: z.string().min(1).nullable(),
+  message: z.string().max(2_000).optional(),
+  githubIssueUrl: z.union([
+    z.url().refine(
+      (value) => /^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+(?:\/|$)/.test(value),
+      "GitHub issue URL required",
+    ),
+    z.literal(""),
+  ]).optional(),
+  draftPullRequestUrl: z.union([
+    z.url().refine(
+      (value) => /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+(?:\/|$)/.test(value),
+      "GitHub pull request URL required",
+    ),
+    z.literal(""),
+  ]).optional(),
+})
+
+async function requireFeedbackAdmin(): Promise<Readonly<{
+  id: string
+  organizationId: string
+}>> {
+  const user = await requireAuth()
+  if (!user.organizationId) throw new Error("No active organization")
+  if (!canManageUserAccess(user)) {
+    throw new Error("Only Compass administrators can manage the Feedback Desk")
+  }
+  return { id: user.id, organizationId: user.organizationId }
+}
+
+export type FeedbackAdminOverview = Readonly<{
+  items: readonly {
+    id: string
+    kind: string
+    status: string
+    priority: string
+    title: string
+    description: string
+    reporterName: string | null
+    source: string
+    assignedToUserId: string | null
+    assignedToName: string | null
+    slaTargetAt: string | null
+    overdue: boolean
+    githubIssueUrl: string | null
+    githubDraftPullRequestUrl: string | null
+    privacyScrubbedAt: string | null
+    createdAt: string
+    updatedAt: string
+  }[]
+  assignees: readonly { id: string; name: string }[]
+  health: readonly {
+    serviceName: string
+    status: string
+    lastHeartbeatAt: string
+    lastSuccessAt: string | null
+    consecutiveFailures: number
+    lastError: string | null
+    stale: boolean
+  }[]
+  bridge: Readonly<{
+    pending: number
+    processing: number
+    failed: number
+    oldestPendingAt: string | null
+  }>
+  lastMaintenance: Readonly<{
+    status: string
+    startedAt: string
+    completedAt: string | null
+    summary: string | null
+  }> | null
+}>
+
+type FeedbackAdminOverviewResult =
+  | { readonly success: true; readonly data: FeedbackAdminOverview }
+  | { readonly success: false; readonly error: string }
+
+export async function getFeedbackAdminOverview(): Promise<FeedbackAdminOverviewResult> {
+  try {
+    const admin = await requireFeedbackAdmin()
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const [itemRows, memberRows, healthRows, bridgeRows, lastMaintenance] =
+      await Promise.all([
+        db.select().from(feedbackDeskItems).where(
+          eq(feedbackDeskItems.organizationId, admin.organizationId),
+        ).orderBy(desc(feedbackDeskItems.updatedAt)).limit(500),
+        db.select({
+          id: users.id,
+          displayName: users.displayName,
+          firstName: users.firstName,
+          lastName: users.lastName,
+          email: users.email,
+          role: organizationMembers.role,
+        }).from(organizationMembers)
+          .innerJoin(users, eq(users.id, organizationMembers.userId))
+          .where(and(
+            eq(organizationMembers.organizationId, admin.organizationId),
+            eq(users.isActive, true),
+          )),
+        db.select().from(feedbackServiceHealth).where(
+          eq(feedbackServiceHealth.organizationId, admin.organizationId),
+        ).orderBy(desc(feedbackServiceHealth.updatedAt)),
+        db.select({
+          status: jarvisBridgeEvents.status,
+          createdAt: jarvisBridgeEvents.createdAt,
+        }).from(jarvisBridgeEvents).where(
+          eq(jarvisBridgeEvents.organizationId, admin.organizationId),
+        ).orderBy(desc(jarvisBridgeEvents.createdAt)).limit(2_000),
+        db.select().from(feedbackMaintenanceRuns).where(
+          eq(feedbackMaintenanceRuns.organizationId, admin.organizationId),
+        ).orderBy(desc(feedbackMaintenanceRuns.startedAt)).limit(1).get(),
+      ])
+    const pendingRows = bridgeRows.filter((row) => row.status === "pending")
+    return {
+      success: true,
+      data: {
+        items: itemRows.map((item) => ({
+          id: item.id,
+          kind: item.kind,
+          status: item.status,
+          priority: item.priority,
+          title: item.title,
+          description: item.description,
+          reporterName: item.reporterName,
+          source: item.source,
+          assignedToUserId: item.assignedToUserId,
+          assignedToName: item.assignedToName,
+          slaTargetAt: item.slaTargetAt,
+          overdue: feedbackIsOverdue(item.status, item.slaTargetAt),
+          githubIssueUrl: item.githubIssueUrl,
+          githubDraftPullRequestUrl: item.githubDraftPullRequestUrl,
+          privacyScrubbedAt: item.privacyScrubbedAt,
+          createdAt: item.createdAt,
+          updatedAt: item.updatedAt,
+        })),
+        assignees: memberRows
+          .filter((member) => isInternalStaffRole(member.role))
+          .map((member) => ({
+            id: member.id,
+            name: member.displayName ?? (
+              [member.firstName, member.lastName].filter(Boolean).join(" ") ||
+              member.email
+            ),
+          })),
+        health: healthRows.map((row) => {
+          const staleAfterMinutes = row.serviceName === "feedback-reconciler" ? 15 : 2
+          return {
+            serviceName: row.serviceName,
+            status: row.status,
+            lastHeartbeatAt: row.lastHeartbeatAt,
+            lastSuccessAt: row.lastSuccessAt,
+            consecutiveFailures: row.consecutiveFailures,
+            lastError: row.lastError,
+            stale:
+              Date.now() - new Date(row.lastHeartbeatAt).getTime() >
+              staleAfterMinutes * 60 * 1_000,
+          }
+        }),
+        bridge: {
+          pending: pendingRows.length,
+          processing: bridgeRows.filter((row) => row.status === "processing").length,
+          failed: bridgeRows.filter((row) => row.status === "failed").length,
+          oldestPendingAt: pendingRows.at(-1)?.createdAt ?? null,
+        },
+        lastMaintenance: lastMaintenance
+          ? {
+              status: lastMaintenance.status,
+              startedAt: lastMaintenance.startedAt,
+              completedAt: lastMaintenance.completedAt,
+              summary: lastMaintenance.summary,
+            }
+          : null,
+      },
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to load Feedback Desk",
+    }
+  }
+}
+
+export async function updateFeedbackAdminItem(
+  input: z.infer<typeof updateSchema>,
+): Promise<Readonly<{
+  success: boolean
+  error?: string
+  changed?: boolean
+  requesterUpdateQueued?: boolean
+}>> {
+  try {
+    const parsed = updateSchema.parse(input)
+    const admin = await requireFeedbackAdmin()
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const item = await db.select().from(feedbackDeskItems).where(and(
+      eq(feedbackDeskItems.id, parsed.id),
+      eq(feedbackDeskItems.organizationId, admin.organizationId),
+    )).get()
+    if (!item) return { success: false, error: "Feedback request not found" }
+    const assignee = parsed.assignedToUserId
+      ? await db.select({
+          id: users.id,
+          displayName: users.displayName,
+          email: users.email,
+          role: organizationMembers.role,
+        }).from(organizationMembers)
+          .innerJoin(users, eq(users.id, organizationMembers.userId))
+          .where(and(
+            eq(organizationMembers.organizationId, admin.organizationId),
+            eq(users.id, parsed.assignedToUserId),
+            eq(users.isActive, true),
+          )).get()
+      : null
+    if (
+      parsed.assignedToUserId &&
+      (!assignee || !isInternalStaffRole(assignee.role))
+    ) {
+      return { success: false, error: "Assignee must be active internal staff" }
+    }
+    const result = await applyFeedbackLifecycleUpdate(db, item, {
+      status: parsed.status,
+      priority: parsed.priority,
+      assignedToUserId: assignee?.id ?? null,
+      assignedToName: assignee?.displayName ?? assignee?.email ?? null,
+      message: parsed.message?.trim() || undefined,
+      githubIssueUrl: parsed.githubIssueUrl === undefined
+        ? undefined
+        : parsed.githubIssueUrl || null,
+      draftPullRequestUrl: parsed.draftPullRequestUrl === undefined
+        ? undefined
+        : parsed.draftPullRequestUrl || null,
+      actorSource: "compass-admin",
+      idempotencyKey: `admin-status:${item.id}:${crypto.randomUUID()}`,
+    })
+    revalidatePath("/dashboard/requests")
+    revalidatePath("/dashboard/requests/manage")
+    return {
+      success: true,
+      changed: result.changed,
+      requesterUpdateQueued: result.requesterUpdateQueued,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Update failed",
+    }
+  }
+}
+
+export async function runFeedbackAdminMaintenance(): Promise<Readonly<{
+  success: boolean
+  error?: string
+}>> {
+  try {
+    const admin = await requireFeedbackAdmin()
+    const { env } = await getCloudflareContext()
+    const configuredOrganizationId = Reflect.get(
+      env,
+      "JARVIS_BRIDGE_ORGANIZATION_ID",
+    )
+    if (configuredOrganizationId !== admin.organizationId) {
+      return {
+        success: false,
+        error: "Feedback reconciliation is not configured for this organization",
+      }
+    }
+    await runFeedbackMaintenance(env, "admin")
+    revalidatePath("/dashboard/requests")
+    revalidatePath("/dashboard/requests/manage")
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Reconciliation failed",
+    }
+  }
+}

--- a/src/app/actions/feedback-admin.ts
+++ b/src/app/actions/feedback-admin.ts
@@ -72,6 +72,8 @@ export type FeedbackAdminOverview = Readonly<{
     slaTargetAt: string | null
     overdue: boolean
     githubIssueUrl: string | null
+    githubIssueCreationApprovedAt: string | null
+    githubIssueCreationApprovedBy: string | null
     githubDraftPullRequestUrl: string | null
     privacyScrubbedAt: string | null
     createdAt: string
@@ -159,6 +161,8 @@ export async function getFeedbackAdminOverview(): Promise<FeedbackAdminOverviewR
           slaTargetAt: item.slaTargetAt,
           overdue: feedbackIsOverdue(item.status, item.slaTargetAt),
           githubIssueUrl: item.githubIssueUrl,
+          githubIssueCreationApprovedAt: item.githubIssueCreationApprovedAt,
+          githubIssueCreationApprovedBy: item.githubIssueCreationApprovedBy,
           githubDraftPullRequestUrl: item.githubDraftPullRequestUrl,
           privacyScrubbedAt: item.privacyScrubbedAt,
           createdAt: item.createdAt,
@@ -207,6 +211,48 @@ export async function getFeedbackAdminOverview(): Promise<FeedbackAdminOverviewR
     return {
       success: false,
       error: error instanceof Error ? error.message : "Failed to load Feedback Desk",
+    }
+  }
+}
+
+export async function setFeedbackGithubIssueCreationApproval(
+  input: Readonly<{ id: string; approved: boolean }>,
+): Promise<Readonly<{ success: boolean; error?: string }>> {
+  try {
+    const parsed = z.object({
+      id: z.string().min(1),
+      approved: z.boolean(),
+    }).parse(input)
+    const admin = await requireFeedbackAdmin()
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const item = await db.select({
+      id: feedbackDeskItems.id,
+      githubIssueUrl: feedbackDeskItems.githubIssueUrl,
+    }).from(feedbackDeskItems).where(and(
+      eq(feedbackDeskItems.id, parsed.id),
+      eq(feedbackDeskItems.organizationId, admin.organizationId),
+    )).get()
+    if (!item) return { success: false, error: "Feedback request not found" }
+    if (item.githubIssueUrl) {
+      return { success: false, error: "This request already has a GitHub issue" }
+    }
+    const now = new Date().toISOString()
+    await db.update(feedbackDeskItems).set({
+      githubIssueCreationApprovedAt: parsed.approved ? now : null,
+      githubIssueCreationApprovedBy: parsed.approved ? admin.id : null,
+      updatedAt: now,
+    }).where(and(
+      eq(feedbackDeskItems.id, item.id),
+      eq(feedbackDeskItems.organizationId, admin.organizationId),
+    ))
+    revalidatePath("/dashboard/requests")
+    revalidatePath("/dashboard/requests/manage")
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Approval update failed",
     }
   }
 }

--- a/src/app/actions/feedback-requests.ts
+++ b/src/app/actions/feedback-requests.ts
@@ -21,7 +21,11 @@ import {
   type FeedbackTimelineEntry,
 } from "@/lib/jarvis/feedback-timeline"
 import { syncFeedbackDeskItemsFromGithub } from "@/lib/jarvis/feedback-github-sync"
+import { linkFeedbackDeskItemToGithub } from "@/lib/jarvis/feedback-github"
 import { requireOrg } from "@/lib/org-scope"
+import { canManageUserAccessRole } from "@/lib/user-roles"
+
+export type FeedbackRequestScope = "mine" | "all"
 
 export type MyFeedbackRequest = {
   readonly id: string
@@ -30,8 +34,12 @@ export type MyFeedbackRequest = {
   readonly priority: string
   readonly title: string
   readonly description: string
+  readonly reporterName: string | null
   readonly githubIssueUrl: string | null
   readonly githubDraftPullRequestUrl: string | null
+  readonly assignedToName: string | null
+  readonly slaTargetAt: string | null
+  readonly lastRequesterUpdateAt: string | null
   readonly createdAt: string
   readonly updatedAt: string
 }
@@ -44,6 +52,8 @@ type MyFeedbackRequestsResult =
   | {
       readonly success: true
       readonly data: readonly MyFeedbackRequest[]
+      readonly scope: FeedbackRequestScope
+      readonly canViewAll: boolean
     }
   | { readonly success: false; readonly error: string }
 
@@ -96,15 +106,20 @@ const requestSelection = {
   priority: feedbackDeskItems.priority,
   title: feedbackDeskItems.title,
   description: feedbackDeskItems.description,
+  reporterName: feedbackDeskItems.reporterName,
   githubIssueUrl: feedbackDeskItems.githubIssueUrl,
   githubDraftPullRequestUrl:
     feedbackDeskItems.githubDraftPullRequestUrl,
+  assignedToName: feedbackDeskItems.assignedToName,
+  slaTargetAt: feedbackDeskItems.slaTargetAt,
+  lastRequesterUpdateAt: feedbackDeskItems.lastRequesterUpdateAt,
   createdAt: feedbackDeskItems.createdAt,
   updatedAt: feedbackDeskItems.updatedAt,
 }
 
 async function recoverConfirmedFeedbackRequests(
   db: ReturnType<typeof getDb>,
+  env: CloudflareEnv,
   input: Readonly<{
     userId: string
     organizationId: string
@@ -147,7 +162,7 @@ async function recoverConfirmedFeedbackRequests(
     const report = confirmedFeedbackReportFromPayload(event.payload)
     if (!report) continue
     const candidate = feedbackCandidateFromReport(report)
-    await enqueueFeedbackDeskItem(db, {
+    const item = await enqueueFeedbackDeskItem(db, {
       organizationId: input.organizationId,
       source: "ask-jarvis",
       sourceId: event.id,
@@ -163,13 +178,20 @@ async function recoverConfirmedFeedbackRequests(
         confirmedAt: event.createdAt,
       },
     })
+    await linkFeedbackDeskItemToGithub(db, env, item)
     existingSourceIds.add(event.id)
     recoveredCount += 1
   }
   return recoveredCount
 }
 
-export async function getMyFeedbackRequests(): Promise<MyFeedbackRequestsResult> {
+function canViewAllRequests(role: string): boolean {
+  return role === "developer" || canManageUserAccessRole(role)
+}
+
+export async function getMyFeedbackRequests(
+  scope: FeedbackRequestScope = "mine",
+): Promise<MyFeedbackRequestsResult> {
   try {
     const user = await requireAuth()
     const organizationId = requireOrg(user)
@@ -177,19 +199,28 @@ export async function getMyFeedbackRequests(): Promise<MyFeedbackRequestsResult>
     const db = getDb(env.DB)
     const { email, googleEmail } = normalizedUserEmails(user)
 
+    const canViewAll = canViewAllRequests(user.role)
+    const viewAll = scope === "all" && canViewAll
     const rows = await db
       .select(requestSelection)
       .from(feedbackDeskItems)
       .where(
         and(
           eq(feedbackDeskItems.organizationId, organizationId),
-          reporterFilter(user.id, email, googleEmail)
+          viewAll
+            ? sql`1 = 1`
+            : reporterFilter(user.id, email, googleEmail)
         )
       )
       .orderBy(desc(feedbackDeskItems.updatedAt))
       .limit(100)
 
-    return { success: true, data: rows }
+    return {
+      success: true,
+      data: rows,
+      scope: viewAll ? "all" : "mine",
+      canViewAll,
+    }
   } catch (error) {
     return {
       success: false,
@@ -217,7 +248,9 @@ export async function getMyFeedbackRequest(
         and(
           eq(feedbackDeskItems.id, requestId),
           eq(feedbackDeskItems.organizationId, organizationId),
-          reporterFilter(user.id, email, googleEmail),
+          canViewAllRequests(user.role)
+            ? sql`1 = 1`
+            : reporterFilter(user.id, email, googleEmail),
         ),
       )
       .get()
@@ -256,26 +289,31 @@ export async function getMyFeedbackRequest(
   }
 }
 
-export async function refreshMyFeedbackRequests(): Promise<FeedbackRefreshResult> {
+export async function refreshMyFeedbackRequests(
+  scope: FeedbackRequestScope = "mine",
+): Promise<FeedbackRefreshResult> {
   try {
     const user = await requireAuth()
     const organizationId = requireOrg(user)
     const { email, googleEmail } = normalizedUserEmails(user)
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
-    const recoveredCount = await recoverConfirmedFeedbackRequests(db, {
+    const recoveredCount = await recoverConfirmedFeedbackRequests(db, env, {
       userId: user.id,
       organizationId,
       reporterName: user.displayName,
       reporterEmail: email,
     })
+    const viewAll = scope === "all" && canViewAllRequests(user.role)
     const rows = await db
       .select()
       .from(feedbackDeskItems)
       .where(
         and(
           eq(feedbackDeskItems.organizationId, organizationId),
-          reporterFilter(user.id, email, googleEmail),
+          viewAll
+            ? sql`1 = 1`
+            : reporterFilter(user.id, email, googleEmail),
         ),
       )
       .orderBy(desc(feedbackDeskItems.updatedAt))

--- a/src/app/actions/feedback-requests.ts
+++ b/src/app/actions/feedback-requests.ts
@@ -21,7 +21,6 @@ import {
   type FeedbackTimelineEntry,
 } from "@/lib/jarvis/feedback-timeline"
 import { syncFeedbackDeskItemsFromGithub } from "@/lib/jarvis/feedback-github-sync"
-import { linkFeedbackDeskItemToGithub } from "@/lib/jarvis/feedback-github"
 import { requireOrg } from "@/lib/org-scope"
 import { canManageUserAccessRole } from "@/lib/user-roles"
 
@@ -119,7 +118,6 @@ const requestSelection = {
 
 async function recoverConfirmedFeedbackRequests(
   db: ReturnType<typeof getDb>,
-  env: CloudflareEnv,
   input: Readonly<{
     userId: string
     organizationId: string
@@ -162,7 +160,7 @@ async function recoverConfirmedFeedbackRequests(
     const report = confirmedFeedbackReportFromPayload(event.payload)
     if (!report) continue
     const candidate = feedbackCandidateFromReport(report)
-    const item = await enqueueFeedbackDeskItem(db, {
+    await enqueueFeedbackDeskItem(db, {
       organizationId: input.organizationId,
       source: "ask-jarvis",
       sourceId: event.id,
@@ -171,6 +169,7 @@ async function recoverConfirmedFeedbackRequests(
       description: candidate.description,
       reporterName: input.reporterName,
       reporterEmail: input.reporterEmail,
+      historicalImport: true,
       metadata: {
         externalActorId: input.userId,
         confirmationEventId: event.id,
@@ -178,7 +177,6 @@ async function recoverConfirmedFeedbackRequests(
         confirmedAt: event.createdAt,
       },
     })
-    await linkFeedbackDeskItemToGithub(db, env, item)
     existingSourceIds.add(event.id)
     recoveredCount += 1
   }
@@ -298,7 +296,7 @@ export async function refreshMyFeedbackRequests(
     const { email, googleEmail } = normalizedUserEmails(user)
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
-    const recoveredCount = await recoverConfirmedFeedbackRequests(db, env, {
+    const recoveredCount = await recoverConfirmedFeedbackRequests(db, {
       userId: user.id,
       organizationId,
       reporterName: user.displayName,

--- a/src/app/api/integrations/jarvis/feedback/[id]/status/route.ts
+++ b/src/app/api/integrations/jarvis/feedback/[id]/status/route.ts
@@ -1,91 +1,62 @@
-import { and, eq, or, sql } from "drizzle-orm"
+import { and, eq } from "drizzle-orm"
 import { z } from "zod/v4"
 
 import { getDb } from "@/db"
-import { organizationMembers, users } from "@/db/schema"
-import {
-  feedbackDeskItems,
-  jarvisBridgeEvents,
-} from "@/db/schema-jarvis"
+import { feedbackDeskItems, jarvisBridgeEvents } from "@/db/schema-jarvis"
 import { getCloudflareContext } from "@/lib/db"
 import {
   getJarvisEnvValue,
   readBoundedBody,
   verifyJarvisRequest,
 } from "@/lib/jarvis/auth"
-import {
-  FEEDBACK_DESK_STATUSES,
-  feedbackStatusLabel,
-  feedbackDraftPullRequestMessage,
-  feedbackRequesterUpdateKind,
-  feedbackStatusMessage,
-  feedbackStatusUsesEmail,
-} from "@/lib/jarvis/feedback-lifecycle"
-import { createSystemNotificationEvent } from "@/lib/notifications/events"
+import { FEEDBACK_DESK_STATUSES } from "@/lib/jarvis/feedback-lifecycle"
+import { applyFeedbackLifecycleUpdate } from "@/lib/jarvis/feedback-status-update"
 
 const statusUpdateSchema = z.object({
   idempotencyKey: z.string().min(1).max(256),
   status: z.enum(FEEDBACK_DESK_STATUSES),
   message: z.string().min(1).max(2_000).optional(),
   priority: z.enum(["low", "normal", "high", "urgent"]).optional(),
-  githubIssueUrl: z.union([z.url().max(2_048), z.null()]).optional(),
-  draftPullRequestUrl: z
-    .union([z.url().max(2_048), z.null()])
-    .optional(),
+  githubIssueUrl: z.union([
+    z.url().max(2_048).refine(
+      (value) => /^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+(?:\/|$)/.test(value),
+      "GitHub issue URL required",
+    ),
+    z.null(),
+  ]).optional(),
+  draftPullRequestUrl: z.union([
+    z.url().max(2_048).refine(
+      (value) => /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+(?:\/|$)/.test(value),
+      "GitHub pull request URL required",
+    ),
+    z.null(),
+  ]).optional(),
 })
-
-function metadataActorId(metadata: string | null): string | null {
-  if (!metadata) return null
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(metadata)
-  } catch {
-    return null
-  }
-  if (typeof parsed !== "object" || parsed === null) return null
-  const actorId = Reflect.get(parsed, "externalActorId")
-  return typeof actorId === "string" && actorId.length > 0
-    ? actorId
-    : null
-}
 
 export async function POST(
   request: Request,
-  { params }: {
-    readonly params: Promise<{ readonly id: string }>
-  }
+  { params }: { readonly params: Promise<{ readonly id: string }> },
 ): Promise<Response> {
   const bodyResult = await readBoundedBody(request)
   if (!bodyResult.success) {
-    return Response.json(
-      { error: bodyResult.error },
-      { status: 413 }
-    )
+    return Response.json({ error: bodyResult.error }, { status: 413 })
   }
-
   const { env } = await getCloudflareContext()
   const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
-  const organizationId = getJarvisEnvValue(
-    env,
-    "JARVIS_BRIDGE_ORGANIZATION_ID"
-  )
+  const organizationId = getJarvisEnvValue(env, "JARVIS_BRIDGE_ORGANIZATION_ID")
   if (!secret || !organizationId) {
     return Response.json(
       { error: "Jarvis lifecycle bridge is not configured" },
-      { status: 503 }
+      { status: 503 },
     )
   }
-
   const verification = await verifyJarvisRequest(
     request,
     secret,
-    bodyResult.rawBody
+    bodyResult.rawBody,
   )
   if (!verification.success) {
-    return Response.json(
-      { error: verification.error },
-      { status: 401 }
-    )
+    return Response.json({ error: verification.error }, { status: 401 })
   }
 
   let body: unknown
@@ -97,220 +68,42 @@ export async function POST(
   const parsed = statusUpdateSchema.safeParse(body)
   if (!parsed.success) {
     return Response.json(
-      {
-        error: "Invalid feedback status update",
-        details: parsed.error.issues,
-      },
-      { status: 400 }
+      { error: "Invalid feedback status update", details: parsed.error.issues },
+      { status: 400 },
     )
   }
 
   const { id } = await params
   const db = getDb(env.DB)
-  const eventKey =
-    `feedback-status:${id}:${parsed.data.idempotencyKey}`
-  const duplicate = await db
-    .select({ id: jarvisBridgeEvents.id })
+  const eventKey = `feedback-status:${id}:${parsed.data.idempotencyKey}`
+  const duplicate = await db.select({ id: jarvisBridgeEvents.id })
     .from(jarvisBridgeEvents)
     .where(eq(jarvisBridgeEvents.idempotencyKey, eventKey))
     .get()
-  if (duplicate) {
-    return Response.json({ success: true, duplicate: true })
-  }
+  if (duplicate) return Response.json({ success: true, duplicate: true })
 
-  const item = await db
-    .select()
-    .from(feedbackDeskItems)
-    .where(
-      and(
-        eq(feedbackDeskItems.id, id),
-        eq(feedbackDeskItems.organizationId, organizationId)
-      )
-    )
-    .get()
+  const item = await db.select().from(feedbackDeskItems).where(and(
+    eq(feedbackDeskItems.id, id),
+    eq(feedbackDeskItems.organizationId, organizationId),
+  )).get()
   if (!item) {
-    return Response.json(
-      { error: "Feedback request not found" },
-      { status: 404 }
-    )
+    return Response.json({ error: "Feedback request not found" }, { status: 404 })
   }
 
-  // Only Ask Jarvis carries an authenticated Compass user ID. External
-  // adapter actor IDs (Telegram/email) must never be treated as user IDs.
-  const actorId =
-    item.source === "ask-jarvis"
-      ? metadataActorId(item.metadata)
-      : null
-  const reporterEmail = item.reporterEmail?.trim().toLowerCase()
-  const recipientFilter =
-    actorId && reporterEmail
-      ? or(
-          eq(users.id, actorId),
-          sql`lower(${users.email}) = ${reporterEmail}`,
-          sql`lower(${users.googleEmail}) = ${reporterEmail}`
-        )
-      : actorId
-        ? eq(users.id, actorId)
-        : reporterEmail
-          ? or(
-              sql`lower(${users.email}) = ${reporterEmail}`,
-              sql`lower(${users.googleEmail}) = ${reporterEmail}`
-            )
-          : null
-  const recipients = recipientFilter
-    ? await db
-        .select({
-          userId: users.id,
-          email: users.email,
-        })
-        .from(organizationMembers)
-        .innerJoin(users, eq(users.id, organizationMembers.userId))
-        .where(
-          and(
-            eq(
-              organizationMembers.organizationId,
-              organizationId
-            ),
-            eq(users.isActive, true),
-            recipientFilter
-          )
-        )
-    : []
-
-  const draftPullRequestUrl =
-    parsed.data.draftPullRequestUrl === undefined
-      ? item.githubDraftPullRequestUrl
-      : parsed.data.draftPullRequestUrl
-  const requesterUpdateKind = feedbackRequesterUpdateKind(
-    item.status,
-    parsed.data.status,
-    item.githubDraftPullRequestUrl,
-    draftPullRequestUrl,
-  )
-  const hasDraftPullRequestUpdate =
-    draftPullRequestUrl !== null &&
-    draftPullRequestUrl !== item.githubDraftPullRequestUrl
-  const now = new Date().toISOString()
-  const message =
-    parsed.data.message ??
-    (hasDraftPullRequestUpdate
-      ? feedbackDraftPullRequestMessage(item.title, draftPullRequestUrl)
-      : feedbackStatusMessage(parsed.data.status, item.title))
-  await db
-    .update(feedbackDeskItems)
-    .set({
-      status: parsed.data.status,
-      priority: parsed.data.priority ?? item.priority,
-      githubIssueUrl:
-        parsed.data.githubIssueUrl === undefined
-          ? item.githubIssueUrl
-          : parsed.data.githubIssueUrl,
-      githubDraftPullRequestUrl: draftPullRequestUrl,
-      updatedAt: now,
-    })
-    .where(eq(feedbackDeskItems.id, id))
-
-  if (requesterUpdateKind && recipients.length > 0) {
-    try {
-      await createSystemNotificationEvent({
-        organizationId,
-        projectId: null,
-        eventType: `feedback.status.${parsed.data.status}`,
-        sourceType: "feedback",
-        sourceId: id,
-        title: `Request update: ${feedbackStatusLabel(parsed.data.status)}`,
-        body: message,
-        href: `/dashboard/requests/${encodeURIComponent(id)}`,
-        priority:
-          parsed.data.status === "needs_info" ? "high" : "normal",
-        audience: "requester",
-        recipients,
-        delivery: {
-          inApp: true,
-          email: feedbackStatusUsesEmail(parsed.data.status),
-          push: feedbackStatusUsesEmail(parsed.data.status),
-        },
-      })
-    } catch (error) {
-      console.error("feedback_lifecycle_notification_failed", {
-        feedbackDeskItemId: id,
-        error:
-          error instanceof Error
-            ? error.message
-            : "Unknown error",
-      })
-    }
-  }
-
-  const statusPayload = JSON.stringify({
-    schemaVersion: 1,
-    feedbackDeskItemId: id,
-    source: item.source,
-    sourceId: item.sourceId,
+  const result = await applyFeedbackLifecycleUpdate(db, item, {
     status: parsed.data.status,
-    title: item.title,
-    message,
-    reporter: {
-      name: item.reporterName,
-      email: item.reporterEmail,
-      externalActorId: actorId,
-    },
-    compass: {
-      organizationId,
-      channelId: item.channelId,
-      messageId: item.messageId,
-      threadId: item.threadId,
-    },
-    metadata: item.metadata,
-    githubIssueUrl:
-      parsed.data.githubIssueUrl === undefined
-        ? item.githubIssueUrl
-        : parsed.data.githubIssueUrl,
-    draftPullRequestUrl,
-    notificationKind: requesterUpdateKind,
-    updatedAt: now,
-  })
-
-  await db.insert(jarvisBridgeEvents).values({
-    id: crypto.randomUUID(),
-    organizationId,
-    direction: "inbound",
-    source: "signet",
-    eventType: "feedback.status_updated",
-    status: "completed",
+    priority: parsed.data.priority,
+    message: parsed.data.message,
+    githubIssueUrl: parsed.data.githubIssueUrl,
+    draftPullRequestUrl: parsed.data.draftPullRequestUrl,
+    actorSource: "signet",
     idempotencyKey: eventKey,
-    feedbackDeskItemId: id,
-    payload: bodyResult.rawBody,
-    result: statusPayload,
-    availableAt: now,
-    completedAt: now,
-    createdAt: now,
-    updatedAt: now,
   })
-  if (requesterUpdateKind) {
-    await db
-      .insert(jarvisBridgeEvents)
-      .values({
-        id: crypto.randomUUID(),
-        organizationId,
-        direction: "outbound",
-        source: item.source,
-        eventType: "feedback.status_changed",
-        idempotencyKey: `notify:${eventKey}`,
-        feedbackDeskItemId: id,
-        payload: statusPayload,
-        availableAt: now,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .onConflictDoNothing()
-  }
-
   return Response.json({
     success: true,
     feedbackDeskItemId: id,
     status: parsed.data.status,
-    notifiedUserCount: requesterUpdateKind ? recipients.length : 0,
-    requesterUpdateQueued: requesterUpdateKind !== null,
+    notifiedUserCount: result.notifiedUserCount,
+    requesterUpdateQueued: result.requesterUpdateQueued,
   })
 }

--- a/src/app/api/integrations/jarvis/health/route.ts
+++ b/src/app/api/integrations/jarvis/health/route.ts
@@ -1,0 +1,50 @@
+import { z } from "zod/v4"
+
+import { getDb } from "@/db"
+import { getCloudflareContext } from "@/lib/db"
+import {
+  getJarvisEnvValue,
+  readBoundedBody,
+  verifyJarvisRequest,
+} from "@/lib/jarvis/auth"
+import { recordFeedbackServiceHealth } from "@/lib/jarvis/feedback-maintenance"
+
+const heartbeatSchema = z.object({
+  serviceName: z.enum(["jarvis-agent-poller", "jarvis-feedback-notifier"]),
+  status: z.enum(["healthy", "degraded", "failed"]),
+  error: z.string().max(2_000).nullable().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+})
+
+export async function POST(request: Request): Promise<Response> {
+  const body = await readBoundedBody(request)
+  if (!body.success) return Response.json({ error: body.error }, { status: 413 })
+  const { env } = await getCloudflareContext()
+  const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
+  const organizationId = getJarvisEnvValue(env, "JARVIS_BRIDGE_ORGANIZATION_ID")
+  if (!secret || !organizationId) {
+    return Response.json({ error: "Jarvis health bridge is not configured" }, { status: 503 })
+  }
+  const verification = await verifyJarvisRequest(request, secret, body.rawBody)
+  if (!verification.success) {
+    return Response.json({ error: verification.error }, { status: 401 })
+  }
+  let value: unknown
+  try {
+    value = JSON.parse(body.rawBody)
+  } catch {
+    return Response.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+  const parsed = heartbeatSchema.safeParse(value)
+  if (!parsed.success) {
+    return Response.json({ error: "Invalid heartbeat" }, { status: 400 })
+  }
+  await recordFeedbackServiceHealth(getDb(env.DB), {
+    serviceName: parsed.data.serviceName,
+    organizationId,
+    status: parsed.data.status,
+    error: parsed.data.error,
+    metadata: parsed.data.metadata,
+  })
+  return Response.json({ success: true })
+}

--- a/src/app/api/operations/feedback/reconcile/route.ts
+++ b/src/app/api/operations/feedback/reconcile/route.ts
@@ -1,0 +1,36 @@
+import { getCloudflareContext } from "@/lib/db"
+import {
+  getJarvisEnvValue,
+  readBoundedBody,
+  verifyJarvisRequest,
+} from "@/lib/jarvis/auth"
+import { runFeedbackMaintenance } from "@/lib/jarvis/feedback-maintenance"
+
+export async function POST(request: Request): Promise<Response> {
+  const body = await readBoundedBody(request)
+  if (!body.success) {
+    return Response.json({ error: body.error }, { status: 413 })
+  }
+  const { env } = await getCloudflareContext()
+  const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
+  if (!secret) {
+    return Response.json({ error: "Maintenance authentication is not configured" }, { status: 503 })
+  }
+  const verification = await verifyJarvisRequest(
+    request,
+    secret,
+    body.rawBody,
+  )
+  if (!verification.success) {
+    return Response.json({ error: verification.error }, { status: 401 })
+  }
+  try {
+    const result = await runFeedbackMaintenance(env, "cron")
+    return Response.json({ success: true, ...result })
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : "Maintenance failed" },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -34,6 +34,7 @@ import {
   canUseAskCompass,
   canUseFieldDesk,
   canUseOfficeTalk,
+  canManageUserAccess,
 } from "@/lib/permissions"
 import { isInternalStaffRole } from "@/lib/user-roles"
 
@@ -60,6 +61,7 @@ export default async function DashboardLayout({
     ? isInternalStaffRole(authUser.role)
     : false
   const canUseDirectMessages = canViewActivity
+  const canManageFeedback = canManageUserAccess(authUser)
   const offlineScopeKey =
     authUser?.organizationId && authUser.id
       ? `${authUser.organizationId}:${authUser.id}`
@@ -97,6 +99,7 @@ export default async function DashboardLayout({
           activeOrgName={activeOrgName}
           canUseFieldDesk={canUseCompassFieldDesk}
           canViewActivity={canViewActivity}
+          canManageFeedback={canManageFeedback}
         />
         <SidebarInset className="overflow-hidden">
           <DesktopOfflineBanner />

--- a/src/app/dashboard/requests/[id]/page.tsx
+++ b/src/app/dashboard/requests/[id]/page.tsx
@@ -26,10 +26,16 @@ function formatDate(value: string): string {
 
 export default async function RequestDetailPage({
   params,
+  searchParams,
 }: {
   readonly params: Promise<{ readonly id: string }>
+  readonly searchParams: Promise<{ readonly scope?: string }>
 }) {
   const { id } = await params
+  const query = await searchParams
+  const backHref = query.scope === "all"
+    ? "/dashboard/requests?scope=all"
+    : "/dashboard/requests"
   const result = await getMyFeedbackRequest(id)
   if (!result.success) notFound()
   const request = result.data
@@ -38,7 +44,7 @@ export default async function RequestDetailPage({
     <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-4 md:p-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <Button variant="ghost" size="sm" asChild>
-          <Link href="/dashboard/requests">
+          <Link href={backHref}>
             <IconArrowLeft className="size-4" />
             All requests
           </Link>
@@ -61,6 +67,10 @@ export default async function RequestDetailPage({
         </h1>
         <p className="mt-2 text-sm text-muted-foreground">
           Submitted {formatDate(request.createdAt)} · Last updated {formatDate(request.updatedAt)}
+        </p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Owner: {request.assignedToName ?? "Awaiting assignment"}
+          {request.slaTargetAt ? ` · Response target ${formatDate(request.slaTargetAt)}` : ""}
         </p>
       </div>
 

--- a/src/app/dashboard/requests/manage/page.tsx
+++ b/src/app/dashboard/requests/manage/page.tsx
@@ -1,0 +1,22 @@
+import { getFeedbackAdminOverview } from "@/app/actions/feedback-admin"
+import { FeedbackDeskAdmin } from "@/components/feedback/feedback-desk-admin"
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+export const dynamic = "force-dynamic"
+
+export default async function FeedbackDeskManagePage() {
+  const result = await getFeedbackAdminOverview()
+  if (!result.success) {
+    return (
+      <div className="mx-auto w-full max-w-7xl p-4 md:p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Feedback Desk unavailable</CardTitle>
+            <CardDescription>{result.error}</CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    )
+  }
+  return <FeedbackDeskAdmin overview={result.data} />
+}

--- a/src/app/dashboard/requests/page.tsx
+++ b/src/app/dashboard/requests/page.tsx
@@ -7,6 +7,7 @@ import {
 import { getMyFeedbackRequests } from "@/app/actions/feedback-requests"
 import { RequestRefreshControl } from "@/app/dashboard/requests/request-refresh-control"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -25,9 +26,16 @@ function formatDate(value: string): string {
   }).format(new Date(value))
 }
 
-export default async function RequestsPage() {
-  const result = await getMyFeedbackRequests()
+export default async function RequestsPage({
+  searchParams,
+}: Readonly<{
+  searchParams: Promise<{ readonly scope?: string }>
+}>) {
+  const params = await searchParams
+  const scope = params.scope === "all" ? "all" : "mine"
+  const result = await getMyFeedbackRequests(scope)
   const requests = result.success ? result.data : []
+  const showingAll = result.success && result.scope === "all"
 
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-4 md:p-6">
@@ -37,13 +45,23 @@ export default async function RequestsPage() {
             Compass Feedback Desk
           </p>
           <h1 className="text-2xl font-semibold tracking-tight">
-            My requests
+            {showingAll ? "All requests" : "My requests"}
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
             Follow each request from receipt through implementation.
           </p>
         </div>
-        <RequestRefreshControl />
+        <div className="flex flex-wrap items-center gap-2">
+          <Button variant={!showingAll ? "secondary" : "ghost"} size="sm" asChild>
+            <Link href="/dashboard/requests">My requests</Link>
+          </Button>
+          {result.success && result.canViewAll && (
+            <Button variant={showingAll ? "secondary" : "ghost"} size="sm" asChild>
+              <Link href="/dashboard/requests?scope=all">All requests</Link>
+            </Button>
+          )}
+          <RequestRefreshControl scope={scope} />
+        </div>
       </div>
 
       {!result.success && (
@@ -74,7 +92,7 @@ export default async function RequestsPage() {
         {requests.map((request) => (
           <Link
             key={request.id}
-            href={`/dashboard/requests/${encodeURIComponent(request.id)}`}
+            href={`/dashboard/requests/${encodeURIComponent(request.id)}${showingAll ? "?scope=all" : ""}`}
             className="group rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <Card className="transition-colors group-hover:border-primary/45 group-hover:bg-muted/20">
@@ -85,6 +103,9 @@ export default async function RequestsPage() {
                       {request.title}
                     </CardTitle>
                     <CardDescription className="mt-1">
+                      {showingAll && request.reporterName
+                        ? `${request.reporterName} · `
+                        : ""}
                       Submitted {formatDate(request.createdAt)}
                     </CardDescription>
                   </div>
@@ -103,7 +124,7 @@ export default async function RequestsPage() {
                     <Badge variant="outline">{request.kind}</Badge>
                   </div>
                   <p className="text-xs text-muted-foreground">
-                    Updated {formatDate(request.updatedAt)}
+                    {request.assignedToName ?? "Awaiting assignment"} · Updated {formatDate(request.updatedAt)}
                   </p>
                 </div>
               </CardContent>

--- a/src/app/dashboard/requests/request-refresh-control.tsx
+++ b/src/app/dashboard/requests/request-refresh-control.tsx
@@ -4,13 +4,18 @@ import { useCallback, useEffect, useRef, useState, useTransition } from "react"
 import { useRouter } from "next/navigation"
 import { IconRefresh } from "@tabler/icons-react"
 
-import { refreshMyFeedbackRequests } from "@/app/actions/feedback-requests"
+import {
+  refreshMyFeedbackRequests,
+  type FeedbackRequestScope,
+} from "@/app/actions/feedback-requests"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
 const REFRESH_INTERVAL_MILLISECONDS = 60_000
 
-export function RequestRefreshControl() {
+export function RequestRefreshControl({
+  scope = "mine",
+}: Readonly<{ scope?: FeedbackRequestScope }>) {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [lastCheckedAt, setLastCheckedAt] = useState<Date | null>(null)
@@ -21,13 +26,13 @@ export function RequestRefreshControl() {
     if (now - lastRefreshStartedAt.current < 5_000) return
     lastRefreshStartedAt.current = now
     startTransition(async () => {
-      const result = await refreshMyFeedbackRequests()
+      const result = await refreshMyFeedbackRequests(scope)
       if (result.success) {
         setLastCheckedAt(new Date(result.checkedAt))
         router.refresh()
       }
     })
-  }, [router])
+  }, [router, scope])
 
   useEffect(() => {
     refresh()

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -137,6 +137,12 @@ const NAV_MAIN = [
     icon: IconMessageReport,
   },
   {
+    title: "Feedback Desk",
+    url: "/dashboard/requests/manage",
+    icon: IconMessageReport,
+    adminOnly: true,
+  },
+  {
     title: "Files",
     url: "/dashboard/files",
     icon: IconFiles,
@@ -167,10 +173,12 @@ function SidebarNav({
   projects,
   canUseFieldDesk,
   canViewActivity,
+  canManageFeedback,
 }: {
   projects: ReadonlyArray<ProjectListItem>
   readonly canUseFieldDesk: boolean
   readonly canViewActivity: boolean
+  readonly canManageFeedback: boolean
 }) {
   const pathname = usePathname()
   const { state } = useSidebar()
@@ -203,7 +211,9 @@ function SidebarNav({
       : item
   )
   const navMain = NAV_MAIN.filter(
-    (item) => !item.internalOnly || canViewActivity
+    (item) =>
+      (!item.internalOnly || canViewActivity) &&
+      (!item.adminOnly || canManageFeedback)
   ).map((item) =>
     typeof item.projectPath === "string"
       ? {
@@ -256,6 +266,7 @@ export function AppSidebar({
   activeOrgName = null,
   canUseFieldDesk = false,
   canViewActivity = false,
+  canManageFeedback = false,
   ...props
 }: React.ComponentProps<typeof Sidebar> & {
   readonly projects?: ReadonlyArray<ProjectListItem>
@@ -264,6 +275,7 @@ export function AppSidebar({
   readonly activeOrgName?: string | null
   readonly canUseFieldDesk?: boolean
   readonly canViewActivity?: boolean
+  readonly canManageFeedback?: boolean
 }) {
   const { isMobile } = useSidebar()
   const { channelId } = useVoiceState()
@@ -278,6 +290,7 @@ export function AppSidebar({
           projects={projects}
           canUseFieldDesk={canUseFieldDesk}
           canViewActivity={canViewActivity}
+          canManageFeedback={canManageFeedback}
         />
       </SidebarContent>
       <SidebarFooter className="border-t border-sidebar-border/60">

--- a/src/components/feedback/feedback-desk-admin.tsx
+++ b/src/components/feedback/feedback-desk-admin.tsx
@@ -3,11 +3,16 @@
 import { useState, useTransition } from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { IconExternalLink, IconRefresh } from "@tabler/icons-react"
+import {
+  IconBrandGithub,
+  IconExternalLink,
+  IconRefresh,
+} from "@tabler/icons-react"
 import { toast } from "sonner"
 
 import {
   runFeedbackAdminMaintenance,
+  setFeedbackGithubIssueCreationApproval,
   updateFeedbackAdminItem,
   type FeedbackAdminOverview,
 } from "@/app/actions/feedback-admin"
@@ -45,6 +50,7 @@ function RequestEditor({
 }>) {
   const router = useRouter()
   const [pending, startTransition] = useTransition()
+  const [approvalPending, startApprovalTransition] = useTransition()
   const [status, setStatus] = useState(knownFeedbackStatus(item.status))
   const [priority, setPriority] = useState(knownFeedbackPriority(item.priority))
   const [assignee, setAssignee] = useState(item.assignedToUserId ?? "")
@@ -81,6 +87,25 @@ function RequestEditor({
     })
   }
 
+  function setGithubCreationApproval(approved: boolean): void {
+    startApprovalTransition(async () => {
+      const result = await setFeedbackGithubIssueCreationApproval({
+        id: item.id,
+        approved,
+      })
+      if (!result.success) {
+        toast.error(result.error ?? "GitHub approval update failed")
+        return
+      }
+      toast.success(
+        approved
+          ? "New GitHub issue approved; run reconciliation when ready"
+          : "New GitHub issue approval removed",
+      )
+      router.refresh()
+    })
+  }
+
   return (
     <Card className={item.overdue ? "border-destructive/60" : undefined}>
       <CardHeader className="gap-2">
@@ -94,6 +119,12 @@ function RequestEditor({
           <div className="flex flex-wrap gap-2">
             {item.overdue && <Badge variant="destructive">SLA overdue</Badge>}
             {!item.assignedToUserId && <Badge variant="outline">Unassigned</Badge>}
+            {!item.githubIssueUrl && item.githubIssueCreationApprovedAt && (
+              <Badge>New GitHub issue approved</Badge>
+            )}
+            {!item.githubIssueUrl && !item.githubIssueCreationApprovedAt && (
+              <Badge variant="outline">GitHub review needed</Badge>
+            )}
             <Badge variant="secondary">{item.kind}</Badge>
           </div>
         </div>
@@ -163,6 +194,27 @@ function RequestEditor({
             />
           </label>
         </div>
+        {!item.githubIssueUrl && (
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-dashed p-3">
+            <p className="max-w-3xl text-xs text-muted-foreground">
+              If this work already exists, paste its GitHub issue or pull request above and save.
+              Approve a new issue only when the request is genuinely untracked.
+            </p>
+            <Button
+              size="sm"
+              variant={item.githubIssueCreationApprovedAt ? "outline" : "secondary"}
+              disabled={approvalPending}
+              onClick={() => setGithubCreationApproval(!item.githubIssueCreationApprovedAt)}
+            >
+              <IconBrandGithub />
+              {approvalPending
+                ? "Updating..."
+                : item.githubIssueCreationApprovedAt
+                  ? "Remove issue approval"
+                  : "Approve new issue"}
+            </Button>
+          </div>
+        )}
         <label className="block space-y-1 text-xs font-medium">
           Requester update (optional)
           <textarea
@@ -205,6 +257,12 @@ export function FeedbackDeskAdmin({ overview }: Readonly<{
   )
   const overdue = openItems.filter((item) => item.overdue).length
   const unassigned = openItems.filter((item) => !item.assignedToUserId).length
+  const githubReviewNeeded = overview.items.filter(
+    (item) => !item.githubIssueUrl && !item.githubIssueCreationApprovedAt,
+  ).length
+  const githubCreationApproved = overview.items.filter(
+    (item) => !item.githubIssueUrl && item.githubIssueCreationApprovedAt,
+  ).length
 
   function reconcile(): void {
     startTransition(async () => {
@@ -240,6 +298,19 @@ export function FeedbackDeskAdmin({ overview }: Readonly<{
         <Card><CardHeader><CardDescription>SLA overdue</CardDescription><CardTitle>{overdue}</CardTitle></CardHeader></Card>
         <Card><CardHeader><CardDescription>Failed bridge events</CardDescription><CardTitle>{overview.bridge.failed}</CardTitle></CardHeader></Card>
       </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">GitHub link preview</CardTitle>
+          <CardDescription>
+            {githubReviewNeeded} request{githubReviewNeeded === 1 ? "" : "s"} need review · {githubCreationApproved} approved for new issue creation
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          Reconciliation will synchronize existing links, but it will not create a missing
+          GitHub issue until an administrator approves that request below.
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader>

--- a/src/components/feedback/feedback-desk-admin.tsx
+++ b/src/components/feedback/feedback-desk-admin.tsx
@@ -1,0 +1,282 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { IconExternalLink, IconRefresh } from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import {
+  runFeedbackAdminMaintenance,
+  updateFeedbackAdminItem,
+  type FeedbackAdminOverview,
+} from "@/app/actions/feedback-admin"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  FEEDBACK_DESK_STATUSES,
+  FEEDBACK_PRIORITIES,
+  feedbackStatusLabel,
+  knownFeedbackPriority,
+  knownFeedbackStatus,
+} from "@/lib/jarvis/feedback-lifecycle"
+
+function formatDate(value: string | null): string {
+  if (!value) return "Never"
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value))
+}
+
+function RequestEditor({
+  item,
+  assignees,
+}: Readonly<{
+  item: FeedbackAdminOverview["items"][number]
+  assignees: FeedbackAdminOverview["assignees"]
+}>) {
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+  const [status, setStatus] = useState(knownFeedbackStatus(item.status))
+  const [priority, setPriority] = useState(knownFeedbackPriority(item.priority))
+  const [assignee, setAssignee] = useState(item.assignedToUserId ?? "")
+  const [message, setMessage] = useState("")
+  const [issueUrl, setIssueUrl] = useState(item.githubIssueUrl ?? "")
+  const [prUrl, setPrUrl] = useState(item.githubDraftPullRequestUrl ?? "")
+
+  function save(): void {
+    startTransition(async () => {
+      const result = await updateFeedbackAdminItem({
+        id: item.id,
+        status,
+        priority,
+        assignedToUserId: assignee || null,
+        message: message || undefined,
+        githubIssueUrl: issueUrl,
+        draftPullRequestUrl: prUrl,
+      })
+      if (!result.success) {
+        toast.error(result.error ?? "Request update failed")
+        return
+      }
+      if (!result.changed) {
+        toast.info("No changes to save")
+        return
+      }
+      setMessage("")
+      toast.success(
+        result.requesterUpdateQueued
+          ? "Request updated; requester update queued"
+          : "Request updated",
+      )
+      router.refresh()
+    })
+  }
+
+  return (
+    <Card className={item.overdue ? "border-destructive/60" : undefined}>
+      <CardHeader className="gap-2">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0">
+            <CardTitle className="text-base">{item.title}</CardTitle>
+            <CardDescription>
+              {item.reporterName ?? "Unknown requester"} · {item.source} · {formatDate(item.createdAt)}
+            </CardDescription>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {item.overdue && <Badge variant="destructive">SLA overdue</Badge>}
+            {!item.assignedToUserId && <Badge variant="outline">Unassigned</Badge>}
+            <Badge variant="secondary">{item.kind}</Badge>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="whitespace-pre-wrap text-sm text-muted-foreground">
+          {item.description}
+        </p>
+        <div className="grid gap-3 md:grid-cols-3">
+          <label className="space-y-1 text-xs font-medium">
+            Status
+            <select
+              className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+              value={status}
+              onChange={(event) => setStatus(knownFeedbackStatus(event.target.value))}
+            >
+              {FEEDBACK_DESK_STATUSES.map((value) => (
+                <option key={value} value={value}>{feedbackStatusLabel(value)}</option>
+              ))}
+            </select>
+          </label>
+          <label className="space-y-1 text-xs font-medium">
+            Priority
+            <select
+              className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+              value={priority}
+              onChange={(event) => setPriority(knownFeedbackPriority(event.target.value))}
+            >
+              {FEEDBACK_PRIORITIES.map((value) => (
+                <option key={value} value={value}>{value}</option>
+              ))}
+            </select>
+          </label>
+          <label className="space-y-1 text-xs font-medium">
+            Owner
+            <select
+              className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+              value={assignee}
+              onChange={(event) => setAssignee(event.target.value)}
+            >
+              <option value="">Unassigned</option>
+              {assignees.map((value) => (
+                <option key={value.id} value={value.id}>{value.name}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <div className="grid gap-3 md:grid-cols-2">
+          <label className="space-y-1 text-xs font-medium">
+            GitHub issue
+            <input
+              className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+              type="url"
+              value={issueUrl}
+              onChange={(event) => setIssueUrl(event.target.value)}
+              placeholder="https://github.com/.../issues/..."
+            />
+          </label>
+          <label className="space-y-1 text-xs font-medium">
+            Pull request
+            <input
+              className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+              type="url"
+              value={prUrl}
+              onChange={(event) => setPrUrl(event.target.value)}
+              placeholder="https://github.com/.../pull/..."
+            />
+          </label>
+        </div>
+        <label className="block space-y-1 text-xs font-medium">
+          Requester update (optional)
+          <textarea
+            className="min-h-20 w-full rounded-md border bg-background px-3 py-2 text-sm"
+            value={message}
+            onChange={(event) => setMessage(event.target.value)}
+            placeholder="Explain what changed or what information is needed."
+          />
+        </label>
+        <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
+          <span>SLA target: {formatDate(item.slaTargetAt)}</span>
+          <div className="flex items-center gap-3">
+            {item.githubIssueUrl && (
+              <Link className="inline-flex items-center gap-1 hover:text-foreground" href={item.githubIssueUrl} target="_blank">
+                Issue <IconExternalLink className="size-3" />
+              </Link>
+            )}
+            {item.githubDraftPullRequestUrl && (
+              <Link className="inline-flex items-center gap-1 hover:text-foreground" href={item.githubDraftPullRequestUrl} target="_blank">
+                PR <IconExternalLink className="size-3" />
+              </Link>
+            )}
+            <Button size="sm" disabled={pending} onClick={save}>
+              {pending ? "Saving..." : "Save and notify"}
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function FeedbackDeskAdmin({ overview }: Readonly<{
+  overview: FeedbackAdminOverview
+}>) {
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+  const openItems = overview.items.filter(
+    (item) => item.status !== "closed" && item.status !== "deployed",
+  )
+  const overdue = openItems.filter((item) => item.overdue).length
+  const unassigned = openItems.filter((item) => !item.assignedToUserId).length
+
+  function reconcile(): void {
+    startTransition(async () => {
+      const result = await runFeedbackAdminMaintenance()
+      if (!result.success) {
+        toast.error(result.error ?? "Reconciliation failed")
+        return
+      }
+      toast.success("Feedback reconciliation completed")
+      router.refresh()
+    })
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-4 md:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-primary">Compass operations</p>
+          <h1 className="text-2xl font-semibold tracking-tight">Feedback Desk</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Organization-wide triage, ownership, requester communication, and bridge health.
+          </p>
+        </div>
+        <Button variant="outline" disabled={pending} onClick={reconcile}>
+          <IconRefresh className={pending ? "animate-spin" : undefined} />
+          {pending ? "Reconciling..." : "Reconcile now"}
+        </Button>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <Card><CardHeader><CardDescription>Open</CardDescription><CardTitle>{openItems.length}</CardTitle></CardHeader></Card>
+        <Card><CardHeader><CardDescription>Unassigned</CardDescription><CardTitle>{unassigned}</CardTitle></CardHeader></Card>
+        <Card><CardHeader><CardDescription>SLA overdue</CardDescription><CardTitle>{overdue}</CardTitle></CardHeader></Card>
+        <Card><CardHeader><CardDescription>Failed bridge events</CardDescription><CardTitle>{overview.bridge.failed}</CardTitle></CardHeader></Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Lifecycle health</CardTitle>
+          <CardDescription>
+            Pending {overview.bridge.pending} · Processing {overview.bridge.processing} · Oldest pending {formatDate(overview.bridge.oldestPendingAt)}
+          </CardDescription>
+          {overview.lastMaintenance && (
+            <CardDescription>
+              Last reconciliation {overview.lastMaintenance.status} · {formatDate(overview.lastMaintenance.completedAt ?? overview.lastMaintenance.startedAt)}
+            </CardDescription>
+          )}
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-3">
+          {overview.health.length === 0 && (
+            <p className="text-sm text-muted-foreground">No service heartbeat has been recorded yet.</p>
+          )}
+          {overview.health.map((service) => (
+            <div key={service.serviceName} className="rounded-md border p-3 text-sm">
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-medium">{service.serviceName}</span>
+                <Badge variant={service.status === "healthy" && !service.stale ? "secondary" : "destructive"}>
+                  {service.stale ? "stale" : service.status}
+                </Badge>
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">Heartbeat {formatDate(service.lastHeartbeatAt)}</p>
+              {service.lastError && <p className="mt-1 text-xs text-destructive">{service.lastError}</p>}
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <div className="space-y-3">
+        {overview.items.map((item) => (
+          <RequestEditor key={item.id} item={item} assignees={overview.assignees} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/db/schema-jarvis.ts
+++ b/src/db/schema-jarvis.ts
@@ -26,6 +26,14 @@ export const feedbackDeskItems = sqliteTable(
     githubIssueUrl: text("github_issue_url"),
     githubIssueNodeId: text("github_issue_node_id"),
     githubDraftPullRequestUrl: text("github_draft_pull_request_url"),
+    assignedToUserId: text("assigned_to_user_id"),
+    assignedToName: text("assigned_to_name"),
+    slaTargetAt: text("sla_target_at"),
+    triagedAt: text("triaged_at"),
+    resolvedAt: text("resolved_at"),
+    lastRequesterUpdateAt: text("last_requester_update_at"),
+    lastGithubSyncAt: text("last_github_sync_at"),
+    privacyScrubbedAt: text("privacy_scrubbed_at"),
     metadata: text("metadata"),
     createdAt: text("created_at").notNull(),
     updatedAt: text("updated_at").notNull(),
@@ -39,6 +47,56 @@ export const feedbackDeskItems = sqliteTable(
       table.organizationId,
       table.status,
       table.createdAt,
+    ),
+    index("feedback_desk_owner_sla_idx").on(
+      table.organizationId,
+      table.assignedToUserId,
+      table.slaTargetAt,
+    ),
+  ],
+)
+
+export const feedbackServiceHealth = sqliteTable(
+  "feedback_service_health",
+  {
+    serviceName: text("service_name").primaryKey(),
+    organizationId: text("organization_id"),
+    status: text("status").notNull(),
+    lastHeartbeatAt: text("last_heartbeat_at").notNull(),
+    lastSuccessAt: text("last_success_at"),
+    lastFailureAt: text("last_failure_at"),
+    consecutiveFailures: integer("consecutive_failures").notNull().default(0),
+    lastError: text("last_error"),
+    metadata: text("metadata"),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    index("feedback_service_health_org_idx").on(
+      table.organizationId,
+      table.updatedAt,
+    ),
+  ],
+)
+
+export const feedbackMaintenanceRuns = sqliteTable(
+  "feedback_maintenance_runs",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id"),
+    operation: text("operation").notNull(),
+    source: text("source").notNull(),
+    status: text("status").notNull(),
+    processedCount: integer("processed_count").notNull().default(0),
+    updatedCount: integer("updated_count").notNull().default(0),
+    failedCount: integer("failed_count").notNull().default(0),
+    summary: text("summary"),
+    startedAt: text("started_at").notNull(),
+    completedAt: text("completed_at"),
+  },
+  (table) => [
+    index("feedback_maintenance_runs_org_idx").on(
+      table.organizationId,
+      table.startedAt,
     ),
   ],
 )
@@ -86,3 +144,7 @@ export type JarvisBridgeEvent =
   typeof jarvisBridgeEvents.$inferSelect
 export type NewJarvisBridgeEvent =
   typeof jarvisBridgeEvents.$inferInsert
+export type FeedbackServiceHealth =
+  typeof feedbackServiceHealth.$inferSelect
+export type FeedbackMaintenanceRun =
+  typeof feedbackMaintenanceRuns.$inferSelect

--- a/src/db/schema-jarvis.ts
+++ b/src/db/schema-jarvis.ts
@@ -25,6 +25,8 @@ export const feedbackDeskItems = sqliteTable(
     threadId: text("thread_id"),
     githubIssueUrl: text("github_issue_url"),
     githubIssueNodeId: text("github_issue_node_id"),
+    githubIssueCreationApprovedAt: text("github_issue_creation_approved_at"),
+    githubIssueCreationApprovedBy: text("github_issue_creation_approved_by"),
     githubDraftPullRequestUrl: text("github_draft_pull_request_url"),
     assignedToUserId: text("assigned_to_user_id"),
     assignedToName: text("assigned_to_name"),
@@ -52,6 +54,11 @@ export const feedbackDeskItems = sqliteTable(
       table.organizationId,
       table.assignedToUserId,
       table.slaTargetAt,
+    ),
+    index("feedback_desk_github_review_idx").on(
+      table.organizationId,
+      table.githubIssueUrl,
+      table.githubIssueCreationApprovedAt,
     ),
   ],
 )

--- a/src/lib/jarvis/__tests__/feedback-lifecycle.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-lifecycle.test.ts
@@ -12,6 +12,7 @@ import {
   knownFeedbackPriority,
   knownFeedbackStatus,
 } from "@/lib/jarvis/feedback-lifecycle"
+import { feedbackGithubLinkAction } from "@/lib/jarvis/feedback-maintenance"
 
 describe("Feedback Desk lifecycle", () => {
   it("uses staff-facing labels for every visible lifecycle state", () => {
@@ -104,5 +105,20 @@ describe("Feedback Desk lifecycle", () => {
   it("normalizes unexpected stored lifecycle values safely", () => {
     expect(knownFeedbackStatus("unexpected")).toBe("new")
     expect(knownFeedbackPriority("unexpected")).toBe("normal")
+  })
+
+  it("requires review before creating a missing historical GitHub issue", () => {
+    expect(feedbackGithubLinkAction({
+      githubIssueUrl: null,
+      githubIssueCreationApprovedAt: null,
+    })).toBe("review")
+    expect(feedbackGithubLinkAction({
+      githubIssueUrl: null,
+      githubIssueCreationApprovedAt: "2026-08-05T12:00:00.000Z",
+    })).toBe("create")
+    expect(feedbackGithubLinkAction({
+      githubIssueUrl: "https://github.com/example/compass/issues/1",
+      githubIssueCreationApprovedAt: null,
+    })).toBe("repair")
   })
 })

--- a/src/lib/jarvis/__tests__/feedback-lifecycle.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-lifecycle.test.ts
@@ -7,6 +7,10 @@ import {
   feedbackRequesterUpdateKind,
   feedbackStatusMessage,
   feedbackStatusUsesEmail,
+  feedbackIsOverdue,
+  feedbackSlaTarget,
+  knownFeedbackPriority,
+  knownFeedbackStatus,
 } from "@/lib/jarvis/feedback-lifecycle"
 
 describe("Feedback Desk lifecycle", () => {
@@ -81,5 +85,24 @@ describe("Feedback Desk lifecycle", () => {
         "https://github.com/High-Performance-Structures/compass/pull/43",
       ),
     ).toBe("draft_pull_request_updated")
+  })
+
+  it("sets tighter response targets for higher priorities", () => {
+    const start = new Date("2026-08-05T12:00:00.000Z")
+    expect(feedbackSlaTarget("urgent", start)).toBe("2026-08-05T16:00:00.000Z")
+    expect(feedbackSlaTarget("normal", start)).toBe("2026-08-08T12:00:00.000Z")
+    expect(feedbackSlaTarget("low", start)).toBe("2026-08-12T12:00:00.000Z")
+  })
+
+  it("flags overdue open work but never resolved work", () => {
+    const now = new Date("2026-08-05T12:00:00.000Z")
+    expect(feedbackIsOverdue("in_progress", "2026-08-05T11:59:59.000Z", now)).toBe(true)
+    expect(feedbackIsOverdue("deployed", "2026-08-05T11:59:59.000Z", now)).toBe(false)
+    expect(feedbackIsOverdue("new", null, now)).toBe(false)
+  })
+
+  it("normalizes unexpected stored lifecycle values safely", () => {
+    expect(knownFeedbackStatus("unexpected")).toBe("new")
+    expect(knownFeedbackPriority("unexpected")).toBe("normal")
   })
 })

--- a/src/lib/jarvis/feedback-desk.ts
+++ b/src/lib/jarvis/feedback-desk.ts
@@ -5,6 +5,7 @@ import {
   jarvisBridgeEvents,
   type FeedbackDeskItem,
 } from "@/db/schema-jarvis"
+import { feedbackSlaTarget } from "@/lib/jarvis/feedback-lifecycle"
 
 type CompassDb = ReturnType<typeof getDb>
 
@@ -132,6 +133,7 @@ export async function enqueueFeedbackDeskItem(
       metadata: input.metadata
         ? JSON.stringify(input.metadata)
         : null,
+      slaTargetAt: feedbackSlaTarget("normal"),
       createdAt: now,
       updatedAt: now,
     })

--- a/src/lib/jarvis/feedback-desk.ts
+++ b/src/lib/jarvis/feedback-desk.ts
@@ -51,6 +51,7 @@ type CreateFeedbackDeskItemInput = {
   readonly messageId?: string | null
   readonly threadId?: string | null
   readonly githubIssueUrl?: string | null
+  readonly historicalImport?: boolean
   readonly metadata?: Readonly<Record<string, unknown>>
 }
 
@@ -153,6 +154,10 @@ export async function enqueueFeedbackDeskItem(
   if (!item) {
     throw new Error("Failed to create feedback desk item")
   }
+
+  // Backfills should restore the durable record without replaying old intake
+  // or receipt notifications as if the request had just been submitted.
+  if (input.historicalImport) return item
 
   const payload = {
     schemaVersion: 1,

--- a/src/lib/jarvis/feedback-github-sync.ts
+++ b/src/lib/jarvis/feedback-github-sync.ts
@@ -1,13 +1,15 @@
-import { eq } from "drizzle-orm"
-
 import type { getDb } from "@/db"
-import { feedbackDeskItems, jarvisBridgeEvents, type FeedbackDeskItem } from "@/db/schema-jarvis"
+import { type FeedbackDeskItem } from "@/db/schema-jarvis"
 import { getJarvisEnvValue } from "@/lib/jarvis/auth"
 import {
   GITHUB_FEEDBACK_PROJECT_TITLE,
   feedbackReference,
 } from "@/lib/jarvis/feedback-github-content"
-import { feedbackStatusLabel, type FeedbackDeskStatus } from "@/lib/jarvis/feedback-lifecycle"
+import {
+  knownFeedbackStatus,
+  type FeedbackDeskStatus,
+} from "@/lib/jarvis/feedback-lifecycle"
+import { applyFeedbackLifecycleUpdate } from "@/lib/jarvis/feedback-status-update"
 
 type CompassDb = ReturnType<typeof getDb>
 type GithubProjectState = Readonly<{
@@ -16,6 +18,7 @@ type GithubProjectState = Readonly<{
   issueUrl: string
   issueState: string
   projectStatus: string | null
+  pullRequestUrl: string | null
 }>
 
 function objectValue(value: unknown): Record<string, unknown> | null {
@@ -61,6 +64,12 @@ function projectStatesFromGraphql(value: unknown): readonly GithubProjectState[]
       issueUrl,
       issueState: stringValue(content, "state") ?? "OPEN",
       projectStatus: projectStatusFromFieldValues(projectItem?.fieldValues),
+      pullRequestUrl: (() => {
+        const pullRequests = objectValue(content?.closedByPullRequestsReferences)?.nodes
+        if (!Array.isArray(pullRequests)) return null
+        const latest = pullRequests.at(-1)
+        return stringValue(objectValue(latest), "url")
+      })(),
     })
   }
   return results
@@ -136,7 +145,17 @@ async function githubProjectStates(env: CloudflareEnv): Promise<readonly GithubP
             ... on ProjectV2 {
               items(first: 100) {
                 nodes {
-                  content { ... on Issue { id title url state } }
+                  content {
+                    ... on Issue {
+                      id
+                      title
+                      url
+                      state
+                      closedByPullRequestsReferences(first: 10) {
+                        nodes { url }
+                      }
+                    }
+                  }
                   fieldValues(first: 20) {
                     nodes {
                       ... on ProjectV2ItemFieldSingleSelectValue {
@@ -182,46 +201,28 @@ export async function syncFeedbackDeskItemsFromGithub(
         : undefined
     if (!state) continue
     const nextStatus = feedbackStatusFromGithub(state.projectStatus, state.issueState)
-    const needsLink = item.githubIssueNodeId === null
+    const needsLink =
+      item.githubIssueNodeId !== state.issueNodeId ||
+      item.githubIssueUrl !== state.issueUrl
     const needsStatus = nextStatus !== null && nextStatus !== item.status
-    if (!needsLink && !needsStatus) continue
+    const needsPullRequest =
+      state.pullRequestUrl !== null &&
+      state.pullRequestUrl !== item.githubDraftPullRequestUrl
+    if (!needsLink && !needsStatus && !needsPullRequest) continue
 
-    const now = new Date().toISOString()
     const message = state.projectStatus
       ? `The Feedback Desk moved this request to ${state.projectStatus}.`
       : `The linked GitHub issue is now ${state.issueState.toLowerCase()}.`
-    await db.update(feedbackDeskItems).set({
-      status: nextStatus ?? item.status,
+    await applyFeedbackLifecycleUpdate(db, item, {
+      status: nextStatus ?? knownFeedbackStatus(item.status),
+      message,
       githubIssueNodeId: state.issueNodeId,
       githubIssueUrl: state.issueUrl,
-      updatedAt: now,
+      draftPullRequestUrl: state.pullRequestUrl ?? undefined,
+      actorSource: "github",
+      idempotencyKey:
+        `github-status:${item.id}:${nextStatus ?? item.status}:${state.projectStatus ?? state.issueState}`,
     })
-      .where(eq(feedbackDeskItems.id, item.id))
-    if (needsStatus && nextStatus) await db.insert(jarvisBridgeEvents).values({
-      id: crypto.randomUUID(),
-      organizationId: item.organizationId,
-      direction: "inbound",
-      source: "github",
-      eventType: "feedback.status_updated",
-      status: "completed",
-      idempotencyKey: `github-status:${item.id}:${nextStatus}:${state.projectStatus ?? state.issueState}`,
-      feedbackDeskItemId: item.id,
-      payload: JSON.stringify({
-        source: "github-project",
-        projectStatus: state.projectStatus,
-        issueState: state.issueState,
-      }),
-      result: JSON.stringify({
-        status: nextStatus,
-        label: feedbackStatusLabel(nextStatus),
-        message,
-        updatedAt: now,
-      }),
-      availableAt: now,
-      completedAt: now,
-      createdAt: now,
-      updatedAt: now,
-    }).onConflictDoNothing()
     updatedCount += 1
   }
   return updatedCount

--- a/src/lib/jarvis/feedback-github.ts
+++ b/src/lib/jarvis/feedback-github.ts
@@ -22,12 +22,18 @@ type GitHubFeedbackConfig = Readonly<{
 type GitHubIssueResponse = Readonly<{
   html_url?: unknown
   node_id?: unknown
+  state?: unknown
 }>
 
 type GraphqlResponse = Readonly<{
   errors?: ReadonlyArray<Readonly<{ message?: unknown }>>
   data?: Readonly<{
     viewer?: Readonly<{
+      projectsV2?: Readonly<{
+        nodes?: ReadonlyArray<Readonly<{ id?: unknown; title?: unknown }>>
+      }>
+    }>
+    organization?: Readonly<{
       projectsV2?: Readonly<{
         nodes?: ReadonlyArray<Readonly<{ id?: unknown; title?: unknown }>>
       }>
@@ -81,14 +87,14 @@ async function feedbackProjectId(
 
   const result = await githubGraphql(
     config,
-    `query FeedbackProject($first: Int!) {
-      viewer {
+    `query FeedbackProject($owner: String!, $first: Int!) {
+      organization(login: $owner) {
         projectsV2(first: $first) { nodes { id title } }
       }
     }`,
-    { first: 100 },
+    { owner: config.repo.split("/")[0] ?? "", first: 100 },
   )
-  const projects = result?.data?.viewer?.projectsV2?.nodes ?? []
+  const projects = result?.data?.organization?.projectsV2?.nodes ?? []
   const matchingProject = projects.find(
     (project) => project.title === GITHUB_FEEDBACK_PROJECT_TITLE,
   )
@@ -137,8 +143,34 @@ export async function linkFeedbackDeskItemToGithub(
   if (!config) return null
 
   if (item.githubIssueUrl) {
-    if (item.githubIssueNodeId) {
-      await addIssueToFeedbackProject(config, item.githubIssueNodeId)
+    let nodeId = item.githubIssueNodeId
+    if (!nodeId) {
+      const match = item.githubIssueUrl.match(
+        /^https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)(?:\/|$)/,
+      )
+      if (match?.[1] === config.repo && match[2]) {
+        try {
+          const response = await fetch(
+            `https://api.github.com/repos/${config.repo}/issues/${match[2]}`,
+            { headers: githubHeaders(config.token) },
+          )
+          if (response.ok) {
+            const issue = await response.json() as GitHubIssueResponse
+            if (typeof issue.node_id === "string") {
+              nodeId = issue.node_id
+              await db.update(feedbackDeskItems).set({
+                githubIssueNodeId: nodeId,
+                updatedAt: new Date().toISOString(),
+              }).where(eq(feedbackDeskItems.id, item.id))
+            }
+          }
+        } catch {
+          // The next maintenance run will retry this safe lookup.
+        }
+      }
+    }
+    if (nodeId) {
+      await addIssueToFeedbackProject(config, nodeId)
     }
     return item.githubIssueUrl
   }

--- a/src/lib/jarvis/feedback-lifecycle.ts
+++ b/src/lib/jarvis/feedback-lifecycle.ts
@@ -12,6 +12,17 @@ export const FEEDBACK_DESK_STATUSES = [
 export type FeedbackDeskStatus =
   (typeof FEEDBACK_DESK_STATUSES)[number]
 
+export const FEEDBACK_PRIORITIES = ["low", "normal", "high", "urgent"] as const
+export type FeedbackPriority = (typeof FEEDBACK_PRIORITIES)[number]
+
+export function knownFeedbackStatus(value: string): FeedbackDeskStatus {
+  return FEEDBACK_DESK_STATUSES.find((status) => status === value) ?? "new"
+}
+
+export function knownFeedbackPriority(value: string): FeedbackPriority {
+  return FEEDBACK_PRIORITIES.find((priority) => priority === value) ?? "normal"
+}
+
 export type FeedbackStaffStage =
   | "submitted"
   | "triaged"
@@ -122,5 +133,42 @@ export function feedbackStatusUsesEmail(
     status === "needs_info" ||
     status === "testing" ||
     status === "deployed"
+  )
+}
+
+const SLA_HOURS_BY_PRIORITY = {
+  low: 168,
+  normal: 72,
+  high: 24,
+  urgent: 4,
+} as const
+
+export function feedbackSlaTarget(
+  priority: string,
+  from = new Date(),
+): string {
+  const hours =
+    priority === "urgent" ||
+    priority === "high" ||
+    priority === "normal" ||
+    priority === "low"
+      ? SLA_HOURS_BY_PRIORITY[priority]
+      : SLA_HOURS_BY_PRIORITY.normal
+  return new Date(from.getTime() + hours * 60 * 60 * 1_000).toISOString()
+}
+
+export function feedbackIsResolved(status: string): boolean {
+  return status === "deployed" || status === "closed"
+}
+
+export function feedbackIsOverdue(
+  status: string,
+  slaTargetAt: string | null,
+  now = new Date(),
+): boolean {
+  return (
+    !feedbackIsResolved(status) &&
+    slaTargetAt !== null &&
+    new Date(slaTargetAt).getTime() < now.getTime()
   )
 }

--- a/src/lib/jarvis/feedback-maintenance.ts
+++ b/src/lib/jarvis/feedback-maintenance.ts
@@ -29,11 +29,23 @@ export type FeedbackMaintenanceResult = Readonly<{
   processedCount: number
   recoveredCount: number
   linkedCount: number
+  missingLinkReviewCount: number
   syncedCount: number
   scrubbedCount: number
   slaBackfilledCount: number
   failedCount: number
 }>
+
+export function feedbackGithubLinkAction(
+  item: Pick<
+    FeedbackDeskItem,
+    "githubIssueUrl" | "githubIssueCreationApprovedAt"
+  >,
+): "repair" | "create" | "review" {
+  if (item.githubIssueUrl) return "repair"
+  if (item.githubIssueCreationApprovedAt) return "create"
+  return "review"
+}
 
 function objectValue(value: unknown): Record<string, unknown> | null {
   return typeof value === "object" && value !== null
@@ -99,6 +111,7 @@ async function recoverLegacyFeedback(
       reporterName: row.name,
       reporterEmail: row.email?.trim().toLowerCase() ?? null,
       githubIssueUrl: row.githubIssueUrl,
+      historicalImport: true,
       metadata: {
         legacyFeedback: true,
         recoveredAt: new Date().toISOString(),
@@ -147,6 +160,7 @@ async function recoverConfirmedPrompts(
       description: candidate.description,
       reporterName: reporter.name,
       reporterEmail: reporter.email,
+      historicalImport: true,
       metadata: {
         externalActorId: reporter.userId,
         confirmationEventId: event.id,
@@ -285,7 +299,13 @@ export async function runFeedbackMaintenance(
       ),
     )).orderBy(feedbackDeskItems.createdAt).limit(250)
     let linkedCount = 0
+    let missingLinkReviewCount = 0
     for (const item of items) {
+      const action = feedbackGithubLinkAction(item)
+      if (action === "review") {
+        missingLinkReviewCount += 1
+        continue
+      }
       const link = await linkFeedbackDeskItemToGithub(db, env, item)
       if (link) linkedCount += 1
       else failedCount += 1
@@ -318,6 +338,7 @@ export async function runFeedbackMaintenance(
       processedCount: allItems.length,
       recoveredCount,
       linkedCount,
+      missingLinkReviewCount,
       syncedCount,
       scrubbedCount: privacy.scrubbed,
       slaBackfilledCount,

--- a/src/lib/jarvis/feedback-maintenance.ts
+++ b/src/lib/jarvis/feedback-maintenance.ts
@@ -1,0 +1,360 @@
+import { and, desc, eq, isNull, or } from "drizzle-orm"
+
+import { getDb } from "@/db"
+import { feedback } from "@/db/schema"
+import {
+  feedbackDeskItems,
+  feedbackMaintenanceRuns,
+  feedbackServiceHealth,
+  jarvisBridgeEvents,
+  type FeedbackDeskItem,
+} from "@/db/schema-jarvis"
+import { getJarvisEnvValue } from "@/lib/jarvis/auth"
+import {
+  confirmedFeedbackReportFromPayload,
+  feedbackCandidateFromReport,
+} from "@/lib/jarvis/feedback-confirmation"
+import {
+  enqueueFeedbackDeskItem,
+  type FeedbackDeskKind,
+} from "@/lib/jarvis/feedback-desk"
+import { linkFeedbackDeskItemToGithub } from "@/lib/jarvis/feedback-github"
+import { githubFeedbackIssueContent } from "@/lib/jarvis/feedback-github-content"
+import { syncFeedbackDeskItemsFromGithub } from "@/lib/jarvis/feedback-github-sync"
+import { feedbackSlaTarget } from "@/lib/jarvis/feedback-lifecycle"
+
+type CompassDb = ReturnType<typeof getDb>
+
+export type FeedbackMaintenanceResult = Readonly<{
+  processedCount: number
+  recoveredCount: number
+  linkedCount: number
+  syncedCount: number
+  scrubbedCount: number
+  slaBackfilledCount: number
+  failedCount: number
+}>
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? Object.fromEntries(Object.entries(value))
+    : null
+}
+
+function stringValue(record: Record<string, unknown> | null, key: string): string | null {
+  const value = record?.[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null
+}
+
+function payloadReporter(payload: string): Readonly<{
+  userId: string | null
+  name: string | null
+  email: string | null
+}> {
+  try {
+    const parsed: unknown = JSON.parse(payload)
+    const user = objectValue(objectValue(parsed)?.user)
+    return {
+      userId: stringValue(user, "id"),
+      name: stringValue(user, "displayName") ?? stringValue(user, "name"),
+      email: stringValue(user, "email")?.toLowerCase() ?? null,
+    }
+  } catch {
+    return { userId: null, name: null, email: null }
+  }
+}
+
+function legacyKind(type: string): FeedbackDeskKind {
+  return type === "bug" || type === "feature" || type === "question"
+    ? type
+    : "general"
+}
+
+async function recoverLegacyFeedback(
+  db: CompassDb,
+  organizationId: string,
+): Promise<number> {
+  const rows = await db.select().from(feedback)
+    .orderBy(desc(feedback.createdAt))
+    .limit(500)
+  const existing = await db.select({ sourceId: feedbackDeskItems.sourceId })
+    .from(feedbackDeskItems)
+    .where(and(
+      eq(feedbackDeskItems.organizationId, organizationId),
+      eq(feedbackDeskItems.source, "feedback-widget"),
+    ))
+  const sourceIds = new Set(existing.map((row) => row.sourceId))
+  let count = 0
+  for (const row of rows) {
+    if (sourceIds.has(row.id)) continue
+    await enqueueFeedbackDeskItem(db, {
+      organizationId,
+      source: "feedback-widget",
+      sourceId: row.id,
+      kind: legacyKind(row.type),
+      title: row.message.trim().slice(0, 160),
+      description: row.message.trim(),
+      reporterName: row.name,
+      reporterEmail: row.email?.trim().toLowerCase() ?? null,
+      githubIssueUrl: row.githubIssueUrl,
+      metadata: {
+        legacyFeedback: true,
+        recoveredAt: new Date().toISOString(),
+      },
+    })
+    sourceIds.add(row.id)
+    count += 1
+  }
+  return count
+}
+
+async function recoverConfirmedPrompts(
+  db: CompassDb,
+  organizationId: string,
+): Promise<number> {
+  const events = await db.select({
+    id: jarvisBridgeEvents.id,
+    payload: jarvisBridgeEvents.payload,
+    createdAt: jarvisBridgeEvents.createdAt,
+  }).from(jarvisBridgeEvents).where(and(
+    eq(jarvisBridgeEvents.organizationId, organizationId),
+    eq(jarvisBridgeEvents.direction, "outbound"),
+    eq(jarvisBridgeEvents.source, "ask-jarvis"),
+    eq(jarvisBridgeEvents.eventType, "agent.prompt"),
+  )).orderBy(desc(jarvisBridgeEvents.createdAt)).limit(1_000)
+  const existing = await db.select({ sourceId: feedbackDeskItems.sourceId })
+    .from(feedbackDeskItems)
+    .where(and(
+      eq(feedbackDeskItems.organizationId, organizationId),
+      eq(feedbackDeskItems.source, "ask-jarvis"),
+    ))
+  const sourceIds = new Set(existing.map((row) => row.sourceId))
+  let count = 0
+  for (const event of events) {
+    if (sourceIds.has(event.id)) continue
+    const report = confirmedFeedbackReportFromPayload(event.payload)
+    if (!report) continue
+    const reporter = payloadReporter(event.payload)
+    const candidate = feedbackCandidateFromReport(report)
+    await enqueueFeedbackDeskItem(db, {
+      organizationId,
+      source: "ask-jarvis",
+      sourceId: event.id,
+      kind: candidate.kind,
+      title: candidate.title,
+      description: candidate.description,
+      reporterName: reporter.name,
+      reporterEmail: reporter.email,
+      metadata: {
+        externalActorId: reporter.userId,
+        confirmationEventId: event.id,
+        recoveredFromConfirmedPrompt: true,
+        confirmedAt: event.createdAt,
+      },
+    })
+    sourceIds.add(event.id)
+    count += 1
+  }
+  return count
+}
+
+function githubIssueNumber(url: string, repo: string): string | null {
+  const escapedRepo = repo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const match = url.match(new RegExp(
+    `^https://github\\.com/${escapedRepo}/issues/(\\d+)(?:/|$)`,
+  ))
+  return match?.[1] ?? null
+}
+
+async function scrubLegacyGithubIssues(
+  db: CompassDb,
+  env: CloudflareEnv,
+  items: readonly FeedbackDeskItem[],
+): Promise<Readonly<{ scrubbed: number; failed: number }>> {
+  const token = getJarvisEnvValue(env, "GITHUB_TOKEN")
+  const repo = getJarvisEnvValue(env, "GITHUB_REPO")
+  if (!token || !repo) return { scrubbed: 0, failed: 0 }
+  let scrubbed = 0
+  let failed = 0
+  for (const item of items) {
+    if (item.privacyScrubbedAt || !item.githubIssueUrl) continue
+    const issueNumber = githubIssueNumber(item.githubIssueUrl, repo)
+    if (!issueNumber) continue
+    const content = githubFeedbackIssueContent(item)
+    try {
+      const response = await fetch(
+        `https://api.github.com/repos/${repo}/issues/${issueNumber}`,
+        {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "User-Agent": "compass-feedback-desk",
+          },
+          body: JSON.stringify({ title: content.title, body: content.body }),
+        },
+      )
+      if (!response.ok) {
+        failed += 1
+        continue
+      }
+      const now = new Date().toISOString()
+      await db.update(feedbackDeskItems).set({
+        privacyScrubbedAt: now,
+        updatedAt: now,
+      }).where(eq(feedbackDeskItems.id, item.id))
+      scrubbed += 1
+    } catch {
+      failed += 1
+    }
+  }
+  return { scrubbed, failed }
+}
+
+export async function recordFeedbackServiceHealth(
+  db: CompassDb,
+  input: Readonly<{
+    serviceName: string
+    organizationId: string | null
+    status: "healthy" | "degraded" | "failed"
+    error?: string | null
+    metadata?: Readonly<Record<string, unknown>>
+  }>,
+): Promise<void> {
+  const now = new Date().toISOString()
+  const existing = await db.select().from(feedbackServiceHealth)
+    .where(eq(feedbackServiceHealth.serviceName, input.serviceName)).get()
+  const failed = input.status === "failed"
+  await db.insert(feedbackServiceHealth).values({
+    serviceName: input.serviceName,
+    organizationId: input.organizationId,
+    status: input.status,
+    lastHeartbeatAt: now,
+    lastSuccessAt: failed ? existing?.lastSuccessAt ?? null : now,
+    lastFailureAt: failed ? now : existing?.lastFailureAt ?? null,
+    consecutiveFailures: failed ? (existing?.consecutiveFailures ?? 0) + 1 : 0,
+    lastError: input.error ?? null,
+    metadata: input.metadata ? JSON.stringify(input.metadata) : null,
+    updatedAt: now,
+  }).onConflictDoUpdate({
+    target: feedbackServiceHealth.serviceName,
+    set: {
+      organizationId: input.organizationId,
+      status: input.status,
+      lastHeartbeatAt: now,
+      lastSuccessAt: failed ? existing?.lastSuccessAt ?? null : now,
+      lastFailureAt: failed ? now : existing?.lastFailureAt ?? null,
+      consecutiveFailures: failed ? (existing?.consecutiveFailures ?? 0) + 1 : 0,
+      lastError: input.error ?? null,
+      metadata: input.metadata ? JSON.stringify(input.metadata) : null,
+      updatedAt: now,
+    },
+  })
+}
+
+export async function runFeedbackMaintenance(
+  env: CloudflareEnv,
+  source: "cron" | "admin",
+): Promise<FeedbackMaintenanceResult> {
+  const db = getDb(env.DB)
+  const organizationId = getJarvisEnvValue(env, "JARVIS_BRIDGE_ORGANIZATION_ID")
+  if (!organizationId) throw new Error("JARVIS_BRIDGE_ORGANIZATION_ID is required")
+  const runId = crypto.randomUUID()
+  const startedAt = new Date().toISOString()
+  await db.insert(feedbackMaintenanceRuns).values({
+    id: runId,
+    organizationId,
+    operation: "reconcile",
+    source,
+    status: "running",
+    startedAt,
+  })
+  let failedCount = 0
+  try {
+    const recoveredCount =
+      await recoverLegacyFeedback(db, organizationId) +
+      await recoverConfirmedPrompts(db, organizationId)
+    const items = await db.select().from(feedbackDeskItems).where(and(
+      eq(feedbackDeskItems.organizationId, organizationId),
+      or(
+        isNull(feedbackDeskItems.githubIssueUrl),
+        isNull(feedbackDeskItems.githubIssueNodeId),
+      ),
+    )).orderBy(feedbackDeskItems.createdAt).limit(250)
+    let linkedCount = 0
+    for (const item of items) {
+      const link = await linkFeedbackDeskItemToGithub(db, env, item)
+      if (link) linkedCount += 1
+      else failedCount += 1
+    }
+    const allItems = await db.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.organizationId, organizationId))
+      .orderBy(desc(feedbackDeskItems.updatedAt)).limit(500)
+    let slaBackfilledCount = 0
+    for (const item of allItems) {
+      if (item.slaTargetAt !== null) continue
+      await db.update(feedbackDeskItems).set({
+        slaTargetAt: feedbackSlaTarget(item.priority, new Date(item.createdAt)),
+      }).where(eq(feedbackDeskItems.id, item.id))
+      slaBackfilledCount += 1
+    }
+    const itemsWithSla = allItems.map((item) => item.slaTargetAt !== null
+      ? item
+      : {
+          ...item,
+          slaTargetAt: feedbackSlaTarget(item.priority, new Date(item.createdAt)),
+        })
+    const syncedCount = await syncFeedbackDeskItemsFromGithub(db, env, itemsWithSla)
+    const privacy = await scrubLegacyGithubIssues(
+      db,
+      env,
+      itemsWithSla.filter((item) => item.source === "feedback-widget"),
+    )
+    failedCount += privacy.failed
+    const result = {
+      processedCount: allItems.length,
+      recoveredCount,
+      linkedCount,
+      syncedCount,
+      scrubbedCount: privacy.scrubbed,
+      slaBackfilledCount,
+      failedCount,
+    }
+    const completedAt = new Date().toISOString()
+    await db.update(feedbackMaintenanceRuns).set({
+      status: failedCount > 0 ? "partial" : "success",
+      processedCount: result.processedCount,
+      updatedCount:
+        recoveredCount + linkedCount + syncedCount + privacy.scrubbed +
+        slaBackfilledCount,
+      failedCount,
+      summary: JSON.stringify(result),
+      completedAt,
+    }).where(eq(feedbackMaintenanceRuns.id, runId))
+    await recordFeedbackServiceHealth(db, {
+      serviceName: "feedback-reconciler",
+      organizationId,
+      status: failedCount > 0 ? "degraded" : "healthy",
+      metadata: result,
+    })
+    return result
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error"
+    await db.update(feedbackMaintenanceRuns).set({
+      status: "failed",
+      failedCount: failedCount + 1,
+      summary: message,
+      completedAt: new Date().toISOString(),
+    }).where(eq(feedbackMaintenanceRuns.id, runId))
+    await recordFeedbackServiceHealth(db, {
+      serviceName: "feedback-reconciler",
+      organizationId,
+      status: "failed",
+      error: message,
+    })
+    throw error
+  }
+}

--- a/src/lib/jarvis/feedback-status-update.ts
+++ b/src/lib/jarvis/feedback-status-update.ts
@@ -1,0 +1,259 @@
+import { and, eq, or, sql } from "drizzle-orm"
+
+import type { getDb } from "@/db"
+import { organizationMembers, users } from "@/db/schema"
+import {
+  feedbackDeskItems,
+  jarvisBridgeEvents,
+  type FeedbackDeskItem,
+} from "@/db/schema-jarvis"
+import {
+  feedbackDraftPullRequestMessage,
+  feedbackIsResolved,
+  feedbackRequesterUpdateKind,
+  feedbackSlaTarget,
+  feedbackStatusLabel,
+  feedbackStatusMessage,
+  feedbackStatusUsesEmail,
+  type FeedbackDeskStatus,
+} from "@/lib/jarvis/feedback-lifecycle"
+import { createSystemNotificationEvent } from "@/lib/notifications/events"
+
+type CompassDb = ReturnType<typeof getDb>
+
+function metadataActorId(metadata: string | null): string | null {
+  if (!metadata) return null
+  try {
+    const parsed: unknown = JSON.parse(metadata)
+    if (typeof parsed !== "object" || parsed === null) return null
+    const actorId = Reflect.get(parsed, "externalActorId")
+    return typeof actorId === "string" && actorId.length > 0
+      ? actorId
+      : null
+  } catch {
+    return null
+  }
+}
+
+async function requesterRecipients(
+  db: CompassDb,
+  item: FeedbackDeskItem,
+): Promise<readonly { readonly userId: string; readonly email: string }[]> {
+  if (!item.organizationId) return []
+  const actorId = item.source === "ask-jarvis"
+    ? metadataActorId(item.metadata)
+    : null
+  const reporterEmail = item.reporterEmail?.trim().toLowerCase() ?? null
+  const filter = actorId && reporterEmail
+    ? or(
+        eq(users.id, actorId),
+        sql`lower(${users.email}) = ${reporterEmail}`,
+        sql`lower(${users.googleEmail}) = ${reporterEmail}`,
+      )
+    : actorId
+      ? eq(users.id, actorId)
+      : reporterEmail
+        ? or(
+            sql`lower(${users.email}) = ${reporterEmail}`,
+            sql`lower(${users.googleEmail}) = ${reporterEmail}`,
+          )
+        : null
+  if (!filter) return []
+  return db
+    .select({ userId: users.id, email: users.email })
+    .from(organizationMembers)
+    .innerJoin(users, eq(users.id, organizationMembers.userId))
+    .where(and(
+      eq(organizationMembers.organizationId, item.organizationId),
+      eq(users.isActive, true),
+      filter,
+    ))
+}
+
+export type FeedbackLifecycleUpdate = Readonly<{
+  status: FeedbackDeskStatus
+  priority?: "low" | "normal" | "high" | "urgent"
+  message?: string
+  githubIssueUrl?: string | null
+  githubIssueNodeId?: string | null
+  draftPullRequestUrl?: string | null
+  assignedToUserId?: string | null
+  assignedToName?: string | null
+  actorSource: string
+  idempotencyKey: string
+}>
+
+export async function applyFeedbackLifecycleUpdate(
+  db: CompassDb,
+  item: FeedbackDeskItem,
+  update: FeedbackLifecycleUpdate,
+): Promise<Readonly<{
+  changed: boolean
+  notifiedUserCount: number
+  requesterUpdateQueued: boolean
+}>> {
+  const priority = update.priority ?? item.priority
+  const issueUrl = update.githubIssueUrl === undefined
+    ? item.githubIssueUrl
+    : update.githubIssueUrl
+  const issueNodeId = update.githubIssueNodeId === undefined
+    ? item.githubIssueNodeId
+    : update.githubIssueNodeId
+  const draftUrl = update.draftPullRequestUrl === undefined
+    ? item.githubDraftPullRequestUrl
+    : update.draftPullRequestUrl
+  const assignedToUserId = update.assignedToUserId === undefined
+    ? item.assignedToUserId
+    : update.assignedToUserId
+  const assignedToName = update.assignedToName === undefined
+    ? item.assignedToName
+    : update.assignedToName
+  const lifecycleUpdateKind = feedbackRequesterUpdateKind(
+    item.status,
+    update.status,
+    item.githubDraftPullRequestUrl,
+    draftUrl,
+  )
+  const requesterUpdateKind = lifecycleUpdateKind ?? (
+    update.message?.trim() ? "status_changed" : null
+  )
+  const changed =
+    item.status !== update.status ||
+    item.priority !== priority ||
+    item.githubIssueUrl !== issueUrl ||
+    item.githubIssueNodeId !== issueNodeId ||
+    item.githubDraftPullRequestUrl !== draftUrl ||
+    item.assignedToUserId !== assignedToUserId ||
+    item.assignedToName !== assignedToName ||
+    update.message?.trim() !== undefined
+  if (!changed) {
+    return { changed: false, notifiedUserCount: 0, requesterUpdateQueued: false }
+  }
+
+  const now = new Date().toISOString()
+  const firstTriage = item.triagedAt === null && update.status !== "new"
+  const firstResolution = item.resolvedAt === null && feedbackIsResolved(update.status)
+  const priorityChanged = item.priority !== priority
+  const hasDraftUpdate = draftUrl !== null && draftUrl !== item.githubDraftPullRequestUrl
+  const message = update.message ?? (
+    hasDraftUpdate
+      ? feedbackDraftPullRequestMessage(item.title, draftUrl)
+      : feedbackStatusMessage(update.status, item.title)
+  )
+
+  const updateStatement = db.update(feedbackDeskItems).set({
+    status: update.status,
+    priority,
+    githubIssueUrl: issueUrl,
+    githubIssueNodeId: issueNodeId,
+    githubDraftPullRequestUrl: draftUrl,
+    assignedToUserId,
+    assignedToName,
+    slaTargetAt:
+      item.slaTargetAt === null || priorityChanged
+        ? feedbackSlaTarget(priority)
+        : item.slaTargetAt,
+    triagedAt: firstTriage ? now : item.triagedAt,
+    resolvedAt: firstResolution ? now : item.resolvedAt,
+    lastRequesterUpdateAt: requesterUpdateKind ? now : item.lastRequesterUpdateAt,
+    lastGithubSyncAt: update.actorSource === "github" ? now : item.lastGithubSyncAt,
+    updatedAt: now,
+  }).where(eq(feedbackDeskItems.id, item.id))
+
+  const recipients = requesterUpdateKind
+    ? await requesterRecipients(db, item)
+    : []
+  const payload = JSON.stringify({
+    schemaVersion: 1,
+    feedbackDeskItemId: item.id,
+    source: item.source,
+    sourceId: item.sourceId,
+    status: update.status,
+    title: item.title,
+    message,
+    reporter: {
+      name: item.reporterName,
+      email: item.reporterEmail,
+      externalActorId: metadataActorId(item.metadata),
+    },
+    compass: {
+      organizationId: item.organizationId,
+      channelId: item.channelId,
+      messageId: item.messageId,
+      threadId: item.threadId,
+    },
+    metadata: item.metadata,
+    githubIssueUrl: issueUrl,
+    draftPullRequestUrl: draftUrl,
+    notificationKind: requesterUpdateKind,
+    updatedAt: now,
+  })
+  const inboundStatement = db.insert(jarvisBridgeEvents).values({
+    id: crypto.randomUUID(),
+    organizationId: item.organizationId,
+    direction: "inbound",
+    source: update.actorSource,
+    eventType: "feedback.status_updated",
+    status: "completed",
+    idempotencyKey: update.idempotencyKey,
+    feedbackDeskItemId: item.id,
+    payload,
+    result: payload,
+    availableAt: now,
+    completedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  }).onConflictDoNothing()
+  if (requesterUpdateKind) {
+    const outboundStatement = db.insert(jarvisBridgeEvents).values({
+      id: crypto.randomUUID(),
+      organizationId: item.organizationId,
+      direction: "outbound",
+      source: item.source,
+      eventType: "feedback.status_changed",
+      idempotencyKey: `notify:${update.idempotencyKey}`,
+      feedbackDeskItemId: item.id,
+      payload,
+      availableAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoNothing()
+    await db.batch([updateStatement, inboundStatement, outboundStatement])
+  } else {
+    await db.batch([updateStatement, inboundStatement])
+  }
+
+  if (requesterUpdateKind && item.organizationId && recipients.length > 0) {
+    try {
+      await createSystemNotificationEvent({
+        organizationId: item.organizationId,
+        projectId: null,
+        eventType: `feedback.status.${update.status}`,
+        sourceType: "feedback",
+        sourceId: item.id,
+        title: `Request update: ${feedbackStatusLabel(update.status)}`,
+        body: message,
+        href: `/dashboard/requests/${encodeURIComponent(item.id)}`,
+        priority: update.status === "needs_info" ? "high" : "normal",
+        audience: "requester",
+        recipients,
+        delivery: {
+          inApp: true,
+          email: feedbackStatusUsesEmail(update.status),
+          push: feedbackStatusUsesEmail(update.status),
+        },
+      })
+    } catch (error) {
+      console.error("feedback_lifecycle_notification_failed", {
+        feedbackDeskItemId: item.id,
+        error: error instanceof Error ? error.message : "Unknown error",
+      })
+    }
+  }
+
+  return {
+    changed: true,
+    notifiedUserCount: requesterUpdateKind ? recipients.length : 0,
+    requesterUpdateQueued: requesterUpdateKind !== null,
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,7 +6,7 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "compass",
 	"account_id": "8716137c706ea3d5c209b330084fa9e2",
-	"main": ".open-next/worker.js",
+	"main": "custom-worker.ts",
 	"compatibility_date": "2025-12-01",
 	"compatibility_flags": [
 		"nodejs_compat",
@@ -18,6 +18,9 @@
 			"custom_domain": true
 		}
 	],
+	"triggers": {
+		"crons": ["*/10 * * * *"]
+	},
 	"assets": {
 		"binding": "ASSETS",
 		"directory": ".open-next/assets"


### PR DESCRIPTION
## What changed

- Adds an administrator Feedback Desk for organization-wide triage, assignment, SLA tracking, requester updates, and service health.
- Adds the developer/admin **My requests / All requests** filter.
- Recovers legacy Feedback and confirmed Ask Jarvis requests.
- Synchronizes existing GitHub issue/project status and closing pull requests.
- Adds scheduled Cloudflare reconciliation and relay health reporting.
- Adds a GitHub-link preview and explicit approval gate before historical requests can create new issues.
- Prevents recovered history from replaying stale receipt/intake notifications.
- Removes reporter personal information from new GitHub issue content and scrubs linked legacy widget issues.

## Why

Employee requests were being stored, but there was no reliable operating loop to assign them, synchronize engineering status, communicate progress back in Compass, or detect failed bridge services. Historical recovery also risked creating duplicate GitHub issues for work that may already exist.

## User and developer impact

Staff can see durable status and updates for their requests. Developers and administrators can view requests across the organization. Administrators can map completed or existing GitHub work first, then approve only genuinely untracked requests for new issue creation.

Production D1 migrations 0092 and 0093 have been applied. Missing historical links remain review-only until approved.

## Validation

- `bunx tsc --noEmit`
- `bunx eslint` on changed TypeScript/TSX files
- `bun test src/lib/jarvis/__tests__` — 33 passing
- Python bridge tests — 29 passing
- `bun run build`
- Local D1 migrations through 0093
- Production D1 migrations 0092 and 0093
