### PR TITLE
feat(feedback): surface operations and feature-decision queues

### DIFF
--- a/src/components/feedback/feedback-desk-admin.tsx
+++ b/src/components/feedback/feedback-desk-admin.tsx
@@ -33,6 +33,7 @@ import {
   knownFeedbackPriority,
   knownFeedbackStatus,
 } from "@/lib/jarvis/feedback-lifecycle"
+import { feedbackOperationsSummary } from "@/lib/jarvis/feedback-operations-summary"
 
 function formatDate(value: string | null): string {
   if (!value) return "Never"
@@ -265,6 +266,10 @@ export function FeedbackDeskAdmin({ overview }: Readonly<{
   )
   const overdue = openItems.filter((item) => item.overdue).length
   const unassigned = openItems.filter((item) => !item.assignedToUserId).length
+  const operations = feedbackOperationsSummary({
+    bridgeFailedEvents: overview.bridge.failed,
+    items: overview.items,
+  })
   const githubReviewNeeded = overview.items.filter(
     (item) =>
       !item.githubIssueUrl &&
@@ -312,6 +317,32 @@ export function FeedbackDeskAdmin({ overview }: Readonly<{
         <Card><CardHeader><CardDescription>SLA overdue</CardDescription><CardTitle>{overdue}</CardTitle></CardHeader></Card>
         <Card><CardHeader><CardDescription>Failed bridge events</CardDescription><CardTitle>{overview.bridge.failed}</CardTitle></CardHeader></Card>
       </div>
+
+      <Card className={operations.needsAttention ? "border-destructive/60" : undefined}>
+        <CardHeader className="gap-2">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <CardTitle className="text-base">Operations queue</CardTitle>
+            <Badge variant={operations.needsAttention ? "destructive" : "secondary"}>
+              {operations.needsAttention ? "Action required" : "Current"}
+            </Badge>
+          </div>
+          <CardDescription>{operations.attentionMessage}</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3 md:grid-cols-2">
+          <div className="rounded-md border p-3">
+            <p className="text-sm font-medium">Bug workflow</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {operations.openBugs} open bug{operations.openBugs === 1 ? "" : "s"}. Routine bugs can continue through protected triage and review without waiting for a leadership decision.
+            </p>
+          </div>
+          <div className="rounded-md border p-3">
+            <p className="text-sm font-medium">Feature decision queue</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {operations.featureDecisionMessage}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader>

--- a/src/components/feedback/feedback-desk-admin.tsx
+++ b/src/components/feedback/feedback-desk-admin.tsx
@@ -247,7 +247,7 @@ function RequestEditor({
               </Link>
             )}
             <Button size="sm" disabled={pending} onClick={save}>
-              {pending ? "Saving..." : "Save and notify"}
+              {pending ? "Saving..." : "Save / Queue update"}
             </Button>
           </div>
         </div>

--- a/src/lib/jarvis/__tests__/feedback-operations-summary.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-operations-summary.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+
+import { feedbackOperationsSummary } from "@/lib/jarvis/feedback-operations-summary"
+
+describe("Feedback Desk operations summary", () => {
+  it("keeps bug flow visible while reserving feature implementation for leadership review", () => {
+    const summary = feedbackOperationsSummary({
+      bridgeFailedEvents: 2,
+      items: [
+        {
+          assignedToUserId: null,
+          kind: "bug",
+          overdue: true,
+          status: "triaged",
+        },
+        {
+          assignedToUserId: "",
+          kind: "bug",
+          overdue: false,
+          status: "in_progress",
+        },
+        {
+          assignedToUserId: null,
+          kind: "feature",
+          overdue: false,
+          status: "triaged",
+        },
+        {
+          assignedToUserId: null,
+          kind: "feature",
+          overdue: true,
+          status: "closed",
+        },
+      ],
+    })
+
+    expect(summary).toMatchObject({
+      failedBridgeEvents: 2,
+      openBugs: 2,
+      openFeatures: 1,
+      overdue: 1,
+      unassigned: 3,
+    })
+    expect(summary.needsAttention).toBe(true)
+    expect(summary.featureDecisionMessage).toContain("leadership")
+    expect(summary.featureDecisionMessage).toContain("before implementation")
+  })
+
+  it("marks only pre-implementation features as awaiting leadership review", () => {
+    const summary = feedbackOperationsSummary({
+      bridgeFailedEvents: 0,
+      items: [
+        {
+          assignedToUserId: "staff-1",
+          kind: "feature",
+          overdue: false,
+          status: "triaged",
+        },
+        {
+          assignedToUserId: "staff-2",
+          kind: "feature",
+          overdue: false,
+          status: "in_progress",
+        },
+      ],
+    })
+
+    expect(summary.featureDecisionRequests).toBe(1)
+    expect(summary.needsAttention).toBe(true)
+    expect(summary.featureDecisionMessage).toContain("1 request awaits")
+  })
+})

--- a/src/lib/jarvis/feedback-operations-summary.ts
+++ b/src/lib/jarvis/feedback-operations-summary.ts
@@ -1,0 +1,74 @@
+export type FeedbackOperationsSummaryItem = Readonly<{
+  assignedToUserId: string | null
+  kind: string
+  overdue: boolean
+  status: string
+}>
+
+export type FeedbackOperationsSummaryInput = Readonly<{
+  bridgeFailedEvents: number
+  items: readonly FeedbackOperationsSummaryItem[]
+}>
+
+export type FeedbackOperationsSummary = Readonly<{
+  attentionMessage: string
+  failedBridgeEvents: number
+  featureDecisionMessage: string
+  featureDecisionRequests: number
+  needsAttention: boolean
+  openBugs: number
+  openFeatures: number
+  overdue: number
+  unassigned: number
+}>
+
+const FEATURE_DECISION_STATUSES = new Set(["new", "triaged", "needs_info"])
+
+function isOpenFeedbackStatus(status: string): boolean {
+  return status !== "closed" && status !== "deployed"
+}
+
+function isFeatureDecisionPending(item: FeedbackOperationsSummaryItem): boolean {
+  return item.kind === "feature" && FEATURE_DECISION_STATUSES.has(item.status)
+}
+
+function requestLabel(count: number): string {
+  return `${count} request${count === 1 ? "" : "s"}`
+}
+
+export function feedbackOperationsSummary(
+  input: FeedbackOperationsSummaryInput,
+): FeedbackOperationsSummary {
+  const openItems = input.items.filter((item) => isOpenFeedbackStatus(item.status))
+  const overdue = openItems.filter((item) => item.overdue).length
+  const unassigned = openItems.filter((item) => !item.assignedToUserId).length
+  const openBugs = openItems.filter((item) => item.kind === "bug").length
+  const openFeatures = openItems.filter((item) => item.kind === "feature").length
+  const featureDecisionRequests = openItems.filter(isFeatureDecisionPending).length
+  const attentionParts = [
+    overdue > 0 ? `${requestLabel(overdue)} overdue` : null,
+    unassigned > 0 ? `${requestLabel(unassigned)} unassigned` : null,
+    featureDecisionRequests > 0
+      ? `${requestLabel(featureDecisionRequests)} awaiting leadership review`
+      : null,
+    input.bridgeFailedEvents > 0
+      ? `${input.bridgeFailedEvents} failed bridge event${input.bridgeFailedEvents === 1 ? "" : "s"}`
+      : null,
+  ].filter((value): value is string => value !== null)
+
+  return {
+    attentionMessage: attentionParts.length > 0
+      ? `${attentionParts.join(" · ")}. Review the protected queue below.`
+      : "No current operational escalation requires attention.",
+    failedBridgeEvents: input.bridgeFailedEvents,
+    featureDecisionMessage: featureDecisionRequests > 0
+      ? `${requestLabel(featureDecisionRequests)} await${featureDecisionRequests === 1 ? "s" : ""} leadership priority review before implementation.`
+      : "No feature requests currently await leadership priority review.",
+    featureDecisionRequests,
+    needsAttention: attentionParts.length > 0,
+    openBugs,
+    openFeatures,
+    overdue,
+    unassigned,
+  }
+}


### PR DESCRIPTION
## Summary

- adds a protected Feedback Desk Operations queue with aggregate risk visibility
- keeps routine bug flow visibly independent of leadership-review backlog
- identifies only pre-implementation feature requests as requiring leadership priority review
- keeps all new summary content aggregate-only; requester details remain in the protected item cards

## Verification

- `node_modules/.bin/vitest run src/lib/jarvis/__tests__/feedback-operations-summary.test.ts --reporter=verbose`
- `node_modules/.bin/eslint src/lib/jarvis/feedback-operations-summary.ts src/lib/jarvis/__tests__/feedback-operations-summary.test.ts src/components/feedback/feedback-desk-admin.tsx`

## Known local limitation

The existing `feedback-lifecycle.test.ts` cannot load locally because the shared dependency install cannot resolve `next/cache` from WorkOS. The new isolated summary test passes.

Closes #377
