### PR TITLE
feat(schedule): add reusable custom phases

### DIFF
--- a/drizzle/0094_schedule_phase_options.sql
+++ b/drizzle/0094_schedule_phase_options.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `schedule_phase_options` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`name` text NOT NULL,
+	`normalized_name` text NOT NULL,
+	`created_by` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `schedule_phase_options_org_name_unique` ON `schedule_phase_options` (`organization_id`,`normalized_name`);
+--> statement-breakpoint
+CREATE INDEX `schedule_phase_options_org_name_idx` ON `schedule_phase_options` (`organization_id`,`name`);

--- a/src/app/actions/schedule-phases.ts
+++ b/src/app/actions/schedule-phases.ts
@@ -1,0 +1,276 @@
+"use server"
+
+import { and, asc, eq, inArray } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import { projects, schedulePhaseOptions, scheduleTasks } from "@/db/schema"
+import {
+  projectTemplates,
+  projectTemplateVersions,
+  scheduleTemplateItems,
+} from "@/db/schema-templates"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import { requireOrg } from "@/lib/org-scope"
+import { requirePermission } from "@/lib/permissions"
+import { PHASE_LABELS, PHASE_ORDER } from "@/lib/schedule/phase-colors"
+
+export type ReusableSchedulePhaseOption = {
+  readonly id: string | null
+  readonly value: string
+  readonly label: string
+  readonly source: "default" | "saved" | "project" | "template"
+}
+
+type PhaseMutationResult =
+  | { readonly success: true; readonly option: ReusableSchedulePhaseOption }
+  | { readonly success: false; readonly error: string }
+
+function normalizedPhaseName(value: string): string {
+  return value.trim().replace(/\s+/g, " ")
+}
+
+function phaseKey(value: string): string {
+  return normalizedPhaseName(value).toLocaleLowerCase()
+}
+
+function validCustomPhase(value: string):
+  | { readonly success: true; readonly name: string; readonly key: string }
+  | { readonly success: false; readonly error: string } {
+  const name = normalizedPhaseName(value)
+  if (name.length === 0) {
+    return { success: false, error: "Enter a phase name." }
+  }
+  if (name.length > 100) {
+    return { success: false, error: "Phase names are limited to 100 characters." }
+  }
+  return { success: true, name, key: phaseKey(name) }
+}
+
+async function verifyProject(input: {
+  readonly projectId: string
+  readonly action: "read" | "update" | "delete"
+}): Promise<{
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string
+  readonly userId: string
+}> {
+  const user = await requireAuth()
+  requirePermission(user, "schedule", input.action)
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const [project] = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.id, input.projectId),
+        eq(projects.organizationId, organizationId)
+      )
+    )
+    .limit(1)
+  if (!project) throw new Error("Project not found or access denied.")
+  return { db, organizationId, userId: user.id }
+}
+
+export async function getSchedulePhaseOptions(
+  projectId: string
+): Promise<readonly ReusableSchedulePhaseOption[]> {
+  const { db, organizationId } = await verifyProject({
+    projectId,
+    action: "read",
+  })
+  const [saved, projectRows, publishedVersions] = await Promise.all([
+    db
+      .select({ id: schedulePhaseOptions.id, name: schedulePhaseOptions.name })
+      .from(schedulePhaseOptions)
+      .where(eq(schedulePhaseOptions.organizationId, organizationId))
+      .orderBy(asc(schedulePhaseOptions.name)),
+    db
+      .select({ phase: scheduleTasks.phase })
+      .from(scheduleTasks)
+      .where(eq(scheduleTasks.projectId, projectId)),
+    db
+      .select({ id: projectTemplateVersions.id })
+      .from(projectTemplateVersions)
+      .innerJoin(
+        projectTemplates,
+        eq(projectTemplates.id, projectTemplateVersions.templateId)
+      )
+      .where(
+        and(
+          eq(projectTemplates.organizationId, organizationId),
+          eq(projectTemplates.lifecycleStatus, "active"),
+          eq(projectTemplateVersions.status, "published")
+        )
+      ),
+  ])
+  const templateRows =
+    publishedVersions.length === 0
+      ? []
+      : await db
+          .select({ phase: scheduleTemplateItems.phase })
+          .from(scheduleTemplateItems)
+          .where(
+            inArray(
+              scheduleTemplateItems.versionId,
+              publishedVersions.map((version) => version.id)
+            )
+          )
+
+  const options = new Map<string, ReusableSchedulePhaseOption>()
+  for (const phase of PHASE_ORDER) {
+    options.set(phaseKey(PHASE_LABELS[phase]), {
+      id: null,
+      value: phase,
+      label: PHASE_LABELS[phase],
+      source: "default",
+    })
+  }
+  for (const item of saved) {
+    const key = phaseKey(item.name)
+    if (!options.has(key)) {
+      options.set(key, {
+        id: item.id,
+        value: item.name,
+        label: item.name,
+        source: "saved",
+      })
+    }
+  }
+  for (const row of projectRows) {
+    const name = normalizedPhaseName(row.phase)
+    const key = phaseKey(name)
+    if (name.length > 0 && !options.has(key)) {
+      options.set(key, {
+        id: null,
+        value: name,
+        label: name,
+        source: "project",
+      })
+    }
+  }
+  for (const row of templateRows) {
+    const name = normalizedPhaseName(row.phase)
+    const key = phaseKey(name)
+    if (name.length > 0 && !options.has(key)) {
+      options.set(key, {
+        id: null,
+        value: name,
+        label: name,
+        source: "template",
+      })
+    }
+  }
+  return [...options.values()]
+}
+
+export async function saveSchedulePhaseOption(input: {
+  readonly projectId: string
+  readonly name: string
+}): Promise<PhaseMutationResult> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    const parsed = validCustomPhase(input.name)
+    if (!parsed.success) return parsed
+    const defaultPhase = PHASE_ORDER.find(
+      (phase) => phaseKey(PHASE_LABELS[phase]) === parsed.key
+    )
+    if (defaultPhase) {
+      return {
+        success: true,
+        option: {
+          id: null,
+          value: defaultPhase,
+          label: PHASE_LABELS[defaultPhase],
+          source: "default",
+        },
+      }
+    }
+    const { db, organizationId, userId } = await verifyProject({
+      projectId: input.projectId,
+      action: "update",
+    })
+    const now = new Date().toISOString()
+    const id = crypto.randomUUID()
+    await db
+      .insert(schedulePhaseOptions)
+      .values({
+        id,
+        organizationId,
+        name: parsed.name,
+        normalizedName: parsed.key,
+        createdBy: userId,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [
+          schedulePhaseOptions.organizationId,
+          schedulePhaseOptions.normalizedName,
+        ],
+        set: { name: parsed.name, updatedAt: now },
+      })
+    const [saved] = await db
+      .select({ id: schedulePhaseOptions.id, name: schedulePhaseOptions.name })
+      .from(schedulePhaseOptions)
+      .where(
+        and(
+          eq(schedulePhaseOptions.organizationId, organizationId),
+          eq(schedulePhaseOptions.normalizedName, parsed.key)
+        )
+      )
+      .limit(1)
+    if (!saved) {
+      return { success: false, error: "The reusable phase could not be saved." }
+    }
+    revalidatePath(`/dashboard/projects/${input.projectId}/schedule`)
+    return {
+      success: true,
+      option: {
+        id: saved.id,
+        value: saved.name,
+        label: saved.name,
+        source: "saved",
+      },
+    }
+  } catch (error) {
+    console.error("Unable to save reusable schedule phase", error)
+    return { success: false, error: "Unable to save the reusable phase." }
+  }
+}
+
+export async function deleteSchedulePhaseOption(input: {
+  readonly projectId: string
+  readonly optionId: string
+}): Promise<{ readonly success: true } | { readonly success: false; readonly error: string }> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    const { db, organizationId } = await verifyProject({
+      projectId: input.projectId,
+      action: "delete",
+    })
+    await db
+      .delete(schedulePhaseOptions)
+      .where(
+        and(
+          eq(schedulePhaseOptions.id, input.optionId),
+          eq(schedulePhaseOptions.organizationId, organizationId)
+        )
+      )
+    revalidatePath(`/dashboard/projects/${input.projectId}/schedule`)
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to delete reusable schedule phase", error)
+    return { success: false, error: "Unable to remove the reusable phase." }
+  }
+}

--- a/src/components/schedule/schedule-item-form-dialog.tsx
+++ b/src/components/schedule/schedule-item-form-dialog.tsx
@@ -47,6 +47,12 @@ import {
   updateDependency,
   deleteDependency
 } from "@/app/actions/schedule"
+import {
+  deleteSchedulePhaseOption,
+  getSchedulePhaseOptions,
+  saveSchedulePhaseOption,
+  type ReusableSchedulePhaseOption,
+} from "@/app/actions/schedule-phases"
 import { sendScheduleTaskReminder } from "@/app/actions/schedule-confirmations"
 import { calculateEndDate } from "@/lib/schedule/business-days"
 import type {
@@ -55,7 +61,7 @@ import type {
   DependencyType,
   WorkdayExceptionData
 } from "@/lib/schedule/types"
-import { PHASE_ORDER, PHASE_LABELS, getPhaseColor } from "@/lib/schedule/phase-colors"
+import { PHASE_ORDER, PHASE_LABELS } from "@/lib/schedule/phase-colors"
 import { DEFAULT_DISPLAY_COLOR, DISPLAY_COLOR_OPTIONS } from "@/lib/schedule/appearance"
 import { STATUS_OPTIONS } from "@/lib/schedule/types"
 import { useRouter } from "next/navigation"
@@ -70,10 +76,14 @@ import {
   loadScheduleTemplateImportOptions
 } from "@/components/schedule/schedule-template-import-options-client"
 
-const phases = PHASE_ORDER.map((value) => ({
+const defaultPhaseOptions: readonly ReusableSchedulePhaseOption[] = PHASE_ORDER.map((value) => ({
+  id: null,
   value,
-  label: PHASE_LABELS[value]
+  label: PHASE_LABELS[value],
+  source: "default"
 }))
+
+const CUSTOM_PHASE_VALUE = "__custom_phase__"
 
 const DEPENDENCY_TYPES: readonly { value: DependencyType; label: string }[] = [
   { value: "FS", label: "Finish-to-Start" },
@@ -86,7 +96,7 @@ const scheduleItemSchema = z.object({
   title: z.string().min(1, "Title is required"),
   startDate: z.string().min(1, "Start date is required"),
   workdays: z.number().min(1, "Must be at least 1 day"),
-  phase: z.string().min(1, "Phase is required"),
+  phase: z.string().trim().min(1, "Phase is required"),
   displayColor: z.string(),
   status: z.enum(["PENDING", "IN_PROGRESS", "COMPLETE", "BLOCKED"]),
   isMilestone: z.boolean(),
@@ -148,6 +158,13 @@ export function ScheduleItemFormDialog({
   const [selectedTemplateItemId, setSelectedTemplateItemId] = useState("")
   const [selectedTemplateTodoIds, setSelectedTemplateTodoIds] = useState<readonly string[]>([])
   const [templateTodosOpen, setTemplateTodosOpen] = useState(false)
+  const [phaseOptions, setPhaseOptions] = useState<
+    readonly ReusableSchedulePhaseOption[]
+  >(defaultPhaseOptions)
+  const [phaseOptionsLoading, setPhaseOptionsLoading] = useState(false)
+  const [customPhaseMode, setCustomPhaseMode] = useState(false)
+  const [customPhaseName, setCustomPhaseName] = useState("")
+  const [saveCustomPhase, setSaveCustomPhase] = useState(true)
 
   const existingPredecessors = useMemo(() => {
     if (!editingTask) return []
@@ -204,6 +221,29 @@ export function ScheduleItemFormDialog({
 
   useEffect(() => {
     if (!open) return
+    let cancelled = false
+    setPhaseOptionsLoading(true)
+    void getSchedulePhaseOptions(projectId)
+      .then((options) => {
+        if (!cancelled) setPhaseOptions(options)
+      })
+      .catch((error: unknown) => {
+        console.error("Unable to load reusable schedule phases", error)
+        if (!cancelled) {
+          setPhaseOptions(defaultPhaseOptions)
+          toast.error("Unable to load saved phases. Compass defaults are available.")
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setPhaseOptionsLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open, projectId])
+
+  useEffect(() => {
+    if (!open) return
     if (editingTask) {
       form.reset({
         title: editingTask.title,
@@ -251,6 +291,9 @@ export function ScheduleItemFormDialog({
       setSelectedTemplateTodoIds([])
       setTemplateTodosOpen(false)
     }
+    setCustomPhaseMode(false)
+    setCustomPhaseName("")
+    setSaveCustomPhase(true)
     setPendingPredecessors([])
   }, [assigneeOptions, editingTask, form, open])
 
@@ -342,7 +385,28 @@ export function ScheduleItemFormDialog({
   }
 
   async function onSubmit(values: ScheduleItemFormValues) {
-    const { notes, ...taskValues } = values
+    let submittedPhase = values.phase
+    if (customPhaseMode && saveCustomPhase) {
+      const phaseResult = await saveSchedulePhaseOption({
+        projectId,
+        name: values.phase,
+      })
+      if (!phaseResult.success) {
+        toast.error(phaseResult.error)
+        return
+      }
+      submittedPhase = phaseResult.option.value
+      setPhaseOptions((current) => {
+        const withoutDuplicate = current.filter(
+          (option) =>
+            option.value.trim().toLocaleLowerCase() !==
+            phaseResult.option.value.trim().toLocaleLowerCase()
+        )
+        return [...withoutDuplicate, phaseResult.option]
+      })
+    }
+    const { notes, ...valuesWithoutNotes } = values
+    const taskValues = { ...valuesWithoutNotes, phase: submittedPhase }
     void notes
     let savedTaskId: string
     let linkedTodoCount = 0
@@ -430,6 +494,34 @@ export function ScheduleItemFormDialog({
       )
     }
     onOpenChange(false)
+  }
+
+  async function removeSelectedSavedPhase(): Promise<void> {
+    const selected = phaseOptions.find(
+      (option) => option.value === watchedPhase && option.source === "saved"
+    )
+    if (!selected?.id) return
+    if (
+      !window.confirm(
+        `Remove “${selected.label}” from the reusable phase catalog? Existing schedule items and templates will not change.`
+      )
+    ) {
+      return
+    }
+    const result = await deleteSchedulePhaseOption({
+      projectId,
+      optionId: selected.id,
+    })
+    if (!result.success) {
+      toast.error(result.error)
+      return
+    }
+    setPhaseOptions((current) =>
+      current.filter((option) => option.id !== selected.id)
+    )
+    toast.success(
+      "Removed from the reusable catalog. It may still appear where it is already in use."
+    )
   }
 
   const addPendingPredecessor = () => {
@@ -687,28 +779,100 @@ export function ScheduleItemFormDialog({
                 )}
               />
 
-              {/* Phase pills */}
-              <div className="flex flex-wrap gap-1.5">
-                {phases.map((p) => {
-                  const colors = getPhaseColor(p.value)
-                  const isSelected = watchedPhase === p.value
-                  return (
-                    <button
-                      key={p.value}
-                      type="button"
-                      className={cn(
-                        "px-2.5 py-1 rounded-md text-xs font-medium transition-all",
-                        isSelected
-                          ? `${colors.badge} ring-1 ring-current/20`
-                          : "bg-muted/50 text-muted-foreground hover:bg-muted"
-                      )}
-                      onClick={() => form.setValue("phase", p.value)}
-                    >
-                      {p.label}
-                    </button>
+              <FormField
+                control={form.control}
+                name="phase"
+                render={({ field }) => {
+                  const selectedSavedPhase = phaseOptions.find(
+                    (option) =>
+                      option.value === field.value && option.source === "saved"
                   )
-                })}
-              </div>
+                  return (
+                    <FormItem>
+                      <FormLabel className="text-[11px] font-medium text-muted-foreground">
+                        Phase
+                      </FormLabel>
+                      <div className="flex items-center gap-2">
+                        <Select
+                          value={customPhaseMode ? CUSTOM_PHASE_VALUE : field.value}
+                          onValueChange={(value) => {
+                            if (value === CUSTOM_PHASE_VALUE) {
+                              setCustomPhaseMode(true)
+                              setCustomPhaseName("")
+                              setSaveCustomPhase(true)
+                              field.onChange("")
+                              return
+                            }
+                            setCustomPhaseMode(false)
+                            setCustomPhaseName("")
+                            field.onChange(value)
+                          }}
+                        >
+                          <FormControl>
+                            <SelectTrigger className="h-9 flex-1">
+                              <SelectValue
+                                placeholder={
+                                  phaseOptionsLoading ? "Loading phases…" : "Choose phase"
+                                }
+                              />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {phaseOptions.map((option) => (
+                              <SelectItem key={`${option.source}-${option.value}`} value={option.value}>
+                                {option.label}
+                              </SelectItem>
+                            ))}
+                            <SelectItem value={CUSTOM_PHASE_VALUE}>
+                              + Add custom phase…
+                            </SelectItem>
+                          </SelectContent>
+                        </Select>
+                        {selectedSavedPhase?.id && !customPhaseMode && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="size-9 shrink-0 text-muted-foreground"
+                            title="Remove from reusable phases"
+                            aria-label={`Remove ${selectedSavedPhase.label} from reusable phases`}
+                            onClick={() => void removeSelectedSavedPhase()}
+                          >
+                            <IconTrash className="size-4" />
+                          </Button>
+                        )}
+                      </div>
+                      {customPhaseMode && (
+                        <div className="space-y-2 rounded-md border bg-muted/20 p-3">
+                          <Input
+                            value={customPhaseName}
+                            maxLength={100}
+                            placeholder="Custom phase name"
+                            autoFocus
+                            onChange={(event) => {
+                              const value = event.currentTarget.value
+                              setCustomPhaseName(value)
+                              field.onChange(value)
+                            }}
+                          />
+                          <label className="flex items-start gap-2 text-xs text-muted-foreground">
+                            <Checkbox
+                              checked={saveCustomPhase}
+                              onCheckedChange={(checked) =>
+                                setSaveCustomPhase(checked === true)
+                              }
+                            />
+                            <span>
+                              Save to the reusable phase list for future schedules and templates
+                            </span>
+                          </label>
+                        </div>
+                      )}
+                      <FormMessage />
+                    </FormItem>
+                  )
+                }}
+              />
 
               <div className="flex items-center gap-2">
                 <span className="text-[11px] text-muted-foreground font-medium">Display color</span>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -573,6 +573,36 @@ export const scheduleSavedViews = sqliteTable(
 export type ScheduleSavedView = typeof scheduleSavedViews.$inferSelect
 export type NewScheduleSavedView = typeof scheduleSavedViews.$inferInsert
 
+export const schedulePhaseOptions = sqliteTable(
+  "schedule_phase_options",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    normalizedName: text("normalized_name").notNull(),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("schedule_phase_options_org_name_unique").on(
+      table.organizationId,
+      table.normalizedName
+    ),
+    index("schedule_phase_options_org_name_idx").on(
+      table.organizationId,
+      table.name
+    ),
+  ]
+)
+
+export type SchedulePhaseOption = typeof schedulePhaseOptions.$inferSelect
+export type NewSchedulePhaseOption = typeof schedulePhaseOptions.$inferInsert
+
 export const projectExternalLinks = sqliteTable("project_external_links", {
   id: text("id").primaryKey(),
   projectId: text("project_id")


### PR DESCRIPTION
## What changed

- replaces fixed schedule phase pills with a reusable phase dropdown
- includes Compass defaults, phases already used by the project, and phases found in published templates
- lets staff enter a custom phase and optionally save it to the organization phase catalog
- lets authorized staff remove saved phases without changing existing schedule items or templates
- adds the D1 schema and migration for reusable phase options

## Why

Project schedules need job-specific phases beyond Compass's built-in construction list, while keeping those additions available for future schedules and template authoring.

## Validation

- `bunx tsc --noEmit`
- focused ESLint on changed TypeScript files
- `bun test src/lib/schedule src/lib/templates` (101 passing)
- `bun run build`
- `git diff --check`
