### PR TITLE
feat(schedule): expand scrollable workspace

### DIFF
--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -460,8 +460,8 @@ test.describe("usable Compass areas", () => {
     const scrollRegion = page.locator(
       '[data-dashboard-scroll-region="schedule"]:visible'
     )
-    const taskList = page.locator(".schedule-gantt-task-list")
-    const chart = page.locator(".gantt-container")
+    const taskList = page.locator(".schedule-gantt-task-list:visible")
+    const chart = page.locator(".gantt-container:visible")
     await expect(taskList).toBeVisible()
     await expect(chart).toBeVisible()
     const outerScrollRange = await scrollRegion.evaluate(

--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -257,6 +257,55 @@ test.describe("usable Compass areas", () => {
     ).toBe(true)
   })
 
+  test("Schedule gives a resized browser a longer scrollable workspace", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 640, height: 700 })
+    const path = "/dashboard/projects/e2e-project-001/schedule?view=list"
+    const response = await page.goto(path)
+    await expectHealthyNavigation(
+      page,
+      response,
+      "/dashboard/projects/e2e-project-001/schedule"
+    )
+
+    const scrollRegion = page.locator(
+      '[data-dashboard-scroll-region="schedule"]:visible'
+    )
+    const workspace = page.locator("[data-schedule-workspace]:visible")
+    await expect(scrollRegion).toHaveCSS("overflow-x", "auto")
+    await expect(workspace).toBeVisible()
+
+    const scrollRange = await scrollRegion.evaluate((element) => ({
+      horizontal: element.scrollWidth - element.clientWidth,
+      vertical: element.scrollHeight - element.clientHeight,
+      clientHeight: element.clientHeight,
+    }))
+    expect(scrollRange.vertical).toBeGreaterThanOrEqual(
+      scrollRange.clientHeight
+    )
+    expect(scrollRange.horizontal).toBeGreaterThan(0)
+
+    const regionBox = await scrollRegion.boundingBox()
+    expect(regionBox).not.toBeNull()
+    if (!regionBox) return
+
+    await scrollRegion.evaluate((element) => {
+      element.scrollLeft = 0
+      element.scrollTop = 0
+    })
+    await page.mouse.move(regionBox.x + 5, regionBox.y + 5)
+    await page.mouse.wheel(240, 0)
+    await expect
+      .poll(() => scrollRegion.evaluate((element) => element.scrollLeft))
+      .toBeGreaterThan(0)
+
+    await page.mouse.wheel(0, 900)
+    await expect
+      .poll(() => scrollRegion.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(0)
+  })
+
   test("Schedule puts view choices and Gantt controls in compact menus", async ({
     page,
   }) => {
@@ -427,7 +476,8 @@ test.describe("usable Compass areas", () => {
           element.scrollTop = paneEdge === "top" ? 0 : element.scrollHeight
         }, edge)
         await scrollRegion.evaluate((element, paneEdge) => {
-          element.scrollTop = paneEdge === "top" ? element.scrollHeight : 0
+          const distance = Math.min(240, element.scrollHeight - element.clientHeight)
+          element.scrollTop = paneEdge === "top" ? distance : 0
         }, edge)
         const initialWorkspaceTop = await scrollRegion.evaluate(
           (element) => element.scrollTop

--- a/src/components/agent/main-content.tsx
+++ b/src/components/agent/main-content.tsx
@@ -18,11 +18,13 @@ export function MainContent({
       data-dashboard-scroll-region={isSchedule ? "schedule" : undefined}
       {...rest}
       className={cn(
-        "flex flex-col overflow-x-hidden min-w-0 min-h-0",
+        "flex flex-col min-w-0 min-h-0",
         "transition-[flex,opacity] duration-300 ease-in-out",
         needsFixedHeight
             ? "flex-1 overflow-hidden"
-            : "flex-1 overflow-y-auto pb-14 md:pb-0",
+            : isSchedule
+              ? "flex-1 overflow-x-auto overflow-y-auto pb-14 md:pb-0"
+              : "flex-1 overflow-x-hidden overflow-y-auto pb-14 md:pb-0",
         classNameProp
       )}
     >

--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -651,7 +651,10 @@ export function ScheduleView({
   }
 
   return (
-    <div className="flex min-h-full flex-col" data-schedule-workspace>
+    <div
+      className="flex min-h-full min-w-[960px] flex-col"
+      data-schedule-workspace
+    >
       <div
         className="mb-1 flex h-8 shrink-0 min-w-0 flex-nowrap items-center gap-1 overflow-x-auto"
         data-schedule-controls
@@ -1196,6 +1199,12 @@ export function ScheduleView({
           />
         )}
       </div>
+
+      <div
+        aria-hidden="true"
+        className="h-[100dvh] shrink-0"
+        data-schedule-scroll-reserve
+      />
 
       {/* New schedule item dialog */}
       {projectId && (


### PR DESCRIPTION
## Summary
- make the Schedule outer workspace scroll in both axes without changing other Dashboard routes
- preserve controls at narrow widths with a 960px Schedule workspace minimum width
- add a full viewport of intentional vertical reserve below Schedule content
- cover constrained-width horizontal and vertical outer scrolling, while retaining Gantt mode and edge-wheel coverage

## Validation
- `bunx tsc --noEmit`
- `bun run build`
- `bun test src/lib/schedule/__tests__/gantt-scroll.test.ts src/lib/schedule/__tests__/gantt-interaction-mode.test.ts` (17 passed)
- focused Playwright across Chromium, Firefox, WebKit (4 passed each)
- independent implementation review: PASS

No schema migration.