### PR TITLE
fix(integrations): parse GoTo SCIM account objects

### DIFF
--- a/src/lib/goto/__tests__/account-discovery.test.ts
+++ b/src/lib/goto/__tests__/account-discovery.test.ts
@@ -36,6 +36,17 @@ describe("accountKeysFromScimIdentity", () => {
     ).toEqual(["account-1", "31416", "account-2"])
   })
 
+  it("supports account and organization objects inside SCIM extensions", () => {
+    expect(
+      accountKeysFromScimIdentity({
+        extension: {
+          account: { key: "account-1" },
+          organization: { id: "account-2" },
+        },
+      })
+    ).toEqual(["account-1", "account-2"])
+  })
+
   it("does not confuse the SCIM user id for an account key", () => {
     expect(accountKeysFromScimIdentity({ id: "user-key" })).toEqual([])
   })
@@ -48,6 +59,9 @@ describe("accountKeysFromScimIdentity", () => {
 
     expect(shape).toContain("userName:string")
     expect(shape).toContain("extension.accountKeys[]:string")
+    expect(shape.indexOf("extension.accountKeys[]:string")).toBeLessThan(
+      shape.indexOf("userName:string")
+    )
     expect(shape).not.toContain("private@example.com")
     expect(shape).not.toContain("secret-account-key")
   })

--- a/src/lib/goto/account-discovery.ts
+++ b/src/lib/goto/account-discovery.ts
@@ -45,6 +45,13 @@ function collectAccountKeys(value: unknown): readonly string[] {
         return keyValue ? [keyValue] : []
       })
     }
+    if (
+      (normalizedKey.includes("account") || normalizedKey === "organization") &&
+      isRecord(field)
+    ) {
+      const keyValue = accountKey(field)
+      if (keyValue) return [keyValue]
+    }
     return Array.isArray(field) || isRecord(field)
       ? collectAccountKeys(field)
       : []
@@ -78,5 +85,12 @@ function collectShapePaths(
 
 /** Returns field paths and types only, never SCIM values or identifiers. */
 export function describeScimIdentityShape(value: unknown): string {
-  return collectShapePaths(value, "", 0).slice(0, 80).join(", ")
+  return [...collectShapePaths(value, "", 0)]
+    .sort((left, right) => {
+      const leftRelevant = /account|organization/i.test(left) ? 0 : 1
+      const rightRelevant = /account|organization/i.test(right) ? 0 : 1
+      return leftRelevant - rightRelevant
+    })
+    .slice(0, 80)
+    .join(", ")
 }


### PR DESCRIPTION
## Summary
- parse GoTo account and organization metadata represented as objects
- prioritize account-related field paths in safe moderator diagnostics
- cover both object variants with focused tests

## Verification
- 11 focused GoTo tests passed
- ESLint passed
- TypeScript passed