### PR TITLE
fix(email): recognize trusted staff aliases

### DIFF
--- a/src/lib/email/__tests__/internal-email-alias.test.ts
+++ b/src/lib/email/__tests__/internal-email-alias.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  sameTrustedInternalEmailMailbox,
+  trustedInternalEmailDomains,
+} from "@/lib/email/internal-email-alias"
+
+describe("internal email aliases", () => {
+  const trustedDomains = trustedInternalEmailDomains({})
+
+  it("recognizes the same staff mailbox across trusted company domains", () => {
+    expect(
+      sameTrustedInternalEmailMailbox({
+        senderEmail: "martine@openrangeconstruction.com",
+        memberEmail: "martine@hps-colorado.com",
+        trustedDomains,
+      })
+    ).toBe(true)
+  })
+
+  it("does not match a different local mailbox", () => {
+    expect(
+      sameTrustedInternalEmailMailbox({
+        senderEmail: "someone-else@openrangeconstruction.com",
+        memberEmail: "martine@hps-colorado.com",
+        trustedDomains,
+      })
+    ).toBe(false)
+  })
+
+  it("does not trust a matching mailbox on an external domain", () => {
+    expect(
+      sameTrustedInternalEmailMailbox({
+        senderEmail: "martine@example.com",
+        memberEmail: "martine@hps-colorado.com",
+        trustedDomains,
+      })
+    ).toBe(false)
+  })
+
+  it("supports additional configured company domains", () => {
+    const configuredDomains = trustedInternalEmailDomains({
+      COMPASS_INTERNAL_EMAIL_DOMAINS: "design.example, nu-tech.example",
+    })
+    expect(
+      sameTrustedInternalEmailMailbox({
+        senderEmail: "staff@design.example",
+        memberEmail: "staff@nu-tech.example",
+        trustedDomains: configuredDomains,
+      })
+    ).toBe(true)
+  })
+})

--- a/src/lib/email/gmail-inbound.ts
+++ b/src/lib/email/gmail-inbound.ts
@@ -329,6 +329,7 @@ async function importCandidate(input: {
   if (duplicate && !retryMisclassifiedReply) return "duplicate"
 
   const projectRoute = await routeProjectInboundEmail({
+    env: input.env,
     db: input.db,
     organizationId: input.organizationId,
     candidate: input.candidate,

--- a/src/lib/email/internal-email-alias.ts
+++ b/src/lib/email/internal-email-alias.ts
@@ -1,0 +1,53 @@
+const DEFAULT_INTERNAL_EMAIL_DOMAINS = [
+  "hps-colorado.com",
+  "openrangeconstruction.com",
+  "openrangeconstruction.ltd",
+]
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function envString(env: unknown, key: string): string | null {
+  if (!isRecord(env)) return process.env[key] ?? null
+  const value = env[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : process.env[key] ?? null
+}
+
+function emailParts(value: string): {
+  readonly localPart: string
+  readonly domain: string
+} | null {
+  const normalized = value.trim().toLowerCase()
+  const separator = normalized.lastIndexOf("@")
+  if (separator <= 0 || separator === normalized.length - 1) return null
+  return {
+    localPart: normalized.slice(0, separator),
+    domain: normalized.slice(separator + 1),
+  }
+}
+
+export function trustedInternalEmailDomains(env: unknown): ReadonlySet<string> {
+  const configured = envString(env, "COMPASS_INTERNAL_EMAIL_DOMAINS")
+    ?.split(",")
+    .map((domain) => domain.trim().toLowerCase())
+    .filter((domain) => domain.length > 0) ?? []
+  return new Set([...DEFAULT_INTERNAL_EMAIL_DOMAINS, ...configured])
+}
+
+export function sameTrustedInternalEmailMailbox(input: {
+  readonly senderEmail: string
+  readonly memberEmail: string
+  readonly trustedDomains: ReadonlySet<string>
+}): boolean {
+  const sender = emailParts(input.senderEmail)
+  const member = emailParts(input.memberEmail)
+  if (!sender || !member) return false
+  return (
+    sender.localPart === member.localPart &&
+    input.trustedDomains.has(sender.domain) &&
+    input.trustedDomains.has(member.domain)
+  )
+}

--- a/src/lib/email/project-inbound-routing.ts
+++ b/src/lib/email/project-inbound-routing.ts
@@ -25,6 +25,10 @@ import {
   projectIdFromInboundAddress,
   type ProjectEmailDestination,
 } from "@/lib/email/project-address"
+import {
+  sameTrustedInternalEmailMailbox,
+  trustedInternalEmailDomains,
+} from "@/lib/email/internal-email-alias"
 import { PROJECT_TODO_RECORD_TYPES } from "@/lib/project-todos"
 
 type Db = ReturnType<typeof getDb>
@@ -97,6 +101,7 @@ function destinationEntityType(destination: ProjectEmailDestination): string {
 }
 
 async function senderCanEmailProject(input: {
+  readonly env: unknown
   readonly db: Db
   readonly organizationId: string
   readonly projectId: string
@@ -136,7 +141,39 @@ async function senderCanEmailProject(input: {
       )
     )
     .limit(1)
-  return Boolean(member)
+  if (member) return true
+
+  // Staff commonly use parallel company-domain aliases (for example,
+  // firstname@hps-colorado.com and firstname@openrangeconstruction.com).
+  // Accept only matching mailboxes across explicitly trusted internal domains.
+  const trustedDomains = trustedInternalEmailDomains(input.env)
+  const activeMembers = await input.db
+    .select({
+      email: users.email,
+      googleEmail: users.googleEmail,
+    })
+    .from(users)
+    .innerJoin(
+      organizationMembers,
+      eq(organizationMembers.userId, users.id)
+    )
+    .where(
+      and(
+        eq(organizationMembers.organizationId, input.organizationId),
+        eq(users.isActive, true)
+      )
+    )
+  return activeMembers.some((activeMember) =>
+    [activeMember.email, activeMember.googleEmail].some(
+      (memberEmail) =>
+        memberEmail !== null &&
+        sameTrustedInternalEmailMailbox({
+          senderEmail: email,
+          memberEmail,
+          trustedDomains,
+        })
+    )
+  )
 }
 
 function rfiNumber(input: {
@@ -425,6 +462,7 @@ async function routeDestination(input: {
 }
 
 export async function routeProjectInboundEmail(input: {
+  readonly env: unknown
   readonly db: Db
   readonly organizationId: string
   readonly candidate: InboundCandidate
@@ -447,6 +485,7 @@ export async function routeProjectInboundEmail(input: {
   }
 
   const senderAllowed = await senderCanEmailProject({
+    env: input.env,
     db: input.db,
     organizationId: input.organizationId,
     projectId,


### PR DESCRIPTION
## What changed

- recognize the same active staff mailbox across approved company email domains
- preserve exact-address authorization for project contacts and organization members
- pass runtime email-domain configuration into project routing
- add regression coverage for trusted aliases, external lookalikes, and configured domains

## Why

Project email routing correctly imported the H-Office to-do from `martine@hps-colorado.com`, but held the daily log sent from `martine@openrangeconstruction.com` for review even though both addresses represent the same active staff user.

## Validation

- `bun test src/lib/email/__tests__/internal-email-alias.test.ts src/lib/email/__tests__/gmail-inbound.test.ts src/lib/email/__tests__/project-address.test.ts`
- focused ESLint on changed files
- `tsc --noEmit`
- production inbound audit confirmed the exact to-do routed and the daily log was safely held pending this fix

The bundled autoreview helper could not start because its local state database is read-only in this sandbox. A manual source review rejected repeated automatic retry of all held messages; the exact held daily log will instead be requeued once after deployment.
