### PR TITLE
feat(activity): track inbound project email

### DIFF
--- a/src/app/dashboard/activity/page.tsx
+++ b/src/app/dashboard/activity/page.tsx
@@ -16,6 +16,7 @@ const CATEGORY_LABELS: Readonly<Record<ActivityCategory, string>> = {
   access: "Access",
   account: "Accounts",
   conversation: "Conversations",
+  email: "Project email",
   file: "Files",
   financial: "Financial",
   presence: "Availability",

--- a/src/lib/activity-log.ts
+++ b/src/lib/activity-log.ts
@@ -5,6 +5,7 @@ export const ACTIVITY_CATEGORIES = [
   "access",
   "account",
   "conversation",
+  "email",
   "file",
   "financial",
   "presence",
@@ -14,7 +15,7 @@ export const ACTIVITY_CATEGORIES = [
 export type ActivityCategory = (typeof ACTIVITY_CATEGORIES)[number]
 
 export type ActivityActor = {
-  readonly id: string
+  readonly id: string | null
   readonly email: string
   readonly displayName: string | null
   readonly firstName: string | null
@@ -26,6 +27,7 @@ type ActivityDb = ReturnType<typeof getDb>
 
 type RecordActivityInput = {
   readonly db: ActivityDb
+  readonly id?: string
   readonly organizationId: string
   readonly projectId?: string | null
   readonly actor: ActivityActor
@@ -61,7 +63,7 @@ export async function recordActivityEvent(
     await input.db
       .insert(activityEvents)
       .values({
-        id: crypto.randomUUID(),
+        id: input.id ?? crypto.randomUUID(),
         organizationId: input.organizationId,
         projectId: input.projectId ?? null,
         actorUserId: input.actor.id,

--- a/src/lib/email/project-inbound-routing.ts
+++ b/src/lib/email/project-inbound-routing.ts
@@ -3,6 +3,7 @@ import "server-only"
 import { and, eq, inArray, or, sql } from "drizzle-orm"
 
 import type { getDb } from "@/db"
+import { recordActivityEvent } from "@/lib/activity-log"
 import {
   dailyLogs,
   organizationMembers,
@@ -58,6 +59,41 @@ function candidateBody(candidate: InboundCandidate): string {
 
 function senderLabel(candidate: InboundCandidate): string {
   return candidate.fromName?.trim() || candidate.fromAddress
+}
+
+function emailActor(candidate: InboundCandidate): {
+  readonly id: null
+  readonly email: string
+  readonly displayName: string | null
+  readonly firstName: null
+  readonly lastName: null
+  readonly role: "project_email"
+} {
+  return {
+    id: null,
+    email: candidate.fromAddress,
+    displayName: candidate.fromName,
+    firstName: null,
+    lastName: null,
+    role: "project_email",
+  }
+}
+
+function destinationLabel(destination: ProjectEmailDestination): string {
+  if (destination === "rfi") return "RFI"
+  if (destination === "rfq") return "RFQ draft"
+  if (destination === "change_order") return "change-order draft"
+  if (destination === "delivery") return "delivery to-do"
+  if (destination === "todo") return "to-do"
+  return "daily log"
+}
+
+function destinationEntityType(destination: ProjectEmailDestination): string {
+  if (destination === "rfi") return "rfi"
+  if (destination === "rfq") return "rfq"
+  if (destination === "change_order") return "change_order"
+  if (destination === "daily_log") return "daily_log"
+  return "todo"
 }
 
 async function senderCanEmailProject(input: {
@@ -418,6 +454,25 @@ export async function routeProjectInboundEmail(input: {
   })
   const destination = projectEmailDestination(input.candidate.subject)
   if (!senderAllowed || !destination) {
+    await recordActivityEvent({
+      db: input.db,
+      id: `project-email-review-${input.candidate.gmailMessageId}`,
+      organizationId: input.organizationId,
+      projectId,
+      actor: emailActor(input.candidate),
+      category: "email",
+      action: "project_email.needs_review",
+      entityType: "project_email",
+      entityId: input.candidate.gmailMessageId,
+      summary: senderAllowed
+        ? `Project email from ${senderLabel(input.candidate)} is awaiting routing review.`
+        : `Project email from an unrecognized sender (${input.candidate.fromAddress}) is awaiting review.`,
+      metadata: {
+        senderAuthorized: senderAllowed,
+        subjectTagged: destination !== null,
+      },
+      createdAt: input.candidate.receivedAt,
+    })
     return { kind: "needs_review", projectId }
   }
 
@@ -428,6 +483,27 @@ export async function routeProjectInboundEmail(input: {
     candidate: input.candidate,
     destination,
     now: new Date().toISOString(),
+  })
+  const title =
+    projectEmailTitle(input.candidate.subject) || input.candidate.subject
+  await recordActivityEvent({
+    db: input.db,
+    id: `project-email-routed-${input.candidate.gmailMessageId}`,
+    organizationId: input.organizationId,
+    projectId,
+    actor: emailActor(input.candidate),
+    category: "email",
+    action: "project_email.routed",
+    entityType: destinationEntityType(destination),
+    entityId: routed.id,
+    summary:
+      `Routed project email from ${senderLabel(input.candidate)} to ` +
+      `${destinationLabel(destination)}: “${title}”.`,
+    metadata: {
+      destination,
+      senderAuthorized: true,
+    },
+    createdAt: input.candidate.receivedAt,
   })
   return {
     kind: "routed",


### PR DESCRIPTION
## Summary
- add a Project email category to Compass Activity
- record every routed project email with its destination and resulting record
- record valid-project messages that need review because the sender or subject tag is not recognized
- use deterministic activity IDs so Gmail sync retries remain idempotent

## Privacy and safety
- events are internal Activity records scoped to the project
- message bodies are not copied into Activity summaries
- unrecognized senders are identified only by email address for staff review

## Verification
- 13 focused email tests passing
- ESLint on changed files
- `bunx tsc --noEmit`
