### PR TITLE
fix(rfis): include project owner fallback

### DIFF
--- a/src/app/dashboard/projects/[id]/rfis/page.tsx
+++ b/src/app/dashboard/projects/[id]/rfis/page.tsx
@@ -194,7 +194,10 @@ export default async function ProjectRfisPage({
       contact.displayName,
     ])
   )
-  const peopleOptions = buildRfiContactOptions(taskAssignees)
+  const peopleOptions = buildRfiContactOptions(
+    taskAssignees,
+    project?.clientName
+  )
 
   return (
     <div className="flex-1 space-y-6 p-4 pt-6 sm:p-6 md:p-8">

--- a/src/lib/rfis/__tests__/contact-options.test.ts
+++ b/src/lib/rfis/__tests__/contact-options.test.ts
@@ -45,4 +45,17 @@ describe("RFI contact options", () => {
     expect(result).toHaveLength(1)
     expect(result[0]?.label).toBe("Sylvi Vogel")
   })
+
+  it("includes the project client when owner contact rows are missing", () => {
+    const result = buildRfiContactOptions(
+      [{ label: "Wes Jones", contactType: "internal" }],
+      "David and Katie Squires"
+    )
+
+    expect(result).toContainEqual({
+      value: "David and Katie Squires",
+      label: "David and Katie Squires",
+      group: "owner",
+    })
+  })
 })

--- a/src/lib/rfis/contact-options.ts
+++ b/src/lib/rfis/contact-options.ts
@@ -33,21 +33,28 @@ function rfiContactGroup(value: string): RfiContactGroup {
 }
 
 export function buildRfiContactOptions(
-  candidates: readonly RfiContactCandidate[]
+  candidates: readonly RfiContactCandidate[],
+  projectOwnerName?: string | null
 ): readonly RfiContactOption[] {
   const options = new Map<string, RfiContactOption>()
 
-  for (const candidate of candidates) {
+  function addCandidate(candidate: RfiContactCandidate): void {
     const label = candidate.label.trim()
-    if (!label) continue
+    if (!label) return
     const key = label.toLocaleLowerCase()
-    if (options.has(key)) continue
+    if (options.has(key)) return
     options.set(key, {
       value: label,
       label,
       group: rfiContactGroup(candidate.contactType),
     })
   }
+
+  for (const candidate of candidates) addCandidate(candidate)
+
+  // Imported projects can have an owner on the project record before their
+  // project-contact rows are reconciled. Keep that owner reachable from RFIs.
+  addCandidate({ label: projectOwnerName ?? "", contactType: "owner" })
 
   const groupOrder = new Map(
     RFI_CONTACT_GROUPS.map((group, index) => [group.value, index])


### PR DESCRIPTION
## Summary
- include the project client in RFI contact pickers when imported project-contact rows have not been reconciled
- keep the project client grouped under Owners in both Assigned to and Requested by
- add regression coverage for the fallback

## Validation
- focused Vitest suite (3 tests)
- ESLint on changed files
- TypeScript no-emit check
- live verification exposed and motivated this follow-up
