### PR TITLE
fix(integrations): discover GoTo account without admin scope

### DIFF
--- a/src/app/api/integrations/goto/setup/route.ts
+++ b/src/app/api/integrations/goto/setup/route.ts
@@ -5,6 +5,7 @@ import { getDb } from "@/db"
 import { gotoInboundSettings } from "@/db/schema"
 import { getCurrentUser } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
+import { gotoSmsOwnerNumbers, normalizeSmsPhoneNumber } from "@/lib/goto/numbers"
 import { gotoWebhookConfig } from "@/lib/goto/webhook-security"
 import { getGotoAccessToken } from "@/lib/notifications/create-event"
 import { requireOrg } from "@/lib/org-scope"
@@ -20,6 +21,38 @@ function stringField(value: unknown, key: string): string | null {
   if (typeof field === "string" && field.trim().length > 0) return field.trim()
   if (typeof field === "number" && Number.isFinite(field)) return String(field)
   return null
+}
+
+function accountKeyFromUserAccounts(
+  value: unknown,
+  ownerNumbers: readonly string[]
+): string | null {
+  if (!isRecord(value) || !Array.isArray(value.items)) return null
+  const accounts = value.items.flatMap((item) => {
+    const accountKey = stringField(item, "accountKey")
+    if (!accountKey || !isRecord(item)) return []
+    const outboundPhoneNumbers = Array.isArray(item.outboundPhoneNumbers)
+      ? item.outboundPhoneNumbers.flatMap((phone) => {
+          const number = stringField(phone, "number")
+          return number ? [normalizeSmsPhoneNumber(number)] : []
+        })
+      : []
+    return [{ accountKey, outboundPhoneNumbers }]
+  })
+  const matchingKeys = [
+    ...new Set(
+      accounts
+        .filter((account) =>
+          account.outboundPhoneNumbers.some((number) =>
+            ownerNumbers.includes(number)
+          )
+        )
+        .map((account) => account.accountKey)
+    ),
+  ]
+  if (matchingKeys.length === 1) return matchingKeys[0] ?? null
+  const allKeys = [...new Set(accounts.map((account) => account.accountKey))]
+  return allKeys.length === 1 ? allKeys[0] ?? null : null
 }
 
 async function responseValue(response: Response): Promise<unknown> {
@@ -74,14 +107,33 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ success: false, error: token.error }, { status: 502 })
   }
   const authHeaders = { Authorization: `Bearer ${token.accessToken}` }
-  const meResponse = await fetch("https://api.getgo.com/admin/rest/v1/me", {
-    headers: authHeaders,
-  })
-  const me = await responseValue(meResponse)
-  const accountKey = stringField(me, "accountKey")
+  let accountKey = token.accountKey
+  if (!accountKey) {
+    // The Admin /me endpoint requires an additional identity scope. The Users
+    // endpoint uses the existing phone-system scope and exposes account keys.
+    const meResponse = await fetch("https://api.goto.com/users/v1/me", {
+      headers: authHeaders,
+    })
+    if (!meResponse.ok) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `GoTo account discovery failed (${meResponse.status}). Verify the users.v1.lines.read scope.`,
+        },
+        { status: 502 }
+      )
+    }
+    accountKey = accountKeyFromUserAccounts(
+      await responseValue(meResponse),
+      gotoSmsOwnerNumbers(env)
+    )
+  }
   if (!accountKey) {
     return NextResponse.json(
-      { success: false, error: "GoTo account key was not available to the configured administrator" },
+      {
+        success: false,
+        error: "GoTo account key could not be matched to a configured Compass text number",
+      },
       { status: 502 }
     )
   }

--- a/src/lib/notifications/create-event.ts
+++ b/src/lib/notifications/create-event.ts
@@ -114,7 +114,11 @@ type SmsDeliveryResult = {
 }
 
 type GotoAccessTokenResult =
-  | { readonly success: true; readonly accessToken: string }
+  | {
+      readonly success: true
+      readonly accessToken: string
+      readonly accountKey: string | null
+    }
   | { readonly success: false; readonly error: string }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -127,6 +131,16 @@ function envString(env: unknown, key: string): string | null {
   return typeof value === "string" && value.trim().length > 0
     ? value
     : process.env[key] ?? null
+}
+
+function gotoAccountKey(value: Record<string, unknown>): string | null {
+  const field = value.account_key ?? value.accountKey
+  if (typeof field === "string" && field.trim().length > 0) {
+    return field.trim()
+  }
+  return typeof field === "number" && Number.isFinite(field)
+    ? String(field)
+    : null
 }
 
 export function isMissingNotificationTableError(
@@ -358,7 +372,11 @@ export async function getGotoAccessToken(
   try {
     const parsed: unknown = JSON.parse(responseText)
     if (isRecord(parsed) && typeof parsed.access_token === "string") {
-      return { success: true, accessToken: parsed.access_token }
+      return {
+        success: true,
+        accessToken: parsed.access_token,
+        accountKey: gotoAccountKey(parsed),
+      }
     }
   } catch {
     return { success: false, error: "GoTo token response was not JSON" }


### PR DESCRIPTION
## Summary
- read the GoTo account key directly from the PAT token exchange when available
- fall back to the phone-system user endpoint instead of the identity-scoped Admin API
- match multi-account responses to Compass's configured GoTo numbers
- return an actionable scope error if phone-system discovery is unavailable

## Verification
- focused ESLint passed
- TypeScript passed with `tsc --noEmit`
- `git diff --check` passed
- production logs reproduced and identified the Admin API 401
