### PR TITLE
fix(email): store daily log attachments

### DIFF
--- a/src/lib/email/__tests__/gmail-inbound.test.ts
+++ b/src/lib/email/__tests__/gmail-inbound.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import type { InboundCandidate } from "@/lib/email/gmail-message-parser"
+import {
+  candidateFromMessage,
+  type InboundCandidate,
+} from "@/lib/email/gmail-message-parser"
 import { isReplyMessage } from "@/lib/email/reply-detection"
 
 function candidate(
@@ -21,6 +24,7 @@ function candidate(
     htmlBody: null,
     snippet: "Original outbound message",
     receivedAt: "2026-08-06T22:19:12.000Z",
+    attachments: [],
     ...overrides,
   }
 }
@@ -42,5 +46,56 @@ describe("isReplyMessage", () => {
     expect(
       isReplyMessage(candidate({ subject: "Re: [O-210-33-RFI-001] Testing" }))
     ).toBe(true)
+  })
+})
+
+describe("candidateFromMessage attachments", () => {
+  it("captures a Gmail attachment reference for later download", () => {
+    const result = candidateFromMessage({
+      id: "message-with-photo",
+      payload: {
+        headers: [
+          { name: "From", value: "Martine <martine@example.com>" },
+          { name: "To", value: "jarvis+project-proj-h-office@hps-colorado.com" },
+          { name: "Subject", value: "[Daily Log]" },
+        ],
+        parts: [
+          {
+            filename: "IMG_6737.jpeg",
+            mimeType: "image/jpeg",
+            body: { attachmentId: "attachment-1", size: 2048 },
+          },
+        ],
+      },
+    })
+
+    expect(result.attachments).toEqual([
+      {
+        attachmentId: "attachment-1",
+        fileName: "IMG_6737.jpeg",
+        mimeType: "image/jpeg",
+        size: 2048,
+        data: null,
+      },
+    ])
+  })
+
+  it("decodes attachment data included directly in a Gmail part", () => {
+    const result = candidateFromMessage({
+      id: "message-with-inline-data",
+      payload: {
+        parts: [
+          {
+            filename: "note.txt",
+            mimeType: "text/plain",
+            body: { data: "cGhvdG8=" },
+          },
+        ],
+      },
+    })
+
+    expect(Array.from(result.attachments[0]?.data ?? [])).toEqual([
+      112, 104, 111, 116, 111,
+    ])
   })
 })

--- a/src/lib/email/__tests__/project-address.test.ts
+++ b/src/lib/email/__tests__/project-address.test.ts
@@ -26,6 +26,7 @@ describe("project inbound email addressing", () => {
     ["[TASK] Confirm delivery", "todo"],
     ["[DELIVERY] Windows arriving Friday", "delivery"],
     ["[DAILY LOG] Site progress", "daily_log"],
+    ["[Daily Log] Site progress", "daily_log"],
   ] as const)("routes %s", (subject, destination) => {
     expect(projectEmailDestination(subject)).toBe(destination)
   })

--- a/src/lib/email/gmail-inbound.ts
+++ b/src/lib/email/gmail-inbound.ts
@@ -23,6 +23,7 @@ import {
   getCompassGmailAccessToken,
 } from "@/lib/email/compass-email"
 import {
+  base64UrlDecodeBytes,
   candidateFromMessage,
   escapeHtml,
   isGmailMessage,
@@ -75,6 +76,17 @@ function isGmailListResponse(value: unknown): value is {
   return (
     (messagesValue === undefined || Array.isArray(messagesValue)) &&
     (nextPageToken === undefined || typeof nextPageToken === "string")
+  )
+}
+
+function isGmailAttachmentResponse(value: unknown): value is {
+  readonly data: string
+  readonly size?: number
+} {
+  return (
+    isRecord(value) &&
+    typeof value.data === "string" &&
+    (value.size === undefined || typeof value.size === "number")
   )
 }
 
@@ -563,6 +575,35 @@ async function fetchJson(input: {
   return JSON.parse(text)
 }
 
+async function hydrateCandidateAttachments(input: {
+  readonly candidate: InboundCandidate
+  readonly accessToken: string
+}): Promise<InboundCandidate> {
+  const attachments = await Promise.all(
+    input.candidate.attachments.map(async (attachment) => {
+      if (attachment.data || !attachment.attachmentId) return attachment
+      const attachmentUrl = new URL(
+        `https://gmail.googleapis.com/gmail/v1/users/me/messages/${input.candidate.gmailMessageId}/attachments/${attachment.attachmentId}`
+      )
+      const response = await fetchJson({
+        url: attachmentUrl.toString(),
+        accessToken: input.accessToken,
+      })
+      if (!isGmailAttachmentResponse(response)) {
+        throw new Error(
+          `Gmail returned an unexpected attachment for ${attachment.fileName}.`
+        )
+      }
+      return {
+        ...attachment,
+        size: attachment.size ?? response.size ?? null,
+        data: base64UrlDecodeBytes(response.data),
+      }
+    })
+  )
+  return { ...input.candidate, attachments }
+}
+
 export async function syncGmailInboundReplies(input: {
   readonly env: unknown
   readonly db: Db
@@ -649,11 +690,34 @@ export async function syncGmailInboundReplies(input: {
           throw new Error(`Gmail returned an unexpected message for ${id}.`)
         }
 
+        const candidateWithoutAttachmentData = candidateFromMessage(messageResponse)
+        const [existingInbound] = await input.db
+          .select({ matchedStatus: inboundEmails.matchedStatus })
+          .from(inboundEmails)
+          .where(
+            eq(
+              inboundEmails.gmailMessageId,
+              candidateWithoutAttachmentData.gmailMessageId
+            )
+          )
+          .limit(1)
+        const retryMisclassifiedReply =
+          existingInbound?.matchedStatus === "ignored_outbound" &&
+          isReplyMessage(candidateWithoutAttachmentData)
+        if (existingInbound && !retryMisclassifiedReply) {
+          skippedDuplicates += 1
+          continue
+        }
+
+        const candidate = await hydrateCandidateAttachments({
+          candidate: candidateWithoutAttachmentData,
+          accessToken: access.accessToken,
+        })
         const result = await importCandidate({
           env: input.env,
           db: input.db,
           organizationId: input.organizationId,
-          candidate: candidateFromMessage(messageResponse),
+          candidate,
         })
 
         if (result === "duplicate") {

--- a/src/lib/email/gmail-message-parser.ts
+++ b/src/lib/email/gmail-message-parser.ts
@@ -1,5 +1,3 @@
-import "server-only"
-
 type GmailHeader = {
   readonly name: string
   readonly value: string
@@ -7,12 +5,23 @@ type GmailHeader = {
 
 type GmailBody = {
   readonly data?: string
+  readonly attachmentId?: string
+  readonly size?: number
 }
 
 type GmailPart = {
   readonly mimeType?: string
+  readonly filename?: string
   readonly body?: GmailBody
   readonly parts?: readonly GmailPart[]
+}
+
+export type InboundAttachment = {
+  readonly attachmentId: string | null
+  readonly fileName: string
+  readonly mimeType: string
+  readonly size: number | null
+  readonly data: Uint8Array | null
 }
 
 export type GmailMessage = {
@@ -40,6 +49,7 @@ export type InboundCandidate = {
   readonly htmlBody: string | null
   readonly snippet: string | null
   readonly receivedAt: string
+  readonly attachments: readonly InboundAttachment[]
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -54,7 +64,7 @@ export function isGmailMessage(value: unknown): value is GmailMessage {
   )
 }
 
-function base64UrlDecode(data: string): string {
+export function base64UrlDecodeBytes(data: string): Uint8Array {
   const normalized = data.replace(/-/g, "+").replace(/_/g, "/")
   const padded = normalized.padEnd(
     normalized.length + ((4 - (normalized.length % 4)) % 4),
@@ -65,7 +75,11 @@ function base64UrlDecode(data: string): string {
   for (let index = 0; index < binary.length; index += 1) {
     bytes[index] = binary.charCodeAt(index)
   }
-  return new TextDecoder().decode(bytes)
+  return bytes
+}
+
+function base64UrlDecode(data: string): string {
+  return new TextDecoder().decode(base64UrlDecodeBytes(data))
 }
 
 function headersByName(headers: readonly GmailHeader[]): Map<string, string> {
@@ -86,7 +100,7 @@ function collectBodies(part: GmailPart | undefined): {
   const text = childBodies.flatMap((child) => child.text)
   const html = childBodies.flatMap((child) => child.html)
 
-  if (part.body?.data) {
+  if (part.body?.data && !part.filename?.trim()) {
     try {
       const decoded = base64UrlDecode(part.body.data)
       if (part.mimeType === "text/html") {
@@ -101,6 +115,37 @@ function collectBodies(part: GmailPart | undefined): {
   }
 
   return { text, html }
+}
+
+function collectAttachments(
+  part: GmailPart | undefined
+): readonly InboundAttachment[] {
+  if (!part) return []
+  const childAttachments = (part.parts ?? []).flatMap(collectAttachments)
+  const fileName = part.filename?.trim() ?? ""
+  if (fileName.length === 0) return childAttachments
+
+  let data: Uint8Array | null = null
+  if (part.body?.data) {
+    try {
+      data = base64UrlDecodeBytes(part.body.data)
+    } catch {
+      data = null
+    }
+  }
+  return [
+    ...childAttachments,
+    {
+      attachmentId: part.body?.attachmentId ?? null,
+      fileName,
+      mimeType: part.mimeType?.trim() || "application/octet-stream",
+      size:
+        typeof part.body?.size === "number" && part.body.size >= 0
+          ? part.body.size
+          : null,
+      data,
+    },
+  ]
 }
 
 export function stripHtml(html: string): string {
@@ -187,5 +232,6 @@ export function candidateFromMessage(message: GmailMessage): InboundCandidate {
     htmlBody: htmlBody.length > 0 ? htmlBody : null,
     snippet: message.snippet ?? null,
     receivedAt: messageDate(message.internalDate),
+    attachments: collectAttachments(message.payload),
   }
 }

--- a/src/lib/email/project-email-attachments.ts
+++ b/src/lib/email/project-email-attachments.ts
@@ -1,0 +1,253 @@
+import "server-only"
+
+import { and, eq } from "drizzle-orm"
+
+import type { getDb } from "@/db"
+import {
+  dailyLogPhotos,
+  projectExternalLinks,
+  projects,
+} from "@/db/schema"
+import { googleAuth } from "@/db/schema-google"
+import { decrypt } from "@/lib/crypto"
+import type { InboundCandidate } from "@/lib/email/gmail-message-parser"
+import { DriveClient } from "@/lib/google/client/drive-client"
+import {
+  getGoogleConfig,
+  getGoogleCryptoSalt,
+  parseServiceAccountKey,
+} from "@/lib/google/config"
+import {
+  MAX_PHOTO_UPLOAD_BATCH_BYTES,
+  MAX_PHOTO_UPLOAD_FILE_BYTES,
+} from "@/lib/photos/upload-limits"
+
+const GOOGLE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
+const DEFAULT_PHOTO_FOLDER_NAME = "Pictures"
+const DEFAULT_COMPASS_GOOGLE_UPLOAD_USER = "compass@hps-colorado.com"
+
+type Db = ReturnType<typeof getDb>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function envString(env: unknown, key: string): string | null {
+  if (!isRecord(env)) return process.env[key] ?? null
+  const value = env[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : process.env[key] ?? null
+}
+
+function safeFileName(value: string): string {
+  const normalized = value.replace(/[/:\\]/g, "-").trim()
+  return normalized.length > 0 ? normalized : "email-attachment"
+}
+
+function driveFolderIdFromUrl(value: string | null): string | null {
+  if (!value) return null
+  return (
+    value.match(/\/folders\/([^/?#]+)/)?.[1] ??
+    value.match(/[?&]id=([^&#]+)/)?.[1] ??
+    null
+  )
+}
+
+function escapeDriveQueryValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")
+}
+
+async function resolvePhotoFolder(input: {
+  readonly db: Db
+  readonly client: DriveClient
+  readonly googleEmail: string
+  readonly projectId: string
+  readonly projectFolderId: string
+  readonly sharedDriveId: string | null
+}): Promise<string> {
+  const [linkedFolder] = await input.db
+    .select({
+      externalId: projectExternalLinks.externalId,
+      externalUrl: projectExternalLinks.externalUrl,
+    })
+    .from(projectExternalLinks)
+    .where(
+      and(
+        eq(projectExternalLinks.projectId, input.projectId),
+        eq(projectExternalLinks.system, "google_progress_photos_folder")
+      )
+    )
+    .limit(1)
+  const linkedFolderId =
+    linkedFolder?.externalId ??
+    driveFolderIdFromUrl(linkedFolder?.externalUrl ?? null)
+  if (linkedFolderId) return linkedFolderId
+
+  for (const name of [DEFAULT_PHOTO_FOLDER_NAME, "Photos"]) {
+    const result = await input.client.listFiles(input.googleEmail, {
+      folderId: input.projectFolderId,
+      driveId: input.sharedDriveId ?? undefined,
+      pageSize: 10,
+      query:
+        `mimeType = '${GOOGLE_FOLDER_MIME_TYPE}' and ` +
+        `name = '${escapeDriveQueryValue(name)}'`,
+    })
+    const folder = result.files[0]
+    if (folder) return folder.id
+  }
+
+  const folder = await input.client.createFolder(input.googleEmail, {
+    name: DEFAULT_PHOTO_FOLDER_NAME,
+    parentId: input.projectFolderId,
+    driveId: input.sharedDriveId ?? undefined,
+  })
+  return folder.id
+}
+
+export async function storeDailyLogEmailAttachments(input: {
+  readonly env: unknown
+  readonly db: Db
+  readonly organizationId: string
+  readonly projectId: string
+  readonly dailyLogId: string
+  readonly candidate: InboundCandidate
+  readonly now: string
+}): Promise<number> {
+  if (input.candidate.attachments.length === 0) return 0
+
+  const totalBytes = input.candidate.attachments.reduce(
+    (total, attachment) => total + (attachment.data?.byteLength ?? 0),
+    0
+  )
+  if (totalBytes > MAX_PHOTO_UPLOAD_BATCH_BYTES) {
+    throw new Error("Email attachments exceed the 90 MB batch limit.")
+  }
+  const oversized = input.candidate.attachments.find(
+    (attachment) =>
+      (attachment.data?.byteLength ?? attachment.size ?? 0) >
+      MAX_PHOTO_UPLOAD_FILE_BYTES
+  )
+  if (oversized) {
+    throw new Error(`${oversized.fileName} exceeds the 50 MB file limit.`)
+  }
+
+  const [project] = await input.db
+    .select({ googleDriveFolderId: projects.googleDriveFolderId })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.id, input.projectId),
+        eq(projects.organizationId, input.organizationId)
+      )
+    )
+    .limit(1)
+  const [driveLink] = await input.db
+    .select({
+      externalId: projectExternalLinks.externalId,
+      externalUrl: projectExternalLinks.externalUrl,
+    })
+    .from(projectExternalLinks)
+    .where(
+      and(
+        eq(projectExternalLinks.projectId, input.projectId),
+        eq(projectExternalLinks.system, "google_drive")
+      )
+    )
+    .limit(1)
+  const projectFolderId =
+    project?.googleDriveFolderId ??
+    driveLink?.externalId ??
+    driveFolderIdFromUrl(driveLink?.externalUrl ?? null)
+  if (!projectFolderId) {
+    throw new Error("Map this project to Google Drive before emailing files.")
+  }
+
+  const [auth] = await input.db
+    .select()
+    .from(googleAuth)
+    .where(eq(googleAuth.organizationId, input.organizationId))
+    .limit(1)
+  if (!auth) throw new Error("Google Drive is not connected.")
+
+  const config = getGoogleConfig(input.env)
+  const keyJson = await decrypt(
+    auth.serviceAccountKeyEncrypted,
+    config.encryptionKey,
+    getGoogleCryptoSalt()
+  )
+  const client = new DriveClient({
+    serviceAccountKey: parseServiceAccountKey(keyJson),
+  })
+  const googleEmail =
+    envString(input.env, "COMPASS_GOOGLE_UPLOAD_USER") ??
+    DEFAULT_COMPASS_GOOGLE_UPLOAD_USER
+  const folderId = await resolvePhotoFolder({
+    db: input.db,
+    client,
+    googleEmail,
+    projectId: input.projectId,
+    projectFolderId,
+    sharedDriveId: auth.sharedDriveId,
+  })
+
+  let storedCount = 0
+  for (let index = 0; index < input.candidate.attachments.length; index += 1) {
+    const attachment = input.candidate.attachments[index]
+    if (!attachment) continue
+    if (!attachment.data) {
+      throw new Error(`Gmail did not return data for ${attachment.fileName}.`)
+    }
+    const photoId =
+      `email-photo-${input.candidate.gmailMessageId}-${index + 1}`
+    const [existing] = await input.db
+      .select({ id: dailyLogPhotos.id })
+      .from(dailyLogPhotos)
+      .where(eq(dailyLogPhotos.id, photoId))
+      .limit(1)
+    if (existing) continue
+
+    const mimeType = attachment.mimeType || "application/octet-stream"
+    const fileName = safeFileName(attachment.fileName)
+    const driveFile = await client.uploadFile(googleEmail, {
+      name: fileName,
+      mimeType,
+      parentId: folderId,
+      driveId: auth.sharedDriveId ?? undefined,
+      data: new Blob([attachment.data.slice().buffer], { type: mimeType }),
+    })
+    await input.db.insert(dailyLogPhotos).values({
+      id: photoId,
+      projectId: input.projectId,
+      dailyLogId: input.dailyLogId,
+      uploadedBy: null,
+      sourceSystem: "email",
+      sourceExternalId:
+        `${input.candidate.gmailMessageId}:` +
+        (attachment.attachmentId ?? String(index + 1)),
+      fileName: driveFile.name,
+      fileSize: Number(driveFile.size ?? attachment.data.byteLength),
+      mimeType: driveFile.mimeType,
+      driveFileId: driveFile.id,
+      driveUrl: driveFile.webViewLink ?? null,
+      thumbnailUrl: mimeType.startsWith("image/")
+        ? `/api/google/download/${driveFile.id}`
+        : null,
+      caption: null,
+      capturedAt: input.candidate.receivedAt,
+      uploadStatus: "uploaded",
+      reviewStatus: "needs_review",
+      ownerVisible: false,
+      subVendorVisible: false,
+      publicShareable: false,
+      photoKind: "progress",
+      schedulePhaseOverride: null,
+      sortOrder: index,
+      createdAt: input.now,
+      updatedAt: input.now,
+    })
+    storedCount += 1
+  }
+
+  return storedCount
+}

--- a/src/lib/email/project-inbound-routing.ts
+++ b/src/lib/email/project-inbound-routing.ts
@@ -29,6 +29,7 @@ import {
   sameTrustedInternalEmailMailbox,
   trustedInternalEmailDomains,
 } from "@/lib/email/internal-email-alias"
+import { storeDailyLogEmailAttachments } from "@/lib/email/project-email-attachments"
 import { PROJECT_TODO_RECORD_TYPES } from "@/lib/project-todos"
 
 type Db = ReturnType<typeof getDb>
@@ -53,12 +54,22 @@ export type ProjectInboundRouteResult =
     }
 
 function candidateBody(candidate: InboundCandidate): string {
-  return (
+  const body = (
     candidate.textBody?.trim() ||
     (candidate.htmlBody ? stripHtml(candidate.htmlBody) : "") ||
     candidate.snippet?.trim() ||
     "(No message body.)"
   )
+  if (candidate.attachments.length === 0) return body
+
+  const attachmentLabels = new Set(
+    candidate.attachments.map((attachment) => `[${attachment.fileName}]`)
+  )
+  return body
+    .split("\n")
+    .filter((line) => !attachmentLabels.has(line.trim()))
+    .join("\n")
+    .trim()
 }
 
 function senderLabel(candidate: InboundCandidate): string {
@@ -399,7 +410,9 @@ async function routeChangeOrder(input: {
 }
 
 async function routeDailyLog(input: {
+  readonly env: unknown
   readonly db: Db
+  readonly organizationId: string
   readonly projectId: string
   readonly candidate: InboundCandidate
   readonly now: string
@@ -432,11 +445,23 @@ async function routeDailyLog(input: {
     })
     .onConflictDoNothing({ target: dailyLogs.id })
 
+  await storeDailyLogEmailAttachments({
+    env: input.env,
+    db: input.db,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    dailyLogId: id,
+    candidate: input.candidate,
+    now: input.now,
+  })
+
   return { id, status: "routed_daily_log" }
 }
 
 async function routeDestination(input: {
+  readonly env: unknown
   readonly db: Db
+  readonly organizationId: string
   readonly projectId: string
   readonly projectNumber: string | null
   readonly candidate: InboundCandidate
@@ -516,7 +541,9 @@ export async function routeProjectInboundEmail(input: {
   }
 
   const routed = await routeDestination({
+    env: input.env,
     db: input.db,
+    organizationId: input.organizationId,
     projectId,
     projectNumber: project.projectNumber,
     candidate: input.candidate,
@@ -537,10 +564,16 @@ export async function routeProjectInboundEmail(input: {
     entityId: routed.id,
     summary:
       `Routed project email from ${senderLabel(input.candidate)} to ` +
-      `${destinationLabel(destination)}: “${title}”.`,
+      `${destinationLabel(destination)}: “${title}”.` +
+      (input.candidate.attachments.length > 0
+        ? ` Stored ${input.candidate.attachments.length} attached ${
+            input.candidate.attachments.length === 1 ? "file" : "files"
+          }.`
+        : ""),
     metadata: {
       destination,
       senderAuthorized: true,
+      attachmentCount: input.candidate.attachments.length,
     },
     createdAt: input.candidate.receivedAt,
   })


### PR DESCRIPTION
## What changed

- parse Gmail attachment metadata and download attachment bytes only for new inbound messages
- store daily-log email attachments in the project's Google Drive photo folder
- link stored files to the generated Compass daily log as reviewable project photos
- remove Gmail attachment filename placeholders from the daily-log narrative
- preserve case-insensitive routing such as `[Daily Log]`

## Why

Inbound project email routing created the daily log but discarded the actual attachment bytes, leaving only a filename placeholder. Field photos sent by email therefore did not appear in Compass.

## Impact

Photos and documents attached to tagged daily-log emails now land with the daily log and remain hidden from owners/subs until staff approves their visibility.

## Validation

- 20 focused email-routing/parser tests pass
- focused ESLint passes
- TypeScript passes with an 8 GB heap
- full production build passes in the pre-push hook
- `git diff --check` passes

