### PR TITLE
fix(rfis): expose inbound email sync failures

### DIFF
--- a/custom-worker.ts
+++ b/custom-worker.ts
@@ -55,6 +55,24 @@ async function syncInboundEmail(env: CloudflareEnv): Promise<void> {
   if (!response.ok) {
     throw new Error(`Inbound email sync failed with ${response.status}`)
   }
+  const payload: unknown = await response.json()
+  if (typeof payload !== "object" || payload === null) {
+    throw new Error("Inbound email sync returned an invalid response")
+  }
+  const summaries = Reflect.get(payload, "summaries")
+  if (!Array.isArray(summaries)) {
+    throw new Error("Inbound email sync returned no summaries")
+  }
+  const errors = summaries.flatMap((summary) => {
+    if (typeof summary !== "object" || summary === null) return []
+    const value = Reflect.get(summary, "errors")
+    return Array.isArray(value)
+      ? value.filter((error): error is string => typeof error === "string")
+      : []
+  })
+  if (errors.length > 0) {
+    throw new Error(`Inbound email sync reported: ${errors.join("; ")}`)
+  }
 }
 
 export default {

--- a/src/app/api/email/gmail-sync/route.ts
+++ b/src/app/api/email/gmail-sync/route.ts
@@ -79,5 +79,19 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     summaries.push({ organizationId, ...summary })
   }
 
+  console.log(
+    "[gmail-sync]",
+    JSON.stringify(
+      summaries.map((summary) => ({
+        organizationId: summary.organizationId,
+        scanned: summary.scanned,
+        imported: summary.imported,
+        posted: summary.posted,
+        needsReview: summary.needsReview,
+        errors: summary.errors,
+      }))
+    )
+  )
+
   return NextResponse.json({ success: true, summaries })
 }

--- a/src/app/dashboard/projects/[id]/rfis/page.tsx
+++ b/src/app/dashboard/projects/[id]/rfis/page.tsx
@@ -21,6 +21,7 @@ import {
   type ProjectRfiEmailRecipientOption,
 } from "@/components/projects/project-rfi-communication-actions"
 import { ProjectRfiDeleteButton } from "@/components/projects/project-rfi-delete-button"
+import { ProjectRfiEmailSyncButton } from "@/components/projects/project-rfi-email-sync-button"
 import { ProjectRfiResponseComposer } from "@/components/projects/project-rfi-response-composer"
 import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
 import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
@@ -240,12 +241,15 @@ export default async function ProjectRfisPage({
               Track questions, assignments, due dates, visibility, and responses.
             </p>
           </div>
-          <ProjectRfiCreateForm
-            projectId={id}
-            projectDriveFolderId={project?.googleDriveFolderId ?? null}
-            companyOrTradeOptions={companyOrTradeOptions}
-            peopleOptions={peopleOptions}
-          />
+          <div className="flex flex-wrap items-center gap-2">
+            <ProjectRfiEmailSyncButton />
+            <ProjectRfiCreateForm
+              projectId={id}
+              projectDriveFolderId={project?.googleDriveFolderId ?? null}
+              companyOrTradeOptions={companyOrTradeOptions}
+              peopleOptions={peopleOptions}
+            />
+          </div>
         </div>
 
         <div className="flex flex-wrap items-center justify-between gap-3">

--- a/src/components/projects/project-rfi-email-sync-button.tsx
+++ b/src/components/projects/project-rfi-email-sync-button.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import * as React from "react"
+import { IconMailCheck, IconLoader2 } from "@tabler/icons-react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+
+type SyncSummary = {
+  readonly scanned?: number
+  readonly posted?: number
+  readonly needsReview?: number
+  readonly errors?: readonly string[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function syncSummaries(value: unknown): readonly SyncSummary[] {
+  if (!isRecord(value) || !Array.isArray(value.summaries)) return []
+  return value.summaries.filter(isRecord)
+}
+
+export function ProjectRfiEmailSyncButton(): React.ReactElement {
+  const router = useRouter()
+  const [syncing, setSyncing] = React.useState(false)
+
+  async function syncReplies(): Promise<void> {
+    setSyncing(true)
+    try {
+      const response = await fetch("/api/email/gmail-sync", { method: "POST" })
+      const payload: unknown = await response.json()
+      if (!response.ok || !isRecord(payload) || payload.success !== true) {
+        const error = isRecord(payload) && typeof payload.error === "string"
+          ? payload.error
+          : "Unable to check email replies."
+        toast.error(error)
+        return
+      }
+
+      const summaries = syncSummaries(payload)
+      const errors = summaries.flatMap((summary) => summary.errors ?? [])
+      const posted = summaries.reduce((total, summary) => total + (summary.posted ?? 0), 0)
+      const needsReview = summaries.reduce(
+        (total, summary) => total + (summary.needsReview ?? 0),
+        0
+      )
+      if (errors.length > 0) {
+        toast.error(errors[0])
+      } else if (posted > 0) {
+        toast.success(`${posted} email ${posted === 1 ? "reply" : "replies"} added to Compass.`)
+      } else if (needsReview > 0) {
+        toast.warning(`${needsReview} email ${needsReview === 1 ? "needs" : "need"} staff review.`)
+      } else {
+        toast.info("No new tracked email replies were found.")
+      }
+      router.refresh()
+    } catch {
+      toast.error("Unable to check email replies.")
+    } finally {
+      setSyncing(false)
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="outline"
+      disabled={syncing}
+      onClick={() => void syncReplies()}
+    >
+      {syncing ? (
+        <IconLoader2 className="size-4 animate-spin" />
+      ) : (
+        <IconMailCheck className="size-4" />
+      )}
+      Check email replies
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- add a staff-facing Check email replies control to the project RFI queue
- refresh the RFI page after a manual Gmail import and report posted, review, or error results
- record safe Gmail sync counts/errors in Worker logs
- fail scheduled sync runs when Gmail reports errors instead of silently returning success

## Validation
- production Next.js build
- TypeScript no-emit check
- ESLint on changed files
- read-only production D1 tracing for O-210-33
