### PR TITLE
fix(videos): recover uploads and restore sound

### DIFF
--- a/src/app/api/projects/[id]/videos/[videoId]/route.ts
+++ b/src/app/api/projects/[id]/videos/[videoId]/route.ts
@@ -71,6 +71,7 @@ export async function GET(
         mimeType: projectVideos.sourceMimeType,
         audience: projectVideos.compassAudience,
         publishStatus: projectVideos.publishStatus,
+        youtubeUrl: projectVideos.youtubeUrl,
       })
       .from(projectVideos)
       .where(
@@ -85,6 +86,12 @@ export async function GET(
       (video.audience === requestedAudience || video.audience === "public")
     if (!video || (!internal && !allowedExternally)) {
       return new Response("Video not found", { status: 404 })
+    }
+    // YouTube's published copy is transcoded for reliable browser audio/video.
+    // Keep this authenticated Compass URL stable so existing Daily Log links
+    // also benefit from the compatible playback copy.
+    if (video.publishStatus === "published" && video.youtubeUrl) {
+      return Response.redirect(video.youtubeUrl, 302)
     }
     const response = await downloadProjectVideoFile({
       env,

--- a/src/app/api/projects/[id]/videos/upload/complete/route.ts
+++ b/src/app/api/projects/[id]/videos/upload/complete/route.ts
@@ -7,7 +7,10 @@ import { dailyLogs, projects, projectVideos } from "@/db/schema"
 import { activityActorName, recordActivityEvent } from "@/lib/activity-log"
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
-import { verifyProjectVideoWebsiteUpload } from "@/lib/email/project-video-attachments"
+import {
+  findProjectVideoWebsiteUpload,
+  verifyProjectVideoWebsiteUpload,
+} from "@/lib/email/project-video-attachments"
 import { requireOrg } from "@/lib/org-scope"
 import { requireFeaturePermission } from "@/lib/permission-enforcement"
 import { projectDepartment } from "@/lib/project-branding"
@@ -61,13 +64,20 @@ export async function POST(
       )
     }
     const driveFileId = textValue(body.driveFileId)
+    const uploadToken = textValue(body.uploadToken)
     const title = textValue(body.title)
     const description = textValue(body.description)
     const audience = audienceValue(body.compassAudience)
     const addToDailyLog = body.addToDailyLog !== false
-    if (!driveFileId) {
+    if (!driveFileId && !uploadToken) {
       return NextResponse.json(
-        { success: false, error: "Google Drive did not return the uploaded file." },
+        { success: false, error: "Google Drive upload details are missing." },
+        { status: 400 }
+      )
+    }
+    if (uploadToken.length > 128) {
+      return NextResponse.json(
+        { success: false, error: "Google Drive upload details are invalid." },
         { status: 400 }
       )
     }
@@ -116,13 +126,30 @@ export async function POST(
       )
     }
 
-    const source = await verifyProjectVideoWebsiteUpload({
-      env,
-      db,
-      organizationId,
-      projectId,
-      driveFileId,
-    })
+    const source = driveFileId
+      ? await verifyProjectVideoWebsiteUpload({
+          env,
+          db,
+          organizationId,
+          projectId,
+          driveFileId,
+        })
+      : await findProjectVideoWebsiteUpload({
+          env,
+          db,
+          organizationId,
+          projectId,
+          uploadToken,
+        })
+    if (!source) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Google Drive is still finishing this upload.",
+        },
+        { status: 409, headers: { "Retry-After": "2" } }
+      )
+    }
     if (!isProjectVideoFile({ fileName: source.fileName, mimeType: source.mimeType })) {
       return NextResponse.json(
         { success: false, error: "The uploaded file is not a supported video." },

--- a/src/app/api/projects/[id]/videos/upload/start/route.ts
+++ b/src/app/api/projects/[id]/videos/upload/start/route.ts
@@ -99,7 +99,12 @@ export async function POST(
       fileSize,
     })
     return NextResponse.json(
-      { success: true, uploadUrl: session.uploadUrl, mimeType },
+      {
+        success: true,
+        uploadUrl: session.uploadUrl,
+        uploadToken: session.uploadToken,
+        mimeType,
+      },
       { headers: { "Cache-Control": "no-store" } }
     )
   } catch (error) {

--- a/src/components/projects/project-video-upload.tsx
+++ b/src/components/projects/project-video-upload.tsx
@@ -25,6 +25,10 @@ import {
   MAX_PROJECT_VIDEO_UPLOAD_BYTES,
   PROJECT_VIDEO_UPLOAD_LIMIT_LABEL,
 } from "@/lib/videos/upload-limits"
+import {
+  shouldAttemptBrowserUploadRecovery,
+  VIDEO_UPLOAD_COMPLETION_RETRY_DELAYS_MS,
+} from "@/lib/videos/upload-recovery"
 
 type UploadStage = "idle" | "starting" | "uploading" | "saving"
 
@@ -63,14 +67,16 @@ function uploadToGoogleDrive(input: {
   readonly mimeType: string
   readonly onProgress: (value: number) => void
   readonly onRequest: (request: XMLHttpRequest | null) => void
-}): Promise<string> {
+}): Promise<string | null> {
   return new Promise((resolve, reject) => {
     const request = new XMLHttpRequest()
+    let uploadedBytes = 0
     input.onRequest(request)
     request.open("PUT", input.uploadUrl)
     request.setRequestHeader("Content-Type", input.mimeType)
     request.upload.addEventListener("progress", (event) => {
       if (!event.lengthComputable) return
+      uploadedBytes = event.loaded
       input.onProgress(Math.round((event.loaded / event.total) * 100))
     })
     request.addEventListener("load", () => {
@@ -95,6 +101,16 @@ function uploadToGoogleDrive(input: {
     })
     request.addEventListener("error", () => {
       input.onRequest(null)
+      if (
+        shouldAttemptBrowserUploadRecovery({
+          uploadedBytes,
+          fileSize: input.file.size,
+        })
+      ) {
+        input.onProgress(100)
+        resolve(null)
+        return
+      }
       reject(new Error("The video upload was interrupted. Please try again."))
     })
     request.addEventListener("abort", () => {
@@ -102,6 +118,12 @@ function uploadToGoogleDrive(input: {
       reject(new Error("Video upload cancelled."))
     })
     request.send(input.file)
+  })
+}
+
+async function wait(value: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    window.setTimeout(resolve, value)
   })
 }
 
@@ -179,6 +201,7 @@ export function ProjectVideoUpload({
         !startResponse.ok ||
         startBody.success !== true ||
         typeof startBody.uploadUrl !== "string" ||
+        typeof startBody.uploadToken !== "string" ||
         typeof startBody.mimeType !== "string"
       ) {
         throw new Error(
@@ -198,24 +221,46 @@ export function ProjectVideoUpload({
       })
 
       setStage("saving")
-      const completeResponse = await fetch(
-        `/api/projects/${encodeURIComponent(projectId)}/videos/upload/complete`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            driveFileId,
-            title: normalizedTitle,
-            description: description.trim(),
-            compassAudience: audience,
-            addToDailyLog,
-          }),
+      let saved = false
+      let completionError = "Compass could not save the uploaded video."
+      for (
+        let attempt = 0;
+        attempt <= VIDEO_UPLOAD_COMPLETION_RETRY_DELAYS_MS.length;
+        attempt += 1
+      ) {
+        const completeResponse = await fetch(
+          `/api/projects/${encodeURIComponent(projectId)}/videos/upload/complete`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              driveFileId,
+              uploadToken: startBody.uploadToken,
+              title: normalizedTitle,
+              description: description.trim(),
+              compassAudience: audience,
+              addToDailyLog,
+            }),
+          }
+        )
+        const completeBody = await responseBody(completeResponse)
+        if (completeResponse.ok && completeBody.success === true) {
+          saved = true
+          break
         }
-      )
-      const completeBody = await responseBody(completeResponse)
-      if (!completeResponse.ok || completeBody.success !== true) {
+        completionError = responseError(
+          completeBody,
+          "Compass could not save the uploaded video."
+        )
+        const retryDelay = VIDEO_UPLOAD_COMPLETION_RETRY_DELAYS_MS[attempt]
+        if (completeResponse.status !== 409 || retryDelay === undefined) break
+        await wait(retryDelay)
+      }
+      if (!saved) {
         throw new Error(
-          responseError(completeBody, "Compass could not save the uploaded video.")
+          driveFileId === null && completionError.includes("still finishing")
+            ? "The video upload was interrupted. Please try again."
+            : completionError
         )
       }
       toast.success("Video uploaded. Review and publish it below.")

--- a/src/lib/email/project-video-attachments.ts
+++ b/src/lib/email/project-video-attachments.ts
@@ -17,6 +17,7 @@ import { MAX_PHOTO_UPLOAD_FILE_BYTES } from "@/lib/photos/upload-limits"
 
 const GOOGLE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
 const VIDEO_FOLDER_NAME = "Videos"
+const WEBSITE_UPLOAD_PROPERTY = "compassUploadId"
 const DEFAULT_COMPASS_GOOGLE_UPLOAD_USER = "compass@hps-colorado.com"
 
 type Db = ReturnType<typeof getDb>
@@ -31,6 +32,7 @@ export type StoredProjectVideoFile = {
 
 export type ProjectVideoUploadSession = {
   readonly uploadUrl: string
+  readonly uploadToken: string
 }
 
 async function driveClient(input: {
@@ -226,6 +228,7 @@ export async function initiateProjectVideoWebsiteUpload(input: {
     projectFolderId,
     sharedDriveId: drive.sharedDriveId,
   })
+  const uploadToken = crypto.randomUUID()
   const uploadUrl = await drive.client.initiateResumableUpload(
     drive.googleEmail,
     {
@@ -234,9 +237,53 @@ export async function initiateProjectVideoWebsiteUpload(input: {
       parentId: videoFolderId,
       driveId: drive.sharedDriveId ?? undefined,
       size: input.fileSize,
+      appProperties: { [WEBSITE_UPLOAD_PROPERTY]: uploadToken },
     }
   )
-  return { uploadUrl }
+  return { uploadUrl, uploadToken }
+}
+
+export async function findProjectVideoWebsiteUpload(input: {
+  readonly env: unknown
+  readonly db: Db
+  readonly organizationId: string
+  readonly projectId: string
+  readonly uploadToken: string
+}): Promise<StoredProjectVideoFile | null> {
+  const projectFolderId = await projectFolder({
+    db: input.db,
+    projectId: input.projectId,
+  })
+  const drive = await driveClient({
+    env: input.env,
+    db: input.db,
+    organizationId: input.organizationId,
+  })
+  const videoFolderId = await resolveVideoFolder({
+    client: drive.client,
+    googleEmail: drive.googleEmail,
+    projectFolderId,
+    sharedDriveId: drive.sharedDriveId,
+  })
+  const files = await drive.client.listFiles(drive.googleEmail, {
+    folderId: videoFolderId,
+    driveId: drive.sharedDriveId ?? undefined,
+    pageSize: 2,
+    query:
+      `appProperties has { key='${WEBSITE_UPLOAD_PROPERTY}' and ` +
+      `value='${escapeDriveQueryValue(input.uploadToken)}' }`,
+  })
+  const file = files.files[0]
+  if (!file) return null
+  const fileSize = Number(file.size ?? 0)
+  if (!Number.isFinite(fileSize) || fileSize <= 0) return null
+  return {
+    driveFileId: file.id,
+    driveUrl: file.webViewLink ?? null,
+    fileName: file.name,
+    fileSize,
+    mimeType: file.mimeType,
+  }
 }
 
 export async function verifyProjectVideoWebsiteUpload(input: {

--- a/src/lib/google/client/drive-client.ts
+++ b/src/lib/google/client/drive-client.ts
@@ -238,6 +238,9 @@ export class DriveClient {
       } else if (options.driveId) {
         metadata.parents = [options.driveId]
       }
+      if (options.appProperties) {
+        metadata.appProperties = options.appProperties
+      }
 
       const params = new URLSearchParams({
         uploadType: "resumable",

--- a/src/lib/google/client/types.ts
+++ b/src/lib/google/client/types.ts
@@ -78,6 +78,7 @@ export type UploadOptions = {
   readonly mimeType: string
   readonly driveId?: string
   readonly size?: number
+  readonly appProperties?: Readonly<Record<string, string>>
 }
 
 export type UploadFileOptions = UploadOptions & {

--- a/src/lib/videos/__tests__/upload-recovery.test.ts
+++ b/src/lib/videos/__tests__/upload-recovery.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import { shouldAttemptBrowserUploadRecovery } from "@/lib/videos/upload-recovery"
+
+describe("completed browser video upload recovery", () => {
+  it("recovers when every byte reached Google Drive before the network error", () => {
+    expect(
+      shouldAttemptBrowserUploadRecovery({
+        uploadedBytes: 1_024,
+        fileSize: 1_024,
+      })
+    ).toBe(true)
+  })
+
+  it("recovers when the browser omits its final progress event", () => {
+    expect(
+      shouldAttemptBrowserUploadRecovery({
+        uploadedBytes: 1_014,
+        fileSize: 1_024,
+      })
+    ).toBe(true)
+  })
+
+  it("does not disguise a genuinely interrupted upload", () => {
+    expect(
+      shouldAttemptBrowserUploadRecovery({
+        uploadedBytes: 1_000,
+        fileSize: 1_024,
+      })
+    ).toBe(false)
+  })
+})

--- a/src/lib/videos/upload-recovery.ts
+++ b/src/lib/videos/upload-recovery.ts
@@ -1,0 +1,19 @@
+export const VIDEO_UPLOAD_COMPLETION_RETRY_DELAYS_MS = [
+  1_000,
+  2_000,
+  3_000,
+  4_000,
+  5_000,
+] as const
+
+export function shouldAttemptBrowserUploadRecovery(input: {
+  readonly uploadedBytes: number
+  readonly fileSize: number
+}): boolean {
+  // Browsers sometimes omit the final progress event when Drive closes the
+  // resumable request after receiving the body. Restrict recovery to the last
+  // one percent so a genuinely interrupted transfer still fails promptly.
+  return (
+    input.fileSize > 0 && input.uploadedBytes * 100 >= input.fileSize * 99
+  )
+}


### PR DESCRIPTION
## What changed

- recover website video uploads when Google Drive receives the file but the browser loses the final resumable-upload response
- tag each Drive upload with a one-time project-scoped recovery token and retry Drive finalization safely
- route existing authenticated Compass video links to YouTube's transcoded published copy so supported audio is preserved
- retain the original Drive source for staff review

## Root cause

Large browser uploads could finish sending every byte and then surface an XMLHttpRequest network error before Compass received the Drive file ID. Published staff playback also used the original Drive stream instead of YouTube's transcoded copy, so browser-incompatible source audio could be silent even though YouTube playback contained sound.

## Validation

- `bun test src/lib/videos/__tests__/video-upload.test.ts src/lib/videos/__tests__/upload-recovery.test.ts src/lib/google/__tests__/youtube-oauth.test.ts`
- `bunx tsc --noEmit`
- targeted ESLint on all touched files
- `bun run build`
- commit and push hooks completed with no errors
