### PR TITLE
fix(integrations): allow GoTo webhook validation

### DIFF
--- a/src/app/api/integrations/goto/inbound/route.ts
+++ b/src/app/api/integrations/goto/inbound/route.ts
@@ -14,6 +14,36 @@ import {
 const MAX_WEBHOOK_BODY_BYTES = 256 * 1024
 const MAX_EVENTS_PER_MINUTE = 120
 
+function isAuthorizedWebhook(request: Request, secret: string): boolean {
+  const suppliedSecret = new URL(request.url).searchParams.get("secret")
+  return constantTimeSecretMatch(secret, suppliedSecret)
+}
+
+async function validateWebhookProbe(request: Request): Promise<Response> {
+  const { env } = await getCloudflareContext()
+  const config = gotoWebhookConfig(env)
+  if (!config) {
+    return Response.json(
+      { error: "GoTo inbound messaging is not configured" },
+      { status: 503 }
+    )
+  }
+  if (!isAuthorizedWebhook(request, config.secret)) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  return new Response(null, { status: 200 })
+}
+
+// GoTo probes the callback with OPTIONS and GET while creating a notification
+// channel. Keep both methods secret-protected and answer before the 2s limit.
+export async function OPTIONS(request: Request): Promise<Response> {
+  return validateWebhookProbe(request)
+}
+
+export async function GET(request: Request): Promise<Response> {
+  return validateWebhookProbe(request)
+}
+
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message.slice(0, 2_000) : "Unknown error"
 }
@@ -36,8 +66,7 @@ export async function POST(request: Request): Promise<Response> {
     return Response.json({ error: "GoTo inbound messaging is not configured" }, { status: 503 })
   }
 
-  const suppliedSecret = new URL(request.url).searchParams.get("secret")
-  if (!constantTimeSecretMatch(config.secret, suppliedSecret)) {
+  if (!isAuthorizedWebhook(request, config.secret)) {
     return Response.json({ error: "Unauthorized" }, { status: 401 })
   }
 

--- a/src/lib/__tests__/middleware-routes.test.ts
+++ b/src/lib/__tests__/middleware-routes.test.ts
@@ -33,4 +33,9 @@ describe("middleware public routes", () => {
       isPublicPath("/api/integrations/sage/pay-applications/requests/extra")
     ).toBe(false)
   })
+
+  it("allows the secret-protected GoTo webhook through WorkOS middleware", () => {
+    expect(isPublicPath("/api/integrations/goto/inbound")).toBe(true)
+    expect(isPublicPath("/api/integrations/goto/setup")).toBe(false)
+  })
 })

--- a/src/lib/public-paths.ts
+++ b/src/lib/public-paths.ts
@@ -21,11 +21,14 @@ const sageBridgePaths = [
   "/api/integrations/sage/pay-applications/results",
 ]
 
+const webhookPaths = ["/api/integrations/goto/inbound"]
+
 export function isPublicPath(pathname: string): boolean {
   return (
     publicPaths.includes(pathname) ||
     bridgePaths.includes(pathname) ||
     sageBridgePaths.includes(pathname) ||
+    webhookPaths.includes(pathname) ||
     pathname.startsWith("/api/auth/") ||
     pathname.startsWith("/api/integrations/jarvis/") ||
     pathname.startsWith("/api/netsuite/") ||


### PR DESCRIPTION
## Summary
- let the secret-protected GoTo inbound webhook bypass interactive WorkOS login
- answer GoTo callback OPTIONS and GET probes with a fast 200 only when the callback secret matches
- keep the setup endpoint private and moderator-only

## Verification
- 16 focused middleware, account-discovery, webhook-security, and inbound-parser tests passed
- focused ESLint passed
- production trace confirmed the prior blocker was callback validation being redirected to login