### PR TITLE
fix(videos): accept canonical Google email scope

### DIFF
--- a/src/lib/google/__tests__/youtube-oauth.test.ts
+++ b/src/lib/google/__tests__/youtube-oauth.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  YOUTUBE_OAUTH_SCOPES,
+  hasRequiredYoutubeScopes,
+} from "@/lib/google/youtube-oauth-scopes"
+
+describe("YouTube OAuth scope validation", () => {
+  it("accepts the requested YouTube scopes", () => {
+    expect(hasRequiredYoutubeScopes([...YOUTUBE_OAUTH_SCOPES])).toBe(true)
+  })
+
+  it("accepts Google's canonical userinfo email scope", () => {
+    expect(
+      hasRequiredYoutubeScopes([
+        "openid",
+        "https://www.googleapis.com/auth/userinfo.email",
+        "https://www.googleapis.com/auth/youtube.readonly",
+        "https://www.googleapis.com/auth/youtube.upload",
+      ])
+    ).toBe(true)
+  })
+
+  it("rejects a grant without YouTube upload access", () => {
+    expect(
+      hasRequiredYoutubeScopes([
+        "openid",
+        "https://www.googleapis.com/auth/userinfo.email",
+        "https://www.googleapis.com/auth/youtube.readonly",
+      ])
+    ).toBe(false)
+  })
+})

--- a/src/lib/google/youtube-oauth-scopes.ts
+++ b/src/lib/google/youtube-oauth-scopes.ts
@@ -1,0 +1,20 @@
+export const YOUTUBE_OAUTH_SCOPES = [
+  "openid",
+  "email",
+  "https://www.googleapis.com/auth/youtube.readonly",
+  "https://www.googleapis.com/auth/youtube.upload",
+] as const
+
+const GOOGLE_SCOPE_EQUIVALENTS: Readonly<
+  Record<string, readonly string[]>
+> = {
+  email: ["email", "https://www.googleapis.com/auth/userinfo.email"],
+}
+
+export function hasRequiredYoutubeScopes(scopes: readonly string[]): boolean {
+  const granted = new Set(scopes)
+  return YOUTUBE_OAUTH_SCOPES.every((scope) => {
+    const equivalents = GOOGLE_SCOPE_EQUIVALENTS[scope] ?? [scope]
+    return equivalents.some((candidate) => granted.has(candidate))
+  })
+}

--- a/src/lib/google/youtube.ts
+++ b/src/lib/google/youtube.ts
@@ -1,16 +1,16 @@
 import "server-only"
 
+import { YOUTUBE_OAUTH_SCOPES } from "@/lib/google/youtube-oauth-scopes"
+
+export {
+  YOUTUBE_OAUTH_SCOPES,
+  hasRequiredYoutubeScopes,
+} from "@/lib/google/youtube-oauth-scopes"
+
 const GOOGLE_AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
 const YOUTUBE_API = "https://www.googleapis.com/youtube/v3"
 const YOUTUBE_UPLOAD_API = "https://www.googleapis.com/upload/youtube/v3"
-
-export const YOUTUBE_OAUTH_SCOPES = [
-  "openid",
-  "email",
-  "https://www.googleapis.com/auth/youtube.readonly",
-  "https://www.googleapis.com/auth/youtube.upload",
-] as const
 
 export const YOUTUBE_CHANNEL_KEYS = ["orc", "hps", "nutech"] as const
 export type YoutubeChannelKey = (typeof YOUTUBE_CHANNEL_KEYS)[number]
@@ -82,11 +82,6 @@ export function getYoutubeOAuthConfig(
     tokenEncryptionKey,
     redirectUri: new URL("/api/google/youtube/callback", redirectOrigin).toString(),
   }
-}
-
-export function hasRequiredYoutubeScopes(scopes: readonly string[]): boolean {
-  const granted = new Set(scopes)
-  return YOUTUBE_OAUTH_SCOPES.every((scope) => granted.has(scope))
 }
 
 export function youtubeTokenSalt(


### PR DESCRIPTION
## Summary

- accept Google's canonical `userinfo.email` OAuth scope as equivalent to `email`
- retain strict checks for YouTube read and upload scopes
- add focused regression coverage for full and partial grants

## Verification

- `bun test src/lib/google/__tests__/youtube-oauth.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- targeted ESLint
- production build via pre-push hook
