### PR TITLE
fix(feedback): close triaged backlog cleanly

### DIFF
--- a/scripts/jarvis-feedback-notifier.py
+++ b/scripts/jarvis-feedback-notifier.py
@@ -185,6 +185,20 @@ def external_actor_id(payload: dict[str, Any]) -> str | None:
     return value.strip() if isinstance(value, str) and value.strip() else None
 
 
+def telegram_delivery_target(payload: dict[str, Any]) -> str | None:
+    actor_id = external_actor_id(payload)
+    if actor_id is None:
+        return None
+    if re.fullmatch(r"-?\d+", actor_id):
+        return f"telegram:{actor_id}"
+    if re.fullmatch(
+        r"telegram:(?:-?\d+|[A-Za-z][A-Za-z0-9_]{4,31})",
+        actor_id,
+    ):
+        return actor_id
+    return None
+
+
 def reporter_email(payload: dict[str, Any]) -> str | None:
     value = reporter_object(payload).get("email")
     if not isinstance(value, str):
@@ -266,10 +280,10 @@ def deliver_event(event: dict[str, Any]) -> bool:
 
     message = message_text(payload)
     if source == "telegram":
-        target = external_actor_id(payload)
-        if target is None or not re.fullmatch(r"-?\d+", target):
+        target = telegram_delivery_target(payload)
+        if target is None:
             raise RuntimeError("Telegram feedback has no valid reply target")
-        send_via_hermes(f"telegram:{target}", message)
+        send_via_hermes(target, message)
         return True
     if source == "jarvis-email":
         target = reporter_email(payload)

--- a/scripts/test_jarvis_feedback_notifier.py
+++ b/scripts/test_jarvis_feedback_notifier.py
@@ -48,6 +48,28 @@ class RoutingTests(unittest.TestCase):
             "Your request was received.",
         )
 
+    def test_telegram_accepts_an_existing_prefixed_username(self) -> None:
+        event = {
+            "id": "event-telegram-username",
+            "eventType": "feedback.status_changed",
+            "source": "telegram",
+            "payload": {
+                "message": "Your request was closed.",
+                "reporter": {
+                    "externalActorId": "telegram:martinevogel"
+                },
+            },
+        }
+
+        with patch.object(MODULE, "send_via_hermes") as sender:
+            requires_ack = MODULE.deliver_event(event)
+
+        self.assertTrue(requires_ack)
+        sender.assert_called_once_with(
+            "telegram:martinevogel",
+            "Your request was closed.",
+        )
+
     def test_email_uses_the_original_sender_address(self) -> None:
         event = {
             "id": "event-2",

--- a/src/components/feedback/feedback-desk-admin.tsx
+++ b/src/components/feedback/feedback-desk-admin.tsx
@@ -28,6 +28,7 @@ import {
 import {
   FEEDBACK_DESK_STATUSES,
   FEEDBACK_PRIORITIES,
+  feedbackIsResolved,
   feedbackStatusLabel,
   knownFeedbackPriority,
   knownFeedbackStatus,
@@ -122,8 +123,15 @@ function RequestEditor({
             {!item.githubIssueUrl && item.githubIssueCreationApprovedAt && (
               <Badge>New GitHub issue approved</Badge>
             )}
-            {!item.githubIssueUrl && !item.githubIssueCreationApprovedAt && (
+            {!item.githubIssueUrl &&
+              !item.githubIssueCreationApprovedAt &&
+              !feedbackIsResolved(item.status) && (
               <Badge variant="outline">GitHub review needed</Badge>
+            )}
+            {!item.githubIssueUrl &&
+              !item.githubIssueCreationApprovedAt &&
+              feedbackIsResolved(item.status) && (
+              <Badge variant="outline">No GitHub issue required</Badge>
             )}
             <Badge variant="secondary">{item.kind}</Badge>
           </div>
@@ -194,7 +202,7 @@ function RequestEditor({
             />
           </label>
         </div>
-        {!item.githubIssueUrl && (
+        {!item.githubIssueUrl && !feedbackIsResolved(item.status) && (
           <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-dashed p-3">
             <p className="max-w-3xl text-xs text-muted-foreground">
               If this work already exists, paste its GitHub issue or pull request above and save.
@@ -258,10 +266,16 @@ export function FeedbackDeskAdmin({ overview }: Readonly<{
   const overdue = openItems.filter((item) => item.overdue).length
   const unassigned = openItems.filter((item) => !item.assignedToUserId).length
   const githubReviewNeeded = overview.items.filter(
-    (item) => !item.githubIssueUrl && !item.githubIssueCreationApprovedAt,
+    (item) =>
+      !item.githubIssueUrl &&
+      !item.githubIssueCreationApprovedAt &&
+      !feedbackIsResolved(item.status),
   ).length
   const githubCreationApproved = overview.items.filter(
-    (item) => !item.githubIssueUrl && item.githubIssueCreationApprovedAt,
+    (item) =>
+      !item.githubIssueUrl &&
+      item.githubIssueCreationApprovedAt &&
+      !feedbackIsResolved(item.status),
   ).length
 
   function reconcile(): void {

--- a/src/lib/jarvis/__tests__/feedback-lifecycle.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-lifecycle.test.ts
@@ -111,14 +111,27 @@ describe("Feedback Desk lifecycle", () => {
     expect(feedbackGithubLinkAction({
       githubIssueUrl: null,
       githubIssueCreationApprovedAt: null,
+      status: "new",
     })).toBe("review")
     expect(feedbackGithubLinkAction({
       githubIssueUrl: null,
       githubIssueCreationApprovedAt: "2026-08-05T12:00:00.000Z",
+      status: "new",
     })).toBe("create")
     expect(feedbackGithubLinkAction({
       githubIssueUrl: "https://github.com/example/compass/issues/1",
       githubIssueCreationApprovedAt: null,
+      status: "closed",
     })).toBe("repair")
+    expect(feedbackGithubLinkAction({
+      githubIssueUrl: null,
+      githubIssueCreationApprovedAt: null,
+      status: "deployed",
+    })).toBe("skip")
+    expect(feedbackGithubLinkAction({
+      githubIssueUrl: null,
+      githubIssueCreationApprovedAt: null,
+      status: "closed",
+    })).toBe("skip")
   })
 })

--- a/src/lib/jarvis/feedback-maintenance.ts
+++ b/src/lib/jarvis/feedback-maintenance.ts
@@ -21,7 +21,10 @@ import {
 import { linkFeedbackDeskItemToGithub } from "@/lib/jarvis/feedback-github"
 import { githubFeedbackIssueContent } from "@/lib/jarvis/feedback-github-content"
 import { syncFeedbackDeskItemsFromGithub } from "@/lib/jarvis/feedback-github-sync"
-import { feedbackSlaTarget } from "@/lib/jarvis/feedback-lifecycle"
+import {
+  feedbackIsResolved,
+  feedbackSlaTarget,
+} from "@/lib/jarvis/feedback-lifecycle"
 
 type CompassDb = ReturnType<typeof getDb>
 
@@ -39,11 +42,12 @@ export type FeedbackMaintenanceResult = Readonly<{
 export function feedbackGithubLinkAction(
   item: Pick<
     FeedbackDeskItem,
-    "githubIssueUrl" | "githubIssueCreationApprovedAt"
+    "githubIssueUrl" | "githubIssueCreationApprovedAt" | "status"
   >,
-): "repair" | "create" | "review" {
+): "repair" | "create" | "review" | "skip" {
   if (item.githubIssueUrl) return "repair"
   if (item.githubIssueCreationApprovedAt) return "create"
+  if (feedbackIsResolved(item.status)) return "skip"
   return "review"
 }
 
@@ -306,6 +310,7 @@ export async function runFeedbackMaintenance(
         missingLinkReviewCount += 1
         continue
       }
+      if (action === "skip") continue
       const link = await linkFeedbackDeskItemToGithub(db, env, item)
       if (link) linkedCount += 1
       else failedCount += 1


### PR DESCRIPTION
## Summary

- treat closed or deployed Feedback Desk items without GitHub issues as resolved decisions
- exclude those items from the GitHub-review queue and show a clear no-issue-required disposition
- accept stored Telegram targets that already include the `telegram:` prefix
- add regression coverage for both lifecycle decisions and Telegram username routing

## Backlog reconciliation

The 21 unlinked production requests were reviewed against current Compass behavior, merged PRs, and existing issues:

- 4 genuinely new issues created: #332–#335
- 3 requests linked to existing issues: #142, #250, #251
- 7 already-delivered requests linked to merged PRs
- 7 test or operational-assistance requests closed without GitHub clutter

## Verification

- `python3 -m unittest scripts/test_jarvis_feedback_notifier.py`
- `bun test src/lib/jarvis/__tests__/feedback-lifecycle.test.ts`
- targeted ESLint
- `git diff --check`
- Next production compile succeeded; the repository's existing generated `.open-next/worker.js` made `custom-worker.ts` report its pre-existing unused `@ts-expect-error` during the subsequent type-check stage.
