### PR TITLE
fix(feedback): run notifier in Hermes environment

### DIFF
--- a/docs/architecture/jarvis-feedback-bridge.md
+++ b/docs/architecture/jarvis-feedback-bridge.md
@@ -223,7 +223,9 @@ through Hermes's existing send adapters, posts Compass-conversation replies
 through the signed reply endpoint, and acknowledges Ask Jarvis/widget events
 after their Compass-native receipt or notification is available. Its local
 delivery ledger prevents a service restart from sending the same external
-update twice before acknowledgement.
+update twice before acknowledgement. The notifier service runs with Hermes's
+virtual-environment Python so those send adapters use the same dependencies as
+the Hermes gateway.
 
 Both private relay services post a signed heartbeat to
 `POST /api/integrations/jarvis/health` at least once per minute. The protected

--- a/ops/systemd/compass-jarvis-feedback-notifier.service
+++ b/ops/systemd/compass-jarvis-feedback-notifier.service
@@ -8,7 +8,7 @@ Type=simple
 EnvironmentFile=%h/.hermes/.env
 Environment=HERMES_AGENT_ROOT=%h/.hermes/hermes-agent
 Environment=COMPASS_FEEDBACK_LEDGER=%h/.local/state/compass/feedback-notifier.json
-ExecStart=/usr/bin/python3 %h/.local/lib/compass/jarvis-feedback-notifier.py
+ExecStart=%h/.hermes/hermes-agent/venv/bin/python %h/.local/lib/compass/jarvis-feedback-notifier.py
 Restart=always
 RestartSec=5
 NoNewPrivileges=true

--- a/scripts/jarvis-feedback-notifier.py
+++ b/scripts/jarvis-feedback-notifier.py
@@ -191,11 +191,15 @@ def telegram_delivery_target(payload: dict[str, Any]) -> str | None:
         return None
     if re.fullmatch(r"-?\d+", actor_id):
         return f"telegram:{actor_id}"
-    if re.fullmatch(
-        r"telegram:(?:-?\d+|[A-Za-z][A-Za-z0-9_]{4,31})",
-        actor_id,
-    ):
+    if re.fullmatch(r"telegram:-?\d+", actor_id):
         return actor_id
+    username_match = re.fullmatch(
+        r"telegram:@?([A-Za-z][A-Za-z0-9_]{4,31})",
+        actor_id,
+    )
+    if username_match:
+        # Hermes expects Telegram usernames in Bot API form, including the @.
+        return f"telegram:@{username_match.group(1)}"
     return None
 
 

--- a/scripts/test_jarvis_feedback_notifier.py
+++ b/scripts/test_jarvis_feedback_notifier.py
@@ -66,7 +66,7 @@ class RoutingTests(unittest.TestCase):
 
         self.assertTrue(requires_ack)
         sender.assert_called_once_with(
-            "telegram:martinevogel",
+            "telegram:@martinevogel",
             "Your request was closed.",
         )
 


### PR DESCRIPTION
## Summary
- run the Compass requester notifier with Hermes' virtual-environment Python
- keep notifier and gateway adapter dependencies aligned across reinstalls
- document the runtime requirement

## Verification
- `python3 -m unittest scripts/test_jarvis_feedback_notifier.py`
- `git diff --check`

This persists the production service correction discovered while replaying the failed requester notification after #337.
