### PR TITLE
fix(integrations): discover GoTo account through SCIM

### DIFF
--- a/src/app/api/integrations/goto/setup/route.ts
+++ b/src/app/api/integrations/goto/setup/route.ts
@@ -5,6 +5,7 @@ import { getDb } from "@/db"
 import { gotoInboundSettings } from "@/db/schema"
 import { getCurrentUser } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
+import { accountKeysFromScimIdentity } from "@/lib/goto/account-discovery"
 import { gotoSmsOwnerNumbers, normalizeSmsPhoneNumber } from "@/lib/goto/numbers"
 import { gotoWebhookConfig } from "@/lib/goto/webhook-security"
 import { getGotoAccessToken } from "@/lib/notifications/create-event"
@@ -108,9 +109,37 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
   const authHeaders = { Authorization: `Bearer ${token.accessToken}` }
   let accountKey = token.accountKey
+  let scimStatus: number | null = null
   if (!accountKey) {
-    // The Admin /me endpoint requires an additional identity scope. The Users
-    // endpoint uses the existing phone-system scope and exposes account keys.
+    // Modern GoTo token responses omit account_key. GoTo documents SCIM /me as
+    // the scope-free replacement; account keys live inside its accounts array.
+    const scimResponse = await fetch(
+      "https://api.getgo.com/identity/v1/Users/me",
+      { headers: { ...authHeaders, Accept: "application/json" } }
+    )
+    scimStatus = scimResponse.status
+    if (scimResponse.ok) {
+      const scimAccountKeys = accountKeysFromScimIdentity(
+        await responseValue(scimResponse)
+      )
+      if (scimAccountKeys.length === 1) {
+        accountKey = scimAccountKeys[0] ?? null
+      } else if (scimAccountKeys.length > 1) {
+        return NextResponse.json(
+          {
+            success: false,
+            error:
+              "GoTo returned multiple accounts. Add users.v1.read to the token so Compass can match the configured text number.",
+          },
+          { status: 502 }
+        )
+      }
+    }
+  }
+  if (!accountKey) {
+    // Scoped tokens can be matched to the configured Compass number through
+    // GoTo Connect /me. Older PATs may not carry users.v1.read, so this remains
+    // a compatibility fallback after the scope-free SCIM endpoint.
     const meResponse = await fetch("https://api.goto.com/users/v1/me", {
       headers: authHeaders,
     })
@@ -118,7 +147,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return NextResponse.json(
         {
           success: false,
-          error: `GoTo account discovery failed (${meResponse.status}). Verify the users.v1.lines.read scope.`,
+          error: `GoTo account discovery failed (SCIM ${scimStatus ?? "unavailable"}; Users ${meResponse.status}). Verify the GoTo PAT and its users.v1.read scope.`,
         },
         { status: 502 }
       )

--- a/src/lib/goto/__tests__/account-discovery.test.ts
+++ b/src/lib/goto/__tests__/account-discovery.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+
+import { accountKeysFromScimIdentity } from "@/lib/goto/account-discovery"
+
+describe("accountKeysFromScimIdentity", () => {
+  it("reads the account keys from the SCIM accounts array", () => {
+    expect(
+      accountKeysFromScimIdentity({
+        accounts: [
+          { key: "account-1", name: "Primary" },
+          { accountKey: "account-2", name: "Secondary" },
+        ],
+      })
+    ).toEqual(["account-1", "account-2"])
+  })
+
+  it("reads an accounts array nested inside a SCIM extension", () => {
+    expect(
+      accountKeysFromScimIdentity({
+        id: "user-key",
+        "urn:ietf:params:scim:schemas:extension:goto:2.0:User": {
+          accounts: [{ account_key: 31416 }],
+        },
+      })
+    ).toEqual(["31416"])
+  })
+
+  it("does not confuse the SCIM user id for an account key", () => {
+    expect(accountKeysFromScimIdentity({ id: "user-key" })).toEqual([])
+  })
+})

--- a/src/lib/goto/account-discovery.ts
+++ b/src/lib/goto/account-discovery.ts
@@ -1,0 +1,46 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function stringField(value: unknown, key: string): string | null {
+  if (!isRecord(value)) return null
+  const field = value[key]
+  if (typeof field === "string" && field.trim().length > 0) return field.trim()
+  if (typeof field === "number" && Number.isFinite(field)) return String(field)
+  return null
+}
+
+function accountKey(value: unknown): string | null {
+  return (
+    stringField(value, "key") ??
+    stringField(value, "accountKey") ??
+    stringField(value, "account_key")
+  )
+}
+
+function collectAccountKeys(value: unknown): readonly string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectAccountKeys(item))
+  }
+  if (!isRecord(value)) return []
+
+  return Object.entries(value).flatMap(([key, field]) => {
+    if (key === "accounts" && Array.isArray(field)) {
+      return field.flatMap((account) => {
+        const keyValue = accountKey(account)
+        return keyValue ? [keyValue] : []
+      })
+    }
+    return Array.isArray(field) || isRecord(field)
+      ? collectAccountKeys(field)
+      : []
+  })
+}
+
+/**
+ * GoTo's modern token response omits account_key. Their scope-free SCIM /me
+ * response exposes it inside an accounts array, sometimes within an extension.
+ */
+export function accountKeysFromScimIdentity(value: unknown): readonly string[] {
+  return [...new Set(collectAccountKeys(value))]
+}


### PR DESCRIPTION
## Summary
- discover the GoTo account key through the documented scope-free SCIM identity endpoint
- retain phone-number matching for tokens with GoTo Connect user scope
- cover top-level and SCIM-extension account arrays with focused tests

## Verification
- bun test src/lib/goto/__tests__/account-discovery.test.ts src/lib/goto/__tests__/inbound.test.ts src/lib/goto/__tests__/webhook-security.test.ts
- bunx eslint src/app/api/integrations/goto/setup/route.ts src/lib/goto/account-discovery.ts src/lib/goto/__tests__/account-discovery.test.ts
- bunx tsc --noEmit