### PR TITLE
feat(schedule): add selective bulk template imports

### DIFF
--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -14,8 +14,11 @@ import {
 } from "@/db/schema"
 import {
   projectTemplateContentItems,
+  projectTemplateApplicationItems,
+  projectTemplateApplications,
   projectTemplates,
   projectTemplateVersions,
+  scheduleTemplateDependencies,
   scheduleTemplateItems
 } from "@/db/schema-templates"
 import { eq, asc, and, inArray } from "drizzle-orm"
@@ -43,6 +46,12 @@ import {
   groupTemplateChecklistItems
 } from "@/lib/templates/template-checklist-hierarchy"
 import { selectTemplateTodos } from "@/lib/templates/template-todo-selection"
+import { buildScheduleTemplateApplication } from "@/lib/templates/schedule-template-application"
+import {
+  normalizeBulkScheduleTemplateOffsets,
+  validateBulkScheduleTemplateSelection,
+  type BulkScheduleTemplateSelection
+} from "@/lib/templates/schedule-template-bulk-selection"
 import { isOwnerScheduleView, type OwnerScheduleView } from "@/lib/schedule/owner-visibility"
 import type {
   TaskStatus,
@@ -153,12 +162,21 @@ async function loadScheduleTemplateItemImport(
   const selected = rows[0]
   if (!selected) return null
 
+  const linkedTodos = await loadScheduleTemplateTodos(db, selected.versionId)
+
+  return { ...selected, linkedTodos }
+}
+
+async function loadScheduleTemplateTodos(
+  db: ReturnType<typeof getDb>,
+  versionId: string
+): Promise<readonly ScheduleTemplateLinkedTodo[]> {
   const taskItems = await db
     .select()
     .from(projectTemplateContentItems)
     .where(
       and(
-        eq(projectTemplateContentItems.versionId, selected.versionId),
+        eq(projectTemplateContentItems.versionId, versionId),
         eq(projectTemplateContentItems.moduleType, "tasks")
       )
     )
@@ -180,7 +198,7 @@ async function loadScheduleTemplateItemImport(
     }))
   }))
 
-  return { ...selected, linkedTodos }
+  return linkedTodos
 }
 
 async function resolveAssignedUserId(
@@ -494,6 +512,357 @@ export async function getScopedSchedule(
       category: exception.category as ExceptionCategory,
       recurrence: exception.recurrence as ExceptionRecurrence
     }))
+  }
+}
+
+export async function importScheduleTemplateItems(
+  projectId: string,
+  data: {
+    readonly templateId: string
+    readonly anchorDate: string
+    readonly selections: readonly BulkScheduleTemplateSelection[]
+  }
+): Promise<
+  | {
+      readonly success: true
+      readonly scheduleItemCount: number
+      readonly dependencyCount: number
+      readonly linkedTodoCount: number
+    }
+  | { readonly success: false; readonly error: string }
+> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    requirePermission(user, "schedule", "update")
+    if (!isInternalStaffRole(user.role)) {
+      return {
+        success: false,
+        error: "Template imports are limited to internal project staff."
+      }
+    }
+    if (data.selections.length === 0) {
+      return { success: false, error: "Choose at least one schedule item." }
+    }
+
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const [project, templateVersion] = await Promise.all([
+      db
+        .select({ id: projects.id })
+        .from(projects)
+        .where(
+          and(
+            eq(projects.id, projectId),
+            eq(projects.organizationId, organizationId)
+          )
+        )
+        .get(),
+      db
+        .select({
+          templateId: projectTemplates.id,
+          templateName: projectTemplates.name,
+          versionId: projectTemplateVersions.id
+        })
+        .from(projectTemplates)
+        .innerJoin(
+          projectTemplateVersions,
+          eq(projectTemplateVersions.templateId, projectTemplates.id)
+        )
+        .where(
+          and(
+            eq(projectTemplates.id, data.templateId),
+            eq(projectTemplates.organizationId, organizationId),
+            eq(projectTemplates.lifecycleStatus, "active"),
+            eq(projectTemplates.reviewStatus, "verified"),
+            eq(projectTemplateVersions.status, "published"),
+            eq(
+              projectTemplateVersions.versionNumber,
+              projectTemplates.currentVersionNumber
+            )
+          )
+        )
+        .get()
+    ])
+    if (!project) {
+      return { success: false, error: "Project not found or access denied" }
+    }
+    if (!templateVersion) {
+      return {
+        success: false,
+        error: "That published schedule template is no longer available."
+      }
+    }
+
+    const [templateItems, templateDependencies, templateTodos, exceptions, lastTask] =
+      await Promise.all([
+        db
+          .select()
+          .from(scheduleTemplateItems)
+          .where(eq(scheduleTemplateItems.versionId, templateVersion.versionId))
+          .orderBy(asc(scheduleTemplateItems.sortOrder)),
+        db
+          .select()
+          .from(scheduleTemplateDependencies)
+          .where(eq(scheduleTemplateDependencies.versionId, templateVersion.versionId)),
+        loadScheduleTemplateTodos(db, templateVersion.versionId),
+        fetchExceptions(db, projectId),
+        db
+          .select({ sortOrder: scheduleTasks.sortOrder })
+          .from(scheduleTasks)
+          .where(eq(scheduleTasks.projectId, projectId))
+          .orderBy(asc(scheduleTasks.sortOrder))
+      ])
+    const lastSortOrder =
+      lastTask.length > 0 ? lastTask[lastTask.length - 1].sortOrder : -1
+    const selection = validateBulkScheduleTemplateSelection({
+      selections: data.selections,
+      availableItemIds: new Set(templateItems.map((item) => item.id)),
+      availableTodoIds: new Set(
+        templateTodos.map((todo) => todo.templateContentItemId)
+      )
+    })
+    if (!selection.success) return selection
+
+    const selectedItemIds = new Set(selection.data.itemIds)
+    const selectedItems = normalizeBulkScheduleTemplateOffsets(
+      templateItems.filter((item) => selectedItemIds.has(item.id))
+    )
+    const selectedDependencies = templateDependencies.filter(
+      (dependency) =>
+        selectedItemIds.has(dependency.predecessorItemId) &&
+        selectedItemIds.has(dependency.successorItemId)
+    )
+    const existingApplicationItem = await db
+      .select({ templateItemId: projectTemplateApplicationItems.templateItemId })
+      .from(projectTemplateApplicationItems)
+      .innerJoin(
+        projectTemplateApplications,
+        eq(
+          projectTemplateApplications.id,
+          projectTemplateApplicationItems.applicationId
+        )
+      )
+      .where(
+        and(
+          eq(projectTemplateApplications.projectId, projectId),
+          eq(projectTemplateApplications.versionId, templateVersion.versionId),
+          eq(projectTemplateApplications.anchorDate, data.anchorDate),
+          eq(projectTemplateApplications.status, "applied"),
+          inArray(projectTemplateApplicationItems.templateItemId, selection.data.itemIds)
+        )
+      )
+      .limit(1)
+      .get()
+    if (existingApplicationItem) {
+      return {
+        success: false,
+        error:
+          "One or more selected schedule items were already imported from this template at that start date."
+      }
+    }
+
+    const build = buildScheduleTemplateApplication({
+      anchorDate: data.anchorDate,
+      items: selectedItems,
+      dependencies: selectedDependencies,
+      exceptions,
+      nextId: crypto.randomUUID,
+      firstSortOrder: lastSortOrder + 1
+    })
+    if (!build.success) return build
+
+    const templateTodoById = new Map(
+      templateTodos.map((todo) => [todo.templateContentItemId, todo])
+    )
+    const applicationId = crypto.randomUUID()
+    const now = new Date().toISOString()
+    const linkedTodoRows = build.data.tasks.flatMap((task) => {
+      const selectedTodoIds =
+        selection.data.todoIdsByItem.get(task.templateItemId) ?? []
+      return selectedTodoIds.flatMap((todoId) => {
+        const todo = templateTodoById.get(todoId)
+        if (!todo) return []
+        return [
+          {
+            id: crypto.randomUUID(),
+            scheduleTaskId: task.id,
+            scheduleTaskStartDate: task.startDate,
+            scheduleTaskEndDate: task.endDateCalculated,
+            todo
+          }
+        ]
+      })
+    })
+    const statements: D1PreparedStatement[] = [
+      env.DB.prepare(
+        `INSERT INTO project_template_applications (
+          id, organization_id, project_id, template_id, version_id,
+          anchor_date, status, applied_by, item_count, dependency_count,
+          options_json, created_at, completed_at
+        ) VALUES (?, ?, ?, ?, ?, ?, 'applied', ?, ?, ?, ?, ?, ?)`
+      ).bind(
+        applicationId,
+        organizationId,
+        projectId,
+        templateVersion.templateId,
+        templateVersion.versionId,
+        data.anchorDate,
+        user.id,
+        build.data.tasks.length + linkedTodoRows.length,
+        build.data.dependencies.length,
+        JSON.stringify({
+          mode: "selected_schedule_items",
+          scheduleItemCount: build.data.tasks.length,
+          linkedTodoCount: linkedTodoRows.length,
+          selectedTemplateItemIds: selection.data.itemIds
+        }),
+        now,
+        now
+      )
+    ]
+
+    for (const task of build.data.tasks) {
+      statements.push(
+        env.DB.prepare(
+          `INSERT INTO schedule_tasks (
+            id, project_id, title, start_date, workdays,
+            end_date_calculated, phase, display_color, status,
+            is_critical_path, is_milestone, percent_complete, assigned_to,
+            assigned_user_id, owner_visible, sub_vendor_visible,
+            confirmation_required, confirmation_status, sort_order,
+            created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'PENDING', 0, ?, 0, ?, NULL,
+            ?, ?, 0, 'not_requested', ?, ?, ?)`
+        ).bind(
+          task.id,
+          projectId,
+          task.title,
+          task.startDate,
+          task.workdays,
+          task.endDateCalculated,
+          task.phase,
+          task.displayColor,
+          task.isMilestone ? 1 : 0,
+          task.assignedTo,
+          task.ownerVisible ? 1 : 0,
+          task.subVendorVisible ? 1 : 0,
+          task.sortOrder,
+          now,
+          now
+        ),
+        env.DB.prepare(
+          `INSERT INTO project_template_application_items (
+            id, application_id, template_item_id, schedule_task_id
+          ) VALUES (?, ?, ?, ?)`
+        ).bind(
+          crypto.randomUUID(),
+          applicationId,
+          task.templateItemId,
+          task.id
+        )
+      )
+    }
+    for (const dependency of build.data.dependencies) {
+      statements.push(
+        env.DB.prepare(
+          `INSERT INTO task_dependencies (
+            id, predecessor_id, successor_id, type, lag_days
+          ) VALUES (?, ?, ?, ?, ?)`
+        ).bind(
+          dependency.id,
+          dependency.predecessorId,
+          dependency.successorId,
+          dependency.type,
+          dependency.lagDays
+        )
+      )
+    }
+    for (const linkedTodo of linkedTodoRows) {
+      statements.push(
+        env.DB.prepare(
+          `INSERT INTO project_operations (
+            id, project_id, source_system, source_record_type,
+            source_record_id, title, description, status, priority,
+            assignee_type, start_date, due_date, sage_write_status,
+            sage_payload_json, sync_direction, sync_status, created_at,
+            updated_at
+          ) VALUES (?, ?, 'compass_template', 'schedule_task', ?, ?, ?,
+            'open', 'normal', 'internal', ?, ?, 'not_ready', ?, 'write',
+            'compass_only', ?, ?)`
+        ).bind(
+          linkedTodo.id,
+          projectId,
+          linkedTodo.scheduleTaskId,
+          linkedTodo.todo.title,
+          linkedTodo.todo.description,
+          linkedTodo.scheduleTaskStartDate,
+          linkedTodo.scheduleTaskEndDate,
+          JSON.stringify({
+            source: "project_template_schedule_item",
+            templateId: templateVersion.templateId,
+            templateName: templateVersion.templateName,
+            versionId: templateVersion.versionId,
+            templateContentItemId: linkedTodo.todo.templateContentItemId,
+            sourceItemId: linkedTodo.todo.sourceItemId,
+            checklistItems: linkedTodo.todo.checklistItems
+          }),
+          now,
+          now
+        )
+      )
+    }
+
+    const batchResults = await env.DB.batch(statements)
+    if (batchResults.some((result) => !result.success)) {
+      throw new Error("Selected template item import batch failed")
+    }
+    try {
+      await recordActivityEvent({
+        db,
+        organizationId,
+        projectId,
+        actor: user,
+        category: "schedule",
+        action: "schedule.template_items_imported",
+        entityType: "project_template_application",
+        entityId: applicationId,
+        summary: `Imported ${build.data.tasks.length} schedule items from “${templateVersion.templateName}”.`,
+        metadata: {
+          templateId: templateVersion.templateId,
+          scheduleItemCount: build.data.tasks.length,
+          dependencyCount: build.data.dependencies.length,
+          linkedTodoCount: linkedTodoRows.length
+        }
+      })
+    } catch (error) {
+      console.error("Unable to record schedule template import activity", error)
+    }
+    try {
+      await recalcCriticalPath(db, projectId)
+    } catch (error) {
+      console.error("Unable to refresh critical path after schedule template import", error)
+    }
+    revalidateSchedulePaths(projectId)
+    if (linkedTodoRows.length > 0) {
+      revalidatePath(`/dashboard/projects/${projectId}/todos`)
+      revalidatePath("/dashboard")
+    }
+    return {
+      success: true,
+      scheduleItemCount: build.data.tasks.length,
+      dependencyCount: build.data.dependencies.length,
+      linkedTodoCount: linkedTodoRows.length
+    }
+  } catch (error) {
+    console.error("Failed to import selected schedule template items:", error)
+    return {
+      success: false,
+      error: "Failed to import selected schedule items."
+    }
   }
 }
 

--- a/src/app/actions/template-import-options.ts
+++ b/src/app/actions/template-import-options.ts
@@ -31,6 +31,7 @@ export type ScheduleTemplateImportTodo = {
 export type ScheduleTemplateImportItem = {
   readonly id: string
   readonly title: string
+  readonly startOffsetWorkdays: number
   readonly workdays: number
   readonly phase: string
   readonly displayColor: string
@@ -38,6 +39,7 @@ export type ScheduleTemplateImportItem = {
   readonly assignedTo: string | null
   readonly ownerVisible: boolean
   readonly subVendorVisible: boolean
+  readonly sortOrder: number
 }
 
 export type ScheduleTemplateImportGroup = {
@@ -150,6 +152,7 @@ export async function getScheduleTemplateImportOptions(): Promise<
         scheduleItems: items.map((item) => ({
           id: item.id,
           title: item.title,
+          startOffsetWorkdays: item.startOffsetWorkdays,
           workdays: item.workdays,
           phase: resolveTemplateSchedulePhase({
             capturedPhase: item.phase,
@@ -159,7 +162,8 @@ export async function getScheduleTemplateImportOptions(): Promise<
           isMilestone: item.isMilestone,
           assignedTo: item.assigneePlaceholder,
           ownerVisible: item.ownerVisible,
-          subVendorVisible: item.subVendorVisible
+          subVendorVisible: item.subVendorVisible,
+          sortOrder: item.sortOrder
         })),
         linkedTodos: todoGroups.map((group) => ({
           id: group.task.id,

--- a/src/components/schedule/schedule-item-form-dialog.tsx
+++ b/src/components/schedule/schedule-item-form-dialog.tsx
@@ -108,6 +108,7 @@ interface ScheduleItemFormDialogProps {
   dependencies?: readonly TaskDependencyData[]
   exceptions?: readonly WorkdayExceptionData[]
   assigneeOptions?: readonly ProjectTaskAssigneeOption[]
+  onBulkTemplateImport?: () => void
 }
 
 interface PendingPredecessor {
@@ -124,7 +125,8 @@ export function ScheduleItemFormDialog({
   allTasks = [],
   dependencies = [],
   exceptions = [],
-  assigneeOptions = []
+  assigneeOptions = [],
+  onBulkTemplateImport
 }: ScheduleItemFormDialogProps) {
   const router = useRouter()
   const isEditing = !!editingTask
@@ -498,9 +500,22 @@ export function ScheduleItemFormDialog({
 
               {!isEditing && (
                 <section className="border-y bg-muted/20 py-3">
-                  <div className="mb-2 flex items-center gap-2 text-xs font-medium">
-                    <IconTemplate className="size-4" />
-                    Import from a published template
+                  <div className="mb-2 flex items-center justify-between gap-3">
+                    <div className="flex items-center gap-2 text-xs font-medium">
+                      <IconTemplate className="size-4" />
+                      Import from a published template
+                    </div>
+                    {onBulkTemplateImport && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 px-2 text-xs"
+                        onClick={onBulkTemplateImport}
+                      >
+                        Import several
+                      </Button>
+                    )}
                   </div>
                   {templateLoading ? (
                     <div className="flex items-center gap-2 text-xs text-muted-foreground">

--- a/src/components/schedule/schedule-template-bulk-import-dialog.tsx
+++ b/src/components/schedule/schedule-template-bulk-import-dialog.tsx
@@ -1,0 +1,392 @@
+"use client"
+
+import { useEffect, useMemo, useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { IconLoader2, IconTemplate } from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import { importScheduleTemplateItems } from "@/app/actions/schedule"
+import {
+  getScheduleTemplateImportOptions,
+  type ScheduleTemplateImportGroup
+} from "@/app/actions/template-import-options"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+
+type ScheduleTemplateBulkImportDialogProps = {
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
+  readonly projectId: string
+}
+
+function localDateValue(): string {
+  const now = new Date()
+  const offset = now.getTimezoneOffset() * 60_000
+  return new Date(now.getTime() - offset).toISOString().slice(0, 10)
+}
+
+function scheduleTimingLabel(input: {
+  readonly selected: boolean
+  readonly templateOffset: number
+  readonly firstSelectedOffset: number | null
+}): string {
+  if (!input.selected || input.firstSelectedOffset === null) {
+    return `template workday ${input.templateOffset + 1}`
+  }
+  const relativeOffset = input.templateOffset - input.firstSelectedOffset
+  if (relativeOffset === 0) return "starts on the chosen date"
+  return `starts ${relativeOffset} workdays after the first selected item`
+}
+
+export function ScheduleTemplateBulkImportDialog({
+  open,
+  onOpenChange,
+  projectId
+}: ScheduleTemplateBulkImportDialogProps) {
+  const router = useRouter()
+  const [templateGroups, setTemplateGroups] = useState<
+    readonly ScheduleTemplateImportGroup[]
+  >([])
+  const [templateId, setTemplateId] = useState("")
+  const [anchorDate, setAnchorDate] = useState(localDateValue)
+  const [selectedItemIds, setSelectedItemIds] = useState<readonly string[]>([])
+  const [todoAssignments, setTodoAssignments] = useState<
+    Readonly<Record<string, string>>
+  >({})
+  const [loading, setLoading] = useState(false)
+  const [isImporting, startImporting] = useTransition()
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    setLoading(true)
+    void getScheduleTemplateImportOptions()
+      .then((groups) => {
+        if (!cancelled) setTemplateGroups(groups)
+      })
+      .catch((error: unknown) => {
+        console.error("Unable to load schedule template options", error)
+        if (!cancelled) toast.error("Unable to load published schedule templates.")
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (open) return
+    setTemplateId("")
+    setSelectedItemIds([])
+    setTodoAssignments({})
+  }, [open])
+
+  const selectedGroup = useMemo(
+    () => templateGroups.find((group) => group.templateId === templateId) ?? null,
+    [templateGroups, templateId]
+  )
+  const selectedItemIdSet = useMemo(
+    () => new Set(selectedItemIds),
+    [selectedItemIds]
+  )
+  const selectedItems = useMemo(
+    () =>
+      (selectedGroup?.scheduleItems ?? []).filter((item) =>
+        selectedItemIdSet.has(item.id)
+      ),
+    [selectedGroup, selectedItemIdSet]
+  )
+  const firstSelectedOffset = useMemo(
+    () =>
+      selectedItems.length === 0
+        ? null
+        : Math.min(...selectedItems.map((item) => item.startOffsetWorkdays)),
+    [selectedItems]
+  )
+
+  function chooseTemplate(nextTemplateId: string): void {
+    setTemplateId(nextTemplateId)
+    setSelectedItemIds([])
+    setTodoAssignments({})
+  }
+
+  function toggleScheduleItem(itemId: string, selected: boolean): void {
+    setSelectedItemIds((current) =>
+      selected
+        ? current.includes(itemId)
+          ? current
+          : [...current, itemId]
+        : current.filter((id) => id !== itemId)
+    )
+    if (!selected) {
+      setTodoAssignments((current) =>
+        Object.fromEntries(
+          Object.entries(current).filter(([, assignedItemId]) => assignedItemId !== itemId)
+        )
+      )
+    }
+  }
+
+  function toggleTodo(todoId: string, selected: boolean): void {
+    if (selected) {
+      const firstItemId = selectedItems[0]?.id
+      if (!firstItemId) return
+      setTodoAssignments((current) => ({ ...current, [todoId]: firstItemId }))
+      return
+    }
+    setTodoAssignments((current) =>
+      Object.fromEntries(Object.entries(current).filter(([id]) => id !== todoId))
+    )
+  }
+
+  function assignTodo(todoId: string, scheduleItemId: string): void {
+    if (!selectedItemIdSet.has(scheduleItemId)) return
+    setTodoAssignments((current) => ({
+      ...current,
+      [todoId]: scheduleItemId
+    }))
+  }
+
+  function handleImport(): void {
+    if (!selectedGroup || selectedItems.length === 0 || !anchorDate) return
+    startImporting(async () => {
+      const result = await importScheduleTemplateItems(projectId, {
+        templateId: selectedGroup.templateId,
+        anchorDate,
+        selections: selectedItems.map((item) => ({
+          templateItemId: item.id,
+          templateTodoIds: Object.entries(todoAssignments).flatMap(
+            ([todoId, assignedItemId]) => assignedItemId === item.id ? [todoId] : []
+          )
+        }))
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(
+        `Imported ${result.scheduleItemCount} schedule item${
+          result.scheduleItemCount === 1 ? "" : "s"
+        }, ${result.dependencyCount} dependenc${
+          result.dependencyCount === 1 ? "y" : "ies"
+        }, and ${result.linkedTodoCount} linked to-do${
+          result.linkedTodoCount === 1 ? "" : "s"
+        }.`
+      )
+      onOpenChange(false)
+      router.refresh()
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[88vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
+        <DialogHeader className="shrink-0 border-b px-6 py-5">
+          <DialogTitle>Import schedule items from a template</DialogTitle>
+          <DialogDescription>
+            Choose only the items this project needs. Dates retain their template spacing,
+            dependencies are preserved between selected items, and optional to-dos can be
+            assigned to one selected schedule item.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-6 py-5">
+          {loading ? (
+            <div className="flex min-h-40 items-center justify-center text-sm text-muted-foreground">
+              <IconLoader2 className="mr-2 size-4 animate-spin" />
+              Loading published templates…
+            </div>
+          ) : templateGroups.length === 0 ? (
+            <div className="flex min-h-40 items-center justify-center gap-3 text-sm text-muted-foreground">
+              <IconTemplate className="size-5" />
+              No published templates contain reusable schedule items.
+            </div>
+          ) : (
+            <>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="bulk-schedule-template">Template</Label>
+                  <Select value={templateId} onValueChange={chooseTemplate}>
+                    <SelectTrigger id="bulk-schedule-template">
+                      <SelectValue placeholder="Choose a published template" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {templateGroups.map((group) => (
+                        <SelectItem key={group.templateId} value={group.templateId}>
+                          {group.templateName}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="bulk-template-anchor-date">First-item start date</Label>
+                  <Input
+                    id="bulk-template-anchor-date"
+                    type="date"
+                    value={anchorDate}
+                    onChange={(event) => setAnchorDate(event.currentTarget.value)}
+                  />
+                </div>
+              </div>
+
+              {selectedGroup && (
+                <section className="border-y py-4">
+                  <div className="mb-3 flex items-center justify-between gap-3">
+                    <div>
+                      <h3 className="text-sm font-semibold">Schedule items</h3>
+                      <p className="text-xs text-muted-foreground">
+                        {selectedItemIds.length} of {selectedGroup.scheduleItems.length} selected
+                      </p>
+                    </div>
+                    <div className="flex gap-1">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() =>
+                          setSelectedItemIds(
+                            selectedGroup.scheduleItems.map((item) => item.id)
+                          )
+                        }
+                      >
+                        Select all
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        disabled={selectedItemIds.length === 0}
+                        onClick={() => {
+                          setSelectedItemIds([])
+                          setTodoAssignments({})
+                        }}
+                      >
+                        Clear
+                      </Button>
+                    </div>
+                  </div>
+                  <div className="max-h-72 divide-y overflow-y-auto border-y">
+                    {selectedGroup.scheduleItems.map((item) => (
+                      <label
+                        key={item.id}
+                        className="flex cursor-pointer items-start gap-3 py-3"
+                      >
+                        <Checkbox
+                          checked={selectedItemIdSet.has(item.id)}
+                          onCheckedChange={(value) =>
+                            toggleScheduleItem(item.id, value === true)
+                          }
+                          aria-label={`Import ${item.title}`}
+                        />
+                        <span className="min-w-0 flex-1">
+                          <span className="block text-sm font-medium">{item.title}</span>
+                          <span className="mt-0.5 block text-xs text-muted-foreground">
+                            {item.phase} · {item.workdays} workday
+                            {item.workdays === 1 ? "" : "s"} · {scheduleTimingLabel({
+                              selected: selectedItemIdSet.has(item.id),
+                              templateOffset: item.startOffsetWorkdays,
+                              firstSelectedOffset
+                            })}
+                          </span>
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {selectedGroup && selectedItems.length > 0 && selectedGroup.linkedTodos.length > 0 && (
+                <section>
+                  <div className="mb-3">
+                    <h3 className="text-sm font-semibold">Optional template to-dos</h3>
+                    <p className="text-xs text-muted-foreground">
+                      Select only what this project needs, then choose the schedule item each
+                      to-do belongs to.
+                    </p>
+                  </div>
+                  <div className="max-h-72 divide-y overflow-y-auto border-y">
+                    {selectedGroup.linkedTodos.map((todo) => {
+                      const assignedItemId = todoAssignments[todo.id]
+                      return (
+                        <div key={todo.id} className="grid gap-3 py-3 sm:grid-cols-[1fr_16rem]">
+                          <label className="flex cursor-pointer items-start gap-3">
+                            <Checkbox
+                              checked={Boolean(assignedItemId)}
+                              onCheckedChange={(value) => toggleTodo(todo.id, value === true)}
+                              aria-label={`Include ${todo.title}`}
+                            />
+                            <span className="min-w-0">
+                              <span className="block text-sm font-medium">{todo.title}</span>
+                              {todo.checklistItemCount > 0 && (
+                                <span className="mt-0.5 block text-xs text-muted-foreground">
+                                  Includes {todo.checklistItemCount} checklist item
+                                  {todo.checklistItemCount === 1 ? "" : "s"}
+                                </span>
+                              )}
+                            </span>
+                          </label>
+                          {assignedItemId && (
+                            <Select
+                              value={assignedItemId}
+                              onValueChange={(value) => assignTodo(todo.id, value)}
+                            >
+                              <SelectTrigger aria-label={`Schedule item for ${todo.title}`}>
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {selectedItems.map((item) => (
+                                  <SelectItem key={item.id} value={item.id}>
+                                    {item.title}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          )}
+                        </div>
+                      )
+                    })}
+                  </div>
+                </section>
+              )}
+            </>
+          )}
+        </div>
+
+        <DialogFooter className="shrink-0 border-t px-6 py-4">
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!selectedGroup || selectedItems.length === 0 || !anchorDate || isImporting}
+            onClick={handleImport}
+          >
+            {isImporting && <IconLoader2 className="mr-2 size-4 animate-spin" />}
+            Import {selectedItems.length || "selected"} item
+            {selectedItems.length === 1 ? "" : "s"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -81,6 +81,7 @@ import { WorkdayExceptionsView } from "./workday-exceptions-view"
 import { ScheduleBaselineView } from "./schedule-baseline-view"
 import { ScheduleItemFormDialog } from "./schedule-item-form-dialog"
 import { ScheduleTemplateDialog } from "./schedule-template-dialog"
+import { ScheduleTemplateBulkImportDialog } from "./schedule-template-bulk-import-dialog"
 import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
 import { ScheduleScopeSwitcher } from "./schedule-scope-switcher"
 import { OwnerScheduleVisibilityControl } from "./owner-schedule-visibility-control"
@@ -224,6 +225,7 @@ export function ScheduleView({
   const [exceptionsOpen, setExceptionsOpen] = useState(false)
   const [importDialogOpen, setImportDialogOpen] = useState(false)
   const [templateDialogOpen, setTemplateDialogOpen] = useState(false)
+  const [bulkTemplateDialogOpen, setBulkTemplateDialogOpen] = useState(false)
   const [isImporting, setIsImporting] = useState(false)
   const [publicationStatus, setPublicationStatus] =
     useState<SchedulePublicationStatus | null>(initialPublicationStatus)
@@ -1077,10 +1079,16 @@ export function ScheduleView({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-48">
               {projectId && (
-                <DropdownMenuItem onClick={() => setTemplateDialogOpen(true)}>
-                  <IconTemplate className="size-4 mr-2" />
-                  Add from template
-                </DropdownMenuItem>
+                <>
+                  <DropdownMenuItem onClick={() => setBulkTemplateDialogOpen(true)}>
+                    <IconTemplate className="size-4 mr-2" />
+                    Import schedule items
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setTemplateDialogOpen(true)}>
+                    <IconTemplate className="size-4 mr-2" />
+                    Add full project setup
+                  </DropdownMenuItem>
+                </>
               )}
               <DropdownMenuItem asChild>
                 <Link href="/dashboard/templates">
@@ -1177,6 +1185,15 @@ export function ScheduleView({
               (exception) => exception.projectId === projectId
             )}
             assigneeOptions={assigneeOptions}
+            onBulkTemplateImport={() => {
+              setTaskFormOpen(false)
+              setBulkTemplateDialogOpen(true)
+            }}
+          />
+          <ScheduleTemplateBulkImportDialog
+            open={bulkTemplateDialogOpen}
+            onOpenChange={setBulkTemplateDialogOpen}
+            projectId={projectId}
           />
           <ScheduleTemplateDialog
             open={templateDialogOpen}

--- a/src/lib/templates/__tests__/schedule-template-bulk-selection.test.ts
+++ b/src/lib/templates/__tests__/schedule-template-bulk-selection.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  normalizeBulkScheduleTemplateOffsets,
+  validateBulkScheduleTemplateSelection
+} from "../schedule-template-bulk-selection"
+
+const availableItemIds = new Set(["schedule-a", "schedule-b"])
+const availableTodoIds = new Set(["todo-a", "todo-b"])
+
+describe("validateBulkScheduleTemplateSelection", () => {
+  it("keeps each selected to-do attached to one selected schedule item", () => {
+    const result = validateBulkScheduleTemplateSelection({
+      selections: [
+        { templateItemId: "schedule-a", templateTodoIds: ["todo-a"] },
+        { templateItemId: "schedule-b", templateTodoIds: ["todo-b"] }
+      ],
+      availableItemIds,
+      availableTodoIds
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.itemIds).toEqual(["schedule-a", "schedule-b"])
+    expect(result.data.todoIdsByItem.get("schedule-a")).toEqual(["todo-a"])
+    expect(result.data.todoIdsByItem.get("schedule-b")).toEqual(["todo-b"])
+  })
+
+  it("rejects assigning the same to-do to more than one schedule item", () => {
+    const result = validateBulkScheduleTemplateSelection({
+      selections: [
+        { templateItemId: "schedule-a", templateTodoIds: ["todo-a"] },
+        { templateItemId: "schedule-b", templateTodoIds: ["todo-a"] }
+      ],
+      availableItemIds,
+      availableTodoIds
+    })
+
+    expect(result).toEqual({
+      success: false,
+      error: "Each template to-do may only be assigned to one schedule item."
+    })
+  })
+
+  it("rejects schedule items that are no longer published", () => {
+    const result = validateBulkScheduleTemplateSelection({
+      selections: [
+        { templateItemId: "missing", templateTodoIds: [] }
+      ],
+      availableItemIds,
+      availableTodoIds
+    })
+
+    expect(result).toEqual({
+      success: false,
+      error: "One or more selected schedule items are no longer available."
+    })
+  })
+})
+
+describe("normalizeBulkScheduleTemplateOffsets", () => {
+  it("anchors the earliest selected item while preserving spacing", () => {
+    const normalized = normalizeBulkScheduleTemplateOffsets([
+      {
+        id: "schedule-b",
+        title: "Second selected item",
+        startOffsetWorkdays: 12,
+        workdays: 2,
+        phase: "Build",
+        displayColor: "blue",
+        isMilestone: false,
+        assigneePlaceholder: null,
+        ownerVisible: true,
+        subVendorVisible: true,
+        sortOrder: 2
+      },
+      {
+        id: "schedule-a",
+        title: "First selected item",
+        startOffsetWorkdays: 10,
+        workdays: 1,
+        phase: "Build",
+        displayColor: "blue",
+        isMilestone: false,
+        assigneePlaceholder: null,
+        ownerVisible: true,
+        subVendorVisible: true,
+        sortOrder: 1
+      }
+    ])
+
+    expect(normalized.map((item) => item.startOffsetWorkdays)).toEqual([2, 0])
+  })
+})

--- a/src/lib/templates/schedule-template-bulk-selection.ts
+++ b/src/lib/templates/schedule-template-bulk-selection.ts
@@ -1,0 +1,95 @@
+import type { ScheduleTemplateItemDefinition } from "./schedule-template-application"
+
+export type BulkScheduleTemplateSelection = {
+  readonly templateItemId: string
+  readonly templateTodoIds: readonly string[]
+}
+
+export type ValidBulkScheduleTemplateSelection = {
+  readonly itemIds: readonly string[]
+  readonly todoIdsByItem: ReadonlyMap<string, readonly string[]>
+}
+
+export type BulkScheduleTemplateSelectionResult =
+  | {
+      readonly success: true
+      readonly data: ValidBulkScheduleTemplateSelection
+    }
+  | { readonly success: false; readonly error: string }
+
+export function normalizeBulkScheduleTemplateOffsets(
+  items: readonly ScheduleTemplateItemDefinition[]
+): readonly ScheduleTemplateItemDefinition[] {
+  if (items.length === 0) return []
+
+  const firstSelectedOffset = Math.min(
+    ...items.map((item) => item.startOffsetWorkdays)
+  )
+  return items.map((item) => ({
+    ...item,
+    startOffsetWorkdays: item.startOffsetWorkdays - firstSelectedOffset
+  }))
+}
+
+export function validateBulkScheduleTemplateSelection(input: {
+  readonly selections: readonly BulkScheduleTemplateSelection[]
+  readonly availableItemIds: ReadonlySet<string>
+  readonly availableTodoIds: ReadonlySet<string>
+}): BulkScheduleTemplateSelectionResult {
+  if (input.selections.length === 0) {
+    return { success: false, error: "Choose at least one schedule item." }
+  }
+  if (input.selections.length > 500) {
+    return {
+      success: false,
+      error: "A bulk import may contain no more than 500 schedule items."
+    }
+  }
+
+  const itemIds = new Set<string>()
+  const assignedTodoIds = new Set<string>()
+  const todoIdsByItem = new Map<string, readonly string[]>()
+
+  for (const selection of input.selections) {
+    if (!input.availableItemIds.has(selection.templateItemId)) {
+      return {
+        success: false,
+        error: "One or more selected schedule items are no longer available."
+      }
+    }
+    if (itemIds.has(selection.templateItemId)) {
+      return {
+        success: false,
+        error: "Each template schedule item may only be imported once."
+      }
+    }
+    itemIds.add(selection.templateItemId)
+
+    const selectedTodoIds = new Set<string>()
+    for (const todoId of selection.templateTodoIds) {
+      if (!input.availableTodoIds.has(todoId)) {
+        return {
+          success: false,
+          error: "One or more selected template to-dos are no longer available."
+        }
+      }
+      if (selectedTodoIds.has(todoId) || assignedTodoIds.has(todoId)) {
+        return {
+          success: false,
+          error: "Each template to-do may only be assigned to one schedule item."
+        }
+      }
+      selectedTodoIds.add(todoId)
+      assignedTodoIds.add(todoId)
+    }
+    todoIdsByItem.set(selection.templateItemId, [...selectedTodoIds])
+  }
+
+  return {
+    success: true,
+    data: {
+      itemIds: [...itemIds],
+      todoIdsByItem
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- adds a selective bulk schedule-item importer for published project templates
- preserves relative workday spacing and dependencies between the selected items
- lets staff choose only the template to-dos needed and attach each to exactly one imported schedule item
- keeps the existing full-project template setup available as a separate action
- makes the importer available from both the schedule overflow menu and the new-item drawer

## Why

Importing one schedule item at a time is slow, while importing an entire template can create unrelated schedule items and to-dos. This gives staff a controlled middle path for building a project schedule from reusable template content.

## Safety and validation

- validates organization, project, role, schedule permission, published template version, item IDs, and to-do IDs on the server
- applies schedule items, dependencies, application tracking, and linked to-dos in one checked D1 batch
- prevents duplicate imports of the same template items at the same project, template version, and anchor date
- normalizes partial-template dates so the earliest selected item starts on the chosen date
- preserves only dependencies whose two endpoints were selected
- 9 focused tests pass
- TypeScript and targeted ESLint pass
- production build passes
