### PR TITLE
feat(projects): add routed project email addresses

### DIFF
--- a/src/app/dashboard/projects/[id]/page.tsx
+++ b/src/app/dashboard/projects/[id]/page.tsx
@@ -44,6 +44,7 @@ import {
   type ProjectRfiSummary,
 } from "@/app/actions/project-rfis"
 import { ProjectActionsMenu } from "@/components/projects/project-actions-menu"
+import { ProjectEmailAddressCard } from "@/components/projects/project-email-address-card"
 import { ProjectWorkspaceShell } from "@/components/projects/project-workspace-shell"
 import {
   allowedWorkflowRoleIds,
@@ -342,6 +343,10 @@ export default async function ProjectSummaryPage({
             {project?.clientName && <> &middot; {project.clientName}</>}
             {project?.projectManager && <> &middot; {project.projectManager}</>}
           </p>
+        </div>
+
+        <div className="mb-4 sm:mb-5">
+          <ProjectEmailAddressCard projectId={id} compact />
         </div>
 
         <section className="mb-4 grid grid-cols-2 gap-x-5 gap-y-3 border-y py-3 sm:mb-5 lg:grid-cols-4">

--- a/src/components/projects/project-audience-preview.tsx
+++ b/src/components/projects/project-audience-preview.tsx
@@ -32,6 +32,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { OwnerCoverPhotoControl } from "@/components/projects/owner-cover-photo-control"
+import { ProjectEmailAddressCard } from "@/components/projects/project-email-address-card"
 import { ProjectAudiencePhotoGallery } from "@/components/projects/project-audience-photo-gallery"
 import { ProjectAudiencePreviewShell } from "@/components/projects/project-audience-preview-shell"
 import { ProjectAudienceSchedule } from "@/components/projects/project-audience-schedule"
@@ -535,6 +536,10 @@ function OwnerProjectPreview({
         </div>
         )}
 
+        {section === "overview" && (
+          <ProjectEmailAddressCard projectId={data.project.id} />
+        )}
+
         {(section === "overview" || section === "updates") && (
         <section
           className={
@@ -793,6 +798,10 @@ export function ProjectAudiencePreview({
             workspaceLabel="Partner project home"
             editable={false}
           />
+        )}
+
+        {section === "overview" && (
+          <ProjectEmailAddressCard projectId={data.project.id} />
         )}
 
         {section === "overview" && (

--- a/src/components/projects/project-email-address-card.tsx
+++ b/src/components/projects/project-email-address-card.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import { IconCopy, IconMail } from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import {
+  PROJECT_EMAIL_SUBJECT_TAGS,
+  projectInboundEmailAddress,
+} from "@/lib/email/project-address"
+import { cn } from "@/lib/utils"
+
+export function ProjectEmailAddressCard({
+  projectId,
+  compact = false,
+}: {
+  readonly projectId: string
+  readonly compact?: boolean
+}): React.ReactElement {
+  const address = projectInboundEmailAddress(projectId)
+
+  async function copyAddress(): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(address)
+      toast.success("Project email address copied")
+    } catch {
+      toast.error("Unable to copy the project email address")
+    }
+  }
+
+  return (
+    <section
+      className={cn(
+        "border-y bg-background/70 py-3",
+        compact ? "px-0" : "px-3 sm:px-4"
+      )}
+      aria-label="Project email address"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <IconMail className="size-4 shrink-0 text-muted-foreground" />
+            <p className="text-xs font-medium uppercase text-muted-foreground">
+              Email this project
+            </p>
+          </div>
+          <a
+            href={`mailto:${address}`}
+            className="mt-1 block break-all text-sm font-medium text-primary hover:underline"
+          >
+            {address}
+          </a>
+        </div>
+        <Button type="button" variant="outline" size="sm" onClick={copyAddress}>
+          <IconCopy className="size-4" />
+          Copy
+        </Button>
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Start the subject with one of these tags to route the email:
+      </p>
+      <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs">
+        {PROJECT_EMAIL_SUBJECT_TAGS.map((item) => (
+          <span key={item.tag}>
+            <span className="font-mono font-medium">{item.tag}</span>{" "}
+            <span className="text-muted-foreground">{item.destination}</span>
+          </span>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/lib/email/__tests__/project-address.test.ts
+++ b/src/lib/email/__tests__/project-address.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  projectEmailDestination,
+  projectEmailTitle,
+  projectIdFromInboundAddress,
+  projectInboundEmailAddress,
+} from "@/lib/email/project-address"
+
+describe("project inbound email addressing", () => {
+  it("creates and parses a durable project address", () => {
+    const address = projectInboundEmailAddress("proj-o-210-mitchell")
+    expect(address).toBe(
+      "jarvis+project-proj-o-210-mitchell@hps-colorado.com"
+    )
+    expect(projectIdFromInboundAddress(`Compass <${address}>`)).toBe(
+      "proj-o-210-mitchell"
+    )
+  })
+
+  it.each([
+    ["[RFI] Missing roof detail", "rfi"],
+    ["[RFQ] Framing package", "rfq"],
+    ["[CHANGE ORDER] Add patio heater", "change_order"],
+    ["[TO-DO] Confirm delivery", "todo"],
+    ["[TASK] Confirm delivery", "todo"],
+    ["[DELIVERY] Windows arriving Friday", "delivery"],
+    ["[DAILY LOG] Site progress", "daily_log"],
+  ] as const)("routes %s", (subject, destination) => {
+    expect(projectEmailDestination(subject)).toBe(destination)
+  })
+
+  it("does not guess an untagged destination", () => {
+    expect(projectEmailDestination("Question about the project")).toBeNull()
+  })
+
+  it("removes the routing tag from the record title", () => {
+    expect(projectEmailTitle("[RFI] Missing roof detail")).toBe(
+      "Missing roof detail"
+    )
+  })
+})

--- a/src/lib/email/gmail-inbound.ts
+++ b/src/lib/email/gmail-inbound.ts
@@ -31,6 +31,7 @@ import {
 } from "@/lib/email/gmail-message-parser"
 import { replyMailboxEmail } from "@/lib/email/reply-tracking"
 import { isReplyMessage } from "@/lib/email/reply-detection"
+import { routeProjectInboundEmail } from "@/lib/email/project-inbound-routing"
 import { canonicalRfiStatus } from "@/lib/rfis/status"
 
 type Db = ReturnType<typeof getDb>
@@ -327,6 +328,39 @@ async function importCandidate(input: {
     isReplyMessage(input.candidate)
   if (duplicate && !retryMisclassifiedReply) return "duplicate"
 
+  const projectRoute = await routeProjectInboundEmail({
+    db: input.db,
+    organizationId: input.organizationId,
+    candidate: input.candidate,
+  })
+  if (projectRoute.kind === "other_organization") return "other_org"
+  if (projectRoute.kind === "needs_review") {
+    await insertInboundAudit({
+      db: input.db,
+      organizationId: input.organizationId,
+      projectId: projectRoute.projectId,
+      replyThreadId: null,
+      candidate: input.candidate,
+      matchedStatus: "needs_review",
+      postedMessageId: null,
+      importedAt: new Date().toISOString(),
+    })
+    return "needs_review"
+  }
+  if (projectRoute.kind === "routed") {
+    await insertInboundAudit({
+      db: input.db,
+      organizationId: input.organizationId,
+      projectId: projectRoute.projectId,
+      replyThreadId: null,
+      candidate: input.candidate,
+      matchedStatus: projectRoute.matchedStatus,
+      postedMessageId: projectRoute.entityId,
+      importedAt: new Date().toISOString(),
+    })
+    return "posted"
+  }
+
   const replyThread = input.candidate.token
     ? await input.db
         .select()
@@ -554,7 +588,8 @@ export async function syncGmailInboundReplies(input: {
   }
 
   const query =
-    envString(input.env, "COMPASS_GMAIL_INBOUND_QUERY") ?? "newer_than:30d cmp-"
+    envString(input.env, "COMPASS_GMAIL_INBOUND_QUERY") ??
+    'newer_than:30d {cmp- "jarvis+project-"}'
   const maxResults = parsePositiveInt(
     envString(input.env, "COMPASS_GMAIL_INBOUND_MAX_RESULTS"),
     25

--- a/src/lib/email/project-address.ts
+++ b/src/lib/email/project-address.ts
@@ -1,0 +1,67 @@
+const PROJECT_EMAIL_MAILBOX = "jarvis@hps-colorado.com"
+const PROJECT_ADDRESS_PREFIX = "project-"
+
+export const PROJECT_EMAIL_SUBJECT_TAGS = [
+  { tag: "[RFI]", destination: "RFI" },
+  { tag: "[RFQ]", destination: "RFQ draft" },
+  { tag: "[CHANGE ORDER]", destination: "Change Order draft" },
+  { tag: "[TO-DO]", destination: "To-Do" },
+  { tag: "[DELIVERY]", destination: "Delivery To-Do" },
+  { tag: "[DAILY LOG]", destination: "Daily Log" },
+] as const
+
+export type ProjectEmailDestination =
+  | "rfi"
+  | "rfq"
+  | "change_order"
+  | "todo"
+  | "delivery"
+  | "daily_log"
+
+function splitEmailAddress(email: string): {
+  readonly localPart: string
+  readonly domain: string
+} | null {
+  const trimmed = email.trim()
+  const atIndex = trimmed.lastIndexOf("@")
+  if (atIndex <= 0 || atIndex === trimmed.length - 1) return null
+  return {
+    localPart: trimmed.slice(0, atIndex),
+    domain: trimmed.slice(atIndex + 1),
+  }
+}
+
+export function projectInboundEmailAddress(projectId: string): string {
+  const mailbox = splitEmailAddress(PROJECT_EMAIL_MAILBOX)
+  if (!mailbox) return PROJECT_EMAIL_MAILBOX
+  return `${mailbox.localPart}+${PROJECT_ADDRESS_PREFIX}${projectId}@${mailbox.domain}`
+}
+
+export function projectIdFromInboundAddress(value: string | null): string | null {
+  if (!value) return null
+  const match = /\+project-(proj-[a-z0-9-]+)@/i.exec(value)
+  return match?.[1]?.toLowerCase() ?? null
+}
+
+export function projectEmailDestination(
+  subject: string
+): ProjectEmailDestination | null {
+  const normalized = subject.trim()
+  if (/^\[rfi\](?:\s|:|-|$)/i.test(normalized)) return "rfi"
+  if (/^\[rfq\](?:\s|:|-|$)/i.test(normalized)) return "rfq"
+  if (/^\[change order\](?:\s|:|-|$)/i.test(normalized)) {
+    return "change_order"
+  }
+  if (/^\[(?:to-do|todo|task)\](?:\s|:|-|$)/i.test(normalized)) return "todo"
+  if (/^\[delivery\](?:\s|:|-|$)/i.test(normalized)) return "delivery"
+  if (/^\[(?:daily log|daily-log|log)\](?:\s|:|-|$)/i.test(normalized)) {
+    return "daily_log"
+  }
+  return null
+}
+
+export function projectEmailTitle(subject: string): string {
+  return subject
+    .replace(/^\[(?:rfi|rfq|change order|to-do|todo|task|delivery|daily log|daily-log|log)\]\s*(?::|-)?\s*/i, "")
+    .trim()
+}

--- a/src/lib/email/project-inbound-routing.ts
+++ b/src/lib/email/project-inbound-routing.ts
@@ -1,0 +1,438 @@
+import "server-only"
+
+import { and, eq, inArray, or, sql } from "drizzle-orm"
+
+import type { getDb } from "@/db"
+import {
+  dailyLogs,
+  organizationMembers,
+  projectContacts,
+  projectChangeOrderHistory,
+  projectChangeOrders,
+  projectOperations,
+  projectRfis,
+  projects,
+  users,
+} from "@/db/schema"
+import {
+  stripHtml,
+  type InboundCandidate,
+} from "@/lib/email/gmail-message-parser"
+import {
+  projectEmailDestination,
+  projectEmailTitle,
+  projectIdFromInboundAddress,
+  type ProjectEmailDestination,
+} from "@/lib/email/project-address"
+import { PROJECT_TODO_RECORD_TYPES } from "@/lib/project-todos"
+
+type Db = ReturnType<typeof getDb>
+
+export type ProjectInboundRouteResult =
+  | { readonly kind: "not_project_email" }
+  | { readonly kind: "other_organization" }
+  | {
+      readonly kind: "needs_review"
+      readonly projectId: string | null
+    }
+  | {
+      readonly kind: "routed"
+      readonly projectId: string
+      readonly entityId: string
+      readonly matchedStatus:
+        | "routed_rfi"
+        | "routed_todo"
+        | "routed_daily_log"
+        | "routed_rfq"
+        | "routed_change_order"
+    }
+
+function candidateBody(candidate: InboundCandidate): string {
+  return (
+    candidate.textBody?.trim() ||
+    (candidate.htmlBody ? stripHtml(candidate.htmlBody) : "") ||
+    candidate.snippet?.trim() ||
+    "(No message body.)"
+  )
+}
+
+function senderLabel(candidate: InboundCandidate): string {
+  return candidate.fromName?.trim() || candidate.fromAddress
+}
+
+async function senderCanEmailProject(input: {
+  readonly db: Db
+  readonly organizationId: string
+  readonly projectId: string
+  readonly senderEmail: string
+}): Promise<boolean> {
+  const email = input.senderEmail.trim().toLowerCase()
+  if (email.length === 0) return false
+
+  const [contact] = await input.db
+    .select({ id: projectContacts.id })
+    .from(projectContacts)
+    .where(
+      and(
+        eq(projectContacts.projectId, input.projectId),
+        eq(projectContacts.active, true),
+        sql`lower(${projectContacts.email}) = ${email}`
+      )
+    )
+    .limit(1)
+  if (contact) return true
+
+  const [member] = await input.db
+    .select({ id: users.id })
+    .from(users)
+    .innerJoin(
+      organizationMembers,
+      eq(organizationMembers.userId, users.id)
+    )
+    .where(
+      and(
+        eq(organizationMembers.organizationId, input.organizationId),
+        eq(users.isActive, true),
+        or(
+          sql`lower(${users.email}) = ${email}`,
+          sql`lower(${users.googleEmail}) = ${email}`
+        )
+      )
+    )
+    .limit(1)
+  return Boolean(member)
+}
+
+function rfiNumber(input: {
+  readonly projectNumber: string | null
+  readonly existingCount: number
+  readonly id: string
+}): string {
+  const sequence = String(input.existingCount + 1).padStart(3, "0")
+  const prefix = input.projectNumber?.trim()
+  return prefix
+    ? `${prefix}-RFI-${sequence}`
+    : `RFI-${sequence}-${input.id.slice(-6).toUpperCase()}`
+}
+
+async function routeRfi(input: {
+  readonly db: Db
+  readonly projectId: string
+  readonly projectNumber: string | null
+  readonly candidate: InboundCandidate
+  readonly now: string
+}): Promise<{ readonly id: string; readonly status: "routed_rfi" }> {
+  const id = `email-rfi-${input.candidate.gmailMessageId}`
+  const existing = await input.db
+    .select({ id: projectRfis.id })
+    .from(projectRfis)
+    .where(eq(projectRfis.projectId, input.projectId))
+  const title =
+    projectEmailTitle(input.candidate.subject) ||
+    `Email from ${senderLabel(input.candidate)}`
+
+  await input.db
+    .insert(projectRfis)
+    .values({
+      id,
+      projectId: input.projectId,
+      sourceSystem: "email",
+      sourceRecordId: input.candidate.gmailMessageId,
+      rfiNumber: rfiNumber({
+        projectNumber: input.projectNumber,
+        existingCount: existing.length,
+        id,
+      }),
+      subject: title,
+      question: candidateBody(input.candidate),
+      status: "new",
+      priority: "normal",
+      audience: "internal",
+      requesterName: senderLabel(input.candidate),
+      submittedAt: input.candidate.receivedAt,
+      createdAt: input.now,
+      updatedAt: input.now,
+    })
+    .onConflictDoNothing({ target: projectRfis.id })
+
+  return { id, status: "routed_rfi" }
+}
+
+async function routeTodo(input: {
+  readonly db: Db
+  readonly projectId: string
+  readonly candidate: InboundCandidate
+  readonly delivery?: boolean
+  readonly now: string
+}): Promise<{ readonly id: string; readonly status: "routed_todo" }> {
+  const id = `email-todo-${input.candidate.gmailMessageId}`
+  const existing = await input.db
+    .select({ id: projectOperations.id })
+    .from(projectOperations)
+    .where(
+      and(
+        eq(projectOperations.projectId, input.projectId),
+        inArray(projectOperations.sourceRecordType, [
+          ...PROJECT_TODO_RECORD_TYPES,
+        ])
+      )
+    )
+  const baseTitle =
+    projectEmailTitle(input.candidate.subject) ||
+    `Email from ${senderLabel(input.candidate)}`
+  const title = input.delivery ? `Delivery: ${baseTitle}` : baseTitle
+
+  await input.db
+    .insert(projectOperations)
+    .values({
+      id,
+      projectId: input.projectId,
+      sourceSystem: "email",
+      sourceRecordType: "staff_task",
+      sourceRecordId: input.candidate.gmailMessageId,
+      sourceRecordNumber: `TASK-${String(existing.length + 1).padStart(3, "0")}`,
+      title,
+      description: candidateBody(input.candidate),
+      status: "open",
+      priority: "normal",
+      assigneeType: "internal",
+      sageWriteStatus: "not_ready",
+      syncDirection: "write",
+      syncStatus: "needs_review",
+      createdAt: input.now,
+      updatedAt: input.now,
+    })
+    .onConflictDoNothing({ target: projectOperations.id })
+
+  return { id, status: "routed_todo" }
+}
+
+async function routeRfq(input: {
+  readonly db: Db
+  readonly projectId: string
+  readonly projectNumber: string | null
+  readonly candidate: InboundCandidate
+  readonly now: string
+}): Promise<{ readonly id: string; readonly status: "routed_rfq" }> {
+  const id = `email-rfq-${input.candidate.gmailMessageId}`
+  const existing = await input.db
+    .select({ id: projectOperations.id })
+    .from(projectOperations)
+    .where(
+      and(
+        eq(projectOperations.projectId, input.projectId),
+        eq(projectOperations.sourceRecordType, "rfq")
+      )
+    )
+  const title =
+    projectEmailTitle(input.candidate.subject) ||
+    `RFQ from ${senderLabel(input.candidate)}`
+  const prefix = input.projectNumber?.trim() || "PROJECT"
+
+  await input.db
+    .insert(projectOperations)
+    .values({
+      id,
+      projectId: input.projectId,
+      sourceSystem: "email",
+      sourceRecordType: "rfq",
+      sourceRecordId: input.candidate.gmailMessageId,
+      sourceRecordNumber:
+        `${prefix}-RFQ-${String(existing.length + 1).padStart(3, "0")}`,
+      title,
+      description: candidateBody(input.candidate),
+      status: "draft",
+      priority: "normal",
+      assigneeType: "vendor",
+      sageWriteStatus: "not_ready",
+      syncDirection: "write",
+      syncStatus: "needs_review",
+      createdAt: input.now,
+      updatedAt: input.now,
+    })
+    .onConflictDoNothing({ target: projectOperations.id })
+
+  return { id, status: "routed_rfq" }
+}
+
+async function routeChangeOrder(input: {
+  readonly db: Db
+  readonly projectId: string
+  readonly projectNumber: string | null
+  readonly candidate: InboundCandidate
+  readonly now: string
+}): Promise<{ readonly id: string; readonly status: "routed_change_order" }> {
+  const id = `email-change-order-${input.candidate.gmailMessageId}`
+  const existing = await input.db
+    .select({ id: projectChangeOrders.id })
+    .from(projectChangeOrders)
+    .where(eq(projectChangeOrders.projectId, input.projectId))
+  const title =
+    projectEmailTitle(input.candidate.subject) ||
+    `Change request from ${senderLabel(input.candidate)}`
+  const prefix = input.projectNumber?.trim() || "PROJECT"
+  const changeOrderNumber =
+    `${prefix}-CO-${String(existing.length + 1).padStart(3, "0")}`
+
+  await input.db
+    .insert(projectChangeOrders)
+    .values({
+      id,
+      projectId: input.projectId,
+      changeOrderNumber,
+      title,
+      scope: candidateBody(input.candidate),
+      status: "draft",
+      audience: "internal",
+      // Email-created requests enter as internal drafts until staff confirms
+      // the sender's owner/sub role and chooses an external audience.
+      requesterType: "internal",
+      requesterName: senderLabel(input.candidate),
+      sourceType: "email_request",
+      sourceRecordId: input.candidate.gmailMessageId,
+      internalNotes:
+        "Created from the project email address; review before submitting.",
+      foxitStatus: "not_started",
+      sageStatus: "not_ready",
+      createdBy: null,
+      submittedAt: null,
+      createdAt: input.now,
+      updatedAt: input.now,
+    })
+    .onConflictDoNothing({ target: projectChangeOrders.id })
+
+  await input.db
+    .insert(projectChangeOrderHistory)
+    .values({
+      id: `email-change-order-history-${input.candidate.gmailMessageId}`,
+      projectId: input.projectId,
+      changeOrderId: id,
+      eventType: "created",
+      fromStatus: null,
+      toStatus: "draft",
+      actorUserId: null,
+      actorName: senderLabel(input.candidate),
+      actorRole: "internal",
+      note: "Created from the project email address for staff review.",
+      metadataJson: JSON.stringify({
+        source: "project_email",
+        gmailMessageId: input.candidate.gmailMessageId,
+      }),
+      createdAt: input.now,
+    })
+    .onConflictDoNothing({ target: projectChangeOrderHistory.id })
+
+  return { id, status: "routed_change_order" }
+}
+
+async function routeDailyLog(input: {
+  readonly db: Db
+  readonly projectId: string
+  readonly candidate: InboundCandidate
+  readonly now: string
+}): Promise<{ readonly id: string; readonly status: "routed_daily_log" }> {
+  const id = `email-daily-log-${input.candidate.gmailMessageId}`
+  const title = projectEmailTitle(input.candidate.subject)
+  const sourceNote = [
+    `Email from ${senderLabel(input.candidate)} <${input.candidate.fromAddress}>`,
+    title.length > 0 ? `Subject: ${title}` : null,
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n")
+
+  await input.db
+    .insert(dailyLogs)
+    .values({
+      id,
+      projectId: input.projectId,
+      authorId: null,
+      sourceSystem: "email",
+      sourceExternalId: input.candidate.gmailMessageId,
+      logDate: input.candidate.receivedAt.slice(0, 10),
+      workCompleted: candidateBody(input.candidate),
+      notes: sourceNote,
+      isClientVisible: false,
+      reviewStatus: "needs_review",
+      syncStatus: "pending",
+      createdAt: input.now,
+      updatedAt: input.now,
+    })
+    .onConflictDoNothing({ target: dailyLogs.id })
+
+  return { id, status: "routed_daily_log" }
+}
+
+async function routeDestination(input: {
+  readonly db: Db
+  readonly projectId: string
+  readonly projectNumber: string | null
+  readonly candidate: InboundCandidate
+  readonly destination: ProjectEmailDestination
+  readonly now: string
+}): Promise<{
+  readonly id: string
+  readonly status:
+    | "routed_rfi"
+    | "routed_todo"
+    | "routed_daily_log"
+    | "routed_rfq"
+    | "routed_change_order"
+}> {
+  if (input.destination === "rfi") return routeRfi(input)
+  if (input.destination === "rfq") return routeRfq(input)
+  if (input.destination === "change_order") return routeChangeOrder(input)
+  if (input.destination === "todo") return routeTodo(input)
+  if (input.destination === "delivery") {
+    return routeTodo({ ...input, delivery: true })
+  }
+  return routeDailyLog(input)
+}
+
+export async function routeProjectInboundEmail(input: {
+  readonly db: Db
+  readonly organizationId: string
+  readonly candidate: InboundCandidate
+}): Promise<ProjectInboundRouteResult> {
+  const projectId = projectIdFromInboundAddress(input.candidate.toAddress)
+  if (!projectId) return { kind: "not_project_email" }
+
+  const [project] = await input.db
+    .select({
+      id: projects.id,
+      organizationId: projects.organizationId,
+      projectNumber: projects.projectNumber,
+    })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .limit(1)
+  if (!project) return { kind: "needs_review", projectId: null }
+  if (project.organizationId !== input.organizationId) {
+    return { kind: "other_organization" }
+  }
+
+  const senderAllowed = await senderCanEmailProject({
+    db: input.db,
+    organizationId: input.organizationId,
+    projectId,
+    senderEmail: input.candidate.fromAddress,
+  })
+  const destination = projectEmailDestination(input.candidate.subject)
+  if (!senderAllowed || !destination) {
+    return { kind: "needs_review", projectId }
+  }
+
+  const routed = await routeDestination({
+    db: input.db,
+    projectId,
+    projectNumber: project.projectNumber,
+    candidate: input.candidate,
+    destination,
+    now: new Date().toISOString(),
+  })
+  return {
+    kind: "routed",
+    projectId,
+    entityId: routed.id,
+    matchedStatus: routed.status,
+  }
+}


### PR DESCRIPTION
## Summary
- give every existing and future project a stable Jarvis project email address
- show the address and routing tags on staff, owner, and partner Overview pages
- route authorized project-contact and internal-staff email into RFI, RFQ, change-order draft, to-do, delivery to-do, or daily-log review workflows
- retain untagged or unauthorized messages in the inbound audit as needing review
- expand Gmail sync discovery to include project-address mail

## Supported subject tags
- `[RFI]`
- `[RFQ]`
- `[CHANGE ORDER]`
- `[TO-DO]` / `[TASK]`
- `[DELIVERY]`
- `[DAILY LOG]`

## Safety
- project IDs are immutable, so no additional address migration or provisioning step is required
- only active project contacts and active internal organization members may create routed records
- externally visible records are not created automatically; email-created records enter internal/draft/review states
- deterministic record IDs make retries idempotent

## Verification
- `bun test src/lib/email/__tests__/project-address.test.ts src/lib/email/__tests__/gmail-inbound.test.ts` (13 passing)
- ESLint on all changed files
- `bunx tsc --noEmit`
- `next build --webpack`
