### PR TITLE
feat(conversations): continue Buildertrend archive threads

### DIFF
--- a/src/app/actions/chat-messages.ts
+++ b/src/app/actions/chat-messages.ts
@@ -37,8 +37,10 @@ import { isDemoUser } from "@/lib/demo"
 import { isInternalStaffRole } from "@/lib/user-roles"
 import { requireOrg } from "@/lib/org-scope"
 import {
+  areArchiveUserMentionsInternal,
   canCreateConversationMessage,
   getConversationChannelAccess,
+  isBuildertrendArchiveChannelId,
   isReplyInConversationChannel,
 } from "@/lib/conversations/channel-access"
 import { revalidatePath } from "next/cache"
@@ -494,6 +496,50 @@ export async function sendMessage(data: {
     })
     if (!activityChannel) {
       return { success: false, error: "Not a member of this channel" }
+    }
+    const mentionedUserIds = Array.from(
+      new Set(
+        (data.mentions ?? []).flatMap((mention) =>
+          mention.mentionType === "user" && mention.targetId
+            ? [mention.targetId]
+            : []
+        )
+      )
+    )
+    if (
+      isBuildertrendArchiveChannelId(data.channelId) &&
+      mentionedUserIds.length > 0
+    ) {
+      const mentionedUsers = await db
+        .select({ id: users.id, role: users.role })
+        .from(users)
+        .innerJoin(
+          organizationMembers,
+          eq(organizationMembers.userId, users.id)
+        )
+        .where(
+          and(
+            eq(organizationMembers.organizationId, activityChannel.organizationId),
+            inArray(users.id, mentionedUserIds)
+          )
+        )
+      const internalMentionedUserIds = new Set(
+        mentionedUsers
+          .filter((mentionedUser) => isInternalStaffRole(mentionedUser.role))
+          .map((mentionedUser) => mentionedUser.id)
+      )
+      if (
+        !areArchiveUserMentionsInternal({
+          channelId: data.channelId,
+          mentionedUserIds,
+          internalUserIds: internalMentionedUserIds,
+        })
+      ) {
+        return {
+          success: false,
+          error: "Buildertrend archive replies can only mention internal teammates.",
+        }
+      }
     }
     if (!canCreateConversationMessage(data)) {
       return {

--- a/src/app/actions/chat-messages.ts
+++ b/src/app/actions/chat-messages.ts
@@ -37,6 +37,7 @@ import { isDemoUser } from "@/lib/demo"
 import { isInternalStaffRole } from "@/lib/user-roles"
 import { requireOrg } from "@/lib/org-scope"
 import {
+  canCreateConversationMessage,
   getConversationChannelAccess,
   isReplyInConversationChannel,
 } from "@/lib/conversations/channel-access"
@@ -493,6 +494,12 @@ export async function sendMessage(data: {
     })
     if (!activityChannel) {
       return { success: false, error: "Not a member of this channel" }
+    }
+    if (!canCreateConversationMessage(data)) {
+      return {
+        success: false,
+        error: "Choose an archived Buildertrend message and reply in its thread.",
+      }
     }
     if (data.threadId) {
       const parentMessage = await db

--- a/src/app/actions/chat-messages.ts
+++ b/src/app/actions/chat-messages.ts
@@ -36,6 +36,10 @@ import {
 import { isDemoUser } from "@/lib/demo"
 import { isInternalStaffRole } from "@/lib/user-roles"
 import { requireOrg } from "@/lib/org-scope"
+import {
+  getConversationChannelAccess,
+  isReplyInConversationChannel,
+} from "@/lib/conversations/channel-access"
 import { revalidatePath } from "next/cache"
 import { enqueueFeedbackDeskItem } from "@/lib/jarvis/feedback-desk"
 import { linkFeedbackDeskItemToGithub } from "@/lib/jarvis/feedback-github"
@@ -482,33 +486,33 @@ export async function sendMessage(data: {
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
 
-    // verify user is a member of the channel
-    const membership = await db
-      .select()
-      .from(channelMembers)
-      .where(
-        and(
-          eq(channelMembers.channelId, data.channelId),
-          eq(channelMembers.userId, user.id)
-        )
-      )
-      .limit(1)
-      .then((rows) => rows[0] ?? null)
-
-    if (!membership) {
+    const activityChannel = await getConversationChannelAccess({
+      db,
+      user,
+      channelId: data.channelId,
+    })
+    if (!activityChannel) {
       return { success: false, error: "Not a member of this channel" }
     }
-    const activityChannel = await db
-      .select({
-        name: channels.name,
-        organizationId: channels.organizationId,
-        projectId: channels.projectId,
-      })
-      .from(channels)
-      .where(eq(channels.id, data.channelId))
-      .get()
-    if (!activityChannel) {
-      return { success: false, error: "Channel not found" }
+    if (data.threadId) {
+      const parentMessage = await db
+        .select({
+          channelId: messages.channelId,
+          threadId: messages.threadId,
+        })
+        .from(messages)
+        .where(eq(messages.id, data.threadId))
+        .limit(1)
+        .then((rows) => rows[0] ?? null)
+      if (
+        !isReplyInConversationChannel({
+          channelId: data.channelId,
+          parentChannelId: parentMessage?.channelId ?? null,
+          parentThreadId: parentMessage?.threadId ?? null,
+        })
+      ) {
+        return { success: false, error: "Reply target not found in this channel" }
+      }
     }
 
     const now = new Date().toISOString()
@@ -885,20 +889,12 @@ export async function getMessages(
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
 
-    // verify user is a member
-    const membership = await db
-      .select()
-      .from(channelMembers)
-      .where(
-        and(
-          eq(channelMembers.channelId, channelId),
-          eq(channelMembers.userId, user.id)
-        )
-      )
-      .limit(1)
-      .then((rows) => rows[0] ?? null)
-
-    if (!membership) {
+    const channel = await getConversationChannelAccess({
+      db,
+      user,
+      channelId,
+    })
+    if (!channel) {
       return { success: false, error: "Not a member of this channel" }
     }
 
@@ -995,20 +991,12 @@ export async function getThreadMessages(
       return { success: false, error: "Parent message not found" }
     }
 
-    // verify user is a member
-    const membership = await db
-      .select()
-      .from(channelMembers)
-      .where(
-        and(
-          eq(channelMembers.channelId, parentMessage.channelId),
-          eq(channelMembers.userId, user.id)
-        )
-      )
-      .limit(1)
-      .then((rows) => rows[0] ?? null)
-
-    if (!membership) {
+    const channel = await getConversationChannelAccess({
+      db,
+      user,
+      channelId: parentMessage.channelId,
+    })
+    if (!channel) {
       return { success: false, error: "Not a member of this channel" }
     }
 
@@ -1109,20 +1097,12 @@ export async function addReaction(messageId: string, emoji: string) {
       return { success: false, error: "Message not found" }
     }
 
-    // verify user is a member of the channel
-    const membership = await db
-      .select()
-      .from(channelMembers)
-      .where(
-        and(
-          eq(channelMembers.channelId, message.channelId),
-          eq(channelMembers.userId, user.id)
-        )
-      )
-      .limit(1)
-      .then((rows) => rows[0] ?? null)
-
-    if (!membership) {
+    const channel = await getConversationChannelAccess({
+      db,
+      user,
+      channelId: message.channelId,
+    })
+    if (!channel) {
       return { success: false, error: "Not a member of this channel" }
     }
 
@@ -1196,20 +1176,12 @@ export async function removeReaction(messageId: string, emoji: string) {
       return { success: false, error: "Message not found" }
     }
 
-    // verify user is a member of the channel
-    const membership = await db
-      .select()
-      .from(channelMembers)
-      .where(
-        and(
-          eq(channelMembers.channelId, message.channelId),
-          eq(channelMembers.userId, user.id)
-        )
-      )
-      .limit(1)
-      .then((rows) => rows[0] ?? null)
-
-    if (!membership) {
+    const channel = await getConversationChannelAccess({
+      db,
+      user,
+      channelId: message.channelId,
+    })
+    if (!channel) {
       return { success: false, error: "Not a member of this channel" }
     }
 

--- a/src/app/actions/chat-messages.ts
+++ b/src/app/actions/chat-messages.ts
@@ -37,6 +37,7 @@ import { isDemoUser } from "@/lib/demo"
 import { isInternalStaffRole } from "@/lib/user-roles"
 import { requireOrg } from "@/lib/org-scope"
 import {
+  areArchiveMentionTypesAllowed,
   areArchiveUserMentionsInternal,
   canCreateConversationMessage,
   getConversationChannelAccess,
@@ -497,6 +498,18 @@ export async function sendMessage(data: {
     if (!activityChannel) {
       return { success: false, error: "Not a member of this channel" }
     }
+    const isBuildertrendArchive = isBuildertrendArchiveChannelId(data.channelId)
+    if (
+      !areArchiveMentionTypesAllowed({
+        channelId: data.channelId,
+        mentionTypes: (data.mentions ?? []).map((mention) => mention.mentionType),
+      })
+    ) {
+      return {
+        success: false,
+        error: "Buildertrend archive replies can only mention internal teammates.",
+      }
+    }
     const mentionedUserIds = Array.from(
       new Set(
         (data.mentions ?? []).flatMap((mention) =>
@@ -506,12 +519,12 @@ export async function sendMessage(data: {
         )
       )
     )
-    if (
-      isBuildertrendArchiveChannelId(data.channelId) &&
-      mentionedUserIds.length > 0
-    ) {
+    if (isBuildertrendArchive && mentionedUserIds.length > 0) {
       const mentionedUsers = await db
-        .select({ id: users.id, role: users.role })
+        .select({
+          id: users.id,
+          organizationRole: organizationMembers.role,
+        })
         .from(users)
         .innerJoin(
           organizationMembers,
@@ -525,7 +538,9 @@ export async function sendMessage(data: {
         )
       const internalMentionedUserIds = new Set(
         mentionedUsers
-          .filter((mentionedUser) => isInternalStaffRole(mentionedUser.role))
+          .filter((mentionedUser) =>
+            isInternalStaffRole(mentionedUser.organizationRole)
+          )
           .map((mentionedUser) => mentionedUser.id)
       )
       if (
@@ -793,7 +808,7 @@ export async function sendMessage(data: {
         )
       )
 
-    if (channel) {
+    if (channel && !isBuildertrendArchive) {
       try {
         await notifyChannelMessage({
           organizationId: channel.organizationId,

--- a/src/app/actions/conversations-realtime.ts
+++ b/src/app/actions/conversations-realtime.ts
@@ -3,9 +3,10 @@
 import { getCloudflareContext } from "@/lib/db"
 import { eq, and, gt, desc, sql } from "drizzle-orm"
 import { getDb } from "@/db"
-import { messages, typingSessions, channelMembers } from "@/db/schema-conversations"
+import { messages, typingSessions } from "@/db/schema-conversations"
 import { users } from "@/db/schema"
 import { getCurrentUser } from "@/lib/auth"
+import { getConversationChannelAccess } from "@/lib/conversations/channel-access"
 
 type TypingUser = {
   id: string
@@ -70,20 +71,12 @@ export async function getChannelUpdates(
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
 
-    // verify user is a member of the channel
-    const membership = await db
-      .select()
-      .from(channelMembers)
-      .where(
-        and(
-          eq(channelMembers.channelId, channelId),
-          eq(channelMembers.userId, user.id)
-        )
-      )
-      .limit(1)
-      .then((rows) => rows[0] ?? null)
-
-    if (!membership) {
+    const channel = await getConversationChannelAccess({
+      db,
+      user,
+      channelId,
+    })
+    if (!channel) {
       return { success: false, error: "Not a member of this channel" }
     }
 
@@ -180,20 +173,12 @@ export async function setTyping(
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
 
-    // verify user is a member of the channel
-    const membership = await db
-      .select()
-      .from(channelMembers)
-      .where(
-        and(
-          eq(channelMembers.channelId, channelId),
-          eq(channelMembers.userId, user.id)
-        )
-      )
-      .limit(1)
-      .then((rows) => rows[0] ?? null)
-
-    if (!membership) {
+    const channel = await getConversationChannelAccess({
+      db,
+      user,
+      channelId,
+    })
+    if (!channel) {
       return { success: false, error: "Not a member of this channel" }
     }
 

--- a/src/app/actions/conversations.ts
+++ b/src/app/actions/conversations.ts
@@ -18,6 +18,7 @@ import { revalidatePath } from "next/cache"
 import { requireOrg } from "@/lib/org-scope"
 import { isDemoUser } from "@/lib/demo"
 import { isInternalStaffRole } from "@/lib/user-roles"
+import { isBuildertrendArchiveChannelId } from "@/lib/conversations/channel-access"
 import {
   directChannelId,
   directParticipantIds,
@@ -277,7 +278,10 @@ export async function listChannels() {
           // External project users only discover conversations they belong to.
           viewerIsInternal
             ? sql`(${channels.isPrivate} = 0 OR ${channelMembers.userId} IS NOT NULL)`
-            : sql`${channelMembers.userId} IS NOT NULL`,
+            : and(
+                sql`${channelMembers.userId} IS NOT NULL`,
+                sql`${channels.id} NOT LIKE 'bt-message-archive-%'`
+              ),
           // not archived
           sql`${channels.archivedAt} IS NULL`
         )
@@ -333,8 +337,9 @@ export async function getChannel(channelId: string) {
       .then((rows) => rows[0] ?? null)
 
     if (
-      (channel.isPrivate || !isInternalStaffRole(user.role)) &&
-      !membership
+      isBuildertrendArchiveChannelId(channel.id)
+        ? !isInternalStaffRole(user.role)
+        : (channel.isPrivate || !isInternalStaffRole(user.role)) && !membership
     ) {
       return { success: false, error: "Access denied" }
     }

--- a/src/app/actions/project-messages.ts
+++ b/src/app/actions/project-messages.ts
@@ -19,6 +19,7 @@ import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { requireOrg } from "@/lib/org-scope"
 import { channelNotificationRecipients } from "@/lib/notifications/audience"
+import { isBuildertrendArchiveChannelId } from "@/lib/conversations/channel-access"
 
 export type ProjectMessageRecipient =
   | { readonly kind: "channel" }
@@ -180,6 +181,13 @@ export async function sendProjectMessage(input: {
     }
     if (!channel.projectId) {
       return { success: false, error: "Choose a project channel first" }
+    }
+    if (isBuildertrendArchiveChannelId(channel.id)) {
+      return {
+        success: false,
+        error:
+          "Buildertrend archive conversations are internal Compass-only. Reply in the channel instead.",
+      }
     }
 
     const sent = await sendMessage({

--- a/src/app/api/conversations/attachments/upload/route.ts
+++ b/src/app/api/conversations/attachments/upload/route.ts
@@ -5,7 +5,6 @@ import { NextRequest, NextResponse } from "next/server"
 import { getDb } from "@/db"
 import {
   channels,
-  channelMembers,
   messageAttachments,
   messages,
 } from "@/db/schema-conversations"
@@ -23,6 +22,7 @@ import {
 } from "@/lib/google/config"
 import { requireOrg } from "@/lib/org-scope"
 import { requirePermission } from "@/lib/permissions"
+import { getConversationChannelAccess } from "@/lib/conversations/channel-access"
 
 const MAX_ATTACHMENT_COUNT = 10
 const MAX_ATTACHMENT_FILE_BYTES = 25 * 1024 * 1024
@@ -203,18 +203,12 @@ export async function POST(
       )
     }
 
-    const membership = await db
-      .select({ id: channelMembers.id })
-      .from(channelMembers)
-      .where(
-        and(
-          eq(channelMembers.channelId, message.channelId),
-          eq(channelMembers.userId, user.id)
-        )
-      )
-      .limit(1)
-      .then((rows) => rows[0] ?? null)
-    if (!membership) {
+    const channel = await getConversationChannelAccess({
+      db,
+      user,
+      channelId: message.channelId,
+    })
+    if (!channel) {
       return NextResponse.json(
         { success: false, error: "You do not have access to this channel." },
         { status: 403 }

--- a/src/app/dashboard/conversations/[channelId]/page.tsx
+++ b/src/app/dashboard/conversations/[channelId]/page.tsx
@@ -10,6 +10,7 @@ import {
   type ProjectRecipientContact,
 } from "@/components/conversations/message-composer"
 import { ThreadPanel } from "@/components/conversations/thread-panel"
+import { isBuildertrendArchiveChannelId } from "@/lib/conversations/channel-access"
 
 export default async function ChannelPage({
   params,
@@ -27,6 +28,7 @@ export default async function ChannelPage({
   }
 
   const channel = channelResult.data
+  const isBuildertrendArchive = isBuildertrendArchiveChannelId(channel.id)
   const messages = messagesResult.success && messagesResult.data ? messagesResult.data : []
   const [contactsSummary, projects] = await Promise.all([
     channel.projectId
@@ -66,11 +68,17 @@ export default async function ChannelPage({
           channelId={channelId}
           initialMessages={messages}
         />
+        {isBuildertrendArchive ? (
+          <div className="border-t bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
+            Continue this Buildertrend archive in Compass. Replies stay internal;
+            original Buildertrend recipients are not notified.
+          </div>
+        ) : null}
         <MessageComposer
           channelId={channelId}
           channelName={channel.name}
           organizationId={channel.organizationId}
-          isProjectChannel={Boolean(channel.projectId)}
+          isProjectChannel={Boolean(channel.projectId) && !isBuildertrendArchive}
           projectRecipients={projectRecipients}
         />
       </div>

--- a/src/app/dashboard/conversations/[channelId]/page.tsx
+++ b/src/app/dashboard/conversations/[channelId]/page.tsx
@@ -70,17 +70,19 @@ export default async function ChannelPage({
         />
         {isBuildertrendArchive ? (
           <div className="border-t bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
-            Continue this Buildertrend archive in Compass. Replies stay internal;
-            original Buildertrend recipients are not notified.
+            Continue this Buildertrend archive in Compass by opening a message thread.
+            Replies stay internal; original Buildertrend recipients are not notified.
+            Mention a teammate to notify them.
           </div>
-        ) : null}
-        <MessageComposer
-          channelId={channelId}
-          channelName={channel.name}
-          organizationId={channel.organizationId}
-          isProjectChannel={Boolean(channel.projectId) && !isBuildertrendArchive}
-          projectRecipients={projectRecipients}
-        />
+        ) : (
+          <MessageComposer
+            channelId={channelId}
+            channelName={channel.name}
+            organizationId={channel.organizationId}
+            isProjectChannel={Boolean(channel.projectId)}
+            projectRecipients={projectRecipients}
+          />
+        )}
       </div>
       <ThreadPanel />
     </div>

--- a/src/app/dashboard/conversations/[channelId]/page.tsx
+++ b/src/app/dashboard/conversations/[channelId]/page.tsx
@@ -72,7 +72,7 @@ export default async function ChannelPage({
           <div className="border-t bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
             Continue this Buildertrend archive in Compass by opening a message thread.
             Replies stay internal; original Buildertrend recipients are not notified.
-            Mention a teammate to notify them.
+            Mention an internal teammate to notify them.
           </div>
         ) : (
           <MessageComposer

--- a/src/components/conversations/conversation-panel-shell.tsx
+++ b/src/components/conversations/conversation-panel-shell.tsx
@@ -15,6 +15,7 @@ import {
   conversationFullViewHref,
   conversationPanelOpenedAnnouncement,
 } from "@/lib/conversations/notification-route"
+import { isBuildertrendArchiveChannelId } from "@/lib/conversations/channel-access"
 import { useConversationPanel } from "./conversation-panel-provider"
 
 type PanelData = Extract<
@@ -283,14 +284,25 @@ function ConversationPanelContent() {
                 This conversation is archived.
               </div>
             ) : (
-              <MessageComposer
-                channelId={data.channel.id}
-                channelName={data.channel.name}
-                organizationId={data.channel.organizationId}
-                isProjectChannel={Boolean(data.channel.projectId)}
-                projectRecipients={data.projectRecipients}
-                onSent={() => void loadConversation(data.channel.id)}
-              />
+              <>
+                {isBuildertrendArchiveChannelId(data.channel.id) ? (
+                  <div className="border-t bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
+                    Continue this Buildertrend archive in Compass. Replies stay internal;
+                    original Buildertrend recipients are not notified.
+                  </div>
+                ) : null}
+                <MessageComposer
+                  channelId={data.channel.id}
+                  channelName={data.channel.name}
+                  organizationId={data.channel.organizationId}
+                  isProjectChannel={
+                    Boolean(data.channel.projectId) &&
+                    !isBuildertrendArchiveChannelId(data.channel.id)
+                  }
+                  projectRecipients={data.projectRecipients}
+                  onSent={() => void loadConversation(data.channel.id)}
+                />
+              </>
             )}
           </div>
         ) : null}

--- a/src/components/conversations/conversation-panel-shell.tsx
+++ b/src/components/conversations/conversation-panel-shell.tsx
@@ -286,8 +286,8 @@ function ConversationPanelContent() {
             ) : isBuildertrendArchiveChannelId(data.channel.id) ? (
               <div className="border-t bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
                 Open this conversation in the center to reply within an archived
-                Buildertrend message thread. Replies stay internal; mention a teammate
-                to notify them.
+                Buildertrend message thread. Replies stay internal; mention an internal
+                teammate to notify them.
               </div>
             ) : (
               <MessageComposer

--- a/src/components/conversations/conversation-panel-shell.tsx
+++ b/src/components/conversations/conversation-panel-shell.tsx
@@ -283,26 +283,21 @@ function ConversationPanelContent() {
               <div className="border-t bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
                 This conversation is archived.
               </div>
+            ) : isBuildertrendArchiveChannelId(data.channel.id) ? (
+              <div className="border-t bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+                Open this conversation in the center to reply within an archived
+                Buildertrend message thread. Replies stay internal; mention a teammate
+                to notify them.
+              </div>
             ) : (
-              <>
-                {isBuildertrendArchiveChannelId(data.channel.id) ? (
-                  <div className="border-t bg-muted/30 px-4 py-2 text-xs text-muted-foreground">
-                    Continue this Buildertrend archive in Compass. Replies stay internal;
-                    original Buildertrend recipients are not notified.
-                  </div>
-                ) : null}
-                <MessageComposer
-                  channelId={data.channel.id}
-                  channelName={data.channel.name}
-                  organizationId={data.channel.organizationId}
-                  isProjectChannel={
-                    Boolean(data.channel.projectId) &&
-                    !isBuildertrendArchiveChannelId(data.channel.id)
-                  }
-                  projectRecipients={data.projectRecipients}
-                  onSent={() => void loadConversation(data.channel.id)}
-                />
-              </>
+              <MessageComposer
+                channelId={data.channel.id}
+                channelName={data.channel.name}
+                organizationId={data.channel.organizationId}
+                isProjectChannel={Boolean(data.channel.projectId)}
+                projectRecipients={data.projectRecipients}
+                onSent={() => void loadConversation(data.channel.id)}
+              />
             )}
           </div>
         ) : null}

--- a/src/lib/conversations/__tests__/channel-access.test.ts
+++ b/src/lib/conversations/__tests__/channel-access.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  areArchiveUserMentionsInternal,
   canAccessConversationChannel,
   canCreateConversationMessage,
   isBuildertrendArchiveChannelId,
@@ -78,6 +79,35 @@ describe("canCreateConversationMessage", () => {
   it("keeps ordinary conversation root posts available", () => {
     expect(
       canCreateConversationMessage({ channelId: "project-staff-123", threadId: undefined })
+    ).toBe(true)
+  })
+})
+
+describe("areArchiveUserMentionsInternal", () => {
+  it("only permits internal teammates to receive direct mentions in an archive", () => {
+    expect(
+      areArchiveUserMentionsInternal({
+        channelId: archiveChannelId,
+        mentionedUserIds: ["staff-user"],
+        internalUserIds: new Set(["staff-user"]),
+      })
+    ).toBe(true)
+    expect(
+      areArchiveUserMentionsInternal({
+        channelId: archiveChannelId,
+        mentionedUserIds: ["external-user"],
+        internalUserIds: new Set(["staff-user"]),
+      })
+    ).toBe(false)
+  })
+
+  it("does not change direct mention behavior for ordinary channels", () => {
+    expect(
+      areArchiveUserMentionsInternal({
+        channelId: "project-staff-123",
+        mentionedUserIds: ["external-user"],
+        internalUserIds: new Set(),
+      })
     ).toBe(true)
   })
 })

--- a/src/lib/conversations/__tests__/channel-access.test.ts
+++ b/src/lib/conversations/__tests__/channel-access.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest"
+import {
+  canAccessConversationChannel,
+  isBuildertrendArchiveChannelId,
+  isReplyInConversationChannel,
+} from "../channel-access"
+
+describe("canAccessConversationChannel", () => {
+  it("allows an internal staff member to continue a public staff archive without a membership row", () => {
+    expect(
+      canAccessConversationChannel({
+        hasMembership: false,
+        isPrivate: false,
+        audience: "staff",
+        role: "project_manager",
+      })
+    ).toBe(true)
+  })
+
+  it("does not grant a public staff archive to an external user without membership", () => {
+    expect(
+      canAccessConversationChannel({
+        hasMembership: false,
+        isPrivate: false,
+        audience: "staff",
+        role: "client",
+      })
+    ).toBe(false)
+  })
+
+  it("continues to honor explicit channel membership for any audience", () => {
+    expect(
+      canAccessConversationChannel({
+        hasMembership: true,
+        isPrivate: true,
+        audience: "clients",
+        role: "client",
+      })
+    ).toBe(true)
+  })
+
+  it("does not widen non-staff public channels without membership", () => {
+    expect(
+      canAccessConversationChannel({
+        hasMembership: false,
+        isPrivate: false,
+        audience: "clients",
+        role: "project_manager",
+      })
+    ).toBe(false)
+  })
+})
+
+describe("isBuildertrendArchiveChannelId", () => {
+  it("recognizes only the imported Buildertrend archive channel namespace", () => {
+    expect(isBuildertrendArchiveChannelId("bt-message-archive-5072748")).toBe(true)
+    expect(isBuildertrendArchiveChannelId("project-team-5072748")).toBe(false)
+  })
+})
+
+describe("isReplyInConversationChannel", () => {
+  it("keeps a reply attached to its top-level Buildertrend archive message", () => {
+    expect(
+      isReplyInConversationChannel({
+        channelId: "bt-message-archive-5072748",
+        parentChannelId: "bt-message-archive-5072748",
+        parentThreadId: null,
+      })
+    ).toBe(true)
+  })
+
+  it("rejects a cross-channel or nested-thread reply target", () => {
+    expect(
+      isReplyInConversationChannel({
+        channelId: "bt-message-archive-5072748",
+        parentChannelId: "another-channel",
+        parentThreadId: null,
+      })
+    ).toBe(false)
+    expect(
+      isReplyInConversationChannel({
+        channelId: "bt-message-archive-5072748",
+        parentChannelId: "bt-message-archive-5072748",
+        parentThreadId: "existing-parent",
+      })
+    ).toBe(false)
+  })
+})

--- a/src/lib/conversations/__tests__/channel-access.test.ts
+++ b/src/lib/conversations/__tests__/channel-access.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  areArchiveMentionTypesAllowed,
   areArchiveUserMentionsInternal,
   canAccessConversationChannel,
   canCreateConversationMessage,
@@ -34,7 +35,19 @@ describe("canAccessConversationChannel", () => {
     ).toBe(false)
   })
 
-  it("continues to honor explicit channel membership for any audience", () => {
+  it("does not grant a public staff archive to an external user even with a stale membership row", () => {
+    expect(
+      canAccessConversationChannel({
+        channelId: archiveChannelId,
+        hasMembership: true,
+        isPrivate: false,
+        audience: "staff",
+        role: "client",
+      })
+    ).toBe(false)
+  })
+
+  it("continues to honor explicit channel membership for any non-archive audience", () => {
     expect(
       canAccessConversationChannel({
         channelId: "project-owner-123",
@@ -79,6 +92,32 @@ describe("canCreateConversationMessage", () => {
   it("keeps ordinary conversation root posts available", () => {
     expect(
       canCreateConversationMessage({ channelId: "project-staff-123", threadId: undefined })
+    ).toBe(true)
+  })
+})
+
+describe("areArchiveMentionTypesAllowed", () => {
+  it("rejects channel-wide mentions in an archive", () => {
+    expect(
+      areArchiveMentionTypesAllowed({
+        channelId: archiveChannelId,
+        mentionTypes: ["channel"],
+      })
+    ).toBe(false)
+    expect(
+      areArchiveMentionTypesAllowed({
+        channelId: archiveChannelId,
+        mentionTypes: ["here"],
+      })
+    ).toBe(false)
+  })
+
+  it("does not change mention types for ordinary channels", () => {
+    expect(
+      areArchiveMentionTypesAllowed({
+        channelId: "project-staff-123",
+        mentionTypes: ["channel", "here", "agent"],
+      })
     ).toBe(true)
   })
 })

--- a/src/lib/conversations/__tests__/channel-access.test.ts
+++ b/src/lib/conversations/__tests__/channel-access.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, it } from "vitest"
 import {
   canAccessConversationChannel,
+  canCreateConversationMessage,
   isBuildertrendArchiveChannelId,
   isReplyInConversationChannel,
 } from "../channel-access"
+
+const archiveChannelId = "bt-message-archive-5072748"
 
 describe("canAccessConversationChannel", () => {
   it("allows an internal staff member to continue a public staff archive without a membership row", () => {
     expect(
       canAccessConversationChannel({
+        channelId: archiveChannelId,
         hasMembership: false,
         isPrivate: false,
         audience: "staff",
@@ -20,6 +24,7 @@ describe("canAccessConversationChannel", () => {
   it("does not grant a public staff archive to an external user without membership", () => {
     expect(
       canAccessConversationChannel({
+        channelId: archiveChannelId,
         hasMembership: false,
         isPrivate: false,
         audience: "staff",
@@ -31,6 +36,7 @@ describe("canAccessConversationChannel", () => {
   it("continues to honor explicit channel membership for any audience", () => {
     expect(
       canAccessConversationChannel({
+        channelId: "project-owner-123",
         hasMembership: true,
         isPrivate: true,
         audience: "clients",
@@ -39,12 +45,13 @@ describe("canAccessConversationChannel", () => {
     ).toBe(true)
   })
 
-  it("does not widen non-staff public channels without membership", () => {
+  it("does not widen ordinary public staff channels without membership", () => {
     expect(
       canAccessConversationChannel({
+        channelId: "project-staff-123",
         hasMembership: false,
         isPrivate: false,
-        audience: "clients",
+        audience: "staff",
         role: "project_manager",
       })
     ).toBe(false)
@@ -53,8 +60,25 @@ describe("canAccessConversationChannel", () => {
 
 describe("isBuildertrendArchiveChannelId", () => {
   it("recognizes only the imported Buildertrend archive channel namespace", () => {
-    expect(isBuildertrendArchiveChannelId("bt-message-archive-5072748")).toBe(true)
+    expect(isBuildertrendArchiveChannelId(archiveChannelId)).toBe(true)
     expect(isBuildertrendArchiveChannelId("project-team-5072748")).toBe(false)
+  })
+})
+
+describe("canCreateConversationMessage", () => {
+  it("requires a Buildertrend archive continuation to name a parent message", () => {
+    expect(
+      canCreateConversationMessage({ channelId: archiveChannelId, threadId: undefined })
+    ).toBe(false)
+    expect(
+      canCreateConversationMessage({ channelId: archiveChannelId, threadId: "parent-message" })
+    ).toBe(true)
+  })
+
+  it("keeps ordinary conversation root posts available", () => {
+    expect(
+      canCreateConversationMessage({ channelId: "project-staff-123", threadId: undefined })
+    ).toBe(true)
   })
 })
 
@@ -62,25 +86,32 @@ describe("isReplyInConversationChannel", () => {
   it("keeps a reply attached to its top-level Buildertrend archive message", () => {
     expect(
       isReplyInConversationChannel({
-        channelId: "bt-message-archive-5072748",
-        parentChannelId: "bt-message-archive-5072748",
+        channelId: archiveChannelId,
+        parentChannelId: archiveChannelId,
         parentThreadId: null,
       })
     ).toBe(true)
   })
 
-  it("rejects a cross-channel or nested-thread reply target", () => {
+  it("rejects a missing, cross-channel, or nested-thread reply target", () => {
     expect(
       isReplyInConversationChannel({
-        channelId: "bt-message-archive-5072748",
+        channelId: archiveChannelId,
+        parentChannelId: null,
+        parentThreadId: null,
+      })
+    ).toBe(false)
+    expect(
+      isReplyInConversationChannel({
+        channelId: archiveChannelId,
         parentChannelId: "another-channel",
         parentThreadId: null,
       })
     ).toBe(false)
     expect(
       isReplyInConversationChannel({
-        channelId: "bt-message-archive-5072748",
-        parentChannelId: "bt-message-archive-5072748",
+        channelId: archiveChannelId,
+        parentChannelId: archiveChannelId,
         parentThreadId: "existing-parent",
       })
     ).toBe(false)

--- a/src/lib/conversations/channel-access.ts
+++ b/src/lib/conversations/channel-access.ts
@@ -26,13 +26,14 @@ export function canAccessConversationChannel(input: {
   readonly audience: string
   readonly role: string
 }): boolean {
-  return (
-    input.hasMembership ||
-    (isBuildertrendArchiveChannelId(input.channelId) &&
+  if (isBuildertrendArchiveChannelId(input.channelId)) {
+    return (
       !input.isPrivate &&
       input.audience === "staff" &&
-      isInternalStaffRole(input.role))
-  )
+      isInternalStaffRole(input.role)
+    )
+  }
+  return input.hasMembership
 }
 
 export function canCreateConversationMessage(input: {
@@ -40,6 +41,16 @@ export function canCreateConversationMessage(input: {
   readonly threadId?: string
 }): boolean {
   return !isBuildertrendArchiveChannelId(input.channelId) || Boolean(input.threadId)
+}
+
+export function areArchiveMentionTypesAllowed(input: {
+  readonly channelId: string
+  readonly mentionTypes: readonly string[]
+}): boolean {
+  return (
+    !isBuildertrendArchiveChannelId(input.channelId) ||
+    input.mentionTypes.every((mentionType) => mentionType === "user")
+  )
 }
 
 export function areArchiveUserMentionsInternal(input: {

--- a/src/lib/conversations/channel-access.ts
+++ b/src/lib/conversations/channel-access.ts
@@ -1,0 +1,96 @@
+import { and, eq } from "drizzle-orm"
+
+import { channelMembers, channels } from "@/db/schema-conversations"
+import type { AuthUser } from "@/lib/auth"
+import { requireOrg } from "@/lib/org-scope"
+import { isInternalStaffRole } from "@/lib/user-roles"
+import type { getDb } from "@/db"
+
+export type ConversationChannelAccess = {
+  readonly id: string
+  readonly name: string
+  readonly organizationId: string
+  readonly projectId: string | null
+  readonly isPrivate: boolean
+  readonly audience: string
+}
+
+export function canAccessConversationChannel(input: {
+  readonly hasMembership: boolean
+  readonly isPrivate: boolean
+  readonly audience: string
+  readonly role: string
+}): boolean {
+  return (
+    input.hasMembership ||
+    (!input.isPrivate &&
+      input.audience === "staff" &&
+      isInternalStaffRole(input.role))
+  )
+}
+
+export function isBuildertrendArchiveChannelId(channelId: string): boolean {
+  return channelId.startsWith("bt-message-archive-")
+}
+
+export function isReplyInConversationChannel(input: {
+  readonly channelId: string
+  readonly parentChannelId: string | null
+  readonly parentThreadId: string | null
+}): boolean {
+  return (
+    input.parentChannelId === input.channelId &&
+    input.parentThreadId === null
+  )
+}
+
+/**
+ * Authorizes regular conversation actions. Buildertrend history channels are
+ * public, staff-only channels and intentionally have no per-user membership
+ * rows, so internal staff may read and continue them while external users
+ * remain strictly membership-scoped.
+ */
+export async function getConversationChannelAccess(input: {
+  readonly db: ReturnType<typeof getDb>
+  readonly user: AuthUser
+  readonly channelId: string
+}): Promise<ConversationChannelAccess | null> {
+  const channel = await input.db
+    .select({
+      id: channels.id,
+      name: channels.name,
+      organizationId: channels.organizationId,
+      projectId: channels.projectId,
+      isPrivate: channels.isPrivate,
+      audience: channels.audience,
+    })
+    .from(channels)
+    .where(eq(channels.id, input.channelId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+
+  if (!channel || channel.organizationId !== requireOrg(input.user)) {
+    return null
+  }
+
+  const membership = await input.db
+    .select({ id: channelMembers.id })
+    .from(channelMembers)
+    .where(
+      and(
+        eq(channelMembers.channelId, input.channelId),
+        eq(channelMembers.userId, input.user.id)
+      )
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+
+  return canAccessConversationChannel({
+    hasMembership: membership !== null,
+    isPrivate: channel.isPrivate,
+    audience: channel.audience,
+    role: input.user.role,
+  })
+    ? channel
+    : null
+}

--- a/src/lib/conversations/channel-access.ts
+++ b/src/lib/conversations/channel-access.ts
@@ -1,10 +1,10 @@
 import { and, eq } from "drizzle-orm"
 
 import { channelMembers, channels } from "@/db/schema-conversations"
+import type { getDb } from "@/db"
 import type { AuthUser } from "@/lib/auth"
 import { requireOrg } from "@/lib/org-scope"
 import { isInternalStaffRole } from "@/lib/user-roles"
-import type { getDb } from "@/db"
 
 export type ConversationChannelAccess = {
   readonly id: string
@@ -15,7 +15,12 @@ export type ConversationChannelAccess = {
   readonly audience: string
 }
 
+export function isBuildertrendArchiveChannelId(channelId: string): boolean {
+  return channelId.startsWith("bt-message-archive-")
+}
+
 export function canAccessConversationChannel(input: {
+  readonly channelId: string
   readonly hasMembership: boolean
   readonly isPrivate: boolean
   readonly audience: string
@@ -23,14 +28,18 @@ export function canAccessConversationChannel(input: {
 }): boolean {
   return (
     input.hasMembership ||
-    (!input.isPrivate &&
+    (isBuildertrendArchiveChannelId(input.channelId) &&
+      !input.isPrivate &&
       input.audience === "staff" &&
       isInternalStaffRole(input.role))
   )
 }
 
-export function isBuildertrendArchiveChannelId(channelId: string): boolean {
-  return channelId.startsWith("bt-message-archive-")
+export function canCreateConversationMessage(input: {
+  readonly channelId: string
+  readonly threadId?: string
+}): boolean {
+  return !isBuildertrendArchiveChannelId(input.channelId) || Boolean(input.threadId)
 }
 
 export function isReplyInConversationChannel(input: {
@@ -45,10 +54,9 @@ export function isReplyInConversationChannel(input: {
 }
 
 /**
- * Authorizes regular conversation actions. Buildertrend history channels are
- * public, staff-only channels and intentionally have no per-user membership
- * rows, so internal staff may read and continue them while external users
- * remain strictly membership-scoped.
+ * Buildertrend history imports are public staff-only channels with no per-user
+ * membership rows. Only that source namespace permits internal staff access
+ * without membership; every other conversation remains membership-scoped.
  */
 export async function getConversationChannelAccess(input: {
   readonly db: ReturnType<typeof getDb>
@@ -86,6 +94,7 @@ export async function getConversationChannelAccess(input: {
     .then((rows) => rows[0] ?? null)
 
   return canAccessConversationChannel({
+    channelId: channel.id,
     hasMembership: membership !== null,
     isPrivate: channel.isPrivate,
     audience: channel.audience,

--- a/src/lib/conversations/channel-access.ts
+++ b/src/lib/conversations/channel-access.ts
@@ -42,6 +42,17 @@ export function canCreateConversationMessage(input: {
   return !isBuildertrendArchiveChannelId(input.channelId) || Boolean(input.threadId)
 }
 
+export function areArchiveUserMentionsInternal(input: {
+  readonly channelId: string
+  readonly mentionedUserIds: readonly string[]
+  readonly internalUserIds: ReadonlySet<string>
+}): boolean {
+  return (
+    !isBuildertrendArchiveChannelId(input.channelId) ||
+    input.mentionedUserIds.every((userId) => input.internalUserIds.has(userId))
+  )
+}
+
 export function isReplyInConversationChannel(input: {
   readonly channelId: string
   readonly parentChannelId: string | null


### PR DESCRIPTION
## Summary
- allow internal staff to read and continue public Buildertrend archive channels even when historical imports have no `channel_members` rows
- scope the no-membership exception to the `bt-message-archive-*` namespace; normal conversations retain their prior rules
- treat Buildertrend archive conversations as internal-only: external members cannot discover or open them, even if legacy membership data exists
- require every archive continuation to reply to a top-level message in the same archive channel; root Composer posts are unavailable
- prevent external delivery: reject `@channel`, `@here`, and agent mentions; validate direct mention targets against the active organization membership role; suppress ordinary channel broadcast notifications for archive replies

## Product behavior
Buildertrend imports are history. To continue one, open an original message thread and reply there. The reply is stored inside Compass; it does **not** notify or send to original Buildertrend recipients. A reply may directly mention a same-organization internal teammate for a Compass notification.

## Validation
- `vitest run src/lib/conversations/__tests__/channel-access.test.ts src/lib/conversations/__tests__/notification-route.test.ts src/components/conversations/__tests__/conversation-panel-state.test.ts src/lib/__tests__/buildertrend-owner-history-promotion.test.ts` — 31 passed
- `tsc --noEmit`
- `bun run lint` — no errors (existing repository warnings only)
- `bun run build` — passed (existing Turbopack trace warnings)

## Notes
No Buildertrend outbound/reply API is implemented in Compass. No database migration is required.