### PR TITLE
fix(rfis): import tracked email replies

### DIFF
--- a/src/lib/email/__tests__/gmail-inbound.test.ts
+++ b/src/lib/email/__tests__/gmail-inbound.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+
+import type { InboundCandidate } from "@/lib/email/gmail-message-parser"
+import { isReplyMessage } from "@/lib/email/reply-detection"
+
+function candidate(
+  overrides: Partial<InboundCandidate> = {}
+): InboundCandidate {
+  return {
+    gmailMessageId: "message-1",
+    gmailThreadId: "thread-1",
+    messageIdHeader: "<message-1@example.com>",
+    inReplyToHeader: null,
+    referencesHeader: null,
+    token: "cmp-1234567890",
+    fromAddress: "person@example.com",
+    fromName: "Person",
+    toAddress: "jarvis+cmp-1234567890@hps-colorado.com",
+    subject: "[O-210-33-RFI-001] Testing RFI feature",
+    textBody: "Original outbound message",
+    htmlBody: null,
+    snippet: "Original outbound message",
+    receivedAt: "2026-08-06T22:19:12.000Z",
+    ...overrides,
+  }
+}
+
+describe("isReplyMessage", () => {
+  it("does not treat the original outbound copy as a reply", () => {
+    expect(isReplyMessage(candidate())).toBe(false)
+  })
+
+  it("recognizes a reply using the In-Reply-To header", () => {
+    expect(
+      isReplyMessage(
+        candidate({ inReplyToHeader: "<original-message@example.com>" })
+      )
+    ).toBe(true)
+  })
+
+  it("recognizes a reply by its subject when clients omit reply headers", () => {
+    expect(
+      isReplyMessage(candidate({ subject: "Re: [O-210-33-RFI-001] Testing" }))
+    ).toBe(true)
+  })
+})

--- a/src/lib/email/gmail-inbound.ts
+++ b/src/lib/email/gmail-inbound.ts
@@ -30,6 +30,7 @@ import {
   type InboundCandidate,
 } from "@/lib/email/gmail-message-parser"
 import { replyMailboxEmail } from "@/lib/email/reply-tracking"
+import { isReplyMessage } from "@/lib/email/reply-detection"
 import { canonicalRfiStatus } from "@/lib/rfis/status"
 
 type Db = ReturnType<typeof getDb>
@@ -293,27 +294,16 @@ async function insertInboundAudit(input: {
       receivedAt: input.candidate.receivedAt,
       importedAt: input.importedAt,
     })
-    .onConflictDoNothing({ target: inboundEmails.gmailMessageId })
-}
-
-async function isReplyThreadCreator(input: {
-  readonly db: Db
-  readonly createdBy: string | null
-  readonly fromAddress: string
-}): Promise<boolean> {
-  if (!input.createdBy) return false
-  const creator = await input.db
-    .select({ email: users.email, googleEmail: users.googleEmail })
-    .from(users)
-    .where(eq(users.id, input.createdBy))
-    .limit(1)
-    .then((rows) => rows[0] ?? null)
-  if (!creator) return false
-
-  const from = input.fromAddress.trim().toLowerCase()
-  return [creator.email, creator.googleEmail]
-    .filter((email): email is string => email !== null)
-    .some((email) => email.trim().toLowerCase() === from)
+    .onConflictDoUpdate({
+      target: inboundEmails.gmailMessageId,
+      set: {
+        projectId: input.projectId,
+        replyThreadId: input.replyThreadId,
+        matchedStatus: input.matchedStatus,
+        postedMessageId: input.postedMessageId,
+        importedAt: input.importedAt,
+      },
+    })
 }
 
 async function importCandidate(input: {
@@ -325,11 +315,17 @@ async function importCandidate(input: {
   "duplicate" | "ignored_outbound" | "needs_review" | "other_org" | "posted"
 > {
   const [duplicate] = await input.db
-    .select({ id: inboundEmails.id })
+    .select({
+      id: inboundEmails.id,
+      matchedStatus: inboundEmails.matchedStatus,
+    })
     .from(inboundEmails)
     .where(eq(inboundEmails.gmailMessageId, input.candidate.gmailMessageId))
     .limit(1)
-  if (duplicate) return "duplicate"
+  const retryMisclassifiedReply =
+    duplicate?.matchedStatus === "ignored_outbound" &&
+    isReplyMessage(input.candidate)
+  if (duplicate && !retryMisclassifiedReply) return "duplicate"
 
   const replyThread = input.candidate.token
     ? await input.db
@@ -345,14 +341,9 @@ async function importCandidate(input: {
     return "other_org"
   }
 
-  if (
-    replyThread &&
-    (await isReplyThreadCreator({
-      db: input.db,
-      createdBy: replyThread.createdBy,
-      fromAddress: input.candidate.fromAddress,
-    }))
-  ) {
+  // The generated mailto CCs Compass, so the original message also lands in
+  // this mailbox with the tracking token. Only replies should enter Compass.
+  if (replyThread && !isReplyMessage(input.candidate)) {
     await insertInboundAudit({
       db: input.db,
       organizationId: input.organizationId,

--- a/src/lib/email/reply-detection.ts
+++ b/src/lib/email/reply-detection.ts
@@ -1,0 +1,13 @@
+type ReplyCandidate = {
+  readonly inReplyToHeader: string | null
+  readonly referencesHeader: string | null
+  readonly subject: string
+}
+
+export function isReplyMessage(candidate: ReplyCandidate): boolean {
+  return Boolean(
+    candidate.inReplyToHeader ||
+      candidate.referencesHeader ||
+      /^\s*(?:re|fw|fwd)\s*:/i.test(candidate.subject)
+  )
+}


### PR DESCRIPTION
## Summary
- distinguish real replies from the original tracked email copy
- reprocess replies previously quarantined as outbound
- preserve inbound audit rows while updating corrected status

## Verification
- `bun test src/lib/email/__tests__/gmail-inbound.test.ts`
- `bunx eslint src/lib/email/gmail-inbound.ts src/lib/email/reply-detection.ts src/lib/email/__tests__/gmail-inbound.test.ts`
- `bunx tsc --noEmit`

## Production evidence
The O-210-33 reply reached Gmail and matched the correct RFI token, but its audit row was marked `ignored_outbound`; this patch safely reprocesses that row.
