### PR TITLE
fix(email): route tagged inbound RFIs

### DIFF
--- a/src/app/actions/inbound-email-review.ts
+++ b/src/app/actions/inbound-email-review.ts
@@ -1,0 +1,282 @@
+"use server"
+
+import { and, desc, eq, sql } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import { inboundEmails, projectRfis, projects } from "@/db/schema"
+import { recordActivityEvent } from "@/lib/activity-log"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { stripHtml } from "@/lib/email/gmail-message-parser"
+import {
+  inboundRecordKind,
+  inboundRecordSubject,
+  matchInboundProject,
+} from "@/lib/email/inbound-routing"
+import { notifyRfiCreated } from "@/lib/notifications/events"
+import { requireOrg } from "@/lib/org-scope"
+import { requireFeaturePermission } from "@/lib/permission-enforcement"
+import { canManageProjectRegistry } from "@/lib/permissions"
+
+export type InboundEmailReviewProject = {
+  readonly id: string
+  readonly projectNumber: string | null
+  readonly name: string
+}
+
+export type InboundEmailReviewItem = {
+  readonly id: string
+  readonly fromAddress: string
+  readonly fromName: string | null
+  readonly toAddress: string | null
+  readonly subject: string
+  readonly bodyPreview: string
+  readonly receivedAt: string
+  readonly kind: "rfi" | null
+  readonly suggestedProjectId: string | null
+}
+
+export type InboundEmailReviewQueue = {
+  readonly items: readonly InboundEmailReviewItem[]
+  readonly projects: readonly InboundEmailReviewProject[]
+}
+
+function bodyText(input: {
+  readonly textBody: string | null
+  readonly htmlBody: string | null
+  readonly snippet: string | null
+}): string {
+  return (
+    input.textBody ??
+    (input.htmlBody ? stripHtml(input.htmlBody) : null) ??
+    input.snippet ??
+    "(No message body.)"
+  ).trim()
+}
+
+function rfiNumberFor(
+  projectNumber: string | null,
+  existingCount: number,
+  id: string
+): string {
+  const sequence = String(existingCount + 1).padStart(3, "0")
+  const prefix = projectNumber?.trim() ?? ""
+  return prefix.length > 0
+    ? `${prefix}-RFI-${sequence}`
+    : `RFI-${sequence}-${id.slice(0, 6).toUpperCase()}`
+}
+
+async function reviewContext(): Promise<{
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string
+  readonly user: Awaited<ReturnType<typeof requireAuth>>
+}> {
+  const user = await requireAuth()
+  if (!canManageProjectRegistry(user)) {
+    throw new Error("Project administration permission is required")
+  }
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  return { db: getDb(env.DB), organizationId, user }
+}
+
+export async function getInboundEmailReviewQueue(): Promise<InboundEmailReviewQueue> {
+  const { db, organizationId } = await reviewContext()
+  const projectRows = await db
+    .select({
+      id: projects.id,
+      projectNumber: projects.projectNumber,
+      name: projects.name,
+    })
+    .from(projects)
+    .where(eq(projects.organizationId, organizationId))
+    .orderBy(projects.projectNumber, projects.name)
+  const emailRows = await db
+    .select()
+    .from(inboundEmails)
+    .where(
+      and(
+        eq(inboundEmails.organizationId, organizationId),
+        eq(inboundEmails.matchedStatus, "needs_review")
+      )
+    )
+    .orderBy(desc(inboundEmails.receivedAt))
+
+  return {
+    projects: projectRows,
+    items: emailRows.map((email) => ({
+      id: email.id,
+      fromAddress: email.fromAddress,
+      fromName: email.fromName,
+      toAddress: email.toAddress,
+      subject: email.subject,
+      bodyPreview: bodyText(email).slice(0, 800),
+      receivedAt: email.receivedAt,
+      kind: inboundRecordKind(email.subject),
+      suggestedProjectId:
+        matchInboundProject(email, projectRows)?.id ?? email.projectId,
+    })),
+  }
+}
+
+function requiredFormString(formData: FormData, key: string): string {
+  const value = formData.get(key)
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${key} is required`)
+  }
+  return value.trim()
+}
+
+export async function routeInboundEmailToRfi(formData: FormData): Promise<void> {
+  const emailId = requiredFormString(formData, "emailId")
+  const projectId = requiredFormString(formData, "projectId")
+  const { db, organizationId, user } = await reviewContext()
+  await requireFeaturePermission(user, "rfis", "create")
+
+  const [email] = await db
+    .select()
+    .from(inboundEmails)
+    .where(
+      and(
+        eq(inboundEmails.id, emailId),
+        eq(inboundEmails.organizationId, organizationId),
+        eq(inboundEmails.matchedStatus, "needs_review")
+      )
+    )
+    .limit(1)
+  if (!email) throw new Error("Inbound email is no longer awaiting review")
+  if (inboundRecordKind(email.subject) !== "rfi") {
+    throw new Error("This email does not have an RFI subject tag")
+  }
+
+  const [project] = await db
+    .select({
+      id: projects.id,
+      name: projects.name,
+      projectNumber: projects.projectNumber,
+    })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.id, projectId),
+        eq(projects.organizationId, organizationId)
+      )
+    )
+    .limit(1)
+  if (!project) throw new Error("Project not found")
+
+  const [existing] = await db
+    .select({ id: projectRfis.id, rfiNumber: projectRfis.rfiNumber })
+    .from(projectRfis)
+    .where(
+      and(
+        eq(projectRfis.sourceSystem, "email"),
+        eq(projectRfis.sourceRecordId, email.gmailMessageId)
+      )
+    )
+    .limit(1)
+
+  let rfi = existing
+  if (!rfi) {
+    const count = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(projectRfis)
+      .where(eq(projectRfis.projectId, project.id))
+      .then((rows) => rows[0]?.count ?? 0)
+    const now = new Date().toISOString()
+    const id = crypto.randomUUID()
+    const rfiNumber = rfiNumberFor(project.projectNumber, count, id)
+    await db.insert(projectRfis).values({
+      id,
+      projectId: project.id,
+      sourceSystem: "email",
+      sourceRecordId: email.gmailMessageId,
+      rfiNumber,
+      subject: inboundRecordSubject(email.subject),
+      question: bodyText(email),
+      answer: null,
+      status: "new",
+      priority: "normal",
+      audience: "internal",
+      requesterName: email.fromName ?? email.fromAddress,
+      assignedToName: null,
+      companyName: null,
+      dueDate: null,
+      submittedAt: email.receivedAt,
+      answeredAt: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    rfi = { id, rfiNumber }
+
+    await recordActivityEvent({
+      db,
+      id: `project-email-routed-${email.gmailMessageId}`,
+      organizationId,
+      projectId: project.id,
+      actor: {
+        id: null,
+        email: email.fromAddress,
+        displayName: email.fromName,
+        firstName: null,
+        lastName: null,
+        role: "project_email",
+      },
+      category: "email",
+      action: "project_email.routed",
+      entityType: "rfi",
+      entityId: id,
+      summary: `Routed project email from ${email.fromName ?? email.fromAddress} to RFI: “${inboundRecordSubject(email.subject)}”.`,
+      metadata: {
+        destination: "rfi",
+        manualReview: true,
+        routedBy: user.id,
+      },
+      createdAt: email.receivedAt,
+    })
+
+    try {
+      await notifyRfiCreated({
+        organizationId,
+        projectId: project.id,
+        rfiId: id,
+        rfiNumber,
+        subject: inboundRecordSubject(email.subject),
+        assignedToName: null,
+        createdBy: user,
+      })
+    } catch (error) {
+      console.error("[inbound-email-review] notification error", error)
+    }
+  }
+
+  await db
+    .update(inboundEmails)
+    .set({
+      projectId: project.id,
+      matchedStatus: "posted",
+      postedMessageId: rfi.id,
+    })
+    .where(eq(inboundEmails.id, email.id))
+
+  revalidatePath("/dashboard/office-maintenance/inbound-email")
+  revalidatePath(`/dashboard/projects/${project.id}/rfis`)
+  revalidatePath("/dashboard/rfis")
+}
+
+export async function dismissInboundEmail(formData: FormData): Promise<void> {
+  const emailId = requiredFormString(formData, "emailId")
+  const { db, organizationId } = await reviewContext()
+  await db
+    .update(inboundEmails)
+    .set({ matchedStatus: "dismissed" })
+    .where(
+      and(
+        eq(inboundEmails.id, emailId),
+        eq(inboundEmails.organizationId, organizationId),
+        eq(inboundEmails.matchedStatus, "needs_review")
+      )
+    )
+  revalidatePath("/dashboard/office-maintenance/inbound-email")
+}

--- a/src/app/dashboard/office-maintenance/inbound-email/page.tsx
+++ b/src/app/dashboard/office-maintenance/inbound-email/page.tsx
@@ -1,0 +1,121 @@
+export const dynamic = "force-dynamic"
+
+import Link from "next/link"
+import { IconArrowLeft, IconInbox, IconMailForward } from "@tabler/icons-react"
+
+import {
+  dismissInboundEmail,
+  getInboundEmailReviewQueue,
+  routeInboundEmailToRfi,
+} from "@/app/actions/inbound-email-review"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+
+function receivedLabel(value: string): string {
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toLocaleString()
+}
+
+export default async function InboundEmailReviewPage(): Promise<React.ReactElement> {
+  const queue = await getInboundEmailReviewQueue()
+
+  return (
+    <main className="mx-auto w-full max-w-5xl space-y-5 p-4 lg:p-6">
+      <header className="border-b pb-4">
+        <Button asChild variant="ghost" size="sm" className="-ml-3 mb-2">
+          <Link href="/dashboard/projects">
+            <IconArrowLeft className="size-4" />
+            Project Hub
+          </Link>
+        </Button>
+        <div className="flex items-center gap-2">
+          <IconInbox className="size-6 text-muted-foreground" />
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Inbound email review
+          </h1>
+        </div>
+        <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+          Route tagged email that Compass could not assign confidently. The
+          original email remains in the audit record after routing or dismissal.
+        </p>
+      </header>
+
+      {queue.items.length === 0 ? (
+        <section className="border border-dashed p-8 text-center">
+          <IconMailForward className="mx-auto size-7 text-muted-foreground" />
+          <h2 className="mt-3 font-semibold">No email needs review</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Confident project matches will create their tagged Compass record automatically.
+          </p>
+        </section>
+      ) : (
+        <section className="space-y-3">
+          {queue.items.map((item) => (
+            <article
+              id={`inbound-${item.id}`}
+              key={item.id}
+              className="border bg-background p-4 shadow-sm"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h2 className="font-semibold">{item.subject}</h2>
+                    <Badge variant={item.kind === "rfi" ? "default" : "secondary"}>
+                      {item.kind === "rfi" ? "RFI" : "Unclassified"}
+                    </Badge>
+                  </div>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    From {item.fromName ?? item.fromAddress} · {receivedLabel(item.receivedAt)}
+                  </p>
+                  {item.toAddress ? (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Delivered to {item.toAddress}
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+
+              <p className="mt-4 whitespace-pre-wrap border-l-2 pl-3 text-sm leading-6">
+                {item.bodyPreview}
+              </p>
+
+              <div className="mt-4 flex flex-col gap-2 border-t pt-4 sm:flex-row sm:items-end">
+                {item.kind === "rfi" ? (
+                  <form action={routeInboundEmailToRfi} className="flex flex-1 flex-col gap-2 sm:flex-row sm:items-end">
+                    <input type="hidden" name="emailId" value={item.id} />
+                    <label className="flex flex-1 flex-col gap-1 text-sm font-medium">
+                      Project
+                      <select
+                        name="projectId"
+                        required
+                        defaultValue={item.suggestedProjectId ?? ""}
+                        className="h-10 border bg-background px-3 font-normal"
+                      >
+                        <option value="" disabled>Select project…</option>
+                        {queue.projects.map((project) => (
+                          <option key={project.id} value={project.id}>
+                            {project.projectNumber ? `${project.projectNumber} — ` : ""}
+                            {project.name}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <Button type="submit">Create RFI</Button>
+                  </form>
+                ) : (
+                  <p className="flex-1 text-sm text-muted-foreground">
+                    Add a supported subject tag before routing this email.
+                  </p>
+                )}
+                <form action={dismissInboundEmail}>
+                  <input type="hidden" name="emailId" value={item.id} />
+                  <Button type="submit" variant="outline">Dismiss</Button>
+                </form>
+              </div>
+            </article>
+          ))}
+        </section>
+      )}
+    </main>
+  )
+}

--- a/src/components/projects/office-maintenance-drawer.tsx
+++ b/src/components/projects/office-maintenance-drawer.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { useState } from "react"
-import { IconSettings, IconTemplate } from "@tabler/icons-react"
+import { IconMailForward, IconSettings, IconTemplate } from "@tabler/icons-react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -123,6 +123,12 @@ export function OfficeMaintenanceDrawer({
           </div>
         </div>
         <div className="space-y-2 px-4">
+          <Button asChild variant="outline" className="w-full justify-start">
+            <Link href="/dashboard/office-maintenance/inbound-email">
+              <IconMailForward className="size-4" />
+              Review inbound email
+            </Link>
+          </Button>
           <div className="space-y-2 border p-3">
             <div>
               <p className="text-sm font-medium">GoTo text routing</p>

--- a/src/lib/email/__tests__/gmail-inbound.test.ts
+++ b/src/lib/email/__tests__/gmail-inbound.test.ts
@@ -50,6 +50,26 @@ describe("isReplyMessage", () => {
 })
 
 describe("candidateFromMessage attachments", () => {
+  it("keeps a project alias ahead of the final Gmail delivery mailbox", () => {
+    const result = candidateFromMessage({
+      id: "message-with-project-alias",
+      payload: {
+        headers: [
+          {
+            name: "To",
+            value: "jarvis+project-proj-h-office@hps-colorado.com",
+          },
+          { name: "Delivered-To", value: "jarvis@hps-colorado.com" },
+          { name: "Subject", value: "[RFI] Office question" },
+        ],
+      },
+    })
+
+    expect(result.toAddress).toBe(
+      "jarvis+project-proj-h-office@hps-colorado.com"
+    )
+  })
+
   it("captures a Gmail attachment reference for later download", () => {
     const result = candidateFromMessage({
       id: "message-with-photo",

--- a/src/lib/email/__tests__/inbound-routing.test.ts
+++ b/src/lib/email/__tests__/inbound-routing.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  inboundRecordKind,
+  inboundRecordSubject,
+  matchInboundProject,
+} from "@/lib/email/inbound-routing"
+
+const projects = [
+  {
+    id: "proj-h-office",
+    projectNumber: "H-OFFICE",
+    name: "Office, High Performance Structures Inc.",
+  },
+  {
+    id: "proj-o-210-mitchell",
+    projectNumber: "O-210-33",
+    name: "Mitchell Residence",
+  },
+]
+
+describe("inbound email routing", () => {
+  it("routes Wes's tagged office test to H-OFFICE", () => {
+    const match = matchInboundProject(
+      {
+        toAddress: "rebekahecrampton@gmail.com",
+        subject: "[RFI] Test RFI for Office Forward",
+        textBody: "How much wood could a woodchuck chuck?",
+        htmlBody: null,
+        snippet: null,
+      },
+      projects
+    )
+
+    expect(inboundRecordKind("[RFI] Test RFI for Office Forward")).toBe("rfi")
+    expect(inboundRecordSubject("[RFI] Test RFI for Office Forward")).toBe(
+      "Test RFI for Office Forward"
+    )
+    expect(match?.id).toBe("proj-h-office")
+  })
+
+  it("prefers an explicit project number", () => {
+    const match = matchInboundProject(
+      {
+        toAddress: "compass@hps-colorado.com",
+        subject: "[RFI] O-210-33 foundation question",
+        textBody: null,
+        htmlBody: null,
+        snippet: null,
+      },
+      projects
+    )
+
+    expect(match?.id).toBe("proj-o-210-mitchell")
+  })
+
+  it("leaves ambiguous tagged email in review", () => {
+    const match = matchInboundProject(
+      {
+        toAddress: "compass@hps-colorado.com",
+        subject: "[RFI] Please review",
+        textBody: "No project number was included.",
+        htmlBody: null,
+        snippet: null,
+      },
+      projects
+    )
+
+    expect(match).toBeNull()
+  })
+})

--- a/src/lib/email/gmail-message-parser.ts
+++ b/src/lib/email/gmail-message-parser.ts
@@ -216,6 +216,13 @@ export function candidateFromMessage(message: GmailMessage): InboundCandidate {
     message.snippet ?? "",
   ].join("\n")
   const from = parseAddress(headers.get("from") ?? null)
+  // Forwarding rules commonly replace To. Preserve the original project alias
+  // when Gmail exposes it so a new tagged email can still be routed correctly.
+  const routedTo =
+    headers.get("x-original-to") ??
+    headers.get("to") ??
+    headers.get("delivered-to") ??
+    null
 
   return {
     gmailMessageId: message.id,
@@ -226,7 +233,7 @@ export function candidateFromMessage(message: GmailMessage): InboundCandidate {
     token: extractToken(searchable),
     fromAddress: from.email,
     fromName: from.name,
-    toAddress: headers.get("to") ?? null,
+    toAddress: routedTo,
     subject: headers.get("subject") ?? "(no subject)",
     textBody: textBody.length > 0 ? textBody : null,
     htmlBody: htmlBody.length > 0 ? htmlBody : null,

--- a/src/lib/email/inbound-routing.ts
+++ b/src/lib/email/inbound-routing.ts
@@ -1,0 +1,72 @@
+export type InboundRoutingCandidate = {
+  readonly toAddress: string | null
+  readonly subject: string
+  readonly textBody: string | null
+  readonly htmlBody: string | null
+  readonly snippet: string | null
+}
+
+export type InboundRoutingProject = {
+  readonly id: string
+  readonly projectNumber: string | null
+  readonly name: string
+}
+
+export type InboundRecordKind = "rfi"
+
+function searchableText(candidate: InboundRoutingCandidate): string {
+  return [
+    candidate.toAddress ?? "",
+    candidate.subject,
+    candidate.textBody ?? "",
+    candidate.htmlBody ?? "",
+    candidate.snippet ?? "",
+  ]
+    .join("\n")
+    .toLowerCase()
+}
+
+function compact(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "")
+}
+
+export function inboundRecordKind(subject: string): InboundRecordKind | null {
+  return /^\s*\[\s*(?:rfi|request\s+for\s+information)\s*\]/i.test(subject)
+    ? "rfi"
+    : null
+}
+
+export function inboundRecordSubject(subject: string): string {
+  const cleaned = subject
+    .replace(/^\s*\[\s*(?:rfi|request\s+for\s+information)\s*\]\s*/i, "")
+    .trim()
+  return cleaned.length > 0 ? cleaned : "Email-submitted RFI"
+}
+
+export function matchInboundProject(
+  candidate: InboundRoutingCandidate,
+  projects: readonly InboundRoutingProject[]
+): InboundRoutingProject | null {
+  const searchable = searchableText(candidate)
+  const compactSearchable = compact(searchable)
+  const exactMatches = projects.filter((project) => {
+    const projectNumber = project.projectNumber?.trim() ?? ""
+    if (projectNumber.length < 4) return false
+    return (
+      searchable.includes(projectNumber.toLowerCase()) ||
+      compactSearchable.includes(compact(projectNumber))
+    )
+  })
+
+  if (exactMatches.length === 1) return exactMatches[0] ?? null
+
+  const officeProject = projects.find(
+    (project) => project.projectNumber?.trim().toUpperCase() === "H-OFFICE"
+  )
+  const officeSignal = /\boffice\b/i.test(
+    `${candidate.toAddress ?? ""}\n${candidate.subject}`
+  )
+  if (officeProject && officeSignal) return officeProject
+
+  return null
+}

--- a/src/lib/email/project-inbound-routing.ts
+++ b/src/lib/email/project-inbound-routing.ts
@@ -21,6 +21,7 @@ import {
   stripHtml,
   type InboundCandidate,
 } from "@/lib/email/gmail-message-parser"
+import { matchInboundProject } from "@/lib/email/inbound-routing"
 import {
   projectEmailDestination,
   projectEmailTitle,
@@ -742,7 +743,18 @@ export async function routeProjectInboundEmail(input: {
   readonly organizationId: string
   readonly candidate: InboundCandidate
 }): Promise<ProjectInboundRouteResult> {
-  const projectId = projectIdFromInboundAddress(input.candidate.toAddress)
+  let projectId = projectIdFromInboundAddress(input.candidate.toAddress)
+  if (!projectId && projectEmailDestination(input.candidate.subject)) {
+    const projectRows = await input.db
+      .select({
+        id: projects.id,
+        projectNumber: projects.projectNumber,
+        name: projects.name,
+      })
+      .from(projects)
+      .where(eq(projects.organizationId, input.organizationId))
+    projectId = matchInboundProject(input.candidate, projectRows)?.id ?? null
+  }
   if (!projectId) return { kind: "not_project_email" }
 
   const senderAllowed = await senderCanEmailProject({


### PR DESCRIPTION
## What changed

- routes tagged inbound email by explicit project number when the project alias is unavailable
- safely recognizes H-OFFICE from an Office-tagged subject, while retaining sender authorization checks
- preserves project aliases ahead of the final Gmail delivery mailbox
- adds an Office Maintenance review queue for ambiguous inbound RFIs
- records staff-routed email RFIs in project activity

## Root cause

The Gmail importer only routed a new tagged message when its recipient retained Compass's project-specific plus address. Wes's forwarded H-Office test reached the monitored mailbox with Rebekah's address instead, so it was audited as `needs_review` but never became an RFI and had no review UI.

## Validation

- `bun test src/lib/email/__tests__/inbound-routing.test.ts src/lib/email/__tests__/gmail-inbound.test.ts` (9 passed)
- focused ESLint on all touched files
- `bunx tsc --noEmit --pretty false`
- `bun run build`

The build completed successfully. Existing Turbopack NFT tracing warnings remain unrelated to this change.