### PR TITLE
feat(videos): add project YouTube publishing workflow

### DIFF
--- a/drizzle/0096_project_videos.sql
+++ b/drizzle/0096_project_videos.sql
@@ -1,0 +1,43 @@
+CREATE TABLE `project_videos` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`project_id` text NOT NULL,
+	`title` text NOT NULL,
+	`description` text,
+	`department` text NOT NULL,
+	`youtube_channel_key` text NOT NULL,
+	`compass_audience` text DEFAULT 'staff' NOT NULL,
+	`youtube_privacy` text DEFAULT 'private' NOT NULL,
+	`publish_status` text DEFAULT 'pending_review' NOT NULL,
+	`source_system` text NOT NULL,
+	`source_external_id` text NOT NULL,
+	`source_file_name` text NOT NULL,
+	`source_mime_type` text NOT NULL,
+	`source_file_size` integer DEFAULT 0 NOT NULL,
+	`drive_file_id` text NOT NULL,
+	`drive_url` text,
+	`linked_entity_type` text,
+	`linked_entity_id` text,
+	`youtube_video_id` text,
+	`youtube_url` text,
+	`youtube_upload_session_url` text,
+	`upload_error` text,
+	`submitted_by_name` text,
+	`submitted_by_email` text,
+	`reviewed_by` text,
+	`reviewed_at` text,
+	`published_at` text,
+	`archived_at` text,
+	`deleted_at` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`reviewed_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `project_videos_source_unique` ON `project_videos` (`source_system`,`source_external_id`);
+--> statement-breakpoint
+CREATE INDEX `project_videos_project_created_idx` ON `project_videos` (`project_id`,`created_at`);
+--> statement-breakpoint
+CREATE INDEX `project_videos_org_status_idx` ON `project_videos` (`organization_id`,`publish_status`,`created_at`);

--- a/drizzle/0097_youtube_channel_connections.sql
+++ b/drizzle/0097_youtube_channel_connections.sql
@@ -1,0 +1,25 @@
+CREATE TABLE `youtube_channel_connections` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`channel_key` text NOT NULL,
+	`channel_id` text NOT NULL,
+	`channel_title` text NOT NULL,
+	`google_account_email` text NOT NULL,
+	`refresh_token_encrypted` text NOT NULL,
+	`granted_scopes` text NOT NULL,
+	`status` text DEFAULT 'connected' NOT NULL,
+	`connected_by` text,
+	`connected_at` text NOT NULL,
+	`last_upload_at` text,
+	`last_error` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`connected_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `youtube_channel_connections_org_key_unique` ON `youtube_channel_connections` (`organization_id`,`channel_key`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `youtube_channel_connections_org_channel_unique` ON `youtube_channel_connections` (`organization_id`,`channel_id`);
+--> statement-breakpoint
+CREATE INDEX `youtube_channel_connections_org_status_idx` ON `youtube_channel_connections` (`organization_id`,`status`);

--- a/src/app/actions/project-videos.ts
+++ b/src/app/actions/project-videos.ts
@@ -1,0 +1,520 @@
+"use server"
+
+import { and, desc, eq, isNull } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import {
+  dailyLogs,
+  projects,
+  projectVideos,
+  youtubeChannelConnections,
+} from "@/db/schema"
+import { recordActivityEvent } from "@/lib/activity-log"
+import { requireAuth } from "@/lib/auth"
+import { decrypt } from "@/lib/crypto"
+import { getCloudflareContext } from "@/lib/db"
+import { downloadProjectVideoFile } from "@/lib/email/project-video-attachments"
+import {
+  getYoutubeOAuthConfig,
+  refreshYoutubeAccessToken,
+  uploadVideoToYoutube,
+  youtubeChannelKey,
+  youtubeTokenSalt,
+} from "@/lib/google/youtube"
+import { requireOrg } from "@/lib/org-scope"
+import { requireFeaturePermission } from "@/lib/permission-enforcement"
+
+export type ProjectVideoAudience = "staff" | "owner" | "sub_vendor" | "public"
+
+export type ProjectVideoItem = {
+  readonly id: string
+  readonly title: string
+  readonly description: string | null
+  readonly department: string
+  readonly youtubeChannelKey: string
+  readonly compassAudience: string
+  readonly youtubePrivacy: string
+  readonly publishStatus: string
+  readonly sourceSystem: string
+  readonly sourceFileName: string
+  readonly sourceMimeType: string
+  readonly sourceFileSize: number
+  readonly driveUrl: string | null
+  readonly linkedEntityType: string | null
+  readonly linkedEntityId: string | null
+  readonly youtubeUrl: string | null
+  readonly uploadError: string | null
+  readonly submittedByName: string | null
+  readonly createdAt: string
+}
+
+export type ProjectVideoWorkspace = {
+  readonly project: {
+    readonly id: string
+    readonly name: string
+    readonly projectNumber: string | null
+  }
+  readonly videos: readonly ProjectVideoItem[]
+  readonly channels: readonly {
+    readonly channelKey: string
+    readonly channelTitle: string
+    readonly status: string
+  }[]
+}
+
+type VideoActionResult =
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string }
+
+async function projectVideoDb(
+  projectId: string,
+  action: "read" | "update"
+): Promise<ReturnType<typeof getDb>> {
+  const user = await requireAuth()
+  await requireFeaturePermission(user, "project-photos", action)
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const [project] = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.id, projectId),
+        eq(projects.organizationId, organizationId)
+      )
+    )
+    .limit(1)
+  if (!project) throw new Error("Project not found")
+  return db
+}
+
+function audience(value: string): ProjectVideoAudience | null {
+  switch (value) {
+    case "staff":
+    case "owner":
+    case "sub_vendor":
+    case "public":
+      return value
+    default:
+      return null
+  }
+}
+
+function youtubePrivacy(value: ProjectVideoAudience): "private" | "unlisted" | "public" {
+  if (value === "staff") return "private"
+  if (value === "public") return "public"
+  return "unlisted"
+}
+
+export async function getProjectVideoWorkspace(
+  projectId: string
+): Promise<ProjectVideoWorkspace> {
+  const db = await projectVideoDb(projectId, "read")
+  const [project] = await db
+    .select({
+      id: projects.id,
+      name: projects.name,
+      projectNumber: projects.projectNumber,
+      organizationId: projects.organizationId,
+    })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .limit(1)
+  if (!project?.organizationId) throw new Error("Project not found")
+
+  const [videos, channels] = await Promise.all([
+    db
+    .select({
+      id: projectVideos.id,
+      title: projectVideos.title,
+      description: projectVideos.description,
+      department: projectVideos.department,
+      youtubeChannelKey: projectVideos.youtubeChannelKey,
+      compassAudience: projectVideos.compassAudience,
+      youtubePrivacy: projectVideos.youtubePrivacy,
+      publishStatus: projectVideos.publishStatus,
+      sourceSystem: projectVideos.sourceSystem,
+      sourceFileName: projectVideos.sourceFileName,
+      sourceMimeType: projectVideos.sourceMimeType,
+      sourceFileSize: projectVideos.sourceFileSize,
+      driveUrl: projectVideos.driveUrl,
+      linkedEntityType: projectVideos.linkedEntityType,
+      linkedEntityId: projectVideos.linkedEntityId,
+      youtubeUrl: projectVideos.youtubeUrl,
+      uploadError: projectVideos.uploadError,
+      submittedByName: projectVideos.submittedByName,
+      createdAt: projectVideos.createdAt,
+    })
+    .from(projectVideos)
+    .where(
+      and(
+        eq(projectVideos.projectId, projectId),
+        isNull(projectVideos.deletedAt)
+      )
+    )
+      .orderBy(desc(projectVideos.createdAt)),
+    db
+      .select({
+        channelKey: youtubeChannelConnections.channelKey,
+        channelTitle: youtubeChannelConnections.channelTitle,
+        status: youtubeChannelConnections.status,
+      })
+      .from(youtubeChannelConnections)
+      .where(eq(youtubeChannelConnections.organizationId, project.organizationId)),
+  ])
+
+  return {
+    project: {
+      id: project.id,
+      name: project.name,
+      projectNumber: project.projectNumber,
+    },
+    videos,
+    channels,
+  }
+}
+
+export async function updateProjectVideoReview(input: {
+  readonly projectId: string
+  readonly videoId: string
+  readonly title: string
+  readonly description: string
+  readonly compassAudience: string
+}): Promise<VideoActionResult> {
+  try {
+    const db = await projectVideoDb(input.projectId, "update")
+    const [existing] = await db
+      .select({ publishStatus: projectVideos.publishStatus })
+      .from(projectVideos)
+      .where(
+        and(
+          eq(projectVideos.id, input.videoId),
+          eq(projectVideos.projectId, input.projectId),
+          isNull(projectVideos.deletedAt)
+        )
+      )
+      .limit(1)
+    if (!existing) return { success: false, error: "Video not found." }
+    if (existing.publishStatus === "published" || existing.publishStatus === "uploading") {
+      return { success: false, error: "A published or uploading video cannot be re-reviewed." }
+    }
+    const normalizedAudience = audience(input.compassAudience)
+    if (!normalizedAudience) {
+      return { success: false, error: "Choose a valid video audience." }
+    }
+    const title = input.title.trim()
+    if (title.length === 0 || title.length > 100) {
+      return { success: false, error: "Video title must be 1 to 100 characters." }
+    }
+    const description = input.description.trim()
+    if (description.length > 5_000) {
+      return { success: false, error: "Video description cannot exceed 5,000 characters." }
+    }
+    const user = await requireAuth()
+    const now = new Date().toISOString()
+    await db
+      .update(projectVideos)
+      .set({
+        title,
+        description: description.length > 0 ? description : null,
+        compassAudience: normalizedAudience,
+        youtubePrivacy: youtubePrivacy(normalizedAudience),
+        publishStatus: "ready_for_upload",
+        reviewedBy: user.id,
+        reviewedAt: now,
+        uploadError: null,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(projectVideos.id, input.videoId),
+          eq(projectVideos.projectId, input.projectId),
+          isNull(projectVideos.deletedAt)
+        )
+      )
+      .run()
+    revalidatePath(`/dashboard/projects/${input.projectId}/videos`)
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Could not save video review.",
+    }
+  }
+}
+
+export async function archiveProjectVideo(input: {
+  readonly projectId: string
+  readonly videoId: string
+}): Promise<VideoActionResult> {
+  try {
+    const db = await projectVideoDb(input.projectId, "update")
+    const now = new Date().toISOString()
+    await db
+      .update(projectVideos)
+      .set({ publishStatus: "archived", archivedAt: now, updatedAt: now })
+      .where(
+        and(
+          eq(projectVideos.id, input.videoId),
+          eq(projectVideos.projectId, input.projectId),
+          isNull(projectVideos.deletedAt)
+        )
+      )
+      .run()
+    revalidatePath(`/dashboard/projects/${input.projectId}/videos`)
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Could not archive video.",
+    }
+  }
+}
+
+export async function deleteProjectVideo(input: {
+  readonly projectId: string
+  readonly videoId: string
+}): Promise<VideoActionResult> {
+  try {
+    const db = await projectVideoDb(input.projectId, "update")
+    const now = new Date().toISOString()
+    const [video] = await db
+      .select({
+        publishStatus: projectVideos.publishStatus,
+        linkedEntityType: projectVideos.linkedEntityType,
+        linkedEntityId: projectVideos.linkedEntityId,
+      })
+      .from(projectVideos)
+      .where(
+        and(
+          eq(projectVideos.id, input.videoId),
+          eq(projectVideos.projectId, input.projectId),
+          isNull(projectVideos.deletedAt)
+        )
+      )
+      .limit(1)
+    if (!video) return { success: false, error: "Video not found." }
+    const deleteVideo = db
+      .update(projectVideos)
+      .set({ publishStatus: "deleted", deletedAt: now, updatedAt: now })
+      .where(
+        and(
+          eq(projectVideos.id, input.videoId),
+          eq(projectVideos.projectId, input.projectId)
+        )
+      )
+    if (
+      video.publishStatus !== "published" &&
+      video.linkedEntityType === "daily_log" &&
+      video.linkedEntityId
+    ) {
+      await db.batch([
+        deleteVideo,
+        db
+          .delete(dailyLogs)
+          .where(
+            and(
+              eq(dailyLogs.id, video.linkedEntityId),
+              eq(dailyLogs.projectId, input.projectId)
+            )
+          ),
+      ])
+    } else {
+      await deleteVideo.run()
+    }
+    revalidatePath(`/dashboard/projects/${input.projectId}/videos`)
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Could not delete video.",
+    }
+  }
+}
+
+export async function publishProjectVideo(input: {
+  readonly projectId: string
+  readonly videoId: string
+  readonly confirmPublic: boolean
+}): Promise<VideoActionResult> {
+  const user = await requireAuth()
+  const organizationId = requireOrg(user)
+  let db: Awaited<ReturnType<typeof projectVideoDb>> | null = null
+  try {
+    db = await projectVideoDb(input.projectId, "update")
+    const [video] = await db
+      .select()
+      .from(projectVideos)
+      .where(
+        and(
+          eq(projectVideos.id, input.videoId),
+          eq(projectVideos.projectId, input.projectId),
+          eq(projectVideos.organizationId, organizationId),
+          isNull(projectVideos.deletedAt)
+        )
+      )
+      .limit(1)
+    if (!video) return { success: false, error: "Video not found." }
+    if (video.publishStatus !== "ready_for_upload" && video.publishStatus !== "upload_failed") {
+      return { success: false, error: "Review and save this video before publishing." }
+    }
+    if (video.youtubePrivacy === "public" && !input.confirmPublic) {
+      return { success: false, error: "Confirm public publication before uploading." }
+    }
+    const channelKey = youtubeChannelKey(video.youtubeChannelKey)
+    if (!channelKey) return { success: false, error: "Video channel is invalid." }
+    const [connection] = await db
+      .select()
+      .from(youtubeChannelConnections)
+      .where(
+        and(
+          eq(youtubeChannelConnections.organizationId, organizationId),
+          eq(youtubeChannelConnections.channelKey, channelKey),
+          eq(youtubeChannelConnections.status, "connected")
+        )
+      )
+      .limit(1)
+    if (!connection) {
+      return { success: false, error: "Connect the assigned YouTube channel first." }
+    }
+
+    const now = new Date().toISOString()
+    await db
+      .update(projectVideos)
+      .set({ publishStatus: "uploading", uploadError: null, updatedAt: now })
+      .where(eq(projectVideos.id, video.id))
+      .run()
+    const { env } = await getCloudflareContext()
+    const config = getYoutubeOAuthConfig(
+      env,
+      "https://compass.openrangeconstruction.ltd"
+    )
+    const refreshToken = await decrypt(
+      connection.refreshTokenEncrypted,
+      config.tokenEncryptionKey,
+      youtubeTokenSalt(organizationId, channelKey)
+    )
+    const accessToken = await refreshYoutubeAccessToken({ config, refreshToken })
+    const source = await downloadProjectVideoFile({
+      env,
+      db,
+      organizationId,
+      driveFileId: video.driveFileId,
+    })
+    if (!source.body) throw new Error("The staged video has no content.")
+    const uploaded = await uploadVideoToYoutube({
+      accessToken,
+      title: video.title,
+      description: video.description,
+      privacy:
+        video.youtubePrivacy === "public"
+          ? "public"
+          : video.youtubePrivacy === "unlisted"
+            ? "unlisted"
+            : "private",
+      mimeType: video.sourceMimeType,
+      fileSize: video.sourceFileSize,
+      body: source.body,
+      onSessionCreated: async (sessionUrl) => {
+        await db
+          ?.update(projectVideos)
+          .set({ youtubeUploadSessionUrl: sessionUrl, updatedAt: now })
+          .where(eq(projectVideos.id, video.id))
+          .run()
+      },
+    })
+    const publishedAt = new Date().toISOString()
+    await db
+      .update(projectVideos)
+      .set({
+        publishStatus: "published",
+        youtubeVideoId: uploaded.videoId,
+        youtubeUrl: uploaded.url,
+        youtubeUploadSessionUrl: null,
+        uploadError: null,
+        publishedAt,
+        updatedAt: publishedAt,
+      })
+      .where(eq(projectVideos.id, video.id))
+      .run()
+    await db
+      .update(youtubeChannelConnections)
+      .set({ lastUploadAt: publishedAt, lastError: null, updatedAt: publishedAt })
+      .where(eq(youtubeChannelConnections.id, connection.id))
+      .run()
+
+    if (video.linkedEntityType === "daily_log" && video.linkedEntityId) {
+      const [dailyLog] = await db
+        .select({ notes: dailyLogs.notes })
+        .from(dailyLogs)
+        .where(eq(dailyLogs.id, video.linkedEntityId))
+        .limit(1)
+      const shareUrl =
+        video.compassAudience === "staff"
+          ? `https://compass.openrangeconstruction.ltd/api/projects/${encodeURIComponent(input.projectId)}/videos/${encodeURIComponent(video.id)}`
+          : uploaded.url
+      const notes = [
+        dailyLog?.notes?.replace(
+          "The share link will appear here after publication.",
+          ""
+        ).trim(),
+        `Video: ${video.title}`,
+        shareUrl,
+      ]
+        .filter((value): value is string => Boolean(value))
+        .join("\n")
+      await db
+        .update(dailyLogs)
+        .set({
+          notes,
+          isClientVisible:
+            video.compassAudience === "owner" ||
+            video.compassAudience === "public",
+          syncStatus: "synced",
+          updatedAt: publishedAt,
+        })
+        .where(eq(dailyLogs.id, video.linkedEntityId))
+        .run()
+    }
+    await recordActivityEvent({
+      db,
+      organizationId,
+      projectId: input.projectId,
+      actor: {
+        id: user.id,
+        email: user.email,
+        displayName: user.displayName,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        role: user.role,
+      },
+      category: "file",
+      action: "project_video.published",
+      entityType: "project_video",
+      entityId: video.id,
+      summary: `Published “${video.title}” to ${connection.channelTitle}.`,
+      metadata: {
+        audience: video.compassAudience,
+        privacy: video.youtubePrivacy,
+        youtubeVideoId: uploaded.videoId,
+      },
+      createdAt: publishedAt,
+    })
+    revalidatePath(`/dashboard/projects/${input.projectId}/videos`)
+    revalidatePath(`/dashboard/projects/${input.projectId}/daily-logs`)
+    return { success: true }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Could not publish video."
+    if (db) {
+      const now = new Date().toISOString()
+      await db
+        .update(projectVideos)
+        .set({ publishStatus: "upload_failed", uploadError: message, updatedAt: now })
+        .where(eq(projectVideos.id, input.videoId))
+        .run()
+    }
+    return { success: false, error: message }
+  }
+}

--- a/src/app/api/google/youtube/callback/route.ts
+++ b/src/app/api/google/youtube/callback/route.ts
@@ -1,0 +1,169 @@
+import { and, eq } from "drizzle-orm"
+import { type NextRequest, NextResponse } from "next/server"
+
+import { getDb } from "@/db"
+import { youtubeChannelConnections } from "@/db/schema"
+import { getCurrentUser } from "@/lib/auth"
+import { encrypt } from "@/lib/crypto"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import { getGoogleAccountIdentity } from "@/lib/google/calendar/oauth"
+import {
+  exchangeYoutubeAuthorizationCode,
+  getAuthorizedYoutubeChannel,
+  getYoutubeOAuthConfig,
+  hasRequiredYoutubeScopes,
+  youtubeChannelKey,
+  youtubeTokenSalt,
+} from "@/lib/google/youtube"
+import { can } from "@/lib/permissions"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+const STATE_COOKIE = "compass_youtube_oauth_state"
+const CHANNEL_COOKIE = "compass_youtube_oauth_channel"
+const PROJECT_COOKIE = "compass_youtube_oauth_project"
+
+function redirectUrl(request: Request, projectId: string | null, status: string): URL {
+  const path = projectId
+    ? `/dashboard/projects/${encodeURIComponent(projectId)}/videos`
+    : "/dashboard/projects"
+  const url = new URL(path, request.url)
+  url.searchParams.set("youtube", status)
+  return url
+}
+
+function redirectAndClear(
+  request: NextRequest,
+  projectId: string | null,
+  status: string
+): NextResponse {
+  const response = NextResponse.redirect(redirectUrl(request, projectId, status))
+  response.cookies.set(STATE_COOKIE, "", {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+  })
+  response.cookies.set(CHANNEL_COOKIE, "", {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+  })
+  response.cookies.set(PROJECT_COOKIE, "", {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+  })
+  return response
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const projectId = request.cookies.get(PROJECT_COOKIE)?.value ?? null
+  const channelKey = youtubeChannelKey(
+    request.cookies.get(CHANNEL_COOKIE)?.value ?? null
+  )
+  const user = await getCurrentUser()
+  if (
+    !user ||
+    isDemoUser(user.id) ||
+    !isInternalStaffRole(user.role) ||
+    !can(user, "project", "update") ||
+    !user.organizationId ||
+    !channelKey
+  ) {
+    return redirectAndClear(request, projectId, "unauthorized")
+  }
+  const returnedState = request.nextUrl.searchParams.get("state")
+  const expectedState = request.cookies.get(STATE_COOKIE)?.value
+  if (!returnedState || !expectedState || returnedState !== expectedState) {
+    return redirectAndClear(request, projectId, "invalid-state")
+  }
+  if (request.nextUrl.searchParams.get("error")) {
+    return redirectAndClear(request, projectId, "cancelled")
+  }
+  const code = request.nextUrl.searchParams.get("code")
+  if (!code) return redirectAndClear(request, projectId, "missing-code")
+
+  try {
+    const { env } = await getCloudflareContext()
+    const config = getYoutubeOAuthConfig(env, request.url)
+    const db = getDb(env.DB)
+    const [existing] = await db
+      .select()
+      .from(youtubeChannelConnections)
+      .where(
+        and(
+          eq(youtubeChannelConnections.organizationId, user.organizationId),
+          eq(youtubeChannelConnections.channelKey, channelKey)
+        )
+      )
+      .limit(1)
+    const grant = await exchangeYoutubeAuthorizationCode({ config, code })
+    if (!hasRequiredYoutubeScopes(grant.scopes)) {
+      return redirectAndClear(request, projectId, "missing-scopes")
+    }
+    const identity = await getGoogleAccountIdentity(grant.accessToken)
+    if (!identity.emailVerified) {
+      return redirectAndClear(request, projectId, "email-not-verified")
+    }
+    const channel = await getAuthorizedYoutubeChannel(grant.accessToken)
+    const refreshTokenEncrypted = grant.refreshToken
+      ? await encrypt(
+          grant.refreshToken,
+          config.tokenEncryptionKey,
+          youtubeTokenSalt(user.organizationId, channelKey)
+        )
+      : existing?.refreshTokenEncrypted ?? null
+    if (!refreshTokenEncrypted) {
+      return redirectAndClear(request, projectId, "missing-refresh-token")
+    }
+    const now = new Date().toISOString()
+    await db
+      .insert(youtubeChannelConnections)
+      .values({
+        id: existing?.id ?? crypto.randomUUID(),
+        organizationId: user.organizationId,
+        channelKey,
+        channelId: channel.id,
+        channelTitle: channel.title,
+        googleAccountEmail: identity.email,
+        refreshTokenEncrypted,
+        grantedScopes: [...grant.scopes].sort().join(" "),
+        status: "connected",
+        connectedBy: user.id,
+        connectedAt: now,
+        lastUploadAt: existing?.lastUploadAt ?? null,
+        lastError: null,
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [
+          youtubeChannelConnections.organizationId,
+          youtubeChannelConnections.channelKey,
+        ],
+        set: {
+          channelId: channel.id,
+          channelTitle: channel.title,
+          googleAccountEmail: identity.email,
+          refreshTokenEncrypted,
+          grantedScopes: [...grant.scopes].sort().join(" "),
+          status: "connected",
+          connectedBy: user.id,
+          connectedAt: now,
+          lastError: null,
+          updatedAt: now,
+        },
+      })
+      .run()
+    return redirectAndClear(request, projectId, "connected")
+  } catch (error) {
+    console.error("YouTube channel connection failed", error)
+    return redirectAndClear(request, projectId, "error")
+  }
+}

--- a/src/app/api/google/youtube/connect/route.ts
+++ b/src/app/api/google/youtube/connect/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server"
+
+import { getCurrentUser } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import {
+  buildYoutubeAuthorizationUrl,
+  getYoutubeOAuthConfig,
+  youtubeChannelKey,
+} from "@/lib/google/youtube"
+import { can } from "@/lib/permissions"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+const STATE_COOKIE = "compass_youtube_oauth_state"
+const CHANNEL_COOKIE = "compass_youtube_oauth_channel"
+const PROJECT_COOKIE = "compass_youtube_oauth_project"
+
+function redirectUrl(request: Request, projectId: string | null, status: string): URL {
+  const path = projectId
+    ? `/dashboard/projects/${encodeURIComponent(projectId)}/videos`
+    : "/dashboard/projects"
+  const url = new URL(path, request.url)
+  url.searchParams.set("youtube", status)
+  return url
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const requestUrl = new URL(request.url)
+  const channelKey = youtubeChannelKey(requestUrl.searchParams.get("channel"))
+  const projectId = requestUrl.searchParams.get("project")
+  const user = await getCurrentUser()
+  if (
+    !user ||
+    isDemoUser(user.id) ||
+    !isInternalStaffRole(user.role) ||
+    !can(user, "project", "update") ||
+    !user.organizationId ||
+    !channelKey
+  ) {
+    return NextResponse.redirect(redirectUrl(request, projectId, "unauthorized"))
+  }
+
+  try {
+    const { env } = await getCloudflareContext()
+    const config = getYoutubeOAuthConfig(env, request.url)
+    const state = crypto.randomUUID()
+    const response = NextResponse.redirect(
+      buildYoutubeAuthorizationUrl({
+        config,
+        state,
+        loginHint: user.googleEmail ?? user.email,
+      })
+    )
+    response.cookies.set(STATE_COOKIE, state, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: 10 * 60,
+    })
+    response.cookies.set(CHANNEL_COOKIE, channelKey, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: 10 * 60,
+    })
+    if (projectId) {
+      response.cookies.set(PROJECT_COOKIE, projectId, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        path: "/",
+        maxAge: 10 * 60,
+      })
+    }
+    return response
+  } catch {
+    return NextResponse.redirect(redirectUrl(request, projectId, "not-configured"))
+  }
+}

--- a/src/app/api/projects/[id]/videos/[videoId]/route.ts
+++ b/src/app/api/projects/[id]/videos/[videoId]/route.ts
@@ -1,0 +1,115 @@
+import { and, eq } from "drizzle-orm"
+import { type NextRequest } from "next/server"
+
+import { getDb } from "@/db"
+import { projectMembers, projectVideos } from "@/db/schema"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { downloadProjectVideoFile } from "@/lib/email/project-video-attachments"
+import {
+  canUseProjectAudience,
+  type ProjectAudience,
+} from "@/lib/project-audience-access"
+import { assertProjectAccess } from "@/lib/project-access"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+function audienceValue(value: string | null): ProjectAudience | null {
+  if (value === "owner" || value === "sub_vendor") return value
+  return null
+}
+
+function safeFileName(value: string): string {
+  return value.replace(/["\r\n]/g, "_")
+}
+
+export async function GET(
+  request: NextRequest,
+  {
+    params,
+  }: {
+    readonly params: Promise<{
+      readonly id: string
+      readonly videoId: string
+    }>
+  }
+): Promise<Response> {
+  try {
+    const user = await requireAuth()
+    const { id: projectId, videoId } = await params
+    const requestedAudience = audienceValue(
+      request.nextUrl.searchParams.get("audience")
+    )
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const project = await assertProjectAccess(db, user, projectId)
+    if (!project.organizationId) {
+      return new Response("Video not found", { status: 404 })
+    }
+    const internal = isInternalStaffRole(user.role)
+    if (!internal) {
+      if (!requestedAudience) {
+        return new Response("Video not found", { status: 404 })
+      }
+      const [membership] = await db
+        .select({ role: projectMembers.role })
+        .from(projectMembers)
+        .where(
+          and(
+            eq(projectMembers.projectId, projectId),
+            eq(projectMembers.userId, user.id)
+          )
+        )
+        .limit(1)
+      if (!canUseProjectAudience(membership?.role ?? null, requestedAudience)) {
+        return new Response("Video not found", { status: 404 })
+      }
+    }
+    const [video] = await db
+      .select({
+        driveFileId: projectVideos.driveFileId,
+        fileName: projectVideos.sourceFileName,
+        mimeType: projectVideos.sourceMimeType,
+        audience: projectVideos.compassAudience,
+        publishStatus: projectVideos.publishStatus,
+      })
+      .from(projectVideos)
+      .where(
+        and(
+          eq(projectVideos.id, videoId),
+          eq(projectVideos.projectId, projectId)
+        )
+      )
+      .limit(1)
+    const allowedExternally =
+      video?.publishStatus === "published" &&
+      (video.audience === requestedAudience || video.audience === "public")
+    if (!video || (!internal && !allowedExternally)) {
+      return new Response("Video not found", { status: 404 })
+    }
+    const response = await downloadProjectVideoFile({
+      env,
+      db,
+      organizationId: project.organizationId,
+      driveFileId: video.driveFileId,
+      range: request.headers.get("range") ?? undefined,
+    })
+    const responseHeaders: Record<string, string> = {
+      "Content-Type": video.mimeType,
+      "Content-Disposition": `inline; filename="${safeFileName(video.fileName)}"`,
+      "Cache-Control": "private, max-age=300",
+      "X-Content-Type-Options": "nosniff",
+      "Accept-Ranges": response.headers.get("Accept-Ranges") ?? "bytes",
+    }
+    const contentRange = response.headers.get("Content-Range")
+    const contentLength = response.headers.get("Content-Length")
+    if (contentRange) responseHeaders["Content-Range"] = contentRange
+    if (contentLength) responseHeaders["Content-Length"] = contentLength
+    return new Response(response.body, {
+      status: response.status,
+      headers: responseHeaders,
+    })
+  } catch (error) {
+    console.error("Project video stream failed", error)
+    return new Response("Video could not be loaded", { status: 500 })
+  }
+}

--- a/src/app/dashboard/projects/[id]/videos/page.tsx
+++ b/src/app/dashboard/projects/[id]/videos/page.tsx
@@ -1,0 +1,30 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+import { notFound } from "next/navigation"
+
+import { getProjectVideoWorkspace } from "@/app/actions/project-videos"
+import { ProjectVideoReview } from "@/components/projects/project-video-review"
+import { redirectIfFeaturePermissionDenied } from "@/lib/permission-redirect"
+
+function hasDigest(error: unknown): error is { readonly digest: string } {
+  return typeof error === "object" && error !== null && "digest" in error
+}
+
+export default async function ProjectVideosPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  let workspace: Awaited<ReturnType<typeof getProjectVideoWorkspace>>
+  try {
+    workspace = await getProjectVideoWorkspace(id)
+  } catch (error) {
+    if (hasDigest(error)) throw error
+    redirectIfFeaturePermissionDenied(error)
+    if (error instanceof Error && error.message === "Project not found") notFound()
+    throw error
+  }
+  return <ProjectVideoReview workspace={workspace} />
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -22,6 +22,7 @@ import {
   IconReceipt,
   IconShoppingCart,
   IconShoppingCartQuestion,
+  IconVideo,
 } from "@tabler/icons-react"
 import { usePathname } from "next/navigation"
 
@@ -96,6 +97,12 @@ const NAV_MAIN = [
     url: "/dashboard/projects",
     icon: IconPhoto,
     projectPath: "/photos",
+  },
+  {
+    title: "Videos",
+    url: "/dashboard/projects",
+    icon: IconVideo,
+    projectPath: "/videos",
   },
   {
     title: "Selections",

--- a/src/components/nav-projects.tsx
+++ b/src/components/nav-projects.tsx
@@ -20,6 +20,7 @@ import {
   IconShoppingCart,
   IconShoppingCartQuestion,
   IconUsers,
+  IconVideo,
 } from "@tabler/icons-react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
@@ -44,6 +45,7 @@ type ProjectSectionKey =
   | "owner-updates"
   | "daily-logs"
   | "photos"
+  | "videos"
   | "selections"
   | "rfis"
   | "rfqs"
@@ -105,6 +107,12 @@ const PROJECT_SECTION_ITEMS: readonly ProjectSectionItem[] = [
     hrefSuffix: "photos",
     icon: IconPhoto,
     section: "photos",
+  },
+  {
+    title: "Videos",
+    hrefSuffix: "videos",
+    icon: IconVideo,
+    section: "videos",
   },
   {
     title: "Selections",
@@ -217,6 +225,7 @@ function activeProjectSection(pathname: string | null): ProjectSectionKey {
     case "estimate":
     case "owner-updates":
     case "photos":
+    case "videos":
     case "selections":
     case "purchase-orders":
     case "rfqs":

--- a/src/components/projects/project-video-review.tsx
+++ b/src/components/projects/project-video-review.tsx
@@ -1,0 +1,367 @@
+"use client"
+
+import * as React from "react"
+import {
+  IconArchive,
+  IconBrandYoutube,
+  IconExternalLink,
+  IconTrash,
+  IconVideo,
+} from "@tabler/icons-react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+
+import {
+  archiveProjectVideo,
+  deleteProjectVideo,
+  publishProjectVideo,
+  updateProjectVideoReview,
+  type ProjectVideoItem,
+  type ProjectVideoWorkspace,
+} from "@/app/actions/project-videos"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+
+const CHANNELS = [
+  { key: "orc", label: "ORC / Design" },
+  { key: "hps", label: "HPS" },
+  { key: "nutech", label: "Nu-Tech" },
+] as const
+
+function formatBytes(value: number): string {
+  if (value < 1024 * 1024) return `${Math.ceil(value / 1024)} KB`
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function statusLabel(value: string): string {
+  return value
+    .split("_")
+    .map((word) => `${word.slice(0, 1).toUpperCase()}${word.slice(1)}`)
+    .join(" ")
+}
+
+function audiencePrivacy(value: string): string {
+  if (value === "public") return "Public on YouTube"
+  if (value === "owner" || value === "sub_vendor") {
+    return "Unlisted on YouTube — anyone with the link can forward it"
+  }
+  return "Private on YouTube"
+}
+
+function VideoReviewCard({
+  projectId,
+  video,
+  channelConnected,
+}: {
+  readonly projectId: string
+  readonly video: ProjectVideoItem
+  readonly channelConnected: boolean
+}): React.ReactElement {
+  const router = useRouter()
+  const [title, setTitle] = React.useState(video.title)
+  const [description, setDescription] = React.useState(video.description ?? "")
+  const [audience, setAudience] = React.useState(video.compassAudience)
+  const [confirmPublic, setConfirmPublic] = React.useState(false)
+  const [pending, startTransition] = React.useTransition()
+
+  function run(
+    action: () => Promise<{ readonly success: boolean; readonly error?: string }>,
+    successMessage: string
+  ): void {
+    startTransition(async () => {
+      const result = await action()
+      if (!result.success) {
+        toast.error(result.error ?? "Compass could not update the video.")
+        return
+      }
+      toast.success(successMessage)
+      router.refresh()
+    })
+  }
+
+  return (
+    <article className="border-border border-b py-6 first:pt-0 last:border-b-0">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline">{statusLabel(video.publishStatus)}</Badge>
+            <Badge variant="secondary">{video.youtubeChannelKey.toUpperCase()}</Badge>
+            <span className="text-muted-foreground text-xs">
+              {formatBytes(video.sourceFileSize)} · {video.sourceFileName}
+            </span>
+          </div>
+          <p className="text-muted-foreground mt-2 text-sm">
+            Submitted by {video.submittedByName ?? "project contact"} ·{" "}
+            {new Date(video.createdAt).toLocaleString()}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {video.driveUrl && (
+            <Button asChild size="sm" variant="outline">
+              <Link href={video.driveUrl} target="_blank" rel="noreferrer">
+                Review source <IconExternalLink />
+              </Link>
+            </Button>
+          )}
+          {video.youtubeUrl && (
+            <Button asChild size="sm">
+              <Link
+                href={
+                  video.compassAudience === "staff"
+                    ? `/api/projects/${encodeURIComponent(projectId)}/videos/${encodeURIComponent(video.id)}`
+                    : video.youtubeUrl
+                }
+                target="_blank"
+                rel="noreferrer"
+              >
+                Watch <IconBrandYoutube />
+              </Link>
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_18rem]">
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor={`video-title-${video.id}`}>YouTube title</Label>
+            <Input
+              id={`video-title-${video.id}`}
+              value={title}
+              maxLength={100}
+              onChange={(event) => setTitle(event.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={`video-description-${video.id}`}>Description</Label>
+            <Textarea
+              id={`video-description-${video.id}`}
+              value={description}
+              maxLength={5000}
+              rows={4}
+              onChange={(event) => setDescription(event.target.value)}
+            />
+          </div>
+        </div>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>Who may receive the link?</Label>
+            <Select value={audience} onValueChange={setAudience}>
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="staff">Staff only</SelectItem>
+                <SelectItem value="owner">Owner</SelectItem>
+                <SelectItem value="sub_vendor">Subs / suppliers</SelectItem>
+                <SelectItem value="public">Public</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-muted-foreground text-xs">
+              {audiencePrivacy(audience)}
+            </p>
+          </div>
+          <div className="bg-muted/45 px-3 py-2 text-sm">
+            Linked to the Daily Log created from this message. The final link is
+            added there after publication.
+          </div>
+          {audience === "public" && (
+            <label className="flex items-start gap-2 text-sm">
+              <Checkbox
+                checked={confirmPublic}
+                onCheckedChange={(checked) => setConfirmPublic(checked === true)}
+              />
+              <span>I confirm this video is approved for public viewing.</span>
+            </label>
+          )}
+        </div>
+      </div>
+
+      {video.uploadError && (
+        <p className="text-destructive mt-4 text-sm">{video.uploadError}</p>
+      )}
+      <div className="mt-5 flex flex-wrap justify-between gap-3">
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            disabled={pending}
+            onClick={() =>
+              run(
+                () => archiveProjectVideo({ projectId, videoId: video.id }),
+                "Video archived."
+              )
+            }
+          >
+            <IconArchive /> Archive
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            disabled={pending}
+            onClick={() => {
+              if (!window.confirm("Delete this video record from Compass?")) return
+              run(
+                () => deleteProjectVideo({ projectId, videoId: video.id }),
+                "Video deleted."
+              )
+            }}
+          >
+            <IconTrash /> Delete
+          </Button>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={pending || video.publishStatus === "published"}
+            onClick={() =>
+              run(
+                () =>
+                  updateProjectVideoReview({
+                    projectId,
+                    videoId: video.id,
+                    title,
+                    description,
+                    compassAudience: audience,
+                  }),
+                "Video review saved."
+              )
+            }
+          >
+            Save review
+          </Button>
+          <Button
+            type="button"
+            disabled={
+              pending ||
+              video.publishStatus === "published" ||
+              !channelConnected ||
+              (audience === "public" && !confirmPublic)
+            }
+            onClick={() =>
+              run(
+                async () => {
+                  const reviewed = await updateProjectVideoReview({
+                    projectId,
+                    videoId: video.id,
+                    title,
+                    description,
+                    compassAudience: audience,
+                  })
+                  if (!reviewed.success) return reviewed
+                  return publishProjectVideo({
+                    projectId,
+                    videoId: video.id,
+                    confirmPublic,
+                  })
+                },
+                "Video published and linked in Compass."
+              )
+            }
+          >
+            <IconBrandYoutube /> Publish
+          </Button>
+        </div>
+      </div>
+      {!channelConnected && (
+        <p className="text-muted-foreground mt-2 text-right text-xs">
+          Connect the {video.youtubeChannelKey.toUpperCase()} channel before publishing.
+        </p>
+      )}
+    </article>
+  )
+}
+
+export function ProjectVideoReview({
+  workspace,
+}: {
+  readonly workspace: ProjectVideoWorkspace
+}): React.ReactElement {
+  const connectedKeys = new Set(
+    workspace.channels
+      .filter((channel) => channel.status === "connected")
+      .map((channel) => channel.channelKey)
+  )
+
+  return (
+    <main className="mx-auto w-full max-w-6xl px-4 py-6 md:px-8">
+      <div className="flex flex-wrap items-end justify-between gap-4 border-b pb-5">
+        <div>
+          <p className="text-muted-foreground text-sm">
+            {workspace.project.projectNumber ?? workspace.project.name}
+          </p>
+          <h1 className="mt-1 flex items-center gap-2 text-2xl font-semibold">
+            <IconVideo /> Project videos
+          </h1>
+          <p className="text-muted-foreground mt-1 max-w-2xl text-sm">
+            Review videos received by text, control their audience, and publish
+            them to the correct company YouTube channel.
+          </p>
+        </div>
+      </div>
+
+      <section className="border-border mt-5 border-b pb-5">
+        <h2 className="text-sm font-semibold">YouTube channels</h2>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {CHANNELS.map((channel) => {
+            const connection = workspace.channels.find(
+              (item) => item.channelKey === channel.key && item.status === "connected"
+            )
+            return (
+              <Button key={channel.key} asChild size="sm" variant="outline">
+                <Link
+                  href={
+                    `/api/google/youtube/connect?channel=${channel.key}` +
+                    `&project=${encodeURIComponent(workspace.project.id)}`
+                  }
+                >
+                  <IconBrandYoutube />
+                  {connection
+                    ? `${channel.label}: ${connection.channelTitle}`
+                    : `Connect ${channel.label}`}
+                </Link>
+              </Button>
+            )
+          })}
+        </div>
+      </section>
+
+      <section className="mt-6">
+        {workspace.videos.length === 0 ? (
+          <div className="border-border flex min-h-56 flex-col items-center justify-center border border-dashed px-6 text-center">
+            <IconVideo className="text-muted-foreground size-8" />
+            <h2 className="mt-3 font-medium">No project videos yet</h2>
+            <p className="text-muted-foreground mt-1 max-w-lg text-sm">
+              Text a video to the project with a subject or first line such as
+              [Video] Railing stain demonstration.
+            </p>
+          </div>
+        ) : (
+          workspace.videos.map((video) => (
+            <VideoReviewCard
+              key={video.id}
+              projectId={workspace.project.id}
+              video={video}
+              channelConnected={connectedKeys.has(video.youtubeChannelKey)}
+            />
+          ))
+        )}
+      </section>
+    </main>
+  )
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -604,6 +604,112 @@ export const gotoInboundSettings = sqliteTable(
 export type GotoInboundSetting = typeof gotoInboundSettings.$inferSelect
 export type NewGotoInboundSetting = typeof gotoInboundSettings.$inferInsert
 
+export const projectVideos = sqliteTable(
+  "project_videos",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    title: text("title").notNull(),
+    description: text("description"),
+    department: text("department").notNull(),
+    youtubeChannelKey: text("youtube_channel_key").notNull(),
+    compassAudience: text("compass_audience").notNull().default("staff"),
+    youtubePrivacy: text("youtube_privacy").notNull().default("private"),
+    publishStatus: text("publish_status").notNull().default("pending_review"),
+    sourceSystem: text("source_system").notNull(),
+    sourceExternalId: text("source_external_id").notNull(),
+    sourceFileName: text("source_file_name").notNull(),
+    sourceMimeType: text("source_mime_type").notNull(),
+    sourceFileSize: integer("source_file_size").notNull().default(0),
+    driveFileId: text("drive_file_id").notNull(),
+    driveUrl: text("drive_url"),
+    linkedEntityType: text("linked_entity_type"),
+    linkedEntityId: text("linked_entity_id"),
+    youtubeVideoId: text("youtube_video_id"),
+    youtubeUrl: text("youtube_url"),
+    youtubeUploadSessionUrl: text("youtube_upload_session_url"),
+    uploadError: text("upload_error"),
+    submittedByName: text("submitted_by_name"),
+    submittedByEmail: text("submitted_by_email"),
+    reviewedBy: text("reviewed_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    reviewedAt: text("reviewed_at"),
+    publishedAt: text("published_at"),
+    archivedAt: text("archived_at"),
+    deletedAt: text("deleted_at"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("project_videos_source_unique").on(
+      table.sourceSystem,
+      table.sourceExternalId
+    ),
+    index("project_videos_project_created_idx").on(
+      table.projectId,
+      table.createdAt
+    ),
+    index("project_videos_org_status_idx").on(
+      table.organizationId,
+      table.publishStatus,
+      table.createdAt
+    ),
+  ]
+)
+
+export type ProjectVideo = typeof projectVideos.$inferSelect
+export type NewProjectVideo = typeof projectVideos.$inferInsert
+
+export const youtubeChannelConnections = sqliteTable(
+  "youtube_channel_connections",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    channelKey: text("channel_key").notNull(),
+    channelId: text("channel_id").notNull(),
+    channelTitle: text("channel_title").notNull(),
+    googleAccountEmail: text("google_account_email").notNull(),
+    refreshTokenEncrypted: text("refresh_token_encrypted").notNull(),
+    grantedScopes: text("granted_scopes").notNull(),
+    status: text("status").notNull().default("connected"),
+    connectedBy: text("connected_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    connectedAt: text("connected_at").notNull(),
+    lastUploadAt: text("last_upload_at"),
+    lastError: text("last_error"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("youtube_channel_connections_org_key_unique").on(
+      table.organizationId,
+      table.channelKey
+    ),
+    uniqueIndex("youtube_channel_connections_org_channel_unique").on(
+      table.organizationId,
+      table.channelId
+    ),
+    index("youtube_channel_connections_org_status_idx").on(
+      table.organizationId,
+      table.status
+    ),
+  ]
+)
+
+export type YoutubeChannelConnection =
+  typeof youtubeChannelConnections.$inferSelect
+export type NewYoutubeChannelConnection =
+  typeof youtubeChannelConnections.$inferInsert
+
 export const scheduleSavedViews = sqliteTable(
   "schedule_saved_views",
   {

--- a/src/lib/email/__tests__/project-address.test.ts
+++ b/src/lib/email/__tests__/project-address.test.ts
@@ -27,6 +27,7 @@ describe("project inbound email addressing", () => {
     ["[DELIVERY] Windows arriving Friday", "delivery"],
     ["[DAILY LOG] Site progress", "daily_log"],
     ["[Daily Log] Site progress", "daily_log"],
+    ["[VIDEO] Railing stain demonstration", "video"],
   ] as const)("routes %s", (subject, destination) => {
     expect(projectEmailDestination(subject)).toBe(destination)
   })
@@ -38,6 +39,12 @@ describe("project inbound email addressing", () => {
   it("removes the routing tag from the record title", () => {
     expect(projectEmailTitle("[RFI] Missing roof detail")).toBe(
       "Missing roof detail"
+    )
+  })
+
+  it("removes the video routing tag from the record title", () => {
+    expect(projectEmailTitle("[Video] Railing stain demonstration")).toBe(
+      "Railing stain demonstration"
     )
   })
 })

--- a/src/lib/email/project-address.ts
+++ b/src/lib/email/project-address.ts
@@ -8,6 +8,7 @@ export const PROJECT_EMAIL_SUBJECT_TAGS = [
   { tag: "[TO-DO]", destination: "To-Do" },
   { tag: "[DELIVERY]", destination: "Delivery To-Do" },
   { tag: "[DAILY LOG]", destination: "Daily Log" },
+  { tag: "[VIDEO]", destination: "Project Video" },
 ] as const
 
 export type ProjectEmailDestination =
@@ -17,6 +18,7 @@ export type ProjectEmailDestination =
   | "todo"
   | "delivery"
   | "daily_log"
+  | "video"
 
 function splitEmailAddress(email: string): {
   readonly localPart: string
@@ -57,11 +59,12 @@ export function projectEmailDestination(
   if (/^\[(?:daily log|daily-log|log)\](?:\s|:|-|$)/i.test(normalized)) {
     return "daily_log"
   }
+  if (/^\[video\](?:\s|:|-|$)/i.test(normalized)) return "video"
   return null
 }
 
 export function projectEmailTitle(subject: string): string {
   return subject
-    .replace(/^\[(?:rfi|rfq|change order|to-do|todo|task|delivery|daily log|daily-log|log)\]\s*(?::|-)?\s*/i, "")
+    .replace(/^\[(?:rfi|rfq|change order|to-do|todo|task|delivery|daily log|daily-log|log|video)\]\s*(?::|-)?\s*/i, "")
     .trim()
 }

--- a/src/lib/email/project-inbound-routing.ts
+++ b/src/lib/email/project-inbound-routing.ts
@@ -13,6 +13,7 @@ import {
   projectChangeOrders,
   projectOperations,
   projectRfis,
+  projectVideos,
   projects,
   users,
 } from "@/db/schema"
@@ -31,6 +32,8 @@ import {
   trustedInternalEmailDomains,
 } from "@/lib/email/internal-email-alias"
 import { storeDailyLogEmailAttachments } from "@/lib/email/project-email-attachments"
+import { storeProjectVideoAttachment } from "@/lib/email/project-video-attachments"
+import { projectDepartment } from "@/lib/project-branding"
 import { PROJECT_TODO_RECORD_TYPES } from "@/lib/project-todos"
 
 type Db = ReturnType<typeof getDb>
@@ -66,6 +69,7 @@ export type ProjectInboundRouteResult =
         | "routed_daily_log"
         | "routed_rfq"
         | "routed_change_order"
+        | "routed_video"
     }
 
 function candidateBody(candidate: InboundCandidate): string {
@@ -118,6 +122,7 @@ function destinationLabel(destination: ProjectEmailDestination): string {
   if (destination === "change_order") return "change-order draft"
   if (destination === "delivery") return "delivery to-do"
   if (destination === "todo") return "to-do"
+  if (destination === "video") return "video review"
   return "daily log"
 }
 
@@ -126,6 +131,7 @@ function destinationEntityType(destination: ProjectEmailDestination): string {
   if (destination === "rfq") return "rfq"
   if (destination === "change_order") return "change_order"
   if (destination === "daily_log") return "daily_log"
+  if (destination === "video") return "project_video"
   return "todo"
 }
 
@@ -483,6 +489,131 @@ async function routeDailyLog(input: {
   return { id, status: "routed_daily_log" }
 }
 
+function isVideoAttachment(attachment: InboundCandidate["attachments"][number]): boolean {
+  return (
+    attachment.mimeType.startsWith("video/") ||
+    /\.(?:3gp|m4v|mov|mp4|webm)$/i.test(attachment.fileName)
+  )
+}
+
+function youtubeChannelForDepartment(
+  department: "O" | "H" | "N" | "D"
+): "orc" | "hps" | "nutech" {
+  if (department === "H") return "hps"
+  if (department === "N") return "nutech"
+  return "orc"
+}
+
+async function routeVideo(input: {
+  readonly env: unknown
+  readonly db: Db
+  readonly organizationId: string
+  readonly projectId: string
+  readonly projectNumber: string | null
+  readonly candidate: InboundCandidate
+  readonly now: string
+  readonly source: ProjectInboundSource
+}): Promise<{ readonly id: string; readonly status: "routed_video" }> {
+  const attachment = input.candidate.attachments.find(isVideoAttachment)
+  if (!attachment) {
+    throw new Error("A [Video] message must include a video attachment.")
+  }
+  const sourceExternalId =
+    `${input.candidate.gmailMessageId}:` +
+    (attachment.attachmentId ?? attachment.fileName)
+  const [existing] = await input.db
+    .select({ id: projectVideos.id })
+    .from(projectVideos)
+    .where(
+      and(
+        eq(projectVideos.sourceSystem, input.source.sourceSystem),
+        eq(projectVideos.sourceExternalId, sourceExternalId)
+      )
+    )
+    .limit(1)
+  if (existing) return { id: existing.id, status: "routed_video" }
+
+  const stored = await storeProjectVideoAttachment({
+    env: input.env,
+    db: input.db,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    attachment,
+  })
+  const department = projectDepartment({
+    projectId: input.projectId,
+    projectNumber: input.projectNumber,
+  })
+  const id = `${input.source.idPrefix}-video-${input.candidate.gmailMessageId}`
+  const dailyLogId =
+    `${input.source.idPrefix}-video-log-${input.candidate.gmailMessageId}`
+  const title =
+    projectEmailTitle(input.candidate.subject) ||
+    attachment.fileName.replace(/\.[^.]+$/, "") ||
+    "Project video"
+  const videoInsert = input.db.insert(projectVideos).values({
+    id,
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    title,
+    description: candidateBody(input.candidate),
+    department,
+    youtubeChannelKey: youtubeChannelForDepartment(department),
+    compassAudience: "staff",
+    youtubePrivacy: "private",
+    publishStatus: "pending_review",
+    sourceSystem: input.source.sourceSystem,
+    sourceExternalId,
+    sourceFileName: stored.fileName,
+    sourceMimeType: stored.mimeType,
+    sourceFileSize: stored.fileSize,
+    driveFileId: stored.driveFileId,
+    driveUrl: stored.driveUrl,
+    linkedEntityType: "daily_log",
+    linkedEntityId: dailyLogId,
+    youtubeVideoId: null,
+    youtubeUrl: null,
+    youtubeUploadSessionUrl: null,
+    uploadError: null,
+    submittedByName: senderLabel(input.candidate),
+    submittedByEmail: input.candidate.fromAddress,
+    reviewedBy: null,
+    reviewedAt: null,
+    publishedAt: null,
+    archivedAt: null,
+    deletedAt: null,
+    createdAt: input.now,
+    updatedAt: input.now,
+  }).onConflictDoNothing({
+    target: [projectVideos.sourceSystem, projectVideos.sourceExternalId],
+  })
+
+  const dailyLogInsert = input.db
+    .insert(dailyLogs)
+    .values({
+      id: dailyLogId,
+      projectId: input.projectId,
+      authorId: null,
+      sourceSystem: input.source.sourceSystem,
+      sourceExternalId: `${input.candidate.gmailMessageId}:video`,
+      logDate: input.candidate.receivedAt.slice(0, 10),
+      workCompleted: title,
+      notes:
+        `Video submitted by ${senderLabel(input.candidate)} for staff review. ` +
+        "The share link will appear here after publication.",
+      isClientVisible: false,
+      reviewStatus: "needs_review",
+      syncStatus: "pending",
+      createdAt: input.now,
+      updatedAt: input.now,
+    })
+    .onConflictDoNothing({ target: dailyLogs.id })
+
+  await input.db.batch([videoInsert, dailyLogInsert])
+
+  return { id, status: "routed_video" }
+}
+
 async function routeDestination(input: {
   readonly env: unknown
   readonly db: Db
@@ -501,6 +632,7 @@ async function routeDestination(input: {
     | "routed_daily_log"
     | "routed_rfq"
     | "routed_change_order"
+    | "routed_video"
 }> {
   if (input.destination === "rfi") return routeRfi(input)
   if (input.destination === "rfq") return routeRfq(input)
@@ -509,6 +641,7 @@ async function routeDestination(input: {
   if (input.destination === "delivery") {
     return routeTodo({ ...input, delivery: true })
   }
+  if (input.destination === "video") return routeVideo(input)
   return routeDailyLog(input)
 }
 

--- a/src/lib/email/project-video-attachments.ts
+++ b/src/lib/email/project-video-attachments.ts
@@ -1,0 +1,218 @@
+import "server-only"
+
+import { and, eq } from "drizzle-orm"
+
+import type { getDb } from "@/db"
+import { projectExternalLinks, projects } from "@/db/schema"
+import { googleAuth } from "@/db/schema-google"
+import { decrypt } from "@/lib/crypto"
+import type { InboundAttachment } from "@/lib/email/gmail-message-parser"
+import { DriveClient } from "@/lib/google/client/drive-client"
+import {
+  getGoogleConfig,
+  getGoogleCryptoSalt,
+  parseServiceAccountKey,
+} from "@/lib/google/config"
+import { MAX_PHOTO_UPLOAD_FILE_BYTES } from "@/lib/photos/upload-limits"
+
+const GOOGLE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
+const VIDEO_FOLDER_NAME = "Videos"
+const DEFAULT_COMPASS_GOOGLE_UPLOAD_USER = "compass@hps-colorado.com"
+
+type Db = ReturnType<typeof getDb>
+
+export type StoredProjectVideoFile = {
+  readonly driveFileId: string
+  readonly driveUrl: string | null
+  readonly fileName: string
+  readonly fileSize: number
+  readonly mimeType: string
+}
+
+async function driveClient(input: {
+  readonly env: unknown
+  readonly db: Db
+  readonly organizationId: string
+}): Promise<{
+  readonly client: DriveClient
+  readonly googleEmail: string
+  readonly sharedDriveId: string | null
+}> {
+  const [auth] = await input.db
+    .select()
+    .from(googleAuth)
+    .where(eq(googleAuth.organizationId, input.organizationId))
+    .limit(1)
+  if (!auth) throw new Error("Google Drive is not connected.")
+
+  const config = getGoogleConfig(input.env)
+  const keyJson = await decrypt(
+    auth.serviceAccountKeyEncrypted,
+    config.encryptionKey,
+    getGoogleCryptoSalt()
+  )
+  return {
+    client: new DriveClient({
+      serviceAccountKey: parseServiceAccountKey(keyJson),
+    }),
+    googleEmail:
+      envString(input.env, "COMPASS_GOOGLE_UPLOAD_USER") ??
+      DEFAULT_COMPASS_GOOGLE_UPLOAD_USER,
+    sharedDriveId: auth.sharedDriveId,
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function envString(env: unknown, key: string): string | null {
+  if (!isRecord(env)) return process.env[key] ?? null
+  const value = env[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : process.env[key] ?? null
+}
+
+function safeFileName(value: string): string {
+  const normalized = value.replace(/[/:\\]/g, "-").trim()
+  return normalized.length > 0 ? normalized : "project-video"
+}
+
+function driveFolderIdFromUrl(value: string | null): string | null {
+  if (!value) return null
+  return (
+    value.match(/\/folders\/([^/?#]+)/)?.[1] ??
+    value.match(/[?&]id=([^&#]+)/)?.[1] ??
+    null
+  )
+}
+
+function escapeDriveQueryValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")
+}
+
+async function projectFolder(input: {
+  readonly db: Db
+  readonly projectId: string
+}): Promise<string> {
+  const [project] = await input.db
+    .select({ googleDriveFolderId: projects.googleDriveFolderId })
+    .from(projects)
+    .where(eq(projects.id, input.projectId))
+    .limit(1)
+  const [driveLink] = await input.db
+    .select({
+      externalId: projectExternalLinks.externalId,
+      externalUrl: projectExternalLinks.externalUrl,
+    })
+    .from(projectExternalLinks)
+    .where(
+      and(
+        eq(projectExternalLinks.projectId, input.projectId),
+        eq(projectExternalLinks.system, "google_drive")
+      )
+    )
+    .limit(1)
+  const folderId =
+    project?.googleDriveFolderId ??
+    driveLink?.externalId ??
+    driveFolderIdFromUrl(driveLink?.externalUrl ?? null)
+  if (!folderId) {
+    throw new Error("Map this project to Google Drive before submitting videos.")
+  }
+  return folderId
+}
+
+async function resolveVideoFolder(input: {
+  readonly client: DriveClient
+  readonly googleEmail: string
+  readonly projectFolderId: string
+  readonly sharedDriveId: string | null
+}): Promise<string> {
+  const result = await input.client.listFiles(input.googleEmail, {
+    folderId: input.projectFolderId,
+    driveId: input.sharedDriveId ?? undefined,
+    pageSize: 10,
+    query:
+      `mimeType = '${GOOGLE_FOLDER_MIME_TYPE}' and ` +
+      `name = '${escapeDriveQueryValue(VIDEO_FOLDER_NAME)}'`,
+  })
+  const existing = result.files[0]
+  if (existing) return existing.id
+
+  const folder = await input.client.createFolder(input.googleEmail, {
+    name: VIDEO_FOLDER_NAME,
+    parentId: input.projectFolderId,
+    driveId: input.sharedDriveId ?? undefined,
+  })
+  return folder.id
+}
+
+export async function storeProjectVideoAttachment(input: {
+  readonly env: unknown
+  readonly db: Db
+  readonly organizationId: string
+  readonly projectId: string
+  readonly attachment: InboundAttachment
+}): Promise<StoredProjectVideoFile> {
+  const data = input.attachment.data
+  if (!data) throw new Error(`Video data is missing for ${input.attachment.fileName}.`)
+  if (data.byteLength > MAX_PHOTO_UPLOAD_FILE_BYTES) {
+    throw new Error(`${input.attachment.fileName} exceeds the 50 MB text-video limit.`)
+  }
+
+  const projectFolderId = await projectFolder({
+    db: input.db,
+    projectId: input.projectId,
+  })
+  const drive = await driveClient({
+    env: input.env,
+    db: input.db,
+    organizationId: input.organizationId,
+  })
+  const videoFolderId = await resolveVideoFolder({
+    client: drive.client,
+    googleEmail: drive.googleEmail,
+    projectFolderId,
+    sharedDriveId: drive.sharedDriveId,
+  })
+  const fileName = safeFileName(input.attachment.fileName)
+  const mimeType = input.attachment.mimeType.startsWith("video/")
+    ? input.attachment.mimeType
+    : "video/mp4"
+  const file = await drive.client.uploadFile(drive.googleEmail, {
+    name: fileName,
+    mimeType,
+    parentId: videoFolderId,
+    driveId: drive.sharedDriveId ?? undefined,
+    data: new Blob([data.slice().buffer], { type: mimeType }),
+  })
+
+  return {
+    driveFileId: file.id,
+    driveUrl: file.webViewLink ?? null,
+    fileName: file.name,
+    fileSize: Number(file.size ?? data.byteLength),
+    mimeType: file.mimeType,
+  }
+}
+
+export async function downloadProjectVideoFile(input: {
+  readonly env: unknown
+  readonly db: Db
+  readonly organizationId: string
+  readonly driveFileId: string
+  readonly range?: string
+}): Promise<Response> {
+  const drive = await driveClient(input)
+  const response = await drive.client.downloadFile(
+    drive.googleEmail,
+    input.driveFileId,
+    { range: input.range }
+  )
+  if (!response.ok) {
+    throw new Error(`Could not download the staged video (${response.status}).`)
+  }
+  return response
+}

--- a/src/lib/google/client/drive-client.ts
+++ b/src/lib/google/client/drive-client.ts
@@ -298,7 +298,8 @@ export class DriveClient {
 
   async downloadFile(
     userEmail: string,
-    fileId: string
+    fileId: string,
+    options?: { readonly range?: string }
   ): Promise<Response> {
     const token = await this.getToken(userEmail)
     const params = new URLSearchParams({
@@ -306,10 +307,14 @@ export class DriveClient {
       supportsAllDrives: "true",
     })
 
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+    }
+    if (options?.range) headers.Range = options.range
     return fetch(
       `${GOOGLE_DRIVE_API}/files/${fileId}?${params.toString()}`,
       {
-        headers: { Authorization: `Bearer ${token}` },
+        headers,
       }
     )
   }

--- a/src/lib/google/youtube.ts
+++ b/src/lib/google/youtube.ts
@@ -1,0 +1,258 @@
+import "server-only"
+
+const GOOGLE_AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+const YOUTUBE_API = "https://www.googleapis.com/youtube/v3"
+const YOUTUBE_UPLOAD_API = "https://www.googleapis.com/upload/youtube/v3"
+
+export const YOUTUBE_OAUTH_SCOPES = [
+  "openid",
+  "email",
+  "https://www.googleapis.com/auth/youtube.readonly",
+  "https://www.googleapis.com/auth/youtube.upload",
+] as const
+
+export const YOUTUBE_CHANNEL_KEYS = ["orc", "hps", "nutech"] as const
+export type YoutubeChannelKey = (typeof YOUTUBE_CHANNEL_KEYS)[number]
+export type YoutubePrivacy = "private" | "unlisted" | "public"
+
+export type YoutubeOAuthConfig = {
+  readonly clientId: string
+  readonly clientSecret: string
+  readonly tokenEncryptionKey: string
+  readonly redirectUri: string
+}
+
+type JsonRecord = Readonly<Record<string, unknown>>
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function stringValue(record: JsonRecord, key: string): string | null {
+  const value = record[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null
+}
+
+function environmentValue(env: object, key: string): string | null {
+  const value = Object.getOwnPropertyDescriptor(env, key)?.value
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim()
+  }
+  const processValue = process.env[key]
+  return typeof processValue === "string" && processValue.trim().length > 0
+    ? processValue.trim()
+    : null
+}
+
+export function youtubeChannelKey(value: string | null): YoutubeChannelKey | null {
+  if (value === "orc" || value === "hps" || value === "nutech") return value
+  return null
+}
+
+export function youtubeChannelLabel(key: YoutubeChannelKey): string {
+  if (key === "hps") return "HPS"
+  if (key === "nutech") return "Nu-Tech"
+  return "ORC"
+}
+
+export function getYoutubeOAuthConfig(
+  env: object,
+  requestUrl: string
+): YoutubeOAuthConfig {
+  const clientId = environmentValue(env, "GOOGLE_OAUTH_CLIENT_ID")
+  const clientSecret = environmentValue(env, "GOOGLE_OAUTH_CLIENT_SECRET")
+  const tokenEncryptionKey = environmentValue(
+    env,
+    "GOOGLE_OAUTH_TOKEN_ENCRYPTION_KEY"
+  )
+  if (!clientId || !clientSecret || !tokenEncryptionKey) {
+    throw new Error("Google OAuth is not configured for YouTube.")
+  }
+  const requestOrigin = new URL(requestUrl)
+  const redirectOrigin =
+    requestOrigin.hostname === "localhost" || requestOrigin.hostname === "127.0.0.1"
+      ? requestOrigin.origin
+      : "https://compass.openrangeconstruction.ltd"
+  return {
+    clientId,
+    clientSecret,
+    tokenEncryptionKey,
+    redirectUri: new URL("/api/google/youtube/callback", redirectOrigin).toString(),
+  }
+}
+
+export function hasRequiredYoutubeScopes(scopes: readonly string[]): boolean {
+  const granted = new Set(scopes)
+  return YOUTUBE_OAUTH_SCOPES.every((scope) => granted.has(scope))
+}
+
+export function youtubeTokenSalt(
+  organizationId: string,
+  channelKey: YoutubeChannelKey
+): string {
+  return `compass-youtube:${organizationId}:${channelKey}`
+}
+
+export function buildYoutubeAuthorizationUrl(input: {
+  readonly config: YoutubeOAuthConfig
+  readonly state: string
+  readonly loginHint: string
+}): string {
+  const url = new URL(GOOGLE_AUTHORIZATION_URL)
+  url.searchParams.set("client_id", input.config.clientId)
+  url.searchParams.set("redirect_uri", input.config.redirectUri)
+  url.searchParams.set("response_type", "code")
+  url.searchParams.set("access_type", "offline")
+  url.searchParams.set("include_granted_scopes", "true")
+  url.searchParams.set("prompt", "consent")
+  url.searchParams.set("scope", YOUTUBE_OAUTH_SCOPES.join(" "))
+  url.searchParams.set("state", input.state)
+  url.searchParams.set("login_hint", input.loginHint)
+  return url.toString()
+}
+
+async function responsePayload(response: Response): Promise<unknown> {
+  try {
+    return await response.json()
+  } catch {
+    return null
+  }
+}
+
+export async function exchangeYoutubeAuthorizationCode(input: {
+  readonly config: YoutubeOAuthConfig
+  readonly code: string
+}): Promise<{
+  readonly accessToken: string
+  readonly refreshToken: string | null
+  readonly scopes: readonly string[]
+}> {
+  const response = await fetch(GOOGLE_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: input.config.clientId,
+      client_secret: input.config.clientSecret,
+      code: input.code,
+      grant_type: "authorization_code",
+      redirect_uri: input.config.redirectUri,
+    }),
+  })
+  const payload = await responsePayload(response)
+  if (!response.ok || !isRecord(payload)) {
+    throw new Error(`YouTube authorization failed (${response.status}).`)
+  }
+  const accessToken = stringValue(payload, "access_token")
+  if (!accessToken) throw new Error("Google did not return an access token.")
+  const scope = stringValue(payload, "scope")
+  return {
+    accessToken,
+    refreshToken: stringValue(payload, "refresh_token"),
+    scopes: scope ? scope.split(/\s+/).filter(Boolean) : YOUTUBE_OAUTH_SCOPES,
+  }
+}
+
+export async function refreshYoutubeAccessToken(input: {
+  readonly config: YoutubeOAuthConfig
+  readonly refreshToken: string
+}): Promise<string> {
+  const response = await fetch(GOOGLE_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: input.config.clientId,
+      client_secret: input.config.clientSecret,
+      refresh_token: input.refreshToken,
+      grant_type: "refresh_token",
+    }),
+  })
+  const payload = await responsePayload(response)
+  if (!response.ok || !isRecord(payload)) {
+    throw new Error(`YouTube token refresh failed (${response.status}).`)
+  }
+  const accessToken = stringValue(payload, "access_token")
+  if (!accessToken) throw new Error("Google did not return an access token.")
+  return accessToken
+}
+
+export async function getAuthorizedYoutubeChannel(
+  accessToken: string
+): Promise<{ readonly id: string; readonly title: string }> {
+  const url = new URL(`${YOUTUBE_API}/channels`)
+  url.searchParams.set("part", "id,snippet")
+  url.searchParams.set("mine", "true")
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
+  const payload = await responsePayload(response)
+  if (!response.ok || !isRecord(payload) || !Array.isArray(payload.items)) {
+    throw new Error(`YouTube channel lookup failed (${response.status}).`)
+  }
+  const item = payload.items.find(isRecord)
+  if (!item) throw new Error("This Google account does not manage a YouTube channel.")
+  const snippet = item.snippet
+  const id = stringValue(item, "id")
+  const title = isRecord(snippet) ? stringValue(snippet, "title") : null
+  if (!id || !title) throw new Error("YouTube returned incomplete channel details.")
+  return { id, title }
+}
+
+export async function uploadVideoToYoutube(input: {
+  readonly accessToken: string
+  readonly title: string
+  readonly description: string | null
+  readonly privacy: YoutubePrivacy
+  readonly mimeType: string
+  readonly fileSize: number
+  readonly body: ReadableStream<Uint8Array>
+  readonly onSessionCreated: (sessionUrl: string) => Promise<void>
+}): Promise<{ readonly videoId: string; readonly url: string }> {
+  const initiateUrl = new URL(`${YOUTUBE_UPLOAD_API}/videos`)
+  initiateUrl.searchParams.set("uploadType", "resumable")
+  initiateUrl.searchParams.set("part", "snippet,status")
+  const initiate = await fetch(initiateUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${input.accessToken}`,
+      "Content-Type": "application/json; charset=UTF-8",
+      "X-Upload-Content-Type": input.mimeType,
+      "X-Upload-Content-Length": String(input.fileSize),
+    },
+    body: JSON.stringify({
+      snippet: {
+        title: input.title,
+        description: input.description ?? "",
+        categoryId: "22",
+      },
+      status: {
+        privacyStatus: input.privacy,
+        selfDeclaredMadeForKids: false,
+      },
+    }),
+  })
+  if (!initiate.ok) {
+    throw new Error(`YouTube upload initialization failed (${initiate.status}).`)
+  }
+  const sessionUrl = initiate.headers.get("Location")
+  if (!sessionUrl) throw new Error("YouTube did not return an upload session.")
+  await input.onSessionCreated(sessionUrl)
+
+  const upload = await fetch(sessionUrl, {
+    method: "PUT",
+    headers: {
+      "Content-Type": input.mimeType,
+      "Content-Length": String(input.fileSize),
+    },
+    body: input.body,
+  })
+  const payload = await responsePayload(upload)
+  if (!upload.ok || !isRecord(payload)) {
+    throw new Error(`YouTube video upload failed (${upload.status}).`)
+  }
+  const videoId = stringValue(payload, "id")
+  if (!videoId) throw new Error("YouTube did not return a video ID.")
+  return { videoId, url: `https://youtu.be/${videoId}` }
+}

--- a/src/lib/goto/__tests__/mime-type.test.ts
+++ b/src/lib/goto/__tests__/mime-type.test.ts
@@ -35,4 +35,19 @@ describe("gotoAttachmentMimeType", () => {
       })
     ).toBe("image/heic")
   })
+
+  it("detects MP4 video when GoTo only declares video", () => {
+    expect(
+      gotoAttachmentMimeType({
+        declaredType: "video",
+        responseType: "application/octet-stream",
+        fileName: "attachment",
+        data: new Uint8Array([
+          0x00, 0x00, 0x00, 0x18,
+          0x66, 0x74, 0x79, 0x70,
+          0x6d, 0x70, 0x34, 0x32,
+        ]),
+      })
+    ).toBe("video/mp4")
+  })
 })

--- a/src/lib/goto/mime-type.ts
+++ b/src/lib/goto/mime-type.ts
@@ -6,6 +6,10 @@ const MIME_BY_EXTENSION: Readonly<Record<string, string>> = {
   jpeg: "image/jpeg",
   jpg: "image/jpeg",
   png: "image/png",
+  m4v: "video/mp4",
+  mov: "video/quicktime",
+  mp4: "video/mp4",
+  "3gp": "video/3gpp",
   webp: "image/webp",
 }
 
@@ -47,6 +51,10 @@ function imageMimeTypeFromBytes(data: Uint8Array): string | null {
   }
   if (bytesMatch(data, 4, [0x66, 0x74, 0x79, 0x70])) {
     const brand = String.fromCharCode(...data.slice(8, 12)).toLowerCase()
+    if (["isom", "iso2", "mp41", "mp42", "m4v "].includes(brand)) {
+      return "video/mp4"
+    }
+    if (brand === "qt  ") return "video/quicktime"
     if (brand === "avif" || brand === "avis") return "image/avif"
     if (["heic", "heix", "hevc", "hevx"].includes(brand)) return "image/heic"
     if (["heif", "heim", "heis", "mif1", "msf1"].includes(brand)) {
@@ -75,6 +83,8 @@ export function gotoAttachmentMimeType(input: {
     mimeTypeFromName(input.fileName) ??
     (input.declaredType.trim().toLowerCase() === "image"
       ? "image/jpeg"
+      : input.declaredType.trim().toLowerCase() === "video"
+        ? "video/mp4"
       : "application/octet-stream")
   )
 }


### PR DESCRIPTION
## Summary
- route `[Video]` project emails and GoTo texts into a reviewable project video plus Daily Log placeholder
- stage original video files in the project Google Drive and record inbound activity
- add Project Videos navigation, audience review, archive/delete controls, and secure staff playback
- connect ORC, HPS, and Nu-Tech YouTube channels with encrypted OAuth credentials
- publish via resumable YouTube uploads and write the final share link back to the Daily Log

## Safety
- staff videos remain private on YouTube and stream only through authenticated Compass access
- owner/sub videos are unlisted with an explicit forwarding warning
- public uploads require explicit confirmation
- video and Daily Log intake records are created atomically

## Deployment order
Apply D1 migrations `0096_project_videos.sql` and `0097_youtube_channel_connections.sql` before deploying application code.

## Validation
- `bun test src/lib/goto/__tests__/mime-type.test.ts src/lib/email/__tests__/project-address.test.ts`
- `tsc --noEmit`
- ESLint on all touched TypeScript/TSX files
- `bun run build`