### PR TITLE
feat(conversations): add workspace side panel

### DIFF
--- a/src/app/actions/conversation-panel.ts
+++ b/src/app/actions/conversation-panel.ts
@@ -1,0 +1,143 @@
+"use server"
+
+import { getMessages } from "@/app/actions/chat-messages"
+import { getChannel } from "@/app/actions/conversations"
+import { getProjectContactsSummary } from "@/app/actions/project-contacts"
+import { getCurrentUser } from "@/lib/auth"
+
+export type ConversationPanelProjectRecipient = {
+  readonly id: string
+  readonly contactType: "owner" | "supplier" | "subcontractor" | "internal"
+  readonly displayName: string
+  readonly companyName: string | null
+  readonly role: string | null
+  readonly trade: string | null
+  readonly email: string | null
+}
+
+type ConversationPanelChannel = {
+  readonly id: string
+  readonly name: string
+  readonly description: string | null
+  readonly organizationId: string
+  readonly projectId: string | null
+  readonly archivedAt: string | null
+}
+
+type ConversationPanelMessage = {
+  readonly id: string
+  readonly channelId: string
+  readonly threadId: string | null
+  readonly content: string
+  readonly contentHtml: string | null
+  readonly editedAt: string | null
+  readonly deletedAt: string | null
+  readonly isPinned: boolean
+  readonly replyCount: number
+  readonly lastReplyAt: string | null
+  readonly createdAt: string
+  readonly user: {
+    readonly id: string
+    readonly displayName: string | null
+    readonly email: string
+    readonly role: string
+    readonly avatarUrl: string | null
+  } | null
+  readonly attachments: readonly {
+    readonly id: string
+    readonly fileName: string
+    readonly mimeType: string
+    readonly fileSize: number
+    readonly storageProvider: string
+    readonly driveFileId: string | null
+    readonly driveUrl: string | null
+    readonly downloadUrl: string | null
+    readonly uploadedAt: string
+    readonly storageUrl: string
+  }[]
+  readonly reactions: readonly {
+    readonly emoji: string
+    readonly count: number
+    readonly reactedByCurrentUser: boolean
+  }[]
+}
+
+export async function getConversationPanelData(channelId: string): Promise<
+  | {
+      readonly success: true
+      readonly data: {
+        readonly channel: ConversationPanelChannel
+        readonly messages: readonly ConversationPanelMessage[]
+        readonly projectRecipients: readonly ConversationPanelProjectRecipient[]
+      }
+    }
+  | { readonly success: false; readonly error: string }
+> {
+  const [channelResult, messagesResult, currentUser] = await Promise.all([
+    getChannel(channelId),
+    getMessages(channelId),
+    getCurrentUser(),
+  ])
+
+  if (!channelResult.success || !channelResult.data || !currentUser) {
+    return {
+      success: false,
+      error:
+        !channelResult.success
+          ? channelResult.error ?? "Unable to load this conversation."
+          : "Unable to load this conversation.",
+    }
+  }
+
+  const channel = channelResult.data
+  const contactsSummary = channel.projectId
+    ? await getProjectContactsSummary(channel.projectId).catch(() => null)
+    : null
+  const messages = messagesResult.success && messagesResult.data
+    ? messagesResult.data.map((message) => ({
+      ...message,
+      user: message.user
+        ? { ...message.user, role: "" }
+        : null,
+      attachments: message.attachments.map((attachment) => ({
+        id: attachment.id,
+        fileName: attachment.fileName,
+        mimeType: attachment.mimeType,
+        fileSize: attachment.fileSize,
+        storageProvider: "r2",
+        driveFileId: null,
+        driveUrl: null,
+        downloadUrl: attachment.storageUrl,
+        uploadedAt: "",
+        storageUrl: attachment.storageUrl,
+      })),
+    }))
+    : []
+
+  const projectRecipients: readonly ConversationPanelProjectRecipient[] =
+    contactsSummary?.allContacts.map((contact) => ({
+      id: contact.id,
+      contactType: contact.contactType,
+      displayName: contact.displayName,
+      companyName: contact.companyName,
+      role: contact.role,
+      trade: contact.trade,
+      email: contact.email,
+    })) ?? []
+
+  return {
+    success: true,
+    data: {
+      channel: {
+        id: channel.id,
+        name: channel.name,
+        description: channel.description,
+        organizationId: channel.organizationId,
+        projectId: channel.projectId,
+        archivedAt: channel.archivedAt,
+      },
+      messages,
+      projectRecipients,
+    },
+  }
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -12,6 +12,8 @@ import { Toaster } from "@/components/ui/sonner"
 import { ChatPanelShell } from "@/components/agent/chat-panel-shell"
 import { MainContent } from "@/components/agent/main-content"
 import { ChatProvider } from "@/components/agent/chat-provider"
+import { ConversationPanelProvider } from "@/components/conversations/conversation-panel-provider"
+import { ConversationPanelShell } from "@/components/conversations/conversation-panel-shell"
 import {
   SidebarInset,
   SidebarProvider,
@@ -73,6 +75,7 @@ export default async function DashboardLayout({
       offlineScopeKey={offlineScopeKey}
       canSubmitCherish={canUseCompassFieldDesk}
     >
+    <ConversationPanelProvider>
     <PresenceProvider>
     <VoiceProvider>
     <SettingsProvider>
@@ -117,6 +120,7 @@ export default async function DashboardLayout({
               {children}
             </MainContent>
             {canUseCompassAgent && <ChatPanelShell />}
+            {canUseDirectMessages && <ConversationPanelShell />}
           </div>
         </SidebarInset>
         <MobileBottomNav canUseFieldDesk={canUseCompassFieldDesk} />
@@ -136,6 +140,7 @@ export default async function DashboardLayout({
     </SettingsProvider>
     </VoiceProvider>
     </PresenceProvider>
+    </ConversationPanelProvider>
     </ChatProvider>
   )
 }

--- a/src/components/__tests__/nav-main-behavior.test.ts
+++ b/src/components/__tests__/nav-main-behavior.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "vitest"
+import { shouldOpenConversationPanel } from "@/components/nav-main"
+
+test("uses the side drawer only for the Conversations link when the panel is available", () => {
+  expect(shouldOpenConversationPanel("Conversations", true)).toBe(true)
+  expect(shouldOpenConversationPanel("Projects", true)).toBe(false)
+  expect(shouldOpenConversationPanel("Conversations", false)).toBe(false)
+})

--- a/src/components/conversations/__tests__/conversation-panel-state.test.ts
+++ b/src/components/conversations/__tests__/conversation-panel-state.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest"
+import {
+  closeConversationPanel,
+  openConversationPanel,
+  openDirectMessagePanel,
+  toggleConversationPanel,
+  type ConversationPanelState,
+} from "../conversation-panel-state"
+
+const closed: ConversationPanelState = {
+  isOpen: false,
+  channelId: null,
+}
+
+describe("conversation panel state", () => {
+  it("opens the direct-message picker without navigating away from the workspace", () => {
+    expect(openDirectMessagePanel(closed)).toEqual({
+      isOpen: true,
+      channelId: null,
+      view: "direct-message-picker",
+    })
+  })
+
+  it("opens directly into the channel chosen from any workspace", () => {
+    expect(openConversationPanel(closed, "channel-42")).toEqual({
+      isOpen: true,
+      channelId: "channel-42",
+    })
+  })
+
+  it("keeps the active channel when reopening the conversation drawer", () => {
+    const open: ConversationPanelState = {
+      isOpen: false,
+      channelId: "channel-42",
+    }
+
+    expect(openConversationPanel(open)).toEqual({
+      isOpen: true,
+      channelId: "channel-42",
+    })
+  })
+
+  it("closes without discarding the active channel so the next open can resume it", () => {
+    const open: ConversationPanelState = {
+      isOpen: true,
+      channelId: "channel-42",
+    }
+
+    expect(closeConversationPanel(open)).toEqual({
+      isOpen: false,
+      channelId: "channel-42",
+    })
+  })
+
+  it("toggles the drawer while preserving its selected channel", () => {
+    const open: ConversationPanelState = {
+      isOpen: true,
+      channelId: "channel-42",
+    }
+
+    expect(toggleConversationPanel(open)).toEqual({
+      isOpen: false,
+      channelId: "channel-42",
+    })
+    expect(toggleConversationPanel(closeConversationPanel(open))).toEqual({
+      isOpen: true,
+      channelId: "channel-42",
+    })
+  })
+})

--- a/src/components/conversations/conversation-panel-provider.tsx
+++ b/src/components/conversations/conversation-panel-provider.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import * as React from "react"
+import {
+  closeConversationPanel,
+  openConversationPanel,
+  openDirectMessagePanel,
+  toggleConversationPanel,
+  type ConversationPanelState,
+} from "./conversation-panel-state"
+
+type ConversationPanelContextValue = ConversationPanelState & {
+  readonly open: (channelId?: string | null) => void
+  readonly openDirectMessages: () => void
+  readonly close: () => void
+  readonly toggle: () => void
+}
+
+const ConversationPanelContext =
+  React.createContext<ConversationPanelContextValue | null>(null)
+
+export function useConversationPanel(): ConversationPanelContextValue {
+  const context = React.useContext(ConversationPanelContext)
+  if (!context) {
+    throw new Error(
+      "useConversationPanel must be used within a ConversationPanelProvider"
+    )
+  }
+  return context
+}
+
+export function useConversationPanelOptional(): ConversationPanelContextValue | null {
+  return React.useContext(ConversationPanelContext)
+}
+
+export function ConversationPanelProvider({
+  children,
+}: {
+  readonly children: React.ReactNode
+}) {
+  const [state, setState] = React.useState<ConversationPanelState>({
+    isOpen: false,
+    channelId: null,
+  })
+
+  const open = React.useCallback((channelId?: string | null) => {
+    setState((current) =>
+      openConversationPanel(
+        current,
+        channelId === undefined ? current.channelId : channelId
+      )
+    )
+  }, [])
+
+  const openDirectMessages = React.useCallback(() => {
+    setState((current) => openDirectMessagePanel(current))
+  }, [])
+
+  const close = React.useCallback(() => {
+    setState((current) => closeConversationPanel(current))
+  }, [])
+
+  const toggle = React.useCallback(() => {
+    setState((current) => toggleConversationPanel(current))
+  }, [])
+
+  const value = React.useMemo(
+    () => ({ ...state, open, openDirectMessages, close, toggle }),
+    [state, open, openDirectMessages, close, toggle]
+  )
+
+  return (
+    <ConversationPanelContext.Provider value={value}>
+      {children}
+    </ConversationPanelContext.Provider>
+  )
+}

--- a/src/components/conversations/conversation-panel-shell.tsx
+++ b/src/components/conversations/conversation-panel-shell.tsx
@@ -1,0 +1,291 @@
+"use client"
+
+import * as React from "react"
+import { ArrowLeft, MessageCircle, PanelRightClose, RefreshCw } from "lucide-react"
+import { getConversationPanelData } from "@/app/actions/conversation-panel"
+import { listChannels } from "@/app/actions/conversations"
+import { DirectMessagePicker } from "@/components/conversations/direct-message-dialog"
+import { MessageComposer } from "@/components/conversations/message-composer"
+import { MessageList } from "@/components/conversations/message-list"
+import { ConversationsProvider } from "@/contexts/conversations-context"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { useConversationPanel } from "./conversation-panel-provider"
+
+type PanelData = Extract<
+  Awaited<ReturnType<typeof getConversationPanelData>>,
+  { readonly success: true }
+>["data"]
+
+type TextChannel = {
+  readonly id: string
+  readonly name: string
+  readonly description: string | null
+  readonly projectId: string | null
+  readonly type: string
+}
+
+function channelLabel(channel: TextChannel): string {
+  return channel.projectId ? `Project · ${channel.name}` : channel.name
+}
+
+function ConversationPanelContent() {
+  const { isOpen, channelId, view, open, close } = useConversationPanel()
+  const [channels, setChannels] = React.useState<readonly TextChannel[]>([])
+  const [channelsLoading, setChannelsLoading] = React.useState(false)
+  const [channelsError, setChannelsError] = React.useState<string | null>(null)
+  const [data, setData] = React.useState<PanelData | null>(null)
+  const [loading, setLoading] = React.useState(false)
+  const [loadError, setLoadError] = React.useState<string | null>(null)
+  const [panelWidth, setPanelWidth] = React.useState(460)
+  const [isResizing, setIsResizing] = React.useState(false)
+  const dragStartX = React.useRef(0)
+  const dragStartWidth = React.useRef(0)
+
+  const loadChannels = React.useCallback(async () => {
+    setChannelsLoading(true)
+    setChannelsError(null)
+    try {
+      const result = await listChannels()
+      if (!result.success || !result.data) {
+        setChannelsError(
+          result.success
+            ? "Unable to load conversations."
+            : result.error ?? "Unable to load conversations."
+        )
+        return
+      }
+      setChannels(result.data.filter((channel) => channel.type === "text"))
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : ""
+      setChannelsError(
+        /server action|unrecognizedaction/i.test(message)
+          ? "Compass was updated while this drawer was open. Reload to continue."
+          : "Unable to load conversations."
+      )
+    } finally {
+      setChannelsLoading(false)
+    }
+  }, [])
+
+  React.useEffect(() => {
+    if (isOpen) void loadChannels()
+  }, [isOpen, loadChannels])
+
+  const loadConversation = React.useCallback(async (id: string) => {
+    setLoading(true)
+    setLoadError(null)
+    setData(null)
+    try {
+      const result = await getConversationPanelData(id)
+      if (!result.success || !result.data) {
+        setLoadError(result.success ? "Unable to load this conversation." : result.error)
+        return
+      }
+      setData(result.data)
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : ""
+      setLoadError(
+        /server action|unrecognizedaction/i.test(message)
+          ? "Compass was updated while this drawer was open. Reload to continue."
+          : "Unable to load this conversation."
+      )
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  React.useEffect(() => {
+    if (!isOpen || !channelId) {
+      setData(null)
+      setLoadError(null)
+      return
+    }
+    void loadConversation(channelId)
+  }, [channelId, isOpen, loadConversation])
+
+  React.useEffect(() => {
+    const onMouseMove = (event: MouseEvent) => {
+      if (!dragStartWidth.current) return
+      const delta = dragStartX.current - event.clientX
+      setPanelWidth(Math.min(720, Math.max(320, dragStartWidth.current + delta)))
+    }
+    const onMouseUp = () => {
+      if (!dragStartWidth.current) return
+      dragStartWidth.current = 0
+      setIsResizing(false)
+      document.body.style.cursor = ""
+      document.body.style.userSelect = ""
+    }
+    window.addEventListener("mousemove", onMouseMove)
+    window.addEventListener("mouseup", onMouseUp)
+    return () => {
+      window.removeEventListener("mousemove", onMouseMove)
+      window.removeEventListener("mouseup", onMouseUp)
+    }
+  }, [])
+
+  const handleResizeStart = React.useCallback((event: React.MouseEvent) => {
+    event.preventDefault()
+    setIsResizing(true)
+    dragStartX.current = event.clientX
+    dragStartWidth.current = panelWidth
+    document.body.style.cursor = "col-resize"
+    document.body.style.userSelect = "none"
+  }, [panelWidth])
+
+  const showDirectMessagePicker = view === "direct-message-picker"
+  const showChannelList = channelId === null && !showDirectMessagePicker
+
+  return (
+    <>
+      <section
+        className={cn(
+          "flex flex-col bg-background",
+          "transition-[width,border-color,box-shadow,opacity,transform] duration-300 ease-in-out",
+          "fixed inset-0 z-50 md:relative md:inset-auto md:z-auto md:my-2 md:mr-2 md:shrink-0 md:overflow-hidden md:rounded-lg md:border md:border-border md:shadow-lg",
+          isResizing && "transition-none",
+          isOpen
+            ? "translate-x-0 md:opacity-100"
+            : "pointer-events-none translate-x-full md:translate-x-0 md:w-0 md:border-transparent md:shadow-none md:opacity-0"
+        )}
+        style={isOpen ? { width: panelWidth } : undefined}
+        aria-hidden={!isOpen}
+        aria-label="Conversations"
+      >
+        <div
+          className="absolute -left-1 top-0 z-10 hidden h-full w-2 cursor-col-resize md:block hover:bg-border/60 active:bg-border"
+          onMouseDown={handleResizeStart}
+        />
+        <header className="flex h-14 shrink-0 items-center gap-2 border-b px-3">
+          {channelId || showDirectMessagePicker ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => open(null)}
+              aria-label="Choose another conversation"
+              title="All conversations"
+            >
+              <ArrowLeft className="size-4" />
+            </Button>
+          ) : (
+            <MessageCircle className="ml-1 size-4 text-muted-foreground" />
+          )}
+          <div className="min-w-0 flex-1">
+            <h2 className="truncate text-sm font-semibold">
+              {data
+                ? `# ${data.channel.name}`
+                : showDirectMessagePicker
+                  ? "New direct message"
+                  : "Conversations"}
+            </h2>
+            {data?.channel.description ? (
+              <p className="truncate text-xs text-muted-foreground">
+                {data.channel.description}
+              </p>
+            ) : null}
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={close}
+            aria-label="Collapse conversations"
+            title="Collapse conversations"
+          >
+            <PanelRightClose className="size-4" />
+          </Button>
+        </header>
+
+        {showDirectMessagePicker ? (
+          <DirectMessagePicker onStarted={(channelId) => open(channelId)} />
+        ) : showChannelList ? (
+          <div className="min-h-0 flex-1 overflow-y-auto p-3">
+            <p className="mb-3 text-xs text-muted-foreground">
+              Open a team or project conversation without leaving this workspace.
+            </p>
+            {channelsLoading ? (
+              <p className="p-3 text-sm text-muted-foreground">Loading conversations...</p>
+            ) : channelsError ? (
+              <div className="space-y-3 p-3 text-center">
+                <p className="text-sm text-muted-foreground">{channelsError}</p>
+                <Button type="button" size="sm" variant="outline" onClick={() => void loadChannels()}>
+                  <RefreshCw className="size-3.5" />
+                  Try again
+                </Button>
+              </div>
+            ) : channels.length === 0 ? (
+              <p className="p-3 text-sm text-muted-foreground">No conversations are available.</p>
+            ) : (
+              <div className="space-y-1">
+                {channels.map((channel) => (
+                  <button
+                    key={channel.id}
+                    type="button"
+                    className="flex w-full flex-col rounded-lg px-3 py-2 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    onClick={() => open(channel.id)}
+                  >
+                    <span className="truncate text-sm font-medium"># {channel.name}</span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {channel.description ?? channelLabel(channel)}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        ) : loading ? (
+          <div className="flex min-h-0 flex-1 items-center justify-center p-6">
+            <p className="text-sm text-muted-foreground">Loading conversation...</p>
+          </div>
+        ) : loadError ? (
+          <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+            <p className="text-sm text-muted-foreground">{loadError}</p>
+            <Button type="button" size="sm" variant="outline" onClick={() => channelId && void loadConversation(channelId)}>
+              <RefreshCw className="size-3.5" />
+              Try again
+            </Button>
+          </div>
+        ) : data ? (
+          <div className="flex min-h-0 flex-1 flex-col">
+            <MessageList
+              channelId={data.channel.id}
+              initialMessages={data.messages}
+              showThreadActions={false}
+            />
+            {data.channel.archivedAt ? (
+              <div className="border-t bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+                This conversation is archived.
+              </div>
+            ) : (
+              <MessageComposer
+                channelId={data.channel.id}
+                channelName={data.channel.name}
+                organizationId={data.channel.organizationId}
+                isProjectChannel={Boolean(data.channel.projectId)}
+                projectRecipients={data.projectRecipients}
+                onSent={() => void loadConversation(data.channel.id)}
+              />
+            )}
+          </div>
+        ) : null}
+      </section>
+      {isOpen ? (
+        <div
+          className="fixed inset-0 z-40 bg-black/20 md:hidden"
+          onClick={close}
+          aria-hidden="true"
+        />
+      ) : null}
+    </>
+  )
+}
+
+export function ConversationPanelShell() {
+  return (
+    <ConversationsProvider wrap={false}>
+      <ConversationPanelContent />
+    </ConversationsProvider>
+  )
+}

--- a/src/components/conversations/conversation-panel-state.ts
+++ b/src/components/conversations/conversation-panel-state.ts
@@ -1,0 +1,44 @@
+export type ConversationPanelView = "direct-message-picker"
+
+export type ConversationPanelState = {
+  readonly isOpen: boolean
+  readonly channelId: string | null
+  /** Omitted for the channel list or an active conversation. */
+  readonly view?: ConversationPanelView
+}
+
+export function openConversationPanel(
+  state: ConversationPanelState,
+  channelId: string | null = state.channelId
+): ConversationPanelState {
+  return {
+    isOpen: true,
+    channelId,
+  }
+}
+
+export function openDirectMessagePanel(
+  state: ConversationPanelState
+): ConversationPanelState {
+  return {
+    ...state,
+    isOpen: true,
+    channelId: null,
+    view: "direct-message-picker",
+  }
+}
+
+export function closeConversationPanel(
+  state: ConversationPanelState
+): ConversationPanelState {
+  return {
+    ...state,
+    isOpen: false,
+  }
+}
+
+export function toggleConversationPanel(
+  state: ConversationPanelState
+): ConversationPanelState {
+  return state.isOpen ? closeConversationPanel(state) : openConversationPanel(state)
+}

--- a/src/components/conversations/direct-message-dialog.tsx
+++ b/src/components/conversations/direct-message-dialog.tsx
@@ -15,7 +15,6 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
@@ -30,26 +29,19 @@ type DirectMessageRecipient = {
   readonly avatarUrl: string | null
 }
 
-export function DirectMessageDialog({
-  open,
-  onOpenChange,
+export function DirectMessagePicker({
+  onStarted,
 }: {
-  readonly open: boolean
-  readonly onOpenChange: (open: boolean) => void
+  readonly onStarted: (channelId: string) => void
 }): React.ReactElement {
-  const router = useRouter()
-  const [recipients, setRecipients] = React.useState<
-    readonly DirectMessageRecipient[]
-  >([])
+  const [recipients, setRecipients] = React.useState<readonly DirectMessageRecipient[]>([])
   const [query, setQuery] = React.useState("")
-  const [loading, setLoading] = React.useState(false)
+  const [loading, setLoading] = React.useState(true)
   const [selectedIds, setSelectedIds] = React.useState<readonly string[]>([])
   const [starting, setStarting] = React.useState(false)
 
   React.useEffect(() => {
-    if (!open) return
     let cancelled = false
-    setLoading(true)
     void listDirectMessageRecipients().then((result) => {
       if (cancelled) return
       if (result.success && result.data) {
@@ -62,13 +54,7 @@ export function DirectMessageDialog({
     return () => {
       cancelled = true
     }
-  }, [open])
-
-  React.useEffect(() => {
-    if (open) return
-    setQuery("")
-    setSelectedIds([])
-  }, [open])
+  }, [])
 
   const normalizedQuery = query.trim().toLocaleLowerCase()
   const filteredRecipients = recipients.filter((recipient) =>
@@ -94,9 +80,7 @@ export function DirectMessageDialog({
         toast.error(result.error ?? "Could not start the conversation.")
         return
       }
-      onOpenChange(false)
-      router.push(`/dashboard/conversations/${result.data.channelId}`)
-      router.refresh()
+      onStarted(result.data.channelId)
     } catch {
       toast.error("Could not start the conversation.")
     } finally {
@@ -105,90 +89,105 @@ export function DirectMessageDialog({
   }
 
   return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3 p-3">
+      <p className="text-xs text-muted-foreground">
+        Select one or more internal team members for a private conversation.
+      </p>
+      <div className="relative">
+        <IconSearch className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.currentTarget.value)}
+          placeholder="Find a team member"
+          className="pl-9"
+          autoFocus
+        />
+      </div>
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="space-y-1 pr-3">
+          {loading ? (
+            <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+              <IconLoader2 className="size-4 animate-spin" />
+              Loading team members…
+            </div>
+          ) : filteredRecipients.length === 0 ? (
+            <p className="py-10 text-center text-sm text-muted-foreground">
+              No matching team members.
+            </p>
+          ) : (
+            filteredRecipients.map((recipient) => {
+              const selected = selectedIds.includes(recipient.id)
+              return (
+                <div
+                  key={recipient.id}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-3 px-3 py-2 text-left hover:bg-accent has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50",
+                    selected && "bg-accent"
+                  )}
+                  onClick={() => {
+                    if (!starting) toggleRecipient(recipient.id, !selected)
+                  }}
+                >
+                  <span className="grid size-9 shrink-0 place-items-center rounded-full bg-primary/10 text-primary">
+                    <IconMessageCircle className="size-4" />
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium">{recipient.name}</span>
+                    <span className="block truncate text-xs text-muted-foreground">{recipient.email}</span>
+                  </span>
+                  <Checkbox
+                    checked={selected}
+                    disabled={starting}
+                    onClick={(event) => event.stopPropagation()}
+                    onCheckedChange={(checked) => toggleRecipient(recipient.id, checked === true)}
+                    aria-label={`Include ${recipient.name}`}
+                  />
+                </div>
+              )
+            })
+          )}
+        </div>
+      </ScrollArea>
+      <div className="flex flex-col gap-2 border-t pt-3 sm:flex-row sm:items-center sm:justify-between">
+        <span className="text-sm text-muted-foreground">
+          {selectedIds.length === 0
+            ? "Choose at least one person"
+            : `${selectedIds.length} team member${selectedIds.length === 1 ? "" : "s"} selected`}
+        </span>
+        <Button type="button" disabled={selectedIds.length === 0 || starting} onClick={() => void startMessage()}>
+          {starting ? <IconLoader2 className="size-4 animate-spin" /> : null}
+          Start conversation
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export function DirectMessageDialog({
+  open,
+  onOpenChange,
+}: {
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
+}): React.ReactElement {
+  const router = useRouter()
+
+  return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="flex max-h-[80vh] flex-col sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>New direct message</DialogTitle>
           <DialogDescription>
             Select one or more internal team members for a private conversation.
           </DialogDescription>
         </DialogHeader>
-        <div className="relative">
-          <IconSearch className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            value={query}
-            onChange={(event) => setQuery(event.currentTarget.value)}
-            placeholder="Find a team member"
-            className="pl-9"
-            autoFocus
-          />
-        </div>
-        <ScrollArea className="max-h-80">
-          <div className="space-y-1 pr-3">
-            {loading ? (
-              <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
-                <IconLoader2 className="size-4 animate-spin" />
-                Loading team members…
-              </div>
-            ) : filteredRecipients.length === 0 ? (
-              <p className="py-10 text-center text-sm text-muted-foreground">
-                No matching team members.
-              </p>
-            ) : (
-              filteredRecipients.map((recipient) => {
-                const selected = selectedIds.includes(recipient.id)
-                return (
-                  <div
-                    key={recipient.id}
-                    className={cn(
-                      "flex cursor-pointer items-center gap-3 px-3 py-2 text-left hover:bg-accent has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50",
-                      selected && "bg-accent"
-                    )}
-                    onClick={() => {
-                      if (!starting) toggleRecipient(recipient.id, !selected)
-                    }}
-                  >
-                    <span className="grid size-9 shrink-0 place-items-center rounded-full bg-primary/10 text-primary">
-                      <IconMessageCircle className="size-4" />
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate text-sm font-medium">
-                        {recipient.name}
-                      </span>
-                      <span className="block truncate text-xs text-muted-foreground">
-                        {recipient.email}
-                      </span>
-                    </span>
-                    <Checkbox
-                      checked={selected}
-                      disabled={starting}
-                      onClick={(event) => event.stopPropagation()}
-                      onCheckedChange={(checked) =>
-                        toggleRecipient(recipient.id, checked === true)
-                      }
-                      aria-label={`Include ${recipient.name}`}
-                    />
-                  </div>
-                )
-              })
-            )}
-          </div>
-        </ScrollArea>
-        <DialogFooter className="items-center sm:justify-between">
-          <span className="text-sm text-muted-foreground">
-            {selectedIds.length === 0
-              ? "Choose at least one person"
-              : `${selectedIds.length} team member${selectedIds.length === 1 ? "" : "s"} selected`}
-          </span>
-          <Button
-            type="button"
-            disabled={selectedIds.length === 0 || starting}
-            onClick={() => void startMessage()}
-          >
-            {starting ? <IconLoader2 className="size-4 animate-spin" /> : null}
-            Start conversation
-          </Button>
-        </DialogFooter>
+        <DirectMessagePicker
+          onStarted={(channelId) => {
+            onOpenChange(false)
+            router.push(`/dashboard/conversations/${channelId}`)
+            router.refresh()
+          }}
+        />
       </DialogContent>
     </Dialog>
   )

--- a/src/components/conversations/message-item.tsx
+++ b/src/components/conversations/message-item.tsx
@@ -62,6 +62,7 @@ type MessageData = {
 
 type MessageItemProps = {
   readonly message: MessageData
+  readonly showThreadAction?: boolean
 }
 
 function getRoleBadge(email: string) {
@@ -85,11 +86,15 @@ function arePropsEqual(prev: MessageItemProps, next: MessageItemProps): boolean 
     prevMsg.deletedAt === nextMsg.deletedAt &&
     prevMsg.attachments?.length === nextMsg.attachments?.length &&
     prevMsg.reactions?.map((reaction) => `${reaction.emoji}:${reaction.count}`).join("|") ===
-      nextMsg.reactions?.map((reaction) => `${reaction.emoji}:${reaction.count}`).join("|")
+      nextMsg.reactions?.map((reaction) => `${reaction.emoji}:${reaction.count}`).join("|") &&
+    prev.showThreadAction === next.showThreadAction
   )
 }
 
-export const MessageItem = React.memo(function MessageItem({ message }: MessageItemProps) {
+export const MessageItem = React.memo(function MessageItem({
+  message,
+  showThreadAction = true,
+}: MessageItemProps) {
   const [isHovered, setIsHovered] = React.useState(false)
   const [isFocused, setIsFocused] = React.useState(false)
   const [reactionOpen, setReactionOpen] = React.useState(false)
@@ -238,7 +243,7 @@ export const MessageItem = React.memo(function MessageItem({ message }: MessageI
           </div>
         )}
 
-        {message.replyCount > 0 && (
+        {showThreadAction && message.replyCount > 0 && (
           <button
             className="mt-2 flex items-center gap-1 text-xs text-primary hover:underline"
             onClick={handleReply}
@@ -256,15 +261,17 @@ export const MessageItem = React.memo(function MessageItem({ message }: MessageI
 
       {(isHovered || isFocused || reactionOpen) && (
         <div className="absolute right-4 top-2 flex gap-1 rounded-md border bg-background p-1 shadow-sm">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7"
-            onClick={handleReply}
-            aria-label="Reply to message"
-          >
-            <MessageSquare className="h-3.5 w-3.5" />
-          </Button>
+          {showThreadAction && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={handleReply}
+              aria-label="Reply to message"
+            >
+              <MessageSquare className="h-3.5 w-3.5" />
+            </Button>
+          )}
           <Popover open={reactionOpen} onOpenChange={setReactionOpen}>
             <PopoverTrigger asChild>
               <Button

--- a/src/components/conversations/message-list.tsx
+++ b/src/components/conversations/message-list.tsx
@@ -45,11 +45,16 @@ type MessageData = {
 type MessageListProps = {
   readonly channelId: string
   readonly initialMessages: readonly MessageData[]
+  readonly showThreadActions?: boolean
 }
 
 const MAX_MESSAGES = 200
 
-export function MessageList({ channelId, initialMessages }: MessageListProps) {
+export function MessageList({
+  channelId,
+  initialMessages,
+  showThreadActions = true,
+}: MessageListProps) {
   // server returns DESC order; reverse for chronological display
   const [messages, setMessages] = React.useState<readonly MessageData[]>(
     [...initialMessages].reverse()
@@ -209,7 +214,11 @@ export function MessageList({ channelId, initialMessages }: MessageListProps) {
               </div>
             </div>
             {group.messages.map((message) => (
-              <MessageItem key={message.id} message={message} />
+              <MessageItem
+                key={message.id}
+                message={message}
+                showThreadAction={showThreadActions}
+              />
             ))}
           </div>
         ))}

--- a/src/components/nav-conversations.tsx
+++ b/src/components/nav-conversations.tsx
@@ -34,6 +34,7 @@ import { cn } from "@/lib/utils"
 import { CreateChannelDialog } from "@/components/conversations/create-channel-dialog"
 import { VoiceChannelStub } from "@/components/conversations/voice-channel-stub"
 import { DirectMessageDialog } from "@/components/conversations/direct-message-dialog"
+import { useConversationPanelOptional } from "@/components/conversations/conversation-panel-provider"
 import { ChevronRight } from "lucide-react"
 
 type ChannelData = {
@@ -67,6 +68,7 @@ function setCategoryCollapsedState(id: string, collapsed: boolean): void {
 export function NavConversations() {
   const pathname = usePathname()
   const { state } = useSidebar()
+  const conversationPanel = useConversationPanelOptional()
   const isExpanded = state === "expanded"
   const [channels, setChannels] = React.useState<ChannelData[]>([])
   const [categories, setCategories] = React.useState<CategoryData[]>([])
@@ -190,36 +192,56 @@ export function NavConversations() {
     })
   }
 
-  const renderChannelItem = (channel: ChannelData) => (
-    <SidebarMenuItem key={channel.id}>
-      <SidebarMenuButton
-        asChild
-        tooltip={channel.name}
-        className={cn(
-          pathname === `/dashboard/conversations/${channel.id}` &&
-            "bg-sidebar-foreground/10 font-medium"
+  const renderChannelItem = (channel: ChannelData) => {
+    const opensInPanel =
+      conversationPanel !== null &&
+      channel.type === "text" &&
+      channel.audience !== "direct"
+    const isPanelChannel =
+      opensInPanel &&
+      conversationPanel?.isOpen === true &&
+      conversationPanel?.channelId === channel.id
+    const channelContent = (
+      <>
+        {channel.audience === "direct" ? (
+          <IconUser className="shrink-0" />
+        ) : channel.projectId ? (
+          <IconBuilding className="shrink-0" />
+        ) : (
+          <IconMessageCircle className="shrink-0" />
         )}
-      >
-        <Link href={`/dashboard/conversations/${channel.id}`}>
-          {channel.audience === "direct" ? (
-            <IconUser className="shrink-0" />
-          ) : channel.projectId ? (
-            <IconBuilding className="shrink-0" />
-          ) : (
-            <IconMessageCircle className="shrink-0" />
-          )}
-          <span className={cn(channel.unreadCount && channel.unreadCount > 0 && "font-semibold")}>
-            {channel.name}
+        <span className={cn(channel.unreadCount && channel.unreadCount > 0 && "font-semibold")}>
+          {channel.name}
+        </span>
+        {channel.unreadCount && channel.unreadCount > 0 && (
+          <span className="ml-auto flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground">
+            {channel.unreadCount}
           </span>
-          {channel.unreadCount && channel.unreadCount > 0 && (
-            <span className="ml-auto flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground">
-              {channel.unreadCount}
-            </span>
+        )}
+      </>
+    )
+
+    return (
+      <SidebarMenuItem key={channel.id}>
+        <SidebarMenuButton
+          asChild
+          tooltip={channel.name}
+          className={cn(
+            (isPanelChannel || pathname === `/dashboard/conversations/${channel.id}`) &&
+              "bg-sidebar-foreground/10 font-medium"
           )}
-        </Link>
-      </SidebarMenuButton>
-    </SidebarMenuItem>
-  )
+        >
+          {opensInPanel ? (
+            <button type="button" onClick={() => conversationPanel?.open(channel.id)}>
+              {channelContent}
+            </button>
+          ) : (
+            <Link href={`/dashboard/conversations/${channel.id}`}>{channelContent}</Link>
+          )}
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    )
+  }
 
   const renderProjectLabel = (project: ProjectListItem) => (
     <SidebarMenuItem key={`project-label-${project.id}`}>

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -10,6 +10,11 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
+import { useConversationPanelOptional } from "@/components/conversations/conversation-panel-provider"
+
+export function shouldOpenConversationPanel(title: string, panelAvailable: boolean): boolean {
+  return title === "Conversations" && panelAvailable
+}
 
 export function NavMain({
   items,
@@ -20,20 +25,33 @@ export function NavMain({
     icon?: Icon
   }[]
 }) {
+  const conversationPanel = useConversationPanelOptional()
+
   return (
     <SidebarGroup>
       <SidebarGroupContent>
         <SidebarMenu>
-          {items.map((item) => (
-            <SidebarMenuItem key={item.title}>
-              <SidebarMenuButton asChild tooltip={item.title}>
-                <Link href={item.url}>
-                  {item.icon && <item.icon />}
-                  <span>{item.title}</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          ))}
+          {items.map((item) => {
+            const opensPanel = shouldOpenConversationPanel(item.title, conversationPanel !== null)
+
+            return (
+              <SidebarMenuItem key={item.title}>
+                <SidebarMenuButton asChild tooltip={item.title}>
+                  {opensPanel ? (
+                    <button type="button" onClick={() => conversationPanel?.open()}>
+                      {item.icon && <item.icon />}
+                      <span>{item.title}</span>
+                    </button>
+                  ) : (
+                    <Link href={item.url}>
+                      {item.icon && <item.icon />}
+                      <span>{item.title}</span>
+                    </Link>
+                  )}
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            )
+          })}
         </SidebarMenu>
       </SidebarGroupContent>
     </SidebarGroup>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -31,7 +31,7 @@ import { NotificationsPopover } from "@/components/notifications-popover"
 import { useCommandMenu } from "@/components/command-menu-provider"
 import { useAgentOptional } from "@/components/agent/chat-provider"
 import { AccountModal } from "@/components/account-modal"
-import { DirectMessageDialog } from "@/components/conversations/direct-message-dialog"
+import { useConversationPanelOptional } from "@/components/conversations/conversation-panel-provider"
 import { getInitials } from "@/lib/utils"
 import type { SidebarUser } from "@/lib/auth"
 
@@ -85,8 +85,8 @@ export function SiteHeader({
   const [headerQuery, setHeaderQuery] = React.useState("")
   const searchInputRef = React.useRef<HTMLInputElement>(null)
   const agentContext = useAgentOptional()
+  const conversationPanel = useConversationPanelOptional()
   const [accountOpen, setAccountOpen] = React.useState(false)
-  const [directMessageOpen, setDirectMessageOpen] = React.useState(false)
   const [isLoggingOut, startLogoutTransition] = React.useTransition()
   const { toggleSidebar } = useSidebar()
 
@@ -157,7 +157,7 @@ export function SiteHeader({
               variant="ghost"
               size="icon"
               className="size-9 shrink-0 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-              onClick={() => setDirectMessageOpen(true)}
+              onClick={() => conversationPanel?.openDirectMessages()}
               aria-label="Direct message a team member"
               title="Direct message"
             >
@@ -260,7 +260,7 @@ export function SiteHeader({
               variant="ghost"
               size="icon"
               className="size-7 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-              onClick={() => setDirectMessageOpen(true)}
+              onClick={() => conversationPanel?.openDirectMessages()}
               aria-label="Direct message a team member"
               title="Direct message"
             >
@@ -318,12 +318,6 @@ export function SiteHeader({
       </div>
 
       <AccountModal open={accountOpen} onOpenChange={setAccountOpen} user={user} />
-      {canUseDirectMessages && (
-        <DirectMessageDialog
-          open={directMessageOpen}
-          onOpenChange={setDirectMessageOpen}
-        />
-      )}
     </header>
   )
 }

--- a/src/contexts/conversations-context.tsx
+++ b/src/contexts/conversations-context.tsx
@@ -56,8 +56,11 @@ export function useConversations() {
 
 export function ConversationsProvider({
   children,
+  wrap = true,
 }: {
   readonly children: React.ReactNode
+  /** Preserve the legacy flex container unless the caller already owns layout. */
+  readonly wrap?: boolean
 }) {
   const [threadOpen, setThreadOpen] = React.useState(false)
   const [threadMessageId, setThreadMessageId] = React.useState<string | null>(null)
@@ -88,9 +91,7 @@ export function ConversationsProvider({
 
   return (
     <ConversationsContext.Provider value={value}>
-      <div className="flex min-h-0 flex-1 overflow-hidden">
-        {children}
-      </div>
+      {wrap ? <div className="flex min-h-0 flex-1 overflow-hidden">{children}</div> : children}
     </ConversationsContext.Provider>
   )
 }


### PR DESCRIPTION
## Summary
- adds a resizable Conversations drawer beside the active Compass workspace
- reuses the existing access-controlled channel, message, and composer actions
- keeps thread actions on the full Conversations page so the compact drawer has no nonfunctional reply controls

## Validation
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun test src/components/conversations/__tests__/conversation-panel-state.test.ts`
- `npx --yes bun run lint` (warnings only, pre-existing)
- `npx --yes bun run build`
- manually opened the drawer beside the local demo dashboard; no route navigation occurred