### PR TITLE
feat(projects): add project information and follow-up workspace

### DIFF
--- a/__tests__/google-project-intake-tracker.test.ts
+++ b/__tests__/google-project-intake-tracker.test.ts
@@ -6,6 +6,8 @@ import {
   buildProjectRegistryRow,
   departmentTrackingDestination,
   locateProjectTrackerLayout,
+  updateProjectTrackerRow,
+  patchProjectTrackerCells,
   type ProjectIntakeTrackerInput,
 } from "@/lib/google/project-intake-tracker"
 import { resolveProjectIntakeIntegrationEmail } from "@/lib/google/project-intake-identity"
@@ -259,5 +261,89 @@ describe("Google Developer-folder project tracking intake", () => {
         driveFolderUrl: null,
       })[0]
     ).toBe("O-211-33A")
+  })
+
+  it("creates patches only for explicitly mapped tracker cells", () => {
+    const layout = locateProjectTrackerLayout([
+      ["Project Number", "Client", "Project Address", "Status", "Created By"],
+    ])
+    expect(layout).not.toBeNull()
+    if (!layout) return
+
+    expect(
+      patchProjectTrackerCells({
+        layout,
+        values: {
+          "project number": "H-430-2150",
+          client: "New Client",
+          "project address": "2150 Grafton Dr.",
+        },
+      }),
+    ).toEqual([
+      { column: 0, value: "H-430-2150" },
+      { column: 1, value: "New Client" },
+      { column: 2, value: "2150 Grafton Dr." },
+    ])
+  })
+
+  it("patches mapped cells using either project number after a partial retry", async () => {
+    const rows = [
+      ["Project Number", "Client", "Project Address", "Status"],
+      ["H-430-2150", "Taylor", "Unknown", "Current"],
+    ]
+    const layout = locateProjectTrackerLayout(rows)
+    expect(layout).not.toBeNull()
+    if (!layout) return
+
+    const writes: {
+      readonly userEmail: string
+      readonly spreadsheetId: string
+      readonly range: string
+      readonly values: ReadonlyArray<ReadonlyArray<unknown>>
+    }[] = []
+    const result = await updateProjectTrackerRow({
+      sheets: {
+        async updateValues(userEmail, input) {
+          writes.push({ userEmail, ...input })
+          return { updatedRange: input.range }
+        },
+      },
+      googleEmail: "integration@example.com",
+      spreadsheetId: "tracker-id",
+      sheetTitle: "Tracker",
+      rows,
+      layout,
+      currentProjectNumbers: ["H-430-00", "H-430-2150"],
+      patches: patchProjectTrackerCells({
+        layout,
+        values: {
+          "project number": "H-430-2150",
+          client: "Taylor",
+          "project address": "2150 Grafton Dr.",
+        },
+      }),
+    })
+
+    expect(result.rowNumber).toBe(2)
+    expect(writes).toEqual([
+      {
+        userEmail: "integration@example.com",
+        spreadsheetId: "tracker-id",
+        range: "'Tracker'!A2",
+        values: [["H-430-2150"]],
+      },
+      {
+        userEmail: "integration@example.com",
+        spreadsheetId: "tracker-id",
+        range: "'Tracker'!B2",
+        values: [["Taylor"]],
+      },
+      {
+        userEmail: "integration@example.com",
+        spreadsheetId: "tracker-id",
+        range: "'Tracker'!C2",
+        values: [["2150 Grafton Dr."]],
+      },
+    ])
   })
 })

--- a/drizzle/0101_project_profile_follow_up.sql
+++ b/drizzle/0101_project_profile_follow_up.sql
@@ -1,0 +1,88 @@
+ALTER TABLE `projects` ADD `mailing_address` text;--> statement-breakpoint
+ALTER TABLE `projects` ADD `client_status` text DEFAULT 'customer' NOT NULL;--> statement-breakpoint
+ALTER TABLE `projects` ADD `job_status_id` text DEFAULT 'current' NOT NULL;--> statement-breakpoint
+UPDATE `projects`
+SET `job_status_id` = CASE UPPER(`status`)
+  WHEN 'COMPLETE' THEN 'complete'
+  WHEN 'CLOSED' THEN 'closed'
+  WHEN 'BID REFUSED' THEN 'bid_refused'
+  WHEN 'BID_REFUSED' THEN 'bid_refused'
+  WHEN 'INACTIVE' THEN 'inactive'
+  WHEN 'ARCHIVE' THEN 'inactive'
+  ELSE 'current'
+END;--> statement-breakpoint
+CREATE TABLE `project_job_statuses` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `label` text NOT NULL,
+  `sage_code` text,
+  `follow_up_cadence_days` integer,
+  `active` integer DEFAULT true NOT NULL,
+  `sort_order` integer DEFAULT 1000 NOT NULL,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);--> statement-breakpoint
+CREATE UNIQUE INDEX `project_job_statuses_org_label_unique` ON `project_job_statuses` (`organization_id`,`label`);--> statement-breakpoint
+CREATE INDEX `project_job_statuses_org_active_idx` ON `project_job_statuses` (`organization_id`,`active`,`sort_order`);--> statement-breakpoint
+CREATE TABLE `project_profile_audit_events` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `project_id` text NOT NULL,
+  `actor_user_id` text,
+  `event_type` text NOT NULL,
+  `entity_type` text NOT NULL,
+  `entity_id` text,
+  `before_json` text,
+  `after_json` text,
+  `created_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`actor_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);--> statement-breakpoint
+CREATE INDEX `project_profile_audit_events_project_created_idx` ON `project_profile_audit_events` (`project_id`,`created_at`);--> statement-breakpoint
+CREATE TABLE `project_notes` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `project_id` text NOT NULL,
+  `content` text NOT NULL,
+  `created_by` text,
+  `updated_by` text,
+  `deleted_by` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  `deleted_at` text,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`updated_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`deleted_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);--> statement-breakpoint
+CREATE INDEX `project_notes_project_created_idx` ON `project_notes` (`project_id`,`created_at`);--> statement-breakpoint
+CREATE TABLE `project_interactions` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `project_id` text NOT NULL,
+  `project_contact_id` text,
+  `interaction_type` text NOT NULL,
+  `direction` text NOT NULL,
+  `source` text DEFAULT 'manual' NOT NULL,
+  `summary` text NOT NULL,
+  `occurred_at` text NOT NULL,
+  `created_by` text,
+  `updated_by` text,
+  `deleted_by` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  `deleted_at` text,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_contact_id`) REFERENCES `project_contacts`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`updated_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`deleted_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);--> statement-breakpoint
+CREATE INDEX `project_interactions_project_occurred_idx` ON `project_interactions` (`project_id`,`occurred_at`);--> statement-breakpoint
+CREATE INDEX `project_interactions_org_occurred_idx` ON `project_interactions` (`organization_id`,`occurred_at`);

--- a/drizzle/0102_project_profile_sync_operations.sql
+++ b/drizzle/0102_project_profile_sync_operations.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `project_profile_sync_operations` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `project_id` text NOT NULL,
+  `operation` text NOT NULL,
+  `status` text DEFAULT 'pending' NOT NULL,
+  `payload_json` text NOT NULL,
+  `error` text,
+  `attempts` integer DEFAULT 0 NOT NULL,
+  `attempted_at` text,
+  `completed_at` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade
+);--> statement-breakpoint
+CREATE INDEX `project_profile_sync_operations_project_status_idx` ON `project_profile_sync_operations` (`project_id`,`status`,`created_at`);

--- a/drizzle/0103_project_follow_ups.sql
+++ b/drizzle/0103_project_follow_ups.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `project_follow_ups` (
+  `project_id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `next_follow_up_at` text NOT NULL,
+  `owner_user_id` text,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`owner_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);

--- a/drizzle/0104_project_number_aliases.sql
+++ b/drizzle/0104_project_number_aliases.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `project_number_aliases` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `project_id` text NOT NULL,
+  `project_number` text NOT NULL,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);--> statement-breakpoint
+CREATE UNIQUE INDEX `project_number_aliases_project_number_unique` ON `project_number_aliases` (`project_id`,`project_number`);--> statement-breakpoint
+CREATE INDEX `project_number_aliases_org_number_idx` ON `project_number_aliases` (`organization_id`,`project_number`);

--- a/drizzle/0105_project_number_namespace.sql
+++ b/drizzle/0105_project_number_namespace.sql
@@ -1,0 +1,111 @@
+CREATE TABLE IF NOT EXISTS `project_number_alias_conflicts` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `project_number` text NOT NULL,
+  `retained_project_id` text NOT NULL,
+  `discarded_project_id` text NOT NULL,
+  `discarded_alias_id` text NOT NULL,
+  `created_at` text NOT NULL
+);--> statement-breakpoint
+INSERT INTO `project_number_alias_conflicts` (
+  `id`,
+  `organization_id`,
+  `project_number`,
+  `retained_project_id`,
+  `discarded_project_id`,
+  `discarded_alias_id`,
+  `created_at`
+)
+SELECT
+  lower(hex(randomblob(16))),
+  candidate.`organization_id`,
+  candidate.`project_number`,
+  retained.`project_id`,
+  candidate.`project_id`,
+  candidate.`id`,
+  candidate.`created_at`
+FROM `project_number_aliases` AS candidate
+JOIN `project_number_aliases` AS retained
+  ON retained.`organization_id` = candidate.`organization_id`
+  AND retained.`project_number` = candidate.`project_number` COLLATE NOCASE
+  AND (
+    retained.`created_at` < candidate.`created_at`
+    OR (retained.`created_at` = candidate.`created_at` AND retained.`id` < candidate.`id`)
+  )
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM `project_number_aliases` AS earlier
+  WHERE earlier.`organization_id` = candidate.`organization_id`
+    AND earlier.`project_number` = candidate.`project_number` COLLATE NOCASE
+    AND (
+      earlier.`created_at` < retained.`created_at`
+      OR (earlier.`created_at` = retained.`created_at` AND earlier.`id` < retained.`id`)
+    )
+);--> statement-breakpoint
+DELETE FROM `project_number_aliases`
+WHERE EXISTS (
+  SELECT 1
+  FROM `project_number_aliases` AS retained
+  WHERE retained.`organization_id` = `project_number_aliases`.`organization_id`
+    AND retained.`project_number` = `project_number_aliases`.`project_number` COLLATE NOCASE
+    AND (
+      retained.`created_at` < `project_number_aliases`.`created_at`
+      OR (retained.`created_at` = `project_number_aliases`.`created_at` AND retained.`id` < `project_number_aliases`.`id`)
+    )
+);--> statement-breakpoint
+DROP INDEX `project_number_aliases_project_number_unique`;--> statement-breakpoint
+CREATE UNIQUE INDEX `project_number_aliases_org_number_unique`
+ON `project_number_aliases` (`organization_id`, `project_number` COLLATE NOCASE);--> statement-breakpoint
+CREATE UNIQUE INDEX `projects_org_project_number_unique`
+ON `projects` (`organization_id`, `project_number` COLLATE NOCASE)
+WHERE `project_number` IS NOT NULL;--> statement-breakpoint
+CREATE TRIGGER `projects_project_number_rejects_alias_on_insert`
+BEFORE INSERT ON `projects`
+WHEN NEW.`project_number` IS NOT NULL
+  AND EXISTS (
+    SELECT 1
+    FROM `project_number_aliases`
+    WHERE `organization_id` = NEW.`organization_id`
+      AND `project_number` = NEW.`project_number` COLLATE NOCASE
+      AND `project_id` <> NEW.`id`
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'project number is reserved as a historical alias');
+END;--> statement-breakpoint
+CREATE TRIGGER `projects_project_number_rejects_alias_on_update`
+BEFORE UPDATE OF `project_number`, `organization_id` ON `projects`
+WHEN NEW.`project_number` IS NOT NULL
+  AND EXISTS (
+    SELECT 1
+    FROM `project_number_aliases`
+    WHERE `organization_id` = NEW.`organization_id`
+      AND `project_number` = NEW.`project_number` COLLATE NOCASE
+      AND `project_id` <> NEW.`id`
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'project number is reserved as a historical alias');
+END;--> statement-breakpoint
+CREATE TRIGGER `project_number_aliases_reject_current_number_on_insert`
+BEFORE INSERT ON `project_number_aliases`
+WHEN EXISTS (
+  SELECT 1
+  FROM `projects`
+  WHERE `organization_id` = NEW.`organization_id`
+    AND `project_number` = NEW.`project_number` COLLATE NOCASE
+    AND `id` <> NEW.`project_id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'project number is active on another project');
+END;--> statement-breakpoint
+CREATE TRIGGER `project_number_aliases_reject_current_number_on_update`
+BEFORE UPDATE OF `project_number`, `organization_id`, `project_id` ON `project_number_aliases`
+WHEN EXISTS (
+  SELECT 1
+  FROM `projects`
+  WHERE `organization_id` = NEW.`organization_id`
+    AND `project_number` = NEW.`project_number` COLLATE NOCASE
+    AND `id` <> NEW.`project_id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'project number is active on another project');
+END;

--- a/drizzle/0106_project_interaction_client_touch.sql
+++ b/drizzle/0106_project_interaction_client_touch.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `project_interactions`
+ADD `qualifies_for_client_touch` integer DEFAULT false NOT NULL;

--- a/drizzle/0107_project_profile_legacy_status_backfill.sql
+++ b/drizzle/0107_project_profile_legacy_status_backfill.sql
@@ -1,0 +1,7 @@
+UPDATE `projects`
+SET `job_status_id` = CASE
+  WHEN upper(trim(`status`)) = 'CLOSED' THEN 'closed'
+  WHEN upper(trim(`status`)) IN ('BID REFUSED', 'BID_REFUSED') THEN 'bid_refused'
+  ELSE `job_status_id`
+END
+WHERE upper(trim(`status`)) IN ('CLOSED', 'BID REFUSED', 'BID_REFUSED');

--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -6,6 +6,7 @@ const applicationErrorText =
 const coreAreas = [
   { name: "dashboard", path: "/dashboard" },
   { name: "projects", path: "/dashboard/projects" },
+  { name: "client follow-up", path: "/dashboard/projects/follow-up" },
   { name: "work calendar", path: "/dashboard/schedule" },
   { name: "RFIs", path: "/dashboard/rfis" },
   { name: "purchase orders", path: "/dashboard/purchase-orders" },
@@ -24,6 +25,7 @@ const projectAreas = [
   { name: "daily logs", suffix: "/daily-logs" },
   { name: "photos", suffix: "/photos" },
   { name: "contacts", suffix: "/contacts" },
+  { name: "project information", suffix: "/information" },
   { name: "financials", suffix: "/financials" },
   { name: "budget", suffix: "/budget" },
   { name: "purchase orders", suffix: "/purchase-orders" },
@@ -140,9 +142,25 @@ test.describe("usable Compass areas", () => {
     }
   })
 
-  test("timezone preference persists after reloading settings", async ({
-    page,
-  }) => {
+  test("project information and client follow-up workspaces render", async ({ page }) => {
+    const projectsResponse = await page.goto("/dashboard/projects")
+    await expectHealthyNavigation(page, projectsResponse, "/dashboard/projects")
+    const projectId = await findProjectId(page)
+    if (!projectId) {
+      test.skip(true, "The deployed demo has no read-only project fixture")
+      return
+    }
+
+    for (const path of [
+      `/dashboard/projects/${projectId}/information`,
+      "/dashboard/projects/follow-up",
+    ]) {
+      const response = await page.goto(path)
+      await expectHealthyNavigation(page, response, path)
+    }
+  })
+
+  test("timezone preference persists after reloading settings", async ({ page }) => {
     const path = "/dashboard/settings"
     const response = await page.goto(path)
     await expectHealthyNavigation(page, response, path)

--- a/src/app/actions/project-contacts.ts
+++ b/src/app/actions/project-contacts.ts
@@ -10,6 +10,7 @@ import {
   projectAccessInvitations,
   projectContacts,
   projectContactSourceLinks,
+  projectProfileSyncOperations,
   projectMembers,
   projects,
   users,
@@ -405,8 +406,46 @@ function revalidateContactPaths(projectId: string): void {
   revalidatePath(`/dashboard/projects/${projectId}`)
   revalidatePath(`/dashboard/projects/${projectId}/contacts`)
   revalidatePath(`/dashboard/projects/${projectId}/contacts/review`)
+  revalidatePath(`/dashboard/projects/${projectId}/information`)
   revalidatePath(`/dashboard/projects/${projectId}/rfis`)
   revalidatePath(`/dashboard/projects/${projectId}/purchase-orders`)
+}
+
+async function queueProjectContactTrackerRefresh(input: {
+  readonly db: Awaited<ReturnType<typeof getDb>>
+  readonly organizationId: string
+  readonly projectId: string
+}): Promise<void> {
+  const [project] = await input.db
+    .select({ projectNumber: projects.projectNumber })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.id, input.projectId),
+        eq(projects.organizationId, input.organizationId),
+      ),
+    )
+    .limit(1)
+  if (!project?.projectNumber) return
+
+  const now = new Date().toISOString()
+  await input.db.insert(projectProfileSyncOperations).values({
+    id: crypto.randomUUID(),
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    operation: "tracker_row_update",
+    status: "pending",
+    payloadJson: JSON.stringify({
+      previousProjectNumber: project.projectNumber,
+      projectNumber: project.projectNumber,
+    }),
+    error: null,
+    attempts: 0,
+    attemptedAt: null,
+    completedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  })
 }
 
 function sourceIdPart(value: string): string {
@@ -1030,6 +1069,11 @@ export async function saveProjectContact(
       })
     }
 
+    await queueProjectContactTrackerRefresh({
+      db,
+      organizationId: orgId,
+      projectId: input.projectId,
+    })
     revalidateContactPaths(input.projectId)
     return { success: true, contactId }
   } catch (error) {
@@ -1210,6 +1254,11 @@ export async function removeProjectContact(
       }
     }
 
+    await queueProjectContactTrackerRefresh({
+      db,
+      organizationId: orgId,
+      projectId,
+    })
     revalidateContactPaths(projectId)
     return { success: true, contactId }
   } catch (error) {

--- a/src/app/actions/project-profile.ts
+++ b/src/app/actions/project-profile.ts
@@ -1,0 +1,1345 @@
+"use server"
+
+import { and, asc, desc, eq, isNull, sql } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import {
+  customers,
+  organizationMembers,
+  projectContacts,
+  projectExternalLinks,
+  projectFollowUps,
+  projectInteractions,
+  projectJobStatuses,
+  projectNotes,
+  projectNumberAliases,
+  projectNumberReservations,
+  projectProfileAuditEvents,
+  projectProfileSyncOperations,
+  projects,
+  users,
+} from "@/db/schema"
+import { googleAuth } from "@/db/schema-google"
+import { requireAuth } from "@/lib/auth"
+import { decrypt } from "@/lib/crypto"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import { requireOrg } from "@/lib/org-scope"
+import { requireFeaturePermission } from "@/lib/permission-enforcement"
+import {
+  canManageProjectRegistry,
+} from "@/lib/permissions"
+import { SheetsClient } from "@/lib/google/client/sheets-client"
+import { DriveClient } from "@/lib/google/client/drive-client"
+import {
+  getGoogleConfig,
+  getGoogleCryptoSalt,
+  parseServiceAccountKey,
+} from "@/lib/google/config"
+import { buildProjectDriveFolderName } from "@/lib/google/project-drive-provisioning"
+import {
+  departmentTrackingDestination,
+  locateProjectTrackerLayout,
+  patchProjectTrackerCells,
+  PROJECT_REGISTRY_DESTINATION,
+  updateProjectTrackerRow,
+  type ProjectIntakeDepartment,
+} from "@/lib/google/project-intake-tracker"
+import { resolveProjectIntakeIntegrationEmail } from "@/lib/google/project-intake-identity"
+import {
+  PROJECT_CLIENT_STATUSES,
+  PROJECT_JOB_STATUS_DEFINITIONS,
+  buildProjectNumberWithAddressSuffix,
+  isEligibleFollowUpOwner,
+  isMeaningfulClientInteraction,
+  projectNumberParts,
+  type ProjectClientStatus,
+} from "@/lib/project-profile"
+import { clientFollowUpState } from "@/lib/project-follow-up"
+import { getProjectAccessRecord } from "@/lib/project-access"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+export type ProjectProfileResult =
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string }
+
+export type ProjectProfileJobStatus = {
+  readonly id: string
+  readonly label: string
+  readonly sageCode: string | null
+  readonly followUpCadenceDays: number | null
+  readonly active: boolean
+  readonly builtIn: boolean
+}
+
+export type ProjectProfileNote = {
+  readonly id: string
+  readonly body: string
+  readonly authorName: string | null
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+export type ProjectProfileInteraction = {
+  readonly id: string
+  readonly interactionType: string
+  readonly direction: string
+  readonly summary: string
+  readonly source: string
+  readonly occurredAt: string
+  readonly authorName: string | null
+  readonly contactId: string | null
+}
+
+export type ProjectFollowUpOwner = {
+  readonly id: string
+  readonly displayName: string
+}
+
+export type ProjectInformation = {
+  readonly project: {
+    readonly id: string
+    readonly name: string
+    readonly projectNumber: string | null
+    readonly projectAddress: string | null
+    readonly mailingAddress: string | null
+    readonly clientStatus: ProjectClientStatus
+    readonly jobStatusId: string
+    readonly status: string
+  }
+  readonly jobStatuses: readonly ProjectProfileJobStatus[]
+  readonly clientContacts: readonly {
+    readonly id: string
+    readonly displayName: string
+  }[]
+  readonly projectNumberAliases: readonly string[]
+  readonly notes: readonly ProjectProfileNote[]
+  readonly interactions: readonly ProjectProfileInteraction[]
+  readonly followUp: {
+    readonly nextFollowUpAt: string
+    readonly ownerUserId: string | null
+    readonly ownerName: string | null
+  } | null
+  readonly syncOperations: readonly {
+    readonly id: string
+    readonly operation: string
+    readonly status: string
+    readonly error: string | null
+    readonly updatedAt: string
+  }[]
+}
+
+function nullableText(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? ""
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function isProjectClientStatus(value: string): value is ProjectClientStatus {
+  return value === "lead" || value === "customer"
+}
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+function profilePath(projectId: string): string {
+  return `/dashboard/projects/${projectId}`
+}
+
+function revalidateProjectProfile(projectId: string): void {
+  revalidatePath(profilePath(projectId))
+  revalidatePath(`${profilePath(projectId)}/information`)
+  revalidatePath("/dashboard/projects")
+  revalidatePath("/dashboard/projects/follow-up")
+}
+
+function trackerDepartment(projectNumber: string | null): ProjectIntakeDepartment | null {
+  const prefix = projectNumber?.trim().slice(0, 1).toUpperCase()
+  if (prefix === "O" || prefix === "H" || prefix === "N" || prefix === "D") {
+    return prefix
+  }
+  return null
+}
+
+function projectAddressParts(address: string | null): {
+  readonly streetNumber: string | null
+  readonly streetName: string | null
+  readonly cityStateZip: string | null
+} {
+  const parts = address?.split(",").map((part) => part.trim()).filter(Boolean) ?? []
+  const street = parts[0] ?? ""
+  const match = /^(\S+)\s+(.+)$/.exec(street)
+  return {
+    streetNumber: match?.[1] ?? null,
+    streetName: match?.[2] ?? (street || null),
+    cityStateZip: parts.slice(1).join(", ") || null,
+  }
+}
+
+function syncProjectNumbers(payloadJson: string): {
+  readonly previousProjectNumber: string
+  readonly projectNumber: string
+} | null {
+  try {
+    const payload: unknown = JSON.parse(payloadJson)
+    if (
+      typeof payload === "object"
+      && payload !== null
+      && "previousProjectNumber" in payload
+      && "projectNumber" in payload
+      && typeof payload.previousProjectNumber === "string"
+      && typeof payload.projectNumber === "string"
+    ) {
+      return {
+        previousProjectNumber: payload.previousProjectNumber,
+        projectNumber: payload.projectNumber,
+      }
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+async function projectSyncClients(input: {
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string
+  readonly environment: Awaited<ReturnType<typeof getCloudflareContext>>["env"]
+}): Promise<{ readonly drive: DriveClient; readonly sheets: SheetsClient; readonly trackerEmail: string }> {
+  if (!input.environment?.DB) throw new Error("Database unavailable")
+  const authRows = await input.db
+    .select({
+      serviceAccountKeyEncrypted: googleAuth.serviceAccountKeyEncrypted,
+      connectorGoogleEmail: users.googleEmail,
+      connectorEmail: users.email,
+    })
+    .from(googleAuth)
+    .innerJoin(users, eq(users.id, googleAuth.connectedBy))
+    .where(eq(googleAuth.organizationId, input.organizationId))
+    .limit(1)
+  const auth = authRows[0]
+  if (!auth) throw new Error("Google Workspace service account is not connected.")
+  const config = getGoogleConfig(input.environment)
+  const keyJson = await decrypt(
+    auth.serviceAccountKeyEncrypted,
+    config.encryptionKey,
+    getGoogleCryptoSalt(),
+  )
+  const serviceAccountKey = parseServiceAccountKey(keyJson)
+  return {
+    drive: new DriveClient({ serviceAccountKey }),
+    sheets: new SheetsClient(serviceAccountKey),
+    trackerEmail: resolveProjectIntakeIntegrationEmail({
+      connectorGoogleEmail: auth.connectorGoogleEmail,
+      connectorEmail: auth.connectorEmail,
+    }),
+  }
+}
+
+async function projectProfileContext(projectId: string, action: "read" | "update") {
+  const user = await requireAuth()
+  requireFeaturePermission(user, "project-hub", action)
+  if (!isInternalStaffRole(user.role)) {
+    throw new Error("Project information is available to internal staff only.")
+  }
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  if (!env?.DB) throw new Error("Database unavailable")
+  const db = getDb(env.DB)
+  const access = await getProjectAccessRecord(db, user, projectId)
+  if (!access || access.organizationId !== organizationId) {
+    throw new Error("Project not found or access denied.")
+  }
+  return { db, organizationId, user }
+}
+
+async function writeAuditEvent(input: {
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string
+  readonly projectId: string
+  readonly actorId: string
+  readonly eventType: string
+  readonly entityType: string
+  readonly entityId: string | null
+  readonly before: unknown
+  readonly after: unknown
+}): Promise<void> {
+  await input.db.insert(projectProfileAuditEvents).values({
+    id: crypto.randomUUID(),
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    actorUserId: input.actorId,
+    eventType: input.eventType,
+    entityType: input.entityType,
+    entityId: input.entityId,
+    beforeJson: JSON.stringify(input.before),
+    afterJson: JSON.stringify(input.after),
+    createdAt: nowIso(),
+  })
+}
+
+async function validJobStatus(input: {
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string
+  readonly jobStatusId: string
+}): Promise<boolean> {
+  if (PROJECT_JOB_STATUS_DEFINITIONS.some((status) => status.id === input.jobStatusId)) {
+    return true
+  }
+  const custom = await input.db
+    .select({ id: projectJobStatuses.id })
+    .from(projectJobStatuses)
+    .where(
+      and(
+        eq(projectJobStatuses.organizationId, input.organizationId),
+        eq(projectJobStatuses.id, input.jobStatusId),
+        eq(projectJobStatuses.active, true),
+      ),
+    )
+    .limit(1)
+  return custom.length === 1
+}
+
+function jobStatusOptions(
+  custom: readonly {
+    readonly id: string
+    readonly label: string
+    readonly sageCode: string | null
+    readonly followUpCadenceDays: number | null
+    readonly active: boolean
+  }[],
+): readonly ProjectProfileJobStatus[] {
+  return [
+    ...PROJECT_JOB_STATUS_DEFINITIONS.map((status) => ({
+      id: status.id,
+      label: status.label,
+      sageCode: null,
+      followUpCadenceDays: status.followUpCadenceDays,
+      active: true,
+      builtIn: true,
+    })),
+    ...custom.map((status) => ({ ...status, builtIn: false })),
+  ]
+}
+
+export async function getProjectFollowUpOwners(
+  projectId: string,
+): Promise<readonly ProjectFollowUpOwner[]> {
+  try {
+    const { db, organizationId } = await projectProfileContext(projectId, "read")
+    const members = await db
+      .select({
+        id: users.id,
+        displayName: users.displayName,
+        email: users.email,
+        active: users.isActive,
+        role: organizationMembers.role,
+      })
+      .from(organizationMembers)
+      .innerJoin(users, eq(users.id, organizationMembers.userId))
+      .where(and(eq(organizationMembers.organizationId, organizationId), eq(users.isActive, true)))
+      .orderBy(asc(users.displayName), asc(users.email))
+    return members
+      .filter((member) => isEligibleFollowUpOwner(member))
+      .map((member) => ({ id: member.id, displayName: member.displayName ?? member.email }))
+  } catch (error) {
+    console.error("Unable to load follow-up owners", error)
+    return []
+  }
+}
+
+export async function getProjectInformation(
+  projectId: string,
+): Promise<ProjectInformation | null> {
+  try {
+    const { db, organizationId } = await projectProfileContext(projectId, "read")
+    const projectRows = await db
+      .select({
+        id: projects.id,
+        name: projects.name,
+        projectNumber: projects.projectNumber,
+        projectAddress: projects.address,
+        mailingAddress: projects.mailingAddress,
+        clientStatus: projects.clientStatus,
+        jobStatusId: projects.jobStatusId,
+        status: projects.status,
+      })
+      .from(projects)
+      .where(and(eq(projects.id, projectId), eq(projects.organizationId, organizationId)))
+      .limit(1)
+    const project = projectRows[0]
+    if (!project) return null
+
+    const [customStatuses, notes, interactions, followUps, operations, aliases, clientContacts] = await Promise.all([
+      db
+        .select({
+          id: projectJobStatuses.id,
+          label: projectJobStatuses.label,
+          sageCode: projectJobStatuses.sageCode,
+          followUpCadenceDays: projectJobStatuses.followUpCadenceDays,
+          active: projectJobStatuses.active,
+        })
+        .from(projectJobStatuses)
+        .where(
+          and(
+            eq(projectJobStatuses.organizationId, organizationId),
+            eq(projectJobStatuses.active, true),
+          ),
+        )
+        .orderBy(asc(projectJobStatuses.sortOrder), asc(projectJobStatuses.label)),
+      db
+        .select({
+          id: projectNotes.id,
+          body: projectNotes.content,
+          authorName: users.displayName,
+          createdAt: projectNotes.createdAt,
+          updatedAt: projectNotes.updatedAt,
+        })
+        .from(projectNotes)
+        .leftJoin(users, eq(users.id, projectNotes.createdBy))
+        .where(and(eq(projectNotes.projectId, projectId), isNull(projectNotes.deletedAt)))
+        .orderBy(desc(projectNotes.createdAt)),
+      db
+        .select({
+          id: projectInteractions.id,
+          interactionType: projectInteractions.interactionType,
+          direction: projectInteractions.direction,
+          summary: projectInteractions.summary,
+          source: projectInteractions.source,
+          occurredAt: projectInteractions.occurredAt,
+          authorName: users.displayName,
+          contactId: projectInteractions.projectContactId,
+        })
+        .from(projectInteractions)
+        .leftJoin(users, eq(users.id, projectInteractions.createdBy))
+        .where(
+          and(
+            eq(projectInteractions.projectId, projectId),
+            eq(projectInteractions.qualifiesForClientTouch, true),
+            isNull(projectInteractions.deletedAt),
+          ),
+        )
+        .orderBy(desc(projectInteractions.occurredAt)),
+      db
+        .select({
+          nextFollowUpAt: projectFollowUps.nextFollowUpAt,
+          ownerUserId: projectFollowUps.ownerUserId,
+          ownerName: users.displayName,
+        })
+        .from(projectFollowUps)
+        .leftJoin(
+          organizationMembers,
+          and(
+            eq(organizationMembers.organizationId, organizationId),
+            eq(organizationMembers.userId, projectFollowUps.ownerUserId),
+          ),
+        )
+        .leftJoin(users, and(eq(users.id, organizationMembers.userId), eq(users.isActive, true)))
+        .where(eq(projectFollowUps.projectId, projectId))
+        .limit(1),
+      db
+        .select({
+          id: projectProfileSyncOperations.id,
+          operation: projectProfileSyncOperations.operation,
+          status: projectProfileSyncOperations.status,
+          error: projectProfileSyncOperations.error,
+          updatedAt: projectProfileSyncOperations.updatedAt,
+        })
+        .from(projectProfileSyncOperations)
+        .where(eq(projectProfileSyncOperations.projectId, projectId))
+        .orderBy(desc(projectProfileSyncOperations.updatedAt))
+        .limit(12),
+      db
+        .select({ projectNumber: projectNumberAliases.projectNumber })
+        .from(projectNumberAliases)
+        .where(eq(projectNumberAliases.projectId, projectId))
+        .orderBy(desc(projectNumberAliases.createdAt)),
+      db
+        .select({ id: projectContacts.id, displayName: projectContacts.displayName })
+        .from(projectContacts)
+        .where(
+          and(
+            eq(projectContacts.projectId, projectId),
+            eq(projectContacts.contactType, "owner"),
+            eq(projectContacts.active, true),
+          ),
+        )
+        .orderBy(desc(projectContacts.primaryContact), asc(projectContacts.sortOrder)),
+    ])
+
+    const clientStatus = isProjectClientStatus(project.clientStatus)
+      ? project.clientStatus
+      : "customer"
+    return {
+      project: { ...project, clientStatus },
+      jobStatuses: jobStatusOptions(customStatuses),
+      clientContacts,
+      projectNumberAliases: aliases.map((alias) => alias.projectNumber),
+      notes,
+      interactions,
+      followUp: followUps[0] ?? null,
+      syncOperations: operations,
+    }
+  } catch (error) {
+    console.error("Unable to load project information", error)
+    return null
+  }
+}
+
+export type ProjectFollowUpQueueItem = {
+  readonly projectId: string
+  readonly projectNumber: string | null
+  readonly projectName: string
+  readonly clientName: string | null
+  readonly clientStatus: ProjectClientStatus
+  readonly jobStatusId: string
+  readonly jobStatusLabel: string
+  readonly state: "current" | "due" | "overdue" | "scheduled" | "unrecorded"
+  readonly businessDaysSinceLastTouch: number | null
+  readonly lastClientInteractionAt: string | null
+  readonly nextFollowUpAt: string | null
+  readonly followUpOwnerName: string | null
+}
+
+export async function getProjectFollowUpQueue(): Promise<
+  readonly ProjectFollowUpQueueItem[]
+> {
+  try {
+    const user = await requireAuth()
+    requireFeaturePermission(user, "project-hub", "read")
+    if (!isInternalStaffRole(user.role)) return []
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    if (!env?.DB) return []
+    const db = getDb(env.DB)
+    const [rows, customStatuses] = await Promise.all([
+      db
+        .select({
+          projectId: projects.id,
+          projectNumber: projects.projectNumber,
+          projectName: projects.name,
+          clientName: projects.clientName,
+          clientStatus: projects.clientStatus,
+          jobStatusId: projects.jobStatusId,
+          occurredAt: projectInteractions.occurredAt,
+          nextFollowUpAt: projectFollowUps.nextFollowUpAt,
+          ownerName: users.displayName,
+        })
+        .from(projects)
+        .leftJoin(projectFollowUps, eq(projectFollowUps.projectId, projects.id))
+        .leftJoin(
+          organizationMembers,
+          and(
+            eq(organizationMembers.organizationId, organizationId),
+            eq(organizationMembers.userId, projectFollowUps.ownerUserId),
+          ),
+        )
+        .leftJoin(users, and(eq(users.id, organizationMembers.userId), eq(users.isActive, true)))
+        .leftJoin(
+          projectInteractions,
+          and(
+            eq(projectInteractions.projectId, projects.id),
+            eq(projectInteractions.qualifiesForClientTouch, true),
+            isNull(projectInteractions.deletedAt),
+          ),
+        )
+        .where(eq(projects.organizationId, organizationId))
+        .orderBy(desc(projectInteractions.occurredAt)),
+      db
+        .select({
+          id: projectJobStatuses.id,
+          label: projectJobStatuses.label,
+          cadenceDays: projectJobStatuses.followUpCadenceDays,
+        })
+        .from(projectJobStatuses)
+        .where(
+          and(
+            eq(projectJobStatuses.organizationId, organizationId),
+            eq(projectJobStatuses.active, true),
+          ),
+        ),
+    ])
+    const customStatusesById = new Map(customStatuses.map((status) => [status.id, status]))
+    const builtInStatusLabels = new Map<string, string>(
+      PROJECT_JOB_STATUS_DEFINITIONS.map((status) => [status.id, status.label]),
+    )
+    const grouped = new Map<
+      string,
+      {
+        readonly projectId: string
+        readonly projectNumber: string | null
+        readonly projectName: string
+        readonly clientName: string | null
+        readonly clientStatus: ProjectClientStatus
+        readonly jobStatusId: string
+        readonly nextFollowUpAt: string | null
+        readonly ownerName: string | null
+        readonly interactions: {
+          readonly occurredAt: string
+          readonly deletedAt: null
+          readonly qualifiesForClientTouch: true
+        }[]
+      }
+    >()
+    for (const row of rows) {
+      let project = grouped.get(row.projectId)
+      if (!project) {
+        const clientStatus = isProjectClientStatus(row.clientStatus)
+          ? row.clientStatus
+          : "customer"
+        project = {
+          projectId: row.projectId,
+          projectNumber: row.projectNumber,
+          projectName: row.projectName,
+          clientName: row.clientName,
+          clientStatus,
+          jobStatusId: row.jobStatusId,
+          nextFollowUpAt: row.nextFollowUpAt,
+          ownerName: row.ownerName,
+          interactions: [],
+        }
+        grouped.set(row.projectId, project)
+      }
+      if (row.occurredAt) {
+        project.interactions.push({
+          occurredAt: row.occurredAt,
+          deletedAt: null,
+          qualifiesForClientTouch: true,
+        })
+      }
+    }
+
+    const queue = [...grouped.values()].flatMap((project) => {
+      const customStatus = customStatusesById.get(project.jobStatusId)
+      const state = clientFollowUpState({
+        jobStatusId: project.jobStatusId,
+        cadenceDays: customStatus ? customStatus.cadenceDays : undefined,
+        interactions: project.interactions,
+        nextFollowUpAt: project.nextFollowUpAt,
+        now: new Date(),
+      })
+      if (!state.eligible || state.state === "excluded") return []
+      const jobStatusLabel =
+        builtInStatusLabels.get(project.jobStatusId) ?? customStatus?.label ?? "Unknown"
+      return [{
+        projectId: project.projectId,
+        projectNumber: project.projectNumber,
+        projectName: project.projectName,
+        clientName: project.clientName,
+        clientStatus: project.clientStatus,
+        jobStatusId: project.jobStatusId,
+        jobStatusLabel,
+        state: state.state,
+        businessDaysSinceLastTouch: state.businessDaysSinceLastTouch,
+        lastClientInteractionAt: state.lastClientInteractionAt,
+        nextFollowUpAt: state.nextFollowUpAt,
+        followUpOwnerName: project.ownerName,
+      }]
+    })
+    const stateOrder: Readonly<Record<ProjectFollowUpQueueItem["state"], number>> = {
+      overdue: 0,
+      due: 1,
+      unrecorded: 2,
+      current: 3,
+      scheduled: 4,
+    }
+    return queue.sort((left, right) => {
+      const stateDifference = stateOrder[left.state] - stateOrder[right.state]
+      if (stateDifference !== 0) return stateDifference
+      const leftTime = left.nextFollowUpAt ?? left.lastClientInteractionAt ?? ""
+      const rightTime = right.nextFollowUpAt ?? right.lastClientInteractionAt ?? ""
+      return leftTime.localeCompare(rightTime)
+    })
+  } catch (error) {
+    console.error("Unable to load project follow-up queue", error)
+    return []
+  }
+}
+
+export async function retryProjectProfileSyncOperation(input: {
+  readonly projectId: string
+  readonly operationId: string
+}): Promise<ProjectProfileResult> {
+  const attemptedAt = nowIso()
+  try {
+    const { db, organizationId, user } = await projectProfileContext(input.projectId, "update")
+    if (isDemoUser(user.id)) return { success: false, error: "Demo data cannot be changed." }
+    const operationRows = await db
+      .select({
+        id: projectProfileSyncOperations.id,
+        operation: projectProfileSyncOperations.operation,
+        payloadJson: projectProfileSyncOperations.payloadJson,
+        attempts: projectProfileSyncOperations.attempts,
+      })
+      .from(projectProfileSyncOperations)
+      .where(
+        and(
+          eq(projectProfileSyncOperations.id, input.operationId),
+          eq(projectProfileSyncOperations.projectId, input.projectId),
+          eq(projectProfileSyncOperations.organizationId, organizationId),
+        ),
+      )
+      .limit(1)
+    const operation = operationRows[0]
+    if (!operation) return { success: false, error: "Synchronization operation not found." }
+    const numbers = syncProjectNumbers(operation.payloadJson)
+    if (!numbers) return { success: false, error: "Synchronization operation has invalid project-number data." }
+    const projectRows = await db
+      .select({
+        id: projects.id,
+        projectNumber: projects.projectNumber,
+        name: projects.name,
+        address: projects.address,
+        mailingAddress: projects.mailingAddress,
+        clientName: projects.clientName,
+        projectManager: projects.projectManager,
+        googleDriveFolderId: projects.googleDriveFolderId,
+      })
+      .from(projects)
+      .where(eq(projects.id, input.projectId))
+      .limit(1)
+    const project = projectRows[0]
+    if (!project || !project.projectNumber) return { success: false, error: "Project number is unavailable." }
+    const clients = await projectSyncClients({ db, organizationId, environment: (await getCloudflareContext()).env })
+    const nextAttempts = operation.attempts + 1
+
+    if (operation.operation === "drive_folder_rename") {
+      const driveLinks = await db
+        .select({ externalId: projectExternalLinks.externalId })
+        .from(projectExternalLinks)
+        .where(and(eq(projectExternalLinks.projectId, input.projectId), eq(projectExternalLinks.system, "google_drive")))
+        .limit(1)
+      const folderId = project.googleDriveFolderId ?? driveLinks[0]?.externalId ?? null
+      if (!folderId) throw new Error("No Google Drive folder is linked to this project.")
+      const address = projectAddressParts(project.address)
+      const folderName = buildProjectDriveFolderName({
+        projectNumber: project.projectNumber,
+        projectName: project.name,
+        streetNumber: address.streetNumber,
+        streetName: address.streetName,
+      })
+      await clients.drive.renameFile(user.googleEmail ?? user.email, folderId, folderName)
+    } else if (operation.operation === "tracker_row_update") {
+      const department = trackerDepartment(project.projectNumber)
+      if (!department) throw new Error("Project number has no supported tracker department.")
+      const contactRows = await db
+        .select({ displayName: projectContacts.displayName, companyName: projectContacts.companyName, email: projectContacts.email, phone: projectContacts.phone })
+        .from(projectContacts)
+        .where(and(eq(projectContacts.projectId, input.projectId), eq(projectContacts.contactType, "owner"), eq(projectContacts.active, true)))
+        .orderBy(desc(projectContacts.primaryContact), asc(projectContacts.sortOrder))
+        .limit(1)
+      const contact = contactRows[0]
+      const address = projectAddressParts(project.address)
+      const clientName = project.clientName ?? contact?.displayName ?? ""
+      const nameParts = clientName.trim().split(/\s+/).filter(Boolean)
+      const firstName = nameParts[0] ?? ""
+      const lastName = nameParts.slice(1).join(" ")
+      const driveFolderUrl = project.googleDriveFolderId ? `https://drive.google.com/drive/folders/${project.googleDriveFolderId}` : ""
+      const trackerDestination = departmentTrackingDestination(department)
+      const registryRows = await clients.sheets.getValues(clients.trackerEmail, { spreadsheetId: PROJECT_REGISTRY_DESTINATION.spreadsheetId, range: "'Registry'!A:ZZ" })
+      const registryLayout = locateProjectTrackerLayout(registryRows)
+      if (!registryLayout) throw new Error("Project Registry has no Project Number or Project ID header.")
+      const syncProjectNumbers = [numbers.previousProjectNumber, project.projectNumber]
+      await updateProjectTrackerRow({
+        sheets: clients.sheets,
+        googleEmail: clients.trackerEmail,
+        spreadsheetId: PROJECT_REGISTRY_DESTINATION.spreadsheetId,
+        sheetTitle: PROJECT_REGISTRY_DESTINATION.sheetTitle,
+        rows: registryRows,
+        layout: registryLayout,
+        currentProjectNumbers: syncProjectNumbers,
+        patches: patchProjectTrackerCells({ layout: registryLayout, values: { "project id": project.projectNumber, "project number": project.projectNumber, "street number code": address.streetNumber ?? "", "street name label": address.streetName ?? project.name, "client first name": firstName, "client last name": lastName, "company name": contact?.companyName ?? "", "city state zip": address.cityStateZip ?? "", "folder link": driveFolderUrl, "lead tracker link": `https://docs.google.com/spreadsheets/d/${trackerDestination.spreadsheetId}` } }),
+      })
+      const departmentRows = await clients.sheets.getValues(clients.trackerEmail, { spreadsheetId: trackerDestination.spreadsheetId, range: "'Tracker'!A:ZZ" })
+      const departmentLayout = locateProjectTrackerLayout(departmentRows)
+      if (!departmentLayout) throw new Error(`${trackerDestination.workbookTitle} has no Project Number or Project ID header.`)
+      await updateProjectTrackerRow({
+        sheets: clients.sheets,
+        googleEmail: clients.trackerEmail,
+        spreadsheetId: trackerDestination.spreadsheetId,
+        sheetTitle: trackerDestination.sheetTitle,
+        rows: departmentRows,
+        layout: departmentLayout,
+        currentProjectNumbers: syncProjectNumbers,
+        patches: patchProjectTrackerCells({ layout: departmentLayout, values: { "project id": project.projectNumber, "project number": project.projectNumber, client: clientName, customer: clientName, "builder gc": contact?.companyName ?? clientName, "contact person": clientName, address: project.address ?? "", "project address": project.address ?? "", phone: contact?.phone ?? "", email: contact?.email ?? "", "billing address": project.mailingAddress ?? "", "folder link": driveFolderUrl } }),
+      })
+    } else {
+      return { success: false, error: "Unsupported synchronization operation." }
+    }
+
+    await db
+      .update(projectProfileSyncOperations)
+      .set({ status: "completed", error: null, attempts: nextAttempts, attemptedAt, completedAt: nowIso(), updatedAt: nowIso() })
+      .where(eq(projectProfileSyncOperations.id, operation.id))
+    await writeAuditEvent({ db, organizationId, projectId: input.projectId, actorId: user.id, eventType: "project_profile_sync_completed", entityType: "project_profile_sync_operation", entityId: operation.id, before: null, after: { operation: operation.operation } })
+    revalidateProjectProfile(input.projectId)
+    return { success: true }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : "External synchronization failed."
+    try {
+      const { db } = await projectProfileContext(input.projectId, "update")
+      await db
+        .update(projectProfileSyncOperations)
+        .set({
+          status: "failed",
+          error: errorMessage.slice(0, 1000),
+          attempts: sql`${projectProfileSyncOperations.attempts} + 1`,
+          attemptedAt,
+          updatedAt: nowIso(),
+        })
+        .where(eq(projectProfileSyncOperations.id, input.operationId))
+    } catch (updateError) {
+      console.error("Unable to record project profile synchronization failure", updateError)
+    }
+    console.error("Unable to synchronize project profile", error)
+    revalidateProjectProfile(input.projectId)
+    return { success: false, error: errorMessage }
+  }
+}
+
+export async function updateProjectInformation(input: {
+  readonly projectId: string
+  readonly projectAddress: string | null
+  readonly mailingAddress: string | null
+  readonly clientStatus: ProjectClientStatus
+  readonly jobStatusId: string
+  readonly addressSuffix: string | null
+  readonly updateClientDefaultMailingAddress: boolean
+}): Promise<ProjectProfileResult> {
+  try {
+    const { db, organizationId, user } = await projectProfileContext(input.projectId, "update")
+    if (isDemoUser(user.id)) return { success: false, error: "Demo data cannot be changed." }
+    if (!PROJECT_CLIENT_STATUSES.includes(input.clientStatus)) {
+      return { success: false, error: "Choose Lead or Customer." }
+    }
+    if (!(await validJobStatus({ db, organizationId, jobStatusId: input.jobStatusId }))) {
+      return { success: false, error: "Choose an active governed job status." }
+    }
+
+    const existingRows = await db
+      .select({
+        id: projects.id,
+        projectNumber: projects.projectNumber,
+        address: projects.address,
+        mailingAddress: projects.mailingAddress,
+        clientStatus: projects.clientStatus,
+        jobStatusId: projects.jobStatusId,
+      })
+      .from(projects)
+      .where(and(eq(projects.id, input.projectId), eq(projects.organizationId, organizationId)))
+      .limit(1)
+    const existing = existingRows[0]
+    if (!existing) return { success: false, error: "Project not found." }
+
+    const projectAddress = nullableText(input.projectAddress)
+    const mailingAddress = nullableText(input.mailingAddress)
+    let projectNumber = existing.projectNumber
+    if (input.addressSuffix !== null && existing.projectNumber) {
+      try {
+        projectNumber = buildProjectNumberWithAddressSuffix(
+          existing.projectNumber,
+          input.addressSuffix,
+        )
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Invalid project-number suffix.",
+        }
+      }
+    }
+
+    const numberChanged = projectNumber !== existing.projectNumber && projectNumber !== null
+    if (numberChanged) {
+      const requestedProjectNumber = projectNumber
+      if (!requestedProjectNumber) return { success: false, error: "Project number is unavailable." }
+      const [projectConflict, aliasConflict] = await Promise.all([
+        db
+          .select({ id: projects.id })
+          .from(projects)
+          .where(
+            and(
+              eq(projects.organizationId, organizationId),
+              eq(projects.projectNumber, requestedProjectNumber),
+            ),
+          )
+          .limit(1),
+        db
+          .select({ projectId: projectNumberAliases.projectId })
+          .from(projectNumberAliases)
+          .where(
+            and(
+              eq(projectNumberAliases.organizationId, organizationId),
+              eq(projectNumberAliases.projectNumber, requestedProjectNumber),
+            ),
+          )
+          .limit(1),
+      ])
+      if (projectConflict[0] && projectConflict[0].id !== existing.id) {
+        return { success: false, error: "That project number already exists." }
+      }
+      if (aliasConflict[0] && aliasConflict[0].projectId !== existing.id) {
+        return { success: false, error: "That project number is reserved by a historical project record." }
+      }
+    }
+
+    const linkedCustomers = input.updateClientDefaultMailingAddress
+      ? await db
+        .select({ id: customers.id })
+        .from(projectContacts)
+        .innerJoin(customers, eq(projectContacts.sourceEntityId, customers.id))
+        .where(
+          and(
+            eq(projectContacts.projectId, input.projectId),
+            eq(projectContacts.sourceEntityType, "customer"),
+          ),
+        )
+      : []
+    const updatedAt = nowIso()
+    const projectUpdate = db
+      .update(projects)
+      .set({
+        projectNumber,
+        address: projectAddress,
+        mailingAddress,
+        clientStatus: input.clientStatus,
+        jobStatusId: input.jobStatusId,
+        updatedAt,
+      })
+      .where(and(eq(projects.id, input.projectId), eq(projects.organizationId, organizationId)))
+    const customerUpdates = linkedCustomers.map((customer) =>
+      db
+        .update(customers)
+        .set({ address: mailingAddress, updatedAt })
+        .where(eq(customers.id, customer.id)),
+    )
+    const auditInsert = db.insert(projectProfileAuditEvents).values({
+      id: crypto.randomUUID(),
+      organizationId,
+      projectId: input.projectId,
+      actorUserId: user.id,
+      eventType: "project_information_updated",
+      entityType: "project",
+      entityId: input.projectId,
+      beforeJson: JSON.stringify(existing),
+      afterJson: JSON.stringify({
+        projectNumber,
+        projectAddress,
+        mailingAddress,
+        clientStatus: input.clientStatus,
+        jobStatusId: input.jobStatusId,
+      }),
+      createdAt: updatedAt,
+    })
+    const syncOperationIds: string[] = []
+
+    if (numberChanged) {
+      if (!existing.projectNumber || !projectNumber) {
+        return { success: false, error: "Project number is unavailable." }
+      }
+      const parts = projectNumberParts(projectNumber)
+      if (!parts) return { success: false, error: "Invalid project number." }
+      const reservationRows = await db
+        .select({ id: projectNumberReservations.id })
+        .from(projectNumberReservations)
+        .where(and(eq(projectNumberReservations.projectId, input.projectId), eq(projectNumberReservations.organizationId, organizationId)))
+        .limit(1)
+      const reservationWrite = reservationRows[0]
+        ? db
+          .update(projectNumberReservations)
+          .set({ projectNumber })
+          .where(eq(projectNumberReservations.id, reservationRows[0].id))
+        : db.insert(projectNumberReservations).values({
+          id: crypto.randomUUID(),
+          organizationId,
+          projectId: input.projectId,
+          department: parts.department,
+          sequence: Number(parts.sequence),
+          projectNumber,
+          createdAt: updatedAt,
+        })
+      const driveOperationId = crypto.randomUUID()
+      const trackerOperationId = crypto.randomUUID()
+      syncOperationIds.push(driveOperationId, trackerOperationId)
+      const syncPayload = JSON.stringify({
+        previousProjectNumber: existing.projectNumber,
+        projectNumber,
+      })
+      await db.batch([
+        projectUpdate,
+        ...customerUpdates,
+        reservationWrite,
+        db.insert(projectNumberAliases).values({
+          id: crypto.randomUUID(),
+          organizationId,
+          projectId: input.projectId,
+          projectNumber: existing.projectNumber,
+          createdBy: user.id,
+          createdAt: updatedAt,
+        }).onConflictDoNothing(),
+        db
+          .update(projectExternalLinks)
+          .set({ externalNumber: projectNumber, updatedAt })
+          .where(
+            and(
+              eq(projectExternalLinks.projectId, input.projectId),
+              eq(projectExternalLinks.externalNumber, existing.projectNumber),
+            ),
+          ),
+        db.insert(projectProfileSyncOperations).values([
+          {
+            id: driveOperationId,
+            organizationId,
+            projectId: input.projectId,
+            operation: "drive_folder_rename",
+            status: "pending",
+            payloadJson: syncPayload,
+            error: null,
+            attempts: 0,
+            attemptedAt: null,
+            completedAt: null,
+            createdAt: updatedAt,
+            updatedAt,
+          },
+          {
+            id: trackerOperationId,
+            organizationId,
+            projectId: input.projectId,
+            operation: "tracker_row_update",
+            status: "pending",
+            payloadJson: syncPayload,
+            error: null,
+            attempts: 0,
+            attemptedAt: null,
+            completedAt: null,
+            createdAt: updatedAt,
+            updatedAt,
+          },
+        ]),
+        auditInsert,
+      ])
+    } else if (projectNumber) {
+      const trackerOperationId = crypto.randomUUID()
+      syncOperationIds.push(trackerOperationId)
+      await db.batch([
+        projectUpdate,
+        ...customerUpdates,
+        db.insert(projectProfileSyncOperations).values({
+          id: trackerOperationId,
+          organizationId,
+          projectId: input.projectId,
+          operation: "tracker_row_update",
+          status: "pending",
+          payloadJson: JSON.stringify({
+            previousProjectNumber: projectNumber,
+            projectNumber,
+          }),
+          error: null,
+          attempts: 0,
+          attemptedAt: null,
+          completedAt: null,
+          createdAt: updatedAt,
+          updatedAt,
+        }),
+        auditInsert,
+      ])
+    } else {
+      await db.batch([projectUpdate, ...customerUpdates, auditInsert])
+    }
+    await Promise.all(
+      syncOperationIds.map((operationId) =>
+        retryProjectProfileSyncOperation({ projectId: input.projectId, operationId }),
+      ),
+    )
+    revalidateProjectProfile(input.projectId)
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to update project information", error)
+    return { success: false, error: "Unable to update project information." }
+  }
+}
+
+export async function createProjectNote(input: {
+  readonly projectId: string
+  readonly body: string
+}): Promise<ProjectProfileResult> {
+  try {
+    const body = nullableText(input.body)
+    if (!body) return { success: false, error: "Enter a note." }
+    const { db, organizationId, user } = await projectProfileContext(input.projectId, "update")
+    if (isDemoUser(user.id)) return { success: false, error: "Demo data cannot be changed." }
+    const timestamp = nowIso()
+    const id = crypto.randomUUID()
+    await db.insert(projectNotes).values({
+      id,
+      organizationId,
+      projectId: input.projectId,
+      content: body,
+      createdBy: user.id,
+      updatedBy: user.id,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      deletedAt: null,
+      deletedBy: null,
+    })
+    await writeAuditEvent({ db, organizationId, projectId: input.projectId, actorId: user.id, eventType: "project_note_created", entityType: "project_note", entityId: id, before: null, after: { body } })
+    revalidateProjectProfile(input.projectId)
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to create project note", error)
+    return { success: false, error: "Unable to create project note." }
+  }
+}
+
+export async function deleteProjectNote(input: {
+  readonly projectId: string
+  readonly noteId: string
+}): Promise<ProjectProfileResult> {
+  try {
+    const { db, organizationId, user } = await projectProfileContext(input.projectId, "update")
+    if (isDemoUser(user.id)) return { success: false, error: "Demo data cannot be changed." }
+    const noteRows = await db
+      .select({ content: projectNotes.content })
+      .from(projectNotes)
+      .where(and(eq(projectNotes.id, input.noteId), eq(projectNotes.projectId, input.projectId), isNull(projectNotes.deletedAt)))
+      .limit(1)
+    const note = noteRows[0]
+    if (!note) return { success: false, error: "Note not found." }
+    const timestamp = nowIso()
+    await db
+      .update(projectNotes)
+      .set({ deletedAt: timestamp, deletedBy: user.id, updatedBy: user.id, updatedAt: timestamp })
+      .where(eq(projectNotes.id, input.noteId))
+    await writeAuditEvent({ db, organizationId, projectId: input.projectId, actorId: user.id, eventType: "project_note_deleted", entityType: "project_note", entityId: input.noteId, before: note, after: null })
+    revalidateProjectProfile(input.projectId)
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to delete project note", error)
+    return { success: false, error: "Unable to delete project note." }
+  }
+}
+
+export async function createProjectInteraction(input: {
+  readonly projectId: string
+  readonly interactionType: string
+  readonly direction: "inbound" | "outbound"
+  readonly summary: string
+  readonly occurredAt: string
+  readonly contactId: string | null
+}): Promise<ProjectProfileResult> {
+  try {
+    const summary = nullableText(input.summary)
+    const occurredAt = nullableText(input.occurredAt)
+    if (!summary || !occurredAt || Number.isNaN(new Date(occurredAt).getTime())) {
+      return { success: false, error: "Enter a summary and valid interaction time." }
+    }
+    const interactionType = nullableText(input.interactionType)
+    if (!interactionType) return { success: false, error: "Choose an interaction type." }
+    if (!isMeaningfulClientInteraction({
+      interactionType,
+      direction: input.direction,
+      source: "manual",
+    })) {
+      return { success: false, error: "Choose a valid client interaction type and direction." }
+    }
+    const { db, organizationId, user } = await projectProfileContext(input.projectId, "update")
+    if (isDemoUser(user.id)) return { success: false, error: "Demo data cannot be changed." }
+    if (!input.contactId) return { success: false, error: "Choose an active client contact." }
+    const contactRows = await db
+      .select({ id: projectContacts.id })
+      .from(projectContacts)
+      .where(
+        and(
+          eq(projectContacts.id, input.contactId),
+          eq(projectContacts.projectId, input.projectId),
+          eq(projectContacts.contactType, "owner"),
+          eq(projectContacts.active, true),
+        ),
+      )
+      .limit(1)
+    if (!contactRows[0]) return { success: false, error: "Choose an active client contact on this project." }
+    const timestamp = nowIso()
+    const id = crypto.randomUUID()
+    await db.insert(projectInteractions).values({
+      id,
+      organizationId,
+      projectId: input.projectId,
+      projectContactId: input.contactId,
+      interactionType,
+      direction: input.direction,
+      summary,
+      source: "manual",
+      qualifiesForClientTouch: true,
+      occurredAt: new Date(occurredAt).toISOString(),
+      createdBy: user.id,
+      updatedBy: user.id,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      deletedAt: null,
+      deletedBy: null,
+    })
+    await writeAuditEvent({ db, organizationId, projectId: input.projectId, actorId: user.id, eventType: "client_interaction_created", entityType: "project_interaction", entityId: id, before: null, after: { interactionType, direction: input.direction, summary, occurredAt } })
+    revalidateProjectProfile(input.projectId)
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to create client interaction", error)
+    return { success: false, error: "Unable to create client interaction." }
+  }
+}
+
+export async function deleteProjectInteraction(input: {
+  readonly projectId: string
+  readonly interactionId: string
+}): Promise<ProjectProfileResult> {
+  try {
+    const { db, organizationId, user } = await projectProfileContext(input.projectId, "update")
+    if (isDemoUser(user.id)) return { success: false, error: "Demo data cannot be changed." }
+    const interactionRows = await db
+      .select({ summary: projectInteractions.summary, occurredAt: projectInteractions.occurredAt })
+      .from(projectInteractions)
+      .where(and(eq(projectInteractions.id, input.interactionId), eq(projectInteractions.projectId, input.projectId), isNull(projectInteractions.deletedAt)))
+      .limit(1)
+    const interaction = interactionRows[0]
+    if (!interaction) return { success: false, error: "Interaction not found." }
+    const timestamp = nowIso()
+    await db
+      .update(projectInteractions)
+      .set({ deletedAt: timestamp, deletedBy: user.id, updatedBy: user.id, updatedAt: timestamp })
+      .where(eq(projectInteractions.id, input.interactionId))
+    await writeAuditEvent({ db, organizationId, projectId: input.projectId, actorId: user.id, eventType: "client_interaction_deleted", entityType: "project_interaction", entityId: input.interactionId, before: interaction, after: null })
+    revalidateProjectProfile(input.projectId)
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to delete client interaction", error)
+    return { success: false, error: "Unable to delete client interaction." }
+  }
+}
+
+export async function setProjectFollowUp(input: {
+  readonly projectId: string
+  readonly nextFollowUpAt: string
+  readonly ownerUserId: string | null
+}): Promise<ProjectProfileResult> {
+  try {
+    const nextFollowUpAt = nullableText(input.nextFollowUpAt)
+    if (!nextFollowUpAt || Number.isNaN(new Date(nextFollowUpAt).getTime())) {
+      return { success: false, error: "Choose a valid follow-up date." }
+    }
+    const { db, organizationId, user } = await projectProfileContext(input.projectId, "update")
+    if (isDemoUser(user.id)) return { success: false, error: "Demo data cannot be changed." }
+    if (input.ownerUserId) {
+      const ownerRows = await db
+        .select({ active: users.isActive, role: organizationMembers.role })
+        .from(organizationMembers)
+        .innerJoin(users, eq(users.id, organizationMembers.userId))
+        .where(
+          and(
+            eq(organizationMembers.organizationId, organizationId),
+            eq(organizationMembers.userId, input.ownerUserId),
+          ),
+        )
+        .limit(1)
+      if (!ownerRows[0] || !isEligibleFollowUpOwner(ownerRows[0])) {
+        return { success: false, error: "Choose an active internal organization member." }
+      }
+    }
+    const timestamp = nowIso()
+    await db
+      .insert(projectFollowUps)
+      .values({
+        projectId: input.projectId,
+        organizationId,
+        nextFollowUpAt: new Date(nextFollowUpAt).toISOString(),
+        ownerUserId: input.ownerUserId,
+        createdBy: user.id,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      })
+      .onConflictDoUpdate({
+        target: projectFollowUps.projectId,
+        set: { nextFollowUpAt: new Date(nextFollowUpAt).toISOString(), ownerUserId: input.ownerUserId, updatedAt: timestamp },
+      })
+    await writeAuditEvent({ db, organizationId, projectId: input.projectId, actorId: user.id, eventType: "project_follow_up_set", entityType: "project_follow_up", entityId: input.projectId, before: null, after: { nextFollowUpAt, ownerUserId: input.ownerUserId } })
+    revalidateProjectProfile(input.projectId)
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to set project follow-up", error)
+    return { success: false, error: "Unable to set project follow-up." }
+  }
+}
+
+export async function clearProjectFollowUp(projectId: string): Promise<ProjectProfileResult> {
+  try {
+    const { db, organizationId, user } = await projectProfileContext(projectId, "update")
+    if (isDemoUser(user.id)) return { success: false, error: "Demo data cannot be changed." }
+    const followUpRows = await db
+      .select({ nextFollowUpAt: projectFollowUps.nextFollowUpAt, ownerUserId: projectFollowUps.ownerUserId })
+      .from(projectFollowUps)
+      .where(eq(projectFollowUps.projectId, projectId))
+      .limit(1)
+    const followUp = followUpRows[0]
+    if (!followUp) return { success: true }
+    await db.delete(projectFollowUps).where(eq(projectFollowUps.projectId, projectId))
+    await writeAuditEvent({ db, organizationId, projectId, actorId: user.id, eventType: "project_follow_up_cleared", entityType: "project_follow_up", entityId: projectId, before: followUp, after: null })
+    revalidateProjectProfile(projectId)
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to clear project follow-up", error)
+    return { success: false, error: "Unable to clear project follow-up." }
+  }
+}
+
+export async function createCustomProjectJobStatus(input: {
+  readonly label: string
+  readonly sageCode: string | null
+  readonly followUpCadenceDays: number | null
+}): Promise<ProjectProfileResult> {
+  try {
+    const user = await requireAuth()
+    requireFeaturePermission(user, "project-hub", "update")
+    if (!canManageProjectRegistry(user)) return { success: false, error: "Only project registry managers can add job statuses." }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    if (!env?.DB) throw new Error("Database unavailable")
+    const db = getDb(env.DB)
+    const label = nullableText(input.label)
+    if (!label) return { success: false, error: "Enter a job-status label." }
+    if (input.followUpCadenceDays !== null && (!Number.isInteger(input.followUpCadenceDays) || input.followUpCadenceDays < 1)) {
+      return { success: false, error: "Follow-up cadence must be a positive whole number." }
+    }
+    const timestamp = nowIso()
+    await db.insert(projectJobStatuses).values({
+      id: crypto.randomUUID(), organizationId, label, sageCode: nullableText(input.sageCode), followUpCadenceDays: input.followUpCadenceDays, active: true, sortOrder: 999, createdBy: user.id, createdAt: timestamp, updatedAt: timestamp,
+    })
+    revalidatePath("/dashboard/projects")
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to add job status", error)
+    return { success: false, error: "Unable to add job status." }
+  }
+}
+
+export async function deactivateCustomProjectJobStatus(
+  statusId: string,
+): Promise<ProjectProfileResult> {
+  try {
+    const user = await requireAuth()
+    requireFeaturePermission(user, "project-hub", "update")
+    if (!canManageProjectRegistry(user)) {
+      return { success: false, error: "Only project registry managers can manage job statuses." }
+    }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    if (!env?.DB) throw new Error("Database unavailable")
+    const db = getDb(env.DB)
+    await db
+      .update(projectJobStatuses)
+      .set({ active: false, updatedAt: nowIso() })
+      .where(and(eq(projectJobStatuses.id, statusId), eq(projectJobStatuses.organizationId, organizationId)))
+    revalidatePath("/dashboard/projects")
+    return { success: true }
+  } catch (error) {
+    console.error("Unable to deactivate project job status", error)
+    return { success: false, error: "Unable to deactivate project job status." }
+  }
+}

--- a/src/app/actions/project-registry.ts
+++ b/src/app/actions/project-registry.ts
@@ -301,7 +301,7 @@ export async function updateProjectRegistry(
     const db = getDb(env.DB)
 
     const existing = await db
-      .select({ id: projects.id })
+      .select({ id: projects.id, projectNumber: projects.projectNumber })
       .from(projects)
       .where(
         and(eq(projects.id, projectId), eq(projects.organizationId, orgId))
@@ -318,6 +318,12 @@ export async function updateProjectRegistry(
       return projectNumberResult
     }
     const projectNumber = projectNumberResult
+    if (projectNumber !== existing[0].projectNumber) {
+      return {
+        success: false,
+        error: "Project number corrections must use Project Information so Drive and tracker links remain synchronized.",
+      }
+    }
     const status = optionValue(
       formData,
       "status",

--- a/src/app/dashboard/projects/[id]/information/page.tsx
+++ b/src/app/dashboard/projects/[id]/information/page.tsx
@@ -1,0 +1,35 @@
+export const dynamic = "force-dynamic"
+
+import { notFound } from "next/navigation"
+
+import { getCurrentUser } from "@/lib/auth"
+import { canManageProjectRegistry } from "@/lib/permissions"
+import {
+  getProjectFollowUpOwners,
+  getProjectInformation,
+} from "@/app/actions/project-profile"
+import { ProjectInformationWorkspace } from "@/components/projects/project-information-workspace"
+
+export default async function ProjectInformationPage({
+  params,
+}: {
+  readonly params: Promise<{ id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  const [information, followUpOwners, currentUser] = await Promise.all([
+    getProjectInformation(id),
+    getProjectFollowUpOwners(id),
+    getCurrentUser(),
+  ])
+  if (!information) notFound()
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto p-4 md:p-6">
+      <ProjectInformationWorkspace
+        information={information}
+        followUpOwners={followUpOwners}
+        canManageJobStatuses={canManageProjectRegistry(currentUser)}
+      />
+    </div>
+  )
+}

--- a/src/app/dashboard/projects/[id]/page.tsx
+++ b/src/app/dashboard/projects/[id]/page.tsx
@@ -349,6 +349,15 @@ export default async function ProjectSummaryPage({
           <ProjectEmailAddressCard projectId={id} compact />
         </div>
 
+        <div className="mb-4 sm:mb-5">
+          <Link
+            href={`/dashboard/projects/${id}/information`}
+            className="inline-flex items-center rounded-md border bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-muted"
+          >
+            Project Information & Follow-up
+          </Link>
+        </div>
+
         <section className="mb-4 grid grid-cols-2 gap-x-5 gap-y-3 border-y py-3 sm:mb-5 lg:grid-cols-4">
           <Link
             href={`/dashboard/projects/${id}/schedule`}

--- a/src/app/dashboard/projects/follow-up/page.tsx
+++ b/src/app/dashboard/projects/follow-up/page.tsx
@@ -1,0 +1,13 @@
+export const dynamic = "force-dynamic"
+
+import { getProjectFollowUpQueue } from "@/app/actions/project-profile"
+import { ProjectFollowUpQueue } from "@/components/projects/project-follow-up-queue"
+
+export default async function ProjectFollowUpPage(): Promise<React.ReactElement> {
+  const items = await getProjectFollowUpQueue()
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto p-4 md:p-6">
+      <ProjectFollowUpQueue items={items} />
+    </div>
+  )
+}

--- a/src/components/projects/project-follow-up-queue.tsx
+++ b/src/components/projects/project-follow-up-queue.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import Link from "next/link"
+import { useMemo, useState, type ReactElement } from "react"
+
+import type { ProjectFollowUpQueueItem } from "@/app/actions/project-profile"
+import { Badge } from "@/components/ui/badge"
+
+const STATE_LABELS: Readonly<Record<ProjectFollowUpQueueItem["state"], string>> = {
+  overdue: "Overdue",
+  due: "Due",
+  unrecorded: "No touch recorded",
+  current: "Current",
+  scheduled: "Scheduled",
+}
+
+function followUpStateFilter(
+  value: string,
+): "all" | ProjectFollowUpQueueItem["state"] | null {
+  if (value === "all") return value
+  if (value === "overdue" || value === "due" || value === "unrecorded" || value === "current" || value === "scheduled") {
+    return value
+  }
+  return null
+}
+
+function clientStatusFilter(value: string): "all" | "lead" | "customer" | null {
+  if (value === "all" || value === "lead" || value === "customer") return value
+  return null
+}
+
+function stateVariant(state: ProjectFollowUpQueueItem["state"]): "default" | "secondary" | "destructive" | "outline" {
+  if (state === "overdue") return "destructive"
+  if (state === "due" || state === "unrecorded") return "secondary"
+  if (state === "scheduled") return "outline"
+  return "default"
+}
+
+function lastTouchLabel(item: ProjectFollowUpQueueItem): string {
+  if (item.businessDaysSinceLastTouch === null) return "No recorded client touch"
+  const unit = item.businessDaysSinceLastTouch === 1 ? "business day" : "business days"
+  return `${item.businessDaysSinceLastTouch} ${unit} ago`
+}
+
+export function ProjectFollowUpQueue({
+  items,
+}: {
+  readonly items: readonly ProjectFollowUpQueueItem[]
+}): ReactElement {
+  const [stateFilter, setStateFilter] = useState<"all" | ProjectFollowUpQueueItem["state"]>("all")
+  const [clientFilter, setClientFilter] = useState<"all" | "lead" | "customer">("all")
+  const [jobStatusFilter, setJobStatusFilter] = useState("all")
+  const jobStatuses = useMemo(
+    () => [...new Set(items.map((item) => item.jobStatusLabel))].sort((left, right) => left.localeCompare(right)),
+    [items],
+  )
+  const filtered = items.filter((item) => {
+    return (stateFilter === "all" || item.state === stateFilter)
+      && (clientFilter === "all" || item.clientStatus === clientFilter)
+      && (jobStatusFilter === "all" || item.jobStatusLabel === jobStatusFilter)
+  })
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Client Follow-up</p>
+        <h1 className="mt-1 text-2xl font-semibold tracking-tight">Active leads and jobs</h1>
+        <p className="mt-1 max-w-3xl text-sm text-muted-foreground">Prioritized by meaningful client touch, a staff-set next follow-up, and the governed job-status cadence. Internal technical activity does not reset this clock.</p>
+      </div>
+      <div className="grid gap-3 rounded-lg border bg-card p-4 sm:grid-cols-3">
+        <label className="space-y-1 text-sm"><span className="font-medium">Follow-up state</span><select className="flex h-9 w-full rounded-md border bg-background px-3" value={stateFilter} onChange={(event) => { const next = followUpStateFilter(event.target.value); if (next !== null) setStateFilter(next) }}><option value="all">All states</option>{Object.entries(STATE_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}</select></label>
+        <label className="space-y-1 text-sm"><span className="font-medium">Client status</span><select className="flex h-9 w-full rounded-md border bg-background px-3" value={clientFilter} onChange={(event) => { const next = clientStatusFilter(event.target.value); if (next !== null) setClientFilter(next) }}><option value="all">Leads and customers</option><option value="lead">Leads</option><option value="customer">Customers</option></select></label>
+        <label className="space-y-1 text-sm"><span className="font-medium">Job status</span><select className="flex h-9 w-full rounded-md border bg-background px-3" value={jobStatusFilter} onChange={(event) => setJobStatusFilter(event.target.value)}><option value="all">All job statuses</option>{jobStatuses.map((status) => <option key={status} value={status}>{status}</option>)}</select></label>
+      </div>
+      <p className="text-sm text-muted-foreground">{filtered.length} {filtered.length === 1 ? "project" : "projects"} shown</p>
+      <div className="overflow-hidden rounded-lg border bg-card">
+        {filtered.length === 0 ? <p className="p-6 text-sm text-muted-foreground">No active leads or jobs match these filters.</p> : <div className="divide-y">{filtered.map((item) => <Link key={item.projectId} href={`/dashboard/projects/${item.projectId}/information`} className="block p-4 transition-colors hover:bg-muted/50"><div className="flex flex-wrap items-start justify-between gap-3"><div><p className="font-medium">{item.projectNumber ? `${item.projectNumber} · ` : ""}{item.projectName}</p><p className="mt-1 text-sm text-muted-foreground">{item.clientName ?? "No client named"} · {item.clientStatus === "lead" ? "Lead" : "Customer"} · {item.jobStatusLabel}</p></div><Badge variant={stateVariant(item.state)}>{STATE_LABELS[item.state]}</Badge></div><div className="mt-3 grid gap-2 text-sm sm:grid-cols-3"><p><span className="text-muted-foreground">Last client touch: </span>{lastTouchLabel(item)}</p><p><span className="text-muted-foreground">Next follow-up: </span>{item.nextFollowUpAt ? new Date(item.nextFollowUpAt).toLocaleString() : "Status cadence"}</p><p><span className="text-muted-foreground">Owner: </span>{item.followUpOwnerName ?? "Unassigned"}</p></div></Link>)}</div>}
+      </div>
+    </div>
+  )
+}

--- a/src/components/projects/project-information-workspace.tsx
+++ b/src/components/projects/project-information-workspace.tsx
@@ -1,0 +1,365 @@
+"use client"
+
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useState, useTransition, type FormEvent, type ReactElement } from "react"
+
+import {
+  clearProjectFollowUp,
+  createCustomProjectJobStatus,
+  createProjectInteraction,
+  createProjectNote,
+  deleteProjectInteraction,
+  deleteProjectNote,
+  retryProjectProfileSyncOperation,
+  setProjectFollowUp,
+  updateProjectInformation,
+  type ProjectFollowUpOwner,
+  type ProjectInformation,
+} from "@/app/actions/project-profile"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+
+function suffixFromProjectNumber(projectNumber: string | null): string {
+  if (!projectNumber) return ""
+  const parts = projectNumber.split("-")
+  return parts[2] ?? ""
+}
+
+function dateTimeLocalValue(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ""
+  const local = new Date(date.getTime() - date.getTimezoneOffset() * 60_000)
+  return local.toISOString().slice(0, 16)
+}
+
+function resultMessage(result: { readonly success: boolean; readonly error?: string }): string {
+  return result.success ? "Saved." : (result.error ?? "Unable to save.")
+}
+
+export function ProjectInformationWorkspace({
+  information,
+  followUpOwners,
+  canManageJobStatuses,
+}: {
+  readonly information: ProjectInformation
+  readonly followUpOwners: readonly ProjectFollowUpOwner[]
+  readonly canManageJobStatuses: boolean
+}): ReactElement {
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+  const [projectAddress, setProjectAddress] = useState(
+    information.project.projectAddress ?? "",
+  )
+  const [mailingAddress, setMailingAddress] = useState(
+    information.project.mailingAddress ?? "",
+  )
+  const [clientStatus, setClientStatus] = useState(information.project.clientStatus)
+  const [jobStatusId, setJobStatusId] = useState(information.project.jobStatusId)
+  const [addressSuffix, setAddressSuffix] = useState(
+    suffixFromProjectNumber(information.project.projectNumber),
+  )
+  const [propagateMailingAddress, setPropagateMailingAddress] = useState(false)
+  const [note, setNote] = useState("")
+  const [interactionType, setInteractionType] = useState("call")
+  const [interactionContactId, setInteractionContactId] = useState(
+    information.clientContacts[0]?.id ?? "",
+  )
+  const [direction, setDirection] = useState<"inbound" | "outbound">("outbound")
+  const [interactionSummary, setInteractionSummary] = useState("")
+  const [interactionTime, setInteractionTime] = useState(
+    dateTimeLocalValue(new Date().toISOString()),
+  )
+  const [followUpAt, setFollowUpAt] = useState(
+    information.followUp ? dateTimeLocalValue(information.followUp.nextFollowUpAt) : "",
+  )
+  const [followUpOwnerId, setFollowUpOwnerId] = useState(
+    information.followUp?.ownerUserId ?? "",
+  )
+  const [newJobStatusLabel, setNewJobStatusLabel] = useState("")
+  const [newJobStatusSageCode, setNewJobStatusSageCode] = useState("")
+  const [newJobStatusCadence, setNewJobStatusCadence] = useState("7")
+  const [message, setMessage] = useState<string | null>(null)
+
+  function refreshAfter(result: { readonly success: boolean; readonly error?: string }): void {
+    setMessage(resultMessage(result))
+    if (result.success) router.refresh()
+  }
+
+  function saveProfile(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    startTransition(async () => {
+      const result = await updateProjectInformation({
+        projectId: information.project.id,
+        projectAddress,
+        mailingAddress,
+        clientStatus,
+        jobStatusId,
+        addressSuffix: information.project.projectNumber ? addressSuffix : null,
+        updateClientDefaultMailingAddress: propagateMailingAddress,
+      })
+      refreshAfter(result)
+    })
+  }
+
+  function saveNote(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    startTransition(async () => {
+      const result = await createProjectNote({ projectId: information.project.id, body: note })
+      if (result.success) setNote("")
+      refreshAfter(result)
+    })
+  }
+
+  function saveInteraction(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    startTransition(async () => {
+      const result = await createProjectInteraction({
+        projectId: information.project.id,
+        interactionType,
+        direction,
+        summary: interactionSummary,
+        occurredAt: interactionTime,
+        contactId: interactionContactId || null,
+      })
+      if (result.success) setInteractionSummary("")
+      refreshAfter(result)
+    })
+  }
+
+  function saveFollowUp(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    startTransition(async () => {
+      const result = await setProjectFollowUp({
+        projectId: information.project.id,
+        nextFollowUpAt: followUpAt,
+        ownerUserId: followUpOwnerId || null,
+      })
+      refreshAfter(result)
+    })
+  }
+
+  function removeNote(noteId: string): void {
+    startTransition(async () => {
+      refreshAfter(await deleteProjectNote({ projectId: information.project.id, noteId }))
+    })
+  }
+
+  function removeInteraction(interactionId: string): void {
+    startTransition(async () => {
+      refreshAfter(
+        await deleteProjectInteraction({ projectId: information.project.id, interactionId }),
+      )
+    })
+  }
+
+  function clearFollowUp(): void {
+    startTransition(async () => {
+      const result = await clearProjectFollowUp(information.project.id)
+      if (result.success) {
+        setFollowUpAt("")
+        setFollowUpOwnerId("")
+      }
+      refreshAfter(result)
+    })
+  }
+
+  function createJobStatus(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    const cadence = Number(newJobStatusCadence)
+    startTransition(async () => {
+      const result = await createCustomProjectJobStatus({
+        label: newJobStatusLabel,
+        sageCode: newJobStatusSageCode || null,
+        followUpCadenceDays: Number.isInteger(cadence) && cadence > 0 ? cadence : null,
+      })
+      if (result.success) {
+        setNewJobStatusLabel("")
+        setNewJobStatusSageCode("")
+      }
+      refreshAfter(result)
+    })
+  }
+
+  function retrySyncOperation(operationId: string): void {
+    startTransition(async () => {
+      refreshAfter(
+        await retryProjectProfileSyncOperation({
+          projectId: information.project.id,
+          operationId,
+        }),
+      )
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Project Information
+          </p>
+          <h1 className="mt-1 text-2xl font-semibold tracking-tight">
+            {information.project.projectNumber
+              ? `${information.project.projectNumber} · ${information.project.name}`
+              : information.project.name}
+          </h1>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            Maintain the project record, meaningful client touches, and the next follow-up in one place.
+          </p>
+          {information.projectNumberAliases.length > 0 && (
+            <p className="mt-2 text-sm text-muted-foreground">
+              Previous project number{information.projectNumberAliases.length === 1 ? "" : "s"}: {information.projectNumberAliases.join(", ")}
+            </p>
+          )}
+        </div>
+        <Button asChild variant="outline">
+          <Link href={`/dashboard/projects/${information.project.id}/contacts`}>
+            Manage contacts and email addresses
+          </Link>
+        </Button>
+      </div>
+
+      {message && (
+        <p className="rounded-md border bg-muted/40 px-3 py-2 text-sm" role="status">
+          {message}
+        </p>
+      )}
+
+      <form className="rounded-lg border bg-card p-4 sm:p-5" onSubmit={saveProfile}>
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <h2 className="font-semibold">Core project record</h2>
+            <p className="text-sm text-muted-foreground">
+              Site and mailing addresses are separate. Project-number department and sequence stay fixed.
+            </p>
+          </div>
+          <Badge variant="outline">Office staff editable</Badge>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="project-address">Project / site address</Label>
+            <Textarea id="project-address" value={projectAddress} onChange={(event) => setProjectAddress(event.target.value)} rows={3} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="mailing-address">Mailing address</Label>
+            <Textarea id="mailing-address" value={mailingAddress} onChange={(event) => setMailingAddress(event.target.value)} rows={3} />
+            <label className="flex items-start gap-2 text-sm text-muted-foreground">
+              <input type="checkbox" checked={propagateMailingAddress} onChange={(event) => setPropagateMailingAddress(event.target.checked)} className="mt-1" />
+              Also update this client’s default mailing address.
+            </label>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="client-status">Client status</Label>
+            <select id="client-status" className="flex h-9 w-full rounded-md border bg-background px-3 text-sm" value={clientStatus} onChange={(event) => setClientStatus(event.target.value === "lead" ? "lead" : "customer")}>
+              <option value="lead">Lead</option>
+              <option value="customer">Customer</option>
+            </select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="job-status">Job status</Label>
+            <select id="job-status" className="flex h-9 w-full rounded-md border bg-background px-3 text-sm" value={jobStatusId} onChange={(event) => setJobStatusId(event.target.value)}>
+              {information.jobStatuses.map((status) => <option key={status.id} value={status.id}>{status.label}</option>)}
+            </select>
+          </div>
+          {information.project.projectNumber && (
+            <div className="space-y-2 md:col-span-2">
+              <Label htmlFor="project-suffix">Address-derived project-number suffix</Label>
+              <div className="flex max-w-md items-center gap-2">
+                <Input id="project-suffix" value={addressSuffix} onChange={(event) => setAddressSuffix(event.target.value)} aria-describedby="project-number-help" />
+                <span className="whitespace-nowrap text-sm text-muted-foreground">→ {information.project.projectNumber.replace(/-[^-]+$/, `-${addressSuffix || "00"}`)}</span>
+              </div>
+              <p id="project-number-help" className="text-xs text-muted-foreground">
+                Changing this queues an in-place Google Drive folder rename and Registry/tracker update. Existing folder ID and link are retained.
+              </p>
+            </div>
+          )}
+        </div>
+        <div className="mt-5 flex justify-end"><Button type="submit" disabled={pending}>Save project information</Button></div>
+      </form>
+
+      {canManageJobStatuses && (
+        <section className="rounded-lg border bg-card p-4 sm:p-5">
+          <h2 className="font-semibold">Governed job statuses</h2>
+          <p className="mt-1 text-sm text-muted-foreground">Administrators may add a Sage-aligned status and its follow-up cadence. Staff can select it but cannot create arbitrary values.</p>
+          <form className="mt-4 grid gap-3 md:grid-cols-4" onSubmit={createJobStatus}>
+            <div className="space-y-2 md:col-span-2"><Label htmlFor="new-job-status">Status label</Label><Input id="new-job-status" value={newJobStatusLabel} onChange={(event) => setNewJobStatusLabel(event.target.value)} required /></div>
+            <div className="space-y-2"><Label htmlFor="new-job-status-code">Sage code</Label><Input id="new-job-status-code" value={newJobStatusSageCode} onChange={(event) => setNewJobStatusSageCode(event.target.value)} /></div>
+            <div className="space-y-2"><Label htmlFor="new-job-status-cadence">Cadence (business days)</Label><Input id="new-job-status-cadence" type="number" min="1" value={newJobStatusCadence} onChange={(event) => setNewJobStatusCadence(event.target.value)} required /></div>
+            <div className="md:col-span-4"><Button type="submit" disabled={pending}>Add governed status</Button></div>
+          </form>
+        </section>
+      )}
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <section className="rounded-lg border bg-card p-4 sm:p-5">
+          <h2 className="font-semibold">Client follow-up</h2>
+          <p className="mt-1 text-sm text-muted-foreground">Set the next explicit follow-up; the queue also calculates status-based staleness from meaningful touches.</p>
+          <form className="mt-4 grid gap-3 sm:grid-cols-2" onSubmit={saveFollowUp}>
+            <div className="space-y-2"><Label htmlFor="follow-up-at">Next follow-up</Label><Input id="follow-up-at" type="datetime-local" value={followUpAt} onChange={(event) => setFollowUpAt(event.target.value)} required /></div>
+            <div className="space-y-2"><Label htmlFor="follow-up-owner">Owner</Label><select id="follow-up-owner" className="flex h-9 w-full rounded-md border bg-background px-3 text-sm" value={followUpOwnerId} onChange={(event) => setFollowUpOwnerId(event.target.value)}><option value="">Unassigned</option>{followUpOwners.map((owner) => <option key={owner.id} value={owner.id}>{owner.displayName}</option>)}</select></div>
+            <div className="flex flex-wrap gap-2 sm:col-span-2"><Button type="submit" disabled={pending}>Set follow-up</Button>{information.followUp && <Button type="button" variant="outline" disabled={pending} onClick={clearFollowUp}>Clear follow-up</Button>}</div>
+          </form>
+          {information.followUp && <p className="mt-4 text-sm">Current: <strong>{new Date(information.followUp.nextFollowUpAt).toLocaleString()}</strong>{information.followUp.ownerName ? ` · ${information.followUp.ownerName}` : " · Unassigned"}</p>}
+        </section>
+
+        <section className="rounded-lg border bg-card p-4 sm:p-5">
+          <h2 className="font-semibold">Log client interaction</h2>
+          <p className="mt-1 text-sm text-muted-foreground">Calls, emails, meetings, site visits, and client-facing sends count as meaningful contact.</p>
+          <form className="mt-4 grid gap-3" onSubmit={saveInteraction}>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              <div className="space-y-2">
+                <Label htmlFor="interaction-contact">Client contact</Label>
+                <select id="interaction-contact" className="flex h-9 w-full rounded-md border bg-background px-3 text-sm" value={interactionContactId} onChange={(event) => setInteractionContactId(event.target.value)} required>
+                  <option value="">Choose a client contact</option>
+                  {information.clientContacts.map((contact) => <option key={contact.id} value={contact.id}>{contact.displayName}</option>)}
+                </select>
+              </div>
+              <div className="space-y-2"><Label htmlFor="interaction-type">Type</Label><select id="interaction-type" className="flex h-9 w-full rounded-md border bg-background px-3 text-sm" value={interactionType} onChange={(event) => setInteractionType(event.target.value)}><option value="call">Call</option><option value="email">Email</option><option value="meeting">Meeting</option><option value="site_visit">Site visit</option><option value="client_send">Client-facing send</option></select></div>
+              <div className="space-y-2"><Label htmlFor="interaction-direction">Direction</Label><select id="interaction-direction" className="flex h-9 w-full rounded-md border bg-background px-3 text-sm" value={direction} onChange={(event) => setDirection(event.target.value === "inbound" ? "inbound" : "outbound")}><option value="outbound">Outbound</option><option value="inbound">Inbound</option></select></div>
+              <div className="space-y-2"><Label htmlFor="interaction-time">When</Label><Input id="interaction-time" type="datetime-local" value={interactionTime} onChange={(event) => setInteractionTime(event.target.value)} required /></div>
+            </div>
+            <div className="space-y-2"><Label htmlFor="interaction-summary">Outcome / summary</Label><Textarea id="interaction-summary" value={interactionSummary} onChange={(event) => setInteractionSummary(event.target.value)} rows={3} required /></div>
+            <div><Button type="submit" disabled={pending}>Log interaction</Button></div>
+          </form>
+        </section>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <section className="rounded-lg border bg-card p-4 sm:p-5">
+          <h2 className="font-semibold">Project notes</h2>
+          <form className="mt-3 space-y-2" onSubmit={saveNote}><Textarea value={note} onChange={(event) => setNote(event.target.value)} placeholder="Add a project note…" rows={3} required /><Button type="submit" disabled={pending}>Add note</Button></form>
+          <div className="mt-4 space-y-3">{information.notes.length === 0 ? <p className="text-sm text-muted-foreground">No project notes yet.</p> : information.notes.map((item) => <article className="rounded-md border p-3" key={item.id}><div className="flex items-start justify-between gap-3"><p className="whitespace-pre-wrap text-sm">{item.body}</p><Button type="button" size="sm" variant="ghost" disabled={pending} onClick={() => removeNote(item.id)}>Delete</Button></div><p className="mt-2 text-xs text-muted-foreground">{item.authorName ?? "Unknown"} · {new Date(item.createdAt).toLocaleString()}</p></article>)}</div>
+        </section>
+        <section className="rounded-lg border bg-card p-4 sm:p-5">
+          <h2 className="font-semibold">Meaningful interaction history</h2>
+          <div className="mt-4 space-y-3">{information.interactions.length === 0 ? <p className="text-sm text-muted-foreground">No meaningful client interaction recorded yet.</p> : information.interactions.map((item) => <article className="rounded-md border p-3" key={item.id}><div className="flex items-start justify-between gap-3"><div><Badge variant="outline">{item.direction} · {item.interactionType}</Badge><p className="mt-2 whitespace-pre-wrap text-sm">{item.summary}</p></div><Button type="button" size="sm" variant="ghost" disabled={pending} onClick={() => removeInteraction(item.id)}>Delete</Button></div><p className="mt-2 text-xs text-muted-foreground">{item.authorName ?? "Unknown"} · {new Date(item.occurredAt).toLocaleString()} · {item.source}</p></article>)}</div>
+        </section>
+      </div>
+
+      {information.syncOperations.length > 0 && (
+        <section className="rounded-lg border bg-card p-4 sm:p-5">
+          <h2 className="font-semibold">External synchronization</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Project edits are retained in Compass. Pending or failed Google synchronization is visible here for safe retry.
+          </p>
+          <div className="mt-3 space-y-2">
+            {information.syncOperations.map((operation) => (
+              <div key={operation.id} className="flex flex-wrap items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm">
+                <span>{operation.operation.replaceAll("_", " ")}</span>
+                <span className="flex flex-wrap items-center gap-2">
+                  <Badge variant={operation.status === "failed" ? "destructive" : operation.status === "completed" ? "default" : "secondary"}>{operation.status}</Badge>
+                  {operation.error && <span className="text-destructive">{operation.error}</span>}
+                  {operation.status !== "completed" && <Button type="button" size="sm" variant="outline" disabled={pending} onClick={() => retrySyncOperation(operation.id)}>Retry</Button>}
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}

--- a/src/db/__tests__/project-profile-schema.test.ts
+++ b/src/db/__tests__/project-profile-schema.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  projectInteractions,
+  projectJobStatuses,
+  projectNotes,
+  projectNumberAliases,
+  projectProfileAuditEvents,
+  projectProfileSyncOperations,
+  projectFollowUps,
+  projects,
+} from "@/db/schema"
+
+describe("project profile persistence contract", () => {
+  it("keeps mailing and project addresses distinct from legacy project data", () => {
+    expect(projects.mailingAddress.name).toBe("mailing_address")
+    expect(projects.clientStatus.name).toBe("client_status")
+    expect(projects.jobStatusId.name).toBe("job_status_id")
+  })
+
+  it("persists governed job statuses separately from projects", () => {
+    expect(projectJobStatuses.organizationId.name).toBe("organization_id")
+    expect(projectJobStatuses.followUpCadenceDays.name).toBe("follow_up_cadence_days")
+    expect(projectJobStatuses.active.name).toBe("active")
+  })
+
+  it("records editable notes, meaningful interactions, and before-after audit history", () => {
+    expect(projectNotes.deletedAt.name).toBe("deleted_at")
+    expect(projectInteractions.occurredAt.name).toBe("occurred_at")
+    expect(projectInteractions.qualifiesForClientTouch.name).toBe("qualifies_for_client_touch")
+    expect(projectInteractions.direction.name).toBe("direction")
+    expect(projectProfileAuditEvents.beforeJson.name).toBe("before_json")
+    expect(projectProfileAuditEvents.afterJson.name).toBe("after_json")
+  })
+
+  it("persists retryable external profile sync work", () => {
+    expect(projectProfileSyncOperations.operation.name).toBe("operation")
+    expect(projectProfileSyncOperations.status.name).toBe("status")
+    expect(projectProfileSyncOperations.payloadJson.name).toBe("payload_json")
+  })
+
+  it("stores a project-owned next follow-up assignment", () => {
+    expect(projectFollowUps.projectId.name).toBe("project_id")
+    expect(projectFollowUps.nextFollowUpAt.name).toBe("next_follow_up_at")
+    expect(projectFollowUps.ownerUserId.name).toBe("owner_user_id")
+  })
+
+  it("retains historical project numbers for search and audit", () => {
+    expect(projectNumberAliases.projectNumber.name).toBe("project_number")
+    expect(projectNumberAliases.projectId.name).toBe("project_id")
+  })
+})

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -452,7 +452,11 @@ export const projects = sqliteTable("projects", {
   projectNumber: text("project_number"),
   name: text("name").notNull(),
   status: text("status").notNull().default("OPEN"),
+  // `address` remains the project/site address for compatibility with existing data.
   address: text("address"),
+  mailingAddress: text("mailing_address"),
+  clientStatus: text("client_status").notNull().default("customer"),
+  jobStatusId: text("job_status_id").notNull().default("current"),
   clientName: text("client_name"),
   projectManager: text("project_manager"),
   organizationId: text("organization_id").references(() => organizations.id),
@@ -501,6 +505,136 @@ export const projectNumberReservations = sqliteTable(
     ),
   ]
 )
+
+export const projectNumberAliases = sqliteTable(
+  "project_number_aliases",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    projectNumber: text("project_number").notNull(),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("project_number_aliases_org_number_unique").on(
+      table.organizationId,
+      table.projectNumber,
+    ),
+  ],
+)
+
+export const projectJobStatuses = sqliteTable(
+  "project_job_statuses",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    label: text("label").notNull(),
+    sageCode: text("sage_code"),
+    followUpCadenceDays: integer("follow_up_cadence_days"),
+    active: integer("active", { mode: "boolean" }).notNull().default(true),
+    sortOrder: integer("sort_order").notNull().default(1000),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("project_job_statuses_org_label_unique").on(
+      table.organizationId,
+      table.label,
+    ),
+    index("project_job_statuses_org_active_idx").on(
+      table.organizationId,
+      table.active,
+      table.sortOrder,
+    ),
+  ],
+)
+
+export const projectProfileAuditEvents = sqliteTable(
+  "project_profile_audit_events",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    actorUserId: text("actor_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    eventType: text("event_type").notNull(),
+    entityType: text("entity_type").notNull(),
+    entityId: text("entity_id"),
+    beforeJson: text("before_json"),
+    afterJson: text("after_json"),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    index("project_profile_audit_events_project_created_idx").on(
+      table.projectId,
+      table.createdAt,
+    ),
+  ],
+)
+
+export const projectProfileSyncOperations = sqliteTable(
+  "project_profile_sync_operations",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    operation: text("operation").notNull(),
+    status: text("status").notNull().default("pending"),
+    payloadJson: text("payload_json").notNull(),
+    error: text("error"),
+    attempts: integer("attempts").notNull().default(0),
+    attemptedAt: text("attempted_at"),
+    completedAt: text("completed_at"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    index("project_profile_sync_operations_project_status_idx").on(
+      table.projectId,
+      table.status,
+      table.createdAt,
+    ),
+  ],
+)
+
+export const projectFollowUps = sqliteTable("project_follow_ups", {
+  projectId: text("project_id")
+    .primaryKey()
+    .references(() => projects.id, { onDelete: "cascade" }),
+  organizationId: text("organization_id")
+    .notNull()
+    .references(() => organizations.id, { onDelete: "cascade" }),
+  nextFollowUpAt: text("next_follow_up_at").notNull(),
+  ownerUserId: text("owner_user_id").references(() => users.id, {
+    onDelete: "set null",
+  }),
+  createdBy: text("created_by").references(() => users.id, {
+    onDelete: "set null",
+  }),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+})
 
 export const activityEvents = sqliteTable(
   "activity_events",
@@ -1561,6 +1695,85 @@ export const projectContacts = sqliteTable("project_contacts", {
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
 })
+
+export const projectNotes = sqliteTable(
+  "project_notes",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    content: text("content").notNull(),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    updatedBy: text("updated_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    deletedBy: text("deleted_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("project_notes_project_created_idx").on(
+      table.projectId,
+      table.createdAt,
+    ),
+  ],
+)
+
+export const projectInteractions = sqliteTable(
+  "project_interactions",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    projectContactId: text("project_contact_id").references(
+      () => projectContacts.id,
+      { onDelete: "set null" },
+    ),
+    interactionType: text("interaction_type").notNull(),
+    direction: text("direction").notNull(),
+    source: text("source").notNull().default("manual"),
+    qualifiesForClientTouch: integer("qualifies_for_client_touch", {
+      mode: "boolean",
+    }).notNull().default(false),
+    summary: text("summary").notNull(),
+    occurredAt: text("occurred_at").notNull(),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    updatedBy: text("updated_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    deletedBy: text("deleted_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [
+    index("project_interactions_project_occurred_idx").on(
+      table.projectId,
+      table.occurredAt,
+    ),
+    index("project_interactions_org_occurred_idx").on(
+      table.organizationId,
+      table.occurredAt,
+    ),
+  ],
+)
 
 export const projectContactSourceLinks = sqliteTable("project_contact_source_links", {
   id: text("id").primaryKey(),

--- a/src/lib/__tests__/project-follow-up.test.ts
+++ b/src/lib/__tests__/project-follow-up.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest"
+
+import { clientFollowUpState } from "@/lib/project-follow-up"
+
+describe("client follow-up state", () => {
+  it("shows business days since the last meaningful client interaction", () => {
+    expect(
+      clientFollowUpState({
+        jobStatusId: "estimate_sent",
+        interactions: [
+          { occurredAt: "2026-08-14T16:00:00.000Z", deletedAt: null, qualifiesForClientTouch: true },
+        ],
+        nextFollowUpAt: null,
+        now: new Date("2026-08-21T16:00:00.000Z"),
+      }),
+    ).toMatchObject({
+      eligible: true,
+      businessDaysSinceLastTouch: 5,
+      state: "overdue",
+    })
+  })
+
+  it("uses a staff-set follow-up date without losing the last-touch age", () => {
+    expect(
+      clientFollowUpState({
+        jobStatusId: "engineering",
+        interactions: [
+          { occurredAt: "2026-08-18T16:00:00.000Z", deletedAt: null, qualifiesForClientTouch: true },
+        ],
+        nextFollowUpAt: "2026-08-25T16:00:00.000Z",
+        now: new Date("2026-08-21T16:00:00.000Z"),
+      }),
+    ).toMatchObject({
+      eligible: true,
+      businessDaysSinceLastTouch: 3,
+      state: "scheduled",
+      nextFollowUpAt: "2026-08-25T16:00:00.000Z",
+    })
+  })
+
+  it("keeps closed work out of the follow-up queue", () => {
+    expect(
+      clientFollowUpState({
+        jobStatusId: "closed",
+        interactions: [
+          { occurredAt: "2026-08-14T16:00:00.000Z", deletedAt: null, qualifiesForClientTouch: true },
+        ],
+        nextFollowUpAt: null,
+        now: new Date("2026-08-21T16:00:00.000Z"),
+      }),
+    ).toEqual({
+      eligible: false,
+      businessDaysSinceLastTouch: null,
+      lastClientInteractionAt: null,
+      nextFollowUpAt: null,
+      state: "excluded",
+    })
+  })
+
+  it("does not count a deleted interaction as a client touch", () => {
+    expect(
+      clientFollowUpState({
+        jobStatusId: "intake",
+        interactions: [
+          { occurredAt: "2026-08-20T16:00:00.000Z", deletedAt: "2026-08-21T16:00:00.000Z", qualifiesForClientTouch: true },
+        ],
+        nextFollowUpAt: null,
+        now: new Date("2026-08-21T16:00:00.000Z"),
+      }),
+    ).toMatchObject({
+      eligible: true,
+      businessDaysSinceLastTouch: null,
+      state: "unrecorded",
+    })
+  })
+
+  it("does not count an interaction that lacks the client-touch flag", () => {
+    expect(
+      clientFollowUpState({
+        jobStatusId: "intake",
+        interactions: [
+          {
+            occurredAt: "2026-08-20T16:00:00.000Z",
+            deletedAt: null,
+            qualifiesForClientTouch: false,
+          },
+        ],
+        nextFollowUpAt: null,
+        now: new Date("2026-08-21T16:00:00.000Z"),
+      }),
+    ).toMatchObject({
+      eligible: true,
+      businessDaysSinceLastTouch: null,
+      state: "unrecorded",
+    })
+  })
+
+  it("supports administrator-governed custom cadence without treating it as a built-in status", () => {
+    expect(
+      clientFollowUpState({
+        jobStatusId: "custom-status-id",
+        cadenceDays: 4,
+        interactions: [
+          { occurredAt: "2026-08-14T16:00:00.000Z", deletedAt: null, qualifiesForClientTouch: true },
+        ],
+        nextFollowUpAt: null,
+        now: new Date("2026-08-21T16:00:00.000Z"),
+      }),
+    ).toMatchObject({ eligible: true, state: "overdue" })
+  })
+
+  it("does not include a custom status with no follow-up cadence", () => {
+    expect(
+      clientFollowUpState({
+        jobStatusId: "custom-complete-id",
+        cadenceDays: null,
+        interactions: [],
+        nextFollowUpAt: null,
+        now: new Date("2026-08-21T16:00:00.000Z"),
+      }),
+    ).toMatchObject({ eligible: false, state: "excluded" })
+  })
+})

--- a/src/lib/__tests__/project-profile.test.ts
+++ b/src/lib/__tests__/project-profile.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  FOLLOW_UP_EXCLUDED_JOB_STATUSES,
+  PROJECT_CLIENT_STATUSES,
+  PROJECT_JOB_STATUS_DEFINITIONS,
+  buildProjectNumberWithAddressSuffix,
+  defaultFollowUpCadenceDays,
+  isFollowUpEligibleJobStatus,
+  isEligibleFollowUpOwner,
+  isMeaningfulClientInteraction,
+  projectNumberParts,
+} from "@/lib/project-profile"
+
+describe("project profile rules", () => {
+  it("keeps client status limited to lead and customer", () => {
+    expect(PROJECT_CLIENT_STATUSES).toEqual(["lead", "customer"])
+  })
+
+  it("keeps the approved Sage-aligned job statuses standardized", () => {
+    expect(PROJECT_JOB_STATUS_DEFINITIONS.map((status) => status.label)).toEqual(
+      expect.arrayContaining([
+        "Intake",
+        "Estimate Sent",
+        "Design Proposal Signed",
+        "Awarded",
+        "Under Construction",
+        "Punchlist",
+        "Bid Refused",
+      ]),
+    )
+  })
+
+  it("replaces only the address-derived number suffix", () => {
+    expect(buildProjectNumberWithAddressSuffix("H-430-00", "2150")).toBe(
+      "H-430-2150",
+    )
+    expect(projectNumberParts("H-430-2150")).toEqual({
+      department: "H",
+      sequence: "430",
+      addressSuffix: "2150",
+    })
+  })
+
+  it("rejects a number edit that would alter the department or sequence", () => {
+    expect(() => buildProjectNumberWithAddressSuffix("H-430-00", "21/50")).toThrow(
+      "letters and numbers",
+    )
+    expect(projectNumberParts("Not a project number")).toBeNull()
+  })
+
+  it("excludes completed and inactive states from client follow-up", () => {
+    for (const statusId of FOLLOW_UP_EXCLUDED_JOB_STATUSES) {
+      expect(isFollowUpEligibleJobStatus(statusId)).toBe(false)
+    }
+    expect(isFollowUpEligibleJobStatus("estimate_sent")).toBe(true)
+  })
+
+  it("uses status-specific client follow-up cadences", () => {
+    expect(defaultFollowUpCadenceDays("intake")).toBe(2)
+    expect(defaultFollowUpCadenceDays("estimate_sent")).toBe(3)
+    expect(defaultFollowUpCadenceDays("engineering")).toBe(7)
+  })
+
+  it("counts only validated client communications as meaningful touches", () => {
+    expect(
+      isMeaningfulClientInteraction({ interactionType: "call", direction: "outbound", source: "manual" }),
+    ).toBe(true)
+    expect(
+      isMeaningfulClientInteraction({ interactionType: "email", direction: "inbound", source: "email" }),
+    ).toBe(true)
+    expect(
+      isMeaningfulClientInteraction({ interactionType: "sms", direction: "inbound", source: "goto_sms" }),
+    ).toBe(true)
+    expect(
+      isMeaningfulClientInteraction({ interactionType: "schedule_change", direction: "outbound", source: "manual" }),
+    ).toBe(false)
+    expect(
+      isMeaningfulClientInteraction({ interactionType: "email", direction: "outbound", source: "background_sync" }),
+    ).toBe(false)
+  })
+
+  it("allows follow-up owners only when they are active internal members", () => {
+    expect(isEligibleFollowUpOwner({ active: true, role: "office" })).toBe(true)
+    expect(isEligibleFollowUpOwner({ active: false, role: "office" })).toBe(false)
+    expect(isEligibleFollowUpOwner({ active: true, role: "owner" })).toBe(false)
+  })
+})

--- a/src/lib/email/project-inbound-routing.ts
+++ b/src/lib/email/project-inbound-routing.ts
@@ -11,6 +11,7 @@ import {
   projectContacts,
   projectChangeOrderHistory,
   projectChangeOrders,
+  projectInteractions,
   projectOperations,
   projectRfis,
   projectVideos,
@@ -35,6 +36,7 @@ import {
 import { storeDailyLogEmailAttachments } from "@/lib/email/project-email-attachments"
 import { storeProjectVideoAttachment } from "@/lib/email/project-video-attachments"
 import { projectDepartment } from "@/lib/project-branding"
+import { isMeaningfulClientInteraction } from "@/lib/project-profile"
 import { youtubeChannelForDepartment } from "@/lib/videos/channel-routing"
 import {
   isYoutubeApiAuditApproved,
@@ -101,6 +103,58 @@ function senderLabel(candidate: InboundCandidate): string {
   return candidate.fromName?.trim() || candidate.fromAddress
 }
 
+async function recordVerifiedInboundClientInteraction(input: {
+  readonly db: Db
+  readonly organizationId: string
+  readonly projectId: string
+  readonly candidate: InboundCandidate
+  readonly source: ProjectInboundSource
+}): Promise<void> {
+  const title = projectEmailTitle(input.candidate.subject) || input.candidate.subject
+  const [contact] = await input.db
+    .select({ id: projectContacts.id })
+    .from(projectContacts)
+    .where(
+      and(
+        eq(projectContacts.projectId, input.projectId),
+        eq(projectContacts.contactType, "owner"),
+        eq(projectContacts.active, true),
+        sql`lower(${projectContacts.email}) = ${input.candidate.fromAddress.trim().toLowerCase()}`,
+      ),
+    )
+    .limit(1)
+  if (!contact) return
+  const interactionType = input.source.kind === "email" ? "email" : "sms"
+  if (!isMeaningfulClientInteraction({
+    interactionType,
+    direction: "inbound",
+    source: input.source.sourceSystem,
+  })) {
+    throw new Error("Verified inbound route has an unsupported client interaction type.")
+  }
+  const summary = `${input.source.label} from ${senderLabel(input.candidate)}: ${title}`
+  await input.db
+    .insert(projectInteractions)
+    .values({
+      id: `project-interaction-${input.source.idPrefix}-${input.candidate.gmailMessageId}`,
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      projectContactId: contact.id,
+      interactionType,
+      direction: "inbound",
+      source: input.source.sourceSystem,
+      qualifiesForClientTouch: true,
+      summary,
+      occurredAt: input.candidate.receivedAt,
+      createdBy: null,
+      updatedBy: null,
+      deletedBy: null,
+      createdAt: input.candidate.receivedAt,
+      updatedAt: input.candidate.receivedAt,
+      deletedAt: null,
+    })
+    .onConflictDoNothing()
+}
 function inboundActor(
   candidate: InboundCandidate,
   source: ProjectInboundSource
@@ -728,6 +782,13 @@ async function routeVerifiedProjectInboundMessage(input: {
       attachmentCount: input.candidate.attachments.length,
     },
     createdAt: input.candidate.receivedAt,
+  })
+  await recordVerifiedInboundClientInteraction({
+    db: input.db,
+    organizationId: input.organizationId,
+    projectId,
+    candidate: input.candidate,
+    source: input.source,
   })
   return {
     kind: "routed",

--- a/src/lib/google/client/sheets-client.ts
+++ b/src/lib/google/client/sheets-client.ts
@@ -171,4 +171,38 @@ export class SheetsClient {
     const updates = objectValue(payload?.updates)
     return { updatedRange: stringValue(updates?.updatedRange) }
   }
+
+  async updateValues(
+    userEmail: string,
+    input: {
+      readonly spreadsheetId: string
+      readonly range: string
+      readonly values: ReadonlyArray<ReadonlyArray<unknown>>
+    }
+  ): Promise<GoogleSheetAppendResult> {
+    const token = await getAccessToken(this.serviceAccountKey, userEmail)
+    const params = new URLSearchParams({ valueInputOption: "RAW" })
+    const range = encodeURIComponent(input.range)
+    const response = await fetch(
+      `${GOOGLE_SHEETS_API}/${input.spreadsheetId}/values/${range}?${params.toString()}`,
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ values: input.values }),
+      }
+    )
+
+    if (!response.ok) {
+      const body = await response.text()
+      throw new Error(
+        `Google Sheets API error (${response.status}): ${body.slice(0, 500)}`
+      )
+    }
+    const payload = objectValue(await response.json())
+    const updates = objectValue(payload?.updates)
+    return { updatedRange: stringValue(updates?.updatedRange) }
+  }
 }

--- a/src/lib/google/project-intake-tracker.ts
+++ b/src/lib/google/project-intake-tracker.ts
@@ -32,6 +32,17 @@ export type ProjectTrackingDestination = {
   readonly divisionLabel: "ORC" | "HPS" | "NuTech" | "Design"
 }
 
+export type ProjectTrackerWriteClient = {
+  readonly updateValues: (
+    userEmail: string,
+    input: {
+      readonly spreadsheetId: string
+      readonly range: string
+      readonly values: ReadonlyArray<ReadonlyArray<unknown>>
+    },
+  ) => Promise<{ readonly updatedRange: string | null }>
+}
+
 export const PROJECT_REGISTRY_DESTINATION = {
   spreadsheetId: "1Gwmxfm2wzVgrmov9qSxnFxyX_WJDa5gPbk6VgoZI46I",
   workbookTitle: "Project Registry",
@@ -118,6 +129,77 @@ export function projectRowNumber(
     if (value.toUpperCase() === normalizedProjectNumber) return rowIndex + 1
   }
   return null
+}
+
+function spreadsheetColumnName(columnCount: number): string {
+  if (!Number.isInteger(columnCount) || columnCount < 1) {
+    throw new Error("Tracker row needs at least one column.")
+  }
+
+  let remaining = columnCount
+  let label = ""
+  while (remaining > 0) {
+    remaining -= 1
+    label = String.fromCharCode(65 + (remaining % 26)) + label
+    remaining = Math.floor(remaining / 26)
+  }
+  return label
+}
+
+function quotedSheetRange(sheetTitle: string, range: string): string {
+  return `'${sheetTitle.replaceAll("'", "''")}'!${range}`
+}
+
+export type ProjectTrackerCellPatch = {
+  readonly column: number
+  readonly value: string
+}
+
+export function patchProjectTrackerCells(input: {
+  readonly layout: ProjectTrackerLayout
+  readonly values: Readonly<Record<string, string>>
+}): readonly ProjectTrackerCellPatch[] {
+  const normalizedValues = new Map(
+    Object.entries(input.values).map(([header, value]) => [normalizedHeader(header), value]),
+  )
+  return input.layout.headers.flatMap((header, column) => {
+    const value = normalizedValues.get(normalizedHeader(header))
+    return value === undefined ? [] : [{ column, value }]
+  })
+}
+
+export async function updateProjectTrackerRow(input: {
+  readonly sheets: ProjectTrackerWriteClient
+  readonly googleEmail: string
+  readonly spreadsheetId: string
+  readonly sheetTitle: string
+  readonly rows: ReadonlyArray<ReadonlyArray<unknown>>
+  readonly layout: ProjectTrackerLayout
+  readonly currentProjectNumbers: readonly string[]
+  readonly patches: readonly ProjectTrackerCellPatch[]
+}): Promise<{ readonly updatedRange: string | null; readonly rowNumber: number }> {
+  const rowNumber = input.currentProjectNumbers
+    .map((projectNumber) => projectRowNumber(input.rows, input.layout, projectNumber))
+    .find((candidate): candidate is number => candidate !== null)
+  if (rowNumber === undefined) {
+    throw new Error(
+      `Project ${input.currentProjectNumbers.join(" or ")} is not present in ${input.sheetTitle}.`,
+    )
+  }
+
+  let updatedRange: string | null = null
+  for (const patch of input.patches) {
+    const result = await input.sheets.updateValues(input.googleEmail, {
+      spreadsheetId: input.spreadsheetId,
+      range: quotedSheetRange(
+        input.sheetTitle,
+        `${spreadsheetColumnName(patch.column + 1)}${rowNumber}`,
+      ),
+      values: [[patch.value]],
+    })
+    updatedRange = result.updatedRange
+  }
+  return { updatedRange, rowNumber }
 }
 
 export function allocateProjectNumber(input: {

--- a/src/lib/project-follow-up.ts
+++ b/src/lib/project-follow-up.ts
@@ -1,0 +1,130 @@
+import { defaultFollowUpCadenceDays } from "@/lib/project-profile"
+
+export type ClientInteractionTime = {
+  readonly occurredAt: string
+  readonly deletedAt: string | null
+  readonly qualifiesForClientTouch: boolean
+}
+
+export type ClientFollowUpState = {
+  readonly eligible: boolean
+  readonly businessDaysSinceLastTouch: number | null
+  readonly lastClientInteractionAt: string | null
+  readonly nextFollowUpAt: string | null
+  readonly state: "current" | "due" | "overdue" | "scheduled" | "unrecorded" | "excluded"
+}
+
+function validDate(value: string): Date | null {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function startOfUtcDay(value: Date): Date {
+  return new Date(
+    Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate()),
+  )
+}
+
+function businessDaysBetween(start: Date, end: Date): number {
+  const firstDay = startOfUtcDay(start)
+  const lastDay = startOfUtcDay(end)
+  if (lastDay.getTime() <= firstDay.getTime()) return 0
+
+  let days = 0
+  const cursor = new Date(firstDay)
+  cursor.setUTCDate(cursor.getUTCDate() + 1)
+  while (cursor.getTime() <= lastDay.getTime()) {
+    const day = cursor.getUTCDay()
+    if (day !== 0 && day !== 6) days += 1
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  }
+  return days
+}
+
+function latestInteraction(
+  interactions: readonly ClientInteractionTime[],
+): ClientInteractionTime | null {
+  return interactions.reduce<ClientInteractionTime | null>((latest, interaction) => {
+    if (
+      !interaction.qualifiesForClientTouch
+      || interaction.deletedAt !== null
+      || validDate(interaction.occurredAt) === null
+    ) {
+      return latest
+    }
+    if (latest === null || interaction.occurredAt > latest.occurredAt) {
+      return interaction
+    }
+    return latest
+  }, null)
+}
+
+export function clientFollowUpState(input: {
+  readonly jobStatusId: string
+  readonly cadenceDays?: number | null
+  readonly interactions: readonly ClientInteractionTime[]
+  readonly nextFollowUpAt: string | null
+  readonly now: Date
+}): ClientFollowUpState {
+  const cadenceDays =
+    input.cadenceDays === undefined
+      ? defaultFollowUpCadenceDays(input.jobStatusId)
+      : input.cadenceDays
+  if (cadenceDays === null) {
+    return {
+      eligible: false,
+      businessDaysSinceLastTouch: null,
+      lastClientInteractionAt: null,
+      nextFollowUpAt: null,
+      state: "excluded",
+    }
+  }
+
+  const latest = latestInteraction(input.interactions)
+  if (!latest) {
+    return {
+      eligible: true,
+      businessDaysSinceLastTouch: null,
+      lastClientInteractionAt: null,
+      nextFollowUpAt: input.nextFollowUpAt,
+      state: "unrecorded",
+    }
+  }
+
+  const occurredAt = validDate(latest.occurredAt)
+  if (!occurredAt) {
+    return {
+      eligible: true,
+      businessDaysSinceLastTouch: null,
+      lastClientInteractionAt: null,
+      nextFollowUpAt: input.nextFollowUpAt,
+      state: "unrecorded",
+    }
+  }
+
+  const businessDaysSinceLastTouch = businessDaysBetween(occurredAt, input.now)
+  const scheduledAt = input.nextFollowUpAt ? validDate(input.nextFollowUpAt) : null
+  if (scheduledAt && scheduledAt.getTime() > input.now.getTime()) {
+    return {
+      eligible: true,
+      businessDaysSinceLastTouch,
+      lastClientInteractionAt: latest.occurredAt,
+      nextFollowUpAt: input.nextFollowUpAt,
+      state: "scheduled",
+    }
+  }
+
+  const state =
+    businessDaysSinceLastTouch > cadenceDays
+      ? "overdue"
+      : businessDaysSinceLastTouch === cadenceDays
+        ? "due"
+        : "current"
+  return {
+    eligible: true,
+    businessDaysSinceLastTouch,
+    lastClientInteractionAt: latest.occurredAt,
+    nextFollowUpAt: input.nextFollowUpAt,
+    state,
+  }
+}

--- a/src/lib/project-profile.ts
+++ b/src/lib/project-profile.ts
@@ -1,0 +1,204 @@
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+export const PROJECT_CLIENT_STATUSES = ["lead", "customer"] as const
+
+const MANUAL_MEANINGFUL_INTERACTION_TYPES = new Set([
+  "call",
+  "email",
+  "meeting",
+  "site_visit",
+  "client_send",
+])
+
+export function isMeaningfulClientInteraction(input: {
+  readonly interactionType: string
+  readonly direction: string
+  readonly source: string
+}): boolean {
+  if (input.source === "manual") {
+    return (
+      (input.direction === "inbound" || input.direction === "outbound")
+      && MANUAL_MEANINGFUL_INTERACTION_TYPES.has(input.interactionType)
+    )
+  }
+  return (
+    input.direction === "inbound"
+    && ((input.source === "email" && input.interactionType === "email")
+      || (input.source === "goto_sms" && input.interactionType === "sms"))
+  )
+}
+
+export function isEligibleFollowUpOwner(input: {
+  readonly active: boolean
+  readonly role: string
+}): boolean {
+  return input.active && isInternalStaffRole(input.role)
+}
+
+export type ProjectClientStatus = (typeof PROJECT_CLIENT_STATUSES)[number]
+
+export type ProjectJobStatusDefinition = {
+  readonly id: string
+  readonly label: string
+  readonly followUpCadenceDays: number | null
+}
+
+export const PROJECT_JOB_STATUS_DEFINITIONS = [
+  { id: "intake", label: "Intake", followUpCadenceDays: 2 },
+  {
+    id: "new_client_info_sent",
+    label: "New Client Info Sent",
+    followUpCadenceDays: 2,
+  },
+  {
+    id: "budget_estimating",
+    label: "Budget Estimating",
+    followUpCadenceDays: 3,
+  },
+  {
+    id: "budget_estimate_sent",
+    label: "Budget Estimate Sent",
+    followUpCadenceDays: 3,
+  },
+  { id: "estimating", label: "Estimating", followUpCadenceDays: 3 },
+  {
+    id: "estimate_sent",
+    label: "Estimate Sent",
+    followUpCadenceDays: 3,
+  },
+  {
+    id: "design_proposal",
+    label: "Design Proposal",
+    followUpCadenceDays: 3,
+  },
+  {
+    id: "design_proposal_sent",
+    label: "Design Proposal Sent",
+    followUpCadenceDays: 3,
+  },
+  {
+    id: "design_proposal_signed",
+    label: "Design Proposal Signed",
+    followUpCadenceDays: 3,
+  },
+  { id: "engineering", label: "Engineering", followUpCadenceDays: 7 },
+  { id: "contract_docs", label: "Contract Docs", followUpCadenceDays: 3 },
+  {
+    id: "contract_docs_sent",
+    label: "Contract Docs Sent",
+    followUpCadenceDays: 3,
+  },
+  {
+    id: "contract_docs_signed",
+    label: "Contract Docs Signed",
+    followUpCadenceDays: 3,
+  },
+  { id: "contract", label: "Contract", followUpCadenceDays: 3 },
+  { id: "awarded", label: "Awarded", followUpCadenceDays: 7 },
+  {
+    id: "awaiting_funding",
+    label: "Awaiting Funding",
+    followUpCadenceDays: 7,
+  },
+  {
+    id: "awaiting_groundbreaking",
+    label: "Awaiting Groundbreaking",
+    followUpCadenceDays: 7,
+  },
+  { id: "permitting", label: "Permitting", followUpCadenceDays: 7 },
+  { id: "in_design", label: "In Design", followUpCadenceDays: 7 },
+  {
+    id: "value_engineering",
+    label: "Value Engineering",
+    followUpCadenceDays: 7,
+  },
+  { id: "takeoff", label: "Takeoff", followUpCadenceDays: 7 },
+  { id: "bracing_out", label: "Bracing Out", followUpCadenceDays: 7 },
+  {
+    id: "under_construction",
+    label: "Under Construction",
+    followUpCadenceDays: 7,
+  },
+  { id: "ordered", label: "Ordered", followUpCadenceDays: 7 },
+  { id: "partial_order", label: "Partial Order", followUpCadenceDays: 7 },
+  {
+    id: "price_sheet_sent",
+    label: "Price Sheet Sent",
+    followUpCadenceDays: 7,
+  },
+  { id: "shipping_tbd", label: "Shipping TBD", followUpCadenceDays: 7 },
+  {
+    id: "awaiting_payment",
+    label: "Awaiting Payment",
+    followUpCadenceDays: 7,
+  },
+  { id: "current", label: "Current", followUpCadenceDays: 7 },
+  { id: "punchlist", label: "Punchlist", followUpCadenceDays: 7 },
+  { id: "complete", label: "Complete", followUpCadenceDays: null },
+  { id: "closed", label: "Closed", followUpCadenceDays: null },
+  { id: "bid_refused", label: "Bid Refused", followUpCadenceDays: null },
+  { id: "inactive", label: "Inactive", followUpCadenceDays: null },
+] as const satisfies readonly ProjectJobStatusDefinition[]
+
+export type ProjectJobStatusId = (typeof PROJECT_JOB_STATUS_DEFINITIONS)[number]["id"]
+
+export const FOLLOW_UP_EXCLUDED_JOB_STATUSES = [
+  "complete",
+  "closed",
+  "bid_refused",
+  "inactive",
+] as const satisfies readonly ProjectJobStatusId[]
+
+export type ProjectNumberParts = {
+  readonly department: "O" | "H" | "N" | "D"
+  readonly sequence: string
+  readonly addressSuffix: string
+}
+
+const PROJECT_NUMBER_PATTERN = /^([OHND])-(\d+)-([A-Z0-9]+)$/i
+
+export function projectNumberParts(value: string): ProjectNumberParts | null {
+  const match = PROJECT_NUMBER_PATTERN.exec(value.trim())
+  if (!match) return null
+
+  const department = match[1]?.toUpperCase()
+  const sequence = match[2]
+  const addressSuffix = match[3]?.toUpperCase()
+  if (
+    (department !== "O" && department !== "H" && department !== "N" && department !== "D") ||
+    !sequence ||
+    !addressSuffix
+  ) {
+    return null
+  }
+
+  return { department, sequence, addressSuffix }
+}
+
+export function buildProjectNumberWithAddressSuffix(
+  projectNumber: string,
+  addressSuffix: string,
+): string {
+  const parts = projectNumberParts(projectNumber)
+  if (!parts) {
+    throw new Error("Project number must include a recognized department and sequence.")
+  }
+
+  const normalizedSuffix = addressSuffix.trim().toUpperCase()
+  if (!/^[A-Z0-9]+$/.test(normalizedSuffix)) {
+    throw new Error("Project-number address suffix may contain only letters and numbers.")
+  }
+
+  return `${parts.department}-${parts.sequence}-${normalizedSuffix}`
+}
+
+export function defaultFollowUpCadenceDays(statusId: string): number | null {
+  return (
+    PROJECT_JOB_STATUS_DEFINITIONS.find((status) => status.id === statusId)
+      ?.followUpCadenceDays ?? null
+  )
+}
+
+export function isFollowUpEligibleJobStatus(statusId: string): boolean {
+  return defaultFollowUpCadenceDays(statusId) !== null
+}


### PR DESCRIPTION
## Summary
- Adds an office-staff Project Information workspace for addresses, client/job status, controlled suffix-only number correction, contacts, notes, and meaningful client interactions.
- Adds Client Follow-up queue with active internal ownership, business-day cadence, and terminal-status exclusions.
- Makes project number corrections atomic, preserves Drive folder identity through in-place rename, applies mapped-cell-only Registry/tracker patches, and retains durable retry/audit state.
- Adds forward D1 migrations through `0107`, including historical-number namespace reconciliation and legacy terminal-status backfill.
- Prevents the legacy Registry action from bypassing the governed project-number workflow.

## Verification
- `bun run test` — 138 files, 798 passed, 3 skipped
- `bunx tsc --noEmit`
- `bun run lint` — 0 errors; 81 existing warnings
- `bun run build`
- Clean local D1 migration replay through `0107`; duplicate-alias and legacy-status upgrade fixtures verified
- Chromium focused E2E: Project Information + Client Follow-up (1/1 passed)
- Two independent final staged-diff reviews: no blockers

## Production rollout
This PR contains D1 migrations. After Worker deployment, run the separate verified production migration step (`db:migrate:prod`); deploying code alone does not apply the schema.