### PR TITLE
fix(test): resolve WorkOS cache import under Node 24

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,9 +5,16 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // AuthKit imports this extensionless ESM path, which Node 24 no longer resolves.
+      "next/cache": path.resolve(__dirname, "./node_modules/next/cache.js"),
     },
   },
   test: {
+    server: {
+      deps: {
+        inline: ["@workos-inc/authkit-nextjs"],
+      },
+    },
     globals: true,
     environment: "node",
     include: ["src/**/__tests__/**/*.test.ts", "__tests__/**/*.test.ts"],


### PR DESCRIPTION
## Summary

- inline AuthKit in Vitest so its ESM imports use the test resolver
- alias AuthKit's extensionless `next/cache` import to Next's explicit `next/cache.js` entrypoint
- preserve production authentication behavior; the change applies only to Vitest

## Root cause

Vitest externalized AuthKit, so Node 24 tried to resolve AuthKit's extensionless `next/cache` ESM import directly and failed before the Jarvis suites executed.

## Validation

- `bunx vitest run src/lib/jarvis/__tests__/feedback-lifecycle.test.ts src/lib/jarvis/__tests__/feedback-timeline.test.ts`
- `bun run test` — 126 files passed, 705 tests passed, 3 skipped
- `bun lint` — passed with existing repository warnings

Fixes #373