### PR TITLE
feat(schedule): select template to-dos during import

### DIFF
--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -42,6 +42,7 @@ import {
   formatTemplateChecklist,
   groupTemplateChecklistItems
 } from "@/lib/templates/template-checklist-hierarchy"
+import { selectTemplateTodos } from "@/lib/templates/template-todo-selection"
 import { isOwnerScheduleView, type OwnerScheduleView } from "@/lib/schedule/owner-visibility"
 import type {
   TaskStatus,
@@ -513,6 +514,7 @@ export async function createTask(
     subVendorVisible?: boolean
     confirmationRequired?: boolean
     templateScheduleItemId?: string | null
+    templateTodoIds?: readonly string[]
   }
 ): Promise<
   | {
@@ -551,6 +553,22 @@ export async function createTask(
       return {
         success: false,
         error: "That published template schedule item is no longer available."
+      }
+    }
+    if (!templateImport && (data.templateTodoIds?.length ?? 0) > 0) {
+      return {
+        success: false,
+        error: "Choose a published template schedule item before adding template to-dos."
+      }
+    }
+    const todoSelection = selectTemplateTodos(
+      templateImport?.linkedTodos ?? [],
+      data.templateTodoIds ?? []
+    )
+    if (todoSelection.missingIds.length > 0) {
+      return {
+        success: false,
+        error: "One or more selected template to-dos are no longer available."
       }
     }
 
@@ -599,36 +617,37 @@ export async function createTask(
       createdAt: now,
       updatedAt: now
     }
-    const linkedTodoRows: (typeof projectOperations.$inferInsert)[] =
-      templateImport?.linkedTodos.map((todo) => ({
-        id: crypto.randomUUID(),
-        projectId,
-        sourceSystem: "compass_template",
-        sourceRecordType: "schedule_task",
-        sourceRecordId: id,
-        title: todo.title,
-        description: todo.description,
-        status: "open",
-        priority: "normal",
-        assigneeType: "internal",
-        startDate: data.startDate,
-        dueDate: endDate,
-        sageWriteStatus: "not_ready",
-        sagePayloadJson: JSON.stringify({
-          source: "project_template_schedule_item",
-          templateId: templateImport.templateId,
-          templateName: templateImport.templateName,
-          versionId: templateImport.versionId,
-          scheduleTemplateItemId: templateImport.scheduleTemplateItemId,
-          templateContentItemId: todo.templateContentItemId,
-          sourceItemId: todo.sourceItemId,
-          checklistItems: todo.checklistItems
-        }),
-        syncDirection: "write",
-        syncStatus: "compass_only",
-        createdAt: now,
-        updatedAt: now
-      })) ?? []
+    const linkedTodoRows: (typeof projectOperations.$inferInsert)[] = templateImport
+      ? todoSelection.selected.map((todo) => ({
+          id: crypto.randomUUID(),
+          projectId,
+          sourceSystem: "compass_template",
+          sourceRecordType: "schedule_task",
+          sourceRecordId: id,
+          title: todo.title,
+          description: todo.description,
+          status: "open",
+          priority: "normal",
+          assigneeType: "internal",
+          startDate: data.startDate,
+          dueDate: endDate,
+          sageWriteStatus: "not_ready",
+          sagePayloadJson: JSON.stringify({
+            source: "project_template_schedule_item",
+            templateId: templateImport.templateId,
+            templateName: templateImport.templateName,
+            versionId: templateImport.versionId,
+            scheduleTemplateItemId: templateImport.scheduleTemplateItemId,
+            templateContentItemId: todo.templateContentItemId,
+            sourceItemId: todo.sourceItemId,
+            checklistItems: todo.checklistItems
+          }),
+          syncDirection: "write",
+          syncStatus: "compass_only",
+          createdAt: now,
+          updatedAt: now
+        }))
+      : []
 
     if (linkedTodoRows.length > 0) {
       // Keep each to-do in its own prepared statement. D1 limits the number of

--- a/src/components/schedule/schedule-item-form-dialog.tsx
+++ b/src/components/schedule/schedule-item-form-dialog.tsx
@@ -38,6 +38,7 @@ import {
   SelectValue
 } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Button } from "@/components/ui/button"
 import {
   createTask,
@@ -140,6 +141,8 @@ export function ScheduleItemFormDialog({
   const [templateLoading, setTemplateLoading] = useState(false)
   const [selectedTemplateId, setSelectedTemplateId] = useState("")
   const [selectedTemplateItemId, setSelectedTemplateItemId] = useState("")
+  const [selectedTemplateTodoIds, setSelectedTemplateTodoIds] = useState<readonly string[]>([])
+  const [templateTodosOpen, setTemplateTodosOpen] = useState(false)
 
   const existingPredecessors = useMemo(() => {
     if (!editingTask) return []
@@ -238,6 +241,8 @@ export function ScheduleItemFormDialog({
       setDetailsOpen(false)
       setSelectedTemplateId("")
       setSelectedTemplateItemId("")
+      setSelectedTemplateTodoIds([])
+      setTemplateTodosOpen(false)
     }
     setPendingPredecessors([])
   }, [assigneeOptions, editingTask, form, open])
@@ -277,6 +282,8 @@ export function ScheduleItemFormDialog({
 
   function applyTemplateScheduleItem(templateItemId: string): void {
     setSelectedTemplateItemId(templateItemId)
+    setSelectedTemplateTodoIds([])
+    setTemplateTodosOpen(false)
     const item = selectedTemplateGroup?.scheduleItems.find(
       (candidate) => candidate.id === templateItemId
     )
@@ -297,6 +304,8 @@ export function ScheduleItemFormDialog({
   function chooseTemplate(templateId: string): void {
     setSelectedTemplateId(templateId)
     setSelectedTemplateItemId("")
+    setSelectedTemplateTodoIds([])
+    setTemplateTodosOpen(false)
     form.setValue("title", "", { shouldDirty: true })
     form.setValue("workdays", 5, { shouldDirty: true })
     form.setValue("phase", "preconstruction", { shouldDirty: true })
@@ -314,6 +323,16 @@ export function ScheduleItemFormDialog({
     if (!watchedStart || !watchedWorkdays || watchedWorkdays < 1) return ""
     return calculateEndDate(watchedStart, watchedWorkdays, exceptions)
   }, [exceptions, watchedStart, watchedWorkdays])
+
+  function toggleTemplateTodo(todoId: string, selected: boolean): void {
+    setSelectedTemplateTodoIds((current) =>
+      selected
+        ? current.includes(todoId)
+          ? current
+          : [...current, todoId]
+        : current.filter((id) => id !== todoId)
+    )
+  }
 
   async function onSubmit(values: ScheduleItemFormValues) {
     const { notes, ...taskValues } = values
@@ -336,7 +355,8 @@ export function ScheduleItemFormDialog({
         ...taskValues,
         assignedTo: taskValues.assignedTo || undefined,
         assignedOptionId,
-        templateScheduleItemId: selectedTemplateItemId || null
+        templateScheduleItemId: selectedTemplateItemId || null,
+        templateTodoIds: selectedTemplateTodoIds
       })
       if (!result.success) {
         toast.error(result.error)
@@ -524,20 +544,86 @@ export function ScheduleItemFormDialog({
                     </div>
                   )}
                   {selectedTemplateGroup && selectedTemplateItemId && (
-                    <div className="mt-2 text-xs text-muted-foreground">
+                    <div className="mt-3 border-t pt-3">
                       {selectedTemplateGroup.linkedTodos.length > 0 ? (
-                        <>
-                          This will also create and link {selectedTemplateGroup.linkedTodos.length}{" "}
-                          template to-do
-                          {selectedTemplateGroup.linkedTodos.length === 1 ? "" : "s"}
-                          {selectedTemplateGroup.linkedTodos.some(
-                            (todo) => todo.checklistItemCount > 0
-                          )
-                            ? ", preserving their checklists."
-                            : "."}
-                        </>
+                        <Collapsible open={templateTodosOpen} onOpenChange={setTemplateTodosOpen}>
+                          <div className="flex items-center justify-between gap-3">
+                            <div>
+                              <p className="text-xs font-medium">Optional template to-dos</p>
+                              <p className="mt-0.5 text-[11px] text-muted-foreground">
+                                {selectedTemplateTodoIds.length} of{" "}
+                                {selectedTemplateGroup.linkedTodos.length} selected · none are added
+                                unless selected
+                              </p>
+                            </div>
+                            <CollapsibleTrigger asChild>
+                              <Button type="button" variant="outline" size="sm" className="h-8">
+                                Choose to-dos
+                                {templateTodosOpen ? (
+                                  <IconChevronDown className="ml-1 size-3.5" />
+                                ) : (
+                                  <IconChevronRight className="ml-1 size-3.5" />
+                                )}
+                              </Button>
+                            </CollapsibleTrigger>
+                          </div>
+                          <CollapsibleContent className="mt-3 border-y">
+                            <div className="flex items-center justify-end gap-1 border-b py-1">
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 px-2 text-xs"
+                                onClick={() =>
+                                  setSelectedTemplateTodoIds(
+                                    selectedTemplateGroup.linkedTodos.map((todo) => todo.id)
+                                  )
+                                }
+                              >
+                                Select all
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 px-2 text-xs"
+                                disabled={selectedTemplateTodoIds.length === 0}
+                                onClick={() => setSelectedTemplateTodoIds([])}
+                              >
+                                Clear
+                              </Button>
+                            </div>
+                            <div className="max-h-52 divide-y overflow-y-auto">
+                              {selectedTemplateGroup.linkedTodos.map((todo) => (
+                                <label
+                                  key={todo.id}
+                                  className="flex cursor-pointer items-start gap-3 py-2.5"
+                                >
+                                  <Checkbox
+                                    checked={selectedTemplateTodoIds.includes(todo.id)}
+                                    onCheckedChange={(value) =>
+                                      toggleTemplateTodo(todo.id, value === true)
+                                    }
+                                    aria-label={`Include ${todo.title}`}
+                                  />
+                                  <span className="min-w-0 flex-1">
+                                    <span className="block text-xs font-medium">{todo.title}</span>
+                                    {todo.checklistItemCount > 0 && (
+                                      <span className="mt-0.5 block text-[11px] text-muted-foreground">
+                                        Includes {todo.checklistItemCount} checklist item
+                                        {todo.checklistItemCount === 1 ? "" : "s"}
+                                      </span>
+                                    )}
+                                  </span>
+                                </label>
+                              ))}
+                            </div>
+                          </CollapsibleContent>
+                        </Collapsible>
                       ) : (
-                        "This template does not include any to-dos to link."
+                        <p className="text-xs text-muted-foreground">
+                          This template does not include any to-dos.
+                        </p>
                       )}
                     </div>
                   )}
@@ -1137,13 +1223,27 @@ export function ScheduleItemFormDialog({
             </div>
 
             {/* Footer */}
-            <div className="flex justify-end gap-2 px-5 py-3 border-t shrink-0">
-              <Button type="button" variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
-                Cancel
-              </Button>
-              <Button type="submit" size="sm">
-                {isEditing ? "Save" : "Create"}
-              </Button>
+            <div className="flex items-center justify-between gap-3 px-5 py-3 border-t shrink-0">
+              <p className="text-[11px] text-muted-foreground">
+                {!isEditing && selectedTemplateItemId
+                  ? `1 schedule item + ${selectedTemplateTodoIds.length} to-do${
+                      selectedTemplateTodoIds.length === 1 ? "" : "s"
+                    }`
+                  : null}
+              </p>
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onOpenChange(false)}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" size="sm">
+                  {isEditing ? "Save" : "Create"}
+                </Button>
+              </div>
             </div>
           </form>
         </Form>

--- a/src/lib/templates/__tests__/template-todo-selection.test.ts
+++ b/src/lib/templates/__tests__/template-todo-selection.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+
+import { selectTemplateTodos } from "@/lib/templates/template-todo-selection"
+
+describe("template to-do selection", () => {
+  const todos = [
+    { templateContentItemId: "todo-1", title: "First" },
+    { templateContentItemId: "todo-2", title: "Second" },
+    { templateContentItemId: "todo-3", title: "Third" }
+  ]
+
+  it("defaults to importing no template to-dos", () => {
+    expect(selectTemplateTodos(todos, [])).toEqual({ selected: [], missingIds: [] })
+  })
+
+  it("returns only selected to-dos in template order", () => {
+    expect(selectTemplateTodos(todos, ["todo-3", "todo-1", "todo-3"])).toEqual({
+      selected: [todos[0], todos[2]],
+      missingIds: []
+    })
+  })
+
+  it("reports selected IDs that do not belong to the template", () => {
+    expect(selectTemplateTodos(todos, ["todo-2", "other-template-todo"])).toEqual({
+      selected: [todos[1]],
+      missingIds: ["other-template-todo"]
+    })
+  })
+})

--- a/src/lib/templates/template-todo-selection.ts
+++ b/src/lib/templates/template-todo-selection.ts
@@ -1,0 +1,21 @@
+export type SelectableTemplateTodo = {
+  readonly templateContentItemId: string
+}
+
+export type TemplateTodoSelection<T extends SelectableTemplateTodo> = {
+  readonly selected: readonly T[]
+  readonly missingIds: readonly string[]
+}
+
+export function selectTemplateTodos<T extends SelectableTemplateTodo>(
+  todos: readonly T[],
+  selectedIds: readonly string[]
+): TemplateTodoSelection<T> {
+  const requestedIds = new Set(selectedIds)
+  const availableIds = new Set(todos.map((todo) => todo.templateContentItemId))
+
+  return {
+    selected: todos.filter((todo) => requestedIds.has(todo.templateContentItemId)),
+    missingIds: [...requestedIds].filter((id) => !availableIds.has(id))
+  }
+}


### PR DESCRIPTION
## Summary
- make template to-dos optional when importing one schedule item
- default to no to-dos and provide Select all / Clear controls with checklist counts
- validate selected to-do IDs against the exact published template before the transactional write
- show the exact schedule item and to-do creation count before saving

## Verification
- `bun test src/lib/templates/__tests__/template-todo-selection.test.ts src/lib/templates/__tests__/template-checklist-hierarchy.test.ts`
- touched-file ESLint
- `bunx tsc --noEmit`
- full production build (including pre-push build)
- local authenticated drawer smoke test (local database has no published template records, so production verification will inspect the populated selector without submitting)

## Review
- manual source review completed; the isolated external autoreview was unavailable because transmitting the local patch to an external review service was not authorized
