### PR TITLE
fix(schedule): expand usable workspace

### DIFF
--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -187,21 +187,19 @@ test.describe("usable Compass areas", () => {
   test("schedule switches between calendar, list, and Gantt", async ({
     page,
   }) => {
-    await page.goto("/dashboard/projects")
-    const projectId = await findProjectId(page)
-    if (!projectId) {
-      test.skip(true, "The deployed demo has no read-only project fixture")
-      return
-    }
-    const schedulePath = `/dashboard/projects/${projectId}/schedule`
+    const schedulePath = "/dashboard/projects/e2e-project-001/schedule"
     const response = await page.goto(schedulePath)
     await expectHealthyNavigation(page, response, schedulePath)
 
-    for (const view of ["Calendar", "List", "Gantt"]) {
+    for (const view of ["Calendar", "List", "Gantt"] as const) {
       await test.step(view, async () => {
-        const switcher = page.locator("button").filter({ hasText: view }).first()
-        await expect(switcher).toBeVisible()
-        await switcher.click()
+        await page.getByRole("button", { name: "Schedule view" }).click()
+        const option = page.getByRole("menuitemradio", { name: view })
+        await expect(option).toBeVisible()
+        await option.click()
+        await page.waitForURL(
+          (url) => url.searchParams.get("view") === view.toLowerCase()
+        )
         await expect(page.locator("body")).not.toContainText(applicationErrorText)
       })
     }
@@ -257,6 +255,71 @@ test.describe("usable Compass areas", () => {
         (element) => element.scrollHeight > element.clientHeight
       )
     ).toBe(true)
+  })
+
+  test("Schedule puts view choices and Gantt controls in compact menus", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 640, height: 700 })
+    const path = "/dashboard/projects/e2e-project-001/schedule?view=list"
+    const response = await page.goto(path)
+    await expectHealthyNavigation(page, response, "/dashboard/projects/e2e-project-001/schedule")
+
+    const toolbar = page.locator("[data-schedule-toolbar]:visible")
+    await expect(toolbar).toBeVisible()
+    expect(
+      await toolbar.evaluate((element) => element.clientHeight)
+    ).toBeLessThanOrEqual(40)
+
+    await page.getByRole("button", { name: "Schedule view" }).click()
+    await expect(
+      page.getByRole("menuitemradio", { name: "Calendar" })
+    ).toBeVisible()
+    await expect(
+      page.getByRole("menuitemradio", { name: "List" })
+    ).toBeChecked()
+    await page.getByRole("menuitemradio", { name: "Gantt" }).click()
+    await page.waitForURL(
+      (url) =>
+        url.searchParams.get("view") === "gantt" && url.searchParams.has("order")
+    )
+    await expect(page.getByRole("button", { name: "Gantt controls" })).toBeVisible()
+
+    await page.getByRole("button", { name: "Gantt controls" }).click()
+    await expect(
+      page.getByRole("menuitemradio", { name: "Day", exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByRole("menuitemradio", { name: "Week" })
+    ).toBeChecked()
+    await expect(
+      page.getByRole("menuitemradio", { name: "Month" })
+    ).toBeVisible()
+    await expect(
+      page.getByRole("menuitemradio", { name: "Year" })
+    ).toBeVisible()
+    await expect(page.getByRole("menuitem", { name: "Today" })).toBeVisible()
+    await page.keyboard.press("Escape")
+  })
+
+  test("Schedule Calendar controls use one compact menu", async ({ page }) => {
+    await page.setViewportSize({ width: 980, height: 700 })
+    const response = await page.goto(
+      "/dashboard/projects/e2e-project-001/schedule?view=calendar"
+    )
+    await expectHealthyNavigation(
+      page,
+      response,
+      "/dashboard/projects/e2e-project-001/schedule"
+    )
+
+    await page.getByRole("button", { name: "Calendar controls" }).click()
+    await expect(
+      page.getByRole("menuitemradio", { name: "Month", exact: true })
+    ).toBeChecked()
+    await expect(
+      page.getByRole("menuitemradio", { name: "Agenda" })
+    ).toBeVisible()
   })
 
   test("project conversation replies enable the explicit send action", async ({

--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -207,6 +207,58 @@ test.describe("usable Compass areas", () => {
     }
   })
 
+  test("Schedule keeps controls compact and gives views a scrollable workspace", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 640, height: 700 })
+    const path = "/dashboard/projects/e2e-project-001/schedule?view=list"
+    const response = await page.goto(path)
+    await expectHealthyNavigation(page, response, "/dashboard/projects/e2e-project-001/schedule")
+
+    const scrollRegion = page.locator(
+      '[data-dashboard-scroll-region="schedule"]:visible'
+    )
+    await expect(scrollRegion).toHaveCSS("overflow-y", "auto")
+
+    const controls = page.locator("[data-schedule-controls]:visible")
+    await expect(controls).toBeVisible()
+    const controlHeight = await controls.evaluate((element) => element.clientHeight)
+    expect(controlHeight).toBeLessThanOrEqual(40)
+    await expect(controls).toHaveCSS("overflow-x", "auto")
+
+    const projectSwitcher = page.getByRole("combobox", {
+      name: "Switch project",
+    })
+    await expect(projectSwitcher).toBeVisible()
+    expect(
+      await projectSwitcher.evaluate((element) => {
+        const row = element.closest("[data-schedule-controls]")
+        if (!row) return false
+        const rowBounds = row.getBoundingClientRect()
+        const controlBounds = element.getBoundingClientRect()
+        return (
+          controlBounds.top >= rowBounds.top &&
+          controlBounds.bottom <= rowBounds.bottom
+        )
+      })
+    ).toBe(true)
+
+    const listActions = page.locator("[data-schedule-list-actions]:visible")
+    await expect(listActions).toBeVisible()
+    await expect(listActions).toHaveCSS("border-top-width", "0px")
+    await expect(listActions).toHaveCSS("padding-top", "0px")
+
+    const workspace = page.locator("[data-schedule-workspace]:visible")
+    await expect(workspace).toBeVisible()
+    const workspaceHeight = await workspace.evaluate((element) => element.clientHeight)
+    expect(workspaceHeight).toBeGreaterThanOrEqual(460)
+    expect(
+      await scrollRegion.evaluate(
+        (element) => element.scrollHeight > element.clientHeight
+      )
+    ).toBe(true)
+  })
+
   test("project conversation replies enable the explicit send action", async ({
     page,
   }) => {

--- a/src/app/dashboard/projects/[id]/schedule/page.tsx
+++ b/src/app/dashboard/projects/[id]/schedule/page.tsx
@@ -101,7 +101,7 @@ export default async function SchedulePage({
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col px-4 py-2 sm:px-6">
+    <div className="flex min-h-full flex-col px-3 py-2 sm:px-4 lg:px-6">
       <ScheduleView
         projectId={id}
         projectName={projectName}

--- a/src/app/dashboard/projects/[id]/schedule/page.tsx
+++ b/src/app/dashboard/projects/[id]/schedule/page.tsx
@@ -101,7 +101,7 @@ export default async function SchedulePage({
   }
 
   return (
-    <div className="px-4 py-2 flex flex-col flex-1 min-h-0">
+    <div className="flex min-h-0 flex-1 flex-col px-4 py-2 sm:px-6">
       <ScheduleView
         projectId={id}
         projectName={projectName}

--- a/src/app/dashboard/schedule/page.tsx
+++ b/src/app/dashboard/schedule/page.tsx
@@ -183,7 +183,7 @@ export default async function SchedulePage({
         : null
 
     return (
-      <div className="flex min-h-0 flex-1 flex-col px-4 py-2">
+      <div className="flex min-h-full flex-col px-3 py-2 sm:px-4 lg:px-6">
         <ScheduleView
           projectId={scope.kind === "project" ? primaryProject?.id ?? null : null}
           projectName={

--- a/src/components/agent/main-content.tsx
+++ b/src/components/agent/main-content.tsx
@@ -11,10 +11,11 @@ export function MainContent({
   const pathname = usePathname()
   const isConversations = pathname?.startsWith("/dashboard/conversations")
   const isSchedule = pathname?.includes("/schedule")
-  const needsFixedHeight = isConversations || isSchedule
+  const needsFixedHeight = isConversations
 
   return (
     <div
+      data-dashboard-scroll-region={isSchedule ? "schedule" : undefined}
       {...rest}
       className={cn(
         "flex flex-col overflow-x-hidden min-w-0 min-h-0",

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -6,6 +6,7 @@ import {
   IconActivity,
   IconCalendarStats,
   IconClipboardCheck,
+  IconTimeline,
   IconClipboardText,
   IconFiles,
   IconFileDollar,
@@ -61,6 +62,16 @@ const PERSISTENT_NAV = [
     url: "/dashboard/schedule?kind=task",
     icon: IconClipboardCheck,
   },
+  {
+    title: "Work Calendar",
+    url: "/dashboard/schedule",
+    icon: IconCalendarStats,
+  },
+  {
+    title: "Schedule",
+    url: "/dashboard/schedule?mode=projects&scope=all&view=gantt",
+    icon: IconTimeline,
+  },
 ]
 
 const NAV_MAIN = [
@@ -74,11 +85,6 @@ const NAV_MAIN = [
     title: "Projects",
     url: "/dashboard/projects",
     icon: IconFolder,
-  },
-  {
-    title: "Work Calendar",
-    url: "/dashboard/schedule",
-    icon: IconCalendarStats,
   },
   {
     title: "Owner Updates",

--- a/src/components/schedule/gantt-chart.tsx
+++ b/src/components/schedule/gantt-chart.tsx
@@ -6,6 +6,7 @@ import type { DisplayColorPalette } from "@/lib/schedule/appearance"
 import { getScheduleItemClasses } from "@/lib/schedule/appearance"
 import {
   dominantScrollAxis,
+  clampGanttScrollOffset,
   lockWheelToDominantAxis,
   normalizeWheelDelta,
   paddingToIncludeDate,
@@ -528,6 +529,48 @@ export function GanttChart({
       ganttRef.current.change_view_mode(viewMode)
     }
   }, [viewMode, loaded])
+
+  useEffect(() => {
+    const wrapper = wrapperRef.current
+    const container = ganttContainerRef.current
+    if (!wrapper || !container || !loaded || typeof ResizeObserver === "undefined") {
+      return
+    }
+
+    let frameId: number | null = null
+    let observedWidth: number | null = null
+    const reconcileAfterResize = (): void => {
+      frameId = requestAnimationFrame(() => {
+        frameId = null
+        const activeContainer = ganttContainerRef.current
+        if (!activeContainer) return
+        activeContainer.scrollLeft = clampGanttScrollOffset(
+          activeContainer.scrollLeft,
+          activeContainer.scrollWidth,
+          activeContainer.clientWidth
+        )
+        activeContainer.scrollTop = clampGanttScrollOffset(
+          activeContainer.scrollTop,
+          activeContainer.scrollHeight,
+          activeContainer.clientHeight
+        )
+        activeContainer.dispatchEvent(new Event("scroll"))
+      })
+    }
+
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      const width = entry?.contentRect.width
+      if (width === undefined || width === observedWidth) return
+      observedWidth = width
+      if (frameId !== null) cancelAnimationFrame(frameId)
+      reconcileAfterResize()
+    })
+    resizeObserver.observe(wrapper)
+    return () => {
+      resizeObserver.disconnect()
+      if (frameId !== null) cancelAnimationFrame(frameId)
+    }
+  }, [loaded])
 
   if (tasks.length === 0) {
     return (

--- a/src/components/schedule/schedule-calendar-view.tsx
+++ b/src/components/schedule/schedule-calendar-view.tsx
@@ -21,8 +21,6 @@ import {
 } from "date-fns"
 import {
   IconCalendar,
-  IconChevronLeft,
-  IconChevronRight,
   IconList,
 } from "@tabler/icons-react"
 
@@ -34,6 +32,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { cn } from "@/lib/utils"
 import { useScheduleDisplayPalette } from "@/hooks/use-schedule-display-palette"
 import { getScheduleItemDisplayColor } from "@/lib/schedule/appearance"
@@ -227,75 +234,57 @@ export function ScheduleCalendarView({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="mb-2 flex flex-wrap items-center gap-2">
-        {mode !== "agenda" && (
-          <>
+      <div className="mb-1 flex h-8 shrink-0 items-center">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
             <Button
-              type="button"
-              variant="outline"
+              aria-label="Calendar controls"
+              className="h-8 px-2 text-xs"
               size="sm"
-              onClick={() => setCurrentDate(new Date())}
-              className="h-8 text-xs"
+              variant="outline"
             >
-              Today
+              <IconCalendar className="size-3.5" />
+              <span className="ml-1.5 capitalize">{mode}</span>
             </Button>
-            <div className="flex items-center">
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="size-8"
-                onClick={() => navigate(-1)}
-                aria-label={`Previous ${mode}`}
-              >
-                <IconChevronLeft className="size-4" />
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="size-8"
-                onClick={() => navigate(1)}
-                aria-label={`Next ${mode}`}
-              >
-                <IconChevronRight className="size-4" />
-              </Button>
-            </div>
-          </>
-        )}
-        <h2 className="min-w-[180px] text-sm font-medium">
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            {mode !== "agenda" && (
+              <>
+                <DropdownMenuItem onClick={() => setCurrentDate(new Date())}>
+                  Today
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => navigate(-1)}>
+                  Previous {mode}
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => navigate(1)}>
+                  Next {mode}
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+              </>
+            )}
+            <DropdownMenuRadioGroup
+              value={mode}
+              onValueChange={(value) => setMode(value as CalendarMode)}
+            >
+              {(
+                [
+                  ["month", "Month", IconCalendar],
+                  ["week", "Week", IconCalendar],
+                  ["day", "Day", IconCalendar],
+                  ["agenda", "Agenda", IconList],
+                ] as const
+              ).map(([value, label, Icon]) => (
+                <DropdownMenuRadioItem key={value} value={value}>
+                  <Icon className="mr-2 size-4" />
+                  {label}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <h2 className="ml-2 truncate text-sm font-medium">
           {dateRangeLabel(mode, currentDate)}
         </h2>
-        <div
-          className="ml-auto inline-flex overflow-hidden rounded-md border"
-          role="group"
-          aria-label="Schedule calendar view"
-        >
-          {(
-            [
-              ["month", "Month", IconCalendar],
-              ["week", "Week", IconCalendar],
-              ["day", "Day", IconCalendar],
-              ["agenda", "Agenda", IconList],
-            ] as const
-          ).map(([value, label, Icon]) => (
-            <Button
-              key={value}
-              type="button"
-              size="sm"
-              variant="ghost"
-              className={cn(
-                "h-8 rounded-none border-r px-2.5 text-xs last:border-r-0",
-                mode === value && "bg-secondary text-secondary-foreground"
-              )}
-              onClick={() => setMode(value)}
-              aria-pressed={mode === value}
-            >
-              <Icon className="size-3.5" />
-              <span className="hidden sm:inline">{label}</span>
-            </Button>
-          ))}
-        </div>
       </div>
 
       {mode === "month" && (

--- a/src/components/schedule/schedule-gantt-view.tsx
+++ b/src/components/schedule/schedule-gantt-view.tsx
@@ -23,6 +23,10 @@ import { Switch } from "@/components/ui/switch"
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import {
@@ -41,6 +45,7 @@ import {
   IconSettings,
   IconZoomIn,
   IconZoomOut,
+  IconCalendar,
 } from "@tabler/icons-react"
 import {
   Select,
@@ -932,56 +937,60 @@ export function ScheduleGanttView({
   )
 
   return (
-    <div className="flex flex-col flex-1 min-h-0">
-      {/* Compact controls row */}
-      <div className="flex items-center gap-2 mb-2">
-        <div className="flex items-center gap-1.5">
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div
+        className="mb-1 flex h-8 shrink-0 items-center"
+        data-gantt-controls
+      >
+        <div className="flex items-center gap-1">
           {isMobile && (
             <Select
               value={mobileView}
-              onValueChange={(val) =>
-                setMobileView(val as "tasks" | "chart")
+              onValueChange={(value) =>
+                setMobileView(value as "tasks" | "chart")
               }
             >
-              <SelectTrigger className="h-7 w-20 text-xs">
+              <SelectTrigger className="h-8 w-20 text-xs">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="chart">Chart</SelectItem>
-                <SelectItem value="tasks">Schedule Items</SelectItem>
+                <SelectItem value="tasks">Items</SelectItem>
               </SelectContent>
             </Select>
           )}
-
-          {/* Day / Week / Month / Year */}
-          <div className="flex items-center rounded-md border bg-muted/40 p-0.5">
-            {(["Day", "Week", "Month", "Year"] as const).map((mode) => (
-              <button
-                key={mode}
-                onClick={() => handleViewModeChange(mode)}
-                className={cn(
-                  "px-2 py-1 text-xs font-medium rounded-sm transition-all",
-                  viewMode === mode
-                    ? "bg-background text-foreground shadow-sm"
-                    : "text-muted-foreground hover:text-foreground"
-                )}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                aria-label="Gantt controls"
+                className="h-8 px-2 text-xs"
+                size="sm"
+                variant="outline"
               >
-                {mode}
-              </button>
-            ))}
-          </div>
-
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={scrollToToday}
-            className="h-7 px-2.5 text-xs"
-          >
-            Today
-          </Button>
+                <IconCalendar className="size-3.5" />
+                <span className="ml-1.5">{viewMode}</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuRadioGroup
+                value={viewMode}
+                onValueChange={(mode) =>
+                  handleViewModeChange(mode as ViewMode)
+                }
+              >
+                {(["Day", "Week", "Month", "Year"] as const).map((mode) => (
+                  <DropdownMenuRadioItem key={mode} value={mode}>
+                    {mode}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={scrollToToday}>Today</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
 
-        <div className="flex items-center gap-1 ml-auto">
+        <div className="ml-auto flex items-center gap-1">
           <Button
             variant="ghost"
             size="icon"
@@ -1008,7 +1017,7 @@ export function ScheduleGanttView({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-48">
-              <div className="px-2 py-1.5 space-y-2">
+              <div className="space-y-2 px-2 py-1.5">
                 <div className="flex items-center justify-between">
                   <span className="text-xs">Group by Phase</span>
                   <Switch

--- a/src/components/schedule/schedule-list-view.tsx
+++ b/src/components/schedule/schedule-list-view.tsx
@@ -552,11 +552,15 @@ export function ScheduleListView({
   }, [focusTaskId, localTasks, table])
 
   return (
-    <div className="flex flex-col flex-1 min-h-0">
-      <div className="mb-2 flex flex-wrap items-center gap-2 border-y py-2">
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div
+        className="mb-1 flex h-8 shrink-0 min-w-0 flex-nowrap items-center gap-1 overflow-x-auto"
+        data-schedule-list-actions
+      >
         <Button
           size="sm"
           variant="outline"
+          className="h-7 shrink-0 px-2 text-xs"
           onClick={() => setDepDialogOpen(true)}
           disabled={!projectId || localTasks.length < 2}
           title={
@@ -636,7 +640,7 @@ export function ScheduleListView({
         )}
       </div>
 
-      <div className="rounded-md border flex-1 overflow-x-auto -mx-2 sm:mx-0">
+      <div className="rounded-md border flex-1 min-h-[30rem] overflow-x-auto -mx-2 sm:mx-0">
         <div className="inline-block min-w-full align-middle">
           <Table>
             <TableHeader>

--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -647,8 +647,11 @@ export function ScheduleView({
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="mb-2 flex min-w-0 flex-nowrap items-center gap-2 overflow-x-auto pb-1">
+    <div className="flex min-h-full flex-col" data-schedule-workspace>
+      <div
+        className="mb-1 flex h-8 shrink-0 min-w-0 flex-nowrap items-center gap-1 overflow-x-auto"
+        data-schedule-controls
+      >
         <nav className="flex shrink-0 items-center gap-1.5 text-sm">
           <Link
             href={
@@ -685,7 +688,7 @@ export function ScheduleView({
                 currentProjectId={projectId}
                 targetSection="schedule"
                 placeholder="Switch schedule project..."
-                className="w-full sm:w-[300px]"
+                className="h-8 w-full sm:w-[300px]"
               />
               <Button asChild variant="outline" size="sm" className="h-8">
                 <Link href="/dashboard/schedule?mode=projects&scope=all&view=gantt">
@@ -742,23 +745,24 @@ export function ScheduleView({
       </div>
 
       {projectId && publicationStatus && (
-        <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1 border-y py-2 text-xs">
-          <span className="font-medium">
-            External schedule:
-            {" "}
+        <div
+          className="mb-1 flex h-8 shrink-0 min-w-0 flex-nowrap items-center gap-2 overflow-x-auto text-xs"
+          data-schedule-publication-controls
+        >
+          <span className="shrink-0 text-muted-foreground">
             {publicationStatus.hasPublishedSchedule
               ? `Published ${new Date(
                   publicationStatus.publishedAt ?? ""
                 ).toLocaleString()}`
-              : "Not yet published"}
+              : "Not published"}
           </span>
           {publicationStatus.hasUnpublishedChanges && (
-            <span className="text-amber-700 dark:text-amber-300">
+            <span className="shrink-0 text-amber-700 dark:text-amber-300">
               Unpublished changes
             </span>
           )}
           <Button
-            className="ml-auto h-7"
+            className="ml-auto h-7 shrink-0 px-2 text-xs"
             size="sm"
             variant={
               publicationStatus.hasUnpublishedChanges
@@ -767,14 +771,14 @@ export function ScheduleView({
             }
             onClick={() => setPublishOpen(true)}
           >
-            <IconSend className="mr-1.5 size-3.5" />
-            Publish schedule
+            <IconSend className="mr-1 size-3.5" />
+            Publish
           </Button>
         </div>
       )}
 
       {/* Action bar: search, filters, overflow */}
-      <div className="mb-2 flex min-w-0 flex-nowrap items-center gap-2 overflow-x-auto pb-1 print:hidden">
+      <div className="mb-1 flex h-8 shrink-0 min-w-0 flex-nowrap items-center gap-1.5 overflow-x-auto print:hidden">
         {/* Search */}
         <div className="relative min-w-0 flex-1 sm:flex-none sm:w-52">
           <IconSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground pointer-events-none" />
@@ -1122,8 +1126,12 @@ export function ScheduleView({
         </div>
       </div>
 
-      {/* View content */}
-      <div className="flex flex-col flex-1 min-h-0">
+      {/* The schedule is a document-scrolling workspace: preserve a useful view height
+          after the compact toolbars, then let the dashboard scroll region carry it. */}
+      <div
+        className="flex min-h-[34rem] flex-1 flex-col"
+        data-schedule-view-content
+      >
         {view === "calendar" && (
           isMobile && !globalMode ? (
             <ScheduleMobileView

--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -9,7 +9,6 @@ import {
 } from "react"
 import Link from "next/link"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
-import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
@@ -40,6 +39,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
@@ -651,6 +652,7 @@ export function ScheduleView({
       <div
         className="mb-1 flex h-8 shrink-0 min-w-0 flex-nowrap items-center gap-1 overflow-x-auto"
         data-schedule-controls
+        data-schedule-toolbar
       >
         <nav className="flex shrink-0 items-center gap-1.5 text-sm">
           <Link
@@ -705,27 +707,42 @@ export function ScheduleView({
             />
           )}
 
-          {/* View switcher */}
-          <div className={cn(
-            "flex items-center rounded-lg border bg-muted/40 p-0.5",
-            isMobile ? "gap-0" : "gap-0",
-          )}>
-            {VIEW_OPTIONS.map(({ value, icon: Icon, label }) => (
-              <button
-                key={value}
-                onClick={() => setView(value)}
-                className={cn(
-                  "flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-all",
-                  view === value
-                    ? "bg-background text-foreground shadow-sm"
-                    : "text-muted-foreground hover:text-foreground"
-                )}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                aria-label="Schedule view"
+                className="h-8 shrink-0 px-2 text-xs"
+                size="sm"
+                variant="outline"
               >
-                <Icon className="size-3.5" />
-                {!isMobile && <span>{label}</span>}
-              </button>
-            ))}
-          </div>
+                {(() => {
+                  const activeView = VIEW_OPTIONS.find(
+                    (option) => option.value === view
+                  )
+                  const ActiveIcon = activeView?.icon ?? IconCalendar
+                  return (
+                    <>
+                      <ActiveIcon className="size-3.5" />
+                      <span className="ml-1.5">{activeView?.label}</span>
+                    </>
+                  )
+                })()}
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuRadioGroup
+                value={view}
+                onValueChange={(value) => setView(value as View)}
+              >
+                {VIEW_OPTIONS.map(({ value, icon: Icon, label }) => (
+                  <DropdownMenuRadioItem key={value} value={value}>
+                    <Icon className="mr-2 size-4" />
+                    {label}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
 
           <Button
             size="sm"

--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -647,10 +647,9 @@ export function ScheduleView({
   }
 
   return (
-    <div className="flex flex-col flex-1 min-h-0">
-      {/* Header: breadcrumb + project switcher + view toggle + new task */}
-      <div className="mb-3 flex flex-col gap-2 lg:flex-row lg:items-center">
-        <nav className="flex min-w-0 items-center gap-1.5 text-sm">
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="mb-2 flex min-w-0 flex-nowrap items-center gap-2 overflow-x-auto pb-1">
+        <nav className="flex shrink-0 items-center gap-1.5 text-sm">
           <Link
             href={
               globalMode || !projectId
@@ -667,7 +666,7 @@ export function ScheduleView({
           </span>
         </nav>
 
-        <div className="flex flex-wrap items-center gap-2 lg:ml-auto lg:justify-end">
+        <div className="ml-auto flex shrink-0 items-center gap-2">
           {globalMode && scope ? (
             <>
               <Button asChild variant="outline" size="sm" className="h-8">
@@ -775,7 +774,7 @@ export function ScheduleView({
       )}
 
       {/* Action bar: search, filters, overflow */}
-      <div className="mb-3 flex flex-wrap items-center gap-2 print:hidden">
+      <div className="mb-2 flex min-w-0 flex-nowrap items-center gap-2 overflow-x-auto pb-1 print:hidden">
         {/* Search */}
         <div className="relative min-w-0 flex-1 sm:flex-none sm:w-52">
           <IconSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground pointer-events-none" />

--- a/src/lib/schedule/__tests__/gantt-scroll.test.ts
+++ b/src/lib/schedule/__tests__/gantt-scroll.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  clampGanttScrollOffset,
   centeredGanttRowScrollTop,
   centeredTimelineScrollLeft,
   dominantScrollAxis,
@@ -35,6 +36,12 @@ describe("Gantt dominant-axis scrolling", () => {
     expect(normalizeWheelDelta(2, 1, 500)).toBe(32)
     expect(normalizeWheelDelta(-1, 2, 500)).toBe(-500)
     expect(normalizeWheelDelta(24, 0, 500)).toBe(24)
+  })
+
+  it("keeps the Gantt scroll position within the resized viewport", () => {
+    expect(clampGanttScrollOffset(1_200, 2_000, 1_000)).toBe(1_000)
+    expect(clampGanttScrollOffset(-20, 2_000, 1_000)).toBe(0)
+    expect(clampGanttScrollOffset(500, 600, 800)).toBe(0)
   })
 
   it("maps independently sized scroll panes to the same relative row", () => {

--- a/src/lib/schedule/gantt-scroll.ts
+++ b/src/lib/schedule/gantt-scroll.ts
@@ -45,6 +45,17 @@ export function normalizeWheelDelta(
   return delta
 }
 
+export function clampGanttScrollOffset(
+  previousOffset: number,
+  scrollSize: number,
+  clientSize: number
+): number {
+  return Math.max(
+    0,
+    Math.min(previousOffset, Math.max(0, scrollSize - clientSize))
+  )
+}
+
 export function synchronizedScrollTop(
   sourceTop: number,
   sourceScrollHeight: number,


### PR DESCRIPTION
## Summary
- allow Schedule pages to use the dashboard document scroll region
- consolidate view, Gantt, and Calendar controls into compact accessible menus
- preserve the Gantt resize recovery and add cross-browser Schedule regression coverage

## Validation
- 20 focused Schedule Playwright checks across Chromium, Firefox, WebKit, mobile Chrome, and mobile Safari
- `bunx tsc --noEmit --pretty false`
- focused ESLint
- `bun run build`
- `git diff --check`

User-reviewed localhost Schedule preview before publication.