### PR TITLE
fix(projects): align create action with project permission

### DIFF
--- a/src/app/dashboard/projects/page.tsx
+++ b/src/app/dashboard/projects/page.tsx
@@ -13,7 +13,10 @@ import { ProjectsHub } from "@/components/projects/projects-hub"
 import { ProjectHubLaunchpad } from "@/components/projects/project-hub-launchpad"
 import { getCurrentUser } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
-import { canManageProjectRegistry } from "@/lib/permissions"
+import {
+  canCreateProject,
+  canManageProjectRegistry,
+} from "@/lib/permissions"
 
 export type ProjectsHubProject = {
   readonly id: string
@@ -62,7 +65,7 @@ export default async function ProjectsPage({
       <ProjectHubLaunchpad
         projects={projectList}
         overview={overview}
-        canManageProjects={canManageProjectRegistry(currentUser)}
+        canManageProjects={canCreateProject(currentUser)}
         intakeAssignees={intakeAssignees}
       />
     )

--- a/src/lib/__tests__/permissions.test.ts
+++ b/src/lib/__tests__/permissions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import type { AuthUser } from "@/lib/auth"
 import { DEMO_USER } from "@/lib/demo"
 import {
+  canCreateProject,
   canManageWorkCalendarEvents,
   canUseAskCompass,
   canUseFieldDesk,
@@ -27,6 +28,52 @@ function userWithRole(role: string): AuthUser {
     updatedAt: "2026-01-01T00:00:00.000Z",
   }
 }
+
+describe("canCreateProject", () => {
+  it.each([
+    "admin",
+    "secondary_admin",
+    "executive",
+    "office",
+    "office_manager",
+    "project_manager",
+    "project_administrator",
+    "assistant_project_manager",
+    "architectural_designer",
+    "drafter",
+    "lead_estimator",
+    "assistant_estimator",
+    "coordinator",
+    "accounting",
+  ])("allows active project-create role %s", (role) => {
+    expect(canCreateProject(userWithRole(role))).toBe(true)
+  })
+
+  it.each([
+    "field_superintendent",
+    "field_crew",
+    "field",
+    "developer",
+    "client",
+    "subcontractor",
+    "supplier",
+    "guest",
+    "unknown",
+  ])("denies non-project-create role %s", (role) => {
+    expect(canCreateProject(userWithRole(role))).toBe(false)
+  })
+
+  it("denies inactive, unauthenticated, and demo users", () => {
+    expect(
+      canCreateProject({
+        ...userWithRole("assistant_project_manager"),
+        isActive: false,
+      }),
+    ).toBe(false)
+    expect(canCreateProject(null)).toBe(false)
+    expect(canCreateProject(DEMO_USER)).toBe(false)
+  })
+})
 
 describe("canUseAskCompass", () => {
   it("allows active staff roles with agent read permission", () => {

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -588,6 +588,18 @@ export function hasAnyPermission(
   return !!resourcePermissions && resourcePermissions.length > 0
 }
 
+export function canCreateProject(user: AuthUser | null): boolean {
+  if (!user || !user.isActive) return false
+  if (
+    isDemoUser(user.id) ||
+    (user.organizationId !== null && isDemoOrg(user.organizationId))
+  ) {
+    return false
+  }
+
+  return can(user, "project", "create")
+}
+
 export function canManageProjectRegistry(user: AuthUser | null): boolean {
   if (!user || !user.isActive) return false
   if (


### PR DESCRIPTION
## Summary\n- align default Project Hub New project visibility with the existing server-side project:create policy\n- retain the separate ?manage registry gate under admin/organization-management authority\n- add a role-matrix regression test including assistant_project_manager\n\n## Validation\n- bun run test src/lib/__tests__/permissions.test.ts src/lib/__tests__/project-audience-team.test.ts (75 passing)\n- bunx tsc --noEmit\n- bun run lint (0 errors; pre-existing warnings)\n- bun run build\n\nFixes the authorization/UI parity defect that hid New project from active internal roles such as assistant project managers while the server already allowed project creation.