### PR TITLE
fix(schedule): stabilize bulk template loading

### DIFF
--- a/src/components/schedule/schedule-item-form-dialog.tsx
+++ b/src/components/schedule/schedule-item-form-dialog.tsx
@@ -64,10 +64,11 @@ import { cn } from "@/lib/utils"
 import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
 import { ProjectAssigneePicker } from "@/components/projects/project-assignee-picker"
 import { ScheduleItemLinks } from "@/components/schedule/schedule-item-links"
+import type { ScheduleTemplateImportGroup } from "@/app/actions/template-import-options"
 import {
-  getScheduleTemplateImportOptions,
-  type ScheduleTemplateImportGroup
-} from "@/app/actions/template-import-options"
+  clearScheduleTemplateImportOptions,
+  loadScheduleTemplateImportOptions
+} from "@/components/schedule/schedule-template-import-options-client"
 
 const phases = PHASE_ORDER.map((value) => ({
   value,
@@ -141,6 +142,8 @@ export function ScheduleItemFormDialog({
     readonly ScheduleTemplateImportGroup[] | null
   >(null)
   const [templateLoading, setTemplateLoading] = useState(false)
+  const [templateLoadError, setTemplateLoadError] = useState(false)
+  const [templateLoadAttempt, setTemplateLoadAttempt] = useState(0)
   const [selectedTemplateId, setSelectedTemplateId] = useState("")
   const [selectedTemplateItemId, setSelectedTemplateItemId] = useState("")
   const [selectedTemplateTodoIds, setSelectedTemplateTodoIds] = useState<readonly string[]>([])
@@ -178,14 +181,16 @@ export function ScheduleItemFormDialog({
     if (!open || isEditing || templateGroups !== null) return
     let cancelled = false
     setTemplateLoading(true)
-    void getScheduleTemplateImportOptions()
+    setTemplateLoadError(false)
+    void loadScheduleTemplateImportOptions()
       .then((groups) => {
         if (!cancelled) setTemplateGroups(groups)
       })
       .catch((error: unknown) => {
         console.error("Unable to load schedule template options", error)
         if (!cancelled) {
-          setTemplateGroups([])
+          setTemplateGroups(null)
+          setTemplateLoadError(true)
           toast.error("Unable to load published schedule templates.")
         }
       })
@@ -195,7 +200,7 @@ export function ScheduleItemFormDialog({
     return () => {
       cancelled = true
     }
-  }, [isEditing, open, templateGroups])
+  }, [isEditing, open, templateGroups, templateLoadAttempt])
 
   useEffect(() => {
     if (!open) return
@@ -521,6 +526,24 @@ export function ScheduleItemFormDialog({
                     <div className="flex items-center gap-2 text-xs text-muted-foreground">
                       <IconLoader2 className="size-3.5 animate-spin" />
                       Loading template schedule items…
+                    </div>
+                  ) : templateLoadError ? (
+                    <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                      <span>Compass could not load the published templates.</span>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-7 px-2 text-xs"
+                        onClick={() => {
+                          clearScheduleTemplateImportOptions()
+                          setTemplateLoadError(false)
+                          setTemplateGroups(null)
+                          setTemplateLoadAttempt((attempt) => attempt + 1)
+                        }}
+                      >
+                        Retry
+                      </Button>
                     </div>
                   ) : templateGroups?.length === 0 ? (
                     <p className="text-xs text-muted-foreground">

--- a/src/components/schedule/schedule-template-bulk-import-dialog.tsx
+++ b/src/components/schedule/schedule-template-bulk-import-dialog.tsx
@@ -6,10 +6,11 @@ import { IconLoader2, IconTemplate } from "@tabler/icons-react"
 import { toast } from "sonner"
 
 import { importScheduleTemplateItems } from "@/app/actions/schedule"
+import type { ScheduleTemplateImportGroup } from "@/app/actions/template-import-options"
 import {
-  getScheduleTemplateImportOptions,
-  type ScheduleTemplateImportGroup
-} from "@/app/actions/template-import-options"
+  clearScheduleTemplateImportOptions,
+  loadScheduleTemplateImportOptions
+} from "@/components/schedule/schedule-template-import-options-client"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
@@ -62,8 +63,8 @@ export function ScheduleTemplateBulkImportDialog({
 }: ScheduleTemplateBulkImportDialogProps) {
   const router = useRouter()
   const [templateGroups, setTemplateGroups] = useState<
-    readonly ScheduleTemplateImportGroup[]
-  >([])
+    readonly ScheduleTemplateImportGroup[] | null
+  >(null)
   const [templateId, setTemplateId] = useState("")
   const [anchorDate, setAnchorDate] = useState(localDateValue)
   const [selectedItemIds, setSelectedItemIds] = useState<readonly string[]>([])
@@ -71,19 +72,26 @@ export function ScheduleTemplateBulkImportDialog({
     Readonly<Record<string, string>>
   >({})
   const [loading, setLoading] = useState(false)
+  const [loadError, setLoadError] = useState(false)
+  const [loadAttempt, setLoadAttempt] = useState(0)
   const [isImporting, startImporting] = useTransition()
 
   useEffect(() => {
     if (!open) return
     let cancelled = false
     setLoading(true)
-    void getScheduleTemplateImportOptions()
+    setLoadError(false)
+    void loadScheduleTemplateImportOptions()
       .then((groups) => {
         if (!cancelled) setTemplateGroups(groups)
       })
       .catch((error: unknown) => {
         console.error("Unable to load schedule template options", error)
-        if (!cancelled) toast.error("Unable to load published schedule templates.")
+        if (!cancelled) {
+          setTemplateGroups(null)
+          setLoadError(true)
+          toast.error("Unable to load published schedule templates.")
+        }
       })
       .finally(() => {
         if (!cancelled) setLoading(false)
@@ -91,7 +99,7 @@ export function ScheduleTemplateBulkImportDialog({
     return () => {
       cancelled = true
     }
-  }, [open])
+  }, [loadAttempt, open])
 
   useEffect(() => {
     if (open) return
@@ -101,7 +109,7 @@ export function ScheduleTemplateBulkImportDialog({
   }, [open])
 
   const selectedGroup = useMemo(
-    () => templateGroups.find((group) => group.templateId === templateId) ?? null,
+    () => templateGroups?.find((group) => group.templateId === templateId) ?? null,
     [templateGroups, templateId]
   )
   const selectedItemIdSet = useMemo(
@@ -215,7 +223,23 @@ export function ScheduleTemplateBulkImportDialog({
               <IconLoader2 className="mr-2 size-4 animate-spin" />
               Loading published templates…
             </div>
-          ) : templateGroups.length === 0 ? (
+          ) : loadError ? (
+            <div className="flex min-h-40 flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground">
+              <p>Compass could not load the published templates.</p>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  clearScheduleTemplateImportOptions()
+                  setLoadError(false)
+                  setTemplateGroups(null)
+                  setLoadAttempt((attempt) => attempt + 1)
+                }}
+              >
+                Retry
+              </Button>
+            </div>
+          ) : templateGroups?.length === 0 ? (
             <div className="flex min-h-40 items-center justify-center gap-3 text-sm text-muted-foreground">
               <IconTemplate className="size-5" />
               No published templates contain reusable schedule items.
@@ -230,7 +254,7 @@ export function ScheduleTemplateBulkImportDialog({
                       <SelectValue placeholder="Choose a published template" />
                     </SelectTrigger>
                     <SelectContent>
-                      {templateGroups.map((group) => (
+                      {templateGroups?.map((group) => (
                         <SelectItem key={group.templateId} value={group.templateId}>
                           {group.templateName}
                         </SelectItem>

--- a/src/components/schedule/schedule-template-import-options-client.ts
+++ b/src/components/schedule/schedule-template-import-options-client.ts
@@ -1,0 +1,58 @@
+"use client"
+
+import {
+  getScheduleTemplateImportOptions,
+  type ScheduleTemplateImportGroup
+} from "@/app/actions/template-import-options"
+
+let scheduleTemplateOptionsPromise:
+  | Promise<readonly ScheduleTemplateImportGroup[]>
+  | null = null
+let scheduleTemplateOptionsLoadedAt: number | null = null
+
+const SCHEDULE_TEMPLATE_OPTIONS_CACHE_MS = 30_000
+
+/**
+ * Share one options request between the single-item and bulk import dialogs.
+ * The single-item dialog often starts loading immediately before the user opens
+ * the bulk importer, so issuing a second Server Action request here is both
+ * wasteful and vulnerable to a deployment changing the action manifest.
+ */
+export function loadScheduleTemplateImportOptions(): Promise<
+  readonly ScheduleTemplateImportGroup[]
+> {
+  const cacheIsFresh =
+    scheduleTemplateOptionsLoadedAt !== null &&
+    Date.now() - scheduleTemplateOptionsLoadedAt <
+      SCHEDULE_TEMPLATE_OPTIONS_CACHE_MS
+  const requestIsInFlight =
+    scheduleTemplateOptionsPromise !== null &&
+    scheduleTemplateOptionsLoadedAt === null
+  if (
+    !requestIsInFlight &&
+    (scheduleTemplateOptionsPromise === null || !cacheIsFresh)
+  ) {
+    const request = getScheduleTemplateImportOptions()
+    scheduleTemplateOptionsLoadedAt = null
+    scheduleTemplateOptionsPromise = request
+      .then((groups) => {
+        scheduleTemplateOptionsLoadedAt = Date.now()
+        return groups
+      })
+      .catch((error: unknown) => {
+        scheduleTemplateOptionsPromise = null
+        scheduleTemplateOptionsLoadedAt = null
+        throw error
+      })
+  }
+  const optionsPromise = scheduleTemplateOptionsPromise
+  if (optionsPromise === null) {
+    return Promise.reject(new Error("Schedule template options request was not initialized."))
+  }
+  return optionsPromise
+}
+
+export function clearScheduleTemplateImportOptions(): void {
+  scheduleTemplateOptionsPromise = null
+  scheduleTemplateOptionsLoadedAt = null
+}


### PR DESCRIPTION
## What changed

- share one short-lived schedule-template options request between the single-item and bulk import dialogs
- prevent the bulk dialog from issuing a second fragile Server Action request when opened immediately
- distinguish a real request failure from a valid empty template library
- add an explicit retry action for both template import paths

## Root cause

The New Schedule Item dialog begins loading published template options as soon as it opens. Selecting **Import several** immediately closed that dialog and caused the bulk importer to issue a second request for the same Server Action. A transient or stale action-manifest failure was then represented by the same empty array used for a genuinely empty template library, producing the incorrect “No published templates” message even though the live library contains verified reusable schedule items.

## Validation

- TypeScript: `tsc --noEmit`
- ESLint on all three changed files
- 9 focused template/schedule tests
- production Next.js build (`next build --webpack`)
- live production reproduction confirmed the template data itself is present and currently retrievable
