### PR TITLE
feat(videos): add direct website uploads

### DIFF
--- a/src/app/api/projects/[id]/videos/upload/complete/route.ts
+++ b/src/app/api/projects/[id]/videos/upload/complete/route.ts
@@ -1,0 +1,257 @@
+import { and, eq } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+import { NextResponse } from "next/server"
+
+import { getDb } from "@/db"
+import { dailyLogs, projects, projectVideos } from "@/db/schema"
+import { activityActorName, recordActivityEvent } from "@/lib/activity-log"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { verifyProjectVideoWebsiteUpload } from "@/lib/email/project-video-attachments"
+import { requireOrg } from "@/lib/org-scope"
+import { requireFeaturePermission } from "@/lib/permission-enforcement"
+import { projectDepartment } from "@/lib/project-branding"
+import { youtubeChannelForDepartment } from "@/lib/videos/channel-routing"
+import {
+  isProjectVideoFile,
+  MAX_PROJECT_VIDEO_UPLOAD_BYTES,
+  PROJECT_VIDEO_UPLOAD_LIMIT_LABEL,
+} from "@/lib/videos/upload-limits"
+
+type VideoAudience = "staff" | "owner" | "sub_vendor" | "public"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function textValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function audienceValue(value: unknown): VideoAudience | null {
+  if (
+    value === "staff" ||
+    value === "owner" ||
+    value === "sub_vendor" ||
+    value === "public"
+  ) {
+    return value
+  }
+  return null
+}
+
+function youtubePrivacy(
+  audience: VideoAudience
+): "private" | "unlisted" | "public" {
+  if (audience === "staff") return "private"
+  if (audience === "public") return "public"
+  return "unlisted"
+}
+
+export async function POST(
+  request: Request,
+  { params }: { readonly params: Promise<{ readonly id: string }> }
+): Promise<Response> {
+  try {
+    const body: unknown = await request.json()
+    if (!isRecord(body)) {
+      return NextResponse.json(
+        { success: false, error: "Uploaded video details are missing." },
+        { status: 400 }
+      )
+    }
+    const driveFileId = textValue(body.driveFileId)
+    const title = textValue(body.title)
+    const description = textValue(body.description)
+    const audience = audienceValue(body.compassAudience)
+    const addToDailyLog = body.addToDailyLog !== false
+    if (!driveFileId) {
+      return NextResponse.json(
+        { success: false, error: "Google Drive did not return the uploaded file." },
+        { status: 400 }
+      )
+    }
+    if (title.length === 0 || title.length > 100) {
+      return NextResponse.json(
+        { success: false, error: "Video title must be 1 to 100 characters." },
+        { status: 400 }
+      )
+    }
+    if (description.length > 5_000) {
+      return NextResponse.json(
+        { success: false, error: "Video description cannot exceed 5,000 characters." },
+        { status: 400 }
+      )
+    }
+    if (!audience) {
+      return NextResponse.json(
+        { success: false, error: "Choose who may receive the video link." },
+        { status: 400 }
+      )
+    }
+
+    const user = await requireAuth()
+    await requireFeaturePermission(user, "project-photos", "update")
+    const organizationId = requireOrg(user)
+    const { id: projectId } = await params
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const [project] = await db
+      .select({
+        id: projects.id,
+        projectNumber: projects.projectNumber,
+      })
+      .from(projects)
+      .where(
+        and(
+          eq(projects.id, projectId),
+          eq(projects.organizationId, organizationId)
+        )
+      )
+      .limit(1)
+    if (!project) {
+      return NextResponse.json(
+        { success: false, error: "Project not found." },
+        { status: 404 }
+      )
+    }
+
+    const source = await verifyProjectVideoWebsiteUpload({
+      env,
+      db,
+      organizationId,
+      projectId,
+      driveFileId,
+    })
+    if (!isProjectVideoFile({ fileName: source.fileName, mimeType: source.mimeType })) {
+      return NextResponse.json(
+        { success: false, error: "The uploaded file is not a supported video." },
+        { status: 400 }
+      )
+    }
+    if (source.fileSize > MAX_PROJECT_VIDEO_UPLOAD_BYTES) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `The uploaded video exceeds the ${PROJECT_VIDEO_UPLOAD_LIMIT_LABEL} limit.`,
+        },
+        { status: 400 }
+      )
+    }
+    const [existing] = await db
+      .select({ id: projectVideos.id })
+      .from(projectVideos)
+      .where(
+        and(
+          eq(projectVideos.sourceSystem, "compass_web"),
+          eq(projectVideos.sourceExternalId, source.driveFileId)
+        )
+      )
+      .limit(1)
+    if (existing) {
+      return NextResponse.json({ success: true, videoId: existing.id })
+    }
+
+    const now = new Date().toISOString()
+    const videoId = `web-video-${crypto.randomUUID()}`
+    const dailyLogId = addToDailyLog
+      ? `web-video-log-${crypto.randomUUID()}`
+      : null
+    const department = projectDepartment({
+      projectId,
+      projectNumber: project.projectNumber,
+    })
+    const submitter = activityActorName(user)
+    const videoInsert = db.insert(projectVideos).values({
+      id: videoId,
+      organizationId,
+      projectId,
+      title,
+      description: description || null,
+      department,
+      youtubeChannelKey: youtubeChannelForDepartment(department),
+      compassAudience: audience,
+      youtubePrivacy: youtubePrivacy(audience),
+      publishStatus: "pending_review",
+      sourceSystem: "compass_web",
+      sourceExternalId: source.driveFileId,
+      sourceFileName: source.fileName,
+      sourceMimeType: source.mimeType,
+      sourceFileSize: source.fileSize,
+      driveFileId: source.driveFileId,
+      driveUrl: source.driveUrl,
+      linkedEntityType: dailyLogId ? "daily_log" : null,
+      linkedEntityId: dailyLogId,
+      youtubeVideoId: null,
+      youtubeUrl: null,
+      youtubeUploadSessionUrl: null,
+      uploadError: null,
+      submittedByName: submitter,
+      submittedByEmail: user.email,
+      reviewedBy: null,
+      reviewedAt: null,
+      publishedAt: null,
+      archivedAt: null,
+      deletedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    if (dailyLogId) {
+      await db.batch([
+        videoInsert,
+        db.insert(dailyLogs).values({
+          id: dailyLogId,
+          projectId,
+          authorId: user.id,
+          sourceSystem: "compass_web",
+          sourceExternalId: `${source.driveFileId}:video`,
+          logDate: now.slice(0, 10),
+          workCompleted: title,
+          notes:
+            `Video uploaded by ${submitter} for staff review. ` +
+            "The share link will appear here after publication.",
+          isClientVisible: false,
+          reviewStatus: "needs_review",
+          syncStatus: "pending",
+          createdAt: now,
+          updatedAt: now,
+        }),
+      ])
+    } else {
+      await videoInsert.run()
+    }
+
+    await recordActivityEvent({
+      db,
+      organizationId,
+      projectId,
+      actor: user,
+      category: "file",
+      action: "project.video_uploaded",
+      entityType: "project_video",
+      entityId: videoId,
+      summary: `Uploaded project video: ${title}.`,
+      metadata: {
+        fileName: source.fileName,
+        fileSize: source.fileSize,
+        channel: youtubeChannelForDepartment(department),
+        dailyLog: Boolean(dailyLogId),
+      },
+    })
+    revalidatePath(`/dashboard/projects/${projectId}/videos`)
+    revalidatePath(`/dashboard/projects/${projectId}/daily-logs`)
+    return NextResponse.json({ success: true, videoId })
+  } catch (error) {
+    console.error("Project video upload completion failed", error)
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Compass could not save the uploaded video.",
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/projects/[id]/videos/upload/start/route.ts
+++ b/src/app/api/projects/[id]/videos/upload/start/route.ts
@@ -1,0 +1,118 @@
+import { and, eq } from "drizzle-orm"
+import { NextResponse } from "next/server"
+
+import { getDb } from "@/db"
+import { projects } from "@/db/schema"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { initiateProjectVideoWebsiteUpload } from "@/lib/email/project-video-attachments"
+import { requireOrg } from "@/lib/org-scope"
+import { requireFeaturePermission } from "@/lib/permission-enforcement"
+import {
+  isProjectVideoFile,
+  MAX_PROJECT_VIDEO_UPLOAD_BYTES,
+  projectVideoMimeType,
+  PROJECT_VIDEO_UPLOAD_LIMIT_LABEL,
+} from "@/lib/videos/upload-limits"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function textValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === "number" ? value : Number.NaN
+}
+
+export async function POST(
+  request: Request,
+  { params }: { readonly params: Promise<{ readonly id: string }> }
+): Promise<Response> {
+  try {
+    const body: unknown = await request.json()
+    if (!isRecord(body)) {
+      return NextResponse.json(
+        { success: false, error: "Video upload details are missing." },
+        { status: 400 }
+      )
+    }
+    const fileName = textValue(body.fileName)
+    const requestedMimeType = textValue(body.mimeType)
+    const fileSize = numberValue(body.fileSize)
+    if (!isProjectVideoFile({ fileName, mimeType: requestedMimeType })) {
+      return NextResponse.json(
+        { success: false, error: "Choose a supported video file." },
+        { status: 400 }
+      )
+    }
+    if (
+      !Number.isSafeInteger(fileSize) ||
+      fileSize <= 0 ||
+      fileSize > MAX_PROJECT_VIDEO_UPLOAD_BYTES
+    ) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Videos must be larger than 0 bytes and no more than ${PROJECT_VIDEO_UPLOAD_LIMIT_LABEL}.`,
+        },
+        { status: 400 }
+      )
+    }
+
+    const user = await requireAuth()
+    await requireFeaturePermission(user, "project-photos", "update")
+    const organizationId = requireOrg(user)
+    const { id: projectId } = await params
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const [project] = await db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(
+        and(
+          eq(projects.id, projectId),
+          eq(projects.organizationId, organizationId)
+        )
+      )
+      .limit(1)
+    if (!project) {
+      return NextResponse.json(
+        { success: false, error: "Project not found." },
+        { status: 404 }
+      )
+    }
+
+    const mimeType = projectVideoMimeType({
+      fileName,
+      mimeType: requestedMimeType,
+    })
+    const session = await initiateProjectVideoWebsiteUpload({
+      env,
+      db,
+      organizationId,
+      projectId,
+      fileName,
+      mimeType,
+      fileSize,
+    })
+    return NextResponse.json(
+      { success: true, uploadUrl: session.uploadUrl, mimeType },
+      { headers: { "Cache-Control": "no-store" } }
+    )
+  } catch (error) {
+    console.error("Project video upload session failed", error)
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Compass could not start the video upload.",
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/components/projects/project-video-review.tsx
+++ b/src/components/projects/project-video-review.tsx
@@ -20,6 +20,7 @@ import {
   type ProjectVideoItem,
   type ProjectVideoWorkspace,
 } from "@/app/actions/project-videos"
+import { ProjectVideoUpload } from "@/components/projects/project-video-upload"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -314,6 +315,11 @@ export function ProjectVideoReview({
           </p>
         </div>
       </div>
+
+      <ProjectVideoUpload
+        projectId={workspace.project.id}
+        projectNumber={workspace.project.projectNumber}
+      />
 
       <section className="border-border mt-5 border-b pb-5">
         <h2 className="text-sm font-semibold">YouTube channels</h2>

--- a/src/components/projects/project-video-upload.tsx
+++ b/src/components/projects/project-video-upload.tsx
@@ -1,0 +1,356 @@
+"use client"
+
+import * as React from "react"
+import { IconUpload, IconVideo, IconX } from "@tabler/icons-react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Progress } from "@/components/ui/progress"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { projectDepartment } from "@/lib/project-branding"
+import { youtubeChannelForDepartment } from "@/lib/videos/channel-routing"
+import {
+  isProjectVideoFile,
+  MAX_PROJECT_VIDEO_UPLOAD_BYTES,
+  PROJECT_VIDEO_UPLOAD_LIMIT_LABEL,
+} from "@/lib/videos/upload-limits"
+
+type UploadStage = "idle" | "starting" | "uploading" | "saving"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+async function responseBody(response: Response): Promise<Record<string, unknown>> {
+  const value: unknown = await response.json()
+  return isRecord(value) ? value : {}
+}
+
+function responseError(
+  body: Readonly<Record<string, unknown>>,
+  fallback: string
+): string {
+  return typeof body.error === "string" && body.error.trim().length > 0
+    ? body.error
+    : fallback
+}
+
+function titleFromFileName(fileName: string): string {
+  const title = fileName.replace(/\.[^.]+$/, "").replace(/[_-]+/g, " ").trim()
+  return title.slice(0, 100) || "Project video"
+}
+
+function channelLabel(channelKey: string): string {
+  if (channelKey === "hps") return "High Performance Structures"
+  if (channelKey === "nutech") return "Nu-Tech Systems"
+  return "Open Range Construction"
+}
+
+function uploadToGoogleDrive(input: {
+  readonly uploadUrl: string
+  readonly file: File
+  readonly mimeType: string
+  readonly onProgress: (value: number) => void
+  readonly onRequest: (request: XMLHttpRequest | null) => void
+}): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const request = new XMLHttpRequest()
+    input.onRequest(request)
+    request.open("PUT", input.uploadUrl)
+    request.setRequestHeader("Content-Type", input.mimeType)
+    request.upload.addEventListener("progress", (event) => {
+      if (!event.lengthComputable) return
+      input.onProgress(Math.round((event.loaded / event.total) * 100))
+    })
+    request.addEventListener("load", () => {
+      input.onRequest(null)
+      if (request.status !== 200 && request.status !== 201) {
+        reject(new Error(`Google Drive upload failed (${request.status}).`))
+        return
+      }
+      let body: unknown = null
+      try {
+        body = JSON.parse(request.responseText)
+      } catch {
+        reject(new Error("Google Drive did not return the uploaded video."))
+        return
+      }
+      if (!isRecord(body) || typeof body.id !== "string" || !body.id) {
+        reject(new Error("Google Drive did not return the uploaded video."))
+        return
+      }
+      input.onProgress(100)
+      resolve(body.id)
+    })
+    request.addEventListener("error", () => {
+      input.onRequest(null)
+      reject(new Error("The video upload was interrupted. Please try again."))
+    })
+    request.addEventListener("abort", () => {
+      input.onRequest(null)
+      reject(new Error("Video upload cancelled."))
+    })
+    request.send(input.file)
+  })
+}
+
+export function ProjectVideoUpload({
+  projectId,
+  projectNumber,
+}: {
+  readonly projectId: string
+  readonly projectNumber: string | null
+}): React.ReactElement {
+  const router = useRouter()
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const requestRef = React.useRef<XMLHttpRequest | null>(null)
+  const [file, setFile] = React.useState<File | null>(null)
+  const [title, setTitle] = React.useState("")
+  const [description, setDescription] = React.useState("")
+  const [audience, setAudience] = React.useState("staff")
+  const [addToDailyLog, setAddToDailyLog] = React.useState(true)
+  const [stage, setStage] = React.useState<UploadStage>("idle")
+  const [progress, setProgress] = React.useState(0)
+  const department = projectDepartment({ projectId, projectNumber })
+  const channelKey = youtubeChannelForDepartment(department)
+  const busy = stage !== "idle"
+
+  function reset(): void {
+    setFile(null)
+    setTitle("")
+    setDescription("")
+    setAudience("staff")
+    setAddToDailyLog(true)
+    setStage("idle")
+    setProgress(0)
+    if (inputRef.current) inputRef.current.value = ""
+  }
+
+  function chooseFile(selected: File | null): void {
+    if (!selected) return
+    if (!isProjectVideoFile({ fileName: selected.name, mimeType: selected.type })) {
+      toast.error("Choose a supported video file.")
+      return
+    }
+    if (selected.size <= 0 || selected.size > MAX_PROJECT_VIDEO_UPLOAD_BYTES) {
+      toast.error(`Videos may be up to ${PROJECT_VIDEO_UPLOAD_LIMIT_LABEL}.`)
+      return
+    }
+    setFile(selected)
+    setTitle(titleFromFileName(selected.name))
+    setProgress(0)
+  }
+
+  async function upload(): Promise<void> {
+    if (!file || busy) return
+    const normalizedTitle = title.trim()
+    if (!normalizedTitle || normalizedTitle.length > 100) {
+      toast.error("Video title must be 1 to 100 characters.")
+      return
+    }
+    try {
+      setStage("starting")
+      setProgress(0)
+      const startResponse = await fetch(
+        `/api/projects/${encodeURIComponent(projectId)}/videos/upload/start`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            fileName: file.name,
+            mimeType: file.type,
+            fileSize: file.size,
+          }),
+        }
+      )
+      const startBody = await responseBody(startResponse)
+      if (
+        !startResponse.ok ||
+        startBody.success !== true ||
+        typeof startBody.uploadUrl !== "string" ||
+        typeof startBody.mimeType !== "string"
+      ) {
+        throw new Error(
+          responseError(startBody, "Compass could not start the video upload.")
+        )
+      }
+
+      setStage("uploading")
+      const driveFileId = await uploadToGoogleDrive({
+        uploadUrl: startBody.uploadUrl,
+        file,
+        mimeType: startBody.mimeType,
+        onProgress: setProgress,
+        onRequest: (request) => {
+          requestRef.current = request
+        },
+      })
+
+      setStage("saving")
+      const completeResponse = await fetch(
+        `/api/projects/${encodeURIComponent(projectId)}/videos/upload/complete`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            driveFileId,
+            title: normalizedTitle,
+            description: description.trim(),
+            compassAudience: audience,
+            addToDailyLog,
+          }),
+        }
+      )
+      const completeBody = await responseBody(completeResponse)
+      if (!completeResponse.ok || completeBody.success !== true) {
+        throw new Error(
+          responseError(completeBody, "Compass could not save the uploaded video.")
+        )
+      }
+      toast.success("Video uploaded. Review and publish it below.")
+      reset()
+      router.refresh()
+    } catch (error) {
+      setStage("idle")
+      toast.error(
+        error instanceof Error ? error.message : "Compass could not upload the video."
+      )
+    }
+  }
+
+  return (
+    <section className="border-border border-b py-5">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h2 className="flex items-center gap-2 text-sm font-semibold">
+            <IconUpload className="size-4" /> Upload from this device
+          </h2>
+          <p className="text-muted-foreground mt-1 max-w-2xl text-sm">
+            Large videos upload directly to the project’s Google Drive folder,
+            then enter the same review and YouTube publishing workflow.
+          </p>
+        </div>
+        {!file && (
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => inputRef.current?.click()}
+          >
+            <IconVideo /> Choose video
+          </Button>
+        )}
+        <Input
+          ref={inputRef}
+          className="sr-only"
+          type="file"
+          accept="video/*,.3g2,.3gp,.avi,.flv,.m4v,.mkv,.mov,.mp4,.mpeg,.mpg,.webm,.wmv"
+          onChange={(event) => chooseFile(event.target.files?.[0] ?? null)}
+        />
+      </div>
+
+      {file && (
+        <div className="mt-5 grid gap-5 lg:grid-cols-[minmax(0,1fr)_18rem]">
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="website-video-title">Video title</Label>
+              <Input
+                id="website-video-title"
+                value={title}
+                maxLength={100}
+                disabled={busy}
+                onChange={(event) => setTitle(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="website-video-description">Description</Label>
+              <Textarea
+                id="website-video-description"
+                value={description}
+                maxLength={5000}
+                rows={3}
+                disabled={busy}
+                onChange={(event) => setDescription(event.target.value)}
+              />
+            </div>
+          </div>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label>Who may receive the link?</Label>
+              <Select value={audience} disabled={busy} onValueChange={setAudience}>
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="staff">Staff only</SelectItem>
+                  <SelectItem value="owner">Owner</SelectItem>
+                  <SelectItem value="sub_vendor">Subs / suppliers</SelectItem>
+                  <SelectItem value="public">Public</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <p className="text-muted-foreground text-sm">
+              Destination: {channelLabel(channelKey)} YouTube
+            </p>
+            <label className="flex items-start gap-2 text-sm">
+              <Checkbox
+                checked={addToDailyLog}
+                disabled={busy}
+                onCheckedChange={(checked) => setAddToDailyLog(checked === true)}
+              />
+              <span>Add a review entry to today’s Daily Log.</span>
+            </label>
+          </div>
+
+          {busy && (
+            <div className="lg:col-span-2">
+              <div className="mb-2 flex justify-between text-sm">
+                <span>
+                  {stage === "starting"
+                    ? "Preparing upload…"
+                    : stage === "saving"
+                      ? "Saving in Compass…"
+                      : "Uploading to Google Drive…"}
+                </span>
+                <span>{stage === "uploading" ? `${progress}%` : ""}</span>
+              </div>
+              <Progress value={stage === "uploading" ? progress : undefined} />
+            </div>
+          )}
+
+          <div className="flex flex-wrap justify-between gap-3 lg:col-span-2">
+            <p className="text-muted-foreground text-xs">
+              {file.name} · {(file.size / (1024 * 1024)).toFixed(1)} MB
+            </p>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                disabled={stage === "starting" || stage === "saving"}
+                onClick={() => {
+                  if (stage === "uploading") requestRef.current?.abort()
+                  else reset()
+                }}
+              >
+                <IconX /> {stage === "uploading" ? "Cancel upload" : "Remove"}
+              </Button>
+              <Button type="button" disabled={busy} onClick={() => void upload()}>
+                <IconUpload /> Upload for review
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/lib/email/project-inbound-routing.ts
+++ b/src/lib/email/project-inbound-routing.ts
@@ -34,6 +34,7 @@ import {
 import { storeDailyLogEmailAttachments } from "@/lib/email/project-email-attachments"
 import { storeProjectVideoAttachment } from "@/lib/email/project-video-attachments"
 import { projectDepartment } from "@/lib/project-branding"
+import { youtubeChannelForDepartment } from "@/lib/videos/channel-routing"
 import { PROJECT_TODO_RECORD_TYPES } from "@/lib/project-todos"
 
 type Db = ReturnType<typeof getDb>
@@ -494,14 +495,6 @@ function isVideoAttachment(attachment: InboundCandidate["attachments"][number]):
     attachment.mimeType.startsWith("video/") ||
     /\.(?:3gp|m4v|mov|mp4|webm)$/i.test(attachment.fileName)
   )
-}
-
-function youtubeChannelForDepartment(
-  department: "O" | "H" | "N" | "D"
-): "orc" | "hps" | "nutech" {
-  if (department === "H") return "hps"
-  if (department === "N") return "nutech"
-  return "orc"
 }
 
 async function routeVideo(input: {

--- a/src/lib/email/project-video-attachments.ts
+++ b/src/lib/email/project-video-attachments.ts
@@ -29,6 +29,10 @@ export type StoredProjectVideoFile = {
   readonly mimeType: string
 }
 
+export type ProjectVideoUploadSession = {
+  readonly uploadUrl: string
+}
+
 async function driveClient(input: {
   readonly env: unknown
   readonly db: Db
@@ -194,6 +198,82 @@ export async function storeProjectVideoAttachment(input: {
     driveUrl: file.webViewLink ?? null,
     fileName: file.name,
     fileSize: Number(file.size ?? data.byteLength),
+    mimeType: file.mimeType,
+  }
+}
+
+export async function initiateProjectVideoWebsiteUpload(input: {
+  readonly env: unknown
+  readonly db: Db
+  readonly organizationId: string
+  readonly projectId: string
+  readonly fileName: string
+  readonly mimeType: string
+  readonly fileSize: number
+}): Promise<ProjectVideoUploadSession> {
+  const projectFolderId = await projectFolder({
+    db: input.db,
+    projectId: input.projectId,
+  })
+  const drive = await driveClient({
+    env: input.env,
+    db: input.db,
+    organizationId: input.organizationId,
+  })
+  const videoFolderId = await resolveVideoFolder({
+    client: drive.client,
+    googleEmail: drive.googleEmail,
+    projectFolderId,
+    sharedDriveId: drive.sharedDriveId,
+  })
+  const uploadUrl = await drive.client.initiateResumableUpload(
+    drive.googleEmail,
+    {
+      name: safeFileName(input.fileName),
+      mimeType: input.mimeType,
+      parentId: videoFolderId,
+      driveId: drive.sharedDriveId ?? undefined,
+      size: input.fileSize,
+    }
+  )
+  return { uploadUrl }
+}
+
+export async function verifyProjectVideoWebsiteUpload(input: {
+  readonly env: unknown
+  readonly db: Db
+  readonly organizationId: string
+  readonly projectId: string
+  readonly driveFileId: string
+}): Promise<StoredProjectVideoFile> {
+  const projectFolderId = await projectFolder({
+    db: input.db,
+    projectId: input.projectId,
+  })
+  const drive = await driveClient({
+    env: input.env,
+    db: input.db,
+    organizationId: input.organizationId,
+  })
+  const videoFolderId = await resolveVideoFolder({
+    client: drive.client,
+    googleEmail: drive.googleEmail,
+    projectFolderId,
+    sharedDriveId: drive.sharedDriveId,
+  })
+  const file = await drive.client.getFile(drive.googleEmail, input.driveFileId)
+  if (file.trashed || !file.parents?.includes(videoFolderId)) {
+    throw new Error("The uploaded video is not in this project's Videos folder.")
+  }
+  const fileSize = Number(file.size ?? 0)
+  if (!Number.isFinite(fileSize) || fileSize <= 0) {
+    throw new Error("Google Drive did not report a valid video size.")
+  }
+  return {
+    driveFileId: file.id,
+    driveUrl: file.webViewLink ?? null,
+    fileName: file.name,
+    fileSize,
     mimeType: file.mimeType,
   }
 }

--- a/src/lib/google/client/drive-client.ts
+++ b/src/lib/google/client/drive-client.ts
@@ -253,6 +253,9 @@ export class DriveClient {
             Authorization: `Bearer ${token}`,
             "Content-Type": "application/json",
             "X-Upload-Content-Type": options.mimeType,
+            ...(options.size === undefined
+              ? {}
+              : { "X-Upload-Content-Length": String(options.size) }),
           },
           body: JSON.stringify(metadata),
         }

--- a/src/lib/google/client/types.ts
+++ b/src/lib/google/client/types.ts
@@ -77,6 +77,7 @@ export type UploadOptions = {
   readonly parentId?: string
   readonly mimeType: string
   readonly driveId?: string
+  readonly size?: number
 }
 
 export type UploadFileOptions = UploadOptions & {

--- a/src/lib/videos/__tests__/video-upload.test.ts
+++ b/src/lib/videos/__tests__/video-upload.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+
+import { youtubeChannelForDepartment } from "@/lib/videos/channel-routing"
+import {
+  isProjectVideoFile,
+  projectVideoMimeType,
+} from "@/lib/videos/upload-limits"
+
+describe("project video channel routing", () => {
+  it("routes each department to its company channel", () => {
+    expect(youtubeChannelForDepartment("O")).toBe("orc")
+    expect(youtubeChannelForDepartment("D")).toBe("orc")
+    expect(youtubeChannelForDepartment("H")).toBe("hps")
+    expect(youtubeChannelForDepartment("N")).toBe("nutech")
+  })
+})
+
+describe("project video file validation", () => {
+  it("accepts browser video MIME types", () => {
+    expect(
+      isProjectVideoFile({ fileName: "walkthrough.mov", mimeType: "video/quicktime" })
+    ).toBe(true)
+  })
+
+  it("accepts known video extensions when a browser omits the MIME type", () => {
+    expect(isProjectVideoFile({ fileName: "walkthrough.MP4", mimeType: "" })).toBe(
+      true
+    )
+    expect(projectVideoMimeType({ fileName: "walkthrough.mov", mimeType: "" })).toBe(
+      "video/quicktime"
+    )
+  })
+
+  it("rejects non-video files", () => {
+    expect(
+      isProjectVideoFile({ fileName: "invoice.pdf", mimeType: "application/pdf" })
+    ).toBe(false)
+  })
+})

--- a/src/lib/videos/channel-routing.ts
+++ b/src/lib/videos/channel-routing.ts
@@ -1,0 +1,11 @@
+import type { ProjectDepartment } from "@/lib/project-branding"
+
+export type YoutubeChannelKey = "orc" | "hps" | "nutech"
+
+export function youtubeChannelForDepartment(
+  department: ProjectDepartment
+): YoutubeChannelKey {
+  if (department === "H") return "hps"
+  if (department === "N") return "nutech"
+  return "orc"
+}

--- a/src/lib/videos/upload-limits.ts
+++ b/src/lib/videos/upload-limits.ts
@@ -1,0 +1,21 @@
+export const MAX_PROJECT_VIDEO_UPLOAD_BYTES = 10 * 1024 * 1024 * 1024
+export const PROJECT_VIDEO_UPLOAD_LIMIT_LABEL = "10 GB"
+
+const VIDEO_FILE_EXTENSION = /\.(?:3g2|3gp|avi|flv|m4v|mkv|mov|mp4|mpeg|mpg|webm|wmv)$/i
+
+export function isProjectVideoFile(input: {
+  readonly fileName: string
+  readonly mimeType: string
+}): boolean {
+  return input.mimeType.startsWith("video/") || VIDEO_FILE_EXTENSION.test(input.fileName)
+}
+
+export function projectVideoMimeType(input: {
+  readonly fileName: string
+  readonly mimeType: string
+}): string {
+  if (input.mimeType.startsWith("video/")) return input.mimeType
+  if (/\.mov$/i.test(input.fileName)) return "video/quicktime"
+  if (/\.webm$/i.test(input.fileName)) return "video/webm"
+  return "video/mp4"
+}


### PR DESCRIPTION
## Summary

- add direct browser uploads to each project's Videos workspace
- send video bytes directly to the project's Google Drive Videos folder, avoiding Worker request-size limits
- show upload progress and allow cancellation
- preserve the existing review, audience, Daily Log, and YouTube publication workflow
- route ORC and Design projects to ORC, HPS projects to HPS, and Nu-Tech projects to Nu-Tech

## Safety and behavior

- requires authenticated project-photo edit permission
- verifies completed Drive uploads belong to the selected project's Videos folder
- validates file type and size before and after upload
- defaults to staff-only review and an optional Daily Log entry
- retains explicit confirmation before public YouTube publication

## Validation

- `bun x tsc --noEmit`
- targeted ESLint: clean
- `vitest run src/lib/videos/__tests__/video-upload.test.ts src/lib/google/__tests__/youtube-oauth.test.ts` (7 tests passed)
- `bun run build` (passed; existing NFT warnings only)
