### PR TITLE
fix(projects): use integration owner for tracker writes

### DIFF
--- a/__tests__/google-project-intake-tracker.test.ts
+++ b/__tests__/google-project-intake-tracker.test.ts
@@ -8,6 +8,7 @@ import {
   locateProjectTrackerLayout,
   type ProjectIntakeTrackerInput,
 } from "@/lib/google/project-intake-tracker"
+import { resolveProjectIntakeIntegrationEmail } from "@/lib/google/project-intake-identity"
 
 const PROJECT: ProjectIntakeTrackerInput = {
   department: "O",
@@ -29,6 +30,21 @@ const PROJECT: ProjectIntakeTrackerInput = {
 }
 
 describe("Google Developer-folder project tracking intake", () => {
+  it("uses the organization connector identity for tracker writes", () => {
+    expect(
+      resolveProjectIntakeIntegrationEmail({
+        connectorGoogleEmail: "integration-owner@hps-colorado.com",
+        connectorEmail: "connector-login@hps-colorado.com",
+      })
+    ).toBe("integration-owner@hps-colorado.com")
+    expect(
+      resolveProjectIntakeIntegrationEmail({
+        connectorGoogleEmail: null,
+        connectorEmail: "connector-login@hps-colorado.com",
+      })
+    ).toBe("connector-login@hps-colorado.com")
+  })
+
   it("locates a shifted tracker header and allocates the next department number", () => {
     const rows = [
       ["Project Lead Tracking"],

--- a/src/app/actions/projects.ts
+++ b/src/app/actions/projects.ts
@@ -40,6 +40,7 @@ import {
   type ProjectIntakeTrackerInput,
   type ProjectTrackerLayout,
 } from "@/lib/google/project-intake-tracker"
+import { resolveProjectIntakeIntegrationEmail } from "@/lib/google/project-intake-identity"
 import { requireOrg } from "@/lib/org-scope"
 import {
   canManageProjectRegistry,
@@ -250,6 +251,7 @@ function intakeClientName(input: CreateProjectIntakeInput): string | null {
 type ProjectWorkspaceClients = {
   readonly sheets: SheetsClient
   readonly drive: DriveClient
+  readonly projectIntakeGoogleEmail: string
 }
 
 async function projectWorkspaceClients(input: {
@@ -258,8 +260,13 @@ async function projectWorkspaceClients(input: {
 }): Promise<ProjectWorkspaceClients> {
   const db = getDb(input.environment.DB)
   const authRows = await db
-    .select()
+    .select({
+      serviceAccountKeyEncrypted: googleAuth.serviceAccountKeyEncrypted,
+      connectorGoogleEmail: users.googleEmail,
+      connectorEmail: users.email,
+    })
     .from(googleAuth)
+    .innerJoin(users, eq(users.id, googleAuth.connectedBy))
     .where(eq(googleAuth.organizationId, input.organizationId))
     .limit(1)
   const auth = authRows[0]
@@ -275,6 +282,10 @@ async function projectWorkspaceClients(input: {
   return {
     sheets: new SheetsClient(serviceAccountKey),
     drive: new DriveClient({ serviceAccountKey }),
+    projectIntakeGoogleEmail: resolveProjectIntakeIntegrationEmail({
+      connectorGoogleEmail: auth.connectorGoogleEmail,
+      connectorEmail: auth.connectorEmail,
+    }),
   }
 }
 
@@ -367,14 +378,15 @@ export async function createProjectIntake(
       environment: env,
       organizationId,
     })
-    const googleEmail = user.googleEmail ?? user.email
+    const submittingGoogleEmail = user.googleEmail ?? user.email
+    const projectIntakeGoogleEmail = googleClients.projectIntakeGoogleEmail
     const departmentDestination = departmentTrackingDestination(department)
     const [registryRows, departmentRows] = await Promise.all([
-      googleClients.sheets.getValues(googleEmail, {
+      googleClients.sheets.getValues(projectIntakeGoogleEmail, {
         spreadsheetId: PROJECT_REGISTRY_DESTINATION.spreadsheetId,
         range: quotedSheetRange(PROJECT_REGISTRY_DESTINATION.sheetTitle, "A:Z"),
       }),
-      googleClients.sheets.getValues(googleEmail, {
+      googleClients.sheets.getValues(projectIntakeGoogleEmail, {
         spreadsheetId: departmentDestination.spreadsheetId,
         range: quotedSheetRange(departmentDestination.sheetTitle, "A:AZ"),
       }),
@@ -642,7 +654,7 @@ export async function createProjectIntake(
     try {
       const drive = await provisionGoogleProjectDriveFolder(
         googleClients.drive,
-        googleEmail,
+        submittingGoogleEmail,
         { department, folderName: driveFolderName }
       )
       projectDriveUrl = drive.folderUrl
@@ -717,7 +729,7 @@ export async function createProjectIntake(
     try {
       registryWrite = await appendProjectRowIfMissing({
         sheets: googleClients.sheets,
-        googleEmail,
+        googleEmail: projectIntakeGoogleEmail,
         spreadsheetId: PROJECT_REGISTRY_DESTINATION.spreadsheetId,
         sheetTitle: PROJECT_REGISTRY_DESTINATION.sheetTitle,
         rows: registryRows,
@@ -735,7 +747,7 @@ export async function createProjectIntake(
     try {
       departmentWrite = await appendProjectRowIfMissing({
         sheets: googleClients.sheets,
-        googleEmail,
+        googleEmail: projectIntakeGoogleEmail,
         spreadsheetId: departmentDestination.spreadsheetId,
         sheetTitle: departmentDestination.sheetTitle,
         rows: departmentRows,

--- a/src/lib/google/project-intake-identity.ts
+++ b/src/lib/google/project-intake-identity.ts
@@ -1,0 +1,13 @@
+export function resolveProjectIntakeIntegrationEmail(input: {
+  readonly connectorGoogleEmail: string | null
+  readonly connectorEmail: string | null
+}): string {
+  const email = input.connectorGoogleEmail ?? input.connectorEmail
+  const normalized = email?.trim()
+  if (!normalized) {
+    throw new Error(
+      "Google Workspace project-tracker integration has no connector identity."
+    )
+  }
+  return normalized
+}


### PR DESCRIPTION
## Summary
- route organization-owned project registry and department tracker reads/writes through the configured Google Workspace connector identity
- preserve the submitting user's Google identity for Drive folder provisioning
- add regression coverage for connector identity resolution

## Root cause
Project intake used the submitting Compass user's Google identity for organization tracker sheets. An authorized creator without direct sheet ACLs received Google Sheets 403 before any project was created.

## Validation
- bun test (752 passed, 3 skipped)
- bunx tsc --noEmit
- bun run lint (warnings only; existing)
- bun run build
- git diff --check