### PR TITLE
fix(videos): keep staff playback in Compass

### DIFF
--- a/src/app/api/projects/[id]/videos/[videoId]/route.ts
+++ b/src/app/api/projects/[id]/videos/[videoId]/route.ts
@@ -94,6 +94,7 @@ export async function GET(
     if (
       video.publishStatus === "published" &&
       video.youtubeUrl &&
+      video.audience !== "staff" &&
       video.youtubePrivacy !== "private"
     ) {
       return Response.redirect(video.youtubeUrl, 302)


### PR DESCRIPTION
Use the authenticated Compass source for staff-only videos even when the stored YouTube privacy label does not match YouTube enforcement.