### PR TITLE
fix(feedback): run notifier in Hermes environment

### DIFF
--- a/docs/architecture/jarvis-feedback-bridge.md
+++ b/docs/architecture/jarvis-feedback-bridge.md
@@ -223,7 +223,9 @@ through Hermes's existing send adapters, posts Compass-conversation replies
 through the signed reply endpoint, and acknowledges Ask Jarvis/widget events
 after their Compass-native receipt or notification is available. Its local
 delivery ledger prevents a service restart from sending the same external
-update twice before acknowledgement.
+update twice before acknowledgement. The notifier service runs with Hermes's
+virtual-environment Python so those send adapters use the same dependencies as
+the Hermes gateway.
 
 Both private relay services post a signed heartbeat to
 `POST /api/integrations/jarvis/health` at least once per minute. The protected

--- a/ops/systemd/compass-jarvis-feedback-notifier.service
+++ b/ops/systemd/compass-jarvis-feedback-notifier.service
@@ -8,7 +8,7 @@ Type=simple
 EnvironmentFile=%h/.hermes/.env
 Environment=HERMES_AGENT_ROOT=%h/.hermes/hermes-agent
 Environment=COMPASS_FEEDBACK_LEDGER=%h/.local/state/compass/feedback-notifier.json
-ExecStart=/usr/bin/python3 %h/.local/lib/compass/jarvis-feedback-notifier.py
+ExecStart=%h/.hermes/hermes-agent/venv/bin/python %h/.local/lib/compass/jarvis-feedback-notifier.py
 Restart=always
 RestartSec=5
 NoNewPrivileges=true


### PR DESCRIPTION
## Summary
- run the Compass requester notifier with Hermes' virtual-environment Python
- keep notifier and gateway adapter dependencies aligned across reinstalls
- document the runtime requirement

## Verification
- `python3 -m unittest scripts/test_jarvis_feedback_notifier.py`
- `git diff --check`

This persists the production service correction discovered while replaying the failed requester notification after #337.
