### PR TITLE
fix(operations): isolate scheduled maintenance jobs

### DIFF
--- a/custom-worker.ts
+++ b/custom-worker.ts
@@ -107,14 +107,34 @@ async function recoverGotoMessageBodies(env: CloudflareEnv): Promise<void> {
   }
 }
 
+function maintenanceErrorLabel(error: unknown): string {
+  if (!(error instanceof Error)) return "Unknown error"
+  const status = /\b[1-5]\d{2}\b/.exec(error.message)?.[0]
+  return status ? `${error.name} status ${status}` : error.name
+}
+
+async function runMaintenanceJob(
+  name: string,
+  job: () => Promise<void>
+): Promise<void> {
+  try {
+    await job()
+  } catch (error) {
+    // Jobs are independent; log only the error class/status to avoid leaking data.
+    console.error(`[scheduled] ${name} failed: ${maintenanceErrorLabel(error)}`)
+  }
+}
+
 export default {
   fetch: worker.fetch,
   async scheduled(_controller, env, ctx): Promise<void> {
     ctx.waitUntil(
       Promise.all([
-        reconcile(env),
-        syncInboundEmail(env),
-        recoverGotoMessageBodies(env),
+        runMaintenanceJob("feedback reconciliation", () => reconcile(env)),
+        runMaintenanceJob("inbound email sync", () => syncInboundEmail(env)),
+        runMaintenanceJob("GoTo message recovery", () =>
+          recoverGotoMessageBodies(env)
+        ),
       ]).then(() => undefined)
     )
   },

--- a/src/lib/__tests__/middleware-routes.test.ts
+++ b/src/lib/__tests__/middleware-routes.test.ts
@@ -43,4 +43,16 @@ describe("middleware public routes", () => {
     expect(isPublicPath("/api/integrations/goto/inbound")).toBe(true)
     expect(isPublicPath("/api/integrations/goto/setup")).toBe(false)
   })
+
+  it("allows only exact independently authenticated maintenance routes", () => {
+    expect(isPublicPath("/api/email/gmail-sync")).toBe(true)
+    expect(isPublicPath("/api/operations/feedback/reconcile")).toBe(true)
+    expect(
+      isPublicPath("/api/operations/goto/recover-message-bodies")
+    ).toBe(true)
+    expect(isPublicPath("/api/operations/goto")).toBe(false)
+    expect(
+      isPublicPath("/api/operations/goto/recover-message-bodies/extra")
+    ).toBe(false)
+  })
 })

--- a/src/lib/public-paths.ts
+++ b/src/lib/public-paths.ts
@@ -25,12 +25,21 @@ const sageBridgePaths = [
 
 const webhookPaths = ["/api/integrations/goto/inbound"]
 
+// These routes bypass WorkOS only so their own bearer/HMAC checks can run.
+// Keep the allowlist exact: none of the route prefixes are public.
+const scheduledMaintenancePaths = [
+  "/api/email/gmail-sync",
+  "/api/operations/feedback/reconcile",
+  "/api/operations/goto/recover-message-bodies",
+]
+
 export function isPublicPath(pathname: string): boolean {
   return (
     publicPaths.includes(pathname) ||
     bridgePaths.includes(pathname) ||
     sageBridgePaths.includes(pathname) ||
     webhookPaths.includes(pathname) ||
+    scheduledMaintenancePaths.includes(pathname) ||
     pathname.startsWith("/api/auth/") ||
     pathname.startsWith("/api/integrations/jarvis/") ||
     pathname.startsWith("/api/netsuite/") ||


### PR DESCRIPTION
## Summary
- allow only the exact bearer/HMAC-protected maintenance endpoints through WorkOS middleware
- isolate feedback, Gmail, and GoTo scheduled jobs so one failure cannot cancel the others
- redact operational error logs to error class and HTTP status only

## Root cause
The internal service-binding calls were redirected by WorkOS to an HTML login response. Gmail attempted to parse that response as JSON, rejecting the shared `Promise.all` maintenance task before GoTo recovery could finish.

## Validation
- `bun test src/lib/__tests__/middleware-routes.test.ts src/lib/goto/__tests__/message-recovery.test.ts`
- `bunx eslint` on changed files
- `bunx tsc --noEmit`
- mandatory pre-push production build
