### PR TITLE
fix(messaging): recover legacy GoTo message bodies

### DIFF
--- a/custom-worker.ts
+++ b/custom-worker.ts
@@ -8,6 +8,8 @@ import {
 
 const RECONCILE_TARGET = "/api/operations/feedback/reconcile"
 const EMAIL_SYNC_TARGET = "/api/email/gmail-sync"
+const GOTO_MESSAGE_RECOVERY_TARGET =
+  "/api/operations/goto/recover-message-bodies"
 
 async function reconcile(env: CloudflareEnv): Promise<void> {
   const body = JSON.stringify({ source: "cron" })
@@ -75,9 +77,45 @@ async function syncInboundEmail(env: CloudflareEnv): Promise<void> {
   }
 }
 
+async function recoverGotoMessageBodies(env: CloudflareEnv): Promise<void> {
+  const body = ""
+  const timestamp = String(Math.floor(Date.now() / 1_000))
+  const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
+  if (!secret) throw new Error("JARVIS_BRIDGE_SECRET is required")
+  const signature = await createJarvisSignature(
+    secret,
+    timestamp,
+    "POST",
+    GOTO_MESSAGE_RECOVERY_TARGET,
+    body
+  )
+  const worker = env.WORKER_SELF_REFERENCE
+  if (!worker) throw new Error("WORKER_SELF_REFERENCE is required")
+  const response = await worker.fetch(
+    `https://compass.internal${GOTO_MESSAGE_RECOVERY_TARGET}`,
+    {
+      method: "POST",
+      headers: {
+        "X-Compass-Timestamp": timestamp,
+        "X-Compass-Signature": signature,
+      },
+      body,
+    }
+  )
+  if (!response.ok) {
+    throw new Error(`GoTo message recovery failed with ${response.status}`)
+  }
+}
+
 export default {
   fetch: worker.fetch,
   async scheduled(_controller, env, ctx): Promise<void> {
-    ctx.waitUntil(Promise.all([reconcile(env), syncInboundEmail(env)]).then(() => undefined))
+    ctx.waitUntil(
+      Promise.all([
+        reconcile(env),
+        syncInboundEmail(env),
+        recoverGotoMessageBodies(env),
+      ]).then(() => undefined)
+    )
   },
 } satisfies ExportedHandler<CloudflareEnv>

--- a/src/app/actions/inbound-sms-review.ts
+++ b/src/app/actions/inbound-sms-review.ts
@@ -38,6 +38,7 @@ export type InboundSmsReviewItem = {
   readonly receivedAt: string
   readonly reviewReason: string | null
   readonly attachmentCount: number
+  readonly recoveryError: string | null
 }
 
 export type InboundSmsReviewQueue = {
@@ -128,6 +129,7 @@ export async function getInboundSmsReviewQueue(): Promise<InboundSmsReviewQueue>
       receivedAt: event.receivedAt,
       reviewReason: event.reviewReason,
       attachmentCount: storedGotoAttachments(event.attachmentMetadata).length,
+      recoveryError: event.error,
     })),
   }
 }

--- a/src/app/api/operations/goto/recover-message-bodies/route.ts
+++ b/src/app/api/operations/goto/recover-message-bodies/route.ts
@@ -1,0 +1,49 @@
+import { getDb } from "@/db"
+import { getCloudflareContext } from "@/lib/db"
+import { recoverLegacyGotoMessageBodies } from "@/lib/goto/message-recovery"
+import {
+  getJarvisEnvValue,
+  readBoundedBody,
+  verifyJarvisRequest,
+} from "@/lib/jarvis/auth"
+
+export async function POST(request: Request): Promise<Response> {
+  const body = await readBoundedBody(request)
+  if (!body.success) {
+    return Response.json({ error: body.error }, { status: 413 })
+  }
+  const { env } = await getCloudflareContext()
+  const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
+  if (!secret) {
+    return Response.json(
+      { error: "Maintenance authentication is not configured" },
+      { status: 503 }
+    )
+  }
+  const verification = await verifyJarvisRequest(
+    request,
+    secret,
+    body.rawBody
+  )
+  if (!verification.success) {
+    return Response.json({ error: verification.error }, { status: 401 })
+  }
+
+  try {
+    const summary = await recoverLegacyGotoMessageBodies({
+      db: getDb(env.DB),
+      env,
+    })
+    return Response.json({ success: true, ...summary })
+  } catch (error) {
+    return Response.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "GoTo message recovery failed",
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/dashboard/office-maintenance/inbound-email/page.tsx
+++ b/src/app/dashboard/office-maintenance/inbound-email/page.tsx
@@ -98,8 +98,9 @@ export default async function InboundEmailReviewPage(): Promise<React.ReactEleme
                 </p>
               ) : (
                 <p className="mt-4 text-sm text-muted-foreground">
-                  This message arrived before Compass retained unmatched text
-                  content. Add a useful title and description before routing it.
+                  {item.recoveryError ??
+                    "Compass is recovering the content of this earlier unmatched text from GoTo."}
+                  {" "}You can add a useful title and description manually if needed.
                 </p>
               )}
 

--- a/src/lib/goto/__tests__/message-recovery.test.ts
+++ b/src/lib/goto/__tests__/message-recovery.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+
+import { parseRetrievedGotoMessage } from "@/lib/goto/message-recovery"
+
+describe("parseRetrievedGotoMessage", () => {
+  it("reads a direct GoTo message response", () => {
+    expect(
+      parseRetrievedGotoMessage({
+        id: "message-1",
+        body: "[RFI] Please verify the opening.",
+        conversationId: "conversation-1",
+      })
+    ).toEqual({
+      body: "[RFI] Please verify the opening.",
+      conversationId: "conversation-1",
+    })
+  })
+
+  it("accepts nested message and collection response shapes", () => {
+    expect(
+      parseRetrievedGotoMessage({
+        message: { body: "Nested text", conversationId: "conversation-2" },
+      })
+    ).toEqual({ body: "Nested text", conversationId: "conversation-2" })
+    expect(
+      parseRetrievedGotoMessage({ items: [{ body: "Listed text" }] })
+    ).toEqual({ body: "Listed text", conversationId: null })
+  })
+
+  it("rejects responses without retained text", () => {
+    expect(parseRetrievedGotoMessage({ id: "message-1" })).toBeNull()
+    expect(parseRetrievedGotoMessage({ body: "   " })).toBeNull()
+    expect(parseRetrievedGotoMessage(null)).toBeNull()
+  })
+})

--- a/src/lib/goto/message-recovery.ts
+++ b/src/lib/goto/message-recovery.ts
@@ -1,0 +1,157 @@
+import { and, eq, isNull, or } from "drizzle-orm"
+
+import type { getDb } from "@/db"
+import { gotoInboundEvents } from "@/db/schema"
+import { getGotoAccessToken } from "@/lib/notifications/create-event"
+
+type Db = ReturnType<typeof getDb>
+
+export type RetrievedGotoMessage = {
+  readonly body: string
+  readonly conversationId: string | null
+}
+
+export type GotoMessageRecoverySummary = {
+  readonly examined: number
+  readonly recovered: number
+  readonly unavailable: number
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : null
+}
+
+function messageCandidate(value: unknown): Record<string, unknown> | null {
+  if (!isRecord(value)) return null
+  if (nonEmptyString(value.body)) return value
+
+  const nested = value.message ?? value.payload
+  if (isRecord(nested) && nonEmptyString(nested.body)) return nested
+
+  if (!Array.isArray(value.items)) return null
+  return value.items.find(
+    (item): item is Record<string, unknown> =>
+      isRecord(item) && nonEmptyString(item.body) !== null
+  ) ?? null
+}
+
+export function parseRetrievedGotoMessage(
+  value: unknown
+): RetrievedGotoMessage | null {
+  const candidate = messageCandidate(value)
+  if (!candidate) return null
+  const body = nonEmptyString(candidate.body)
+  if (!body) return null
+  return {
+    body,
+    conversationId: nonEmptyString(candidate.conversationId),
+  }
+}
+
+async function retrieveGotoMessage(
+  messageId: string,
+  accessToken: string
+): Promise<
+  | { readonly kind: "found"; readonly message: RetrievedGotoMessage }
+  | { readonly kind: "unavailable"; readonly status: number }
+> {
+  const response = await fetch(
+    `https://api.goto.com/messaging/v1/messages/${encodeURIComponent(messageId)}`,
+    {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  )
+  if (!response.ok) {
+    if (response.status === 400 || response.status === 404) {
+      return { kind: "unavailable", status: response.status }
+    }
+    throw new Error(`GoTo message retrieval failed (${response.status}).`)
+  }
+
+  const value: unknown = await response.json()
+  const message = parseRetrievedGotoMessage(value)
+  if (!message) {
+    return { kind: "unavailable", status: 200 }
+  }
+  return { kind: "found", message }
+}
+
+export async function recoverLegacyGotoMessageBodies(input: {
+  readonly db: Db
+  readonly env: unknown
+  readonly limit?: number
+}): Promise<GotoMessageRecoverySummary> {
+  const rows = await input.db
+    .select({
+      id: gotoInboundEvents.id,
+      messageId: gotoInboundEvents.messageId,
+    })
+    .from(gotoInboundEvents)
+    .where(
+      and(
+        eq(gotoInboundEvents.status, "needs_review"),
+        eq(gotoInboundEvents.reviewReason, "legacy_project_unmatched"),
+        or(
+          isNull(gotoInboundEvents.messageBody),
+          eq(gotoInboundEvents.messageBody, "")
+        ),
+        isNull(gotoInboundEvents.error)
+      )
+    )
+    .limit(input.limit ?? 50)
+
+  if (rows.length === 0) {
+    return { examined: 0, recovered: 0, unavailable: 0 }
+  }
+
+  const token = await getGotoAccessToken(input.env)
+  if (!token.success) {
+    throw new Error(`GoTo message recovery could not authenticate: ${token.error}`)
+  }
+
+  let recovered = 0
+  let unavailable = 0
+  for (const row of rows) {
+    const result = await retrieveGotoMessage(row.messageId, token.accessToken)
+    const now = new Date().toISOString()
+    if (result.kind === "found") {
+      await input.db
+        .update(gotoInboundEvents)
+        .set({
+          messageBody: result.message.body,
+          conversationId: result.message.conversationId,
+          reviewReason: "missing_project",
+          error: null,
+          updatedAt: now,
+        })
+        .where(eq(gotoInboundEvents.id, row.id))
+        .run()
+      recovered += 1
+      continue
+    }
+
+    await input.db
+      .update(gotoInboundEvents)
+      .set({
+        error:
+          result.status === 200
+            ? "GoTo returned no retained text for this historical message."
+            : `Historical message is no longer available from GoTo (${result.status}).`,
+        updatedAt: now,
+      })
+      .where(eq(gotoInboundEvents.id, row.id))
+      .run()
+    unavailable += 1
+  }
+
+  return { examined: rows.length, recovered, unavailable }
+}


### PR DESCRIPTION
## Summary
- recover blank historical inbound SMS bodies from GoTo using retained message IDs
- run recovery through the authenticated scheduled-maintenance path
- explain records that GoTo no longer retains instead of showing unexplained blank fields

## Validation
- `bun test src/lib/goto/__tests__/message-recovery.test.ts`
- `bunx tsc --noEmit`
- `bunx eslint` on changed files
- `NODE_OPTIONS=--max-old-space-size=8192 bun run build`

## Notes
- message content and credentials are never logged
- no conversation components were changed, avoiding overlap with the ongoing Hermes conversation work
