### PR TITLE
feat(videos): prepare YouTube API audit compliance

### DIFF
--- a/docs/wip/youtube-api-audit-2026-08-07.md
+++ b/docs/wip/youtube-api-audit-2026-08-07.md
@@ -1,0 +1,128 @@
+# Compass YouTube API compliance audit package
+
+Status: preparation in progress  
+Prepared: 2026-08-07  
+Applicant organization: Open Range Construction, Ltd.  
+API client: Compass  
+Primary URL: https://compass.openrangeconstruction.ltd
+
+## Purpose
+
+Compass is an authenticated construction project-management application. Its
+YouTube integration lets authorized internal staff stage project videos, review
+their metadata and audience, and publish them to a company-managed YouTube
+channel. Compass adds the resulting playback link to the relevant project record
+or Daily Log. Compass does not provide YouTube search, recommendations, channel
+analytics, advertising, or a replacement YouTube experience.
+
+The audit is needed because videos uploaded by an unaudited API project are
+restricted to private viewing. Approval will allow authorized staff to choose
+unlisted or public publication where appropriate. Staff-only distribution will
+default to unlisted after approval because YouTube private videos are viewable
+only by the channel account, not the full Compass staff audience.
+
+## User flow
+
+```mermaid
+flowchart LR
+  A["Authorized staff device or project text/email"] --> B["Compass authenticated intake"]
+  B --> C["Google Drive staging folder"]
+  C --> D["Staff review: title, description, audience, channel"]
+  D --> E["Explicit publish action"]
+  E --> F["YouTube Data API resumable upload"]
+  F --> G["ORC, HPS, or Nu-Tech company channel"]
+  G --> H["YouTube playback link"]
+  H --> I["Compass project video record / Daily Log"]
+```
+
+## Access and security controls
+
+- WorkOS authenticates Compass users.
+- Compass role and project-access checks run before project media can be read or
+  changed.
+- Only internal staff with project-update permission can connect a YouTube
+  channel, review a video, or publish it.
+- OAuth state is stored in a short-lived, HTTP-only, secure, same-site cookie and
+  verified on callback.
+- OAuth refresh tokens are encrypted before database storage and used only on
+  the server.
+- Channel connections are organization-scoped and channel-key scoped.
+- The publishing screen shows the destination channel, intended audience, and
+  YouTube visibility before upload.
+- Public publication requires a separate explicit confirmation.
+- Authorized staff can disconnect a channel. Compass removes the stored token
+  record and attempts to revoke the Google OAuth grant.
+- Users can also revoke access from Google Account permissions.
+- Publication and connection activity is auditable in Compass.
+
+## Requested OAuth scopes
+
+- `openid`
+- `email`
+- `https://www.googleapis.com/auth/youtube.readonly`
+- `https://www.googleapis.com/auth/youtube.upload`
+
+The identity scopes identify the Google account completing authorization. The
+read-only YouTube scope identifies the managed channel. The upload scope creates
+the explicitly approved video upload. Compass does not request access to delete
+videos, read private user activity, manage comments, or access YouTube Analytics.
+
+## Data stored
+
+- Google account email used for the connection
+- YouTube channel ID and channel title
+- Granted OAuth scopes and connection timestamps
+- Encrypted OAuth refresh token
+- Staff-entered video title, description, audience, and destination channel
+- Source Drive file ID and published YouTube video ID/URL
+- Upload status, errors, and activity timestamps
+
+## Retention and deletion
+
+Connection metadata and the encrypted refresh token remain only while the
+connection is active or as required in security records. Disconnecting removes
+the connection record and attempts OAuth revocation. A Google user can also
+revoke Compass from Google Account permissions. Project videos follow the
+organization's project-record retention requirements. A channel manager can
+remove an already-published video in YouTube Studio.
+
+## Public compliance URLs
+
+- Privacy Policy: https://compass.openrangeconstruction.ltd/privacy
+- Terms of Service: https://compass.openrangeconstruction.ltd/terms
+- Google Privacy Policy: https://policies.google.com/privacy
+- Google API Services User Data Policy:
+  https://developers.google.com/terms/api-services-user-data-policy
+- YouTube Terms of Service: https://www.youtube.com/t/terms
+
+## Required evidence checklist
+
+- [ ] Homepage screenshot showing Compass name and Privacy / Terms links
+- [ ] Privacy Policy screenshots showing Google/YouTube disclosure, Google
+      Privacy Policy link, Limited Use statement, retention, deletion, and
+      revocation
+- [ ] Terms screenshot showing YouTube Terms and Community Guidelines
+- [ ] OAuth consent screenshots showing application name and requested scopes
+- [ ] Project-video upload screenshot
+- [ ] Video review screenshot showing title, description, channel, audience,
+      privacy explanation, and public confirmation
+- [ ] Published-video / Daily Log link screenshot
+- [ ] YouTube channel connection and disconnect controls screenshot
+- [ ] Architecture diagram exported to PDF or PNG
+- [ ] User-flow diagram exported to PDF or PNG
+- [ ] Reviewer demo-account instructions
+- [ ] Google Cloud project number
+- [ ] Legal contact name, business address, phone, and submission email
+
+## Post-approval activation
+
+Compass contains a fail-closed `YOUTUBE_API_AUDIT_APPROVED` feature switch.
+Production must leave it unset until Google confirms approval. After approval:
+
+1. Set `YOUTUBE_API_AUDIT_APPROVED=true` in the production Worker environment.
+2. Reconnect each managed YouTube channel if Google requires refreshed consent.
+3. Re-upload videos that Google locked private; existing locked uploads cannot be
+   converted by the unaudited API client.
+4. Verify an unlisted staff video with sound on desktop and mobile.
+5. Verify owner/sub and public audience behavior.
+6. Record the approval date and audit correspondence in this document.

--- a/docs/wip/youtube-api-audit-form-draft-2026-08-07.md
+++ b/docs/wip/youtube-api-audit-form-draft-2026-08-07.md
@@ -1,0 +1,124 @@
+# YouTube API audit form draft — Compass
+
+This is a working draft for Google's Audit and Quota Extension Form. Confirm all
+legal and contact information before submission.
+
+## Request
+
+- Request type: Initial API compliance audit to remove the private-only upload
+  restriction. No quota increase is presently required.
+- Applying as: An organization / registered business
+- Organization legal name: Open Range Construction, Ltd.
+- Primary contact legal name: **Martine to confirm exact legal name**
+- Contact email: martine@openrangeconstruction.com
+- Business address: **Martine to provide/confirm**
+- Phone: **Martine to provide/confirm**
+
+## API client
+
+- API client name: Compass
+- Does the name contain “YouTube”?: No
+- Primary access URL: https://compass.openrangeconstruction.ltd
+- Privacy Policy: https://compass.openrangeconstruction.ltd/privacy
+- Terms of Service: https://compass.openrangeconstruction.ltd/terms
+- Publicly accessible: No. Compass is an authenticated, invite-only project
+  management service. Public Privacy and Terms pages are accessible without a
+  login.
+- Google Cloud project number: **Pending authenticated Google Cloud lookup**
+- Use-case category: Video Uploading & Account Management
+- Secondary category if offered: Internal Company Tool
+
+## Short use-case summary
+
+Compass is an authenticated construction project-management application used by
+Open Range Construction, Ltd., its affiliated operating departments, invited
+project owners, subcontractors, and suppliers. Authorized internal staff can
+upload a project video from a device or route a video received through a project
+text/email intake. Compass stages the source in the project's Google Drive video
+folder. Staff review the title, description, company YouTube channel, Compass
+audience, and YouTube visibility, then explicitly publish the selected video.
+Compass stores the resulting YouTube URL on the project video record and, when
+requested, the related Daily Log. Compass does not offer YouTube search,
+recommendations, advertising, analytics, bulk channel scraping, or a substitute
+YouTube viewing service.
+
+## End users
+
+- Internal employees and authorized company administrators
+- Invited custom-home owners and project clients
+- Invited subcontractors and suppliers
+
+Only authorized internal staff can connect a YouTube channel or publish a video.
+Owners, subcontractors, and suppliers may receive a permitted project link but
+cannot connect company channels or publish through the API.
+
+## Why YouTube API access is necessary
+
+Compass routes project videos to the appropriate existing company channel (ORC,
+HPS, or Nu-Tech) without requiring staff to download the file, leave the project
+context, manually upload it in YouTube Studio, copy the link, and return to the
+correct Daily Log. The integration preserves project context, creates an
+auditable publication workflow, and reduces the risk of publishing to the wrong
+channel or audience.
+
+## OAuth and data usage
+
+Requested scopes:
+
+- `openid`
+- `email`
+- `https://www.googleapis.com/auth/youtube.readonly`
+- `https://www.googleapis.com/auth/youtube.upload`
+
+Compass uses OAuth identity to label the connected company account, read-only
+channel access to confirm the managed channel ID and title, and upload access only
+after an authorized staff user explicitly publishes a reviewed video. Refresh
+tokens are encrypted at rest and remain server-side. Compass does not sell API
+data or use it for advertising or unrelated profiling.
+
+## User controls
+
+- The connection screen identifies every connected company channel.
+- Authorized staff can disconnect a channel from Compass.
+- Disconnect removes the stored connection record and attempts OAuth token
+  revocation.
+- Google users may independently revoke Compass from Google Account permissions.
+- Staff can archive or delete the Compass video record.
+- Channel managers can delete an already-published video in YouTube Studio.
+- Public publication requires an explicit confirmation.
+
+## Expected usage
+
+- Three managed company channels
+- Internal construction-project videos, typically short field demonstrations,
+  progress documentation, or instructional clips
+- Expected volume: well below 100 uploads per day
+- Requested quota: default quota; no extension requested unless the form requires
+  a numeric request for the initial audit
+
+## Reviewer access
+
+- Demo URL: https://compass.openrangeconstruction.ltd/login
+- Demo account: **Create a time-limited reviewer account after Google requests or
+  immediately before submission**
+- Reviewer role: internal test user with access only to a non-production audit
+  project and a test YouTube connection
+- Reviewer instructions: **Attach final step-by-step after the evidence build is
+  deployed**
+
+## Evidence files
+
+Combine screenshots and diagrams into one PDF smaller than 10 MB if the form
+offers one evidence field. Otherwise upload the separately labeled PNG/PDF files
+listed in `youtube-api-audit-2026-08-07.md`.
+
+## Final attestations requiring Martine
+
+- Confirm all company and contact information is exact.
+- Confirm the submission is complete and truthful.
+- Accept the YouTube API Services Terms of Service.
+- Accept the Google Privacy Policy acknowledgment.
+- Accept the Developer Policies acknowledgment.
+- Accept the demo-account waiver if reviewer credentials are supplied.
+- Consent to Google's processing of the submission and support-call recording.
+- Submit the form.

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -34,9 +34,15 @@ export default function AuthLayout({
         </Card>
 
         {/* footer */}
-        <p className="text-center text-xs text-muted-foreground mt-4">
-          High Performance Structures
-        </p>
+        <div className="text-muted-foreground mt-4 flex items-center justify-center gap-3 text-xs">
+          <span>High Performance Structures</span>
+          <a href="/privacy" className="underline underline-offset-4">
+            Privacy
+          </a>
+          <a href="/terms" className="underline underline-offset-4">
+            Terms
+          </a>
+        </div>
       </div>
       <Toaster position="bottom-right" />
     </div>

--- a/src/app/actions/project-videos.ts
+++ b/src/app/actions/project-videos.ts
@@ -24,6 +24,10 @@ import {
 } from "@/lib/google/youtube"
 import { requireOrg } from "@/lib/org-scope"
 import { requireFeaturePermission } from "@/lib/permission-enforcement"
+import {
+  isYoutubeApiAuditApproved,
+  youtubePrivacyForAudience,
+} from "@/lib/videos/youtube-audit"
 
 export type ProjectVideoAudience = "staff" | "owner" | "sub_vendor" | "public"
 
@@ -61,6 +65,7 @@ export type ProjectVideoWorkspace = {
     readonly channelTitle: string
     readonly status: string
   }[]
+  readonly youtubeAuditApproved: boolean
 }
 
 type VideoActionResult =
@@ -102,16 +107,11 @@ function audience(value: string): ProjectVideoAudience | null {
   }
 }
 
-function youtubePrivacy(value: ProjectVideoAudience): "private" | "unlisted" | "public" {
-  if (value === "staff") return "private"
-  if (value === "public") return "public"
-  return "unlisted"
-}
-
 export async function getProjectVideoWorkspace(
   projectId: string
 ): Promise<ProjectVideoWorkspace> {
   const db = await projectVideoDb(projectId, "read")
+  const { env } = await getCloudflareContext()
   const [project] = await db
     .select({
       id: projects.id,
@@ -173,6 +173,7 @@ export async function getProjectVideoWorkspace(
     },
     videos,
     channels,
+    youtubeAuditApproved: isYoutubeApiAuditApproved(env),
   }
 }
 
@@ -213,6 +214,7 @@ export async function updateProjectVideoReview(input: {
       return { success: false, error: "Video description cannot exceed 5,000 characters." }
     }
     const user = await requireAuth()
+    const { env } = await getCloudflareContext()
     const now = new Date().toISOString()
     await db
       .update(projectVideos)
@@ -220,7 +222,10 @@ export async function updateProjectVideoReview(input: {
         title,
         description: description.length > 0 ? description : null,
         compassAudience: normalizedAudience,
-        youtubePrivacy: youtubePrivacy(normalizedAudience),
+        youtubePrivacy: youtubePrivacyForAudience({
+          audience: normalizedAudience,
+          auditApproved: isYoutubeApiAuditApproved(env),
+        }),
         publishStatus: "ready_for_upload",
         reviewedBy: user.id,
         reviewedAt: now,
@@ -241,6 +246,72 @@ export async function updateProjectVideoReview(input: {
     return {
       success: false,
       error: error instanceof Error ? error.message : "Could not save video review.",
+    }
+  }
+}
+
+export async function disconnectYoutubeChannel(input: {
+  readonly projectId: string
+  readonly channelKey: string
+}): Promise<
+  | { readonly success: true; readonly revoked: boolean }
+  | { readonly success: false; readonly error: string }
+> {
+  try {
+    const user = await requireAuth()
+    const organizationId = requireOrg(user)
+    const db = await projectVideoDb(input.projectId, "update")
+    const channelKey = youtubeChannelKey(input.channelKey)
+    if (!channelKey) {
+      return { success: false, error: "YouTube channel is invalid." }
+    }
+    const [connection] = await db
+      .select()
+      .from(youtubeChannelConnections)
+      .where(
+        and(
+          eq(youtubeChannelConnections.organizationId, organizationId),
+          eq(youtubeChannelConnections.channelKey, channelKey)
+        )
+      )
+      .limit(1)
+    if (!connection) return { success: true, revoked: true }
+
+    const { env } = await getCloudflareContext()
+    const config = getYoutubeOAuthConfig(
+      env,
+      "https://compass.openrangeconstruction.ltd"
+    )
+    let revoked = false
+    try {
+      const refreshToken = await decrypt(
+        connection.refreshTokenEncrypted,
+        config.tokenEncryptionKey,
+        youtubeTokenSalt(organizationId, channelKey)
+      )
+      const response = await fetch("https://oauth2.googleapis.com/revoke", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ token: refreshToken }),
+      })
+      revoked = response.ok
+    } catch {
+      revoked = false
+    }
+
+    await db
+      .delete(youtubeChannelConnections)
+      .where(eq(youtubeChannelConnections.id, connection.id))
+      .run()
+    revalidatePath(`/dashboard/projects/${input.projectId}/videos`)
+    return { success: true, revoked }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "YouTube channel could not be disconnected.",
     }
   }
 }

--- a/src/app/api/projects/[id]/videos/upload/complete/route.ts
+++ b/src/app/api/projects/[id]/videos/upload/complete/route.ts
@@ -20,6 +20,10 @@ import {
   MAX_PROJECT_VIDEO_UPLOAD_BYTES,
   PROJECT_VIDEO_UPLOAD_LIMIT_LABEL,
 } from "@/lib/videos/upload-limits"
+import {
+  isYoutubeApiAuditApproved,
+  youtubePrivacyForAudience,
+} from "@/lib/videos/youtube-audit"
 
 type VideoAudience = "staff" | "owner" | "sub_vendor" | "public"
 
@@ -41,14 +45,6 @@ function audienceValue(value: unknown): VideoAudience | null {
     return value
   }
   return null
-}
-
-function youtubePrivacy(
-  audience: VideoAudience
-): "private" | "unlisted" | "public" {
-  if (audience === "staff") return "private"
-  if (audience === "public") return "public"
-  return "unlisted"
 }
 
 export async function POST(
@@ -198,7 +194,10 @@ export async function POST(
       department,
       youtubeChannelKey: youtubeChannelForDepartment(department),
       compassAudience: audience,
-      youtubePrivacy: youtubePrivacy(audience),
+      youtubePrivacy: youtubePrivacyForAudience({
+        audience,
+        auditApproved: isYoutubeApiAuditApproved(env),
+      }),
       publishStatus: "pending_review",
       sourceSystem: "compass_web",
       sourceExternalId: source.driveFileId,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1122,15 +1122,26 @@ export default function Home(): React.JSX.Element {
 				>
 					&copy; 2026 Compass
 				</span>
-				<span
+				<div
 					className={
-						"text-[10px] uppercase " +
-						"tracking-[0.15em] " +
-						"text-[#E8E4DC]/25"
+						"flex items-center gap-4 text-[10px] " +
+						"uppercase tracking-[0.15em] text-[#E8E4DC]/35"
 					}
 				>
-					Open Source (MIT)
-				</span>
+					<Link
+						href="/privacy"
+						className="transition-colors hover:text-[#E8E4DC]/70"
+					>
+						Privacy
+					</Link>
+					<Link
+						href="/terms"
+						className="transition-colors hover:text-[#E8E4DC]/70"
+					>
+						Terms
+					</Link>
+					<span>Open Source (MIT)</span>
+				</div>
 			</footer>
 		</div>
 	);

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,179 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | Compass",
+  description: "How Compass collects, uses, protects, and deletes information.",
+};
+
+const GOOGLE_PRIVACY_POLICY = "https://policies.google.com/privacy";
+const GOOGLE_PERMISSIONS = "https://myaccount.google.com/permissions";
+const GOOGLE_API_DATA_POLICY =
+  "https://developers.google.com/terms/api-services-user-data-policy";
+
+export default function PrivacyPolicyPage(): React.ReactElement {
+  return (
+    <main className="bg-background text-foreground min-h-screen">
+      <article className="mx-auto max-w-3xl px-6 py-12 md:py-16">
+        <Link href="/" className="text-primary text-sm font-medium">
+          ← Compass
+        </Link>
+        <p className="text-muted-foreground mt-10 text-sm">
+          Effective August 7, 2026
+        </p>
+        <h1 className="mt-2 text-3xl font-semibold tracking-tight">
+          Privacy Policy
+        </h1>
+        <p className="text-muted-foreground mt-4 leading-7">
+          Compass is a construction project-management service operated for Open
+          Range Construction, Ltd. and affiliated operating departments,
+          including High Performance Structures, Inc. This policy explains how
+          Compass handles information when staff, owners, subcontractors,
+          suppliers, and invited project participants use the service.
+        </p>
+
+        <section className="mt-10 space-y-4">
+          <h2 className="text-xl font-semibold">
+            Information Compass processes
+          </h2>
+          <p className="leading-7">
+            Compass processes account and contact information, project records,
+            schedules, messages, files, photos, videos, financial workflow
+            records, activity history, device and security information, and
+            information users intentionally submit to project workspaces. Access
+            is limited by role, organization, project membership, and configured
+            project visibility.
+          </p>
+        </section>
+
+        <section className="mt-10 space-y-4">
+          <h2 className="text-xl font-semibold">
+            Google and YouTube information
+          </h2>
+          <p className="leading-7">
+            Authorized internal administrators may connect company-managed
+            Google and YouTube accounts. Compass requests only the OAuth scopes
+            displayed on Google&apos;s consent screen. For YouTube, Compass uses
+            authorization to identify the selected company channel and upload
+            user-selected project videos with their title, description,
+            audience, and visibility choices.
+          </p>
+          <p className="leading-7">
+            Compass stores the connected Google account email, YouTube channel
+            ID and title, granted scopes, connection timestamps, and an
+            encrypted OAuth refresh token. Tokens are used server-side and are
+            not exposed to project participants. Compass does not sell Google
+            user data or use it for advertising, credit, or unrelated profiling.
+          </p>
+          <p className="leading-7">
+            Compass&apos;s use and transfer of information received from Google
+            APIs complies with the Google API Services User Data Policy,
+            including its Limited Use requirements. Review Google&apos;s own
+            practices in the{" "}
+            <a
+              className="text-primary underline underline-offset-4"
+              href={GOOGLE_PRIVACY_POLICY}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Google Privacy Policy
+            </a>{" "}
+            and the{" "}
+            <a
+              className="text-primary underline underline-offset-4"
+              href={GOOGLE_API_DATA_POLICY}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Google API Services User Data Policy
+            </a>
+            .
+          </p>
+        </section>
+
+        <section className="mt-10 space-y-4">
+          <h2 className="text-xl font-semibold">How information is used</h2>
+          <p className="leading-7">
+            Information is used to provide project collaboration, scheduling,
+            communications, file and media workflows, requested integrations,
+            notifications, security, auditing, support, and service improvement.
+            Compass does not use YouTube API data to create independent
+            advertising profiles or to recreate YouTube&apos;s service.
+          </p>
+        </section>
+
+        <section className="mt-10 space-y-4">
+          <h2 className="text-xl font-semibold">Sharing and visibility</h2>
+          <p className="leading-7">
+            Project information is shared only with authorized organization
+            members, invited project participants, service providers needed to
+            operate Compass, and integrations a permitted administrator enables.
+            YouTube videos may be private, unlisted, or public as shown before
+            publication. An unlisted YouTube link can be viewed and forwarded by
+            anyone who obtains the link, even when Compass distributes it only
+            to authorized users.
+          </p>
+        </section>
+
+        <section className="mt-10 space-y-4">
+          <h2 className="text-xl font-semibold">
+            Retention, deletion, and revocation
+          </h2>
+          <p className="leading-7">
+            Compass retains project information according to business,
+            contractual, legal, and backup requirements. Google OAuth tokens and
+            connected-channel metadata are retained only while the connection is
+            active or as required for security records. An authorized
+            administrator can disconnect a YouTube channel from the
+            project-video workspace. Compass then removes the stored connection
+            and attempts to revoke the Google token.
+          </p>
+          <p className="leading-7">
+            A Google user may also revoke Compass directly from{" "}
+            <a
+              className="text-primary underline underline-offset-4"
+              href={GOOGLE_PERMISSIONS}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Google Account permissions
+            </a>
+            . Users may request deletion or correction through their Compass
+            administrator. Removing a Compass connection does not automatically
+            delete videos already published to a company YouTube channel; a
+            channel manager can remove those videos in YouTube Studio or request
+            assistance.
+          </p>
+        </section>
+
+        <section className="mt-10 space-y-4">
+          <h2 className="text-xl font-semibold">Security</h2>
+          <p className="leading-7">
+            Compass uses authentication, authorization checks, encrypted
+            integration credentials, server-side token handling, activity
+            records, and access controls designed to protect project and
+            integration data. No system can guarantee absolute security, so
+            suspected misuse should be reported promptly.
+          </p>
+        </section>
+
+        <section className="mt-10 space-y-4 border-t pt-8">
+          <h2 className="text-xl font-semibold">Contact</h2>
+          <p className="leading-7">
+            Privacy, access, correction, and deletion requests may be sent to{" "}
+            <a
+              className="text-primary underline underline-offset-4"
+              href="mailto:martine@openrangeconstruction.com"
+            >
+              martine@openrangeconstruction.com
+            </a>
+            .
+          </p>
+          <p className="text-muted-foreground text-sm">
+            Open Range Construction, Ltd. · Colorado, United States
+          </p>
+        </section>
+      </article>
+    </main>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,145 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Terms of Service | Compass",
+  description: "Terms governing authorized use of Compass.",
+};
+
+export default function TermsPage(): React.ReactElement {
+  return (
+    <main className="bg-background text-foreground min-h-screen">
+      <article className="mx-auto max-w-3xl px-6 py-12 md:py-16">
+        <Link href="/" className="text-primary text-sm font-medium">
+          ← Compass
+        </Link>
+        <p className="text-muted-foreground mt-10 text-sm">
+          Effective August 7, 2026
+        </p>
+        <h1 className="mt-2 text-3xl font-semibold tracking-tight">
+          Terms of Service
+        </h1>
+        <p className="text-muted-foreground mt-4 leading-7">
+          These terms govern authorized use of Compass, a construction
+          project-management service operated for Open Range Construction, Ltd.
+          and affiliated operating departments.
+        </p>
+
+        <section className="mt-10 space-y-4">
+          <h2 className="text-xl font-semibold">Authorized access</h2>
+          <p className="leading-7">
+            Users may access only the organization, projects, records, and
+            functions made available to their account. Users must protect their
+            credentials, provide accurate information, and promptly report
+            unauthorized access. Access may be suspended or removed when a
+            project relationship ends or when necessary to protect Compass,
+            project participants, or company data.
+          </p>
+        </section>
+
+        <section className="mt-10 space-y-4">
+          <h2 className="text-xl font-semibold">Project content</h2>
+          <p className="leading-7">
+            Users retain their rights in content they submit. By submitting
+            content, a user authorizes Compass and its connected service
+            providers to store, process, reproduce, transmit, display, and
+            publish that content only as necessary to provide the selected
+            project workflow and audience.
+          </p>
+          <p className="leading-7">
+            Users must have permission to submit project files, photos, videos,
+            personal information, and third-party materials. Users may not
+            submit unlawful, infringing, deceptive, unsafe, malicious, or
+            confidential information outside the project audience authorized to
+            receive it.
+          </p>
+        </section>
+
+        <section className="mt-10 space-y-4">
+          <h2 className="text-xl font-semibold">YouTube publishing</h2>
+          <p className="leading-7">
+            Authorized staff may connect company-managed YouTube channels and
+            publish selected project videos. Before publishing, users must
+            choose the intended audience and confirm public publication when
+            applicable. Users certify that uploaded videos comply with the{" "}
+            <a
+              className="text-primary underline underline-offset-4"
+              href="https://www.youtube.com/t/terms"
+              target="_blank"
+              rel="noreferrer"
+            >
+              YouTube Terms of Service
+            </a>{" "}
+            and{" "}
+            <a
+              className="text-primary underline underline-offset-4"
+              href="https://www.youtube.com/howyoutubeworks/policies/community-guidelines/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Community Guidelines
+            </a>
+            .
+          </p>
+          <p className="leading-7">
+            Private videos are limited by YouTube&apos;s account controls.
+            Unlisted videos do not appear in normal public discovery, but anyone
+            who obtains the URL may view or forward it. Public videos are
+            visible through YouTube. Compass does not guarantee that a recipient
+            will keep an unlisted URL confidential.
+          </p>
+        </section>
+
+        <section className="mt-10 space-y-4">
+          <h2 className="text-xl font-semibold">Service and integrations</h2>
+          <p className="leading-7">
+            Third-party integrations remain subject to their providers&apos;
+            terms, availability, permissions, and technical limits. Compass may
+            update, suspend, or discontinue an integration when required for
+            security, compliance, reliability, or provider changes.
+          </p>
+        </section>
+
+        <section className="mt-10 space-y-4">
+          <h2 className="text-xl font-semibold">Responsible use</h2>
+          <p className="leading-7">
+            Users may not bypass permissions, probe for unauthorized data,
+            interfere with service operation, impersonate another person, upload
+            malware, or use Compass to violate law, contractual duties,
+            intellectual-property rights, privacy rights, or third-party
+            platform rules.
+          </p>
+        </section>
+
+        <section className="mt-10 space-y-4">
+          <h2 className="text-xl font-semibold">Records and decisions</h2>
+          <p className="leading-7">
+            Compass supports project communication and workflow but does not
+            replace signed contracts, professional judgment, legal advice,
+            engineering review, safety obligations, or accounting controls.
+            Users remain responsible for reviewing information before relying on
+            it for a project decision.
+          </p>
+        </section>
+
+        <section className="mt-10 space-y-4 border-t pt-8">
+          <h2 className="text-xl font-semibold">Contact</h2>
+          <p className="leading-7">
+            Questions about these terms may be sent to{" "}
+            <a
+              className="text-primary underline underline-offset-4"
+              href="mailto:martine@openrangeconstruction.com"
+            >
+              martine@openrangeconstruction.com
+            </a>
+            . Review the{" "}
+            <Link className="text-primary underline" href="/privacy">
+              Privacy Policy
+            </Link>{" "}
+            for information about data use, revocation, and deletion.
+          </p>
+        </section>
+      </article>
+    </main>
+  );
+}

--- a/src/components/projects/project-video-review.tsx
+++ b/src/components/projects/project-video-review.tsx
@@ -15,6 +15,7 @@ import { toast } from "sonner"
 import {
   archiveProjectVideo,
   deleteProjectVideo,
+  disconnectYoutubeChannel,
   publishProjectVideo,
   updateProjectVideoReview,
   type ProjectVideoItem,
@@ -61,14 +62,22 @@ function audiencePrivacy(value: string): string {
   return "Private on YouTube"
 }
 
+function staffAudiencePrivacy(auditApproved: boolean): string {
+  return auditApproved
+    ? "Unlisted on YouTube — Compass distributes the link to authorized users"
+    : "Private on YouTube until Google approves the Compass API audit"
+}
+
 function VideoReviewCard({
   projectId,
   video,
   channelConnected,
+  youtubeAuditApproved,
 }: {
   readonly projectId: string
   readonly video: ProjectVideoItem
   readonly channelConnected: boolean
+  readonly youtubeAuditApproved: boolean
 }): React.ReactElement {
   const router = useRouter()
   const [title, setTitle] = React.useState(video.title)
@@ -171,7 +180,9 @@ function VideoReviewCard({
               </SelectContent>
             </Select>
             <p className="text-muted-foreground text-xs">
-              {audiencePrivacy(audience)}
+              {audience === "staff"
+                ? staffAudiencePrivacy(youtubeAuditApproved)
+                : audiencePrivacy(audience)}
             </p>
           </div>
           <div className="bg-muted/45 px-3 py-2 text-sm">
@@ -293,6 +304,8 @@ export function ProjectVideoReview({
 }: {
   readonly workspace: ProjectVideoWorkspace
 }): React.ReactElement {
+  const router = useRouter()
+  const [channelPending, startTransition] = React.useTransition()
   const connectedKeys = new Set(
     workspace.channels
       .filter((channel) => channel.status === "connected")
@@ -328,20 +341,59 @@ export function ProjectVideoReview({
             const connection = workspace.channels.find(
               (item) => item.channelKey === channel.key && item.status === "connected"
             )
+            if (!connection) {
+              return (
+                <Button key={channel.key} asChild size="sm" variant="outline">
+                  <Link
+                    href={
+                      `/api/google/youtube/connect?channel=${channel.key}` +
+                      `&project=${encodeURIComponent(workspace.project.id)}`
+                    }
+                  >
+                    <IconBrandYoutube /> Connect {channel.label}
+                  </Link>
+                </Button>
+              )
+            }
             return (
-              <Button key={channel.key} asChild size="sm" variant="outline">
-                <Link
-                  href={
-                    `/api/google/youtube/connect?channel=${channel.key}` +
-                    `&project=${encodeURIComponent(workspace.project.id)}`
-                  }
+              <div key={channel.key} className="flex items-center gap-1">
+                <Badge variant="outline">
+                  <IconBrandYoutube /> {channel.label}: {connection.channelTitle}
+                </Badge>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  disabled={channelPending}
+                  onClick={() => {
+                    if (
+                      !window.confirm(
+                        `Disconnect ${connection.channelTitle} from Compass?`
+                      )
+                    ) {
+                      return
+                    }
+                    startTransition(async () => {
+                      const result = await disconnectYoutubeChannel({
+                        projectId: workspace.project.id,
+                        channelKey: channel.key,
+                      })
+                      if (!result.success) {
+                        toast.error(result.error)
+                        return
+                      }
+                      toast.success(
+                        result.revoked
+                          ? "YouTube access revoked and connection removed."
+                          : "Connection removed. Also review Google Account permissions."
+                      )
+                      router.refresh()
+                    })
+                  }}
                 >
-                  <IconBrandYoutube />
-                  {connection
-                    ? `${channel.label}: ${connection.channelTitle}`
-                    : `Connect ${channel.label}`}
-                </Link>
-              </Button>
+                  Disconnect
+                </Button>
+              </div>
             )
           })}
         </div>
@@ -364,6 +416,7 @@ export function ProjectVideoReview({
               projectId={workspace.project.id}
               video={video}
               channelConnected={connectedKeys.has(video.youtubeChannelKey)}
+              youtubeAuditApproved={workspace.youtubeAuditApproved}
             />
           ))
         )}

--- a/src/lib/email/project-inbound-routing.ts
+++ b/src/lib/email/project-inbound-routing.ts
@@ -35,6 +35,10 @@ import { storeDailyLogEmailAttachments } from "@/lib/email/project-email-attachm
 import { storeProjectVideoAttachment } from "@/lib/email/project-video-attachments"
 import { projectDepartment } from "@/lib/project-branding"
 import { youtubeChannelForDepartment } from "@/lib/videos/channel-routing"
+import {
+  isYoutubeApiAuditApproved,
+  youtubePrivacyForAudience,
+} from "@/lib/videos/youtube-audit"
 import { PROJECT_TODO_RECORD_TYPES } from "@/lib/project-todos"
 
 type Db = ReturnType<typeof getDb>
@@ -553,7 +557,10 @@ async function routeVideo(input: {
     department,
     youtubeChannelKey: youtubeChannelForDepartment(department),
     compassAudience: "staff",
-    youtubePrivacy: "private",
+    youtubePrivacy: youtubePrivacyForAudience({
+      audience: "staff",
+      auditApproved: isYoutubeApiAuditApproved(input.env),
+    }),
     publishStatus: "pending_review",
     sourceSystem: input.source.sourceSystem,
     sourceExternalId,

--- a/src/lib/videos/__tests__/youtube-audit.test.ts
+++ b/src/lib/videos/__tests__/youtube-audit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isYoutubeApiAuditApproved,
+  youtubePrivacyForAudience,
+} from "@/lib/videos/youtube-audit";
+
+describe("YouTube API audit policy", () => {
+  it("fails closed until Google approves the API project", () => {
+    expect(isYoutubeApiAuditApproved({})).toBe(false);
+    expect(
+      youtubePrivacyForAudience({ audience: "staff", auditApproved: false }),
+    ).toBe("private");
+  });
+
+  it("enables approved staff sharing without making it public", () => {
+    expect(
+      isYoutubeApiAuditApproved({ YOUTUBE_API_AUDIT_APPROVED: "true" }),
+    ).toBe(true);
+    expect(
+      youtubePrivacyForAudience({ audience: "staff", auditApproved: true }),
+    ).toBe("unlisted");
+  });
+
+  it("keeps invited audiences unlisted and explicit public videos public", () => {
+    expect(
+      youtubePrivacyForAudience({ audience: "owner", auditApproved: false }),
+    ).toBe("unlisted");
+    expect(
+      youtubePrivacyForAudience({
+        audience: "sub_vendor",
+        auditApproved: false,
+      }),
+    ).toBe("unlisted");
+    expect(
+      youtubePrivacyForAudience({ audience: "public", auditApproved: false }),
+    ).toBe("public");
+  });
+});

--- a/src/lib/videos/youtube-audit.ts
+++ b/src/lib/videos/youtube-audit.ts
@@ -1,0 +1,28 @@
+export type ProjectVideoAudience = "staff" | "owner" | "sub_vendor" | "public";
+
+function environmentValue(env: unknown, key: string): string | null {
+  const value =
+    typeof env === "object" && env !== null
+      ? Object.getOwnPropertyDescriptor(env, key)?.value
+      : null;
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  const processValue = process.env[key];
+  return typeof processValue === "string" && processValue.trim().length > 0
+    ? processValue.trim()
+    : null;
+}
+
+export function isYoutubeApiAuditApproved(env: unknown): boolean {
+  return environmentValue(env, "YOUTUBE_API_AUDIT_APPROVED") === "true";
+}
+
+export function youtubePrivacyForAudience(input: {
+  readonly audience: ProjectVideoAudience;
+  readonly auditApproved: boolean;
+}): "private" | "unlisted" | "public" {
+  if (input.audience === "public") return "public";
+  if (input.audience === "staff" && !input.auditApproved) return "private";
+  return "unlisted";
+}


### PR DESCRIPTION
## Summary

- add public Compass Privacy Policy and Terms pages with Google/YouTube disclosures
- add organization-scoped YouTube OAuth disconnect and token revocation controls
- add a fail-closed audit-approval flag so staff uploads remain private until Google approves the API client, then become unlisted
- document the Compass YouTube architecture, evidence checklist, and draft Google audit-form responses

## Why

Google forces uploads from unaudited YouTube API projects to private visibility. Compass needs a compliant, reviewable OAuth and publication flow before requesting an API compliance audit and enabling staff-visible unlisted playback.

## User impact

The current production behavior stays private until Google confirms approval. Authorized staff gain a visible Disconnect control, and public Privacy/Terms pages support the audit. After approval, setting `YOUTUBE_API_AUDIT_APPROVED=true` will make staff publication unlisted without making it public.

## Validation

- focused YouTube audit, upload, and OAuth tests: 10 passed
- `bunx tsc --noEmit`
- targeted ESLint
- full `bun run build`
- full pre-push production build
- manual scoped security/correctness review (automated reviewer was unavailable because its local Codex state DB is read-only)
