### PR TITLE
fix(feedback): normalize Hermes Telegram usernames

### DIFF
--- a/scripts/jarvis-feedback-notifier.py
+++ b/scripts/jarvis-feedback-notifier.py
@@ -191,11 +191,15 @@ def telegram_delivery_target(payload: dict[str, Any]) -> str | None:
         return None
     if re.fullmatch(r"-?\d+", actor_id):
         return f"telegram:{actor_id}"
-    if re.fullmatch(
-        r"telegram:(?:-?\d+|[A-Za-z][A-Za-z0-9_]{4,31})",
-        actor_id,
-    ):
+    if re.fullmatch(r"telegram:-?\d+", actor_id):
         return actor_id
+    username_match = re.fullmatch(
+        r"telegram:@?([A-Za-z][A-Za-z0-9_]{4,31})",
+        actor_id,
+    )
+    if username_match:
+        # Hermes expects Telegram usernames in Bot API form, including the @.
+        return f"telegram:@{username_match.group(1)}"
     return None
 
 

--- a/scripts/test_jarvis_feedback_notifier.py
+++ b/scripts/test_jarvis_feedback_notifier.py
@@ -66,7 +66,7 @@ class RoutingTests(unittest.TestCase):
 
         self.assertTrue(requires_ack)
         sender.assert_called_once_with(
-            "telegram:martinevogel",
+            "telegram:@martinevogel",
             "Your request was closed.",
         )
 


### PR DESCRIPTION
## Summary
- normalize stored Telegram username targets to Hermes' required `@username` form
- preserve numeric Telegram chat IDs unchanged
- cover the requester-notification route with a regression test

## Verification
- `python3 -m unittest scripts/test_jarvis_feedback_notifier.py`
- `git diff --check origin/main...HEAD`

Follow-up to #336 after replaying the previously failed production requester notification.
