### PR TITLE
feat(staff-board): recover internal staff board

### DIFF
--- a/drizzle/0109_staff_board_posts.sql
+++ b/drizzle/0109_staff_board_posts.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS `staff_board_posts` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL REFERENCES `organizations`(`id`) ON DELETE cascade,
+  `author_id` text NOT NULL REFERENCES `users`(`id`) ON DELETE restrict,
+  `title` text NOT NULL,
+  `body` text NOT NULL,
+  `is_pinned` integer NOT NULL DEFAULT 0,
+  `archived_at` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `staff_board_posts_org_created_idx`
+  ON `staff_board_posts` (`organization_id`, `created_at`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `staff_board_posts_org_pinned_idx`
+  ON `staff_board_posts` (`organization_id`, `is_pinned`, `created_at`);

--- a/src/app/actions/notifications.ts
+++ b/src/app/actions/notifications.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { and, desc, eq, isNull } from "drizzle-orm"
+import { and, desc, eq, isNull, ne, or } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
@@ -23,6 +23,7 @@ import {
 } from "@/lib/notifications/sms-consent"
 import { isValidSmsQuietHoursTime } from "@/lib/notifications/sms-policy"
 import { requireOrg } from "@/lib/org-scope"
+import { hasActiveStaffBoardOrganization } from "@/lib/staff-board"
 import { isValidTimeZone } from "@/lib/work-calendar"
 
 export type NotificationPreferenceState = {
@@ -427,6 +428,17 @@ export async function getNotificationCenter(): Promise<NotificationCenterResult>
     const user = await requireAuth()
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
+    const canReadStaffBoardNotifications = await hasActiveStaffBoardOrganization(user)
+    const staffBoardOrganizationId = canReadStaffBoardNotifications
+      ? requireOrg(user)
+      : null
+    const staffBoardNotificationScope =
+      staffBoardOrganizationId === null
+        ? ne(notificationEvents.eventType, "staff_board.post_created")
+        : or(
+            ne(notificationEvents.eventType, "staff_board.post_created"),
+            eq(notificationEvents.organizationId, staffBoardOrganizationId)
+          )
 
     const rows = await db
       .select({
@@ -450,7 +462,8 @@ export async function getNotificationCenter(): Promise<NotificationCenterResult>
         and(
           eq(notificationRecipients.userId, user.id),
           eq(notificationRecipients.inApp, true),
-          isNull(notificationRecipients.dismissedAt)
+          isNull(notificationRecipients.dismissedAt),
+          staffBoardNotificationScope
         )
       )
       .orderBy(desc(notificationRecipients.createdAt))

--- a/src/app/actions/staff-board.ts
+++ b/src/app/actions/staff-board.ts
@@ -1,0 +1,278 @@
+"use server"
+
+import { and, desc, eq, isNull, sql } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import { organizationMembers, staffBoardPosts, users } from "@/db/schema"
+import { getCurrentUser } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import { requireOrg } from "@/lib/org-scope"
+import { createNotificationEvent } from "@/lib/notifications/events"
+import { requirePermission } from "@/lib/permissions"
+import {
+  hasActiveStaffBoardOrganization,
+  validateStaffBoardPost,
+} from "@/lib/staff-board"
+import { isInternalStaffRole, USER_ROLES } from "@/lib/user-roles"
+
+export type StaffBoardPost = {
+  readonly id: string
+  readonly title: string
+  readonly body: string
+  readonly isPinned: boolean
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly author: {
+    readonly id: string
+    readonly displayName: string | null
+    readonly email: string
+  }
+}
+
+type StaffBoardResult =
+  | { readonly success: true; readonly data: readonly StaffBoardPost[] }
+  | { readonly success: false; readonly error: string }
+
+type StaffBoardActionResult =
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string }
+
+async function requireStaffBoardUser() {
+  const user = await getCurrentUser()
+  if (!user || !(await hasActiveStaffBoardOrganization(user))) {
+    return null
+  }
+  return user
+}
+
+export async function listStaffBoardPosts(): Promise<StaffBoardResult> {
+  try {
+    const user = await requireStaffBoardUser()
+    if (!user) return { success: false, error: "Staff access required" }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const rows = await db
+      .select({
+        id: staffBoardPosts.id,
+        title: staffBoardPosts.title,
+        body: staffBoardPosts.body,
+        isPinned: staffBoardPosts.isPinned,
+        createdAt: staffBoardPosts.createdAt,
+        updatedAt: staffBoardPosts.updatedAt,
+        authorId: users.id,
+        authorDisplayName: users.displayName,
+        authorEmail: users.email,
+      })
+      .from(staffBoardPosts)
+      .innerJoin(users, eq(users.id, staffBoardPosts.authorId))
+      .where(
+        and(
+          eq(staffBoardPosts.organizationId, organizationId),
+          isNull(staffBoardPosts.archivedAt)
+        )
+      )
+      .orderBy(desc(staffBoardPosts.isPinned), desc(staffBoardPosts.createdAt))
+      .limit(100)
+
+    return {
+      success: true,
+      data: rows.map((row) => ({
+        id: row.id,
+        title: row.title,
+        body: row.body,
+        isPinned: row.isPinned,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        author: {
+          id: row.authorId,
+          displayName: row.authorDisplayName,
+          email: row.authorEmail,
+        },
+      })),
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to load staff board",
+    }
+  }
+}
+
+export async function createStaffBoardPost(input: unknown): Promise<StaffBoardActionResult> {
+  try {
+    const user = await requireStaffBoardUser()
+    if (!user) return { success: false, error: "Staff access required" }
+    if (isDemoUser(user.id)) return { success: false, error: "DEMO_READ_ONLY" }
+    const validation = validateStaffBoardPost(input)
+    if (!validation.success) return validation
+
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const now = new Date().toISOString()
+    const postId = crypto.randomUUID()
+    await db.insert(staffBoardPosts).values({
+      id: postId,
+      organizationId,
+      authorId: user.id,
+      title: validation.data.title,
+      body: validation.data.body,
+      isPinned: false,
+      archivedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    try {
+      const recipients = await db
+        .select({ userId: users.id, email: users.email, role: organizationMembers.role })
+        .from(users)
+        .innerJoin(organizationMembers, eq(organizationMembers.userId, users.id))
+        .where(
+          and(
+            eq(organizationMembers.organizationId, organizationId),
+            eq(users.isActive, true)
+          )
+        )
+        .then((rows) =>
+          rows
+            .filter(
+              (row) => row.userId !== user.id && isInternalStaffRole(row.role)
+            )
+            .map((row) => ({ userId: row.userId, email: row.email }))
+        )
+
+      if (recipients.length > 0) {
+        await createNotificationEvent({
+          organizationId,
+          projectId: null,
+          eventType: "staff_board.post_created",
+          sourceType: "staff_board_post",
+          sourceId: postId,
+          title: validation.data.title,
+          body: `${user.displayName ?? user.email} posted to the Staff Board.`,
+          href: "/dashboard/staff-board",
+          priority: "normal",
+          audience: "internal",
+          createdBy: user.id,
+          recipients,
+          recipientRoles: USER_ROLES.filter(isInternalStaffRole),
+          delivery: { inApp: true, email: false, push: false },
+        })
+      }
+    } catch {
+      // The post is the primary action; a notification outage must not make a
+      // successful post look failed and invite the user to submit it twice.
+    }
+
+    revalidatePath("/dashboard/staff-board")
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to create staff board post",
+    }
+  }
+}
+
+export async function deleteStaffBoardPost(
+  postId: string
+): Promise<StaffBoardActionResult> {
+  try {
+    const user = await requireStaffBoardUser()
+    if (!user) return { success: false, error: "Staff access required" }
+    if (isDemoUser(user.id)) return { success: false, error: "DEMO_READ_ONLY" }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const post = await db
+      .select({ id: staffBoardPosts.id, authorId: staffBoardPosts.authorId })
+      .from(staffBoardPosts)
+      .where(
+        and(
+          eq(staffBoardPosts.id, postId),
+          eq(staffBoardPosts.organizationId, organizationId),
+          isNull(staffBoardPosts.archivedAt)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!post) return { success: false, error: "Post not found" }
+
+    if (post.authorId !== user.id) {
+      try {
+        requirePermission(user, "channels", "moderate")
+      } catch {
+        return { success: false, error: "Only the author or a moderator can remove posts" }
+      }
+    }
+
+    await db
+      .update(staffBoardPosts)
+      .set({ archivedAt: new Date().toISOString(), updatedAt: new Date().toISOString() })
+      .where(
+        and(
+          eq(staffBoardPosts.id, postId),
+          eq(staffBoardPosts.organizationId, organizationId),
+          isNull(staffBoardPosts.archivedAt)
+        )
+      )
+    revalidatePath("/dashboard/staff-board")
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to remove staff board post",
+    }
+  }
+}
+
+export async function toggleStaffBoardPostPin(
+  postId: string
+): Promise<StaffBoardActionResult> {
+  try {
+    const user = await requireStaffBoardUser()
+    if (!user) return { success: false, error: "Staff access required" }
+    if (isDemoUser(user.id)) return { success: false, error: "DEMO_READ_ONLY" }
+    requirePermission(user, "channels", "moderate")
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const post = await db
+      .select({ id: staffBoardPosts.id })
+      .from(staffBoardPosts)
+      .where(
+        and(
+          eq(staffBoardPosts.id, postId),
+          eq(staffBoardPosts.organizationId, organizationId),
+          isNull(staffBoardPosts.archivedAt)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!post) return { success: false, error: "Post not found" }
+    await db
+      .update(staffBoardPosts)
+      .set({
+        isPinned: sql`NOT ${staffBoardPosts.isPinned}`,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(
+        and(
+          eq(staffBoardPosts.id, postId),
+          eq(staffBoardPosts.organizationId, organizationId),
+          isNull(staffBoardPosts.archivedAt)
+        )
+      )
+    revalidatePath("/dashboard/staff-board")
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to update staff board post",
+    }
+  }
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -39,6 +39,7 @@ import {
   canManageUserAccess,
 } from "@/lib/permissions"
 import { isInternalStaffRole } from "@/lib/user-roles"
+import { hasActiveStaffBoardOrganization } from "@/lib/staff-board"
 
 export default async function DashboardLayout({
   children,
@@ -61,6 +62,9 @@ export default async function DashboardLayout({
   const canUseCompassOfficeTalk = canUseOfficeTalk(authUser)
   const canViewActivity = authUser
     ? isInternalStaffRole(authUser.role)
+    : false
+  const canViewStaffBoard = authUser
+    ? await hasActiveStaffBoardOrganization(authUser)
     : false
   const canUseDirectMessages = canViewActivity
   const canManageFeedback = canManageUserAccess(authUser)
@@ -103,6 +107,7 @@ export default async function DashboardLayout({
           canUseFieldDesk={canUseCompassFieldDesk}
           canViewActivity={canViewActivity}
           canManageFeedback={canManageFeedback}
+          canViewStaffBoard={canViewStaffBoard}
         />
         <SidebarInset className="overflow-hidden">
           <DesktopOfflineBanner />

--- a/src/app/dashboard/staff-board/page.tsx
+++ b/src/app/dashboard/staff-board/page.tsx
@@ -1,0 +1,35 @@
+import { redirect } from "next/navigation"
+
+import { listStaffBoardPosts } from "@/app/actions/staff-board"
+import { StaffBoardView } from "@/components/staff-board-view"
+import { can } from "@/lib/permissions"
+import { canAccessStaffBoard, hasActiveStaffBoardOrganization } from "@/lib/staff-board"
+import { getCurrentUser } from "@/lib/auth"
+
+export default async function StaffBoardPage(): Promise<React.ReactNode> {
+  const user = await getCurrentUser()
+  if (
+    !user ||
+    !canAccessStaffBoard(user.role, user.isActive, user.organizationType) ||
+    !(await hasActiveStaffBoardOrganization(user))
+  ) {
+    redirect("/dashboard/access-restricted")
+  }
+
+  const result = await listStaffBoardPosts()
+  if (!result.success) {
+    return (
+      <div className="flex h-full items-center justify-center p-8 text-sm text-destructive">
+        {result.error}
+      </div>
+    )
+  }
+
+  return (
+    <StaffBoardView
+      initialPosts={result.data}
+      currentUserId={user.id}
+      canModerate={can(user, "channels", "moderate")}
+    />
+  )
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import {
   IconAddressBook,
   IconActivity,
+  IconBellRinging,
   IconCalendarStats,
   IconClipboardCheck,
   IconTimeline,
@@ -80,6 +81,12 @@ const NAV_MAIN = [
     url: "/dashboard/activity",
     icon: IconActivity,
     internalOnly: true,
+  },
+  {
+    title: "Staff Board",
+    url: "/dashboard/staff-board",
+    icon: IconBellRinging,
+    staffBoardOnly: true,
   },
   {
     title: "Projects",
@@ -187,11 +194,13 @@ function SidebarNav({
   canUseFieldDesk,
   canViewActivity,
   canManageFeedback,
+  canViewStaffBoard,
 }: {
   projects: ReadonlyArray<ProjectListItem>
   readonly canUseFieldDesk: boolean
   readonly canViewActivity: boolean
   readonly canManageFeedback: boolean
+  readonly canViewStaffBoard: boolean
 }) {
   const pathname = usePathname()
   const { state } = useSidebar()
@@ -226,7 +235,8 @@ function SidebarNav({
   const navMain = NAV_MAIN.filter(
     (item) =>
       (!item.internalOnly || canViewActivity) &&
-      (!item.adminOnly || canManageFeedback)
+      (!item.adminOnly || canManageFeedback) &&
+      (!item.staffBoardOnly || canViewStaffBoard)
   ).map((item) =>
     typeof item.projectPath === "string"
       ? {
@@ -280,6 +290,7 @@ export function AppSidebar({
   canUseFieldDesk = false,
   canViewActivity = false,
   canManageFeedback = false,
+  canViewStaffBoard = false,
   ...props
 }: React.ComponentProps<typeof Sidebar> & {
   readonly projects?: ReadonlyArray<ProjectListItem>
@@ -289,6 +300,7 @@ export function AppSidebar({
   readonly canUseFieldDesk?: boolean
   readonly canViewActivity?: boolean
   readonly canManageFeedback?: boolean
+  readonly canViewStaffBoard?: boolean
 }) {
   const { isMobile } = useSidebar()
   const { channelId } = useVoiceState()
@@ -304,6 +316,7 @@ export function AppSidebar({
           canUseFieldDesk={canUseFieldDesk}
           canViewActivity={canViewActivity}
           canManageFeedback={canManageFeedback}
+          canViewStaffBoard={canViewStaffBoard}
         />
       </SidebarContent>
       <SidebarFooter className="border-t border-sidebar-border/60">

--- a/src/components/staff-board-view.tsx
+++ b/src/components/staff-board-view.tsx
@@ -1,0 +1,207 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import {
+  IconBellRinging,
+  IconPin,
+  IconPinFilled,
+  IconSend,
+  IconTrash,
+} from "@tabler/icons-react"
+
+import {
+  createStaffBoardPost,
+  deleteStaffBoardPost,
+  toggleStaffBoardPostPin,
+  type StaffBoardPost,
+} from "@/app/actions/staff-board"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+function authorName(post: StaffBoardPost): string {
+  return post.author.displayName ?? post.author.email
+}
+
+function postDate(value: string): string {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime())
+    ? value
+    : date.toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+}
+
+export function StaffBoardView({
+  initialPosts,
+  currentUserId,
+  canModerate,
+}: {
+  readonly initialPosts: readonly StaffBoardPost[]
+  readonly currentUserId: string
+  readonly canModerate: boolean
+}) {
+  const router = useRouter()
+  const [title, setTitle] = useState("")
+  const [body, setBody] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [busyPostId, setBusyPostId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function submitPost(): Promise<void> {
+    setSubmitting(true)
+    setError(null)
+    const result = await createStaffBoardPost({ title, body })
+    if (!result.success) {
+      setError(result.error)
+      setSubmitting(false)
+      return
+    }
+    setTitle("")
+    setBody("")
+    setSubmitting(false)
+    router.refresh()
+  }
+
+  async function removePost(postId: string): Promise<void> {
+    if (!window.confirm("Remove this Staff Board post?")) return
+    setBusyPostId(postId)
+    setError(null)
+    const result = await deleteStaffBoardPost(postId)
+    if (!result.success) setError(result.error)
+    setBusyPostId(null)
+    if (result.success) router.refresh()
+  }
+
+  async function togglePin(postId: string): Promise<void> {
+    setBusyPostId(postId)
+    setError(null)
+    const result = await toggleStaffBoardPostPin(postId)
+    if (!result.success) setError(result.error)
+    setBusyPostId(null)
+    if (result.success) router.refresh()
+  }
+
+  return (
+    <div className="mx-auto flex h-full w-full max-w-5xl flex-col gap-6 overflow-y-auto p-4 md:p-8">
+      <header className="flex flex-col gap-2 border-b pb-5">
+        <div className="flex items-center gap-3">
+          <div className="rounded-lg bg-primary/10 p-2 text-primary">
+            <IconBellRinging className="size-6" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">Staff Board</h1>
+            <p className="text-sm text-muted-foreground">
+              One place for company-wide updates, reminders, and notices for Compass staff.
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <Card>
+        <CardHeader className="gap-1">
+          <CardTitle className="text-base">Post an update</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Every active internal staff member can see new posts. A quiet in-app notification is sent to the team.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Input
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="Short update title"
+            maxLength={120}
+            aria-label="Staff Board post title"
+          />
+          <Textarea
+            value={body}
+            onChange={(event) => setBody(event.target.value)}
+            placeholder="Write the update for the team..."
+            maxLength={5000}
+            rows={4}
+            aria-label="Staff Board post message"
+          />
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs text-muted-foreground">
+              Keep project-specific discussion in Conversations.
+            </p>
+            <Button type="button" onClick={() => void submitPost()} disabled={submitting}>
+              <IconSend className="size-4" />
+              {submitting ? "Posting..." : "Post update"}
+            </Button>
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </CardContent>
+      </Card>
+
+      <section className="space-y-4" aria-labelledby="staff-board-posts-heading">
+        <div className="flex items-center justify-between gap-3">
+          <h2 id="staff-board-posts-heading" className="text-lg font-semibold">
+            Team updates
+          </h2>
+          <span className="text-sm text-muted-foreground">
+            {initialPosts.length} {initialPosts.length === 1 ? "post" : "posts"}
+          </span>
+        </div>
+        {initialPosts.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center text-sm text-muted-foreground">
+              No updates yet. The first post will appear here for the whole staff team.
+            </CardContent>
+          </Card>
+        ) : (
+          initialPosts.map((post) => (
+            <Card key={post.id} className={post.isPinned ? "border-primary/40" : undefined}>
+              <CardHeader className="gap-2">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <CardTitle className="flex items-center gap-2 text-base">
+                      {post.isPinned && <IconPinFilled className="size-4 text-primary" />}
+                      <span className="truncate">{post.title}</span>
+                    </CardTitle>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {authorName(post)} · {postDate(post.createdAt)}
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1">
+                    {canModerate && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={post.isPinned ? "Unpin post" : "Pin post"}
+                        disabled={busyPostId === post.id}
+                        onClick={() => void togglePin(post.id)}
+                      >
+                        <IconPin className="size-4" />
+                      </Button>
+                    )}
+                    {(canModerate || post.author.id === currentUserId) && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Remove post"
+                        disabled={busyPostId === post.id}
+                        onClick={() => void removePost(post.id)}
+                      >
+                        <IconTrash className="size-4" />
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <p className="whitespace-pre-wrap text-sm leading-6">{post.body}</p>
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -74,6 +74,36 @@ export const cherishPulseResponses = sqliteTable("cherish_pulse_responses", {
   updatedAt: text("updated_at").notNull(),
 })
 
+export const staffBoardPosts = sqliteTable(
+  "staff_board_posts",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    authorId: text("author_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "restrict" }),
+    title: text("title").notNull(),
+    body: text("body").notNull(),
+    isPinned: integer("is_pinned", { mode: "boolean" }).notNull().default(false),
+    archivedAt: text("archived_at"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    index("staff_board_posts_org_created_idx").on(
+      table.organizationId,
+      table.createdAt
+    ),
+    index("staff_board_posts_org_pinned_idx").on(
+      table.organizationId,
+      table.isPinned,
+      table.createdAt
+    ),
+  ]
+)
+
 export const notificationPreferences = sqliteTable("notification_preferences", {
   userId: text("user_id")
     .primaryKey()

--- a/src/lib/__tests__/staff-board.test.ts
+++ b/src/lib/__tests__/staff-board.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  canAccessStaffBoard,
+  validateStaffBoardPost,
+} from "@/lib/staff-board"
+
+describe("staff board access", () => {
+  it("allows active internal staff and rejects external roles", () => {
+    expect(canAccessStaffBoard("office", true, "internal")).toBe(true)
+    expect(canAccessStaffBoard("field_crew", true, "internal")).toBe(true)
+    expect(canAccessStaffBoard("owner", true, "client")).toBe(false)
+    expect(canAccessStaffBoard("office", false, "internal")).toBe(false)
+    expect(canAccessStaffBoard("office", true, "client")).toBe(false)
+  })
+})
+
+describe("staff board post validation", () => {
+  it("trims valid titles and bodies", () => {
+    expect(
+      validateStaffBoardPost({
+        title: "  Monday update  ",
+        body: "  The office is closed Friday.  ",
+      })
+    ).toEqual({
+      success: true,
+      data: {
+        title: "Monday update",
+        body: "The office is closed Friday.",
+      },
+    })
+  })
+
+  it("rejects missing or oversized content", () => {
+    expect(validateStaffBoardPost({ title: "", body: "A post" })).toEqual({
+      success: false,
+      error: "Add a title.",
+    })
+    expect(validateStaffBoardPost({ title: "Update", body: "" })).toEqual({
+      success: false,
+      error: "Add a message.",
+    })
+    expect(
+      validateStaffBoardPost({ title: "x".repeat(121), body: "A post" })
+    ).toEqual({
+      success: false,
+      error: "Titles must be 120 characters or fewer.",
+    })
+    expect(
+      validateStaffBoardPost({ title: "Update", body: "x".repeat(5001) })
+    ).toEqual({
+      success: false,
+      error: "Messages must be 5,000 characters or fewer.",
+    })
+  })
+})

--- a/src/lib/notifications/create-event.ts
+++ b/src/lib/notifications/create-event.ts
@@ -78,6 +78,7 @@ export type CreateNotificationInput = {
   readonly audience: string
   readonly createdBy: string | null
   readonly recipients: readonly NotificationRecipientInput[]
+  readonly recipientRoles?: readonly string[]
   readonly delivery: NotificationDelivery
 }
 
@@ -598,6 +599,16 @@ async function persistNotificationEvent(
 
   const { env } = await getCloudflareContext()
   const db = getDb(env.DB)
+  const recipientConditions = [
+    eq(organizationMembers.organizationId, input.organizationId),
+    eq(users.isActive, true),
+    inArray(organizationMembers.userId, requestedRecipientIds),
+  ]
+  if (input.recipientRoles !== undefined) {
+    recipientConditions.push(
+      inArray(organizationMembers.role, input.recipientRoles)
+    )
+  }
   const recipients = await db
     .select({
       userId: users.id,
@@ -606,16 +617,7 @@ async function persistNotificationEvent(
     })
     .from(organizationMembers)
     .innerJoin(users, eq(users.id, organizationMembers.userId))
-    .where(
-      and(
-        eq(
-          organizationMembers.organizationId,
-          input.organizationId
-        ),
-        eq(users.isActive, true),
-        inArray(organizationMembers.userId, requestedRecipientIds)
-      )
-    )
+    .where(and(...recipientConditions))
   if (recipients.length === 0) return
 
   const projectNumber = input.projectId

--- a/src/lib/staff-board.ts
+++ b/src/lib/staff-board.ts
@@ -1,0 +1,91 @@
+import { and, eq } from "drizzle-orm"
+
+import { getDb } from "@/db"
+import { organizations } from "@/db/schema"
+import type { AuthUser } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+const MAX_TITLE_LENGTH = 120
+const MAX_BODY_LENGTH = 5000
+
+type StaffBoardPostInput = {
+  readonly title: string
+  readonly body: string
+}
+
+type StaffBoardValidationResult =
+  | { readonly success: true; readonly data: StaffBoardPostInput }
+  | { readonly success: false; readonly error: string }
+
+export function canAccessStaffBoard(
+  role: string | null | undefined,
+  isActive: boolean,
+  organizationType: string | null | undefined
+): boolean {
+  if (
+    !isActive ||
+    organizationType !== "internal" ||
+    role === null ||
+    role === undefined
+  ) {
+    return false
+  }
+  return isInternalStaffRole(role)
+}
+
+export async function hasActiveStaffBoardOrganization(
+  user: AuthUser
+): Promise<boolean> {
+  if (!canAccessStaffBoard(user.role, user.isActive, user.organizationType)) {
+    return false
+  }
+  if (!user.organizationId) return false
+
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const organizationsFound = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(
+      and(
+        eq(organizations.id, user.organizationId),
+        eq(organizations.type, "internal"),
+        eq(organizations.isActive, true)
+      )
+    )
+    .limit(1)
+  return organizationsFound.length > 0
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+export function validateStaffBoardPost(
+  input: unknown
+): StaffBoardValidationResult {
+  if (!isRecord(input)) {
+    return { success: false, error: "Add a title and message." }
+  }
+  const candidate = input
+  const title = typeof candidate.title === "string" ? candidate.title.trim() : ""
+  const body = typeof candidate.body === "string" ? candidate.body.trim() : ""
+
+  if (title.length === 0) return { success: false, error: "Add a title." }
+  if (body.length === 0) return { success: false, error: "Add a message." }
+  if (title.length > MAX_TITLE_LENGTH) {
+    return {
+      success: false,
+      error: `Titles must be ${MAX_TITLE_LENGTH} characters or fewer.`,
+    }
+  }
+  if (body.length > MAX_BODY_LENGTH) {
+    return {
+      success: false,
+      error: `Messages must be ${MAX_BODY_LENGTH.toLocaleString()} characters or fewer.`,
+    }
+  }
+
+  return { success: true, data: { title, body } }
+}


### PR DESCRIPTION
## Summary
- Recover the internal Staff Board route, navigation, schema, migration, and CRUD actions.
- Enforce active internal organization and staff-role authorization at page, navigation, action, mutation, recipient, and notification-read boundaries.
- Add confirmation-protected deletion, moderator pinning, focused validation/access tests, and local UI evidence.

## Verification
- `bun test src/lib/__tests__/staff-board.test.ts` — passed (3 tests).
- `bunx drizzle-kit check` — passed.
- `bun lint` — passed with existing warnings only.
- `bun run build` — passed.
- Live localhost UI — Staff Board form, staff-only sidebar item, Team updates count, and created post confirmed in `staff-board-final.png`.
- Full `bun test` remains environment-blocked by unrelated existing Bun/native `better-sqlite3`, `bun:sqlite`, and Playwright/Vitest compatibility failures.

## Security review
- Independent fail-closed review passed after remediation.
- No merge or deployment performed.

## Notes
- Local UI verification used only isolated local D1 fixtures; no production data or credentials were modified.