### PR TITLE
feat(conversations): open notification chats in side panel

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -75,7 +75,7 @@ export default async function DashboardLayout({
       offlineScopeKey={offlineScopeKey}
       canSubmitCherish={canUseCompassFieldDesk}
     >
-    <ConversationPanelProvider>
+    <ConversationPanelProvider enabled={canUseDirectMessages}>
     <PresenceProvider>
     <VoiceProvider>
     <SettingsProvider>

--- a/src/components/conversations/conversation-panel-provider.tsx
+++ b/src/components/conversations/conversation-panel-provider.tsx
@@ -35,8 +35,11 @@ export function useConversationPanelOptional(): ConversationPanelContextValue | 
 
 export function ConversationPanelProvider({
   children,
+  enabled = true,
 }: {
   readonly children: React.ReactNode
+  /** Only provide panel actions when a visible dashboard drawer is mounted. */
+  readonly enabled?: boolean
 }) {
   const [state, setState] = React.useState<ConversationPanelState>({
     isOpen: false,
@@ -70,7 +73,7 @@ export function ConversationPanelProvider({
   )
 
   return (
-    <ConversationPanelContext.Provider value={value}>
+    <ConversationPanelContext.Provider value={enabled ? value : null}>
       {children}
     </ConversationPanelContext.Provider>
   )

--- a/src/components/conversations/conversation-panel-shell.tsx
+++ b/src/components/conversations/conversation-panel-shell.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import * as React from "react"
-import { ArrowLeft, MessageCircle, PanelRightClose, RefreshCw } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { ArrowLeft, ExternalLink, MessageCircle, PanelRightClose, RefreshCw } from "lucide-react"
 import { getConversationPanelData } from "@/app/actions/conversation-panel"
 import { listChannels } from "@/app/actions/conversations"
 import { DirectMessagePicker } from "@/components/conversations/direct-message-dialog"
@@ -10,6 +11,10 @@ import { MessageList } from "@/components/conversations/message-list"
 import { ConversationsProvider } from "@/contexts/conversations-context"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
+import {
+  conversationFullViewHref,
+  conversationPanelOpenedAnnouncement,
+} from "@/lib/conversations/notification-route"
 import { useConversationPanel } from "./conversation-panel-provider"
 
 type PanelData = Extract<
@@ -30,6 +35,7 @@ function channelLabel(channel: TextChannel): string {
 }
 
 function ConversationPanelContent() {
+  const router = useRouter()
   const { isOpen, channelId, view, open, close } = useConversationPanel()
   const [channels, setChannels] = React.useState<readonly TextChannel[]>([])
   const [channelsLoading, setChannelsLoading] = React.useState(false)
@@ -139,6 +145,9 @@ function ConversationPanelContent() {
 
   return (
     <>
+      <p className="sr-only" aria-live="polite" aria-atomic="true">
+        {isOpen && channelId ? conversationPanelOpenedAnnouncement() : ""}
+      </p>
       <section
         className={cn(
           "flex flex-col bg-background",
@@ -186,6 +195,21 @@ function ConversationPanelContent() {
               </p>
             ) : null}
           </div>
+          {channelId ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => {
+                close()
+                router.push(conversationFullViewHref(channelId))
+              }}
+              aria-label="Open conversation in center"
+              title="Open in center"
+            >
+              <ExternalLink className="size-4" />
+            </Button>
+          ) : null}
           <Button
             type="button"
             variant="ghost"

--- a/src/components/notifications-popover.tsx
+++ b/src/components/notifications-popover.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type MouseEvent,
 } from "react"
 import Link from "next/link"
 import {
@@ -37,6 +38,8 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { useConversationPanelOptional } from "@/components/conversations/conversation-panel-provider"
+import { notificationPanelChannelId } from "@/lib/conversations/notification-route"
 
 function iconFor(item: NotificationCenterItem): typeof IconClipboardCheck {
   if (item.eventType.startsWith("rfi.")) return IconMessageCircle
@@ -67,7 +70,10 @@ function NotificationsList({
   readonly notifications: readonly NotificationCenterItem[]
   readonly loading: boolean
   readonly onClear: () => void
-  readonly onNavigate: (item: NotificationCenterItem) => void
+  readonly onNavigate: (
+    item: NotificationCenterItem,
+    event: MouseEvent<HTMLAnchorElement>
+  ) => void
 }) {
   return (
     <>
@@ -83,7 +89,7 @@ function NotificationsList({
               <Link
                 key={item.id}
                 href={item.href}
-                onClick={() => onNavigate(item)}
+                onClick={(event) => onNavigate(item, event)}
                 className="hover:bg-muted/50 flex gap-3 border-b px-4 py-3 transition-colors last:border-0"
               >
                 <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
@@ -134,6 +140,7 @@ function NotificationsList({
 
 export function NotificationsPopover() {
   const isMobile = useIsMobile()
+  const conversationPanel = useConversationPanelOptional()
   const [open, setOpen] = useState(false)
   const [loading, setLoading] = useState(true)
   const [notifications, setNotifications] =
@@ -209,7 +216,27 @@ export function NotificationsPopover() {
     }
   }
 
-  async function navigate(item: NotificationCenterItem): Promise<void> {
+  async function navigate(
+    item: NotificationCenterItem,
+    event: MouseEvent<HTMLAnchorElement>
+  ): Promise<void> {
+    const channelId = notificationPanelChannelId({
+      href: item.href,
+      isMobile,
+      hasConversationPanel: conversationPanel !== null,
+    })
+    const isPlainClick =
+      event.button === 0 &&
+      !event.metaKey &&
+      !event.ctrlKey &&
+      !event.shiftKey &&
+      !event.altKey
+
+    if (channelId && isPlainClick) {
+      event.preventDefault()
+      conversationPanel?.open(channelId)
+    }
+
     setOpen(false)
     if (item.readAt) return
     setNotifications((items) =>

--- a/src/lib/conversations/__tests__/notification-route.test.ts
+++ b/src/lib/conversations/__tests__/notification-route.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+import {
+  conversationChannelIdFromNotificationHref,
+  conversationFullViewHref,
+  conversationPanelOpenedAnnouncement,
+  notificationPanelChannelId,
+} from "../notification-route"
+
+describe("conversationChannelIdFromNotificationHref", () => {
+  it("recognizes a Compass conversation route and decodes its channel id", () => {
+    expect(
+      conversationChannelIdFromNotificationHref(
+        "/dashboard/conversations/direct%3Amartine-wes?source=notification"
+      )
+    ).toBe("direct:martine-wes")
+  })
+
+  it("builds the existing full-page route when the user explicitly opens a conversation in the center", () => {
+    expect(conversationFullViewHref("direct:martine/wes")).toBe(
+      "/dashboard/conversations/direct%3Amartine%2Fwes"
+    )
+  })
+
+  it("announces a drawer-opened conversation without changing workspace focus", () => {
+    expect(conversationPanelOpenedAnnouncement()).toBe(
+      "Conversation opened in side panel."
+    )
+  })
+
+  it("uses the drawer only on desktop when the dashboard conversation panel is available", () => {
+    expect(
+      notificationPanelChannelId({
+        href: "/dashboard/conversations/channel-42",
+        isMobile: false,
+        hasConversationPanel: true,
+      })
+    ).toBe("channel-42")
+    expect(
+      notificationPanelChannelId({
+        href: "/dashboard/conversations/channel-42",
+        isMobile: true,
+        hasConversationPanel: true,
+      })
+    ).toBeNull()
+    expect(
+      notificationPanelChannelId({
+        href: "/dashboard/conversations/channel-42",
+        isMobile: false,
+        hasConversationPanel: false,
+      })
+    ).toBeNull()
+  })
+
+  it("does not treat unrelated, nested, or external destinations as panel conversations", () => {
+    expect(conversationChannelIdFromNotificationHref("/dashboard/projects/project-42")).toBeNull()
+    expect(
+      conversationChannelIdFromNotificationHref(
+        "/dashboard/conversations/channel-42/meeting"
+      )
+    ).toBeNull()
+    expect(
+      conversationChannelIdFromNotificationHref(
+        "https://example.com/dashboard/conversations/channel-42"
+      )
+    ).toBeNull()
+    expect(conversationChannelIdFromNotificationHref("//example.com/dashboard/conversations/channel-42")).toBeNull()
+  })
+})

--- a/src/lib/conversations/notification-route.ts
+++ b/src/lib/conversations/notification-route.ts
@@ -1,0 +1,43 @@
+const CONVERSATION_PATH_PREFIX = "/dashboard/conversations/"
+
+export function conversationPanelOpenedAnnouncement(): string {
+  return "Conversation opened in side panel."
+}
+
+export function conversationFullViewHref(channelId: string): string {
+  return `${CONVERSATION_PATH_PREFIX}${encodeURIComponent(channelId)}`
+}
+
+/**
+ * Returns the channel id only for a first-party full-page conversation route.
+ * Other notification targets must continue through their normal navigation path.
+ */
+export function notificationPanelChannelId({
+  href,
+  isMobile,
+  hasConversationPanel,
+}: {
+  readonly href: string
+  readonly isMobile: boolean
+  readonly hasConversationPanel: boolean
+}): string | null {
+  if (isMobile || !hasConversationPanel) return null
+  return conversationChannelIdFromNotificationHref(href)
+}
+
+export function conversationChannelIdFromNotificationHref(
+  href: string
+): string | null {
+  if (!href.startsWith(CONVERSATION_PATH_PREFIX)) return null
+
+  try {
+    const url = new URL(href, "https://compass.local")
+    const pathAfterPrefix = url.pathname.slice(CONVERSATION_PATH_PREFIX.length)
+    if (!pathAfterPrefix || pathAfterPrefix.includes("/")) return null
+
+    const channelId = decodeURIComponent(pathAfterPrefix)
+    return channelId.length > 0 ? channelId : null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- Opens eligible desktop conversation and direct-message notifications in the existing right-side drawer, preserving the active dashboard workspace.
- Preserves normal navigation for mobile, modified/new-tab clicks, non-conversation targets, and users without a mounted drawer.
- Adds an explicit, accessible **Open conversation in center** control to move a selected drawer conversation to its existing full-page route.
- Announces drawer opening through a polite live region without stealing focus.

## Validation
- `npx --yes bun test src/lib/conversations/__tests__/notification-route.test.ts src/components/conversations/__tests__/conversation-panel-state.test.ts src/components/__tests__/nav-main-behavior.test.ts`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun run lint` *(0 errors; existing repository warnings only)*
- `npx --yes bun run build` *(completed; existing Turbopack trace warnings only)*
- Browser smoke: notification click kept `/dashboard`, opened the 460px drawer, rendered the selected conversation, exposed the center control, and confirmed the live-region announcement.

## Scope
This intentionally does not implement the separate Email correspondence experience; that work is tracked in #390.