### PR TITLE
feat(projects): govern custom job status labels

### DIFF
--- a/drizzle/0108_project_job_status_label_namespace.sql
+++ b/drizzle/0108_project_job_status_label_namespace.sql
@@ -1,0 +1,323 @@
+CREATE TABLE IF NOT EXISTS `project_job_status_label_migration_staging` (
+  `status_id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `label` text NOT NULL,
+  `normalized_label` text NOT NULL,
+  CONSTRAINT `project_job_status_label_ascii` CHECK (
+    instr(`label`, char(0)) = 0
+    AND `label` NOT GLOB '*[^ -~]*'
+    AND `label` = trim(`label`)
+    AND `label` <> ''
+  ),
+  CHECK (instr(`normalized_label`, char(0)) = 0),
+  CHECK (`normalized_label` NOT GLOB '*[^ -~]*'),
+  CHECK (`normalized_label` <> '')
+);--> statement-breakpoint
+INSERT OR REPLACE INTO `project_job_status_label_migration_staging` (
+  `status_id`,
+  `organization_id`,
+  `label`,
+  `normalized_label`
+)
+SELECT
+  `id`,
+  `organization_id`,
+  `label`,
+  lower(trim(`label`))
+FROM `project_job_statuses`;--> statement-breakpoint
+DELETE FROM `project_job_status_label_migration_staging`
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM `project_job_statuses`
+  WHERE `project_job_statuses`.`id` = `project_job_status_label_migration_staging`.`status_id`
+);--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `project_job_status_label_cross_tenant_validation` (
+  `project_id` text PRIMARY KEY NOT NULL,
+  `project_organization_id` text,
+  `status_organization_id` text NOT NULL,
+  CONSTRAINT `project_job_status_cross_tenant_reference` CHECK (
+    `project_organization_id` IS NOT NULL
+    AND `project_organization_id` = `status_organization_id`
+  )
+);--> statement-breakpoint
+INSERT OR REPLACE INTO `project_job_status_label_cross_tenant_validation` (
+  `project_id`,
+  `project_organization_id`,
+  `status_organization_id`
+)
+SELECT
+  `projects`.`id`,
+  `projects`.`organization_id`,
+  candidate.`organization_id`
+FROM `projects`
+JOIN `project_job_statuses` AS candidate
+  ON candidate.`id` = `projects`.`job_status_id`
+WHERE `projects`.`organization_id` IS NULL
+  OR `projects`.`organization_id` <> candidate.`organization_id`;--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `project_job_status_label_conflicts` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `normalized_label` text NOT NULL,
+  `retained_status_id` text NOT NULL,
+  `retained_label` text NOT NULL,
+  `discarded_status_id` text NOT NULL,
+  `discarded_label` text NOT NULL,
+  `discarded_sage_code` text,
+  `discarded_follow_up_cadence_days` integer,
+  `discarded_active` integer NOT NULL,
+  `created_at` text NOT NULL
+);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `project_job_status_label_conflicts_org_idx`
+ON `project_job_status_label_conflicts` (`organization_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `project_job_status_label_conflicts_discarded_unique`
+ON `project_job_status_label_conflicts` (`discarded_status_id`);--> statement-breakpoint
+INSERT OR IGNORE INTO `project_job_status_label_conflicts` (
+  `id`,
+  `organization_id`,
+  `normalized_label`,
+  `retained_status_id`,
+  `retained_label`,
+  `discarded_status_id`,
+  `discarded_label`,
+  `discarded_sage_code`,
+  `discarded_follow_up_cadence_days`,
+  `discarded_active`,
+  `created_at`
+)
+SELECT
+  lower(hex(randomblob(16))),
+  candidate.`organization_id`,
+  candidate_key.`normalized_label`,
+  retained.`id`,
+  retained.`label`,
+  candidate.`id`,
+  candidate.`label`,
+  candidate.`sage_code`,
+  candidate.`follow_up_cadence_days`,
+  candidate.`active`,
+  candidate.`created_at`
+FROM `project_job_statuses` AS candidate
+JOIN `project_job_status_label_migration_staging` AS candidate_key
+  ON candidate_key.`status_id` = candidate.`id`
+JOIN `project_job_statuses` AS retained
+  ON retained.`organization_id` = candidate.`organization_id`
+JOIN `project_job_status_label_migration_staging` AS retained_key
+  ON retained_key.`status_id` = retained.`id`
+  AND retained_key.`normalized_label` = candidate_key.`normalized_label`
+  AND (
+    retained.`created_at` < candidate.`created_at`
+    OR (retained.`created_at` = candidate.`created_at` AND retained.`id` < candidate.`id`)
+  )
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM `project_job_statuses` AS earlier
+  JOIN `project_job_status_label_migration_staging` AS earlier_key
+    ON earlier_key.`status_id` = earlier.`id`
+  WHERE earlier.`organization_id` = candidate.`organization_id`
+    AND earlier_key.`normalized_label` = candidate_key.`normalized_label`
+    AND (
+      earlier.`created_at` < retained.`created_at`
+      OR (earlier.`created_at` = retained.`created_at` AND earlier.`id` < retained.`id`)
+    )
+);--> statement-breakpoint
+UPDATE `projects`
+SET `job_status_id` = (
+  SELECT retained.`id`
+  FROM `project_job_statuses` AS candidate
+  JOIN `project_job_status_label_migration_staging` AS candidate_key
+    ON candidate_key.`status_id` = candidate.`id`
+  JOIN `project_job_statuses` AS retained
+    ON retained.`organization_id` = candidate.`organization_id`
+  JOIN `project_job_status_label_migration_staging` AS retained_key
+    ON retained_key.`status_id` = retained.`id`
+    AND retained_key.`normalized_label` = candidate_key.`normalized_label`
+    AND (
+      retained.`created_at` < candidate.`created_at`
+      OR (retained.`created_at` = candidate.`created_at` AND retained.`id` < candidate.`id`)
+    )
+  WHERE candidate.`id` = `projects`.`job_status_id`
+    AND candidate.`organization_id` = `projects`.`organization_id`
+  ORDER BY retained.`created_at`, retained.`id`
+  LIMIT 1
+)
+WHERE EXISTS (
+  SELECT 1
+  FROM `project_job_statuses` AS candidate
+  JOIN `project_job_status_label_migration_staging` AS candidate_key
+    ON candidate_key.`status_id` = candidate.`id`
+  JOIN `project_job_statuses` AS retained
+    ON retained.`organization_id` = candidate.`organization_id`
+  JOIN `project_job_status_label_migration_staging` AS retained_key
+    ON retained_key.`status_id` = retained.`id`
+    AND retained_key.`normalized_label` = candidate_key.`normalized_label`
+    AND (
+      retained.`created_at` < candidate.`created_at`
+      OR (retained.`created_at` = candidate.`created_at` AND retained.`id` < candidate.`id`)
+    )
+  WHERE candidate.`id` = `projects`.`job_status_id`
+    AND candidate.`organization_id` = `projects`.`organization_id`
+);--> statement-breakpoint
+DELETE FROM `project_job_statuses`
+WHERE EXISTS (
+  SELECT 1
+  FROM `project_job_statuses` AS retained
+  JOIN `project_job_status_label_migration_staging` AS retained_key
+    ON retained_key.`status_id` = retained.`id`
+  JOIN `project_job_status_label_migration_staging` AS candidate_key
+    ON candidate_key.`status_id` = `project_job_statuses`.`id`
+    AND candidate_key.`normalized_label` = retained_key.`normalized_label`
+  WHERE retained.`organization_id` = `project_job_statuses`.`organization_id`
+    AND (
+      retained.`created_at` < `project_job_statuses`.`created_at`
+      OR (retained.`created_at` = `project_job_statuses`.`created_at` AND retained.`id` < `project_job_statuses`.`id`)
+    )
+);--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `project_job_status_label_keys` (
+  `status_id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `normalized_label` text NOT NULL,
+  CHECK (instr(`normalized_label`, char(0)) = 0),
+  CHECK (`normalized_label` NOT GLOB '*[^ -~]*'),
+  CHECK (`normalized_label` <> ''),
+  FOREIGN KEY (`status_id`) REFERENCES `project_job_statuses`(`id`) ON DELETE cascade,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON DELETE cascade
+);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `project_job_status_label_keys_org_normalized_unique`
+ON `project_job_status_label_keys` (`organization_id`, `normalized_label`);--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `project_job_status_label_keys_integrity_insert`
+BEFORE INSERT ON `project_job_status_label_keys`
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM `project_job_statuses`
+  WHERE `id` = NEW.`status_id`
+    AND `organization_id` = NEW.`organization_id`
+    AND lower(trim(`label`)) = NEW.`normalized_label`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'Project job-status label key must match its status.');
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `project_job_status_label_keys_integrity_update`
+BEFORE UPDATE OF `status_id`, `organization_id`, `normalized_label` ON `project_job_status_label_keys`
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM `project_job_statuses`
+  WHERE `id` = NEW.`status_id`
+    AND `organization_id` = NEW.`organization_id`
+    AND lower(trim(`label`)) = NEW.`normalized_label`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'Project job-status label key must match its status.');
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `project_job_status_label_keys_integrity_delete`
+BEFORE DELETE ON `project_job_status_label_keys`
+WHEN EXISTS (
+  SELECT 1
+  FROM `project_job_statuses`
+  WHERE `id` = OLD.`status_id`
+)
+BEGIN
+  SELECT RAISE(ABORT, 'Project job-status label key cannot be removed while its status exists.');
+END;--> statement-breakpoint
+INSERT INTO `project_job_status_label_keys` (`status_id`, `organization_id`, `normalized_label`)
+SELECT `id`, `organization_id`, lower(trim(`label`))
+FROM `project_job_statuses`
+WHERE 1
+ON CONFLICT(`status_id`) DO UPDATE SET
+  `organization_id` = excluded.`organization_id`,
+  `normalized_label` = excluded.`normalized_label`;--> statement-breakpoint
+DELETE FROM `project_job_status_label_keys`
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM `project_job_statuses`
+  WHERE `project_job_statuses`.`id` = `project_job_status_label_keys`.`status_id`
+);--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `project_job_statuses_ascii_namespace_insert`
+BEFORE INSERT ON `project_job_statuses`
+WHEN NEW.`label` = ''
+  OR instr(NEW.`label`, char(0)) <> 0
+  OR NEW.`label` GLOB '*[^ -~]*'
+  OR NEW.`label` <> trim(NEW.`label`)
+BEGIN
+  SELECT RAISE(ABORT, 'Project job-status labels must be non-empty, trimmed printable ASCII.');
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `project_job_statuses_ascii_namespace_update`
+BEFORE UPDATE OF `label`, `organization_id` ON `project_job_statuses`
+WHEN NEW.`label` = ''
+  OR instr(NEW.`label`, char(0)) <> 0
+  OR NEW.`label` GLOB '*[^ -~]*'
+  OR NEW.`label` <> trim(NEW.`label`)
+BEGIN
+  SELECT RAISE(ABORT, 'Project job-status labels must be non-empty, trimmed printable ASCII.');
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `project_job_statuses_ascii_namespace_key_insert`
+AFTER INSERT ON `project_job_statuses`
+BEGIN
+  INSERT INTO `project_job_status_label_keys` (`status_id`, `organization_id`, `normalized_label`)
+  VALUES (NEW.`id`, NEW.`organization_id`, lower(trim(NEW.`label`)));
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `project_job_statuses_ascii_namespace_key_update`
+AFTER UPDATE OF `label`, `organization_id` ON `project_job_statuses`
+BEGIN
+  UPDATE `project_job_status_label_keys`
+  SET
+    `organization_id` = NEW.`organization_id`,
+    `normalized_label` = lower(trim(NEW.`label`))
+  WHERE `status_id` = NEW.`id`;
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `project_job_statuses_ascii_namespace_key_delete`
+AFTER DELETE ON `project_job_statuses`
+BEGIN
+  DELETE FROM `project_job_status_label_keys` WHERE `status_id` = OLD.`id`;
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `projects_project_job_status_namespace_insert`
+BEFORE INSERT ON `projects`
+WHEN NEW.`job_status_id` IS NULL
+  OR (
+    NEW.`job_status_id` NOT IN (
+      'intake', 'new_client_info_sent', 'budget_estimating', 'budget_estimate_sent',
+      'estimating', 'estimate_sent', 'design_proposal', 'design_proposal_sent',
+      'design_proposal_signed', 'engineering', 'contract_docs', 'contract_docs_sent',
+      'contract_docs_signed', 'contract', 'awarded', 'awaiting_funding',
+      'awaiting_groundbreaking', 'permitting', 'in_design', 'value_engineering',
+      'takeoff', 'bracing_out', 'under_construction', 'ordered', 'partial_order',
+      'price_sheet_sent', 'shipping_tbd', 'awaiting_payment', 'current', 'punchlist',
+      'complete', 'closed', 'bid_refused', 'inactive'
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM `project_job_statuses`
+      WHERE `id` = NEW.`job_status_id`
+        AND NEW.`organization_id` IS NOT NULL
+        AND `organization_id` = NEW.`organization_id`
+    )
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'Project job status must be an approved built-in or organization-owned custom status.');
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `projects_project_job_status_namespace_update`
+BEFORE UPDATE OF `job_status_id`, `organization_id` ON `projects`
+WHEN NEW.`job_status_id` IS NULL
+  OR (
+    NEW.`job_status_id` NOT IN (
+      'intake', 'new_client_info_sent', 'budget_estimating', 'budget_estimate_sent',
+      'estimating', 'estimate_sent', 'design_proposal', 'design_proposal_sent',
+      'design_proposal_signed', 'engineering', 'contract_docs', 'contract_docs_sent',
+      'contract_docs_signed', 'contract', 'awarded', 'awaiting_funding',
+      'awaiting_groundbreaking', 'permitting', 'in_design', 'value_engineering',
+      'takeoff', 'bracing_out', 'under_construction', 'ordered', 'partial_order',
+      'price_sheet_sent', 'shipping_tbd', 'awaiting_payment', 'current', 'punchlist',
+      'complete', 'closed', 'bid_refused', 'inactive'
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM `project_job_statuses`
+      WHERE `id` = NEW.`job_status_id`
+        AND NEW.`organization_id` IS NOT NULL
+        AND `organization_id` = NEW.`organization_id`
+    )
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'Project job status must be an approved built-in or organization-owned custom status.');
+END;--> statement-breakpoint
+DROP TABLE `project_job_status_label_cross_tenant_validation`;--> statement-breakpoint
+DROP TABLE `project_job_status_label_migration_staging`;

--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -160,6 +160,21 @@ test.describe("usable Compass areas", () => {
     }
   })
 
+  test("project information explains approved job-status selection", async ({ page }) => {
+    const projectsResponse = await page.goto("/dashboard/projects")
+    await expectHealthyNavigation(page, projectsResponse, "/dashboard/projects")
+    const projectId = await findProjectId(page)
+    if (!projectId) {
+      test.skip(true, "The demo workspace does not expose a project to test")
+      return
+    }
+
+    const response = await page.goto(`/dashboard/projects/${projectId}/information`)
+    await expectHealthyNavigation(page, response, `/dashboard/projects/${projectId}/information`)
+    await expect(page.getByRole("combobox", { name: "Approved job status" })).toBeVisible()
+    await expect(page.getByText(/Choose the approved operational stage for this project/)).toBeVisible()
+  })
+
   test("timezone preference persists after reloading settings", async ({ page }) => {
     const path = "/dashboard/settings"
     const response = await page.goto(path)

--- a/src/app/actions/project-profile.ts
+++ b/src/app/actions/project-profile.ts
@@ -11,6 +11,7 @@ import {
   projectExternalLinks,
   projectFollowUps,
   projectInteractions,
+  projectJobStatusLabelKeys,
   projectJobStatuses,
   projectNotes,
   projectNumberAliases,
@@ -51,8 +52,11 @@ import {
   PROJECT_CLIENT_STATUSES,
   PROJECT_JOB_STATUS_DEFINITIONS,
   buildProjectNumberWithAddressSuffix,
+  isBuiltInProjectJobStatusLabel,
   isEligibleFollowUpOwner,
   isMeaningfulClientInteraction,
+  isSupportedProjectJobStatusLabel,
+  normalizeProjectJobStatusLabel,
   projectNumberParts,
   type ProjectClientStatus,
 } from "@/lib/project-profile"
@@ -1304,6 +1308,32 @@ export async function createCustomProjectJobStatus(input: {
     const db = getDb(env.DB)
     const label = nullableText(input.label)
     if (!label) return { success: false, error: "Enter a job-status label." }
+    if (!isSupportedProjectJobStatusLabel(label)) {
+      return {
+        success: false,
+        error: "Custom job-status labels must use printable basic Latin characters.",
+      }
+    }
+    const normalizedLabel = normalizeProjectJobStatusLabel(label)
+    if (isBuiltInProjectJobStatusLabel(label)) {
+      return {
+        success: false,
+        error: "That standard status is already available in the Job status menu.",
+      }
+    }
+    const existingCustomStatuses = await db
+      .select({ statusId: projectJobStatusLabelKeys.statusId })
+      .from(projectJobStatusLabelKeys)
+      .where(
+        and(
+          eq(projectJobStatusLabelKeys.organizationId, organizationId),
+          eq(projectJobStatusLabelKeys.normalizedLabel, normalizedLabel),
+        ),
+      )
+      .limit(1)
+    if (existingCustomStatuses.length > 0) {
+      return { success: false, error: "That custom status already exists." }
+    }
     if (input.followUpCadenceDays !== null && (!Number.isInteger(input.followUpCadenceDays) || input.followUpCadenceDays < 1)) {
       return { success: false, error: "Follow-up cadence must be a positive whole number." }
     }

--- a/src/components/projects/project-information-workspace.tsx
+++ b/src/components/projects/project-information-workspace.tsx
@@ -260,10 +260,13 @@ export function ProjectInformationWorkspace({
             </select>
           </div>
           <div className="space-y-2">
-            <Label htmlFor="job-status">Job status</Label>
-            <select id="job-status" className="flex h-9 w-full rounded-md border bg-background px-3 text-sm" value={jobStatusId} onChange={(event) => setJobStatusId(event.target.value)}>
+            <Label htmlFor="job-status">Approved job status</Label>
+            <select id="job-status" aria-describedby="job-status-help" className="flex h-9 w-full rounded-md border bg-background px-3 text-sm" value={jobStatusId} onChange={(event) => setJobStatusId(event.target.value)}>
               {information.jobStatuses.map((status) => <option key={status.id} value={status.id}>{status.label}</option>)}
             </select>
+            <p id="job-status-help" className="text-xs text-muted-foreground">
+              Choose the approved operational stage for this project. {canManageJobStatuses ? "If a shared stage is genuinely missing, add it in the administrator-only section below." : "Only registry managers can add a shared status."}
+            </p>
           </div>
           {information.project.projectNumber && (
             <div className="space-y-2 md:col-span-2">
@@ -283,13 +286,15 @@ export function ProjectInformationWorkspace({
 
       {canManageJobStatuses && (
         <section className="rounded-lg border bg-card p-4 sm:p-5">
-          <h2 className="font-semibold">Governed job statuses</h2>
-          <p className="mt-1 text-sm text-muted-foreground">Administrators may add a Sage-aligned status and its follow-up cadence. Staff can select it but cannot create arbitrary values.</p>
+          <h2 className="font-semibold">Add an organization-specific status</h2>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            The Approved job status menu contains Compass’s standard Sage-aligned stages and any organization-specific stages already approved by a registry manager. Use this administrator-only form only when your organization has approved a genuinely missing shared stage. It becomes available to every project in this organization; it does not change Sage automatically.
+          </p>
           <form className="mt-4 grid gap-3 md:grid-cols-4" onSubmit={createJobStatus}>
-            <div className="space-y-2 md:col-span-2"><Label htmlFor="new-job-status">Status label</Label><Input id="new-job-status" value={newJobStatusLabel} onChange={(event) => setNewJobStatusLabel(event.target.value)} required /></div>
-            <div className="space-y-2"><Label htmlFor="new-job-status-code">Sage code</Label><Input id="new-job-status-code" value={newJobStatusSageCode} onChange={(event) => setNewJobStatusSageCode(event.target.value)} /></div>
-            <div className="space-y-2"><Label htmlFor="new-job-status-cadence">Cadence (business days)</Label><Input id="new-job-status-cadence" type="number" min="1" value={newJobStatusCadence} onChange={(event) => setNewJobStatusCadence(event.target.value)} required /></div>
-            <div className="md:col-span-4"><Button type="submit" disabled={pending}>Add governed status</Button></div>
+            <div className="space-y-2 md:col-span-2"><Label htmlFor="new-job-status">Custom status label</Label><Input id="new-job-status" value={newJobStatusLabel} onChange={(event) => setNewJobStatusLabel(event.target.value)} placeholder="For example: Warranty" aria-describedby="new-job-status-help" required /><p id="new-job-status-help" className="text-xs text-muted-foreground">Use printable basic Latin characters so the organization-wide label is unique.</p></div>
+            <div className="space-y-2"><Label htmlFor="new-job-status-code">Optional Sage reference code</Label><Input id="new-job-status-code" value={newJobStatusSageCode} onChange={(event) => setNewJobStatusSageCode(event.target.value)} /></div>
+            <div className="space-y-2"><Label htmlFor="new-job-status-cadence">Follow-up cadence (business days)</Label><Input id="new-job-status-cadence" type="number" min="1" value={newJobStatusCadence} onChange={(event) => setNewJobStatusCadence(event.target.value)} required /></div>
+            <div className="md:col-span-4"><Button type="submit" disabled={pending}>Add custom status</Button></div>
           </form>
         </section>
       )}

--- a/src/db/__tests__/project-job-status-namespace.test.ts
+++ b/src/db/__tests__/project-job-status-namespace.test.ts
@@ -1,0 +1,454 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import { PROJECT_JOB_STATUS_DEFINITIONS } from "@/lib/project-profile"
+
+type TestStatement = {
+  readonly get: () => unknown
+}
+
+type TestDatabase = {
+  readonly exec: (query: string) => void
+  readonly prepare: (query: string) => TestStatement
+  readonly close: () => void
+}
+
+type TestDatabaseModule = {
+  readonly Database: new (filename: string) => TestDatabase
+}
+
+function isTestDatabaseModule(value: unknown): value is TestDatabaseModule {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "Database" in value &&
+    typeof value.Database === "function"
+  )
+}
+
+const profileMigration = readFileSync(
+  resolve(process.cwd(), "drizzle/0101_project_profile_follow_up.sql"),
+  "utf8",
+)
+const namespaceMigration = readFileSync(
+  resolve(process.cwd(), "drizzle/0108_project_job_status_label_namespace.sql"),
+  "utf8",
+)
+
+async function openDatabase(): Promise<TestDatabase> {
+  if ("Bun" in globalThis) {
+    const bunSqliteSpecifier = "bun:sqlite"
+    const sqliteModule: unknown = await import(bunSqliteSpecifier)
+    if (!isTestDatabaseModule(sqliteModule)) {
+      throw new Error("bun:sqlite did not provide a Database constructor")
+    }
+    return new sqliteModule.Database(":memory:")
+  }
+
+  const { default: Database } = await import("better-sqlite3")
+  return new Database(":memory:")
+}
+
+function scalar(database: TestDatabase, query: string): unknown {
+  const row = database.prepare(query).get()
+  if (row === null || typeof row !== "object" || !("value" in row)) {
+    throw new Error("Expected a scalar result")
+  }
+  return row.value
+}
+
+describe("project job-status label namespace migration", () => {
+  it("reconciles case-variant custom statuses without losing project references", async () => {
+    const database = await openDatabase()
+    try {
+      database.exec(`
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE organizations (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE users (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE projects (
+          id TEXT PRIMARY KEY NOT NULL,
+          organization_id TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'OPEN'
+        );
+        INSERT INTO organizations (id) VALUES ('org-1'), ('org-2');
+      `)
+      database.exec(profileMigration)
+      database.exec(`
+        INSERT INTO project_job_statuses (
+          id, organization_id, label, active, sort_order, created_at, updated_at
+        ) VALUES
+          ('status-a', 'org-1', 'Warranty', 1, 1000, '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z'),
+          ('status-b', 'org-1', 'warranty', 1, 1000, '2026-08-02T00:00:00.000Z', '2026-08-02T00:00:00.000Z'),
+          ('status-c', 'org-1', 'WARRANTY', 1, 1000, '2026-08-02T00:00:00.000Z', '2026-08-02T00:00:00.000Z'),
+          ('status-tie-z', 'org-1', 'Turnover', 1, 1000, '2026-08-03T00:00:00.000Z', '2026-08-03T00:00:00.000Z'),
+          ('status-tie-a', 'org-1', 'turnover', 1, 1000, '2026-08-03T00:00:00.000Z', '2026-08-03T00:00:00.000Z'),
+          ('status-org2', 'org-2', 'Warranty', 1, 1000, '2026-08-03T00:00:00.000Z', '2026-08-03T00:00:00.000Z');
+        INSERT INTO projects (id, organization_id, status, job_status_id)
+        VALUES
+          ('project-1', 'org-1', 'OPEN', 'status-b'),
+          ('project-2', 'org-1', 'OPEN', 'status-c'),
+          ('project-3', 'org-1', 'OPEN', 'status-tie-z');
+      `)
+
+      database.exec(namespaceMigration)
+
+      expect(
+        scalar(
+          database,
+          "SELECT job_status_id AS value FROM projects WHERE id = 'project-1'",
+        ),
+      ).toBe("status-a")
+      expect(
+        scalar(
+          database,
+          "SELECT job_status_id AS value FROM projects WHERE id = 'project-2'",
+        ),
+      ).toBe("status-a")
+      expect(
+        scalar(
+          database,
+          "SELECT job_status_id AS value FROM projects WHERE id = 'project-3'",
+        ),
+      ).toBe("status-tie-a")
+      expect(
+        scalar(
+          database,
+          "SELECT COUNT(*) AS value FROM project_job_statuses WHERE organization_id = 'org-1'",
+        ),
+      ).toBe(2)
+      expect(
+        scalar(
+          database,
+          "SELECT normalized_label AS value FROM project_job_status_label_keys WHERE status_id = 'status-a'",
+        ),
+      ).toBe("warranty")
+      expect(
+        scalar(
+          database,
+          "SELECT status_id AS value FROM project_job_status_label_keys WHERE organization_id = 'org-1' AND normalized_label = 'turnover'",
+        ),
+      ).toBe("status-tie-a")
+      expect(
+        scalar(
+          database,
+          "SELECT status_id AS value FROM project_job_status_label_keys WHERE organization_id = 'org-2' AND normalized_label = 'warranty'",
+        ),
+      ).toBe("status-org2")
+      expect(
+        scalar(
+          database,
+          "SELECT retained_status_id AS value FROM project_job_status_label_conflicts WHERE discarded_status_id = 'status-b'",
+        ),
+      ).toBe("status-a")
+      expect(
+        scalar(
+          database,
+          "SELECT discarded_label AS value FROM project_job_status_label_conflicts WHERE discarded_status_id = 'status-b'",
+        ),
+      ).toBe("warranty")
+      expect(() =>
+        database.exec(`
+          INSERT INTO project_job_statuses (
+            id, organization_id, label, active, sort_order, created_at, updated_at
+          ) VALUES ('status-d', 'org-1', 'WARRANTY', 1, 1000, '2026-08-03T00:00:00.000Z', '2026-08-03T00:00:00.000Z')
+        `),
+      ).toThrow()
+      expect(() =>
+        database.exec(`
+          INSERT INTO project_job_statuses (
+            id, organization_id, label, active, sort_order, created_at, updated_at
+          ) VALUES ('status-empty', 'org-1', '', 1, 1000, '2026-08-03T00:00:00.000Z', '2026-08-03T00:00:00.000Z')
+        `),
+      ).toThrow()
+      expect(() =>
+        database.exec(`
+          INSERT INTO project_job_statuses (
+            id, organization_id, label, active, sort_order, created_at, updated_at
+          ) VALUES ('status-nul', 'org-1', 'Good' || char(0) || 'Bad', 1, 1000, '2026-08-03T00:00:00.000Z', '2026-08-03T00:00:00.000Z')
+        `),
+      ).toThrow(/Project job-status labels must be non-empty, trimmed printable ASCII/)
+      expect(() =>
+        database.exec("UPDATE project_job_status_label_keys SET normalized_label = 'tampered' WHERE status_id = 'status-a'"),
+      ).toThrow(/Project job-status label key must match its status/)
+      expect(() =>
+        database.exec("DELETE FROM project_job_status_label_keys WHERE status_id = 'status-a'"),
+      ).toThrow(/Project job-status label key cannot be removed/)
+      database.exec("UPDATE project_job_statuses SET label = 'Coverage' WHERE id = 'status-a'")
+      expect(
+        scalar(
+          database,
+          "SELECT normalized_label AS value FROM project_job_status_label_keys WHERE status_id = 'status-a'",
+        ),
+      ).toBe("coverage")
+      database.exec(namespaceMigration)
+      expect(
+        scalar(
+          database,
+          "SELECT normalized_label AS value FROM project_job_status_label_keys WHERE status_id = 'status-a'",
+        ),
+      ).toBe("coverage")
+    } finally {
+      database.close()
+    }
+  })
+
+  it("fails closed for legacy Unicode labels and resumes after remediation", async () => {
+    const database = await openDatabase()
+    try {
+      database.exec(`
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE organizations (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE users (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE projects (
+          id TEXT PRIMARY KEY NOT NULL,
+          organization_id TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'OPEN'
+        );
+        INSERT INTO organizations (id) VALUES ('org-1'), ('org-2');
+      `)
+      database.exec(profileMigration)
+      database.exec(`
+        INSERT INTO project_job_statuses (
+          id, organization_id, label, active, sort_order, created_at, updated_at
+        ) VALUES ('status-unicode', 'org-1', 'État', 1, 1000, '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z')
+      `)
+
+      expect(() => database.exec(namespaceMigration)).toThrow(/project_job_status_label_ascii/)
+      database.exec("UPDATE project_job_statuses SET label = 'Etat' WHERE id = 'status-unicode'")
+      database.exec(namespaceMigration)
+      expect(
+        scalar(
+          database,
+          "SELECT normalized_label AS value FROM project_job_status_label_keys WHERE status_id = 'status-unicode'",
+        ),
+      ).toBe("etat")
+    } finally {
+      database.close()
+    }
+  })
+
+  it("fails closed before deleting a duplicate referenced by a project without an organization", async () => {
+    const database = await openDatabase()
+    try {
+      database.exec(`
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE organizations (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE users (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE projects (
+          id TEXT PRIMARY KEY NOT NULL,
+          organization_id TEXT,
+          status TEXT NOT NULL DEFAULT 'OPEN'
+        );
+        INSERT INTO organizations (id) VALUES ('org-1');
+      `)
+      database.exec(profileMigration)
+      database.exec(`
+        INSERT INTO project_job_statuses (
+          id, organization_id, label, active, sort_order, created_at, updated_at
+        ) VALUES
+          ('status-early', 'org-1', 'Warranty', 1, 1000, '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z'),
+          ('status-late', 'org-1', 'warranty', 1, 1000, '2026-08-02T00:00:00.000Z', '2026-08-02T00:00:00.000Z');
+        INSERT INTO projects (id, organization_id, status, job_status_id)
+        VALUES ('project-null-organization', NULL, 'OPEN', 'status-late');
+      `)
+
+      expect(() => database.exec(namespaceMigration)).toThrow(
+        /project_job_status_cross_tenant_reference/,
+      )
+      expect(
+        scalar(
+          database,
+          "SELECT COUNT(*) AS value FROM project_job_statuses WHERE organization_id = 'org-1'",
+        ),
+      ).toBe(2)
+      expect(
+        scalar(
+          database,
+          "SELECT job_status_id AS value FROM projects WHERE id = 'project-null-organization'",
+        ),
+      ).toBe("status-late")
+    } finally {
+      database.close()
+    }
+  })
+
+  it("fails closed before deleting a duplicate referenced across organizations", async () => {
+    const database = await openDatabase()
+    try {
+      database.exec(`
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE organizations (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE users (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE projects (
+          id TEXT PRIMARY KEY NOT NULL,
+          organization_id TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'OPEN'
+        );
+        INSERT INTO organizations (id) VALUES ('org-1'), ('org-2');
+      `)
+      database.exec(profileMigration)
+      database.exec(`
+        INSERT INTO project_job_statuses (
+          id, organization_id, label, active, sort_order, created_at, updated_at
+        ) VALUES
+          ('status-early', 'org-1', 'Warranty', 1, 1000, '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z'),
+          ('status-late', 'org-1', 'warranty', 1, 1000, '2026-08-02T00:00:00.000Z', '2026-08-02T00:00:00.000Z');
+        INSERT INTO projects (id, organization_id, status, job_status_id)
+        VALUES ('project-cross-tenant', 'org-2', 'OPEN', 'status-late');
+      `)
+
+      expect(() => database.exec(namespaceMigration)).toThrow(
+        /project_job_status_cross_tenant_reference/,
+      )
+      expect(
+        scalar(
+          database,
+          "SELECT COUNT(*) AS value FROM project_job_statuses WHERE organization_id = 'org-1'",
+        ),
+      ).toBe(2)
+      expect(
+        scalar(
+          database,
+          "SELECT job_status_id AS value FROM projects WHERE id = 'project-cross-tenant'",
+        ),
+      ).toBe("status-late")
+    } finally {
+      database.close()
+    }
+  })
+
+  it("fails closed for legacy labels containing an embedded NUL", async () => {
+    const database = await openDatabase()
+    try {
+      database.exec(`
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE organizations (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE users (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE projects (id TEXT PRIMARY KEY NOT NULL, organization_id TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'OPEN');
+        INSERT INTO organizations (id) VALUES ('org-1');
+      `)
+      database.exec(profileMigration)
+      database.exec(`
+        INSERT INTO project_job_statuses (id, organization_id, label, active, sort_order, created_at, updated_at)
+        VALUES ('nul-status', 'org-1', 'Good' || char(0) || 'Bad', 1, 1000, '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z')
+      `)
+
+      expect(() => database.exec(namespaceMigration)).toThrow(/project_job_status_label_ascii/)
+      expect(scalar(database, "SELECT COUNT(*) AS value FROM project_job_statuses")).toBe(1)
+    } finally {
+      database.close()
+    }
+  })
+
+  it("fails closed for a whitespace-invalid retained legacy duplicate", async () => {
+    const database = await openDatabase()
+    try {
+      database.exec(`
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE organizations (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE users (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE projects (id TEXT PRIMARY KEY NOT NULL, organization_id TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'OPEN');
+        INSERT INTO organizations (id) VALUES ('org-1');
+      `)
+      database.exec(profileMigration)
+      database.exec(`
+        INSERT INTO project_job_statuses (id, organization_id, label, active, sort_order, created_at, updated_at)
+        VALUES
+          ('early-space', 'org-1', ' Warranty ', 1, 1000, '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z'),
+          ('later-valid', 'org-1', 'warranty', 1, 1000, '2026-08-02T00:00:00.000Z', '2026-08-02T00:00:00.000Z')
+      `)
+
+      expect(() => database.exec(namespaceMigration)).toThrow(/project_job_status_label_ascii/)
+      expect(scalar(database, "SELECT COUNT(*) AS value FROM project_job_statuses")).toBe(2)
+    } finally {
+      database.close()
+    }
+  })
+
+  it("fails closed for a unique custom status referenced across organizations", async () => {
+    const database = await openDatabase()
+    try {
+      database.exec(`
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE organizations (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE users (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE projects (id TEXT PRIMARY KEY NOT NULL, organization_id TEXT, status TEXT NOT NULL DEFAULT 'OPEN');
+        INSERT INTO organizations (id) VALUES ('org-1'), ('org-2');
+      `)
+      database.exec(profileMigration)
+      database.exec(`
+        INSERT INTO project_job_statuses (id, organization_id, label, active, sort_order, created_at, updated_at)
+        VALUES ('unique-org-1', 'org-1', 'Warranty', 1, 1000, '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z');
+        INSERT INTO projects (id, organization_id, status, job_status_id)
+        VALUES ('cross-tenant-unique', 'org-2', 'OPEN', 'unique-org-1');
+      `)
+
+      expect(() => database.exec(namespaceMigration)).toThrow(/project_job_status_cross_tenant_reference/)
+      expect(scalar(database, "SELECT job_status_id AS value FROM projects WHERE id = 'cross-tenant-unique'")).toBe("unique-org-1")
+    } finally {
+      database.close()
+    }
+  })
+
+  it("fails closed for a unique custom status referenced by a project without an organization", async () => {
+    const database = await openDatabase()
+    try {
+      database.exec(`
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE organizations (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE users (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE projects (id TEXT PRIMARY KEY NOT NULL, organization_id TEXT, status TEXT NOT NULL DEFAULT 'OPEN');
+        INSERT INTO organizations (id) VALUES ('org-1');
+      `)
+      database.exec(profileMigration)
+      database.exec(`
+        INSERT INTO project_job_statuses (id, organization_id, label, active, sort_order, created_at, updated_at)
+        VALUES ('unique-org-1', 'org-1', 'Warranty', 1, 1000, '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z');
+        INSERT INTO projects (id, organization_id, status, job_status_id)
+        VALUES ('null-tenant-unique', NULL, 'OPEN', 'unique-org-1');
+      `)
+
+      expect(() => database.exec(namespaceMigration)).toThrow(/project_job_status_cross_tenant_reference/)
+      expect(scalar(database, "SELECT job_status_id AS value FROM projects WHERE id = 'null-tenant-unique'")).toBe("unique-org-1")
+    } finally {
+      database.close()
+    }
+  })
+
+  it("rejects future cross-tenant, NULL-tenant, and unknown custom project-status writes", async () => {
+    const database = await openDatabase()
+    try {
+      database.exec(`
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE organizations (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE users (id TEXT PRIMARY KEY NOT NULL);
+        CREATE TABLE projects (id TEXT PRIMARY KEY NOT NULL, organization_id TEXT, status TEXT NOT NULL DEFAULT 'OPEN');
+        INSERT INTO organizations (id) VALUES ('org-1'), ('org-2');
+      `)
+      database.exec(profileMigration)
+      database.exec(`
+        INSERT INTO project_job_statuses (id, organization_id, label, active, sort_order, created_at, updated_at)
+        VALUES ('org-1-custom', 'org-1', 'Warranty', 1, 1000, '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z');
+        INSERT INTO projects (id, organization_id, status, job_status_id)
+        VALUES ('project-org-2', 'org-2', 'OPEN', 'current');
+      `)
+      database.exec(namespaceMigration)
+
+      expect(() => database.exec("UPDATE projects SET job_status_id = 'org-1-custom' WHERE id = 'project-org-2'")).toThrow(/Project job status/)
+      expect(() => database.exec("UPDATE projects SET organization_id = NULL, job_status_id = 'org-1-custom' WHERE id = 'project-org-2'")).toThrow(/Project job status/)
+      expect(() => database.exec("UPDATE projects SET job_status_id = 'not-a-built-in-or-custom-status' WHERE id = 'project-org-2'")).toThrow(/Project job status/)
+      expect(() => database.exec("UPDATE projects SET job_status_id = 'current' WHERE id = 'project-org-2'")).not.toThrow()
+      for (const status of PROJECT_JOB_STATUS_DEFINITIONS) {
+        expect(() =>
+          database.exec(
+            `UPDATE projects SET job_status_id = '${status.id}' WHERE id = 'project-org-2'`,
+          ),
+        ).not.toThrow()
+      }
+    } finally {
+      database.close()
+    }
+  })
+})

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -561,6 +561,48 @@ export const projectJobStatuses = sqliteTable(
   ],
 )
 
+export const projectJobStatusLabelKeys = sqliteTable(
+  "project_job_status_label_keys",
+  {
+    statusId: text("status_id")
+      .primaryKey()
+      .references(() => projectJobStatuses.id, { onDelete: "cascade" }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    normalizedLabel: text("normalized_label").notNull(),
+  },
+  (table) => [
+    uniqueIndex("project_job_status_label_keys_org_normalized_unique").on(
+      table.organizationId,
+      table.normalizedLabel,
+    ),
+  ],
+)
+
+export const projectJobStatusLabelConflicts = sqliteTable(
+  "project_job_status_label_conflicts",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id").notNull(),
+    normalizedLabel: text("normalized_label").notNull(),
+    retainedStatusId: text("retained_status_id").notNull(),
+    retainedLabel: text("retained_label").notNull(),
+    discardedStatusId: text("discarded_status_id").notNull(),
+    discardedLabel: text("discarded_label").notNull(),
+    discardedSageCode: text("discarded_sage_code"),
+    discardedFollowUpCadenceDays: integer("discarded_follow_up_cadence_days"),
+    discardedActive: integer("discarded_active", { mode: "boolean" }).notNull(),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    index("project_job_status_label_conflicts_org_idx").on(table.organizationId),
+    uniqueIndex("project_job_status_label_conflicts_discarded_unique").on(
+      table.discardedStatusId,
+    ),
+  ],
+)
+
 export const projectProfileAuditEvents = sqliteTable(
   "project_profile_audit_events",
   {

--- a/src/lib/__tests__/project-profile.test.ts
+++ b/src/lib/__tests__/project-profile.test.ts
@@ -9,6 +9,9 @@ import {
   isFollowUpEligibleJobStatus,
   isEligibleFollowUpOwner,
   isMeaningfulClientInteraction,
+  isBuiltInProjectJobStatusLabel,
+  isSupportedProjectJobStatusLabel,
+  normalizeProjectJobStatusLabel,
   projectNumberParts,
 } from "@/lib/project-profile"
 
@@ -29,6 +32,15 @@ describe("project profile rules", () => {
         "Bid Refused",
       ]),
     )
+  })
+
+  it("recognizes built-in status labels before an administrator creates a custom status", () => {
+    expect(isBuiltInProjectJobStatusLabel("Intake")).toBe(true)
+    expect(isBuiltInProjectJobStatusLabel(" estimate sent ")).toBe(true)
+    expect(isBuiltInProjectJobStatusLabel("Warranty")).toBe(false)
+    expect(isSupportedProjectJobStatusLabel("Warranty / punch-list")).toBe(true)
+    expect(isSupportedProjectJobStatusLabel("État")).toBe(false)
+    expect(normalizeProjectJobStatusLabel(" Warranty ")).toBe("warranty")
   })
 
   it("replaces only the address-derived number suffix", () => {

--- a/src/lib/project-profile.ts
+++ b/src/lib/project-profile.ts
@@ -142,6 +142,23 @@ export const PROJECT_JOB_STATUS_DEFINITIONS = [
 
 export type ProjectJobStatusId = (typeof PROJECT_JOB_STATUS_DEFINITIONS)[number]["id"]
 
+const PROJECT_JOB_STATUS_LABEL_PATTERN = /^[\x20-\x7E]+$/
+
+export function normalizeProjectJobStatusLabel(label: string): string {
+  return label.trim().toLowerCase()
+}
+
+export function isSupportedProjectJobStatusLabel(label: string): boolean {
+  return label === label.trim() && PROJECT_JOB_STATUS_LABEL_PATTERN.test(label)
+}
+
+export function isBuiltInProjectJobStatusLabel(label: string): boolean {
+  const normalizedLabel = normalizeProjectJobStatusLabel(label)
+  return PROJECT_JOB_STATUS_DEFINITIONS.some(
+    (status) => normalizeProjectJobStatusLabel(status.label) === normalizedLabel,
+  )
+}
+
 export const FOLLOW_UP_EXCLUDED_JOB_STATUSES = [
   "complete",
   "closed",


### PR DESCRIPTION
## Summary
- enforce organization-scoped canonical namespaces for custom project job statuses
- fail closed on unsafe legacy status labels or cross-tenant/NULL custom-status references
- add database triggers that preserve built-in Sage-aligned statuses while enforcing custom-status tenancy
- clarify the Project Information administrator workflow for approved and organization-specific labels

## Validation
- [x] independent fail-closed staged review, no security or logic findings
- [x] focused migration tests: 18 passed
- [x] full Vitest: 808 passed, 3 skipped
- [x] TypeScript and targeted ESLint
- [x] isolated local D1 replay and direct integrity probes
- [x] production build

## Release note
This PR includes D1 migration `0108_project_job_status_label_namespace.sql`; after merge it requires the separate production migration command before Worker deployment.