### PR TITLE
fix(integrations): read GoTo SCIM account values

### DIFF
--- a/src/lib/goto/__tests__/account-discovery.test.ts
+++ b/src/lib/goto/__tests__/account-discovery.test.ts
@@ -28,6 +28,22 @@ describe("accountKeysFromScimIdentity", () => {
     ).toEqual(["31416"])
   })
 
+  it("reads account values from GoTo's getgo 1.0 SCIM extension", () => {
+    expect(
+      accountKeysFromScimIdentity({
+        "urn:scim:schemas:extension:getgo:1.0": {
+          accounts: [
+            {
+              value: "account-1",
+              display: "Primary account",
+              entitlements: ["messaging"],
+            },
+          ],
+        },
+      })
+    ).toEqual(["account-1"])
+  })
+
   it("supports GoTo account arrays containing identifiers directly", () => {
     expect(
       accountKeysFromScimIdentity({

--- a/src/lib/goto/account-discovery.ts
+++ b/src/lib/goto/account-discovery.ts
@@ -23,6 +23,9 @@ function accountKey(value: unknown): string | null {
     stringField(value, "account_key") ??
     stringField(value, "accountId") ??
     stringField(value, "account_id") ??
+    // GoTo's getgo:1.0 SCIM extension represents accounts as
+    // { value: <account key>, display, entitlements } objects.
+    stringField(value, "value") ??
     stringField(value, "id")
   )
 }


### PR DESCRIPTION
## Summary
- parse account identifiers from GoTo getgo:1.0 SCIM account objects
- cover the exact production SCIM shape with a regression test

## Verification
- bun test src/lib/goto/__tests__/account-discovery.test.ts
- bunx eslint src/lib/goto/account-discovery.ts src/lib/goto/__tests__/account-discovery.test.ts
- TypeScript reached only the pre-existing generated custom-worker.ts unused @ts-expect-error after raising the heap limit