### PR TITLE
fix(auth): keep compliance pages public

### DIFF
--- a/src/lib/__tests__/middleware-routes.test.ts
+++ b/src/lib/__tests__/middleware-routes.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from "vitest"
 import { isPublicPath } from "@/lib/public-paths"
 
 describe("middleware public routes", () => {
+  it("keeps legal and compliance disclosures public", () => {
+    expect(isPublicPath("/privacy")).toBe(true)
+    expect(isPublicPath("/terms")).toBe(true)
+  })
+
   it("allows the HMAC-authenticated Jarvis bridge through WorkOS middleware", () => {
     expect(isPublicPath("/api/integrations/jarvis/events")).toBe(true)
     expect(

--- a/src/lib/public-paths.ts
+++ b/src/lib/public-paths.ts
@@ -7,6 +7,8 @@ const publicPaths = [
   "/invite",
   "/callback",
   "/demo",
+  "/privacy",
+  "/terms",
   "/manifest.json",
 ]
 


### PR DESCRIPTION
## Summary

- allow unauthenticated access to `/privacy` and `/terms`
- add a regression test covering both compliance routes

## Why

The pages deployed in #372 but WorkOS middleware redirected unauthenticated visitors to login. Google's YouTube API audit requires publicly accessible Privacy and Terms pages.

## Validation

- `bun test src/lib/__tests__/middleware-routes.test.ts` — 5 passed
- targeted ESLint — clean
- full pre-push production build — passed
