### PR TITLE
fix(integrations): harden GoTo SCIM discovery

### DIFF
--- a/src/app/api/integrations/goto/setup/route.ts
+++ b/src/app/api/integrations/goto/setup/route.ts
@@ -5,7 +5,10 @@ import { getDb } from "@/db"
 import { gotoInboundSettings } from "@/db/schema"
 import { getCurrentUser } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
-import { accountKeysFromScimIdentity } from "@/lib/goto/account-discovery"
+import {
+  accountKeysFromScimIdentity,
+  describeScimIdentityShape,
+} from "@/lib/goto/account-discovery"
 import { gotoSmsOwnerNumbers, normalizeSmsPhoneNumber } from "@/lib/goto/numbers"
 import { gotoWebhookConfig } from "@/lib/goto/webhook-security"
 import { getGotoAccessToken } from "@/lib/notifications/create-event"
@@ -119,9 +122,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     )
     scimStatus = scimResponse.status
     if (scimResponse.ok) {
-      const scimAccountKeys = accountKeysFromScimIdentity(
-        await responseValue(scimResponse)
-      )
+      const scimIdentity = await responseValue(scimResponse)
+      const scimAccountKeys = accountKeysFromScimIdentity(scimIdentity)
       if (scimAccountKeys.length === 1) {
         accountKey = scimAccountKeys[0] ?? null
       } else if (scimAccountKeys.length > 1) {
@@ -133,6 +135,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           },
           { status: 502 }
         )
+      } else {
+        console.warn("GoTo SCIM identity did not expose an account key", {
+          shape: describeScimIdentityShape(scimIdentity),
+        })
       }
     }
   }

--- a/src/lib/goto/__tests__/account-discovery.test.ts
+++ b/src/lib/goto/__tests__/account-discovery.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { accountKeysFromScimIdentity } from "@/lib/goto/account-discovery"
+import {
+  accountKeysFromScimIdentity,
+  describeScimIdentityShape,
+} from "@/lib/goto/account-discovery"
 
 describe("accountKeysFromScimIdentity", () => {
   it("reads the account keys from the SCIM accounts array", () => {
@@ -35,5 +38,17 @@ describe("accountKeysFromScimIdentity", () => {
 
   it("does not confuse the SCIM user id for an account key", () => {
     expect(accountKeysFromScimIdentity({ id: "user-key" })).toEqual([])
+  })
+
+  it("reports only field paths and types for safe diagnostics", () => {
+    const shape = describeScimIdentityShape({
+      userName: "private@example.com",
+      extension: { accountKeys: ["secret-account-key"] },
+    })
+
+    expect(shape).toContain("userName:string")
+    expect(shape).toContain("extension.accountKeys[]:string")
+    expect(shape).not.toContain("private@example.com")
+    expect(shape).not.toContain("secret-account-key")
   })
 })

--- a/src/lib/goto/account-discovery.ts
+++ b/src/lib/goto/account-discovery.ts
@@ -34,7 +34,12 @@ function collectAccountKeys(value: unknown): readonly string[] {
   if (!isRecord(value)) return []
 
   return Object.entries(value).flatMap(([key, field]) => {
-    if (key.toLowerCase() === "accounts" && Array.isArray(field)) {
+    const normalizedKey = key.toLowerCase().replace(/[^a-z0-9]/g, "")
+    if (normalizedKey === "accountkey") {
+      const keyValue = accountKey(field)
+      return keyValue ? [keyValue] : []
+    }
+    if (normalizedKey.includes("account") && Array.isArray(field)) {
       return field.flatMap((account) => {
         const keyValue = accountKey(account)
         return keyValue ? [keyValue] : []
@@ -52,4 +57,26 @@ function collectAccountKeys(value: unknown): readonly string[] {
  */
 export function accountKeysFromScimIdentity(value: unknown): readonly string[] {
   return [...new Set(collectAccountKeys(value))]
+}
+
+function collectShapePaths(
+  value: unknown,
+  path: string,
+  depth: number
+): readonly string[] {
+  if (depth > 5) return [`${path}:…`]
+  if (Array.isArray(value)) {
+    if (value.length === 0) return [`${path}:array(empty)`]
+    return collectShapePaths(value[0], `${path}[]`, depth + 1)
+  }
+  if (!isRecord(value)) return [`${path}:${typeof value}`]
+
+  return Object.entries(value).flatMap(([key, field]) =>
+    collectShapePaths(field, path ? `${path}.${key}` : key, depth + 1)
+  )
+}
+
+/** Returns field paths and types only, never SCIM values or identifiers. */
+export function describeScimIdentityShape(value: unknown): string {
+  return collectShapePaths(value, "", 0).slice(0, 80).join(", ")
 }


### PR DESCRIPTION
## Summary
- support explicit account-key arrays and fields across GoTo SCIM variants
- add safe structural diagnostics that log field names and types only
- verify diagnostics never expose SCIM values or identifiers

## Verification
- 10 focused GoTo tests passed
- ESLint passed
- TypeScript passed