### PR TITLE
feat(integrations): complete guarded cutover and Sage polling

### DIFF
--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,37 @@
+# Compass private integration services
+
+These units run private-network integration workers outside Cloudflare. They
+must not contain secret values. Secrets are injected at process start by the
+host's secret broker.
+
+## Sage pay-application poller
+
+Install the poller and units on the private bridge host:
+
+```bash
+install -d "$HOME/.local/lib/compass"
+install -m 0755 scripts/sage_pay_application_poller.py \
+  "$HOME/.local/lib/compass/sage_pay_application_poller.py"
+install -d "$HOME/.config/systemd/user"
+install -m 0644 deploy/systemd/compass-sage-pay-application-poller.service \
+  "$HOME/.config/systemd/user/"
+install -m 0644 deploy/systemd/compass-sage-pay-application-poller.timer \
+  "$HOME/.config/systemd/user/"
+systemctl --user daemon-reload
+systemctl --user enable --now compass-sage-pay-application-poller.timer
+```
+
+The secret broker must expose `HPS_SAGE_SQL_PASSWORD` and
+`SAGE_BRIDGE_SECRET`. The latter must match the Cloudflare Worker secret. The
+SQL account is read-only and the poller never sends SQL credentials to
+Compass.
+
+Useful health checks:
+
+```bash
+systemctl --user status compass-sage-pay-application-poller.timer
+journalctl --user -u compass-sage-pay-application-poller.service -n 50 --no-pager
+```
+
+The timer invokes a single, lock-protected poll each minute. A successful idle
+run reports `requested: 0` and `processed: 0`; that is a healthy state.

--- a/deploy/systemd/compass-sage-pay-application-poller.service
+++ b/deploy/systemd/compass-sage-pay-application-poller.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Compass Sage pay-application read-only poll
+After=network-online.target signet-daemon-2645508.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/home/jarvis/.bun/install/global/node_modules/signetai-linux-x64/bin/signet secret exec --secret HPS_SAGE_SQL_PASSWORD --secret SAGE_BRIDGE_SECRET --timeout 55 /usr/bin/python3 /home/jarvis/.local/lib/compass/sage_pay_application_poller.py --once

--- a/deploy/systemd/compass-sage-pay-application-poller.timer
+++ b/deploy/systemd/compass-sage-pay-application-poller.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Poll Compass for Sage pay-application read requests
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=60s
+AccuracySec=5s
+Persistent=true
+Unit=compass-sage-pay-application-poller.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/wip/sage-api-bridge-2026-05-14.md
+++ b/docs/wip/sage-api-bridge-2026-05-14.md
@@ -80,3 +80,37 @@ request ID together with the timestamp, method, target, and raw body. Compass
 consumes poll request IDs once, rejects replayed polls, and only reports the
 bridge online after a recent authenticated poll. Production and
 non-production environments must use distinct `SAGE_BRIDGE_SECRET` values.
+
+### Private poller deployment
+
+The reference poller is `scripts/sage_pay_application_poller.py`; its systemd
+units are in `deploy/systemd/`. The deployed process:
+
+- runs on a private-network bridge host, never in a browser;
+- receives the SQL password and HMAC secret from the host secret broker;
+- connects with a dedicated read-only Sage identity;
+- claims bounded Compass requests once per minute;
+- reads only the latest AIA header and its G703 lines;
+- derives total earned less retainage from populated Sage header totals when
+  Sage's `ttlern` field is empty;
+- posts a revisioned, project-scoped snapshot back to Compass; and
+- uses a process lock so overlapping timer invocations cannot duplicate work.
+
+Operational installation and health-check commands are documented in
+`deploy/systemd/README.md`. Do not place SQL credentials or the shared HMAC
+secret in a unit file, command history, repository file, or application log.
+
+### Production validation checklist
+
+Before treating a project as connected:
+
+1. Confirm the Compass project maps both Sage's stable job identity and its
+   numeric AIA job key.
+2. Request a read from the project Budget / G703 workspace.
+3. Confirm the bridge run completes and the heartbeat remains current.
+4. Reconcile header contract, completed-and-stored, retainage, prior
+   certificates, current payment, and balance totals against Sage.
+5. Reconcile the sum and count of normalized G703 lines against the Sage AIA
+   lines.
+6. Keep the imported application internal until a staff member reviews and
+   intentionally publishes it to an owner.

--- a/scripts/build-buildertrend-legacy-reconciliation-sql.mjs
+++ b/scripts/build-buildertrend-legacy-reconciliation-sql.mjs
@@ -1,0 +1,24 @@
+import { writeFile } from "node:fs/promises"
+import { resolve } from "node:path"
+
+import { buildLegacyBuildertrendReconciliationSql } from "../src/lib/buildertrend/legacy-reconciliation.ts"
+
+const args = process.argv.slice(2)
+const organizationFlagIndex = args.indexOf("--organization-id")
+const outputFlagIndex = args.indexOf("--output")
+
+const organizationId =
+  organizationFlagIndex >= 0 ? args[organizationFlagIndex + 1]?.trim() : undefined
+const outputPath =
+  outputFlagIndex >= 0 ? args[outputFlagIndex + 1]?.trim() : undefined
+
+if (!organizationId || !outputPath) {
+  throw new Error(
+    "Usage: bun scripts/build-buildertrend-legacy-reconciliation-sql.mjs --organization-id <id> --output <file>"
+  )
+}
+
+const sql = buildLegacyBuildertrendReconciliationSql(organizationId)
+const absoluteOutputPath = resolve(process.cwd(), outputPath)
+await writeFile(absoluteOutputPath, sql, "utf8")
+console.log(`Wrote guarded Buildertrend legacy reconciliation SQL to ${absoluteOutputPath}`)

--- a/scripts/sage_pay_application_poller.py
+++ b/scripts/sage_pay_application_poller.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+"""Read-only Sage 100 Contractor pay-application poller for Compass.
+
+SQL credentials and the Compass HMAC secret are injected by Signet. The
+process never sends SQL credentials to Compass and never writes to Sage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import fcntl
+import hashlib
+import hmac
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+import uuid
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+
+DEFAULT_COMPASS_BASE_URL = "https://compass.openrangeconstruction.ltd"
+DEFAULT_SAGE_SERVER = "100.100.201.24"
+DEFAULT_SAGE_PORT = 14330
+DEFAULT_SAGE_DATABASE = "High Performance Structures Inc"
+DEFAULT_SAGE_USERNAME = "hps_jarvis_readonly"
+REQUESTS_TARGET = "/api/integrations/sage/pay-applications/requests?limit=10"
+RESULTS_TARGET = "/api/integrations/sage/pay-applications/results"
+LOCK_PATH = Path("/tmp/compass-sage-pay-application-poller.lock")
+SNAPSHOT_MAPPING_VERSION = "v2"
+
+
+CSI_DIVISIONS = {
+    "00": "Procurement and Contracting Requirements",
+    "01": "General Requirements",
+    "02": "Existing Conditions",
+    "03": "Concrete",
+    "04": "Masonry",
+    "05": "Metals",
+    "06": "Wood, Plastics, and Composites",
+    "07": "Thermal and Moisture Protection",
+    "08": "Openings",
+    "09": "Finishes",
+    "10": "Specialties",
+    "11": "Equipment",
+    "12": "Furnishings",
+    "13": "Special Construction",
+    "14": "Conveying Equipment",
+    "21": "Fire Suppression",
+    "22": "Plumbing",
+    "23": "Heating, Ventilating, and Air Conditioning",
+    "25": "Integrated Automation",
+    "26": "Electrical",
+    "27": "Communications",
+    "28": "Electronic Safety and Security",
+    "31": "Earthwork",
+    "32": "Exterior Improvements",
+    "33": "Utilities",
+    "34": "Transportation",
+    "35": "Waterway and Marine Construction",
+    "40": "Process Integration",
+    "41": "Material Processing and Handling Equipment",
+    "42": "Process Heating, Cooling, and Drying Equipment",
+    "43": "Process Gas and Liquid Handling, Purification, and Storage Equipment",
+    "44": "Pollution and Waste Control Equipment",
+    "45": "Industry-Specific Manufacturing Equipment",
+    "46": "Water and Wastewater Equipment",
+    "48": "Electrical Power Generation",
+}
+
+
+class PollerError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class PollRequest:
+    run_id: str
+    project_id: str
+    sage_job_id: str | None
+    sage_job_number: str | None
+    claim_token: str
+
+
+def text(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def money(value: Any) -> float:
+    if value is None:
+        return 0.0
+    if isinstance(value, Decimal):
+        return round(float(value), 2)
+    return round(float(value), 2)
+
+
+def iso_date(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, dt.datetime):
+        return value.date().isoformat()
+    if isinstance(value, dt.date):
+        return value.isoformat()
+    normalized = text(value)
+    if normalized is None:
+        return None
+    return normalized[:10]
+
+
+def iso_timestamp(value: Any) -> str:
+    if isinstance(value, dt.datetime):
+        timestamp = value
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=dt.timezone.utc)
+        return timestamp.isoformat()
+    if isinstance(value, dt.date):
+        return dt.datetime.combine(
+            value, dt.time.min, tzinfo=dt.timezone.utc
+        ).isoformat()
+    normalized = text(value)
+    return normalized or "unknown"
+
+
+def division_code(line: Mapping[str, Any]) -> str:
+    for field in ("dscrpt", "cdenme"):
+        description = text(line.get(field)) or ""
+        match = re.match(r"^(\d{2})(?:\s|$)", description)
+        if match:
+            return match.group(1)
+
+    for field in ("divnum", "master_divnum"):
+        raw = line.get(field)
+        if raw is None:
+            continue
+        try:
+            number = int(Decimal(str(raw)))
+            if number == 100:
+                return "00"
+            if 0 <= number <= 99:
+                return f"{number:02d}"
+        except (ValueError, TypeError, ArithmeticError):
+            pass
+
+    cost_code = text(line.get("cstcde")) or ""
+    digits = "".join(character for character in cost_code if character.isdigit())
+    return digits[:2] if len(digits) >= 2 else "00"
+
+
+def normalized_cost_code(value: Any) -> str:
+    if isinstance(value, Decimal):
+        return format(value, "f")
+    return text(value) or "Unassigned"
+
+
+def build_snapshot(
+    request: PollRequest,
+    header: Mapping[str, Any],
+    lines: Sequence[Mapping[str, Any]],
+    captured_at: str,
+) -> dict[str, Any]:
+    if not lines:
+        raise PollerError("The Sage pay application has no G703 lines")
+
+    header_updated = iso_timestamp(header.get("upddte"))
+    line_updated = max(iso_timestamp(line.get("upddte")) for line in lines)
+    source_application_id = f"sage-aiafrm:{header['recnum']}"
+    source_revision = (
+        f"mapping={SNAPSHOT_MAPPING_VERSION};header={header_updated};"
+        f"lines={line_updated};count={len(lines)}"
+    )
+
+    normalized_lines: list[dict[str, Any]] = []
+    for index, line in enumerate(lines):
+        code = division_code(line)
+        normalized_lines.append(
+            {
+                "sourceLineId": f"sage-aialin:{line['recnum']}:{line['linnum']}",
+                "costCode": normalized_cost_code(line.get("cstcde")),
+                "csiDivision": code,
+                "csiDivisionName": CSI_DIVISIONS.get(code, f"Division {code}"),
+                "description": text(line.get("dscrpt"))
+                or text(line.get("cdenme"))
+                or "Sage G703 line",
+                "originalEstimate": money(line.get("schamt")),
+                "priorChanges": money(line.get("chgamt")),
+                "currentChanges": 0.0,
+                "totalChanges": money(line.get("chgamt")),
+                "adjustedEstimate": money(line.get("newcon")),
+                "previousWorkCompleted": money(line.get("prvbll")),
+                "currentWorkCompleted": money(line.get("curbll")),
+                "storedMaterials": money(line.get("strmat")),
+                "totalCompletedStoredToDate": money(line.get("ttlcmp")),
+                "retainageHeld": money(line.get("retamt")),
+                "balanceToFinish": money(line.get("balfin")),
+                "sortOrder": index,
+            }
+        )
+
+    # Sage's ttlern field is not populated on the live AIA headers even when
+    # the G703 has completed work. Derive the AIA "total earned less
+    # retainage" from the populated header totals so the value is both
+    # auditable and consistent with the line-level reconciliation.
+    total_completed_stored = money(header.get("cmpttl"))
+    retainage_held = money(header.get("ttlret"))
+    total_earned_less_retainage = round(
+        total_completed_stored - retainage_held, 2
+    )
+
+    return {
+        "runId": request.run_id,
+        "claimToken": request.claim_token,
+        "capturedAt": captured_at,
+        "header": {
+            "sourceApplicationId": source_application_id,
+            "sourceRevision": source_revision,
+            "sageJobId": text(header.get("sage_job_id")),
+            "sageJobNumber": text(header.get("jobnum")),
+            "applicationNumber": text(header.get("appnum"))
+            or text(header.get("recnum"))
+            or "Unknown",
+            "periodTo": iso_date(header.get("period")),
+            "status": text(header.get("status")) or "unknown",
+            "originalContractSum": money(header.get("schttl")),
+            "netChanges": money(header.get("chgttl")),
+            "contractSumToDate": money(header.get("conttl")),
+            "totalCompletedStoredToDate": total_completed_stored,
+            "retainageHeld": retainage_held,
+            "totalEarnedLessRetainage": total_earned_less_retainage,
+            "previousCertificates": money(header.get("prvbil")),
+            "currentPaymentDue": money(header.get("crtdue")),
+            "balanceToFinish": money(header.get("balfin")),
+        },
+        "lines": normalized_lines,
+    }
+
+
+def signature(
+    secret: str,
+    timestamp: str,
+    request_id: str,
+    method: str,
+    target: str,
+    raw_body: str,
+) -> str:
+    payload = f"{timestamp}.{request_id}.{method.upper()}.{target}.{raw_body}"
+    digest = hmac.new(
+        secret.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+    return f"sha256={digest}"
+
+
+def signed_json_request(
+    base_url: str,
+    secret: str,
+    method: str,
+    target: str,
+    body: Mapping[str, Any] | None = None,
+    timeout: int = 30,
+) -> Any:
+    raw_body = "" if body is None else json.dumps(body, separators=(",", ":"))
+    timestamp = str(int(time.time()))
+    request_id = str(uuid.uuid4())
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "Mozilla/5.0 Compass-Sage-Bridge/1.0",
+        "X-Compass-Timestamp": timestamp,
+        "X-Compass-Request-Id": request_id,
+        "X-Compass-Signature": signature(
+            secret, timestamp, request_id, method, target, raw_body
+        ),
+    }
+    data = None
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+        data = raw_body.encode("utf-8")
+    request = urllib.request.Request(
+        f"{base_url.rstrip('/')}{target}", data=data, headers=headers, method=method
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")[:1000]
+        raise PollerError(f"Compass returned HTTP {error.code}: {detail}") from error
+    except urllib.error.URLError as error:
+        raise PollerError(f"Compass request failed: {error.reason}") from error
+
+
+def parse_poll_requests(payload: Any) -> list[PollRequest]:
+    if not isinstance(payload, Mapping):
+        raise PollerError("Compass returned an invalid poll response")
+    raw_requests = payload.get("requests")
+    if not isinstance(raw_requests, list):
+        raise PollerError("Compass poll response is missing requests")
+
+    requests: list[PollRequest] = []
+    for raw in raw_requests:
+        if not isinstance(raw, Mapping):
+            raise PollerError("Compass returned an invalid sync request")
+        run_id = text(raw.get("id"))
+        project_id = text(raw.get("projectId"))
+        claim_token = text(raw.get("claimToken"))
+        if run_id is None or project_id is None or claim_token is None:
+            raise PollerError("Compass returned an incomplete sync request")
+        requests.append(
+            PollRequest(
+                run_id=run_id,
+                project_id=project_id,
+                sage_job_id=text(raw.get("sageJobId")),
+                sage_job_number=text(raw.get("sageJobNumber")),
+                claim_token=claim_token,
+            )
+        )
+    return requests
+
+
+def resolve_sage_job(request: PollRequest) -> int:
+    # Compass stores Sage's stable row identity in sage_job_id and the numeric
+    # actrec.recnum used by AIA tables in sage_job_number.
+    for candidate in (request.sage_job_number, request.sage_job_id):
+        if candidate is None:
+            continue
+        try:
+            return int(Decimal(candidate))
+        except (ValueError, TypeError, ArithmeticError):
+            continue
+    raise PollerError(
+        f"Project {request.project_id} does not have a numeric Sage job mapping"
+    )
+
+
+def fetch_latest_application(cursor: Any, sage_job: int) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    cursor.execute(
+        """
+        SELECT TOP 1
+          application.recnum, application.jobnum, job._idnum AS sage_job_id,
+          application.appnum, application.period, application.status,
+          application.schttl, application.chgttl, application.conttl,
+          application.cmpttl, application.ttlret, application.ttlern,
+          application.prvbil, application.crtdue, application.balfin,
+          application.upddte
+        FROM dbo.aiafrm application
+        JOIN dbo.actrec job ON job.recnum=application.jobnum
+        WHERE application.jobnum=%s
+        ORDER BY application.period DESC, application.appnum DESC,
+          application.recnum DESC
+        """,
+        (sage_job,),
+    )
+    header = cursor.fetchone()
+    if not header:
+        raise PollerError(f"No Sage pay application exists for job {sage_job}")
+    cursor.execute(
+        """
+        SELECT
+          line.recnum, line.linnum, line.divnum, line.cstcde,
+          cost_code.cdenme, cost_code.divnum AS master_divnum, line.dscrpt,
+          line.schamt, line.chgamt,
+          line.newcon, line.prvbll, line.curbll, line.strmat, line.ttlcmp,
+          line.retamt, line.balfin, line.upddte
+        FROM dbo.aialin line
+        LEFT JOIN dbo.cstcde cost_code ON cost_code.recnum=line.cstcde
+        WHERE line.recnum=%s
+        ORDER BY line.linnum
+        """,
+        (header["recnum"],),
+    )
+    return dict(header), [dict(line) for line in cursor.fetchall()]
+
+
+def connect_sage() -> Any:
+    try:
+        import pymssql
+    except ImportError as error:
+        raise PollerError("pymssql is not installed") from error
+
+    password = os.environ.get("HPS_SAGE_SQL_PASSWORD", "").strip()
+    if not password:
+        raise PollerError("HPS_SAGE_SQL_PASSWORD is not available")
+    try:
+        return pymssql.connect(
+            server=os.environ.get("HPS_SAGE_SQL_SERVER", DEFAULT_SAGE_SERVER),
+            port=int(os.environ.get("HPS_SAGE_SQL_PORT", str(DEFAULT_SAGE_PORT))),
+            user=os.environ.get("HPS_SAGE_SQL_USERNAME", DEFAULT_SAGE_USERNAME),
+            password=password,
+            database=os.environ.get(
+                "HPS_SAGE_SQL_DATABASE", DEFAULT_SAGE_DATABASE
+            ),
+            # Sage's login trigger recognizes the established Jarvis read-only
+            # application identity and the broken-bar separator.
+            appname="Sage100Contractor¦JarvisCompassPayAppRO",
+            login_timeout=15,
+            timeout=120,
+            autocommit=True,
+        )
+    except Exception as error:
+        raise PollerError(
+            f"Sage SQL connection failed: {type(error).__name__}"
+        ) from error
+
+
+def process_requests(requests: Iterable[PollRequest], base_url: str, secret: str) -> int:
+    processed = 0
+    connection = connect_sage()
+    try:
+        cursor = connection.cursor(as_dict=True)
+        for request in requests:
+            sage_job = resolve_sage_job(request)
+            header, lines = fetch_latest_application(cursor, sage_job)
+            captured_at = dt.datetime.now(dt.timezone.utc).isoformat()
+            snapshot = build_snapshot(request, header, lines, captured_at)
+            signed_json_request(
+                base_url, secret, "POST", RESULTS_TARGET, snapshot, timeout=45
+            )
+            processed += 1
+    finally:
+        connection.close()
+    return processed
+
+
+def poll_once(base_url: str, secret: str) -> tuple[int, int]:
+    payload = signed_json_request(
+        base_url, secret, "GET", REQUESTS_TARGET, timeout=30
+    )
+    requests = parse_poll_requests(payload)
+    if not requests:
+        return 0, 0
+    processed = process_requests(requests, base_url, secret)
+    return len(requests), processed
+
+
+def acquire_lock() -> Any:
+    lock = LOCK_PATH.open("w", encoding="utf-8")
+    try:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as error:
+        lock.close()
+        raise PollerError("Another Sage pay-application poller is active") from error
+    return lock
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--once", action="store_true", help="Poll once and exit")
+    args = parser.parse_args()
+
+    base_url = os.environ.get("COMPASS_BASE_URL", DEFAULT_COMPASS_BASE_URL).strip()
+    secret = os.environ.get("SAGE_BRIDGE_SECRET", "").strip()
+    if len(secret) < 32:
+        raise PollerError("SAGE_BRIDGE_SECRET is not available or is too short")
+
+    lock = acquire_lock()
+    try:
+        while True:
+            requested, processed = poll_once(base_url, secret)
+            print(
+                json.dumps(
+                    {
+                        "status": "ok",
+                        "requested": requested,
+                        "processed": processed,
+                        "at": dt.datetime.now(dt.timezone.utc).isoformat(),
+                    }
+                ),
+                flush=True,
+            )
+            if args.once:
+                return 0
+            time.sleep(30)
+    finally:
+        lock.close()
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except PollerError as error:
+        print(json.dumps({"status": "error", "error": str(error)}), file=sys.stderr)
+        raise SystemExit(1) from error

--- a/scripts/test_sage_pay_application_poller.py
+++ b/scripts/test_sage_pay_application_poller.py
@@ -1,0 +1,174 @@
+import datetime as dt
+import hashlib
+import hmac
+import sys
+import unittest
+from decimal import Decimal
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from sage_pay_application_poller import (
+    PollRequest,
+    build_snapshot,
+    parse_poll_requests,
+    resolve_sage_job,
+    signature,
+)
+
+
+class SagePayApplicationPollerTests(unittest.TestCase):
+    def test_signature_matches_compass_contract(self) -> None:
+        actual = signature(
+            "a" * 32,
+            "1720000000",
+            "00000000-0000-4000-8000-000000000000",
+            "GET",
+            "/api/example?limit=10",
+            "",
+        )
+        payload = (
+            "1720000000.00000000-0000-4000-8000-000000000000."
+            "GET./api/example?limit=10."
+        )
+        expected = hmac.new(
+            ("a" * 32).encode(), payload.encode(), hashlib.sha256
+        ).hexdigest()
+        self.assertEqual(actual, f"sha256={expected}")
+
+    def test_build_snapshot_maps_native_aia_fields(self) -> None:
+        request = PollRequest(
+            run_id="11111111-1111-4111-8111-111111111111",
+            project_id="project-1",
+            sage_job_id="620",
+            sage_job_number="O-170-2684",
+            claim_token="22222222-2222-4222-8222-222222222222",
+        )
+        header = {
+            "recnum": 13,
+            "jobnum": 620,
+            "sage_job_id": "78021b5e-5342-f111-a841-bccd992bc5d1",
+            "appnum": 3,
+            "period": dt.date(2026, 6, 30),
+            "status": 5,
+            "schttl": Decimal("100.00"),
+            "chgttl": Decimal("10.00"),
+            "conttl": Decimal("110.00"),
+            "cmpttl": Decimal("70.00"),
+            "ttlret": Decimal("5.00"),
+            # Sage leaves this field empty/zero on live AIA headers.
+            "ttlern": Decimal("0.00"),
+            "prvbil": Decimal("20.00"),
+            "crtdue": Decimal("45.00"),
+            "balfin": Decimal("45.00"),
+            "upddte": dt.datetime(2026, 7, 1, 12, 0),
+        }
+        lines = [
+            {
+                "recnum": 13,
+                "linnum": 1,
+                "divnum": None,
+                "master_divnum": 3,
+                "cstcde": Decimal("31200000.000"),
+                "cdenme": "Concrete",
+                "dscrpt": "Foundations",
+                "schamt": Decimal("100.00"),
+                "chgamt": Decimal("10.00"),
+                "newcon": Decimal("110.00"),
+                "prvbll": Decimal("20.00"),
+                "curbll": Decimal("50.00"),
+                "strmat": Decimal("0.00"),
+                "ttlcmp": Decimal("70.00"),
+                "retamt": Decimal("5.00"),
+                "balfin": Decimal("45.00"),
+                "upddte": dt.datetime(2026, 7, 1, 12, 1),
+            }
+        ]
+
+        snapshot = build_snapshot(
+            request, header, lines, "2026-07-01T18:00:00+00:00"
+        )
+
+        self.assertEqual(snapshot["header"]["sourceApplicationId"], "sage-aiafrm:13")
+        self.assertTrue(snapshot["header"]["sourceRevision"].startswith("mapping=v2;"))
+        self.assertEqual(
+            snapshot["header"]["sageJobId"],
+            "78021b5e-5342-f111-a841-bccd992bc5d1",
+        )
+        self.assertEqual(snapshot["header"]["sageJobNumber"], "620")
+        self.assertEqual(snapshot["header"]["totalEarnedLessRetainage"], 65.0)
+        self.assertEqual(snapshot["header"]["currentPaymentDue"], 45.0)
+        self.assertEqual(snapshot["lines"][0]["csiDivision"], "03")
+        self.assertEqual(snapshot["lines"][0]["totalChanges"], 10.0)
+        self.assertEqual(snapshot["lines"][0]["retainageHeld"], 5.0)
+
+    def test_buildertrend_style_special_cost_codes_use_description_division(self) -> None:
+        request = PollRequest(
+            run_id="11111111-1111-4111-8111-111111111111",
+            project_id="project-1",
+            sage_job_id="620",
+            sage_job_number="O-170-2684",
+            claim_token="22222222-2222-4222-8222-222222222222",
+        )
+        header = {
+            "recnum": 13,
+            "jobnum": 620,
+            "sage_job_id": 2630,
+            "appnum": 3,
+            "period": dt.date(2026, 6, 30),
+            "status": 5,
+            "schttl": 300,
+            "chgttl": 0,
+            "conttl": 300,
+            "cmpttl": 0,
+            "ttlret": 0,
+            "ttlern": 0,
+            "prvbil": 0,
+            "crtdue": 0,
+            "balfin": 300,
+            "upddte": dt.datetime(2026, 7, 1, 12, 0),
+        }
+        lines = [
+            {
+                "recnum": 13,
+                "linnum": 1,
+                "divnum": None,
+                "master_divnum": 100,
+                "cstcde": Decimal("11.000"),
+                "cdenme": "00 31 21.19 - Photographic Information",
+                "dscrpt": "00 31 21.19 - Photographic Information",
+                "schamt": 300,
+                "chgamt": 0,
+                "newcon": 300,
+                "prvbll": 0,
+                "curbll": 0,
+                "strmat": 0,
+                "ttlcmp": 0,
+                "retamt": 0,
+                "balfin": 300,
+                "upddte": dt.datetime(2026, 7, 1, 12, 1),
+            }
+        ]
+
+        snapshot = build_snapshot(
+            request, header, lines, "2026-07-01T18:00:00+00:00"
+        )
+        self.assertEqual(snapshot["lines"][0]["csiDivision"], "00")
+
+    def test_parse_requests_rejects_incomplete_claims(self) -> None:
+        with self.assertRaisesRegex(Exception, "incomplete"):
+            parse_poll_requests({"requests": [{"id": "run-only"}]})
+
+    def test_sage_job_number_is_the_aia_job_key(self) -> None:
+        request = PollRequest(
+            run_id="11111111-1111-4111-8111-111111111111",
+            project_id="project-1",
+            sage_job_id="2630",
+            sage_job_number="620",
+            claim_token="22222222-2222-4222-8222-222222222222",
+        )
+        self.assertEqual(resolve_sage_job(request), 620)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/lib/buildertrend/__tests__/legacy-reconciliation.test.ts
+++ b/src/lib/buildertrend/__tests__/legacy-reconciliation.test.ts
@@ -1,0 +1,305 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { buildLegacyBuildertrendReconciliationSql } from "../legacy-reconciliation"
+
+type TestStatement = {
+  readonly get: () => unknown
+}
+
+type TestDatabase = {
+  readonly exec: (sql: string) => unknown
+  readonly prepare: (sql: string) => TestStatement
+  readonly close: () => void
+}
+
+type TestDatabaseModule = {
+  readonly Database: new (filename: string) => TestDatabase
+}
+
+function isTestDatabaseModule(value: unknown): value is TestDatabaseModule {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "Database" in value &&
+    typeof value.Database === "function"
+  )
+}
+
+async function createDatabase(): Promise<TestDatabase> {
+  const sqliteModule: unknown = await import("bun:sqlite")
+  if (!isTestDatabaseModule(sqliteModule)) {
+    throw new Error("bun:sqlite did not provide a Database constructor")
+  }
+  return new sqliteModule.Database(":memory:")
+}
+
+const guardedMigrationSql = readFileSync(
+  resolve(process.cwd(), "drizzle/0084_buildertrend_staging_foundation.sql"),
+  "utf8"
+).replaceAll("--> statement-breakpoint", "")
+
+const legacySchemaSql = `
+CREATE TABLE buildertrend_import_runs (
+  id TEXT PRIMARY KEY, organization_id TEXT, source_method TEXT NOT NULL,
+  source_label TEXT NOT NULL, status TEXT NOT NULL, started_by TEXT,
+  started_at TEXT NOT NULL, completed_at TEXT,
+  raw_artifact_drive_file_id TEXT, raw_artifact_drive_url TEXT, notes TEXT,
+  summary_json TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+);
+CREATE TABLE buildertrend_source_records (
+  id TEXT PRIMARY KEY, import_run_id TEXT NOT NULL, organization_id TEXT,
+  project_id TEXT, source_scope TEXT NOT NULL, source_record_type TEXT NOT NULL,
+  buildertrend_job_id TEXT, buildertrend_lead_id TEXT,
+  buildertrend_record_id TEXT, buildertrend_record_number TEXT,
+  buildertrend_url TEXT, title TEXT NOT NULL, record_date TEXT,
+  record_status TEXT, source_status TEXT, department_code TEXT,
+  client_name TEXT, contact_name TEXT, contact_email TEXT, amount REAL,
+  searchable_text TEXT, normalized_summary TEXT, raw_payload_json TEXT,
+  archive_drive_folder_id TEXT, archive_drive_file_id TEXT,
+  archive_drive_url TEXT, review_status TEXT NOT NULL,
+  promotion_status TEXT NOT NULL, promoted_record_type TEXT,
+  promoted_record_id TEXT, sage_reconciliation_status TEXT NOT NULL,
+  notes TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+);
+CREATE TABLE buildertrend_archive_files (
+  id TEXT PRIMARY KEY, import_run_id TEXT NOT NULL, source_record_id TEXT,
+  organization_id TEXT, project_id TEXT, source_scope TEXT NOT NULL,
+  source_record_type TEXT NOT NULL, buildertrend_job_id TEXT,
+  buildertrend_lead_id TEXT, buildertrend_file_id TEXT, buildertrend_url TEXT,
+  file_name TEXT NOT NULL, mime_type TEXT, file_size INTEGER,
+  drive_folder_id TEXT, drive_file_id TEXT, drive_url TEXT,
+  thumbnail_drive_file_id TEXT, thumbnail_url TEXT, checksum TEXT,
+  captured_at TEXT, visibility TEXT NOT NULL, review_status TEXT NOT NULL,
+  metadata_json TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+);
+CREATE TABLE buildertrend_access_candidates (
+  id TEXT PRIMARY KEY, import_run_id TEXT NOT NULL, source_record_id TEXT,
+  organization_id TEXT, project_id TEXT, buildertrend_job_id TEXT,
+  buildertrend_lead_id TEXT, buildertrend_contact_id TEXT,
+  buildertrend_access_role TEXT, contact_name TEXT NOT NULL, company_name TEXT,
+  email TEXT, phone TEXT, proposed_contact_type TEXT NOT NULL,
+  proposed_project_role TEXT, matched_user_id TEXT, matched_customer_id TEXT,
+  matched_vendor_id TEXT, match_status TEXT NOT NULL,
+  match_confidence REAL NOT NULL, portal_access_status TEXT NOT NULL,
+  review_status TEXT NOT NULL, notes TEXT, created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+`
+
+function scalar(database: TestDatabase, sql: string): unknown {
+  const row = database.prepare(sql).get()
+  if (row === null || typeof row !== "object") return undefined
+  return Object.values(row)[0]
+}
+
+function executeReconciliation(database: TestDatabase, sql: string): void {
+  for (const statement of sql.split(";\n")) {
+    const trimmed = statement.trim()
+    if (trimmed.length === 0) continue
+    if (trimmed.startsWith("SELECT ")) {
+      database.prepare(trimmed).get()
+      continue
+    }
+    database.exec(trimmed)
+  }
+}
+
+describe("legacy Buildertrend staging reconciliation", () => {
+  let database: TestDatabase
+
+  beforeEach(async () => {
+    database = await createDatabase()
+    database.exec(`
+      PRAGMA foreign_keys = ON;
+      CREATE TABLE organizations (id TEXT PRIMARY KEY);
+      CREATE TABLE users (id TEXT PRIMARY KEY);
+      CREATE TABLE customers (id TEXT PRIMARY KEY);
+      CREATE TABLE vendors (id TEXT PRIMARY KEY);
+      CREATE TABLE projects (
+        id TEXT PRIMARY KEY,
+        organization_id TEXT NOT NULL REFERENCES organizations(id)
+      );
+      INSERT INTO organizations (id) VALUES ('org-main'), ('org-other');
+      INSERT INTO projects (id, organization_id)
+      VALUES ('project-main', 'org-main'), ('project-other', 'org-other');
+    `)
+    database.exec(legacySchemaSql)
+    database.exec(guardedMigrationSql)
+    database.exec(`
+      INSERT INTO buildertrend_import_runs VALUES
+        ('run-shared', NULL, 'browser_capture', 'Shared capture', 'completed',
+         NULL, '2026-07-01T00:00:00Z', '2026-07-01T01:00:00Z', NULL, NULL,
+         'legacy notes', '{}', '2026-07-01T00:00:00Z', '2026-07-01T01:00:00Z'),
+        ('run-orphan', NULL, 'browser_capture', 'Orphan capture', 'completed',
+         NULL, '2026-07-02T00:00:00Z', '2026-07-02T01:00:00Z', NULL, NULL,
+         NULL, '{}', '2026-07-02T00:00:00Z', '2026-07-02T01:00:00Z');
+      INSERT INTO buildertrend_source_records VALUES
+        ('record-main', 'run-shared', NULL, 'project-main', 'job', 'schedule',
+         'job-main', NULL, 'source-main', NULL, NULL, 'Main schedule', NULL,
+         NULL, NULL, 'O', NULL, NULL, NULL, NULL, NULL, NULL, '{}',
+         'folder-main', 'file-main', 'https://drive.test/main', 'verified',
+         'promoted', 'schedule_item', 'schedule-main', 'matched', NULL,
+         '2026-07-01T00:00:00Z', '2026-07-01T01:00:00Z'),
+        ('record-other', 'run-shared', NULL, 'project-other', 'job', 'job',
+         'job-other', NULL, 'source-other', NULL, NULL, 'Other job', NULL,
+         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, '{}',
+         NULL, NULL, NULL, 'needs_review', 'archive_only', NULL, NULL,
+         'not_reviewed', NULL, '2026-07-01T00:00:00Z',
+         '2026-07-01T01:00:00Z');
+      INSERT INTO buildertrend_archive_files VALUES
+        ('photo-main', 'run-shared', 'record-main', NULL, 'project-main', 'job',
+         'photo', 'job-main', NULL, 'photo-1', NULL, 'photo.jpg', 'image/jpeg',
+         100, 'folder-main', 'photo-drive', 'https://drive.test/photo', NULL,
+         NULL, 'checksum-1', '2026-07-01T00:30:00Z', 'owner', 'verified', '{}',
+         '2026-07-01T00:00:00Z', '2026-07-01T01:00:00Z');
+      INSERT INTO buildertrend_access_candidates VALUES
+        ('access-main', 'run-shared', 'record-main', NULL, 'project-main',
+         'job-main', NULL, 'contact-1', 'owner', 'Example Owner', NULL,
+         'owner@example.test', NULL, 'customer', 'owner', NULL, NULL, NULL,
+         'matched', 0.95, 'granted', 'needs_review', NULL,
+         '2026-07-01T00:00:00Z', '2026-07-01T01:00:00Z');
+    `)
+  })
+
+  it("splits shared runs by tenant and preserves reviewed archive evidence", () => {
+    const sql = buildLegacyBuildertrendReconciliationSql("org-main")
+    executeReconciliation(database, sql)
+
+    expect(scalar(database, "SELECT COUNT(*) FROM buildertrend_staging_runs")).toBe(3)
+    expect(scalar(database, "SELECT COUNT(*) FROM buildertrend_staging_records")).toBe(2)
+    expect(scalar(database, "SELECT COUNT(*) FROM buildertrend_staging_files")).toBe(1)
+    expect(
+      scalar(database, "SELECT verified_drive_file_id FROM buildertrend_staging_files")
+    ).toBe("photo-drive")
+    expect(
+      scalar(
+        database,
+        "SELECT verified_archive_drive_file_id FROM buildertrend_staging_records WHERE id = 'legacy-record:record-main'"
+      )
+    ).toBe("file-main")
+    expect(scalar(database, "SELECT COUNT(*) FROM buildertrend_staging_observations")).toBe(4)
+  })
+
+  it("never carries forward an implicit portal grant", () => {
+    executeReconciliation(
+      database,
+      buildLegacyBuildertrendReconciliationSql("org-main")
+    )
+
+    expect(
+      scalar(database, "SELECT portal_access_status FROM buildertrend_staging_access_candidates")
+    ).toBe("not_granted")
+    expect(
+      scalar(database, "SELECT match_status FROM buildertrend_staging_access_candidates")
+    ).toBe("unmatched")
+  })
+
+  it("is idempotent and does not overwrite guarded review decisions", () => {
+    const sql = buildLegacyBuildertrendReconciliationSql("org-main")
+    executeReconciliation(database, sql)
+    database.exec(`
+      UPDATE buildertrend_staging_records
+      SET review_status = 'reviewed', review_notes = 'Human decision'
+      WHERE id = 'legacy-record:record-main';
+    `)
+    executeReconciliation(database, sql)
+
+    expect(scalar(database, "SELECT COUNT(*) FROM buildertrend_staging_records")).toBe(2)
+    expect(
+      scalar(
+        database,
+        "SELECT review_notes FROM buildertrend_staging_records WHERE id = 'legacy-record:record-main'"
+      )
+    ).toBe("Human decision")
+  })
+
+  it("quarantines a legacy tenant conflict under the linked project's tenant", () => {
+    database.exec(`
+      DELETE FROM buildertrend_archive_files WHERE source_record_id = 'record-main';
+      DELETE FROM buildertrend_access_candidates WHERE source_record_id = 'record-main';
+      UPDATE buildertrend_source_records
+      SET organization_id = 'org-other'
+      WHERE id = 'record-main';
+    `)
+    expect(
+      scalar(
+        database,
+        `SELECT COUNT(*)
+         FROM buildertrend_source_records source_record
+         JOIN projects project ON project.id = source_record.project_id
+         WHERE source_record.organization_id IS NOT NULL
+           AND source_record.organization_id <> project.organization_id`
+      )
+    ).toBe(1)
+
+    executeReconciliation(
+      database,
+      buildLegacyBuildertrendReconciliationSql("org-main")
+    )
+    expect(
+      scalar(
+        database,
+        "SELECT organization_id FROM buildertrend_staging_records WHERE id = 'legacy-record:record-main'"
+      )
+    ).toBe("org-main")
+    expect(
+      scalar(
+        database,
+        "SELECT review_status FROM buildertrend_staging_records WHERE id = 'legacy-record:record-main'"
+      )
+    ).toBe("unresolved_reference")
+    expect(
+      scalar(
+        database,
+        "SELECT promotion_status FROM buildertrend_staging_records WHERE id = 'legacy-record:record-main'"
+      )
+    ).toBe("archive_only")
+  })
+
+  it("aborts before durable writes when the selected tenant does not exist", () => {
+    expect(() =>
+      executeReconciliation(
+        database,
+        buildLegacyBuildertrendReconciliationSql("missing-organization")
+      )
+    ).toThrow()
+    expect(scalar(database, "SELECT COUNT(*) FROM buildertrend_staging_runs")).toBe(0)
+    expect(scalar(database, "SELECT COUNT(*) FROM buildertrend_staging_records")).toBe(0)
+  })
+
+  it("aborts when a file inherits a conflicting tenant through its source record", () => {
+    database.exec(`
+      UPDATE buildertrend_archive_files
+      SET project_id = NULL, organization_id = 'org-other'
+      WHERE id = 'photo-main';
+    `)
+
+    expect(() =>
+      executeReconciliation(
+        database,
+        buildLegacyBuildertrendReconciliationSql("org-main")
+      )
+    ).toThrow()
+    expect(scalar(database, "SELECT COUNT(*) FROM buildertrend_staging_files")).toBe(0)
+  })
+
+  it("aborts when an access candidate links projects across tenants", () => {
+    database.exec(`
+      UPDATE buildertrend_access_candidates
+      SET project_id = 'project-other'
+      WHERE id = 'access-main';
+    `)
+
+    expect(() =>
+      executeReconciliation(
+        database,
+        buildLegacyBuildertrendReconciliationSql("org-main")
+      )
+    ).toThrow()
+    expect(
+      scalar(database, "SELECT COUNT(*) FROM buildertrend_staging_access_candidates")
+    ).toBe(0)
+  })
+})

--- a/src/lib/buildertrend/legacy-reconciliation.ts
+++ b/src/lib/buildertrend/legacy-reconciliation.ts
@@ -1,0 +1,556 @@
+function sqlText(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`
+}
+
+/**
+ * Builds an idempotent, archive-only bridge from the abandoned 0062 tables to
+ * the guarded 0084 Buildertrend staging model. Operational Compass tables are
+ * deliberately outside the scope of this reconciliation.
+ */
+export function buildLegacyBuildertrendReconciliationSql(
+  defaultOrganizationId: string
+): string {
+  const organizationId = defaultOrganizationId.trim()
+  if (organizationId.length === 0) {
+    throw new Error("A default organization ID is required")
+  }
+
+  const defaultOrg = sqlText(organizationId)
+  return `-- Fail closed before any durable write. A CHECK violation stops the
+-- batch instead of merely returning an error-looking value to the caller.
+DROP TABLE IF EXISTS temp.buildertrend_reconciliation_guard;
+CREATE TEMP TABLE buildertrend_reconciliation_guard (
+  check_name TEXT PRIMARY KEY,
+  valid INTEGER NOT NULL CHECK (valid = 1)
+);
+INSERT INTO buildertrend_reconciliation_guard (check_name, valid)
+SELECT 'selected organization exists',
+  CASE WHEN (SELECT COUNT(*) FROM organizations WHERE id = ${defaultOrg}) = 1
+    THEN 1 ELSE 0 END;
+
+-- File/access conflicts abort. Record conflicts are quarantined below using the
+-- linked project's tenant because one historical sample job was stamped with
+-- the production tenant while belonging to a separate demo workspace.
+INSERT INTO buildertrend_reconciliation_guard (check_name, valid)
+SELECT 'file tenant evidence is consistent', CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM buildertrend_archive_files source_file
+    LEFT JOIN projects file_project ON file_project.id = source_file.project_id
+    LEFT JOIN buildertrend_source_records source_record
+      ON source_record.id = source_file.source_record_id
+    LEFT JOIN projects record_project ON record_project.id = source_record.project_id
+    WHERE (source_file.project_id IS NOT NULL AND file_project.id IS NULL)
+      OR (source_file.source_record_id IS NOT NULL AND source_record.id IS NULL)
+      OR (file_project.organization_id IS NOT NULL
+        AND record_project.organization_id IS NOT NULL
+        AND file_project.organization_id <> record_project.organization_id)
+      OR (source_file.organization_id IS NOT NULL
+        AND COALESCE(file_project.organization_id, record_project.organization_id) IS NOT NULL
+        AND source_file.organization_id <>
+          COALESCE(file_project.organization_id, record_project.organization_id))
+      OR (source_record.organization_id IS NOT NULL
+        AND record_project.organization_id IS NOT NULL
+        AND source_record.organization_id <> record_project.organization_id)
+  ) THEN 1 ELSE 0 END;
+
+INSERT INTO buildertrend_reconciliation_guard (check_name, valid)
+SELECT 'access tenant evidence is consistent', CASE WHEN NOT EXISTS (
+    SELECT 1
+    FROM buildertrend_access_candidates source_access
+    LEFT JOIN projects access_project ON access_project.id = source_access.project_id
+    LEFT JOIN buildertrend_source_records source_record
+      ON source_record.id = source_access.source_record_id
+    LEFT JOIN projects record_project ON record_project.id = source_record.project_id
+    WHERE (source_access.project_id IS NOT NULL AND access_project.id IS NULL)
+      OR (source_access.source_record_id IS NOT NULL AND source_record.id IS NULL)
+      OR (access_project.organization_id IS NOT NULL
+        AND record_project.organization_id IS NOT NULL
+        AND access_project.organization_id <> record_project.organization_id)
+      OR (source_access.organization_id IS NOT NULL
+        AND COALESCE(access_project.organization_id, record_project.organization_id) IS NOT NULL
+        AND source_access.organization_id <>
+          COALESCE(access_project.organization_id, record_project.organization_id))
+      OR (source_record.organization_id IS NOT NULL
+        AND record_project.organization_id IS NOT NULL
+        AND source_record.organization_id <> record_project.organization_id)
+  ) THEN 1 ELSE 0 END;
+
+INSERT OR IGNORE INTO buildertrend_staging_runs (
+  id,
+  organization_id,
+  run_key,
+  manifest_fingerprint,
+  source_method,
+  source_label,
+  status,
+  started_by,
+  started_at,
+  completed_at,
+  raw_artifact_drive_file_id,
+  raw_artifact_drive_url,
+  source_notes,
+  summary_json,
+  created_at,
+  updated_at
+)
+WITH run_org AS (
+  SELECT id AS legacy_run_id, COALESCE(organization_id, ${defaultOrg}) AS organization_id
+  FROM buildertrend_import_runs
+  UNION
+  SELECT source_record.import_run_id,
+    COALESCE(project.organization_id, source_record.organization_id, ${defaultOrg})
+  FROM buildertrend_source_records source_record
+  LEFT JOIN projects project ON project.id = source_record.project_id
+  UNION
+  SELECT source_file.import_run_id,
+    COALESCE(
+      file_project.organization_id,
+      source_file.organization_id,
+      record_project.organization_id,
+      source_record.organization_id,
+      ${defaultOrg}
+    )
+  FROM buildertrend_archive_files source_file
+  LEFT JOIN projects file_project ON file_project.id = source_file.project_id
+  LEFT JOIN buildertrend_source_records source_record
+    ON source_record.id = source_file.source_record_id
+  LEFT JOIN projects record_project ON record_project.id = source_record.project_id
+  UNION
+  SELECT source_access.import_run_id,
+    COALESCE(
+      access_project.organization_id,
+      source_access.organization_id,
+      record_project.organization_id,
+      source_record.organization_id,
+      ${defaultOrg}
+    )
+  FROM buildertrend_access_candidates source_access
+  LEFT JOIN projects access_project ON access_project.id = source_access.project_id
+  LEFT JOIN buildertrend_source_records source_record
+    ON source_record.id = source_access.source_record_id
+  LEFT JOIN projects record_project ON record_project.id = source_record.project_id
+)
+SELECT
+  'legacy-run:' || source_run.id || ':' || run_org.organization_id,
+  run_org.organization_id,
+  'legacy-run:' || source_run.id,
+  'legacy-reconciliation-v1:' || source_run.id || ':' ||
+    run_org.organization_id || ':' || source_run.updated_at,
+  source_run.source_method,
+  source_run.source_label,
+  source_run.status,
+  source_run.started_by,
+  source_run.started_at,
+  source_run.completed_at,
+  source_run.raw_artifact_drive_file_id,
+  source_run.raw_artifact_drive_url,
+  trim(COALESCE(source_run.notes || char(10), '') ||
+    'Reconciled from legacy Buildertrend staging run ' || source_run.id),
+  source_run.summary_json,
+  source_run.created_at,
+  source_run.updated_at
+FROM buildertrend_import_runs source_run
+JOIN run_org ON run_org.legacy_run_id = source_run.id;
+
+INSERT OR IGNORE INTO buildertrend_staging_records (
+  id,
+  organization_id,
+  source_key,
+  requested_project_id,
+  project_id,
+  source_scope,
+  source_record_type,
+  buildertrend_job_id,
+  buildertrend_lead_id,
+  buildertrend_record_id,
+  buildertrend_record_number,
+  buildertrend_url,
+  title,
+  record_date,
+  record_status,
+  source_status,
+  department_code,
+  client_name,
+  contact_name,
+  contact_email,
+  amount,
+  searchable_text,
+  normalized_summary,
+  raw_payload_json,
+  source_archive_drive_folder_id,
+  source_archive_drive_file_id,
+  source_archive_drive_url,
+  verified_archive_drive_folder_id,
+  verified_archive_drive_file_id,
+  verified_archive_drive_url,
+  review_status,
+  promotion_status,
+  promoted_record_type,
+  promoted_record_id,
+  sage_reconciliation_status,
+  source_notes,
+  created_at,
+  updated_at
+)
+SELECT
+  'legacy-record:' || source_record.id,
+  COALESCE(project.organization_id, source_record.organization_id, ${defaultOrg}),
+  'legacy-record:' || source_record.id,
+  source_record.project_id,
+  source_record.project_id,
+  source_record.source_scope,
+  source_record.source_record_type,
+  source_record.buildertrend_job_id,
+  source_record.buildertrend_lead_id,
+  source_record.buildertrend_record_id,
+  source_record.buildertrend_record_number,
+  source_record.buildertrend_url,
+  source_record.title,
+  source_record.record_date,
+  source_record.record_status,
+  source_record.source_status,
+  source_record.department_code,
+  source_record.client_name,
+  source_record.contact_name,
+  source_record.contact_email,
+  source_record.amount,
+  source_record.searchable_text,
+  source_record.normalized_summary,
+  source_record.raw_payload_json,
+  source_record.archive_drive_folder_id,
+  source_record.archive_drive_file_id,
+  source_record.archive_drive_url,
+  CASE WHEN source_record.review_status = 'verified'
+      AND NOT (
+        source_record.organization_id IS NOT NULL
+        AND project.organization_id IS NOT NULL
+        AND source_record.organization_id <> project.organization_id
+      )
+    THEN source_record.archive_drive_folder_id END,
+  CASE WHEN source_record.review_status = 'verified'
+      AND NOT (
+        source_record.organization_id IS NOT NULL
+        AND project.organization_id IS NOT NULL
+        AND source_record.organization_id <> project.organization_id
+      )
+    THEN source_record.archive_drive_file_id END,
+  CASE WHEN source_record.review_status = 'verified'
+      AND NOT (
+        source_record.organization_id IS NOT NULL
+        AND project.organization_id IS NOT NULL
+        AND source_record.organization_id <> project.organization_id
+      )
+    THEN source_record.archive_drive_url END,
+  CASE WHEN source_record.organization_id IS NOT NULL
+      AND project.organization_id IS NOT NULL
+      AND source_record.organization_id <> project.organization_id
+    THEN 'unresolved_reference'
+    ELSE source_record.review_status
+  END,
+  CASE WHEN source_record.organization_id IS NOT NULL
+      AND project.organization_id IS NOT NULL
+      AND source_record.organization_id <> project.organization_id
+    THEN 'archive_only'
+    ELSE source_record.promotion_status
+  END,
+  source_record.promoted_record_type,
+  source_record.promoted_record_id,
+  source_record.sage_reconciliation_status,
+  trim(COALESCE(source_record.notes || char(10), '') ||
+    'Legacy source record: ' || source_record.id ||
+    '; legacy run: ' || source_record.import_run_id ||
+    CASE WHEN source_record.organization_id IS NOT NULL
+        AND project.organization_id IS NOT NULL
+        AND source_record.organization_id <> project.organization_id
+      THEN '; quarantined tenant conflict: source=' ||
+        source_record.organization_id || ', project=' || project.organization_id
+      ELSE ''
+    END),
+  source_record.created_at,
+  source_record.updated_at
+FROM buildertrend_source_records source_record
+LEFT JOIN projects project ON project.id = source_record.project_id;
+
+INSERT OR IGNORE INTO buildertrend_staging_files (
+  id,
+  organization_id,
+  source_key,
+  requested_source_record_key,
+  source_record_id,
+  requested_project_id,
+  project_id,
+  source_scope,
+  source_record_type,
+  buildertrend_job_id,
+  buildertrend_lead_id,
+  buildertrend_file_id,
+  buildertrend_url,
+  file_name,
+  mime_type,
+  file_size,
+  source_drive_folder_id,
+  source_drive_file_id,
+  source_drive_url,
+  source_thumbnail_drive_file_id,
+  source_thumbnail_url,
+  verified_drive_folder_id,
+  verified_drive_file_id,
+  verified_drive_url,
+  verified_thumbnail_drive_file_id,
+  verified_thumbnail_url,
+  source_checksum,
+  verified_checksum,
+  captured_at,
+  visibility,
+  review_status,
+  source_metadata_json,
+  created_at,
+  updated_at
+)
+SELECT
+  'legacy-file:' || source_file.id,
+  COALESCE(
+    file_project.organization_id,
+    source_file.organization_id,
+    record_project.organization_id,
+    source_record.organization_id,
+    ${defaultOrg}
+  ),
+  'legacy-file:' || source_file.id,
+  CASE WHEN source_file.source_record_id IS NOT NULL
+    THEN 'legacy-record:' || source_file.source_record_id END,
+  CASE WHEN source_file.source_record_id IS NOT NULL
+    THEN 'legacy-record:' || source_file.source_record_id END,
+  source_file.project_id,
+  source_file.project_id,
+  source_file.source_scope,
+  source_file.source_record_type,
+  source_file.buildertrend_job_id,
+  source_file.buildertrend_lead_id,
+  source_file.buildertrend_file_id,
+  source_file.buildertrend_url,
+  source_file.file_name,
+  source_file.mime_type,
+  source_file.file_size,
+  source_file.drive_folder_id,
+  source_file.drive_file_id,
+  source_file.drive_url,
+  source_file.thumbnail_drive_file_id,
+  source_file.thumbnail_url,
+  CASE WHEN source_file.review_status IN ('approved', 'verified')
+    THEN source_file.drive_folder_id END,
+  CASE WHEN source_file.review_status IN ('approved', 'verified')
+    THEN source_file.drive_file_id END,
+  CASE WHEN source_file.review_status IN ('approved', 'verified')
+    THEN source_file.drive_url END,
+  CASE WHEN source_file.review_status IN ('approved', 'verified')
+    THEN source_file.thumbnail_drive_file_id END,
+  CASE WHEN source_file.review_status IN ('approved', 'verified')
+    THEN source_file.thumbnail_url END,
+  source_file.checksum,
+  CASE WHEN source_file.review_status IN ('approved', 'verified')
+    THEN source_file.checksum END,
+  source_file.captured_at,
+  source_file.visibility,
+  source_file.review_status,
+  json_object(
+    'legacyId', source_file.id,
+    'legacyImportRunId', source_file.import_run_id,
+    'legacyMetadata', CASE
+      WHEN json_valid(source_file.metadata_json) THEN json(source_file.metadata_json)
+      ELSE source_file.metadata_json
+    END
+  ),
+  source_file.created_at,
+  source_file.updated_at
+FROM buildertrend_archive_files source_file
+LEFT JOIN projects file_project ON file_project.id = source_file.project_id
+LEFT JOIN buildertrend_source_records source_record
+  ON source_record.id = source_file.source_record_id
+LEFT JOIN projects record_project ON record_project.id = source_record.project_id;
+
+INSERT OR IGNORE INTO buildertrend_staging_access_candidates (
+  id,
+  organization_id,
+  source_key,
+  requested_source_record_key,
+  source_record_id,
+  requested_project_id,
+  project_id,
+  buildertrend_job_id,
+  buildertrend_lead_id,
+  buildertrend_contact_id,
+  buildertrend_access_role,
+  contact_name,
+  company_name,
+  email,
+  phone,
+  proposed_contact_type,
+  proposed_project_role,
+  match_status,
+  match_confidence,
+  portal_access_status,
+  review_status,
+  source_notes,
+  created_at,
+  updated_at
+)
+SELECT
+  'legacy-access:' || source_access.id,
+  COALESCE(
+    access_project.organization_id,
+    source_access.organization_id,
+    record_project.organization_id,
+    source_record.organization_id,
+    ${defaultOrg}
+  ),
+  'legacy-access:' || source_access.id,
+  CASE WHEN source_access.source_record_id IS NOT NULL
+    THEN 'legacy-record:' || source_access.source_record_id END,
+  CASE WHEN source_access.source_record_id IS NOT NULL
+    THEN 'legacy-record:' || source_access.source_record_id END,
+  source_access.project_id,
+  source_access.project_id,
+  source_access.buildertrend_job_id,
+  source_access.buildertrend_lead_id,
+  source_access.buildertrend_contact_id,
+  source_access.buildertrend_access_role,
+  source_access.contact_name,
+  source_access.company_name,
+  source_access.email,
+  source_access.phone,
+  source_access.proposed_contact_type,
+  source_access.proposed_project_role,
+  'unmatched',
+  0,
+  'not_granted',
+  source_access.review_status,
+  trim(COALESCE(source_access.notes || char(10), '') ||
+    'Legacy access candidate: ' || source_access.id ||
+    '; prior match status: ' || source_access.match_status ||
+    '; prior portal status: ' || source_access.portal_access_status),
+  source_access.created_at,
+  source_access.updated_at
+FROM buildertrend_access_candidates source_access
+LEFT JOIN projects access_project ON access_project.id = source_access.project_id
+LEFT JOIN buildertrend_source_records source_record
+  ON source_record.id = source_access.source_record_id
+LEFT JOIN projects record_project ON record_project.id = source_record.project_id;
+
+INSERT OR IGNORE INTO buildertrend_staging_observations (
+  id,
+  import_run_id,
+  organization_id,
+  entity_kind,
+  entity_key,
+  entity_id,
+  observed_payload_json,
+  observed_at
+)
+SELECT
+  'legacy-observation:record:' || source_record.id,
+  'legacy-run:' || source_record.import_run_id || ':' ||
+    COALESCE(project.organization_id, source_record.organization_id, ${defaultOrg}),
+  COALESCE(project.organization_id, source_record.organization_id, ${defaultOrg}),
+  'record',
+  'legacy-record:' || source_record.id,
+  'legacy-record:' || source_record.id,
+  json_object(
+    'legacyTable', 'buildertrend_source_records',
+    'legacyId', source_record.id,
+    'legacyImportRunId', source_record.import_run_id,
+    'sourceKey', 'legacy-record:' || source_record.id
+  ),
+  source_record.updated_at
+FROM buildertrend_source_records source_record
+LEFT JOIN projects project ON project.id = source_record.project_id;
+
+INSERT OR IGNORE INTO buildertrend_staging_observations (
+  id,
+  import_run_id,
+  organization_id,
+  entity_kind,
+  entity_key,
+  entity_id,
+  observed_payload_json,
+  observed_at
+)
+SELECT
+  'legacy-observation:file:' || source_file.id,
+  'legacy-run:' || source_file.import_run_id || ':' ||
+    COALESCE(
+      file_project.organization_id,
+      source_file.organization_id,
+      record_project.organization_id,
+      source_record.organization_id,
+      ${defaultOrg}
+    ),
+  COALESCE(
+    file_project.organization_id,
+    source_file.organization_id,
+    record_project.organization_id,
+    source_record.organization_id,
+    ${defaultOrg}
+  ),
+  'file',
+  'legacy-file:' || source_file.id,
+  'legacy-file:' || source_file.id,
+  json_object(
+    'legacyTable', 'buildertrend_archive_files',
+    'legacyId', source_file.id,
+    'legacyImportRunId', source_file.import_run_id,
+    'sourceKey', 'legacy-file:' || source_file.id
+  ),
+  source_file.updated_at
+FROM buildertrend_archive_files source_file
+LEFT JOIN projects file_project ON file_project.id = source_file.project_id
+LEFT JOIN buildertrend_source_records source_record
+  ON source_record.id = source_file.source_record_id
+LEFT JOIN projects record_project ON record_project.id = source_record.project_id;
+
+INSERT OR IGNORE INTO buildertrend_staging_observations (
+  id,
+  import_run_id,
+  organization_id,
+  entity_kind,
+  entity_key,
+  entity_id,
+  observed_payload_json,
+  observed_at
+)
+SELECT
+  'legacy-observation:access:' || source_access.id,
+  'legacy-run:' || source_access.import_run_id || ':' ||
+    COALESCE(
+      access_project.organization_id,
+      source_access.organization_id,
+      record_project.organization_id,
+      source_record.organization_id,
+      ${defaultOrg}
+    ),
+  COALESCE(
+    access_project.organization_id,
+    source_access.organization_id,
+    record_project.organization_id,
+    source_record.organization_id,
+    ${defaultOrg}
+  ),
+  'access_candidate',
+  'legacy-access:' || source_access.id,
+  'legacy-access:' || source_access.id,
+  json_object(
+    'legacyTable', 'buildertrend_access_candidates',
+    'legacyId', source_access.id,
+    'legacyImportRunId', source_access.import_run_id,
+    'sourceKey', 'legacy-access:' || source_access.id
+  ),
+  source_access.updated_at
+FROM buildertrend_access_candidates source_access
+LEFT JOIN projects access_project ON access_project.id = source_access.project_id
+LEFT JOIN buildertrend_source_records source_record
+  ON source_record.id = source_access.source_record_id
+LEFT JOIN projects record_project ON record_project.id = source_record.project_id;
+
+DROP TABLE temp.buildertrend_reconciliation_guard;
+`
+}


### PR DESCRIPTION
## Summary

- reconcile legacy Buildertrend staging into the guarded tenant-scoped model
- deploy and document the read-only Sage pay-application poller
- preserve staff review gates for imported financial and owner-visible data

## Verification

- production build passed
- lint passed with existing warnings only
- Buildertrend reconciliation tests: 7 passed
- Sage poller tests: 5 passed
- live user timer active/enabled and latest poll completed successfully
- Loomis and Loeffler G703 line totals reconcile exactly to their imported headers

## Known external exception

The 219 recovered private Buildertrend photos are packaged locally by project. Google Drive upload remains blocked by the connector safety gate despite explicit owner authorization; no unsafe workaround was used.