### PR TITLE
fix(schedule): release Gantt edge scrolling

### DIFF
--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -395,6 +395,59 @@ test.describe("usable Compass areas", () => {
     expect(chartTop).toBeGreaterThan(0)
   })
 
+  test("Gantt releases edge wheel input to the surrounding Schedule workspace", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1366, height: 768 })
+    const response = await page.goto(
+      "/dashboard/projects/e2e-project-001/schedule?view=gantt&order=chronological"
+    )
+    await expectHealthyNavigation(
+      page,
+      response,
+      "/dashboard/projects/e2e-project-001/schedule"
+    )
+
+    const scrollRegion = page.locator(
+      '[data-dashboard-scroll-region="schedule"]:visible'
+    )
+    const taskList = page.locator(".schedule-gantt-task-list")
+    const chart = page.locator(".gantt-container")
+    await expect(taskList).toBeVisible()
+    await expect(chart).toBeVisible()
+    const outerScrollRange = await scrollRegion.evaluate(
+      (element) => element.scrollHeight - element.clientHeight
+    )
+    expect(outerScrollRange).toBeGreaterThan(0)
+
+    for (const pane of [taskList, chart]) {
+      for (const edge of ["top", "bottom"] as const) {
+        await pane.evaluate((element, paneEdge) => {
+          element.style.height = "120px"
+          element.scrollTop = paneEdge === "top" ? 0 : element.scrollHeight
+        }, edge)
+        await scrollRegion.evaluate((element, paneEdge) => {
+          element.scrollTop = paneEdge === "top" ? element.scrollHeight : 0
+        }, edge)
+        const initialWorkspaceTop = await scrollRegion.evaluate(
+          (element) => element.scrollTop
+        )
+        const paneBox = await pane.boundingBox()
+        expect(paneBox).not.toBeNull()
+        if (!paneBox) return
+
+        await page.mouse.move(
+          paneBox.x + paneBox.width / 2,
+          paneBox.y + paneBox.height / 2
+        )
+        await page.mouse.wheel(0, edge === "top" ? -240 : 240)
+        await expect
+          .poll(() => scrollRegion.evaluate((element) => element.scrollTop))
+          .not.toBe(initialWorkspaceTop)
+      }
+    }
+  })
+
   test("Schedule Calendar controls use one compact menu", async ({ page }) => {
     await page.setViewportSize({ width: 980, height: 700 })
     const response = await page.goto(

--- a/src/components/schedule/gantt-chart.tsx
+++ b/src/components/schedule/gantt-chart.tsx
@@ -325,7 +325,24 @@ export function GanttChart({
         container.clientHeight,
         locked.deltaY
       )
-      if (!canScrollHorizontally && !canScrollVertically) return
+      if (!canScrollHorizontally && !canScrollVertically) {
+        const workspace = wrapper.closest<HTMLElement>(
+          '[data-dashboard-scroll-region="schedule"]'
+        )
+        if (
+          workspace &&
+          canScrollGanttAxis(
+            workspace.scrollTop,
+            workspace.scrollHeight,
+            workspace.clientHeight,
+            locked.deltaY
+          )
+        ) {
+          e.preventDefault()
+          workspace.scrollTop += locked.deltaY
+        }
+        return
+      }
 
       e.preventDefault()
       container.scrollLeft += locked.deltaX

--- a/src/components/schedule/gantt.css
+++ b/src/components/schedule/gantt.css
@@ -10,14 +10,12 @@
   height: 100% !important;
   max-height: 100%;
   min-height: 0;
-  overscroll-behavior: contain;
   scrollbar-gutter: stable;
   scrollbar-width: thin;
   scrollbar-color: oklch(0.72 0.02 95 / 0.7) transparent;
 }
 
 .schedule-gantt-task-list {
-  overscroll-behavior: contain;
   scrollbar-gutter: stable;
   scrollbar-width: thin;
   scrollbar-color: oklch(0.72 0.02 95 / 0.7) transparent;

--- a/src/components/schedule/schedule-gantt-view.tsx
+++ b/src/components/schedule/schedule-gantt-view.tsx
@@ -348,7 +348,24 @@ export function ScheduleGanttView({
         taskList.clientHeight,
         locked.deltaY
       )
-      if (!canScrollHorizontally && !canScrollVertically) return
+      if (!canScrollHorizontally && !canScrollVertically) {
+        const workspace = taskList.closest<HTMLElement>(
+          '[data-dashboard-scroll-region="schedule"]'
+        )
+        if (
+          workspace &&
+          canScrollGanttAxis(
+            workspace.scrollTop,
+            workspace.scrollHeight,
+            workspace.clientHeight,
+            locked.deltaY
+          )
+        ) {
+          event.preventDefault()
+          workspace.scrollTop += locked.deltaY
+        }
+        return
+      }
 
       event.preventDefault()
       taskList.scrollLeft += locked.deltaX


### PR DESCRIPTION
## Summary
- hand off vertical wheel input from a Gantt pane at its top/bottom boundary to the outer Schedule workspace
- preserve Default/Power-user pane behavior and Shift+wheel timeline panning
- add browser E2E coverage for real wheel handoff over both panes and both boundaries

## Validation
- focused Gantt unit tests (17/17)
- TypeScript and production build
- targeted Playwright Chromium, Firefox, and WebKit