### PR TITLE
fix(rfis): include complete contact audience

### DIFF
--- a/src/app/dashboard/projects/[id]/rfis/page.tsx
+++ b/src/app/dashboard/projects/[id]/rfis/page.tsx
@@ -34,6 +34,7 @@ import {
   rfiMatchesStatusFilter,
   type RfiStatusFilter,
 } from "@/lib/rfis/status"
+import { buildRfiContactOptions } from "@/lib/rfis/contact-options"
 import { cn } from "@/lib/utils"
 import { redirectIfFeaturePermissionDenied } from "@/lib/permission-redirect"
 
@@ -193,13 +194,7 @@ export default async function ProjectRfisPage({
       contact.displayName,
     ])
   )
-  const peopleOptions = unique(
-    contacts.map((contact) =>
-      contact.companyName && contact.companyName !== contact.displayName
-        ? `${contact.displayName} - ${contact.companyName}`
-        : contact.displayName
-    )
-  )
+  const peopleOptions = buildRfiContactOptions(taskAssignees)
 
   return (
     <div className="flex-1 space-y-6 p-4 pt-6 sm:p-6 md:p-8">

--- a/src/components/projects/project-rfi-create-form.tsx
+++ b/src/components/projects/project-rfi-create-form.tsx
@@ -25,12 +25,16 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet"
 import { Textarea } from "@/components/ui/textarea"
+import {
+  RFI_CONTACT_GROUPS,
+  type RfiContactOption,
+} from "@/lib/rfis/contact-options"
 
 type ProjectRfiCreateFormProps = {
   readonly projectId: string
   readonly projectDriveFolderId: string | null
   readonly companyOrTradeOptions: readonly string[]
-  readonly peopleOptions: readonly string[]
+  readonly peopleOptions: readonly RfiContactOption[]
 }
 
 const DOCUMENT_INPUT_CLASS =
@@ -272,11 +276,21 @@ export function ProjectRfiCreateForm({
                 className={DOCUMENT_SELECT_CLASS}
               >
                 <option value="">Choose project contact</option>
-                {peopleOptions.map((option) => (
-                  <option key={option} value={option}>
-                    {option}
-                  </option>
-                ))}
+                {RFI_CONTACT_GROUPS.map((group) => {
+                  const options = peopleOptions.filter(
+                    (option) => option.group === group.value
+                  )
+                  if (options.length === 0) return null
+                  return (
+                    <optgroup key={group.value} label={group.label}>
+                      {options.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </optgroup>
+                  )
+                })}
               </select>
               <Input
                 name="assignedToNameCustom"
@@ -294,11 +308,21 @@ export function ProjectRfiCreateForm({
                 className={DOCUMENT_SELECT_CLASS}
               >
                 <option value="">Choose project contact</option>
-                {peopleOptions.map((option) => (
-                  <option key={option} value={option}>
-                    {option}
-                  </option>
-                ))}
+                {RFI_CONTACT_GROUPS.map((group) => {
+                  const options = peopleOptions.filter(
+                    (option) => option.group === group.value
+                  )
+                  if (options.length === 0) return null
+                  return (
+                    <optgroup key={group.value} label={group.label}>
+                      {options.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </optgroup>
+                  )
+                })}
               </select>
               <Input
                 name="requesterNameCustom"

--- a/src/lib/rfis/__tests__/contact-options.test.ts
+++ b/src/lib/rfis/__tests__/contact-options.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildRfiContactOptions,
+  RFI_CONTACT_GROUPS,
+} from "@/lib/rfis/contact-options"
+
+describe("RFI contact options", () => {
+  it("includes and groups staff, owners, subcontractors, and suppliers", () => {
+    const result = buildRfiContactOptions([
+      { label: "Wes Jones", contactType: "internal" },
+      { label: "Tanis Loomis", contactType: "owner" },
+      { label: "Acme Electric", contactType: "subcontractor" },
+      { label: "Front Range Supply", contactType: "supplier" },
+    ])
+
+    expect(result).toEqual([
+      { value: "Wes Jones", label: "Wes Jones", group: "internal" },
+      { value: "Tanis Loomis", label: "Tanis Loomis", group: "owner" },
+      {
+        value: "Acme Electric",
+        label: "Acme Electric",
+        group: "subcontractor",
+      },
+      {
+        value: "Front Range Supply",
+        label: "Front Range Supply",
+        group: "supplier",
+      },
+    ])
+    expect(RFI_CONTACT_GROUPS.map((group) => group.label)).toEqual([
+      "Internal staff",
+      "Owners",
+      "Subcontractors",
+      "Suppliers",
+    ])
+  })
+
+  it("deduplicates the same person across project and directory sources", () => {
+    const result = buildRfiContactOptions([
+      { label: "Sylvi Vogel", contactType: "internal" },
+      { label: " sylvi vogel ", contactType: "internal" },
+    ])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.label).toBe("Sylvi Vogel")
+  })
+})

--- a/src/lib/rfis/contact-options.ts
+++ b/src/lib/rfis/contact-options.ts
@@ -1,0 +1,61 @@
+export type RfiContactGroup =
+  | "internal"
+  | "owner"
+  | "subcontractor"
+  | "supplier"
+
+export type RfiContactOption = {
+  readonly value: string
+  readonly label: string
+  readonly group: RfiContactGroup
+}
+
+type RfiContactCandidate = {
+  readonly label: string
+  readonly contactType: string
+}
+
+export const RFI_CONTACT_GROUPS: readonly {
+  readonly value: RfiContactGroup
+  readonly label: string
+}[] = [
+  { value: "internal", label: "Internal staff" },
+  { value: "owner", label: "Owners" },
+  { value: "subcontractor", label: "Subcontractors" },
+  { value: "supplier", label: "Suppliers" },
+]
+
+function rfiContactGroup(value: string): RfiContactGroup {
+  if (value === "owner") return "owner"
+  if (value === "subcontractor") return "subcontractor"
+  if (value === "supplier") return "supplier"
+  return "internal"
+}
+
+export function buildRfiContactOptions(
+  candidates: readonly RfiContactCandidate[]
+): readonly RfiContactOption[] {
+  const options = new Map<string, RfiContactOption>()
+
+  for (const candidate of candidates) {
+    const label = candidate.label.trim()
+    if (!label) continue
+    const key = label.toLocaleLowerCase()
+    if (options.has(key)) continue
+    options.set(key, {
+      value: label,
+      label,
+      group: rfiContactGroup(candidate.contactType),
+    })
+  }
+
+  const groupOrder = new Map(
+    RFI_CONTACT_GROUPS.map((group, index) => [group.value, index])
+  )
+  return Array.from(options.values()).sort((first, second) => {
+    const groupDifference =
+      (groupOrder.get(first.group) ?? 0) -
+      (groupOrder.get(second.group) ?? 0)
+    return groupDifference || first.label.localeCompare(second.label)
+  })
+}


### PR DESCRIPTION
## What changed

- populate RFI **Assigned to** and **Requested by** from the complete project task-assignee directory
- include active internal staff, project owners, subcontractors, and suppliers
- include active directory subcontractors and suppliers when they are not already project contacts
- organize both native dropdowns into labeled contact groups
- preserve manual entry for contacts not yet in Compass

## Root cause

The RFI form built its people dropdown exclusively from the project-contact summary. That excluded organization staff who were not duplicated on the project and excluded active supplier/subcontractor directory entries. The scheduling assignee source already combines the correct audiences and deduplicates project and directory records, so the RFI form now uses that established source.

## Validation

- TypeScript: `tsc --noEmit`
- ESLint on all changed files
- focused RFI contact-option tests: 2 passed
- production Next.js build (`next build --webpack`)
