### PR TITLE
fix(schedule): add configurable Gantt scrolling

### DIFF
--- a/drizzle/0100_user_schedule_preferences.sql
+++ b/drizzle/0100_user_schedule_preferences.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `user_schedule_preferences` (
+  `user_id` text PRIMARY KEY NOT NULL,
+  `gantt_scroll_mode` text DEFAULT 'default' NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -302,6 +302,99 @@ test.describe("usable Compass areas", () => {
     await page.keyboard.press("Escape")
   })
 
+  test("Gantt lets each user choose synchronized or independent vertical panes", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1366, height: 768 })
+    const response = await page.goto(
+      "/dashboard/projects/e2e-project-001/schedule?view=gantt&order=chronological"
+    )
+    await expectHealthyNavigation(
+      page,
+      response,
+      "/dashboard/projects/e2e-project-001/schedule"
+    )
+
+    const scrollRegion = page.locator(
+      '[data-dashboard-scroll-region="schedule"]:visible'
+    )
+    const controls = page.locator("[data-schedule-controls]:visible")
+    const outerScrollRange = await scrollRegion.evaluate((region) =>
+      region.scrollHeight - region.clientHeight
+    )
+    const controlsHeight = await controls.evaluate(
+      (controlsElement) => controlsElement.getBoundingClientRect().height
+    )
+    expect(outerScrollRange).toBeGreaterThanOrEqual(controlsHeight)
+
+    await page.getByRole("button", { name: "Gantt settings" }).click()
+    const powerUserSwitch = page.getByRole("switch", {
+      name: "Use power-user Gantt scrolling",
+    })
+    await expect(powerUserSwitch).toBeVisible()
+    const taskList = page.locator(".schedule-gantt-task-list")
+    const chart = page.locator(".gantt-container")
+    if (await powerUserSwitch.isChecked()) {
+      await powerUserSwitch.click()
+    }
+    await expect(powerUserSwitch).not.toBeChecked()
+    await expect(taskList).toBeVisible()
+    await expect(chart).toBeVisible()
+    await taskList.evaluate((element) => {
+      element.style.height = "120px"
+      element.scrollTop = 0
+    })
+    await chart.evaluate((element) => {
+      element.style.height = "120px"
+      element.scrollTop = 0
+    })
+
+    await page.keyboard.press("Escape")
+    await page.getByRole("button", { name: "Gantt controls" }).click()
+    await page.getByRole("menuitem", { name: "Today" }).click()
+    await expect
+      .poll(() => taskList.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0)
+    await expect
+      .poll(() => chart.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0)
+
+    await taskList.evaluate((element) => {
+      element.scrollTop = Math.min(96, element.scrollHeight - element.clientHeight)
+      element.dispatchEvent(new Event("scroll"))
+    })
+    const synchronizedChartTop = await chart.evaluate((element) => element.scrollTop)
+    expect(synchronizedChartTop).toBeGreaterThan(0)
+
+    await page.getByRole("button", { name: "Gantt settings" }).click()
+    await expect(powerUserSwitch).toBeVisible()
+    await powerUserSwitch.click()
+    await expect(powerUserSwitch).toBeChecked()
+    await taskList.evaluate((element) => {
+      element.scrollTop = 0
+    })
+    await chart.evaluate((element) => {
+      element.scrollTop = 0
+    })
+
+    await page.keyboard.press("Escape")
+    await page.getByRole("button", { name: "Gantt controls" }).click()
+    await page.getByRole("menuitem", { name: "Today" }).click()
+    await expect
+      .poll(() => chart.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0)
+    expect(await taskList.evaluate((element) => element.scrollTop)).toBe(0)
+
+    await taskList.evaluate((element) => {
+      element.scrollTop = Math.min(96, element.scrollHeight - element.clientHeight)
+      element.dispatchEvent(new Event("scroll"))
+    })
+    const listTop = await taskList.evaluate((element) => element.scrollTop)
+    const chartTop = await chart.evaluate((element) => element.scrollTop)
+    expect(listTop).toBeGreaterThan(0)
+    expect(chartTop).toBeGreaterThan(0)
+  })
+
   test("Schedule Calendar controls use one compact menu", async ({ page }) => {
     await page.setViewportSize({ width: 980, height: 700 })
     const response = await page.goto(

--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -742,7 +742,7 @@ test.describe("usable Compass areas", () => {
     const dayDialog = page.getByRole("dialog")
     await expect(dayDialog).toContainText("5 work items scheduled for this day")
     for (const title of [
-      "Regression Schedule Item",
+      "Gantt overflow schedule item 19",
       "Overflow schedule item two",
       "Overflow schedule item three",
       "Overflow schedule item four",

--- a/scripts/seed-e2e-local.mjs
+++ b/scripts/seed-e2e-local.mjs
@@ -225,11 +225,16 @@ const upsert = db.transaction(() => {
       content = excluded.content
   `).run(now)
 
-  const overflowScheduleItems = Array.from({ length: 18 }, (_, index) => [
-    `e2e-schedule-${String(index + 2).padStart(3, "0")}`,
-    `Overflow schedule item ${index + 2}`,
-    index + 2,
-  ])
+  const overflowScheduleItems = [
+    ["e2e-schedule-002", "Overflow schedule item two", 2],
+    ["e2e-schedule-003", "Overflow schedule item three", 3],
+    ["e2e-schedule-004", "Overflow schedule item four", 4],
+    ...Array.from({ length: 15 }, (_, index) => [
+      `e2e-schedule-${String(index + 5).padStart(3, "0")}`,
+      `Gantt overflow schedule item ${index + 5}`,
+      index + 5,
+    ]),
+  ]
   const upsertOverflowScheduleItem = db.prepare(`
     INSERT INTO schedule_tasks (
       id, project_id, title, start_date, workdays, end_date_calculated, phase,
@@ -247,7 +252,12 @@ const upsert = db.transaction(() => {
       updated_at = excluded.updated_at
   `)
   for (const [id, title, sortOrder] of overflowScheduleItems) {
-    const date = id === "e2e-schedule-019" ? today : previousWeek
+    const date =
+      sortOrder <= 4 || sortOrder === 19
+        ? today
+        : new Date(Date.now() - (21 - (sortOrder - 5)) * 24 * 60 * 60 * 1000)
+            .toISOString()
+            .slice(0, 10)
     upsertOverflowScheduleItem.run(
       id,
       title,

--- a/scripts/seed-e2e-local.mjs
+++ b/scripts/seed-e2e-local.mjs
@@ -5,6 +5,9 @@ import { dirname, resolve } from "node:path"
 const databasePath = resolve(process.env.LOCAL_DB_PATH || "local.db")
 const now = new Date().toISOString()
 const today = now.slice(0, 10)
+const previousWeek = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+  .toISOString()
+  .slice(0, 10)
 const publishedScheduleSnapshot = JSON.stringify({
   version: 1,
   tasks: [
@@ -161,6 +164,11 @@ const upsert = db.transaction(() => {
   `).run(now)
 
   db.prepare(`
+    DELETE FROM user_schedule_preferences
+    WHERE user_id = 'demo-user-001'
+  `).run()
+
+  db.prepare(`
     INSERT INTO schedule_tasks (
       id, project_id, title, start_date, workdays, end_date_calculated, phase,
       display_color, status, is_critical_path, is_milestone, percent_complete,
@@ -176,7 +184,7 @@ const upsert = db.transaction(() => {
       end_date_calculated = excluded.end_date_calculated,
       status = excluded.status,
       updated_at = excluded.updated_at
-  `).run(today, today, now, now)
+  `).run(previousWeek, previousWeek, now, now)
 
   db.prepare(`
     INSERT INTO channels (
@@ -217,11 +225,11 @@ const upsert = db.transaction(() => {
       content = excluded.content
   `).run(now)
 
-  const overflowScheduleItems = [
-    ["e2e-schedule-002", "Overflow schedule item two", 2],
-    ["e2e-schedule-003", "Overflow schedule item three", 3],
-    ["e2e-schedule-004", "Overflow schedule item four", 4],
-  ]
+  const overflowScheduleItems = Array.from({ length: 18 }, (_, index) => [
+    `e2e-schedule-${String(index + 2).padStart(3, "0")}`,
+    `Overflow schedule item ${index + 2}`,
+    index + 2,
+  ])
   const upsertOverflowScheduleItem = db.prepare(`
     INSERT INTO schedule_tasks (
       id, project_id, title, start_date, workdays, end_date_calculated, phase,
@@ -239,11 +247,12 @@ const upsert = db.transaction(() => {
       updated_at = excluded.updated_at
   `)
   for (const [id, title, sortOrder] of overflowScheduleItems) {
+    const date = id === "e2e-schedule-019" ? today : previousWeek
     upsertOverflowScheduleItem.run(
       id,
       title,
-      today,
-      today,
+      date,
+      date,
       sortOrder,
       now,
       now

--- a/src/app/actions/user-schedule-preferences.ts
+++ b/src/app/actions/user-schedule-preferences.ts
@@ -1,0 +1,84 @@
+"use server"
+
+import { eq } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import { userSchedulePreferences } from "@/db/schema"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import {
+  DEFAULT_GANTT_SCROLL_MODE,
+  isGanttScrollMode,
+  type GanttScrollMode,
+} from "@/lib/schedule/gantt-interaction-mode"
+
+export type UserSchedulePreferences = {
+  readonly ganttScrollMode: GanttScrollMode
+}
+
+type SchedulePreferenceActionResult =
+  | { readonly success: true; readonly data: UserSchedulePreferences }
+  | { readonly success: false; readonly error: string }
+
+const defaultPreferences: UserSchedulePreferences = {
+  ganttScrollMode: DEFAULT_GANTT_SCROLL_MODE,
+}
+
+export async function getUserSchedulePreferences(): Promise<UserSchedulePreferences> {
+  try {
+    const user = await requireAuth()
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const row = await db
+      .select({ ganttScrollMode: userSchedulePreferences.ganttScrollMode })
+      .from(userSchedulePreferences)
+      .where(eq(userSchedulePreferences.userId, user.id))
+      .get()
+
+    return row && isGanttScrollMode(row.ganttScrollMode)
+      ? { ganttScrollMode: row.ganttScrollMode }
+      : defaultPreferences
+  } catch (error) {
+    console.warn("Unable to load user Schedule preferences", error)
+    return defaultPreferences
+  }
+}
+
+export async function updateGanttScrollMode(
+  ganttScrollMode: GanttScrollMode
+): Promise<SchedulePreferenceActionResult> {
+  if (!isGanttScrollMode(ganttScrollMode)) {
+    return { success: false, error: "Choose a valid Gantt scrolling mode." }
+  }
+
+  try {
+    const user = await requireAuth()
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const now = new Date().toISOString()
+
+    await db
+      .insert(userSchedulePreferences)
+      .values({
+        userId: user.id,
+        ganttScrollMode,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: userSchedulePreferences.userId,
+        set: { ganttScrollMode, updatedAt: now },
+      })
+
+    revalidatePath("/dashboard/schedule")
+    return { success: true, data: { ganttScrollMode } }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to save the Gantt scrolling mode.",
+    }
+  }
+}

--- a/src/app/dashboard/projects/[id]/schedule/page.tsx
+++ b/src/app/dashboard/projects/[id]/schedule/page.tsx
@@ -16,6 +16,7 @@ import { ScheduleView } from "@/components/schedule/schedule-view"
 import type { ScheduleData, ScheduleBaselineData } from "@/lib/schedule/types"
 import type { OwnerScheduleView } from "@/lib/schedule/owner-visibility"
 import { getScheduleSavedViews } from "@/app/actions/schedule-saved-views"
+import { getUserSchedulePreferences } from "@/app/actions/user-schedule-preferences"
 import {
   getSchedulePublicationStatus,
   type SchedulePublicationStatus,
@@ -58,9 +59,10 @@ export default async function SchedulePage({
   let assigneeOptions: ProjectTaskAssigneeOption[] = []
   let ownerScheduleView: OwnerScheduleView = "items"
   let publicationStatus: SchedulePublicationStatus | null = null
-  const [savedViews, currentUser] = await Promise.all([
+  const [savedViews, currentUser, schedulePreferences] = await Promise.all([
     getScheduleSavedViews(),
     getCurrentUser(),
+    getUserSchedulePreferences(),
   ])
 
   try {
@@ -113,6 +115,7 @@ export default async function SchedulePage({
         focusTaskId={focusTaskId}
         ownerScheduleView={ownerScheduleView}
         savedViews={savedViews}
+        ganttScrollMode={schedulePreferences.ganttScrollMode}
         currentUserAssigneeTerms={scheduleAssigneeTerms(currentUser)}
         publicationStatus={publicationStatus}
       />

--- a/src/app/dashboard/schedule/page.tsx
+++ b/src/app/dashboard/schedule/page.tsx
@@ -20,6 +20,7 @@ import type {
 } from "@/lib/schedule/project-scope"
 import type { ProjectDepartment } from "@/lib/project-branding"
 import { getScheduleSavedViews } from "@/app/actions/schedule-saved-views"
+import { getUserSchedulePreferences } from "@/app/actions/user-schedule-preferences"
 import { getSchedulePublicationStatus } from "@/app/actions/schedule-publications"
 import { getCurrentUser } from "@/lib/auth"
 import { scheduleAssigneeTerms } from "@/lib/schedule/saved-views"
@@ -95,10 +96,11 @@ export default async function SchedulePage({
 }): Promise<React.ReactElement> {
   const query = await searchParams
   if (firstValue(query.mode) === "projects") {
-    const [allProjects, savedViews, currentUser] = await Promise.all([
+    const [allProjects, savedViews, currentUser, schedulePreferences] = await Promise.all([
       getProjects(),
       getScheduleSavedViews(),
       getCurrentUser(),
+      getUserSchedulePreferences(),
     ])
     const requestedScope = firstValue(query.scope)
     const scopeKind = isScopeKind(requestedScope) ? requestedScope : "all"
@@ -200,6 +202,7 @@ export default async function SchedulePage({
           globalMode
           ownerScheduleView={ownerScheduleView}
           savedViews={savedViews}
+          ganttScrollMode={schedulePreferences.ganttScrollMode}
           currentUserAssigneeTerms={scheduleAssigneeTerms(currentUser)}
           publicationStatus={publicationStatus}
         />

--- a/src/components/schedule/gantt-chart.tsx
+++ b/src/components/schedule/gantt-chart.tsx
@@ -7,6 +7,7 @@ import { getScheduleItemClasses } from "@/lib/schedule/appearance"
 import {
   dominantScrollAxis,
   clampGanttScrollOffset,
+  canScrollGanttAxis,
   lockWheelToDominantAxis,
   normalizeWheelDelta,
   paddingToIncludeDate,
@@ -312,6 +313,19 @@ export function GanttChart({
         normalizeWheelDelta(rawDeltaY, e.deltaMode, pageSize)
       )
       if (locked.deltaX === 0 && locked.deltaY === 0) return
+      const canScrollHorizontally = canScrollGanttAxis(
+        container.scrollLeft,
+        container.scrollWidth,
+        container.clientWidth,
+        locked.deltaX
+      )
+      const canScrollVertically = canScrollGanttAxis(
+        container.scrollTop,
+        container.scrollHeight,
+        container.clientHeight,
+        locked.deltaY
+      )
+      if (!canScrollHorizontally && !canScrollVertically) return
 
       e.preventDefault()
       container.scrollLeft += locked.deltaX

--- a/src/components/schedule/schedule-gantt-view.tsx
+++ b/src/components/schedule/schedule-gantt-view.tsx
@@ -6,6 +6,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useTransition,
   type UIEvent,
 } from "react"
 import {
@@ -67,6 +68,12 @@ import {
 } from "@/lib/schedule/gantt-transform"
 import type { DisplayItem, FrappeTask } from "@/lib/schedule/gantt-transform"
 import { updateTask } from "@/app/actions/schedule"
+import { updateGanttScrollMode } from "@/app/actions/user-schedule-preferences"
+import {
+  DEFAULT_GANTT_SCROLL_MODE,
+  type GanttScrollMode,
+  shouldSynchronizeGanttPanes,
+} from "@/lib/schedule/gantt-interaction-mode"
 import { countBusinessDays } from "@/lib/schedule/business-days"
 import { effectivePercentComplete } from "@/lib/schedule/progress"
 import {
@@ -93,6 +100,7 @@ import type { ScheduleProjectData } from "@/lib/schedule/project-scope"
 import { projectScheduleLabel } from "@/lib/schedule/project-scope"
 import {
   centeredGanttRowScrollTop,
+  canScrollGanttAxis,
   ganttRowIndexForScrollTop,
   lockWheelToDominantAxis,
   nearestScheduleRowIndexForDate,
@@ -114,6 +122,7 @@ interface ScheduleGanttViewProps {
   readonly exceptions: readonly WorkdayExceptionData[]
   readonly assigneeOptions: readonly ProjectTaskAssigneeOption[]
   readonly projects?: readonly ScheduleProjectData[]
+  readonly ganttScrollMode?: GanttScrollMode
   readonly groupByPhase?: boolean
   readonly onGroupByPhaseChange?: (grouped: boolean) => void
 }
@@ -125,6 +134,7 @@ export function ScheduleGanttView({
   exceptions,
   assigneeOptions,
   projects = [],
+  ganttScrollMode = DEFAULT_GANTT_SCROLL_MODE,
   groupByPhase = false,
   onGroupByPhaseChange,
 }: ScheduleGanttViewProps) {
@@ -150,6 +160,8 @@ export function ScheduleGanttView({
   )
   const [focusedTaskId, setFocusedTaskId] = useState<string | null>(null)
   const [mobileView, setMobileView] = useState<"tasks" | "chart">("chart")
+  const [scrollMode, setScrollMode] = useState<GanttScrollMode>(ganttScrollMode)
+  const [isSavingScrollMode, startScrollModeTransition] = useTransition()
   const [panMode] = useState(false)
   const taskListRef = useRef<HTMLDivElement>(null)
   const ganttContainerRef = useRef<HTMLElement | null>(null)
@@ -172,6 +184,10 @@ export function ScheduleGanttView({
   useEffect(() => {
     setPhaseGrouping(groupByPhase)
   }, [groupByPhase])
+
+  useEffect(() => {
+    setScrollMode(ganttScrollMode)
+  }, [ganttScrollMode])
 
   const [hasLoadedPalette, setHasLoadedPalette] = useState(false)
 
@@ -247,6 +263,20 @@ export function ScheduleGanttView({
     setColumnWidth(defaultWidths[mode])
   }
 
+  const handleScrollModeChange = (powerUser: boolean): void => {
+    const nextMode: GanttScrollMode = powerUser ? "power" : "default"
+    if (nextMode === scrollMode) return
+    const previousMode = scrollMode
+    setScrollMode(nextMode)
+    startScrollModeTransition(async () => {
+      const result = await updateGanttScrollMode(nextMode)
+      if (!result.success) {
+        setScrollMode(previousMode)
+        toast.error(result.error)
+      }
+    })
+  }
+
   const rememberScrollPosition = useCallback(
     (position: GanttScrollPosition) => {
       scrollPositionRef.current = position
@@ -306,6 +336,19 @@ export function ScheduleGanttView({
         normalizeWheelDelta(rawDeltaY, event.deltaMode, pageSize)
       )
       if (locked.deltaX === 0 && locked.deltaY === 0) return
+      const canScrollHorizontally = canScrollGanttAxis(
+        taskList.scrollLeft,
+        taskList.scrollWidth,
+        taskList.clientWidth,
+        locked.deltaX
+      )
+      const canScrollVertically = canScrollGanttAxis(
+        taskList.scrollTop,
+        taskList.scrollHeight,
+        taskList.clientHeight,
+        locked.deltaY
+      )
+      if (!canScrollHorizontally && !canScrollVertically) return
 
       event.preventDefault()
       taskList.scrollLeft += locked.deltaX
@@ -366,7 +409,7 @@ export function ScheduleGanttView({
             container.scrollLeft = position.left
           }
           container.scrollTop = position.top
-          if (taskListRef.current) {
+          if (taskListRef.current && shouldSynchronizeGanttPanes(scrollMode)) {
             taskListRef.current.scrollTop = synchronizedScrollTop(
               position.top,
               container.scrollHeight,
@@ -378,14 +421,14 @@ export function ScheduleGanttView({
         })
       })
     },
-    [projectId, scrollStorageKey]
+    [projectId, scrollMode, scrollStorageKey]
   )
 
   const handleGanttScroll = useCallback(
     (position: GanttScrollPosition) => {
       const taskList = taskListRef.current
       const ganttContainer = ganttContainerRef.current
-      if (taskList && ganttContainer) {
+      if (taskList && ganttContainer && shouldSynchronizeGanttPanes(scrollMode)) {
         const synchronizedTop = synchronizedScrollTop(
           position.top,
           ganttContainer.scrollHeight,
@@ -399,14 +442,14 @@ export function ScheduleGanttView({
       }
       rememberScrollPosition(position)
     },
-    [rememberScrollPosition]
+    [rememberScrollPosition, scrollMode]
   )
 
   const handleTaskListScroll = useCallback(
     (event: UIEvent<HTMLDivElement>) => {
       const top = event.currentTarget.scrollTop
       const ganttContainer = ganttContainerRef.current
-      if (ganttContainer) {
+      if (ganttContainer && shouldSynchronizeGanttPanes(scrollMode)) {
         const synchronizedTop = synchronizedScrollTop(
           top,
           event.currentTarget.scrollHeight,
@@ -443,7 +486,7 @@ export function ScheduleGanttView({
           : {}),
       })
     },
-    [rememberScrollPosition]
+    [rememberScrollPosition, scrollMode]
   )
 
   const openTaskEditor = useCallback(
@@ -636,7 +679,7 @@ export function ScheduleGanttView({
     ganttContainer.scrollTop = ganttTop
 
     const taskList = taskListRef.current
-    if (taskList) {
+    if (taskList && shouldSynchronizeGanttPanes(scrollMode)) {
       taskList.scrollTop = synchronizedScrollTop(
         ganttTop,
         ganttContainer.scrollHeight,
@@ -657,7 +700,7 @@ export function ScheduleGanttView({
     // Start the smooth horizontal movement last. Assigning scrollTop after
     // scrollTo({ behavior: "smooth" }) cancels that animation in browsers.
     scrollToTodayRef.current?.()
-  }, [displayItems])
+  }, [displayItems, scrollMode])
 
   const taskTable = (
     <Table className="table-fixed">
@@ -1012,12 +1055,37 @@ export function ScheduleGanttView({
 
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="size-7">
+              <Button
+                aria-label="Gantt settings"
+                variant="ghost"
+                size="icon"
+                className="size-7"
+              >
                 <IconSettings className="size-3.5" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-48">
               <div className="space-y-2 px-2 py-1.5">
+                <div className="border-b pb-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <div>
+                      <span className="text-xs">Power-user scrolling</span>
+                      <p className="text-[10px] leading-snug text-muted-foreground">
+                        Scroll task list and chart independently.
+                      </p>
+                    </div>
+                    <Switch
+                      aria-label="Use power-user Gantt scrolling"
+                      checked={scrollMode === "power"}
+                      disabled={isSavingScrollMode}
+                      onCheckedChange={handleScrollModeChange}
+                      className="scale-75"
+                    />
+                  </div>
+                  <p className="mt-1 text-[10px] leading-snug text-muted-foreground">
+                    Default keeps rows aligned. Shift + wheel pans the timeline horizontally in either mode.
+                  </p>
+                </div>
                 <div className="flex items-center justify-between">
                   <span className="text-xs">Group by Phase</span>
                   <Switch

--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -109,6 +109,7 @@ import {
   type ScheduleOrderMode,
 } from "@/lib/schedule/task-ordering"
 import type { OwnerScheduleView } from "@/lib/schedule/owner-visibility"
+import type { GanttScrollMode } from "@/lib/schedule/gantt-interaction-mode"
 import {
   deleteScheduleView,
   saveScheduleView,
@@ -150,6 +151,7 @@ interface ScheduleViewProps {
   readonly globalMode?: boolean
   readonly ownerScheduleView?: OwnerScheduleView
   readonly savedViews?: readonly SavedScheduleViewData[]
+  readonly ganttScrollMode?: GanttScrollMode
   readonly currentUserAssigneeTerms?: readonly string[]
   readonly publicationStatus?: SchedulePublicationStatus | null
 }
@@ -168,6 +170,7 @@ export function ScheduleView({
   globalMode = false,
   ownerScheduleView = "items",
   savedViews: initialSavedViews = [],
+  ganttScrollMode = "default",
   currentUserAssigneeTerms = [],
   publicationStatus: initialPublicationStatus = null,
 }: ScheduleViewProps) {
@@ -1146,7 +1149,7 @@ export function ScheduleView({
       {/* The schedule is a document-scrolling workspace: preserve a useful view height
           after the compact toolbars, then let the dashboard scroll region carry it. */}
       <div
-        className="flex min-h-[34rem] flex-1 flex-col"
+        className="flex min-h-[calc(100dvh-3.5rem)] flex-1 flex-col"
         data-schedule-view-content
       >
         {view === "calendar" && (
@@ -1185,6 +1188,7 @@ export function ScheduleView({
             exceptions={initialData.exceptions}
             assigneeOptions={assigneeOptions}
             projects={scheduleProjects}
+            ganttScrollMode={ganttScrollMode}
             groupByPhase={groupMode === "phase"}
             onGroupByPhaseChange={(grouped) =>
               setGroupMode(grouped ? "phase" : "none")

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -710,6 +710,14 @@ export type YoutubeChannelConnection =
 export type NewYoutubeChannelConnection =
   typeof youtubeChannelConnections.$inferInsert
 
+export const userSchedulePreferences = sqliteTable("user_schedule_preferences", {
+  userId: text("user_id")
+    .primaryKey()
+    .references(() => users.id, { onDelete: "cascade" }),
+  ganttScrollMode: text("gantt_scroll_mode").notNull().default("default"),
+  updatedAt: text("updated_at").notNull(),
+})
+
 export const scheduleSavedViews = sqliteTable(
   "schedule_saved_views",
   {

--- a/src/lib/schedule/__tests__/gantt-interaction-mode.test.ts
+++ b/src/lib/schedule/__tests__/gantt-interaction-mode.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import {
+  DEFAULT_GANTT_SCROLL_MODE,
+  isGanttScrollMode,
+  shouldSynchronizeGanttPanes,
+} from "@/lib/schedule/gantt-interaction-mode"
+
+describe("Gantt interaction mode", () => {
+  it("keeps synchronized scrolling as the default", () => {
+    expect(DEFAULT_GANTT_SCROLL_MODE).toBe("default")
+    expect(shouldSynchronizeGanttPanes(DEFAULT_GANTT_SCROLL_MODE)).toBe(true)
+  })
+
+  it("allows power users to keep their vertical pane positions independent", () => {
+    expect(isGanttScrollMode("power")).toBe(true)
+    expect(shouldSynchronizeGanttPanes("power")).toBe(false)
+  })
+
+  it("rejects unrecognized persisted values", () => {
+    expect(isGanttScrollMode("expert")).toBe(false)
+  })
+})

--- a/src/lib/schedule/__tests__/gantt-scroll.test.ts
+++ b/src/lib/schedule/__tests__/gantt-scroll.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  canScrollGanttAxis,
   clampGanttScrollOffset,
   centeredGanttRowScrollTop,
   centeredTimelineScrollLeft,
@@ -42,6 +43,12 @@ describe("Gantt dominant-axis scrolling", () => {
     expect(clampGanttScrollOffset(1_200, 2_000, 1_000)).toBe(1_000)
     expect(clampGanttScrollOffset(-20, 2_000, 1_000)).toBe(0)
     expect(clampGanttScrollOffset(500, 600, 800)).toBe(0)
+  })
+
+  it("releases wheel events to the page when a Gantt pane reaches its edge", () => {
+    expect(canScrollGanttAxis(0, 1_000, 400, -64)).toBe(false)
+    expect(canScrollGanttAxis(600, 1_000, 400, 64)).toBe(false)
+    expect(canScrollGanttAxis(300, 1_000, 400, 64)).toBe(true)
   })
 
   it("maps independently sized scroll panes to the same relative row", () => {

--- a/src/lib/schedule/gantt-interaction-mode.ts
+++ b/src/lib/schedule/gantt-interaction-mode.ts
@@ -1,0 +1,13 @@
+export const GANTT_SCROLL_MODES = ["default", "power"] as const
+
+export type GanttScrollMode = (typeof GANTT_SCROLL_MODES)[number]
+
+export const DEFAULT_GANTT_SCROLL_MODE: GanttScrollMode = "default"
+
+export function isGanttScrollMode(value: unknown): value is GanttScrollMode {
+  return value === "default" || value === "power"
+}
+
+export function shouldSynchronizeGanttPanes(mode: GanttScrollMode): boolean {
+  return mode === "default"
+}

--- a/src/lib/schedule/gantt-scroll.ts
+++ b/src/lib/schedule/gantt-scroll.ts
@@ -45,6 +45,16 @@ export function normalizeWheelDelta(
   return delta
 }
 
+export function canScrollGanttAxis(
+  offset: number,
+  scrollSize: number,
+  clientSize: number,
+  delta: number
+): boolean {
+  const maximumOffset = Math.max(0, scrollSize - clientSize)
+  return delta < 0 ? offset > 0 : delta > 0 && offset < maximumOffset
+}
+
 export function clampGanttScrollOffset(
   previousOffset: number,
   scrollSize: number,


### PR DESCRIPTION
## Summary
- restore reliable Gantt pane scrolling at viewport boundaries so the Schedule workspace can continue scrolling
- add a per-user Gantt settings switch: Default synchronizes list/chart rows and Today; Power-user permits independent vertical panes
- retain Shift + wheel horizontal timeline panning in both modes
- add a durable preference migration plus cross-browser E2E coverage for the modes, Today behavior, and outer workspace overflow

## Validation
- `bun test src/lib/schedule/__tests__/gantt-scroll.test.ts src/lib/schedule/__tests__/gantt-interaction-mode.test.ts`
- focused Playwright test: Chromium, Firefox, WebKit
- `bunx tsc --noEmit`
- `bun run build`
- independent review: PASS

## Notes
- Default mode is the product baseline. Power-user mode is opt-in and persisted per authenticated user.