### PR TITLE
fix(rfis): unify tracked response workflow

### DIFF
--- a/src/app/actions/project-rfis.ts
+++ b/src/app/actions/project-rfis.ts
@@ -117,6 +117,7 @@ export type UpdateProjectRfiInput = {
   readonly answer: string | null
   readonly status: string
   readonly audience: string
+  readonly mentionedUserIds?: readonly string[]
 }
 
 export type ProjectRfiEmailDraftResult =
@@ -552,6 +553,7 @@ export async function updateProjectRfi(
         status,
         requesterName: existing.requesterName,
         assignedToName: existing.assignedToName,
+        mentionedUserIds: input.mentionedUserIds,
         updatedBy: user,
       })
     } catch (notificationError) {
@@ -634,7 +636,7 @@ export async function createProjectRfiEmailDraft(
         "",
         `Open in Compass: ${appOrigin(env)}/dashboard/projects/${encodeURIComponent(projectId)}/rfis?item=${encodeURIComponent(rfi.id)}`,
         "",
-        "Please keep Compass in CC (or use Reply All) so the response stays attached to this RFI and the project conversation.",
+        "Please keep Compass in CC (or use Reply All) so the response stays attached to this RFI.",
       ].join("\n"),
     })
 

--- a/src/app/dashboard/projects/[id]/rfis/page.tsx
+++ b/src/app/dashboard/projects/[id]/rfis/page.tsx
@@ -1,8 +1,6 @@
 import Link from "next/link"
-import { redirect } from "next/navigation"
 import {
   IconArrowLeft,
-  IconCircleCheck,
   IconClock,
   IconMessageQuestion,
 } from "@tabler/icons-react"
@@ -10,7 +8,6 @@ import {
 import {
   getProjectRfiInboundEmails,
   getProjectRfis,
-  updateProjectRfi,
 } from "@/app/actions/project-rfis"
 import {
   getProjectContactsSummary,
@@ -24,11 +21,11 @@ import {
   type ProjectRfiEmailRecipientOption,
 } from "@/components/projects/project-rfi-communication-actions"
 import { ProjectRfiDeleteButton } from "@/components/projects/project-rfi-delete-button"
+import { ProjectRfiResponseComposer } from "@/components/projects/project-rfi-response-composer"
 import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
 import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Textarea } from "@/components/ui/textarea"
 import {
   canonicalRfiStatus,
   compareRfisForQueue,
@@ -39,16 +36,6 @@ import {
 } from "@/lib/rfis/status"
 import { cn } from "@/lib/utils"
 import { redirectIfFeaturePermissionDenied } from "@/lib/permission-redirect"
-
-function readFormText(formData: FormData, name: string): string {
-  const value = formData.get(name)
-  return typeof value === "string" ? value : ""
-}
-
-function cleanFormText(formData: FormData, name: string): string | null {
-  const value = readFormText(formData, name).trim()
-  return value.length > 0 ? value : null
-}
 
 function formatDate(value: string | null): string {
   if (!value) return "No due date"
@@ -213,26 +200,6 @@ export default async function ProjectRfisPage({
         : contact.displayName
     )
   )
-
-  async function updateRfiAction(formData: FormData): Promise<void> {
-    "use server"
-
-    const result = await updateProjectRfi(
-      id,
-      readFormText(formData, "rfiId"),
-      {
-        answer: cleanFormText(formData, "answer"),
-        status: readFormText(formData, "status"),
-        audience: readFormText(formData, "audience"),
-      }
-    )
-
-    if (!result.success) {
-      throw new Error(result.error)
-    }
-
-    redirect(`/dashboard/projects/${id}/rfis`)
-  }
 
   return (
     <div className="flex-1 space-y-6 p-4 pt-6 sm:p-6 md:p-8">
@@ -456,41 +423,12 @@ export default async function ProjectRfisPage({
                   </div>
                 ) : null}
 
-                <form action={updateRfiAction} className="mt-4 space-y-3">
-                  <input type="hidden" name="rfiId" value={rfi.id} />
-                  <Textarea
-                    name="answer"
-                    defaultValue=""
-                    placeholder="Add a response, decision, follow-up question, or next step"
-                  />
-                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_1fr_auto]">
-                    <select
-                      name="status"
-                      defaultValue={canonicalStatus}
-                      className="h-9 rounded-md border bg-background px-3 text-sm"
-                    >
-                      <option value="new">New</option>
-                      <option value="in_progress">In progress</option>
-                      <option value="info_needed">Additional information needed</option>
-                      <option value="complete">Complete</option>
-                      <option value="void">Void</option>
-                    </select>
-                    <select
-                      name="audience"
-                      defaultValue={rfi.audience}
-                      className="h-9 rounded-md border bg-background px-3 text-sm"
-                    >
-                      <option value="internal">Internal only</option>
-                      <option value="sub_vendor">Sub/vendor visible</option>
-                      <option value="owner">Owner visible</option>
-                      <option value="public">Owner and sub/vendor visible</option>
-                    </select>
-                    <Button type="submit" variant="outline">
-                      <IconCircleCheck className="size-4" />
-                      Save
-                    </Button>
-                  </div>
-                </form>
+                <ProjectRfiResponseComposer
+                  projectId={id}
+                  rfiId={rfi.id}
+                  status={canonicalStatus}
+                  audience={rfi.audience}
+                />
               </article>
             )
           })

--- a/src/components/conversations/mention-suggestion.tsx
+++ b/src/components/conversations/mention-suggestion.tsx
@@ -186,15 +186,20 @@ const MentionList = React.forwardRef<
 
 MentionList.displayName = "MentionList"
 
-export function createMentionSuggestion(organizationId: string) {
+export function createMentionSuggestion(
+  organizationId: string,
+  options: { readonly peopleOnly?: boolean } = {}
+) {
   return {
     items: async ({ query }: { query: string }) => {
       // static entries
-      const staticItems: MentionItem[] = [
-        { id: "channel", label: "channel", type: "group" },
-        { id: "here", label: "here", type: "group" },
-        { id: "compass-agent", label: "Compass", type: "agent" },
-      ]
+      const staticItems: MentionItem[] = options.peopleOnly
+        ? []
+        : [
+            { id: "channel", label: "channel", type: "group" },
+            { id: "here", label: "here", type: "group" },
+            { id: "compass-agent", label: "Compass", type: "agent" },
+          ]
 
       // fetch users
       const usersResult = await searchMentionableUsers(query)

--- a/src/components/projects/project-rfi-communication-actions.tsx
+++ b/src/components/projects/project-rfi-communication-actions.tsx
@@ -1,8 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { IconMail, IconMessageCircle, IconLoader2 } from "@tabler/icons-react"
-import Link from "next/link"
+import { IconMail, IconLoader2 } from "@tabler/icons-react"
 import { toast } from "sonner"
 
 import { createProjectRfiEmailDraft } from "@/app/actions/project-rfis"
@@ -83,12 +82,6 @@ export function ProjectRfiCommunicationActions({
 
   return (
     <>
-      <Button asChild type="button" size="sm" variant="outline">
-        <Link href={`/dashboard/conversations?projectId=${encodeURIComponent(projectId)}`}>
-          <IconMessageCircle className="size-4" />
-          Conversation
-        </Link>
-      </Button>
       <Button type="button" size="sm" variant="outline" onClick={openEmailDialog}>
         <IconMail className="size-4" />
         Email
@@ -100,7 +93,8 @@ export function ProjectRfiCommunicationActions({
             <DialogTitle>Email {rfiNumber}</DialogTitle>
             <DialogDescription>
               Opens your default email app. Compass is automatically copied so
-              replies can return to this RFI and its project conversation.
+              replies can return to this RFI. Use the response area on the RFI
+              for Compass messages and @mentions.
             </DialogDescription>
           </DialogHeader>
 

--- a/src/components/projects/project-rfi-response-composer.tsx
+++ b/src/components/projects/project-rfi-response-composer.tsx
@@ -1,0 +1,172 @@
+"use client"
+
+import * as React from "react"
+import Mention from "@tiptap/extension-mention"
+import Placeholder from "@tiptap/extension-placeholder"
+import StarterKit from "@tiptap/starter-kit"
+import { EditorContent, useEditor, type JSONContent } from "@tiptap/react"
+import { IconAt, IconCircleCheck, IconLoader2 } from "@tabler/icons-react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+
+import { updateProjectRfi } from "@/app/actions/project-rfis"
+import { createMentionSuggestion } from "@/components/conversations/mention-suggestion"
+import { Button } from "@/components/ui/button"
+
+function mentionedUserIds(document: JSONContent): readonly string[] {
+  const ids = new Set<string>()
+
+  function walk(node: JSONContent): void {
+    if (node.type === "mention") {
+      const id = node.attrs?.id
+      if (
+        typeof id === "string" &&
+        id !== "channel" &&
+        id !== "here" &&
+        id !== "compass-agent"
+      ) {
+        ids.add(id)
+      }
+    }
+    for (const child of node.content ?? []) walk(child)
+  }
+
+  walk(document)
+  return Array.from(ids)
+}
+
+export function ProjectRfiResponseComposer({
+  projectId,
+  rfiId,
+  status,
+  audience,
+}: {
+  readonly projectId: string
+  readonly rfiId: string
+  readonly status: string
+  readonly audience: string
+}): React.ReactElement {
+  const router = useRouter()
+  const [selectedStatus, setSelectedStatus] = React.useState(status)
+  const [selectedAudience, setSelectedAudience] = React.useState(audience)
+  const [saving, setSaving] = React.useState(false)
+  const [hasResponse, setHasResponse] = React.useState(false)
+
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit.configure({
+        heading: false,
+        horizontalRule: false,
+      }),
+      Placeholder.configure({
+        placeholder: "Add a response, decision, follow-up question, or next step",
+      }),
+      Mention.configure({
+        HTMLAttributes: { class: "mention" },
+        suggestion: createMentionSuggestion(projectId, { peopleOnly: true }),
+        renderText({ node }) {
+          return `@${node.attrs.label ?? node.attrs.id}`
+        },
+      }),
+    ],
+    editorProps: {
+      attributes: {
+        class:
+          "min-h-24 rounded-md border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring",
+      },
+    },
+    onUpdate: ({ editor: updatedEditor }) => {
+      setHasResponse(updatedEditor.getText().trim().length > 0)
+    },
+  })
+
+  async function save(): Promise<void> {
+    if (!editor || saving) return
+    const response = editor.getText().trim()
+    setSaving(true)
+    try {
+      const mentions = mentionedUserIds(editor.getJSON())
+      const result = await updateProjectRfi(projectId, rfiId, {
+        answer: response || null,
+        status: selectedStatus,
+        audience: selectedAudience,
+        mentionedUserIds: mentions,
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      editor.commands.clearContent()
+      setHasResponse(false)
+      toast.success(
+        response
+          ? mentions.length > 0
+            ? "Response saved to this RFI. Mentioned users were notified."
+            : "Response saved to this RFI."
+          : "RFI settings updated."
+      )
+      router.refresh()
+    } catch (error) {
+      toast.error(
+        error instanceof Error &&
+          error.message.includes("Server Action") &&
+          error.message.includes("was not found")
+          ? "Compass was updated while this page was open. Refresh and try again; your response is still here."
+          : error instanceof Error
+            ? error.message
+            : "Unable to save this RFI response."
+      )
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="mt-4 space-y-3">
+      <EditorContent editor={editor} />
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <IconAt className="size-3.5" />
+        Type @ and a name to notify a Compass user. Every response remains attached to this RFI.
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_1fr_auto]">
+        <select
+          aria-label="RFI status"
+          value={selectedStatus}
+          onChange={(event) => setSelectedStatus(event.currentTarget.value)}
+          className="h-9 rounded-md border bg-background px-3 text-sm"
+        >
+          <option value="new">New</option>
+          <option value="in_progress">In progress</option>
+          <option value="info_needed">Additional information needed</option>
+          <option value="complete">Complete</option>
+          <option value="void">Void</option>
+        </select>
+        <select
+          aria-label="RFI audience"
+          value={selectedAudience}
+          onChange={(event) => setSelectedAudience(event.currentTarget.value)}
+          className="h-9 rounded-md border bg-background px-3 text-sm"
+        >
+          <option value="internal">Internal only</option>
+          <option value="sub_vendor">Sub/vendor visible</option>
+          <option value="owner">Owner visible</option>
+          <option value="public">Owner and sub/vendor visible</option>
+        </select>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={saving || (!hasResponse && selectedStatus === status && selectedAudience === audience)}
+          onClick={() => void save()}
+        >
+          {saving ? (
+            <IconLoader2 className="size-4 animate-spin" />
+          ) : (
+            <IconCircleCheck className="size-4" />
+          )}
+          Save
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/email/__tests__/mailto.test.ts
+++ b/src/lib/email/__tests__/mailto.test.ts
@@ -13,6 +13,20 @@ describe("trackedMailtoHref", () => {
 
     expect(href).toContain("mailto:owner%40example.com")
     expect(href).toContain("cc=jarvis%2Bcmp-token%40hps-colorado.com")
-    expect(href).toContain("subject=%5BRFI-4%5D+Roof+framing")
+    expect(href).toContain("subject=%5BRFI-4%5D%20Roof%20framing")
+    expect(href).not.toContain("+")
+  })
+
+  it("percent-encodes spaces and line breaks for default mail apps", () => {
+    const href = trackedMailtoHref({
+      to: ["owner@example.com"],
+      cc: "jarvis@example.com",
+      subject: "RFI follow up",
+      body: "First line\n\nSecond line",
+    })
+
+    expect(href).toContain("subject=RFI%20follow%20up")
+    expect(href).toContain("body=First%20line%0A%0ASecond%20line")
+    expect(href).not.toContain("+")
   })
 })

--- a/src/lib/email/mailto.ts
+++ b/src/lib/email/mailto.ts
@@ -10,10 +10,16 @@ export function trackedMailtoHref(input: {
   readonly body: string
 }): string {
   const recipients = input.to.map((value) => value.trim()).filter(Boolean)
-  const query = new URLSearchParams({
-    cc: emailAddress(input.cc),
-    subject: input.subject,
-    body: input.body,
-  })
-  return `mailto:${recipients.map(encodeURIComponent).join(",")}?${query.toString()}`
+  // URLSearchParams serializes spaces as `+`, which browsers understand but
+  // several desktop mail clients preserve literally. Mailto fields are safer
+  // with percent encoding so spaces and line breaks survive the app handoff.
+  const fields = [
+    ["cc", emailAddress(input.cc)],
+    ["subject", input.subject],
+    ["body", input.body],
+  ]
+  const query = fields
+    .map(([name, value]) => `${name}=${encodeURIComponent(value)}`)
+    .join("&")
+  return `mailto:${recipients.map(encodeURIComponent).join(",")}?${query}`
 }

--- a/src/lib/notifications/events.ts
+++ b/src/lib/notifications/events.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm"
+import { and, eq, inArray } from "drizzle-orm"
 
 import { getDb } from "@/db"
 import {
@@ -45,6 +45,7 @@ type RfiUpdatedNotificationInput = {
   readonly status: string
   readonly requesterName: string | null
   readonly assignedToName: string | null
+  readonly mentionedUserIds?: readonly string[]
   readonly updatedBy: AuthUser
 }
 
@@ -286,15 +287,49 @@ export async function notifyRfiUpdated(
 ): Promise<void> {
   const { env } = await getCloudflareContext()
   const db = getDb(env.DB)
-  const recipients = (
-    await projectAssignmentRecipients(
-      db,
-      input.organizationId,
-      input.projectId,
-      [input.requesterName, input.assignedToName]
+  const assignmentRecipients = await projectAssignmentRecipients(
+    db,
+    input.organizationId,
+    input.projectId,
+    [input.requesterName, input.assignedToName]
+  )
+  const recipients = new Map<string, NotificationRecipientInput>()
+  for (const recipient of assignmentRecipients) {
+    if (recipient.userId !== input.updatedBy.id) {
+      recipients.set(recipient.userId, recipient)
+    }
+  }
+  const mentionedUserIds = Array.from(
+    new Set(
+      (input.mentionedUserIds ?? []).filter(
+        (userId) => userId.length > 0 && userId !== input.updatedBy.id
+      )
     )
-  ).filter((recipient) => recipient.userId !== input.updatedBy.id)
-  if (recipients.length === 0) return
+  )
+  if (mentionedUserIds.length > 0) {
+    const mentionedUsers = await db
+      .select({
+        userId: users.id,
+        email: users.email,
+        googleEmail: users.googleEmail,
+      })
+      .from(users)
+      .innerJoin(
+        organizationMembers,
+        and(
+          eq(organizationMembers.userId, users.id),
+          eq(organizationMembers.organizationId, input.organizationId)
+        )
+      )
+      .where(and(inArray(users.id, mentionedUserIds), eq(users.isActive, true)))
+    for (const mentionedUser of mentionedUsers) {
+      recipients.set(mentionedUser.userId, {
+        userId: mentionedUser.userId,
+        email: mentionedUser.googleEmail?.trim() || mentionedUser.email,
+      })
+    }
+  }
+  if (recipients.size === 0) return
 
   await createNotificationEvent({
     organizationId: input.organizationId,
@@ -304,11 +339,11 @@ export async function notifyRfiUpdated(
     sourceId: input.rfiId,
     title: `${input.rfiNumber}: ${input.subject}`,
     body: `${input.updatedBy.displayName ?? input.updatedBy.email} updated this RFI to ${input.status.replace(/_/g, " ")}.`,
-    href: `/dashboard/projects/${input.projectId}/rfis`,
+    href: `/dashboard/projects/${input.projectId}/rfis?item=${encodeURIComponent(input.rfiId)}#rfi-${encodeURIComponent(input.rfiId)}`,
     priority: "normal",
     audience: "participants",
     createdBy: input.updatedBy.id,
-    recipients,
+    recipients: Array.from(recipients.values()),
     delivery: {
       inApp: true,
       email: true,


### PR DESCRIPTION
## What changed

- percent-encode RFI `mailto:` subjects and bodies so default mail apps receive spaces and line breaks instead of literal plus signs
- make the RFI response area the canonical Compass communication thread
- add people-only `@mention` suggestions and notify mentioned Compass users
- remove the unscoped Conversation button that could open an unrelated project conversation
- deep-link RFI notifications back to the exact RFI

## Root cause

`URLSearchParams` serialized mail fields with form-style `+` spaces, which some mail clients preserve literally. The prior Conversation link included only the project ID, so it had no RFI identity to resolve and could fall through to an unrelated channel.

## Validation

- `bun test src/lib/email/__tests__/mailto.test.ts src/lib/rfis/__tests__/communication.test.ts src/lib/rfis/__tests__/status.test.ts`
- `bunx tsc --noEmit`
- targeted ESLint on all changed files
- `bun run build`
