### PR TITLE
feat(rfis): restore tracked communication and group messages

### DIFF
--- a/custom-worker.ts
+++ b/custom-worker.ts
@@ -7,6 +7,7 @@ import {
 } from "./src/lib/jarvis/auth"
 
 const RECONCILE_TARGET = "/api/operations/feedback/reconcile"
+const EMAIL_SYNC_TARGET = "/api/email/gmail-sync"
 
 async function reconcile(env: CloudflareEnv): Promise<void> {
   const body = JSON.stringify({ source: "cron" })
@@ -39,9 +40,26 @@ async function reconcile(env: CloudflareEnv): Promise<void> {
   }
 }
 
+async function syncInboundEmail(env: CloudflareEnv): Promise<void> {
+  const secret = getJarvisEnvValue(env, "COMPASS_EMAIL_SYNC_SECRET")
+  if (!secret) throw new Error("COMPASS_EMAIL_SYNC_SECRET is required")
+  const worker = env.WORKER_SELF_REFERENCE
+  if (!worker) throw new Error("WORKER_SELF_REFERENCE is required")
+  const response = await worker.fetch(
+    `https://compass.internal${EMAIL_SYNC_TARGET}`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${secret}` },
+    },
+  )
+  if (!response.ok) {
+    throw new Error(`Inbound email sync failed with ${response.status}`)
+  }
+}
+
 export default {
   fetch: worker.fetch,
   async scheduled(_controller, env, ctx): Promise<void> {
-    ctx.waitUntil(reconcile(env))
+    ctx.waitUntil(Promise.all([reconcile(env), syncInboundEmail(env)]).then(() => undefined))
   },
 } satisfies ExportedHandler<CloudflareEnv>

--- a/drizzle/0053_email_reply_threads.sql
+++ b/drizzle/0053_email_reply_threads.sql
@@ -1,0 +1,61 @@
+CREATE TABLE `email_reply_threads` (
+  `id` text PRIMARY KEY NOT NULL,
+  `token` text NOT NULL,
+  `organization_id` text NOT NULL,
+  `project_id` text,
+  `channel_id` text,
+  `source_type` text NOT NULL,
+  `source_id` text NOT NULL,
+  `source_number` text,
+  `reply_to_address` text NOT NULL,
+  `subject` text NOT NULL,
+  `status` text DEFAULT 'active' NOT NULL,
+  `created_by` text,
+  `last_inbound_at` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `email_reply_threads_token_idx` ON `email_reply_threads` (`token`);
+--> statement-breakpoint
+CREATE INDEX `email_reply_threads_org_project_idx` ON `email_reply_threads` (`organization_id`,`project_id`);
+--> statement-breakpoint
+CREATE INDEX `email_reply_threads_source_idx` ON `email_reply_threads` (`source_type`,`source_id`);
+--> statement-breakpoint
+CREATE TABLE `inbound_emails` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `project_id` text,
+  `reply_thread_id` text,
+  `token` text,
+  `gmail_message_id` text NOT NULL,
+  `gmail_thread_id` text,
+  `message_id_header` text,
+  `in_reply_to_header` text,
+  `references_header` text,
+  `from_address` text NOT NULL,
+  `from_name` text,
+  `to_address` text,
+  `subject` text NOT NULL,
+  `text_body` text,
+  `html_body` text,
+  `snippet` text,
+  `matched_status` text DEFAULT 'needs_review' NOT NULL,
+  `posted_message_id` text,
+  `received_at` text NOT NULL,
+  `imported_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`reply_thread_id`) REFERENCES `email_reply_threads`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `inbound_emails_gmail_message_id_idx` ON `inbound_emails` (`gmail_message_id`);
+--> statement-breakpoint
+CREATE INDEX `inbound_emails_org_project_idx` ON `inbound_emails` (`organization_id`,`project_id`);
+--> statement-breakpoint
+CREATE INDEX `inbound_emails_reply_thread_idx` ON `inbound_emails` (`reply_thread_id`);
+--> statement-breakpoint
+CREATE INDEX `inbound_emails_status_idx` ON `inbound_emails` (`matched_status`);

--- a/src/app/actions/conversations.ts
+++ b/src/app/actions/conversations.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import { getCloudflareContext } from "@/lib/db"
-import { eq, and, sql, ne } from "drizzle-orm"
+import { eq, and, sql, ne, inArray } from "drizzle-orm"
 import { getDb } from "@/db"
 import {
   channels,
@@ -18,20 +18,10 @@ import { revalidatePath } from "next/cache"
 import { requireOrg } from "@/lib/org-scope"
 import { isDemoUser } from "@/lib/demo"
 import { isInternalStaffRole } from "@/lib/user-roles"
-
-async function directChannelId(
-  organizationId: string,
-  firstUserId: string,
-  secondUserId: string
-): Promise<string> {
-  const participants = [firstUserId, secondUserId].sort().join(":")
-  const bytes = new TextEncoder().encode(`${organizationId}:${participants}`)
-  const digest = await crypto.subtle.digest("SHA-256", bytes)
-  const hash = Array.from(new Uint8Array(digest))
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("")
-  return `direct-${hash.slice(0, 32)}`
-}
+import {
+  directChannelId,
+  directParticipantIds,
+} from "@/lib/conversations/direct-channel"
 
 async function ensureChannelMember(
   db: ReturnType<typeof getDb>,
@@ -134,7 +124,7 @@ export async function listDirectMessageRecipients() {
   }
 }
 
-export async function createDirectMessage(targetUserId: string) {
+export async function createDirectMessage(targetUserIds: readonly string[]) {
   try {
     const user = await getCurrentUser()
     if (!user || !isInternalStaffRole(user.role)) {
@@ -143,14 +133,20 @@ export async function createDirectMessage(targetUserId: string) {
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
-    if (targetUserId === user.id) {
-      return { success: false, error: "Choose another team member" }
+    const requestedTargetIds = Array.from(
+      new Set(targetUserIds.filter((targetUserId) => targetUserId !== user.id))
+    )
+    if (requestedTargetIds.length === 0) {
+      return { success: false, error: "Choose at least one team member" }
+    }
+    if (requestedTargetIds.length > 20) {
+      return { success: false, error: "Choose no more than 20 team members" }
     }
 
     const organizationId = requireOrg(user)
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
-    const target = await db
+    const targets = await db
       .select({
         id: users.id,
         name: users.displayName,
@@ -165,18 +161,19 @@ export async function createDirectMessage(targetUserId: string) {
           eq(organizationMembers.organizationId, organizationId)
         )
       )
-      .where(and(eq(users.id, targetUserId), eq(users.isActive, true)))
-      .get()
+      .where(
+        and(inArray(users.id, requestedTargetIds), eq(users.isActive, true))
+      )
 
-    if (!target || !isInternalStaffRole(target.role)) {
-      return { success: false, error: "Team member not found" }
+    if (
+      targets.length !== requestedTargetIds.length ||
+      targets.some((target) => !isInternalStaffRole(target.role))
+    ) {
+      return { success: false, error: "One or more team members were not found" }
     }
 
-    const channelId = await directChannelId(
-      organizationId,
-      user.id,
-      target.id
-    )
+    const participantIds = directParticipantIds(user.id, requestedTargetIds)
+    const channelId = await directChannelId(organizationId, participantIds)
     const now = new Date().toISOString()
     const existingChannel = await db
       .select({ id: channels.id })
@@ -185,11 +182,18 @@ export async function createDirectMessage(targetUserId: string) {
       .get()
 
     if (!existingChannel) {
+      const participantNames = [
+        user.displayName ?? user.email,
+        ...targets.map((target) => target.name ?? target.email),
+      ].sort((first, second) => first.localeCompare(second))
       await db.insert(channels).values({
         id: channelId,
-        name: `${user.displayName ?? user.email} · ${target.name ?? target.email}`,
+        name: participantNames.join(" · "),
         type: "text",
-        description: "Private direct message",
+        description:
+          participantIds.length === 2
+            ? "Private direct message"
+            : "Private group message",
         organizationId,
         projectId: null,
         categoryId: null,
@@ -203,8 +207,9 @@ export async function createDirectMessage(targetUserId: string) {
       })
     }
 
-    await ensureChannelMember(db, channelId, user.id, now)
-    await ensureChannelMember(db, channelId, target.id, now)
+    for (const participantId of participantIds) {
+      await ensureChannelMember(db, channelId, participantId, now)
+    }
 
     revalidatePath("/dashboard/conversations")
     return { success: true, data: { channelId } }

--- a/src/app/actions/project-rfis.ts
+++ b/src/app/actions/project-rfis.ts
@@ -1,10 +1,16 @@
 "use server"
 
-import { and, asc, eq } from "drizzle-orm"
+import { and, asc, desc, eq } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
-import { projectRfiAttachments, projectRfis, projects } from "@/db/schema"
+import {
+  emailReplyThreads,
+  inboundEmails,
+  projectRfiAttachments,
+  projectRfis,
+  projects,
+} from "@/db/schema"
 import {
   notifyRfiCreated,
   notifyRfiUpdated,
@@ -12,8 +18,15 @@ import {
 import { requireAuth } from "@/lib/auth"
 import type { AuthUser } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
+import { trackedMailtoHref } from "@/lib/email/mailto"
+import {
+  appendReplyTokenText,
+  createEmailReplyThread,
+} from "@/lib/email/reply-tracking"
 import { requireOrg } from "@/lib/org-scope"
 import { requireFeaturePermission } from "@/lib/permission-enforcement"
+import { appendRfiCommunication } from "@/lib/rfis/communication"
+import { isInternalStaffRole } from "@/lib/user-roles"
 import {
   validRfiAudience,
   validRfiPriority,
@@ -27,6 +40,15 @@ export type ProjectRfiAttachmentItem = {
   readonly fileSize: number
   readonly storageUrl: string | null
   readonly storageStatus: string
+}
+
+export type ProjectRfiInboundEmailItem = {
+  readonly id: string
+  readonly rfiId: string
+  readonly from: string
+  readonly subject: string
+  readonly body: string
+  readonly receivedAt: string
 }
 
 export type ProjectRfiItem = {
@@ -64,6 +86,7 @@ type ProjectRfiActionResult =
 
 type ProjectUpdateContext = {
   readonly db: ReturnType<typeof getDb>
+  readonly env: unknown
   readonly user: AuthUser
   readonly orgId: string
   readonly projectNumber: string | null
@@ -95,6 +118,14 @@ export type UpdateProjectRfiInput = {
   readonly status: string
   readonly audience: string
 }
+
+export type ProjectRfiEmailDraftResult =
+  | {
+      readonly success: true
+      readonly href: string
+      readonly trackingAddress: string
+    }
+  | { readonly success: false; readonly error: string }
 
 async function verifyProjectAccess(
   projectId: string
@@ -146,7 +177,7 @@ async function getProjectUpdateContext(
     throw new Error("Project not found")
   }
 
-  return { db, user, orgId, projectNumber: existing[0].projectNumber }
+  return { db, env, user, orgId, projectNumber: existing[0].projectNumber }
 }
 
 function cleanText(value: string | null): string | null {
@@ -305,6 +336,49 @@ export async function getProjectRfis(
   return rows.map((row) => toRfiItem(row, attachmentsByRfi.get(row.id) ?? []))
 }
 
+export async function getProjectRfiInboundEmails(
+  projectId: string
+): Promise<readonly ProjectRfiInboundEmailItem[]> {
+  const user = await requireAuth()
+  await requireFeaturePermission(user, "rfis", "read")
+  if (!isInternalStaffRole(user.role)) return []
+  const db = await verifyProjectAccess(projectId)
+  const rows = await db
+    .select({
+      id: inboundEmails.id,
+      rfiId: emailReplyThreads.sourceId,
+      fromAddress: inboundEmails.fromAddress,
+      fromName: inboundEmails.fromName,
+      subject: inboundEmails.subject,
+      textBody: inboundEmails.textBody,
+      snippet: inboundEmails.snippet,
+      receivedAt: inboundEmails.receivedAt,
+    })
+    .from(inboundEmails)
+    .innerJoin(
+      emailReplyThreads,
+      eq(emailReplyThreads.id, inboundEmails.replyThreadId)
+    )
+    .where(
+      and(
+        eq(inboundEmails.projectId, projectId),
+        eq(inboundEmails.matchedStatus, "posted"),
+        eq(emailReplyThreads.sourceType, "rfi")
+      )
+    )
+    .orderBy(desc(inboundEmails.receivedAt))
+
+  return rows.map((row) => ({
+    id: row.id,
+    rfiId: row.rfiId,
+    from: row.fromName ?? row.fromAddress,
+    subject: row.subject,
+    body:
+      row.textBody?.trim() || row.snippet?.trim() || "Email reply received.",
+    receivedAt: row.receivedAt,
+  }))
+}
+
 export async function createProjectRfi(
   projectId: string,
   input: CreateProjectRfiInput
@@ -411,6 +485,8 @@ export async function updateProjectRfi(
       .select({
         rfiNumber: projectRfis.rfiNumber,
         subject: projectRfis.subject,
+        answer: projectRfis.answer,
+        answeredAt: projectRfis.answeredAt,
         requesterName: projectRfis.requesterName,
         assignedToName: projectRfis.assignedToName,
       })
@@ -428,7 +504,15 @@ export async function updateProjectRfi(
     }
 
     const now = new Date().toISOString()
-    const answer = cleanText(input.answer)
+    const response = cleanText(input.answer)
+    const answer = response
+      ? appendRfiCommunication({
+          existing: existing.answer,
+          message: response,
+          author: user.displayName ?? user.email,
+          occurredAt: now,
+        })
+      : existing.answer
     const requestedStatus = validRfiStatus(input.status)
     const audience = validRfiAudience(input.audience)
     if (!requestedStatus) {
@@ -438,14 +522,17 @@ export async function updateProjectRfi(
       return { success: false, error: "Please choose a valid RFI audience." }
     }
     const status =
-      answer && requestedStatus === "new" ? "in_progress" : requestedStatus
+      response && requestedStatus === "new" ? "in_progress" : requestedStatus
     await db
       .update(projectRfis)
       .set({
         answer,
         status,
         audience,
-        answeredAt: status === "complete" ? now : null,
+        answeredAt:
+          response || status === "complete"
+            ? existing.answeredAt ?? now
+            : existing.answeredAt,
         updatedAt: now,
       })
       .where(and(eq(projectRfis.id, rfiId), eq(projectRfis.projectId, projectId)))
@@ -476,6 +563,96 @@ export async function updateProjectRfi(
     return {
       success: false,
       error: error instanceof Error ? error.message : "Failed to update RFI",
+    }
+  }
+}
+
+function validEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+}
+
+function appOrigin(env: unknown): string {
+  if (typeof env === "object" && env !== null) {
+    const value = Reflect.get(env, "NEXT_PUBLIC_APP_URL")
+    if (typeof value === "string" && value.trim()) return value.replace(/\/$/, "")
+  }
+  return "https://compass.openrangeconstruction.ltd"
+}
+
+export async function createProjectRfiEmailDraft(
+  projectId: string,
+  rfiId: string,
+  recipientEmails: readonly string[]
+): Promise<ProjectRfiEmailDraftResult> {
+  try {
+    const { db, env, user, orgId, projectNumber } =
+      await getProjectUpdateContext(projectId)
+    const to = Array.from(
+      new Set(recipientEmails.map((email) => email.trim().toLowerCase()))
+    ).filter(validEmail)
+    if (to.length === 0) {
+      return { success: false, error: "Choose at least one email recipient." }
+    }
+    if (to.length > 20) {
+      return { success: false, error: "Choose no more than 20 recipients." }
+    }
+
+    const rfi = await db
+      .select({
+        id: projectRfis.id,
+        rfiNumber: projectRfis.rfiNumber,
+        subject: projectRfis.subject,
+        question: projectRfis.question,
+      })
+      .from(projectRfis)
+      .where(
+        and(eq(projectRfis.id, rfiId), eq(projectRfis.projectId, projectId))
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!rfi) return { success: false, error: "RFI not found." }
+
+    const subject = `[${rfi.rfiNumber}] ${rfi.subject}`
+    const thread = await createEmailReplyThread({
+      env,
+      db,
+      organizationId: orgId,
+      projectId,
+      sourceType: "rfi",
+      sourceId: rfi.id,
+      sourceNumber: rfi.rfiNumber,
+      subject,
+      createdBy: user.id,
+    })
+    const body = appendReplyTokenText({
+      token: thread.token,
+      body: [
+        `${projectNumber ?? "Project"} RFI ${rfi.rfiNumber}`,
+        rfi.subject,
+        "",
+        rfi.question,
+        "",
+        `Open in Compass: ${appOrigin(env)}/dashboard/projects/${encodeURIComponent(projectId)}/rfis?item=${encodeURIComponent(rfi.id)}`,
+        "",
+        "Please keep Compass in CC (or use Reply All) so the response stays attached to this RFI and the project conversation.",
+      ].join("\n"),
+    })
+
+    return {
+      success: true,
+      href: trackedMailtoHref({
+        to,
+        cc: thread.replyToAddress,
+        subject,
+        body,
+      }),
+      trackingAddress: thread.replyToAddress,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to prepare RFI email.",
     }
   }
 }

--- a/src/app/api/email/gmail-sync/route.ts
+++ b/src/app/api/email/gmail-sync/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { getDb } from "@/db"
+import { getCurrentUser } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import {
+  listGoogleAuthOrganizationIds,
+  syncGmailInboundReplies,
+} from "@/lib/email/gmail-inbound"
+import { requireOrg } from "@/lib/org-scope"
+import { can } from "@/lib/permissions"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function envString(env: unknown, key: string): string | null {
+  if (!isRecord(env)) return process.env[key] ?? null
+  const value = env[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : process.env[key] ?? null
+}
+
+function bearerToken(request: NextRequest): string | null {
+  const header = request.headers.get("authorization")
+  if (!header) return null
+  const match = /^Bearer\s+(.+)$/i.exec(header)
+  return match ? match[1].trim() : null
+}
+
+async function requestedOrganizationIds(input: {
+  readonly request: NextRequest
+  readonly env: unknown
+  readonly db: ReturnType<typeof getDb>
+}): Promise<
+  | { readonly success: true; readonly organizationIds: readonly string[] }
+  | { readonly success: false; readonly status: number; readonly error: string }
+> {
+  const configuredSecret = envString(input.env, "COMPASS_EMAIL_SYNC_SECRET")
+  const requestSecret =
+    bearerToken(input.request) ?? input.request.headers.get("x-compass-sync-secret")
+
+  if (
+    configuredSecret &&
+    requestSecret &&
+    requestSecret === configuredSecret
+  ) {
+    const organizationIds = await listGoogleAuthOrganizationIds({ db: input.db })
+    return { success: true, organizationIds }
+  }
+
+  const user = await getCurrentUser()
+  if (!user) {
+    return { success: false, status: 401, error: "Unauthorized" }
+  }
+  if (!can(user, "channels", "moderate")) {
+    return { success: false, status: 403, error: "Forbidden" }
+  }
+
+  return { success: true, organizationIds: [requireOrg(user)] }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const orgs = await requestedOrganizationIds({ request, env, db })
+  if (!orgs.success) {
+    return NextResponse.json({ success: false, error: orgs.error }, { status: orgs.status })
+  }
+
+  const summaries = []
+  for (const organizationId of orgs.organizationIds) {
+    const summary = await syncGmailInboundReplies({
+      env,
+      db,
+      organizationId,
+    })
+    summaries.push({ organizationId, ...summary })
+  }
+
+  return NextResponse.json({ success: true, summaries })
+}

--- a/src/app/dashboard/projects/[id]/rfis/page.tsx
+++ b/src/app/dashboard/projects/[id]/rfis/page.tsx
@@ -7,13 +7,22 @@ import {
   IconMessageQuestion,
 } from "@tabler/icons-react"
 
-import { getProjectRfis, updateProjectRfi } from "@/app/actions/project-rfis"
+import {
+  getProjectRfiInboundEmails,
+  getProjectRfis,
+  updateProjectRfi,
+} from "@/app/actions/project-rfis"
 import {
   getProjectContactsSummary,
   getProjectTaskAssigneeOptions,
+  type ProjectContactItem,
 } from "@/app/actions/project-contacts"
 import { getProjects } from "@/app/actions/projects"
 import { ProjectRfiCreateForm } from "@/components/projects/project-rfi-create-form"
+import {
+  ProjectRfiCommunicationActions,
+  type ProjectRfiEmailRecipientOption,
+} from "@/components/projects/project-rfi-communication-actions"
 import { ProjectRfiDeleteButton } from "@/components/projects/project-rfi-delete-button"
 import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
 import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
@@ -50,6 +59,16 @@ function formatDate(value: string | null): string {
   })
 }
 
+function formatDateTime(value: string): string {
+  return new Date(value).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })
+}
+
 function label(value: string): string {
   return value
     .split("_")
@@ -69,6 +88,52 @@ function unique(values: readonly (string | null | undefined)[]): readonly string
 
 function rfiTaskTitle(subject: string): string {
   return `Follow up RFI: ${subject}`
+}
+
+function normalizedMatchValue(value: string | null): string {
+  return value?.trim().toLocaleLowerCase() ?? ""
+}
+
+function rfiEmailRecipients(
+  rfi: {
+    readonly requesterName: string | null
+    readonly assignedToName: string | null
+    readonly companyName: string | null
+  },
+  contacts: readonly ProjectContactItem[]
+): readonly ProjectRfiEmailRecipientOption[] {
+  const targets = [rfi.requesterName, rfi.assignedToName, rfi.companyName]
+    .map(normalizedMatchValue)
+    .filter(Boolean)
+  const byEmail = new Map<string, ProjectRfiEmailRecipientOption>()
+
+  for (const contact of contacts) {
+    const email = contact.email?.trim().toLocaleLowerCase() ?? ""
+    if (!email) continue
+    const contactValues = [contact.displayName, contact.companyName]
+      .map(normalizedMatchValue)
+      .filter(Boolean)
+    const recommended = targets.some((target) =>
+      contactValues.some(
+        (candidate) => target.includes(candidate) || candidate.includes(target)
+      )
+    )
+    const label =
+      contact.companyName && contact.companyName !== contact.displayName
+        ? `${contact.displayName} - ${contact.companyName}`
+        : contact.displayName
+    const existing = byEmail.get(email)
+    if (!existing || (!existing.recommended && recommended)) {
+      byEmail.set(email, { email, label, recommended })
+    }
+  }
+
+  return Array.from(byEmail.values()).sort((first, second) => {
+    if (first.recommended !== second.recommended) {
+      return first.recommended ? -1 : 1
+    }
+    return first.label.localeCompare(second.label)
+  })
 }
 
 const RFI_FILTERS: readonly {
@@ -104,12 +169,13 @@ export default async function ProjectRfisPage({
     ? query.item[0] ?? null
     : query.item ?? null
   const statusFilter = parseRfiStatusFilter(query.status)
-  const [projects, rfis, contactsSummary, taskAssigneeOptions] =
+  const [projects, rfis, contactsSummary, taskAssigneeOptions, inboundEmails] =
     await Promise.all([
       getProjects(),
       getProjectRfis(id),
       getProjectContactsSummary(id, "internal"),
       getProjectTaskAssigneeOptions(id),
+      getProjectRfiInboundEmails(id),
     ]).catch((error: unknown) => {
       redirectIfFeaturePermissionDenied(error)
       throw error
@@ -126,6 +192,12 @@ export default async function ProjectRfisPage({
     .filter((rfi) => rfiMatchesStatusFilter(rfi.status, statusFilter))
     .sort(compareRfisForQueue)
   const contacts = contactsSummary.allContacts
+  const inboundEmailsByRfi = new Map(
+    rfis.map((rfi) => [
+      rfi.id,
+      inboundEmails.filter((email) => email.rfiId === rfi.id),
+    ])
+  )
   const companyOrTradeOptions = unique(
     contacts.flatMap((contact) => [
       contact.companyName,
@@ -302,6 +374,12 @@ export default async function ProjectRfisPage({
                       }
                       assigneeOptions={taskAssignees}
                     />
+                    <ProjectRfiCommunicationActions
+                      projectId={id}
+                      rfiId={rfi.id}
+                      rfiNumber={rfi.rfiNumber}
+                      recipientOptions={rfiEmailRecipients(rfi, contacts)}
+                    />
                   </div>
                 </div>
                 <p className="mt-3 text-sm text-muted-foreground">{rfi.question}</p>
@@ -346,12 +424,44 @@ export default async function ProjectRfisPage({
                   </div>
                 )}
 
+                {(inboundEmailsByRfi.get(rfi.id) ?? []).length > 0 ? (
+                  <div className="mt-3 border-l-2 border-l-brand-nutech-gold bg-muted/20 px-3 py-2">
+                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      Email replies · Internal review
+                    </p>
+                    <div className="mt-2 space-y-3">
+                      {(inboundEmailsByRfi.get(rfi.id) ?? []).map((email) => (
+                        <div key={email.id} className="border-t pt-2 first:border-t-0 first:pt-0">
+                          <div className="flex flex-wrap justify-between gap-2 text-xs text-muted-foreground">
+                            <span>{email.from}</span>
+                            <span>{formatDateTime(email.receivedAt)}</span>
+                          </div>
+                          <p className="mt-1 text-sm font-medium">{email.subject}</p>
+                          <p className="mt-1 whitespace-pre-wrap text-sm">{email.body}</p>
+                        </div>
+                      ))}
+                    </div>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      These replies remain internal until staff adds an approved response below.
+                    </p>
+                  </div>
+                ) : null}
+
+                {rfi.answer ? (
+                  <div className="mt-4 border-l-2 border-l-brand-hps-primary bg-muted/20 px-3 py-2">
+                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      Communication history
+                    </p>
+                    <p className="mt-2 whitespace-pre-wrap text-sm">{rfi.answer}</p>
+                  </div>
+                ) : null}
+
                 <form action={updateRfiAction} className="mt-4 space-y-3">
                   <input type="hidden" name="rfiId" value={rfi.id} />
                   <Textarea
                     name="answer"
-                    defaultValue={rfi.answer ?? ""}
-                    placeholder="Response, decision, additional question, or next step"
+                    defaultValue=""
+                    placeholder="Add a response, decision, follow-up question, or next step"
                   />
                   <div className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_1fr_auto]">
                     <select

--- a/src/components/conversations/direct-message-dialog.tsx
+++ b/src/components/conversations/direct-message-dialog.tsx
@@ -10,15 +10,18 @@ import {
   listDirectMessageRecipients,
 } from "@/app/actions/conversations"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import { cn } from "@/lib/utils"
 
 type DirectMessageRecipient = {
   readonly id: string
@@ -40,7 +43,8 @@ export function DirectMessageDialog({
   >([])
   const [query, setQuery] = React.useState("")
   const [loading, setLoading] = React.useState(false)
-  const [startingId, setStartingId] = React.useState<string | null>(null)
+  const [selectedIds, setSelectedIds] = React.useState<readonly string[]>([])
+  const [starting, setStarting] = React.useState(false)
 
   React.useEffect(() => {
     if (!open) return
@@ -60,6 +64,12 @@ export function DirectMessageDialog({
     }
   }, [open])
 
+  React.useEffect(() => {
+    if (open) return
+    setQuery("")
+    setSelectedIds([])
+  }, [open])
+
   const normalizedQuery = query.trim().toLocaleLowerCase()
   const filteredRecipients = recipients.filter((recipient) =>
     `${recipient.name} ${recipient.email}`
@@ -67,18 +77,31 @@ export function DirectMessageDialog({
       .includes(normalizedQuery)
   )
 
-  async function startMessage(recipientId: string): Promise<void> {
-    setStartingId(recipientId)
-    const result = await createDirectMessage(recipientId)
-    setStartingId(null)
-    if (!result.success || !result.data) {
-      toast.error(result.error ?? "Could not start the message.")
-      return
+  function toggleRecipient(recipientId: string, selected: boolean): void {
+    setSelectedIds((current) =>
+      selected
+        ? Array.from(new Set([...current, recipientId]))
+        : current.filter((id) => id !== recipientId)
+    )
+  }
+
+  async function startMessage(): Promise<void> {
+    if (selectedIds.length === 0) return
+    setStarting(true)
+    try {
+      const result = await createDirectMessage(selectedIds)
+      if (!result.success || !result.data) {
+        toast.error(result.error ?? "Could not start the conversation.")
+        return
+      }
+      onOpenChange(false)
+      router.push(`/dashboard/conversations/${result.data.channelId}`)
+      router.refresh()
+    } catch {
+      toast.error("Could not start the conversation.")
+    } finally {
+      setStarting(false)
     }
-    onOpenChange(false)
-    setQuery("")
-    router.push(`/dashboard/conversations/${result.data.channelId}`)
-    router.refresh()
   }
 
   return (
@@ -87,7 +110,7 @@ export function DirectMessageDialog({
         <DialogHeader>
           <DialogTitle>New direct message</DialogTitle>
           <DialogDescription>
-            Start a private conversation with an internal team member.
+            Select one or more internal team members for a private conversation.
           </DialogDescription>
         </DialogHeader>
         <div className="relative">
@@ -112,35 +135,60 @@ export function DirectMessageDialog({
                 No matching team members.
               </p>
             ) : (
-              filteredRecipients.map((recipient) => (
-                <Button
-                  key={recipient.id}
-                  type="button"
-                  variant="ghost"
-                  className="h-auto w-full justify-start gap-3 px-3 py-2 text-left"
-                  disabled={startingId !== null}
-                  onClick={() => void startMessage(recipient.id)}
-                >
-                  <span className="grid size-9 shrink-0 place-items-center rounded-full bg-primary/10 text-primary">
-                    {startingId === recipient.id ? (
-                      <IconLoader2 className="size-4 animate-spin" />
-                    ) : (
-                      <IconMessageCircle className="size-4" />
+              filteredRecipients.map((recipient) => {
+                const selected = selectedIds.includes(recipient.id)
+                return (
+                  <div
+                    key={recipient.id}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-3 px-3 py-2 text-left hover:bg-accent has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50",
+                      selected && "bg-accent"
                     )}
-                  </span>
-                  <span className="min-w-0">
-                    <span className="block truncate text-sm font-medium">
-                      {recipient.name}
+                    onClick={() => {
+                      if (!starting) toggleRecipient(recipient.id, !selected)
+                    }}
+                  >
+                    <span className="grid size-9 shrink-0 place-items-center rounded-full bg-primary/10 text-primary">
+                      <IconMessageCircle className="size-4" />
                     </span>
-                    <span className="block truncate text-xs text-muted-foreground">
-                      {recipient.email}
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium">
+                        {recipient.name}
+                      </span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {recipient.email}
+                      </span>
                     </span>
-                  </span>
-                </Button>
-              ))
+                    <Checkbox
+                      checked={selected}
+                      disabled={starting}
+                      onClick={(event) => event.stopPropagation()}
+                      onCheckedChange={(checked) =>
+                        toggleRecipient(recipient.id, checked === true)
+                      }
+                      aria-label={`Include ${recipient.name}`}
+                    />
+                  </div>
+                )
+              })
             )}
           </div>
         </ScrollArea>
+        <DialogFooter className="items-center sm:justify-between">
+          <span className="text-sm text-muted-foreground">
+            {selectedIds.length === 0
+              ? "Choose at least one person"
+              : `${selectedIds.length} team member${selectedIds.length === 1 ? "" : "s"} selected`}
+          </span>
+          <Button
+            type="button"
+            disabled={selectedIds.length === 0 || starting}
+            onClick={() => void startMessage()}
+          >
+            {starting ? <IconLoader2 className="size-4 animate-spin" /> : null}
+            Start conversation
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   )

--- a/src/components/projects/project-rfi-communication-actions.tsx
+++ b/src/components/projects/project-rfi-communication-actions.tsx
@@ -1,0 +1,169 @@
+"use client"
+
+import * as React from "react"
+import { IconMail, IconMessageCircle, IconLoader2 } from "@tabler/icons-react"
+import Link from "next/link"
+import { toast } from "sonner"
+
+import { createProjectRfiEmailDraft } from "@/app/actions/project-rfis"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+
+export type ProjectRfiEmailRecipientOption = {
+  readonly email: string
+  readonly label: string
+  readonly recommended: boolean
+}
+
+export function ProjectRfiCommunicationActions({
+  projectId,
+  rfiId,
+  rfiNumber,
+  recipientOptions,
+}: {
+  readonly projectId: string
+  readonly rfiId: string
+  readonly rfiNumber: string
+  readonly recipientOptions: readonly ProjectRfiEmailRecipientOption[]
+}): React.ReactElement {
+  const [open, setOpen] = React.useState(false)
+  const [selected, setSelected] = React.useState<readonly string[]>([])
+  const [manualEmail, setManualEmail] = React.useState("")
+  const [starting, setStarting] = React.useState(false)
+
+  function openEmailDialog(): void {
+    setSelected(
+      recipientOptions
+        .filter((option) => option.recommended)
+        .map((option) => option.email)
+    )
+    setManualEmail("")
+    setOpen(true)
+  }
+
+  function toggleEmail(email: string, checked: boolean): void {
+    setSelected((current) =>
+      checked
+        ? Array.from(new Set([...current, email]))
+        : current.filter((candidate) => candidate !== email)
+    )
+  }
+
+  async function openDefaultEmailApp(): Promise<void> {
+    const manual = manualEmail.trim()
+    const recipients = manual
+      ? Array.from(new Set([...selected, manual]))
+      : selected
+    if (recipients.length === 0) {
+      toast.error("Choose or enter at least one recipient.")
+      return
+    }
+
+    setStarting(true)
+    const result = await createProjectRfiEmailDraft(projectId, rfiId, recipients)
+    setStarting(false)
+    if (!result.success) {
+      toast.error(result.error)
+      return
+    }
+
+    setOpen(false)
+    toast.info("Keep Compass in CC or use Reply All so responses stay with this RFI.")
+    window.location.href = result.href
+  }
+
+  return (
+    <>
+      <Button asChild type="button" size="sm" variant="outline">
+        <Link href={`/dashboard/conversations?projectId=${encodeURIComponent(projectId)}`}>
+          <IconMessageCircle className="size-4" />
+          Conversation
+        </Link>
+      </Button>
+      <Button type="button" size="sm" variant="outline" onClick={openEmailDialog}>
+        <IconMail className="size-4" />
+        Email
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Email {rfiNumber}</DialogTitle>
+            <DialogDescription>
+              Opens your default email app. Compass is automatically copied so
+              replies can return to this RFI and its project conversation.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="max-h-64 space-y-1 overflow-y-auto border-y py-2">
+            {recipientOptions.length === 0 ? (
+              <p className="px-2 py-4 text-sm text-muted-foreground">
+                No project contacts have an email address yet.
+              </p>
+            ) : (
+              recipientOptions.map((option) => {
+                const checked = selected.includes(option.email)
+                return (
+                  <label
+                    key={option.email}
+                    className="flex cursor-pointer items-center gap-3 px-2 py-2 hover:bg-muted"
+                  >
+                    <Checkbox
+                      checked={checked}
+                      onCheckedChange={(value) =>
+                        toggleEmail(option.email, value === true)
+                      }
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium">
+                        {option.label}
+                      </span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {option.email}
+                      </span>
+                    </span>
+                    {option.recommended ? (
+                      <span className="text-xs text-muted-foreground">RFI contact</span>
+                    ) : null}
+                  </label>
+                )
+              })
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor={`rfi-manual-email-${rfiId}`} className="text-sm font-medium">
+              Or enter another email
+            </label>
+            <Input
+              id={`rfi-manual-email-${rfiId}`}
+              type="email"
+              value={manualEmail}
+              onChange={(event) => setManualEmail(event.currentTarget.value)}
+              placeholder="name@example.com"
+            />
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="button" disabled={starting} onClick={() => void openDefaultEmailApp()}>
+              {starting ? <IconLoader2 className="size-4 animate-spin" /> : <IconMail className="size-4" />}
+              Open email app
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -209,6 +209,84 @@ export const notificationDeliveries = sqliteTable("notification_deliveries", {
   createdAt: text("created_at").notNull(),
 })
 
+export const emailReplyThreads = sqliteTable(
+  "email_reply_threads",
+  {
+    id: text("id").primaryKey(),
+    token: text("token").notNull(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id").references(() => projects.id, {
+      onDelete: "cascade",
+    }),
+    channelId: text("channel_id"),
+    sourceType: text("source_type").notNull(),
+    sourceId: text("source_id").notNull(),
+    sourceNumber: text("source_number"),
+    replyToAddress: text("reply_to_address").notNull(),
+    subject: text("subject").notNull(),
+    status: text("status").notNull().default("active"),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    lastInboundAt: text("last_inbound_at"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("email_reply_threads_token_idx").on(table.token),
+    index("email_reply_threads_org_project_idx").on(
+      table.organizationId,
+      table.projectId
+    ),
+    index("email_reply_threads_source_idx").on(table.sourceType, table.sourceId),
+  ]
+)
+
+export const inboundEmails = sqliteTable(
+  "inbound_emails",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id").references(() => projects.id, {
+      onDelete: "set null",
+    }),
+    replyThreadId: text("reply_thread_id").references(
+      () => emailReplyThreads.id,
+      { onDelete: "set null" }
+    ),
+    token: text("token"),
+    gmailMessageId: text("gmail_message_id").notNull(),
+    gmailThreadId: text("gmail_thread_id"),
+    messageIdHeader: text("message_id_header"),
+    inReplyToHeader: text("in_reply_to_header"),
+    referencesHeader: text("references_header"),
+    fromAddress: text("from_address").notNull(),
+    fromName: text("from_name"),
+    toAddress: text("to_address"),
+    subject: text("subject").notNull(),
+    textBody: text("text_body"),
+    htmlBody: text("html_body"),
+    snippet: text("snippet"),
+    matchedStatus: text("matched_status").notNull().default("needs_review"),
+    postedMessageId: text("posted_message_id"),
+    receivedAt: text("received_at").notNull(),
+    importedAt: text("imported_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("inbound_emails_gmail_message_id_idx").on(table.gmailMessageId),
+    index("inbound_emails_org_project_idx").on(
+      table.organizationId,
+      table.projectId
+    ),
+    index("inbound_emails_reply_thread_idx").on(table.replyThreadId),
+    index("inbound_emails_status_idx").on(table.matchedStatus),
+  ]
+)
+
 export const organizationInvites = sqliteTable("organization_invites", {
   id: text("id").primaryKey(),
   organizationId: text("organization_id")
@@ -1680,6 +1758,10 @@ export type NewNotificationRecipient =
 export type NotificationDelivery = typeof notificationDeliveries.$inferSelect
 export type NewNotificationDelivery =
   typeof notificationDeliveries.$inferInsert
+export type EmailReplyThread = typeof emailReplyThreads.$inferSelect
+export type NewEmailReplyThread = typeof emailReplyThreads.$inferInsert
+export type InboundEmail = typeof inboundEmails.$inferSelect
+export type NewInboundEmail = typeof inboundEmails.$inferInsert
 export type OrganizationInvite = typeof organizationInvites.$inferSelect
 export type NewOrganizationInvite = typeof organizationInvites.$inferInsert
 export type Team = typeof teams.$inferSelect

--- a/src/lib/conversations/__tests__/direct-channel.test.ts
+++ b/src/lib/conversations/__tests__/direct-channel.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  directChannelId,
+  directParticipantIds,
+} from "@/lib/conversations/direct-channel"
+
+describe("direct conversation identity", () => {
+  it("deduplicates and sorts the complete participant set", () => {
+    expect(directParticipantIds("user-b", ["user-c", "user-a", "user-c"])).toEqual([
+      "user-a",
+      "user-b",
+      "user-c",
+    ])
+  })
+
+  it("uses the same channel for the same participants in any order", async () => {
+    const first = await directChannelId("org-1", ["user-a", "user-b", "user-c"])
+    const second = await directChannelId("org-1", ["user-c", "user-a", "user-b"])
+
+    expect(second).toBe(first)
+  })
+
+  it("keeps different private groups in different channels", async () => {
+    const first = await directChannelId("org-1", ["user-a", "user-b"])
+    const second = await directChannelId("org-1", ["user-a", "user-b", "user-c"])
+
+    expect(second).not.toBe(first)
+  })
+})

--- a/src/lib/conversations/direct-channel.ts
+++ b/src/lib/conversations/direct-channel.ts
@@ -1,0 +1,19 @@
+export function directParticipantIds(
+  currentUserId: string,
+  targetUserIds: readonly string[]
+): readonly string[] {
+  return Array.from(new Set([currentUserId, ...targetUserIds])).sort()
+}
+
+export async function directChannelId(
+  organizationId: string,
+  participantIds: readonly string[]
+): Promise<string> {
+  const participants = [...participantIds].sort().join(":")
+  const bytes = new TextEncoder().encode(`${organizationId}:${participants}`)
+  const digest = await crypto.subtle.digest("SHA-256", bytes)
+  const hash = Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+  return `direct-${hash.slice(0, 32)}`
+}

--- a/src/lib/email/__tests__/mailto.test.ts
+++ b/src/lib/email/__tests__/mailto.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+
+import { trackedMailtoHref } from "@/lib/email/mailto"
+
+describe("trackedMailtoHref", () => {
+  it("opens the default mail app with a Compass tracking address in CC", () => {
+    const href = trackedMailtoHref({
+      to: ["owner@example.com"],
+      cc: "Compass <jarvis+cmp-token@hps-colorado.com>",
+      subject: "[RFI-4] Roof framing",
+      body: "Please reply all.",
+    })
+
+    expect(href).toContain("mailto:owner%40example.com")
+    expect(href).toContain("cc=jarvis%2Bcmp-token%40hps-colorado.com")
+    expect(href).toContain("subject=%5BRFI-4%5D+Roof+framing")
+  })
+})

--- a/src/lib/email/compass-email.ts
+++ b/src/lib/email/compass-email.ts
@@ -190,6 +190,7 @@ export async function getCompassGmailAccessToken(input: {
   readonly db: ReturnType<typeof getDb>
   readonly organizationId: string | null
   readonly scopes: readonly string[]
+  readonly sender?: string
 }): Promise<
   | { readonly success: true; readonly accessToken: string; readonly sender: string }
   | { readonly success: false; readonly error: string }
@@ -205,6 +206,7 @@ export async function getCompassGmailAccessToken(input: {
   const from =
     envString(input.env, "COMPASS_EMAIL_FROM") ?? DEFAULT_COMPASS_EMAIL_FROM
   const sender =
+    input.sender ??
     envString(input.env, "COMPASS_GMAIL_SENDER") ??
     extractEmailAddress(from) ??
     DEFAULT_COMPASS_GMAIL_USER

--- a/src/lib/email/compass-email.ts
+++ b/src/lib/email/compass-email.ts
@@ -20,7 +20,12 @@ export type CompassEmailInput = {
   readonly db: ReturnType<typeof getDb>
   readonly organizationId: string | null
   readonly to: readonly string[]
+  readonly cc?: readonly string[]
   readonly replyTo?: string
+  readonly headers?: readonly {
+    readonly name: string
+    readonly value: string
+  }[]
   readonly subject: string
   readonly text: string
   readonly html?: string
@@ -33,7 +38,10 @@ export type CompassEmailDeliveryResult = {
   readonly error: string | null
 }
 
-const GMAIL_SEND_SCOPE = "https://www.googleapis.com/auth/gmail.send"
+export const COMPASS_GMAIL_SEND_SCOPE =
+  "https://www.googleapis.com/auth/gmail.send"
+export const COMPASS_GMAIL_READONLY_SCOPE =
+  "https://www.googleapis.com/auth/gmail.readonly"
 const DEFAULT_COMPASS_EMAIL_FROM = "Compass <compass@hps-colorado.com>"
 const DEFAULT_COMPASS_GMAIL_USER = "compass@hps-colorado.com"
 
@@ -56,11 +64,17 @@ function googleConfigEnv(env: unknown): Record<string, string | undefined> {
   for (const [key, value] of Object.entries(env)) {
     if (typeof value === "string") values[key] = value
   }
+
   return values
 }
 
 function escapeHeader(value: string): string {
   return value.replace(/[\r\n]+/g, " ").trim()
+}
+
+function safeHeaderName(value: string): string | null {
+  const name = value.trim()
+  return /^[A-Za-z0-9-]+$/.test(name) ? name : null
 }
 
 function extractEmailAddress(value: string): string {
@@ -71,23 +85,42 @@ function extractEmailAddress(value: string): string {
 function base64urlString(value: string): string {
   const bytes = new TextEncoder().encode(value)
   let binary = ""
-  for (const byte of bytes) binary += String.fromCharCode(byte)
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
   return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
+function mimeBoundary(): string {
+  return `compass-${crypto.randomUUID()}`
 }
 
 function buildMimeMessage(input: {
   readonly from: string
   readonly to: readonly string[]
+  readonly cc: readonly string[]
   readonly replyTo: string | null
+  readonly headers: readonly {
+    readonly name: string
+    readonly value: string
+  }[]
   readonly subject: string
   readonly text: string
   readonly html: string | null
 }): string {
+  const customHeaders = input.headers
+    .map((header) => {
+      const name = safeHeaderName(header.name)
+      return name ? `${name}: ${escapeHeader(header.value)}` : null
+    })
+    .filter((line): line is string => line !== null)
   const headers = [
     `From: ${escapeHeader(input.from)}`,
     `To: ${input.to.map(escapeHeader).join(", ")}`,
+    input.cc.length > 0 ? `Cc: ${input.cc.map(escapeHeader).join(", ")}` : null,
     input.replyTo ? `Reply-To: ${escapeHeader(input.replyTo)}` : null,
     `Subject: ${escapeHeader(input.subject)}`,
+    ...customHeaders,
     "MIME-Version: 1.0",
   ].filter((line): line is string => line !== null)
 
@@ -101,7 +134,7 @@ function buildMimeMessage(input: {
     ].join("\r\n")
   }
 
-  const boundary = `compass-${crypto.randomUUID()}`
+  const boundary = mimeBoundary()
   return [
     ...headers,
     `Content-Type: multipart/alternative; boundary="${boundary}"`,
@@ -129,32 +162,46 @@ function providerMessageId(value: unknown): string | null {
   return typeof messageId === "string" ? messageId : null
 }
 
-async function sendGmail(
-  input: CompassEmailInput
-): Promise<CompassEmailDeliveryResult> {
+async function getGoogleServiceAccountKey(input: {
+  readonly env: unknown
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string | null
+}): Promise<string | null> {
   const config = getGoogleConfig(googleConfigEnv(input.env))
-  const rows = input.organizationId
-    ? await input.db
+  const query = input.organizationId
+    ? input.db
         .select()
         .from(googleAuth)
         .where(eq(googleAuth.organizationId, input.organizationId))
         .limit(1)
-    : await input.db.select().from(googleAuth).limit(1)
-  const row = rows[0]
-  if (!row) {
-    return {
-      status: "pending_provider",
-      provider: "gmail",
-      providerMessageId: null,
-      error: "Google Workspace service account is not connected.",
-    }
-  }
+    : input.db.select().from(googleAuth).limit(1)
+  const row = await query.then((rows) => rows[0] ?? null)
+  if (!row) return null
 
-  const keyJson = await decrypt(
+  return decrypt(
     row.serviceAccountKeyEncrypted,
     config.encryptionKey,
     getGoogleCryptoSalt()
   )
+}
+
+export async function getCompassGmailAccessToken(input: {
+  readonly env: unknown
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string | null
+  readonly scopes: readonly string[]
+}): Promise<
+  | { readonly success: true; readonly accessToken: string; readonly sender: string }
+  | { readonly success: false; readonly error: string }
+> {
+  const keyJson = await getGoogleServiceAccountKey(input)
+  if (!keyJson) {
+    return {
+      success: false,
+      error: "Google Workspace service account is not connected.",
+    }
+  }
+
   const from =
     envString(input.env, "COMPASS_EMAIL_FROM") ?? DEFAULT_COMPASS_EMAIL_FROM
   const sender =
@@ -162,15 +209,45 @@ async function sendGmail(
     extractEmailAddress(from) ??
     DEFAULT_COMPASS_GMAIL_USER
   const serviceAccountKey = parseServiceAccountKey(keyJson)
-  const jwt = await createServiceAccountJWT(serviceAccountKey, sender, [
-    GMAIL_SEND_SCOPE,
-  ])
+  const jwt = await createServiceAccountJWT(
+    serviceAccountKey,
+    sender,
+    input.scopes
+  )
   const token = await exchangeJWTForAccessToken(jwt)
+
+  return {
+    success: true,
+    accessToken: token.access_token,
+    sender,
+  }
+}
+
+async function sendGmail(input: CompassEmailInput): Promise<CompassEmailDeliveryResult> {
+  const access = await getCompassGmailAccessToken({
+    env: input.env,
+    db: input.db,
+    organizationId: input.organizationId,
+    scopes: [COMPASS_GMAIL_SEND_SCOPE],
+  })
+  if (!access.success) {
+    return {
+      status: "pending_provider",
+      provider: "gmail",
+      providerMessageId: null,
+      error: access.error,
+    }
+  }
+
+  const from =
+    envString(input.env, "COMPASS_EMAIL_FROM") ?? DEFAULT_COMPASS_EMAIL_FROM
   const raw = base64urlString(
     buildMimeMessage({
       from,
       to: input.to,
+      cc: input.cc ?? [],
       replyTo: input.replyTo ?? null,
+      headers: input.headers ?? [],
       subject: input.subject,
       text: input.text,
       html: input.html ?? null,
@@ -182,7 +259,7 @@ async function sendGmail(
     {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${token.access_token}`,
+        Authorization: `Bearer ${access.accessToken}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ raw }),
@@ -217,22 +294,32 @@ async function sendResend(
     }
   }
 
+  const requestBody: Record<string, unknown> = {
+    from:
+      envString(input.env, "COMPASS_EMAIL_FROM") ?? DEFAULT_COMPASS_EMAIL_FROM,
+    to: input.to,
+    subject: input.subject,
+    text: input.text,
+  }
+  if (input.html) requestBody.html = input.html
+  if (input.cc && input.cc.length > 0) requestBody.cc = input.cc
+  if (input.replyTo) requestBody.reply_to = input.replyTo
+  if (input.headers && input.headers.length > 0) {
+    const headers: Record<string, string> = {}
+    for (const header of input.headers) {
+      const name = safeHeaderName(header.name)
+      if (name) headers[name] = header.value
+    }
+    requestBody.headers = headers
+  }
+
   const response = await fetch("https://api.resend.com/emails", {
     method: "POST",
     headers: {
       Authorization: `Bearer ${apiKey}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({
-      from:
-        envString(input.env, "COMPASS_EMAIL_FROM") ??
-        DEFAULT_COMPASS_EMAIL_FROM,
-      to: input.to,
-      reply_to: input.replyTo,
-      subject: input.subject,
-      text: input.text,
-      html: input.html,
-    }),
+    body: JSON.stringify(requestBody),
   })
   const responseText = await response.text()
   let id: string | null = null
@@ -255,7 +342,10 @@ export async function sendCompassEmail(
 ): Promise<CompassEmailDeliveryResult> {
   const preferredProvider =
     envString(input.env, "COMPASS_EMAIL_PROVIDER") ?? "gmail"
-  if (preferredProvider === "resend") return sendResend(input)
+
+  if (preferredProvider === "resend") {
+    return sendResend(input)
+  }
 
   const gmailDelivery = await sendGmail(input)
   if (gmailDelivery.status === "sent") return gmailDelivery

--- a/src/lib/email/gmail-inbound.ts
+++ b/src/lib/email/gmail-inbound.ts
@@ -7,6 +7,7 @@ import {
   emailReplyThreads,
   inboundEmails,
   organizationMembers,
+  projectRfis,
   projects,
   users,
 } from "@/db/schema"
@@ -28,14 +29,18 @@ import {
   stripHtml,
   type InboundCandidate,
 } from "@/lib/email/gmail-message-parser"
+import { replyMailboxEmail } from "@/lib/email/reply-tracking"
+import { canonicalRfiStatus } from "@/lib/rfis/status"
 
 type Db = ReturnType<typeof getDb>
 
 export type GmailInboundSyncSummary = {
   readonly scanned: number
   readonly imported: number
+  readonly ignoredOutbound: number
   readonly posted: number
   readonly skippedDuplicates: number
+  readonly skippedOtherOrganization: number
   readonly needsReview: number
   readonly errors: readonly string[]
 }
@@ -60,11 +65,15 @@ function parsePositiveInt(value: string | null, fallback: number): number {
 
 function isGmailListResponse(value: unknown): value is {
   readonly messages?: readonly { readonly id?: string }[]
+  readonly nextPageToken?: string
 } {
   if (!isRecord(value)) return false
   const messagesValue = value.messages
-  if (messagesValue === undefined) return true
-  return Array.isArray(messagesValue)
+  const nextPageToken = value.nextPageToken
+  return (
+    (messagesValue === undefined || Array.isArray(messagesValue)) &&
+    (nextPageToken === undefined || typeof nextPageToken === "string")
+  )
 }
 
 function projectChannelName(project: {
@@ -153,6 +162,8 @@ async function ensureProjectChannel(input: {
         eq(channels.organizationId, input.organizationId),
         eq(channels.projectId, input.projectId),
         eq(channels.type, "text"),
+        eq(channels.isPrivate, false),
+        eq(channels.audience, "staff"),
         sql`${channels.archivedAt} IS NULL`
       )
     )
@@ -247,12 +258,72 @@ function messageHtml(candidate: InboundCandidate): string {
 </div>`
 }
 
+async function insertInboundAudit(input: {
+  readonly db: Db
+  readonly organizationId: string
+  readonly projectId: string | null
+  readonly replyThreadId: string | null
+  readonly candidate: InboundCandidate
+  readonly matchedStatus: string
+  readonly postedMessageId: string | null
+  readonly importedAt: string
+}): Promise<void> {
+  await input.db
+    .insert(inboundEmails)
+    .values({
+      id: crypto.randomUUID(),
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      replyThreadId: input.replyThreadId,
+      token: input.candidate.token,
+      gmailMessageId: input.candidate.gmailMessageId,
+      gmailThreadId: input.candidate.gmailThreadId,
+      messageIdHeader: input.candidate.messageIdHeader,
+      inReplyToHeader: input.candidate.inReplyToHeader,
+      referencesHeader: input.candidate.referencesHeader,
+      fromAddress: input.candidate.fromAddress,
+      fromName: input.candidate.fromName,
+      toAddress: input.candidate.toAddress,
+      subject: input.candidate.subject,
+      textBody: input.candidate.textBody,
+      htmlBody: input.candidate.htmlBody,
+      snippet: input.candidate.snippet,
+      matchedStatus: input.matchedStatus,
+      postedMessageId: input.postedMessageId,
+      receivedAt: input.candidate.receivedAt,
+      importedAt: input.importedAt,
+    })
+    .onConflictDoNothing({ target: inboundEmails.gmailMessageId })
+}
+
+async function isReplyThreadCreator(input: {
+  readonly db: Db
+  readonly createdBy: string | null
+  readonly fromAddress: string
+}): Promise<boolean> {
+  if (!input.createdBy) return false
+  const creator = await input.db
+    .select({ email: users.email, googleEmail: users.googleEmail })
+    .from(users)
+    .where(eq(users.id, input.createdBy))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  if (!creator) return false
+
+  const from = input.fromAddress.trim().toLowerCase()
+  return [creator.email, creator.googleEmail]
+    .filter((email): email is string => email !== null)
+    .some((email) => email.trim().toLowerCase() === from)
+}
+
 async function importCandidate(input: {
   readonly env: unknown
   readonly db: Db
   readonly organizationId: string
   readonly candidate: InboundCandidate
-}): Promise<"duplicate" | "needs_review" | "posted"> {
+}): Promise<
+  "duplicate" | "ignored_outbound" | "needs_review" | "other_org" | "posted"
+> {
   const [duplicate] = await input.db
     .select({ id: inboundEmails.id })
     .from(inboundEmails)
@@ -270,32 +341,43 @@ async function importCandidate(input: {
     : null
   const now = new Date().toISOString()
 
+  if (replyThread && replyThread.organizationId !== input.organizationId) {
+    return "other_org"
+  }
+
+  if (
+    replyThread &&
+    (await isReplyThreadCreator({
+      db: input.db,
+      createdBy: replyThread.createdBy,
+      fromAddress: input.candidate.fromAddress,
+    }))
+  ) {
+    await insertInboundAudit({
+      db: input.db,
+      organizationId: input.organizationId,
+      projectId: replyThread.projectId,
+      replyThreadId: replyThread.id,
+      candidate: input.candidate,
+      matchedStatus: "ignored_outbound",
+      postedMessageId: null,
+      importedAt: now,
+    })
+    return "ignored_outbound"
+  }
+
   if (
     !replyThread ||
-    replyThread.organizationId !== input.organizationId ||
     !replyThread.projectId
   ) {
-    await input.db.insert(inboundEmails).values({
-      id: crypto.randomUUID(),
+    await insertInboundAudit({
+      db: input.db,
       organizationId: input.organizationId,
       projectId: replyThread?.projectId ?? null,
       replyThreadId: replyThread?.id ?? null,
-      token: input.candidate.token,
-      gmailMessageId: input.candidate.gmailMessageId,
-      gmailThreadId: input.candidate.gmailThreadId,
-      messageIdHeader: input.candidate.messageIdHeader,
-      inReplyToHeader: input.candidate.inReplyToHeader,
-      referencesHeader: input.candidate.referencesHeader,
-      fromAddress: input.candidate.fromAddress,
-      fromName: input.candidate.fromName,
-      toAddress: input.candidate.toAddress,
-      subject: input.candidate.subject,
-      textBody: input.candidate.textBody,
-      htmlBody: input.candidate.htmlBody,
-      snippet: input.candidate.snippet,
+      candidate: input.candidate,
       matchedStatus: "needs_review",
       postedMessageId: null,
-      receivedAt: input.candidate.receivedAt,
       importedAt: now,
     })
     return "needs_review"
@@ -307,27 +389,14 @@ async function importCandidate(input: {
     organizationId: input.organizationId,
   })
   if (!systemUserId) {
-    await input.db.insert(inboundEmails).values({
-      id: crypto.randomUUID(),
+    await insertInboundAudit({
+      db: input.db,
       organizationId: input.organizationId,
       projectId: replyThread.projectId,
       replyThreadId: replyThread.id,
-      token: input.candidate.token,
-      gmailMessageId: input.candidate.gmailMessageId,
-      gmailThreadId: input.candidate.gmailThreadId,
-      messageIdHeader: input.candidate.messageIdHeader,
-      inReplyToHeader: input.candidate.inReplyToHeader,
-      referencesHeader: input.candidate.referencesHeader,
-      fromAddress: input.candidate.fromAddress,
-      fromName: input.candidate.fromName,
-      toAddress: input.candidate.toAddress,
-      subject: input.candidate.subject,
-      textBody: input.candidate.textBody,
-      htmlBody: input.candidate.htmlBody,
-      snippet: input.candidate.snippet,
+      candidate: input.candidate,
       matchedStatus: "needs_review",
       postedMessageId: null,
-      receivedAt: input.candidate.receivedAt,
       importedAt: now,
     })
     return "needs_review"
@@ -343,27 +412,14 @@ async function importCandidate(input: {
     }))
 
   if (!channelId) {
-    await input.db.insert(inboundEmails).values({
-      id: crypto.randomUUID(),
+    await insertInboundAudit({
+      db: input.db,
       organizationId: input.organizationId,
       projectId: replyThread.projectId,
       replyThreadId: replyThread.id,
-      token: input.candidate.token,
-      gmailMessageId: input.candidate.gmailMessageId,
-      gmailThreadId: input.candidate.gmailThreadId,
-      messageIdHeader: input.candidate.messageIdHeader,
-      inReplyToHeader: input.candidate.inReplyToHeader,
-      referencesHeader: input.candidate.referencesHeader,
-      fromAddress: input.candidate.fromAddress,
-      fromName: input.candidate.fromName,
-      toAddress: input.candidate.toAddress,
-      subject: input.candidate.subject,
-      textBody: input.candidate.textBody,
-      htmlBody: input.candidate.htmlBody,
-      snippet: input.candidate.snippet,
+      candidate: input.candidate,
       matchedStatus: "needs_review",
       postedMessageId: null,
-      receivedAt: input.candidate.receivedAt,
       importedAt: now,
     })
     return "needs_review"
@@ -374,22 +430,39 @@ async function importCandidate(input: {
     systemUserId,
   })
 
-  const messageId = crypto.randomUUID()
-  await input.db.insert(messages).values({
-    id: messageId,
-    channelId,
-    threadId: null,
-    userId: systemUserId,
-    content: messageContent(input.candidate),
-    contentHtml: messageHtml(input.candidate),
-    editedAt: null,
-    deletedAt: null,
-    deletedBy: null,
-    isPinned: false,
-    replyCount: 0,
-    lastReplyAt: null,
-    createdAt: input.candidate.receivedAt,
-  })
+  const messageId = `email-${input.candidate.gmailMessageId}`
+  const insertedMessages = await input.db
+    .insert(messages)
+    .values({
+      id: messageId,
+      channelId,
+      threadId: null,
+      userId: systemUserId,
+      content: messageContent(input.candidate),
+      contentHtml: messageHtml(input.candidate),
+      editedAt: null,
+      deletedAt: null,
+      deletedBy: null,
+      isPinned: false,
+      replyCount: 0,
+      lastReplyAt: null,
+      createdAt: input.candidate.receivedAt,
+    })
+    .onConflictDoNothing({ target: messages.id })
+    .returning({ id: messages.id })
+  if (insertedMessages.length === 0) {
+    await insertInboundAudit({
+      db: input.db,
+      organizationId: input.organizationId,
+      projectId: replyThread.projectId,
+      replyThreadId: replyThread.id,
+      candidate: input.candidate,
+      matchedStatus: "posted",
+      postedMessageId: messageId,
+      importedAt: now,
+    })
+    return "duplicate"
+  }
   await input.db
     .update(channelReadState)
     .set({
@@ -409,27 +482,38 @@ async function importCandidate(input: {
       updatedAt: now,
     })
     .where(eq(emailReplyThreads.id, replyThread.id))
-  await input.db.insert(inboundEmails).values({
-    id: crypto.randomUUID(),
+  if (replyThread.sourceType === "rfi") {
+    const rfi = await input.db
+      .select({ status: projectRfis.status })
+      .from(projectRfis)
+      .where(
+        and(
+          eq(projectRfis.id, replyThread.sourceId),
+          eq(projectRfis.projectId, replyThread.projectId)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (rfi && canonicalRfiStatus(rfi.status) === "new") {
+      await input.db
+        .update(projectRfis)
+        .set({ status: "in_progress", updatedAt: now })
+        .where(
+          and(
+            eq(projectRfis.id, replyThread.sourceId),
+            eq(projectRfis.projectId, replyThread.projectId)
+          )
+        )
+    }
+  }
+  await insertInboundAudit({
+    db: input.db,
     organizationId: input.organizationId,
     projectId: replyThread.projectId,
     replyThreadId: replyThread.id,
-    token: input.candidate.token,
-    gmailMessageId: input.candidate.gmailMessageId,
-    gmailThreadId: input.candidate.gmailThreadId,
-    messageIdHeader: input.candidate.messageIdHeader,
-    inReplyToHeader: input.candidate.inReplyToHeader,
-    referencesHeader: input.candidate.referencesHeader,
-    fromAddress: input.candidate.fromAddress,
-    fromName: input.candidate.fromName,
-    toAddress: input.candidate.toAddress,
-    subject: input.candidate.subject,
-    textBody: input.candidate.textBody,
-    htmlBody: input.candidate.htmlBody,
-    snippet: input.candidate.snippet,
+    candidate: input.candidate,
     matchedStatus: "posted",
     postedMessageId: messageId,
-    receivedAt: input.candidate.receivedAt,
     importedAt: now,
   })
 
@@ -463,13 +547,16 @@ export async function syncGmailInboundReplies(input: {
     db: input.db,
     organizationId: input.organizationId,
     scopes: [COMPASS_GMAIL_READONLY_SCOPE],
+    sender: replyMailboxEmail(input.env),
   })
   if (!access.success) {
     return {
       scanned: 0,
       imported: 0,
+      ignoredOutbound: 0,
       posted: 0,
       skippedDuplicates: 0,
+      skippedOtherOrganization: 0,
       needsReview: 0,
       errors: [access.error],
     }
@@ -481,32 +568,45 @@ export async function syncGmailInboundReplies(input: {
     envString(input.env, "COMPASS_GMAIL_INBOUND_MAX_RESULTS"),
     25
   )
-  const listUrl = new URL(
-    "https://gmail.googleapis.com/gmail/v1/users/me/messages"
+  const maxPages = parsePositiveInt(
+    envString(input.env, "COMPASS_GMAIL_INBOUND_MAX_PAGES"),
+    20
   )
-  listUrl.searchParams.set("q", query)
-  listUrl.searchParams.set("maxResults", String(maxResults))
 
   const errors: string[] = []
   let scanned = 0
   let imported = 0
+  let ignoredOutbound = 0
   let posted = 0
   let skippedDuplicates = 0
+  let skippedOtherOrganization = 0
   let needsReview = 0
 
   try {
-    const listResponse = await fetchJson({
-      url: listUrl.toString(),
-      accessToken: access.accessToken,
-    })
-    if (!isGmailListResponse(listResponse)) {
-      throw new Error("Gmail returned an unexpected message list.")
+    const messageIds = new Set<string>()
+    let pageToken: string | null = null
+    for (let page = 0; page < maxPages; page += 1) {
+      const listUrl = new URL(
+        "https://gmail.googleapis.com/gmail/v1/users/me/messages"
+      )
+      listUrl.searchParams.set("q", query)
+      listUrl.searchParams.set("maxResults", String(maxResults))
+      if (pageToken) listUrl.searchParams.set("pageToken", pageToken)
+      const listResponse = await fetchJson({
+        url: listUrl.toString(),
+        accessToken: access.accessToken,
+      })
+      if (!isGmailListResponse(listResponse)) {
+        throw new Error("Gmail returned an unexpected message list.")
+      }
+      for (const message of listResponse.messages ?? []) {
+        if (message.id) messageIds.add(message.id)
+      }
+      pageToken = listResponse.nextPageToken ?? null
+      if (!pageToken) break
     }
 
-    const messageIds = (listResponse.messages ?? [])
-      .map((message) => message.id ?? null)
-      .filter((id): id is string => id !== null)
-    scanned = messageIds.length
+    scanned = messageIds.size
 
     for (const id of messageIds) {
       try {
@@ -531,6 +631,10 @@ export async function syncGmailInboundReplies(input: {
 
         if (result === "duplicate") {
           skippedDuplicates += 1
+        } else if (result === "ignored_outbound") {
+          ignoredOutbound += 1
+        } else if (result === "other_org") {
+          skippedOtherOrganization += 1
         } else {
           imported += 1
           if (result === "posted") posted += 1
@@ -547,8 +651,10 @@ export async function syncGmailInboundReplies(input: {
   return {
     scanned,
     imported,
+    ignoredOutbound,
     posted,
     skippedDuplicates,
+    skippedOtherOrganization,
     needsReview,
     errors,
   }

--- a/src/lib/email/gmail-inbound.ts
+++ b/src/lib/email/gmail-inbound.ts
@@ -1,0 +1,564 @@
+import "server-only"
+
+import { and, eq, inArray, sql } from "drizzle-orm"
+
+import { getDb } from "@/db"
+import {
+  emailReplyThreads,
+  inboundEmails,
+  organizationMembers,
+  projects,
+  users,
+} from "@/db/schema"
+import { googleAuth } from "@/db/schema-google"
+import {
+  channelMembers,
+  channelReadState,
+  channels,
+  messages,
+} from "@/db/schema-conversations"
+import {
+  COMPASS_GMAIL_READONLY_SCOPE,
+  getCompassGmailAccessToken,
+} from "@/lib/email/compass-email"
+import {
+  candidateFromMessage,
+  escapeHtml,
+  isGmailMessage,
+  stripHtml,
+  type InboundCandidate,
+} from "@/lib/email/gmail-message-parser"
+
+type Db = ReturnType<typeof getDb>
+
+export type GmailInboundSyncSummary = {
+  readonly scanned: number
+  readonly imported: number
+  readonly posted: number
+  readonly skippedDuplicates: number
+  readonly needsReview: number
+  readonly errors: readonly string[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function envString(env: unknown, key: string): string | null {
+  if (!isRecord(env)) return process.env[key] ?? null
+  const value = env[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : process.env[key] ?? null
+}
+
+function parsePositiveInt(value: string | null, fallback: number): number {
+  if (!value) return fallback
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function isGmailListResponse(value: unknown): value is {
+  readonly messages?: readonly { readonly id?: string }[]
+} {
+  if (!isRecord(value)) return false
+  const messagesValue = value.messages
+  if (messagesValue === undefined) return true
+  return Array.isArray(messagesValue)
+}
+
+function projectChannelName(project: {
+  readonly projectNumber: string | null
+  readonly name: string
+}): string {
+  const source = project.projectNumber ?? project.name
+  const slug = source
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48)
+  return `${slug.length > 0 ? slug : "project"}-team`
+}
+
+async function findSystemUser(input: {
+  readonly env: unknown
+  readonly db: Db
+  readonly organizationId: string
+}): Promise<string | null> {
+  const preferredEmails = [
+    envString(input.env, "COMPASS_INBOUND_USER_EMAIL"),
+    "compass@hps-colorado.com",
+    "jarvis@hps-colorado.com",
+  ].filter((email): email is string => email !== null)
+
+  if (preferredEmails.length > 0) {
+    const [preferred] = await input.db
+      .select({ id: users.id })
+      .from(users)
+      .innerJoin(
+        organizationMembers,
+        eq(organizationMembers.userId, users.id)
+      )
+      .where(
+        and(
+          eq(organizationMembers.organizationId, input.organizationId),
+          inArray(users.email, preferredEmails),
+          eq(users.isActive, true)
+        )
+      )
+      .limit(1)
+    if (preferred) return preferred.id
+  }
+
+  const [fallback] = await input.db
+    .select({ id: users.id })
+    .from(users)
+    .innerJoin(organizationMembers, eq(organizationMembers.userId, users.id))
+    .where(
+      and(
+        eq(organizationMembers.organizationId, input.organizationId),
+        inArray(organizationMembers.role, ["admin", "owner", "office"]),
+        eq(users.isActive, true)
+      )
+    )
+    .limit(1)
+
+  return fallback?.id ?? null
+}
+
+async function ensureProjectChannel(input: {
+  readonly db: Db
+  readonly organizationId: string
+  readonly projectId: string
+  readonly systemUserId: string
+}): Promise<string | null> {
+  const [project] = await input.db
+    .select({
+      id: projects.id,
+      name: projects.name,
+      projectNumber: projects.projectNumber,
+      organizationId: projects.organizationId,
+    })
+    .from(projects)
+    .where(eq(projects.id, input.projectId))
+    .limit(1)
+  if (!project || project.organizationId !== input.organizationId) return null
+
+  const [existing] = await input.db
+    .select({ id: channels.id })
+    .from(channels)
+    .where(
+      and(
+        eq(channels.organizationId, input.organizationId),
+        eq(channels.projectId, input.projectId),
+        eq(channels.type, "text"),
+        sql`${channels.archivedAt} IS NULL`
+      )
+    )
+    .orderBy(channels.createdAt)
+    .limit(1)
+  if (existing) return existing.id
+
+  const now = new Date().toISOString()
+  const channelId = crypto.randomUUID()
+  await input.db.insert(channels).values({
+    id: channelId,
+    name: projectChannelName(project),
+    type: "text",
+    description: "Project staff conversation",
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    categoryId: null,
+    isPrivate: false,
+    audience: "staff",
+    createdBy: input.systemUserId,
+    sortOrder: 0,
+    archivedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  })
+
+  return channelId
+}
+
+async function ensureSystemMembership(input: {
+  readonly db: Db
+  readonly channelId: string
+  readonly systemUserId: string
+}): Promise<void> {
+  const [existing] = await input.db
+    .select({ id: channelMembers.id })
+    .from(channelMembers)
+    .where(
+      and(
+        eq(channelMembers.channelId, input.channelId),
+        eq(channelMembers.userId, input.systemUserId)
+      )
+    )
+    .limit(1)
+  if (existing) return
+
+  const now = new Date().toISOString()
+  await input.db.insert(channelMembers).values({
+    id: crypto.randomUUID(),
+    channelId: input.channelId,
+    userId: input.systemUserId,
+    role: "member",
+    notifyLevel: "mentions",
+    joinedAt: now,
+  })
+  await input.db.insert(channelReadState).values({
+    id: crypto.randomUUID(),
+    userId: input.systemUserId,
+    channelId: input.channelId,
+    lastReadMessageId: null,
+    lastReadAt: now,
+    unreadCount: 0,
+  })
+}
+
+function messageContent(candidate: InboundCandidate): string {
+  const body =
+    candidate.textBody ??
+    (candidate.htmlBody ? stripHtml(candidate.htmlBody) : null) ??
+    candidate.snippet ??
+    "(No message body.)"
+
+  return [
+    `Email reply from ${candidate.fromName ?? candidate.fromAddress}`,
+    `Subject: ${candidate.subject}`,
+    "",
+    body.trim(),
+  ].join("\n")
+}
+
+function messageHtml(candidate: InboundCandidate): string {
+  const body =
+    candidate.textBody ??
+    (candidate.htmlBody ? stripHtml(candidate.htmlBody) : null) ??
+    candidate.snippet ??
+    "(No message body.)"
+
+  return `<div class="compass-email-reply">
+  <p><strong>Email reply from ${escapeHtml(candidate.fromName ?? candidate.fromAddress)}</strong></p>
+  <p><span style="color:#6b7280;">Subject:</span> ${escapeHtml(candidate.subject)}</p>
+  <div style="white-space:pre-wrap;">${escapeHtml(body.trim())}</div>
+</div>`
+}
+
+async function importCandidate(input: {
+  readonly env: unknown
+  readonly db: Db
+  readonly organizationId: string
+  readonly candidate: InboundCandidate
+}): Promise<"duplicate" | "needs_review" | "posted"> {
+  const [duplicate] = await input.db
+    .select({ id: inboundEmails.id })
+    .from(inboundEmails)
+    .where(eq(inboundEmails.gmailMessageId, input.candidate.gmailMessageId))
+    .limit(1)
+  if (duplicate) return "duplicate"
+
+  const replyThread = input.candidate.token
+    ? await input.db
+        .select()
+        .from(emailReplyThreads)
+        .where(eq(emailReplyThreads.token, input.candidate.token))
+        .limit(1)
+        .then((rows) => rows[0] ?? null)
+    : null
+  const now = new Date().toISOString()
+
+  if (
+    !replyThread ||
+    replyThread.organizationId !== input.organizationId ||
+    !replyThread.projectId
+  ) {
+    await input.db.insert(inboundEmails).values({
+      id: crypto.randomUUID(),
+      organizationId: input.organizationId,
+      projectId: replyThread?.projectId ?? null,
+      replyThreadId: replyThread?.id ?? null,
+      token: input.candidate.token,
+      gmailMessageId: input.candidate.gmailMessageId,
+      gmailThreadId: input.candidate.gmailThreadId,
+      messageIdHeader: input.candidate.messageIdHeader,
+      inReplyToHeader: input.candidate.inReplyToHeader,
+      referencesHeader: input.candidate.referencesHeader,
+      fromAddress: input.candidate.fromAddress,
+      fromName: input.candidate.fromName,
+      toAddress: input.candidate.toAddress,
+      subject: input.candidate.subject,
+      textBody: input.candidate.textBody,
+      htmlBody: input.candidate.htmlBody,
+      snippet: input.candidate.snippet,
+      matchedStatus: "needs_review",
+      postedMessageId: null,
+      receivedAt: input.candidate.receivedAt,
+      importedAt: now,
+    })
+    return "needs_review"
+  }
+
+  const systemUserId = await findSystemUser({
+    env: input.env,
+    db: input.db,
+    organizationId: input.organizationId,
+  })
+  if (!systemUserId) {
+    await input.db.insert(inboundEmails).values({
+      id: crypto.randomUUID(),
+      organizationId: input.organizationId,
+      projectId: replyThread.projectId,
+      replyThreadId: replyThread.id,
+      token: input.candidate.token,
+      gmailMessageId: input.candidate.gmailMessageId,
+      gmailThreadId: input.candidate.gmailThreadId,
+      messageIdHeader: input.candidate.messageIdHeader,
+      inReplyToHeader: input.candidate.inReplyToHeader,
+      referencesHeader: input.candidate.referencesHeader,
+      fromAddress: input.candidate.fromAddress,
+      fromName: input.candidate.fromName,
+      toAddress: input.candidate.toAddress,
+      subject: input.candidate.subject,
+      textBody: input.candidate.textBody,
+      htmlBody: input.candidate.htmlBody,
+      snippet: input.candidate.snippet,
+      matchedStatus: "needs_review",
+      postedMessageId: null,
+      receivedAt: input.candidate.receivedAt,
+      importedAt: now,
+    })
+    return "needs_review"
+  }
+
+  const channelId =
+    replyThread.channelId ??
+    (await ensureProjectChannel({
+      db: input.db,
+      organizationId: input.organizationId,
+      projectId: replyThread.projectId,
+      systemUserId,
+    }))
+
+  if (!channelId) {
+    await input.db.insert(inboundEmails).values({
+      id: crypto.randomUUID(),
+      organizationId: input.organizationId,
+      projectId: replyThread.projectId,
+      replyThreadId: replyThread.id,
+      token: input.candidate.token,
+      gmailMessageId: input.candidate.gmailMessageId,
+      gmailThreadId: input.candidate.gmailThreadId,
+      messageIdHeader: input.candidate.messageIdHeader,
+      inReplyToHeader: input.candidate.inReplyToHeader,
+      referencesHeader: input.candidate.referencesHeader,
+      fromAddress: input.candidate.fromAddress,
+      fromName: input.candidate.fromName,
+      toAddress: input.candidate.toAddress,
+      subject: input.candidate.subject,
+      textBody: input.candidate.textBody,
+      htmlBody: input.candidate.htmlBody,
+      snippet: input.candidate.snippet,
+      matchedStatus: "needs_review",
+      postedMessageId: null,
+      receivedAt: input.candidate.receivedAt,
+      importedAt: now,
+    })
+    return "needs_review"
+  }
+  await ensureSystemMembership({
+    db: input.db,
+    channelId,
+    systemUserId,
+  })
+
+  const messageId = crypto.randomUUID()
+  await input.db.insert(messages).values({
+    id: messageId,
+    channelId,
+    threadId: null,
+    userId: systemUserId,
+    content: messageContent(input.candidate),
+    contentHtml: messageHtml(input.candidate),
+    editedAt: null,
+    deletedAt: null,
+    deletedBy: null,
+    isPinned: false,
+    replyCount: 0,
+    lastReplyAt: null,
+    createdAt: input.candidate.receivedAt,
+  })
+  await input.db
+    .update(channelReadState)
+    .set({
+      unreadCount: sql`${channelReadState.unreadCount} + 1`,
+    })
+    .where(
+      and(
+        eq(channelReadState.channelId, channelId),
+        sql`${channelReadState.userId} != ${systemUserId}`
+      )
+    )
+  await input.db
+    .update(emailReplyThreads)
+    .set({
+      channelId,
+      lastInboundAt: input.candidate.receivedAt,
+      updatedAt: now,
+    })
+    .where(eq(emailReplyThreads.id, replyThread.id))
+  await input.db.insert(inboundEmails).values({
+    id: crypto.randomUUID(),
+    organizationId: input.organizationId,
+    projectId: replyThread.projectId,
+    replyThreadId: replyThread.id,
+    token: input.candidate.token,
+    gmailMessageId: input.candidate.gmailMessageId,
+    gmailThreadId: input.candidate.gmailThreadId,
+    messageIdHeader: input.candidate.messageIdHeader,
+    inReplyToHeader: input.candidate.inReplyToHeader,
+    referencesHeader: input.candidate.referencesHeader,
+    fromAddress: input.candidate.fromAddress,
+    fromName: input.candidate.fromName,
+    toAddress: input.candidate.toAddress,
+    subject: input.candidate.subject,
+    textBody: input.candidate.textBody,
+    htmlBody: input.candidate.htmlBody,
+    snippet: input.candidate.snippet,
+    matchedStatus: "posted",
+    postedMessageId: messageId,
+    receivedAt: input.candidate.receivedAt,
+    importedAt: now,
+  })
+
+  return "posted"
+}
+
+async function fetchJson(input: {
+  readonly url: string
+  readonly accessToken: string
+}): Promise<unknown> {
+  const response = await fetch(input.url, {
+    headers: {
+      Authorization: `Bearer ${input.accessToken}`,
+    },
+  })
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(`Gmail request failed (${response.status}): ${text}`)
+  }
+  if (text.length === 0) return null
+  return JSON.parse(text)
+}
+
+export async function syncGmailInboundReplies(input: {
+  readonly env: unknown
+  readonly db: Db
+  readonly organizationId: string
+}): Promise<GmailInboundSyncSummary> {
+  const access = await getCompassGmailAccessToken({
+    env: input.env,
+    db: input.db,
+    organizationId: input.organizationId,
+    scopes: [COMPASS_GMAIL_READONLY_SCOPE],
+  })
+  if (!access.success) {
+    return {
+      scanned: 0,
+      imported: 0,
+      posted: 0,
+      skippedDuplicates: 0,
+      needsReview: 0,
+      errors: [access.error],
+    }
+  }
+
+  const query =
+    envString(input.env, "COMPASS_GMAIL_INBOUND_QUERY") ?? "newer_than:30d cmp-"
+  const maxResults = parsePositiveInt(
+    envString(input.env, "COMPASS_GMAIL_INBOUND_MAX_RESULTS"),
+    25
+  )
+  const listUrl = new URL(
+    "https://gmail.googleapis.com/gmail/v1/users/me/messages"
+  )
+  listUrl.searchParams.set("q", query)
+  listUrl.searchParams.set("maxResults", String(maxResults))
+
+  const errors: string[] = []
+  let scanned = 0
+  let imported = 0
+  let posted = 0
+  let skippedDuplicates = 0
+  let needsReview = 0
+
+  try {
+    const listResponse = await fetchJson({
+      url: listUrl.toString(),
+      accessToken: access.accessToken,
+    })
+    if (!isGmailListResponse(listResponse)) {
+      throw new Error("Gmail returned an unexpected message list.")
+    }
+
+    const messageIds = (listResponse.messages ?? [])
+      .map((message) => message.id ?? null)
+      .filter((id): id is string => id !== null)
+    scanned = messageIds.length
+
+    for (const id of messageIds) {
+      try {
+        const messageUrl = new URL(
+          `https://gmail.googleapis.com/gmail/v1/users/me/messages/${id}`
+        )
+        messageUrl.searchParams.set("format", "full")
+        const messageResponse = await fetchJson({
+          url: messageUrl.toString(),
+          accessToken: access.accessToken,
+        })
+        if (!isGmailMessage(messageResponse)) {
+          throw new Error(`Gmail returned an unexpected message for ${id}.`)
+        }
+
+        const result = await importCandidate({
+          env: input.env,
+          db: input.db,
+          organizationId: input.organizationId,
+          candidate: candidateFromMessage(messageResponse),
+        })
+
+        if (result === "duplicate") {
+          skippedDuplicates += 1
+        } else {
+          imported += 1
+          if (result === "posted") posted += 1
+          if (result === "needs_review") needsReview += 1
+        }
+      } catch (error) {
+        errors.push(error instanceof Error ? error.message : `Failed ${id}`)
+      }
+    }
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : "Gmail sync failed")
+  }
+
+  return {
+    scanned,
+    imported,
+    posted,
+    skippedDuplicates,
+    needsReview,
+    errors,
+  }
+}
+
+export async function listGoogleAuthOrganizationIds(input: {
+  readonly db: Db
+}): Promise<readonly string[]> {
+  const rows = await input.db
+    .select({ organizationId: googleAuth.organizationId })
+    .from(googleAuth)
+  return rows.map((row) => row.organizationId)
+}

--- a/src/lib/email/gmail-message-parser.ts
+++ b/src/lib/email/gmail-message-parser.ts
@@ -1,0 +1,191 @@
+import "server-only"
+
+type GmailHeader = {
+  readonly name: string
+  readonly value: string
+}
+
+type GmailBody = {
+  readonly data?: string
+}
+
+type GmailPart = {
+  readonly mimeType?: string
+  readonly body?: GmailBody
+  readonly parts?: readonly GmailPart[]
+}
+
+export type GmailMessage = {
+  readonly id: string
+  readonly threadId?: string
+  readonly snippet?: string
+  readonly internalDate?: string
+  readonly payload?: GmailPart & {
+    readonly headers?: readonly GmailHeader[]
+  }
+}
+
+export type InboundCandidate = {
+  readonly gmailMessageId: string
+  readonly gmailThreadId: string | null
+  readonly messageIdHeader: string | null
+  readonly inReplyToHeader: string | null
+  readonly referencesHeader: string | null
+  readonly token: string | null
+  readonly fromAddress: string
+  readonly fromName: string | null
+  readonly toAddress: string | null
+  readonly subject: string
+  readonly textBody: string | null
+  readonly htmlBody: string | null
+  readonly snippet: string | null
+  readonly receivedAt: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+export function isGmailMessage(value: unknown): value is GmailMessage {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    (value.threadId === undefined || typeof value.threadId === "string")
+  )
+}
+
+function base64UrlDecode(data: string): string {
+  const normalized = data.replace(/-/g, "+").replace(/_/g, "/")
+  const padded = normalized.padEnd(
+    normalized.length + ((4 - (normalized.length % 4)) % 4),
+    "="
+  )
+  const binary = atob(padded)
+  const bytes = new Uint8Array(binary.length)
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index)
+  }
+  return new TextDecoder().decode(bytes)
+}
+
+function headersByName(headers: readonly GmailHeader[]): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const header of headers) {
+    map.set(header.name.toLowerCase(), header.value)
+  }
+  return map
+}
+
+function collectBodies(part: GmailPart | undefined): {
+  readonly text: readonly string[]
+  readonly html: readonly string[]
+} {
+  if (!part) return { text: [], html: [] }
+
+  const childBodies = (part.parts ?? []).map(collectBodies)
+  const text = childBodies.flatMap((child) => child.text)
+  const html = childBodies.flatMap((child) => child.html)
+
+  if (part.body?.data) {
+    try {
+      const decoded = base64UrlDecode(part.body.data)
+      if (part.mimeType === "text/html") {
+        return { text, html: [...html, decoded] }
+      }
+      if (part.mimeType === "text/plain" || !part.mimeType) {
+        return { text: [...text, decoded], html }
+      }
+    } catch {
+      return { text, html }
+    }
+  }
+
+  return { text, html }
+}
+
+export function stripHtml(html: string): string {
+  return html
+    .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, " ")
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, " ")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/\s+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()
+}
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
+function extractToken(value: string): string | null {
+  const match = /\bcmp-[a-z0-9]{10,40}\b/i.exec(value)
+  return match ? match[0].toLowerCase() : null
+}
+
+function parseAddress(value: string | null): {
+  readonly name: string | null
+  readonly email: string
+} {
+  if (!value) return { name: null, email: "unknown@example.invalid" }
+  const match = /^(?:"?([^"<]*)"?\s*)?<([^<>]+)>$/.exec(value.trim())
+  if (match) {
+    const name = match[1]?.trim()
+    return {
+      name: name && name.length > 0 ? name : null,
+      email: match[2].trim().toLowerCase(),
+    }
+  }
+  return { name: null, email: value.trim().toLowerCase() }
+}
+
+function messageDate(internalDate: string | undefined): string {
+  if (!internalDate) return new Date().toISOString()
+  const millis = Number.parseInt(internalDate, 10)
+  if (!Number.isFinite(millis)) return new Date().toISOString()
+  return new Date(millis).toISOString()
+}
+
+export function candidateFromMessage(message: GmailMessage): InboundCandidate {
+  const headers = headersByName(message.payload?.headers ?? [])
+  const bodies = collectBodies(message.payload)
+  const textBody = bodies.text.join("\n\n").trim()
+  const htmlBody = bodies.html.join("\n\n").trim()
+  const searchable = [
+    headers.get("x-compass-reply-token") ?? "",
+    headers.get("to") ?? "",
+    headers.get("cc") ?? "",
+    headers.get("subject") ?? "",
+    textBody,
+    htmlBody,
+    message.snippet ?? "",
+  ].join("\n")
+  const from = parseAddress(headers.get("from") ?? null)
+
+  return {
+    gmailMessageId: message.id,
+    gmailThreadId: message.threadId ?? null,
+    messageIdHeader: headers.get("message-id") ?? null,
+    inReplyToHeader: headers.get("in-reply-to") ?? null,
+    referencesHeader: headers.get("references") ?? null,
+    token: extractToken(searchable),
+    fromAddress: from.email,
+    fromName: from.name,
+    toAddress: headers.get("to") ?? null,
+    subject: headers.get("subject") ?? "(no subject)",
+    textBody: textBody.length > 0 ? textBody : null,
+    htmlBody: htmlBody.length > 0 ? htmlBody : null,
+    snippet: message.snippet ?? null,
+    receivedAt: messageDate(message.internalDate),
+  }
+}

--- a/src/lib/email/mailto.ts
+++ b/src/lib/email/mailto.ts
@@ -1,0 +1,19 @@
+function emailAddress(value: string): string {
+  const match = /<([^<>]+)>/.exec(value)
+  return (match?.[1] ?? value).trim()
+}
+
+export function trackedMailtoHref(input: {
+  readonly to: readonly string[]
+  readonly cc: string
+  readonly subject: string
+  readonly body: string
+}): string {
+  const recipients = input.to.map((value) => value.trim()).filter(Boolean)
+  const query = new URLSearchParams({
+    cc: emailAddress(input.cc),
+    subject: input.subject,
+    body: input.body,
+  })
+  return `mailto:${recipients.map(encodeURIComponent).join(",")}?${query.toString()}`
+}

--- a/src/lib/email/reply-tracking.ts
+++ b/src/lib/email/reply-tracking.ts
@@ -34,13 +34,17 @@ export function createReplyToken(): string {
   return `cmp-${crypto.randomUUID().replace(/-/g, "").slice(0, 18)}`
 }
 
+export function replyMailboxEmail(env: unknown): string {
+  const mailbox = envString(env, "COMPASS_REPLY_MAILBOX") ?? DEFAULT_REPLY_MAILBOX
+  const parts = splitEmailAddress(mailbox) ?? splitEmailAddress(DEFAULT_REPLY_MAILBOX)
+  return parts ? `${parts.localPart}@${parts.domain}` : DEFAULT_REPLY_MAILBOX
+}
+
 export function trackedReplyAddress(input: {
   readonly env: unknown
   readonly token: string
 }): string {
-  const mailbox =
-    envString(input.env, "COMPASS_REPLY_MAILBOX") ?? DEFAULT_REPLY_MAILBOX
-  const parts = splitEmailAddress(mailbox) ?? splitEmailAddress(DEFAULT_REPLY_MAILBOX)
+  const parts = splitEmailAddress(replyMailboxEmail(input.env))
   if (!parts) return DEFAULT_REPLY_MAILBOX
 
   return `Compass <${parts.localPart}+${input.token}@${parts.domain}>`

--- a/src/lib/email/reply-tracking.ts
+++ b/src/lib/email/reply-tracking.ts
@@ -1,0 +1,111 @@
+import "server-only"
+
+import { emailReplyThreads } from "@/db/schema"
+import type { getDb } from "@/db"
+
+const DEFAULT_REPLY_MAILBOX = "jarvis@hps-colorado.com"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function envString(env: unknown, key: string): string | null {
+  if (!isRecord(env)) return process.env[key] ?? null
+  const value = env[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : process.env[key] ?? null
+}
+
+function splitEmailAddress(email: string): {
+  readonly localPart: string
+  readonly domain: string
+} | null {
+  const trimmed = email.trim()
+  const atIndex = trimmed.lastIndexOf("@")
+  if (atIndex <= 0 || atIndex === trimmed.length - 1) return null
+  return {
+    localPart: trimmed.slice(0, atIndex),
+    domain: trimmed.slice(atIndex + 1),
+  }
+}
+
+export function createReplyToken(): string {
+  return `cmp-${crypto.randomUUID().replace(/-/g, "").slice(0, 18)}`
+}
+
+export function trackedReplyAddress(input: {
+  readonly env: unknown
+  readonly token: string
+}): string {
+  const mailbox =
+    envString(input.env, "COMPASS_REPLY_MAILBOX") ?? DEFAULT_REPLY_MAILBOX
+  const parts = splitEmailAddress(mailbox) ?? splitEmailAddress(DEFAULT_REPLY_MAILBOX)
+  if (!parts) return DEFAULT_REPLY_MAILBOX
+
+  return `Compass <${parts.localPart}+${input.token}@${parts.domain}>`
+}
+
+export function appendReplyTokenText(input: {
+  readonly body: string
+  readonly token: string
+}): string {
+  return `${input.body}
+
+--
+Replying to this email will attach your response to Compass.
+Compass reply token: ${input.token}`
+}
+
+export function appendReplyTokenHtml(input: {
+  readonly html: string
+  readonly token: string
+}): string {
+  return `${input.html}
+<p style="margin-top:24px;color:#6b7280;font-size:12px;line-height:1.5;border-top:1px solid #e5e7eb;padding-top:12px;">
+  Replying to this email will attach your response to Compass.<br>
+  Compass reply token: ${input.token}
+</p>`
+}
+
+export async function createEmailReplyThread(input: {
+  readonly env: unknown
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string
+  readonly projectId: string | null
+  readonly channelId?: string | null
+  readonly sourceType: string
+  readonly sourceId: string
+  readonly sourceNumber: string | null
+  readonly subject: string
+  readonly createdBy: string | null
+}): Promise<{
+  readonly id: string
+  readonly token: string
+  readonly replyToAddress: string
+}> {
+  const id = crypto.randomUUID()
+  const token = createReplyToken()
+  const replyToAddress = trackedReplyAddress({ env: input.env, token })
+  const now = new Date().toISOString()
+
+  await input.db.insert(emailReplyThreads).values({
+    id,
+    token,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    channelId: input.channelId ?? null,
+    sourceType: input.sourceType,
+    sourceId: input.sourceId,
+    sourceNumber: input.sourceNumber,
+    replyToAddress,
+    subject: input.subject,
+    status: "active",
+    createdBy: input.createdBy,
+    lastInboundAt: null,
+    createdAt: now,
+    updatedAt: now,
+  })
+
+  return { id, token, replyToAddress }
+}

--- a/src/lib/rfis/__tests__/communication.test.ts
+++ b/src/lib/rfis/__tests__/communication.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+
+import { appendRfiCommunication } from "@/lib/rfis/communication"
+
+describe("appendRfiCommunication", () => {
+  it("preserves imported history and appends a labeled response", () => {
+    const result = appendRfiCommunication({
+      existing: "Buildertrend response",
+      message: "Please confirm the revised dimension.",
+      author: "Martine Vogel",
+      occurredAt: "2026-08-06T15:30:00.000Z",
+    })
+
+    expect(result).toContain("Buildertrend response")
+    expect(result).toContain("Martine Vogel")
+    expect(result).toContain("Please confirm the revised dimension.")
+  })
+
+  it("does not erase history when no message is supplied", () => {
+    expect(
+      appendRfiCommunication({
+        existing: "Existing response",
+        message: "  ",
+        author: "Someone",
+        occurredAt: "2026-08-06T15:30:00.000Z",
+      })
+    ).toBe("Existing response")
+  })
+})

--- a/src/lib/rfis/communication.ts
+++ b/src/lib/rfis/communication.ts
@@ -1,0 +1,23 @@
+export function appendRfiCommunication(input: {
+  readonly existing: string | null
+  readonly message: string
+  readonly author: string
+  readonly occurredAt: string
+}): string | null {
+  const message = input.message.trim()
+  if (!message) return input.existing
+
+  const author = input.author.trim() || "Compass user"
+  const timestamp = new Date(input.occurredAt).toLocaleString("en-US", {
+    timeZone: "America/Denver",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  })
+  const entry = `${author} · ${timestamp}\n${message}`
+  const existing = input.existing?.trim() ?? ""
+  return existing ? `${existing}\n\n${entry}` : entry
+}


### PR DESCRIPTION
## What changed

- Restores multi-recipient private messaging as one shared, deterministic group conversation.
- Preserves imported Buildertrend RFI history and appends new staff-approved responses instead of overwriting prior content.
- Adds RFI conversation and email actions with project-contact selection, default-mail-app composition, exact-record deep links, and Compass reply tracking.
- Syncs tracked Gmail replies into a staff-only internal review timeline with pagination, idempotency, and organization/privacy safeguards.

## Why

Staff need reliable group messages and a complete RFI correspondence loop while Buildertrend is being retired, without exposing unreviewed inbound email content to owners or subcontractors.

## Validation

- Focused unit tests: 6 passed
- bunx tsc --noEmit
- targeted ESLint
- bun run build
- final local autoreview: clean