### PR TITLE
fix(integrations): support GoTo SCIM account shapes

### DIFF
--- a/src/lib/goto/__tests__/account-discovery.test.ts
+++ b/src/lib/goto/__tests__/account-discovery.test.ts
@@ -25,6 +25,14 @@ describe("accountKeysFromScimIdentity", () => {
     ).toEqual(["31416"])
   })
 
+  it("supports GoTo account arrays containing identifiers directly", () => {
+    expect(
+      accountKeysFromScimIdentity({
+        Accounts: ["account-1", 31416, { id: "account-2" }],
+      })
+    ).toEqual(["account-1", "31416", "account-2"])
+  })
+
   it("does not confuse the SCIM user id for an account key", () => {
     expect(accountKeysFromScimIdentity({ id: "user-key" })).toEqual([])
   })

--- a/src/lib/goto/account-discovery.ts
+++ b/src/lib/goto/account-discovery.ts
@@ -11,10 +11,19 @@ function stringField(value: unknown, key: string): string | null {
 }
 
 function accountKey(value: unknown): string | null {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim()
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value)
+  }
   return (
     stringField(value, "key") ??
     stringField(value, "accountKey") ??
-    stringField(value, "account_key")
+    stringField(value, "account_key") ??
+    stringField(value, "accountId") ??
+    stringField(value, "account_id") ??
+    stringField(value, "id")
   )
 }
 
@@ -25,7 +34,7 @@ function collectAccountKeys(value: unknown): readonly string[] {
   if (!isRecord(value)) return []
 
   return Object.entries(value).flatMap(([key, field]) => {
-    if (key === "accounts" && Array.isArray(field)) {
+    if (key.toLowerCase() === "accounts" && Array.isArray(field)) {
       return field.flatMap((account) => {
         const keyValue = accountKey(account)
         return keyValue ? [keyValue] : []


### PR DESCRIPTION
## Summary
- support scalar, id-based, and case-varied GoTo SCIM account arrays
- preserve the rule that only identifiers inside an accounts array can become account keys
- add focused coverage for the live response variants

## Verification
- 9 focused GoTo tests passed
- ESLint passed
- TypeScript passed