### PR TITLE
[verified] fix: add fail-closed staff board

### DIFF
--- a/drizzle/0109_staff_board_posts.sql
+++ b/drizzle/0109_staff_board_posts.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS `staff_board_posts` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL REFERENCES `organizations`(`id`) ON DELETE cascade,
+  `author_id` text NOT NULL REFERENCES `users`(`id`) ON DELETE restrict,
+  `title` text NOT NULL,
+  `body` text NOT NULL,
+  `is_pinned` integer NOT NULL DEFAULT 0,
+  `archived_at` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `staff_board_posts_org_created_idx`
+  ON `staff_board_posts` (`organization_id`, `created_at`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `staff_board_posts_org_pinned_idx`
+  ON `staff_board_posts` (`organization_id`, `is_pinned`, `created_at`);

--- a/src/app/actions/__tests__/notifications.test.ts
+++ b/src/app/actions/__tests__/notifications.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const deps = vi.hoisted(() => ({
+  getActiveStaffBoardOrganization: vi.fn(),
+  requireAuth: vi.fn(),
+  getCloudflareContext: vi.fn(),
+  getDb: vi.fn(),
+}))
+
+vi.mock("@/lib/staff-board", () => ({
+  getActiveStaffBoardOrganization: deps.getActiveStaffBoardOrganization,
+}))
+vi.mock("@/lib/auth", () => ({
+  getCurrentUser: vi.fn(),
+  requireAuth: deps.requireAuth,
+}))
+vi.mock("@/lib/db", () => ({ getCloudflareContext: deps.getCloudflareContext }))
+vi.mock("@/db", () => ({ getDb: deps.getDb }))
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
+
+const { getNotificationCenter } = await import("@/app/actions/notifications")
+
+const user = {
+  id: "staff-1",
+  email: "staff@example.com",
+  firstName: "Staff",
+  lastName: "User",
+  displayName: "Staff User",
+  avatarUrl: null,
+  dashboardDeskPhotoUrl: null,
+  sidebarDeskPhotoUrl: null,
+  role: "office",
+  organizationId: "org-1",
+  organizationType: "internal",
+  isActive: true,
+} as const
+
+describe("notification center Staff Board authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    deps.requireAuth.mockResolvedValue(user)
+    deps.getCloudflareContext.mockResolvedValue({ env: { DB: {} } })
+    deps.getActiveStaffBoardOrganization.mockResolvedValue(null)
+    deps.getDb.mockReturnValue({
+      select: vi.fn(() => ({
+        from: vi.fn().mockReturnThis(),
+        innerJoin: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        orderBy: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue([]),
+      })),
+    })
+  })
+
+  it("revalidates the current user before reading notification rows", async () => {
+    const result = await getNotificationCenter()
+
+    expect(result.success).toBe(true)
+    expect(deps.getActiveStaffBoardOrganization).toHaveBeenCalledWith(user)
+  })
+})

--- a/src/app/actions/__tests__/staff-board.test.ts
+++ b/src/app/actions/__tests__/staff-board.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const deps = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(), getDb: vi.fn(), getCloudflareContext: vi.fn(),
+  getActiveStaffBoardOrganization: vi.fn(), getStaffBoardRecipients: vi.fn(),
+  validateStaffBoardPost: vi.fn(), isDemoUser: vi.fn(), revalidatePath: vi.fn(),
+  requirePermission: vi.fn(),
+}))
+vi.mock("@/lib/auth", () => ({ getCurrentUser: deps.getCurrentUser }))
+vi.mock("@/db", () => ({ getDb: deps.getDb }))
+vi.mock("@/lib/db", () => ({ getCloudflareContext: deps.getCloudflareContext }))
+vi.mock("@/lib/staff-board", () => ({ getActiveStaffBoardOrganization: deps.getActiveStaffBoardOrganization, getStaffBoardRecipients: deps.getStaffBoardRecipients, validateStaffBoardPost: deps.validateStaffBoardPost }))
+vi.mock("@/lib/demo", () => ({ isDemoUser: deps.isDemoUser }))
+vi.mock("@/lib/permissions", () => ({ requirePermission: deps.requirePermission }))
+vi.mock("next/cache", () => ({ revalidatePath: deps.revalidatePath }))
+
+const { createStaffBoardPost, toggleStaffBoardPostPin } = await import("@/app/actions/staff-board")
+
+const internalUser = {
+  id: "staff-1", email: "staff@example.com", firstName: "Staff", lastName: "One", displayName: "Staff One",
+  avatarUrl: null, role: "office", googleEmail: null, isActive: true, lastLoginAt: null,
+  organizationId: "org-1", organizationName: "HPS", organizationType: "internal",
+  createdAt: "2026-01-01T00:00:00.000Z", updatedAt: "2026-01-01T00:00:00.000Z",
+} as const
+
+function makeDb() {
+  const insert = vi.fn(() => ({ values: vi.fn(() => ({ statement: "insert" })) }))
+  const updateReturning = vi.fn().mockResolvedValue([{ id: "post-1" }])
+  const where = vi.fn(() => ({ returning: updateReturning }))
+  const set = vi.fn(() => ({ where }))
+  const update = vi.fn(() => ({ set }))
+  return { insert, update, select: vi.fn(), batch: vi.fn().mockResolvedValue([]), updateReturning }
+}
+
+describe("staff board action authorization and persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    deps.getCloudflareContext.mockResolvedValue({ env: { DB: {} } })
+    deps.isDemoUser.mockReturnValue(false)
+    deps.validateStaffBoardPost.mockReturnValue({ success: true, data: { title: "Update", body: "Message" } })
+  })
+
+  it("denies an external caller before opening a database context", async () => {
+    deps.getCurrentUser.mockResolvedValue({ ...internalUser, role: "client", organizationType: "client" })
+    deps.getActiveStaffBoardOrganization.mockResolvedValue(null)
+    const db = makeDb(); deps.getDb.mockReturnValue(db)
+    await expect(createStaffBoardPost({ title: "Update", body: "Message" })).resolves.toEqual({ success: false, error: "Staff access required" })
+    expect(deps.getActiveStaffBoardOrganization).toHaveBeenCalledTimes(1)
+    expect(deps.getDb).not.toHaveBeenCalled(); expect(db.insert).not.toHaveBeenCalled()
+  })
+
+  it("batches the post and in-app notification rows as one persistence unit", async () => {
+    deps.getCurrentUser.mockResolvedValue(internalUser)
+    deps.getActiveStaffBoardOrganization.mockResolvedValue("org-1")
+    deps.getStaffBoardRecipients.mockResolvedValue([{ userId: "staff-2", email: "two@example.com" }])
+    const db = makeDb(); deps.getDb.mockReturnValue(db)
+    await expect(createStaffBoardPost({ title: "Update", body: "Message" })).resolves.toEqual({ success: true })
+    expect(db.batch).toHaveBeenCalledTimes(1)
+    expect(db.batch.mock.calls[0]?.[0]).toHaveLength(3); expect(db.insert).toHaveBeenCalledTimes(3)
+  })
+
+  it("pins with one organization-scoped atomic update and no read-before-write", async () => {
+    deps.getCurrentUser.mockResolvedValue(internalUser); deps.getActiveStaffBoardOrganization.mockResolvedValue("org-1")
+    const db = makeDb(); deps.getDb.mockReturnValue(db)
+    await expect(toggleStaffBoardPostPin("post-1")).resolves.toEqual({ success: true })
+    expect(db.select).not.toHaveBeenCalled(); expect(db.update).toHaveBeenCalledTimes(1); expect(db.updateReturning).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/actions/notifications.ts
+++ b/src/app/actions/notifications.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { and, desc, eq, isNull } from "drizzle-orm"
+import { and, desc, eq, isNull, not, or, sql } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
@@ -12,6 +12,7 @@ import {
 } from "@/db/schema"
 import { getCurrentUser, requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
+import { getActiveStaffBoardOrganization } from "@/lib/staff-board"
 import {
   isMissingNotificationTableError,
   queueSmsDelivery,
@@ -422,9 +423,29 @@ export async function sendTestSmsNotification(): Promise<NotificationSmsTestResu
   }
 }
 
+function staffBoardNotificationScope(
+  organizationId: string | null
+): ReturnType<typeof sql> {
+  const staffBoardEvent = sql`source_type = 'staff_board'`
+  const eventLink = sql`staff_board_event.id = notification_recipients.event_id`
+  const hiddenStaffBoardEvent = sql`NOT EXISTS (
+    SELECT 1 FROM notification_events AS staff_board_event
+    WHERE ${eventLink} AND ${staffBoardEvent}
+  )`
+  if (organizationId === null) return hiddenStaffBoardEvent
+  return sql`(${hiddenStaffBoardEvent} OR EXISTS (
+    SELECT 1 FROM notification_events AS staff_board_event
+    WHERE ${eventLink}
+      AND ${staffBoardEvent}
+      AND staff_board_event.organization_id = ${organizationId}
+  ))`
+}
+
 export async function getNotificationCenter(): Promise<NotificationCenterResult> {
   try {
     const user = await requireAuth()
+    const activeStaffBoardOrganizationId =
+      await getActiveStaffBoardOrganization(user)
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
 
@@ -450,7 +471,19 @@ export async function getNotificationCenter(): Promise<NotificationCenterResult>
         and(
           eq(notificationRecipients.userId, user.id),
           eq(notificationRecipients.inApp, true),
-          isNull(notificationRecipients.dismissedAt)
+          isNull(notificationRecipients.dismissedAt),
+          activeStaffBoardOrganizationId === null
+            ? not(eq(notificationEvents.sourceType, "staff_board"))
+            : or(
+                not(eq(notificationEvents.sourceType, "staff_board")),
+                and(
+                  eq(notificationEvents.sourceType, "staff_board"),
+                  eq(
+                    notificationEvents.organizationId,
+                    activeStaffBoardOrganizationId
+                  )
+                )
+              )
         )
       )
       .orderBy(desc(notificationRecipients.createdAt))
@@ -482,6 +515,8 @@ export async function markNotificationRead(
 ): Promise<NotificationActionResult> {
   try {
     const user = await requireAuth()
+    const activeStaffBoardOrganizationId =
+      await getActiveStaffBoardOrganization(user)
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
     const now = new Date().toISOString()
@@ -492,7 +527,8 @@ export async function markNotificationRead(
       .where(
         and(
           eq(notificationRecipients.id, recipientId),
-          eq(notificationRecipients.userId, user.id)
+          eq(notificationRecipients.userId, user.id),
+          staffBoardNotificationScope(activeStaffBoardOrganizationId)
         )
       )
 
@@ -512,6 +548,8 @@ export async function markNotificationRead(
 export async function markAllNotificationsRead(): Promise<NotificationActionResult> {
   try {
     const user = await requireAuth()
+    const activeStaffBoardOrganizationId =
+      await getActiveStaffBoardOrganization(user)
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
     const now = new Date().toISOString()
@@ -522,7 +560,8 @@ export async function markAllNotificationsRead(): Promise<NotificationActionResu
       .where(
         and(
           eq(notificationRecipients.userId, user.id),
-          isNull(notificationRecipients.readAt)
+          isNull(notificationRecipients.readAt),
+          staffBoardNotificationScope(activeStaffBoardOrganizationId)
         )
       )
 

--- a/src/app/actions/staff-board.ts
+++ b/src/app/actions/staff-board.ts
@@ -1,0 +1,288 @@
+"use server"
+
+import { and, desc, eq, isNull, sql } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import {
+  notificationEvents,
+  notificationRecipients,
+  staffBoardPosts,
+  users,
+} from "@/db/schema"
+import { getCurrentUser } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import {
+  getActiveStaffBoardOrganization,
+  getStaffBoardRecipients,
+  validateStaffBoardPost,
+} from "@/lib/staff-board"
+import { requirePermission } from "@/lib/permissions"
+
+export type StaffBoardPost = {
+  readonly id: string
+  readonly title: string
+  readonly body: string
+  readonly isPinned: boolean
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly author: {
+    readonly id: string
+    readonly displayName: string | null
+    readonly email: string
+  }
+}
+
+type StaffBoardResult =
+  | { readonly success: true; readonly data: readonly StaffBoardPost[] }
+  | { readonly success: false; readonly error: string }
+
+type StaffBoardActionResult =
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string }
+
+type StaffBoardContext = {
+  readonly user: NonNullable<Awaited<ReturnType<typeof getCurrentUser>>>
+  readonly organizationId: string
+}
+
+async function requireStaffBoardContext(): Promise<StaffBoardContext | null> {
+  const user = await getCurrentUser()
+  if (!user) return null
+  const organizationId = await getActiveStaffBoardOrganization(user)
+  if (!organizationId) return null
+  return { user, organizationId }
+}
+
+async function staffBoardDb(): Promise<ReturnType<typeof getDb>> {
+  const { env } = await getCloudflareContext()
+  return getDb(env.DB)
+}
+
+export async function listStaffBoardPosts(): Promise<StaffBoardResult> {
+  try {
+    const context = await requireStaffBoardContext()
+    if (!context) return { success: false, error: "Staff access required" }
+    const db = await staffBoardDb()
+    const rows = await db
+      .select({
+        id: staffBoardPosts.id,
+        title: staffBoardPosts.title,
+        body: staffBoardPosts.body,
+        isPinned: staffBoardPosts.isPinned,
+        createdAt: staffBoardPosts.createdAt,
+        updatedAt: staffBoardPosts.updatedAt,
+        authorId: users.id,
+        authorDisplayName: users.displayName,
+        authorEmail: users.email,
+      })
+      .from(staffBoardPosts)
+      .innerJoin(users, eq(users.id, staffBoardPosts.authorId))
+      .where(
+        and(
+          eq(staffBoardPosts.organizationId, context.organizationId),
+          isNull(staffBoardPosts.archivedAt)
+        )
+      )
+      .orderBy(desc(staffBoardPosts.isPinned), desc(staffBoardPosts.createdAt))
+      .limit(100)
+
+    return {
+      success: true,
+      data: rows.map((row) => ({
+        id: row.id,
+        title: row.title,
+        body: row.body,
+        isPinned: row.isPinned,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        author: {
+          id: row.authorId,
+          displayName: row.authorDisplayName,
+          email: row.authorEmail,
+        },
+      })),
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to load staff board",
+    }
+  }
+}
+
+export async function createStaffBoardPost(
+  input: unknown
+): Promise<StaffBoardActionResult> {
+  try {
+    const context = await requireStaffBoardContext()
+    if (!context) return { success: false, error: "Staff access required" }
+    if (isDemoUser(context.user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    const validation = validateStaffBoardPost(input)
+    if (!validation.success) return validation
+
+    const db = await staffBoardDb()
+    const now = new Date().toISOString()
+    const postId = crypto.randomUUID()
+    const eventId = crypto.randomUUID()
+    const recipients = await getStaffBoardRecipients(
+      db,
+      context.organizationId,
+      context.user.id
+    )
+
+    const postStatement = db.insert(staffBoardPosts).values({
+        id: postId,
+        organizationId: context.organizationId,
+        authorId: context.user.id,
+        title: validation.data.title,
+        body: validation.data.body,
+        isPinned: false,
+        archivedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+    if (recipients.length === 0) {
+      await db.batch([postStatement])
+    } else {
+      await db.batch([
+        postStatement,
+        db.insert(notificationEvents).values({
+          id: eventId,
+          organizationId: context.organizationId,
+          projectId: null,
+          eventType: "staff_board.post_created",
+          sourceType: "staff_board",
+          sourceId: postId,
+          title: validation.data.title,
+          body: `${context.user.displayName ?? context.user.email} posted to the Staff Board.`,
+          href: "/dashboard/staff-board",
+          priority: "normal",
+          audience: "internal",
+          createdBy: context.user.id,
+          createdAt: now,
+        }),
+        ...recipients.map((recipient) =>
+          db.insert(notificationRecipients).values({
+            id: crypto.randomUUID(),
+            eventId,
+            userId: recipient.userId,
+            inApp: true,
+            email: false,
+            sms: false,
+            push: false,
+            readAt: null,
+            dismissedAt: null,
+            createdAt: now,
+          })
+        )
+      ])
+    }
+
+    revalidatePath("/dashboard/staff-board")
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to create staff board post",
+    }
+  }
+}
+
+export async function deleteStaffBoardPost(
+  postId: string
+): Promise<StaffBoardActionResult> {
+  try {
+    const context = await requireStaffBoardContext()
+    if (!context) return { success: false, error: "Staff access required" }
+    if (isDemoUser(context.user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    const db = await staffBoardDb()
+    const post = await db
+      .select({ id: staffBoardPosts.id, authorId: staffBoardPosts.authorId })
+      .from(staffBoardPosts)
+      .where(
+        and(
+          eq(staffBoardPosts.id, postId),
+          eq(staffBoardPosts.organizationId, context.organizationId),
+          isNull(staffBoardPosts.archivedAt)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!post) return { success: false, error: "Post not found" }
+
+    const isAuthor = post.authorId === context.user.id
+    if (!isAuthor) {
+      try {
+        requirePermission(context.user, "channels", "moderate")
+      } catch {
+        return {
+          success: false,
+          error: "Only the author or a moderator can remove posts",
+        }
+      }
+    }
+
+    const where = and(
+      eq(staffBoardPosts.id, postId),
+      eq(staffBoardPosts.organizationId, context.organizationId),
+      ...(isAuthor ? [eq(staffBoardPosts.authorId, context.user.id)] : []),
+      isNull(staffBoardPosts.archivedAt)
+    )
+    const removed = await db
+      .update(staffBoardPosts)
+      .set({ archivedAt: new Date().toISOString(), updatedAt: new Date().toISOString() })
+      .where(where)
+      .returning({ id: staffBoardPosts.id })
+    if (removed.length === 0) return { success: false, error: "Post not found" }
+    revalidatePath("/dashboard/staff-board")
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to remove staff board post",
+    }
+  }
+}
+
+export async function toggleStaffBoardPostPin(
+  postId: string
+): Promise<StaffBoardActionResult> {
+  try {
+    const context = await requireStaffBoardContext()
+    if (!context) return { success: false, error: "Staff access required" }
+    if (isDemoUser(context.user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    requirePermission(context.user, "channels", "moderate")
+    const db = await staffBoardDb()
+    const updated = await db
+      .update(staffBoardPosts)
+      .set({
+        isPinned: sql`NOT ${staffBoardPosts.isPinned}`,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(
+        and(
+          eq(staffBoardPosts.id, postId),
+          eq(staffBoardPosts.organizationId, context.organizationId),
+          isNull(staffBoardPosts.archivedAt)
+        )
+      )
+      .returning({ id: staffBoardPosts.id })
+    if (updated.length === 0) return { success: false, error: "Post not found" }
+    revalidatePath("/dashboard/staff-board")
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to update staff board post",
+    }
+  }
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -39,6 +39,7 @@ import {
   canManageUserAccess,
 } from "@/lib/permissions"
 import { isInternalStaffRole } from "@/lib/user-roles"
+import { hasActiveStaffBoardOrganization } from "@/lib/staff-board"
 
 export default async function DashboardLayout({
   children,
@@ -61,6 +62,9 @@ export default async function DashboardLayout({
   const canUseCompassOfficeTalk = canUseOfficeTalk(authUser)
   const canViewActivity = authUser
     ? isInternalStaffRole(authUser.role)
+    : false
+  const canViewStaffBoard = authUser
+    ? await hasActiveStaffBoardOrganization(authUser)
     : false
   const canUseDirectMessages = canViewActivity
   const canManageFeedback = canManageUserAccess(authUser)
@@ -103,6 +107,7 @@ export default async function DashboardLayout({
           canUseFieldDesk={canUseCompassFieldDesk}
           canViewActivity={canViewActivity}
           canManageFeedback={canManageFeedback}
+          canViewStaffBoard={canViewStaffBoard}
         />
         <SidebarInset className="overflow-hidden">
           <DesktopOfflineBanner />

--- a/src/app/dashboard/staff-board/page.tsx
+++ b/src/app/dashboard/staff-board/page.tsx
@@ -1,0 +1,31 @@
+import { redirect } from "next/navigation"
+
+import { listStaffBoardPosts } from "@/app/actions/staff-board"
+import { StaffBoardView } from "@/components/staff-board-view"
+import { can } from "@/lib/permissions"
+import { hasActiveStaffBoardOrganization } from "@/lib/staff-board"
+import { getCurrentUser } from "@/lib/auth"
+
+export default async function StaffBoardPage(): Promise<React.ReactNode> {
+  const user = await getCurrentUser()
+  if (!user || !(await hasActiveStaffBoardOrganization(user))) {
+    redirect("/dashboard/access-restricted")
+  }
+
+  const result = await listStaffBoardPosts()
+  if (!result.success) {
+    return (
+      <div className="flex h-full items-center justify-center p-8 text-sm text-destructive">
+        {result.error}
+      </div>
+    )
+  }
+
+  return (
+    <StaffBoardView
+      initialPosts={result.data}
+      currentUserId={user.id}
+      canModerate={can(user, "channels", "moderate")}
+    />
+  )
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import {
   IconAddressBook,
   IconActivity,
+  IconBellRinging,
   IconCalendarStats,
   IconClipboardCheck,
   IconTimeline,
@@ -82,6 +83,12 @@ const NAV_MAIN = [
     internalOnly: true,
   },
   {
+    title: "Staff Board",
+    url: "/dashboard/staff-board",
+    icon: IconBellRinging,
+    staffBoardOnly: true,
+  },
+  {
     title: "Projects",
     url: "/dashboard/projects",
     icon: IconFolder,
@@ -155,6 +162,7 @@ const NAV_MAIN = [
     icon: IconMessageReport,
     adminOnly: true,
   },
+
   {
     title: "Files",
     url: "/dashboard/files",
@@ -187,11 +195,13 @@ function SidebarNav({
   canUseFieldDesk,
   canViewActivity,
   canManageFeedback,
+  canViewStaffBoard,
 }: {
   projects: ReadonlyArray<ProjectListItem>
   readonly canUseFieldDesk: boolean
   readonly canViewActivity: boolean
   readonly canManageFeedback: boolean
+  readonly canViewStaffBoard: boolean
 }) {
   const pathname = usePathname()
   const { state } = useSidebar()
@@ -226,7 +236,8 @@ function SidebarNav({
   const navMain = NAV_MAIN.filter(
     (item) =>
       (!item.internalOnly || canViewActivity) &&
-      (!item.adminOnly || canManageFeedback)
+      (!item.adminOnly || canManageFeedback) &&
+      (!item.staffBoardOnly || canViewStaffBoard)
   ).map((item) =>
     typeof item.projectPath === "string"
       ? {
@@ -280,6 +291,7 @@ export function AppSidebar({
   canUseFieldDesk = false,
   canViewActivity = false,
   canManageFeedback = false,
+  canViewStaffBoard = false,
   ...props
 }: React.ComponentProps<typeof Sidebar> & {
   readonly projects?: ReadonlyArray<ProjectListItem>
@@ -289,6 +301,7 @@ export function AppSidebar({
   readonly canUseFieldDesk?: boolean
   readonly canViewActivity?: boolean
   readonly canManageFeedback?: boolean
+  readonly canViewStaffBoard?: boolean
 }) {
   const { isMobile } = useSidebar()
   const { channelId } = useVoiceState()
@@ -304,6 +317,7 @@ export function AppSidebar({
           canUseFieldDesk={canUseFieldDesk}
           canViewActivity={canViewActivity}
           canManageFeedback={canManageFeedback}
+          canViewStaffBoard={canViewStaffBoard}
         />
       </SidebarContent>
       <SidebarFooter className="border-t border-sidebar-border/60">

--- a/src/components/staff-board-view.tsx
+++ b/src/components/staff-board-view.tsx
@@ -1,0 +1,207 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import {
+  IconBellRinging,
+  IconPin,
+  IconPinFilled,
+  IconSend,
+  IconTrash,
+} from "@tabler/icons-react"
+
+import {
+  createStaffBoardPost,
+  deleteStaffBoardPost,
+  toggleStaffBoardPostPin,
+  type StaffBoardPost,
+} from "@/app/actions/staff-board"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+function authorName(post: StaffBoardPost): string {
+  return post.author.displayName ?? post.author.email
+}
+
+function postDate(value: string): string {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime())
+    ? value
+    : date.toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+}
+
+export function StaffBoardView({
+  initialPosts,
+  currentUserId,
+  canModerate,
+}: {
+  readonly initialPosts: readonly StaffBoardPost[]
+  readonly currentUserId: string
+  readonly canModerate: boolean
+}) {
+  const router = useRouter()
+  const [title, setTitle] = useState("")
+  const [body, setBody] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [busyPostId, setBusyPostId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function submitPost(): Promise<void> {
+    setSubmitting(true)
+    setError(null)
+    const result = await createStaffBoardPost({ title, body })
+    if (!result.success) {
+      setError(result.error)
+      setSubmitting(false)
+      return
+    }
+    setTitle("")
+    setBody("")
+    setSubmitting(false)
+    router.refresh()
+  }
+
+  async function removePost(postId: string): Promise<void> {
+    if (!window.confirm("Remove this Staff Board post?")) return
+    setBusyPostId(postId)
+    setError(null)
+    const result = await deleteStaffBoardPost(postId)
+    if (!result.success) setError(result.error)
+    setBusyPostId(null)
+    if (result.success) router.refresh()
+  }
+
+  async function togglePin(postId: string): Promise<void> {
+    setBusyPostId(postId)
+    setError(null)
+    const result = await toggleStaffBoardPostPin(postId)
+    if (!result.success) setError(result.error)
+    setBusyPostId(null)
+    if (result.success) router.refresh()
+  }
+
+  return (
+    <div className="mx-auto flex h-full w-full max-w-5xl flex-col gap-6 overflow-y-auto p-4 md:p-8">
+      <header className="flex flex-col gap-2 border-b pb-5">
+        <div className="flex items-center gap-3">
+          <div className="rounded-lg bg-primary/10 p-2 text-primary">
+            <IconBellRinging className="size-6" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">Staff Board</h1>
+            <p className="text-sm text-muted-foreground">
+              One place for company-wide updates, reminders, and notices for Compass staff.
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <Card>
+        <CardHeader className="gap-1">
+          <CardTitle className="text-base">Post an update</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Every active internal staff member can see new posts. A quiet in-app notification is sent to the team.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Input
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="Short update title"
+            maxLength={120}
+            aria-label="Staff Board post title"
+          />
+          <Textarea
+            value={body}
+            onChange={(event) => setBody(event.target.value)}
+            placeholder="Write the update for the team..."
+            maxLength={5000}
+            rows={4}
+            aria-label="Staff Board post message"
+          />
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs text-muted-foreground">
+              Keep project-specific discussion in Conversations.
+            </p>
+            <Button type="button" onClick={() => void submitPost()} disabled={submitting}>
+              <IconSend className="size-4" />
+              {submitting ? "Posting..." : "Post update"}
+            </Button>
+          </div>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </CardContent>
+      </Card>
+
+      <section className="space-y-4" aria-labelledby="staff-board-posts-heading">
+        <div className="flex items-center justify-between gap-3">
+          <h2 id="staff-board-posts-heading" className="text-lg font-semibold">
+            Team updates
+          </h2>
+          <span className="text-sm text-muted-foreground">
+            {initialPosts.length} {initialPosts.length === 1 ? "post" : "posts"}
+          </span>
+        </div>
+        {initialPosts.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center text-sm text-muted-foreground">
+              No updates yet. The first post will appear here for the whole staff team.
+            </CardContent>
+          </Card>
+        ) : (
+          initialPosts.map((post) => (
+            <Card key={post.id} className={post.isPinned ? "border-primary/40" : undefined}>
+              <CardHeader className="gap-2">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <CardTitle className="flex items-center gap-2 text-base">
+                      {post.isPinned && <IconPinFilled className="size-4 text-primary" />}
+                      <span className="truncate">{post.title}</span>
+                    </CardTitle>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {authorName(post)} · {postDate(post.createdAt)}
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1">
+                    {canModerate && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={post.isPinned ? "Unpin post" : "Pin post"}
+                        disabled={busyPostId === post.id}
+                        onClick={() => void togglePin(post.id)}
+                      >
+                        <IconPin className="size-4" />
+                      </Button>
+                    )}
+                    {(canModerate || post.author.id === currentUserId) && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Remove post"
+                        disabled={busyPostId === post.id}
+                        onClick={() => void removePost(post.id)}
+                      >
+                        <IconTrash className="size-4" />
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <p className="whitespace-pre-wrap text-sm leading-6">{post.body}</p>
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -74,6 +74,36 @@ export const cherishPulseResponses = sqliteTable("cherish_pulse_responses", {
   updatedAt: text("updated_at").notNull(),
 })
 
+export const staffBoardPosts = sqliteTable(
+  "staff_board_posts",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    authorId: text("author_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "restrict" }),
+    title: text("title").notNull(),
+    body: text("body").notNull(),
+    isPinned: integer("is_pinned", { mode: "boolean" }).notNull().default(false),
+    archivedAt: text("archived_at"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    index("staff_board_posts_org_created_idx").on(
+      table.organizationId,
+      table.createdAt
+    ),
+    index("staff_board_posts_org_pinned_idx").on(
+      table.organizationId,
+      table.isPinned,
+      table.createdAt
+    ),
+  ]
+)
+
 export const notificationPreferences = sqliteTable("notification_preferences", {
   userId: text("user_id")
     .primaryKey()

--- a/src/lib/staff-board/__tests__/staff-board.test.ts
+++ b/src/lib/staff-board/__tests__/staff-board.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  canAccessStaffBoard,
+  isActiveInternalStaffMembership,
+  selectStaffBoardRecipients,
+  validateStaffBoardPost,
+} from "@/lib/staff-board"
+
+describe("staff board access", () => {
+  it("allows only an active internal staff member in the active internal organization", () => {
+    expect(canAccessStaffBoard("office", true, "internal")).toBe(true)
+    expect(
+      isActiveInternalStaffMembership({
+        userId: "staff-1",
+        requestedUserId: "staff-1",
+        memberOrganizationId: "org-1",
+        requestedOrganizationId: "org-1",
+        userIsActive: true,
+        organizationIsActive: true,
+        organizationType: "internal",
+        memberRole: "office",
+      })
+    ).toBe(true)
+  })
+
+  it("rejects inactive, external, mismatched, and unbound memberships", () => {
+    const base = {
+      userId: "staff-1",
+      requestedUserId: "staff-1",
+      memberOrganizationId: "org-1",
+      requestedOrganizationId: "org-1",
+      userIsActive: true,
+      organizationIsActive: true,
+      organizationType: "internal",
+      memberRole: "office",
+    } as const
+
+    expect(isActiveInternalStaffMembership({ ...base, userIsActive: false })).toBe(false)
+    expect(isActiveInternalStaffMembership({ ...base, organizationIsActive: false })).toBe(false)
+    expect(isActiveInternalStaffMembership({ ...base, organizationType: "client" })).toBe(false)
+    expect(isActiveInternalStaffMembership({ ...base, memberRole: "client" })).toBe(false)
+    expect(isActiveInternalStaffMembership({ ...base, memberOrganizationId: "org-2" })).toBe(false)
+    expect(isActiveInternalStaffMembership({ ...base, requestedUserId: "other-user" })).toBe(false)
+  })
+})
+
+describe("staff board recipients", () => {
+  it("keeps only active internal members of the same organization and excludes the author", () => {
+    expect(
+      selectStaffBoardRecipients(
+        [
+          { userId: "author", email: "author@example.com", organizationId: "org-1", isActive: true, role: "office" },
+          { userId: "staff", email: "staff@example.com", organizationId: "org-1", isActive: true, role: "field_crew" },
+          { userId: "inactive", email: "inactive@example.com", organizationId: "org-1", isActive: false, role: "office" },
+          { userId: "external", email: "external@example.com", organizationId: "org-1", isActive: true, role: "client" },
+          { userId: "other-org", email: "other@example.com", organizationId: "org-2", isActive: true, role: "office" },
+        ],
+        "author",
+        "org-1"
+      )
+    ).toEqual([{ userId: "staff", email: "staff@example.com" }])
+  })
+})
+
+describe("staff board post validation", () => {
+  it("trims valid titles and bodies", () => {
+    expect(
+      validateStaffBoardPost({
+        title: "  Monday update  ",
+        body: "  The office is closed Friday.  ",
+      })
+    ).toEqual({
+      success: true,
+      data: {
+        title: "Monday update",
+        body: "The office is closed Friday.",
+      },
+    })
+  })
+
+  it("rejects missing or oversized content", () => {
+    expect(validateStaffBoardPost({ title: "", body: "A post" })).toEqual({
+      success: false,
+      error: "Add a title.",
+    })
+    expect(validateStaffBoardPost({ title: "Update", body: "" })).toEqual({
+      success: false,
+      error: "Add a message.",
+    })
+    expect(validateStaffBoardPost({ title: "x".repeat(121), body: "A post" })).toEqual({
+      success: false,
+      error: "Titles must be 120 characters or fewer.",
+    })
+    expect(validateStaffBoardPost({ title: "Update", body: "x".repeat(5001) })).toEqual({
+      success: false,
+      error: "Messages must be 5,000 characters or fewer.",
+    })
+  })
+})

--- a/src/lib/staff-board/index.ts
+++ b/src/lib/staff-board/index.ts
@@ -1,0 +1,107 @@
+import { and, eq, inArray } from "drizzle-orm"
+
+import { getDb } from "@/db"
+import {
+  notificationPreferences,
+  organizations,
+  organizationMembers,
+  users,
+} from "@/db/schema"
+import type { AuthUser } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { isInternalStaffRole, USER_ROLES } from "@/lib/user-roles"
+
+const MAX_TITLE_LENGTH = 120
+const MAX_BODY_LENGTH = 5000
+const INTERNAL_STAFF_ROLES = USER_ROLES.filter(isInternalStaffRole)
+
+export type StaffBoardPostInput = { readonly title: string; readonly body: string }
+export type StaffBoardValidationResult =
+  | { readonly success: true; readonly data: StaffBoardPostInput }
+  | { readonly success: false; readonly error: string }
+export type StaffBoardMembershipCheck = {
+  readonly userId: string
+  readonly requestedUserId: string
+  readonly memberOrganizationId: string
+  readonly requestedOrganizationId: string
+  readonly userIsActive: boolean
+  readonly organizationIsActive: boolean
+  readonly organizationType: string
+  readonly memberRole: string
+}
+export type StaffBoardRecipientRow = {
+  readonly userId: string
+  readonly email: string
+  readonly organizationId: string
+  readonly isActive: boolean
+  readonly role: string
+}
+export type StaffBoardRecipient = { readonly userId: string; readonly email: string }
+
+export function canAccessStaffBoard(role: string | null | undefined, isActive: boolean, organizationType: string | null | undefined): boolean {
+  if (!isActive || organizationType !== "internal" || role === null || role === undefined) return false
+  return isInternalStaffRole(role)
+}
+
+export function isActiveInternalStaffMembership(membership: StaffBoardMembershipCheck): boolean {
+  return membership.userId === membership.requestedUserId &&
+    membership.memberOrganizationId === membership.requestedOrganizationId &&
+    membership.userIsActive && membership.organizationIsActive &&
+    membership.organizationType === "internal" && isInternalStaffRole(membership.memberRole)
+}
+
+export function selectStaffBoardRecipients(rows: readonly StaffBoardRecipientRow[], authorId: string, organizationId: string): readonly StaffBoardRecipient[] {
+  return rows.filter((row) => row.userId !== authorId && row.organizationId === organizationId && row.isActive && isInternalStaffRole(row.role)).map((row) => ({ userId: row.userId, email: row.email }))
+}
+
+export async function hasActiveStaffBoardOrganization(user: AuthUser): Promise<boolean> {
+  if (!user.organizationId || !canAccessStaffBoard(user.role, user.isActive, user.organizationType)) return false
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const rows = await db.select({
+    userId: users.id,
+    requestedUserId: users.id,
+    memberOrganizationId: organizationMembers.organizationId,
+    requestedOrganizationId: organizations.id,
+    userIsActive: users.isActive,
+    organizationIsActive: organizations.isActive,
+    organizationType: organizations.type,
+    memberRole: organizationMembers.role,
+  }).from(users).innerJoin(organizationMembers, eq(organizationMembers.userId, users.id)).innerJoin(organizations, eq(organizations.id, organizationMembers.organizationId)).where(and(
+    eq(users.id, user.id), eq(organizationMembers.organizationId, user.organizationId), eq(organizations.id, user.organizationId),
+    eq(users.isActive, true), eq(organizations.isActive, true), eq(organizations.type, "internal"), inArray(organizationMembers.role, INTERNAL_STAFF_ROLES)
+  )).limit(1)
+  return rows.some(isActiveInternalStaffMembership)
+}
+
+export async function getActiveStaffBoardOrganization(user: AuthUser): Promise<string | null> {
+  if (!(await hasActiveStaffBoardOrganization(user))) return null
+  return user.organizationId
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> { return typeof value === "object" && value !== null }
+
+export function validateStaffBoardPost(input: unknown): StaffBoardValidationResult {
+  if (!isRecord(input)) return { success: false, error: "Add a title and message." }
+  const title = typeof input.title === "string" ? input.title.trim() : ""
+  const body = typeof input.body === "string" ? input.body.trim() : ""
+  if (title.length === 0) return { success: false, error: "Add a title." }
+  if (body.length === 0) return { success: false, error: "Add a message." }
+  if (title.length > MAX_TITLE_LENGTH) return { success: false, error: `Titles must be ${MAX_TITLE_LENGTH} characters or fewer.` }
+  if (body.length > MAX_BODY_LENGTH) return { success: false, error: `Messages must be ${MAX_BODY_LENGTH.toLocaleString()} characters or fewer.` }
+  return { success: true, data: { title, body } }
+}
+
+export async function getStaffBoardRecipients(db: ReturnType<typeof getDb>, organizationId: string, authorId: string): Promise<readonly StaffBoardRecipient[]> {
+  const rows = await db.select({
+    userId: users.id,
+    email: users.email,
+    organizationId: organizationMembers.organizationId,
+    isActive: users.isActive,
+    role: organizationMembers.role,
+    inAppEnabled: notificationPreferences.inAppEnabled,
+  }).from(organizationMembers).innerJoin(users, eq(users.id, organizationMembers.userId)).innerJoin(organizations, eq(organizations.id, organizationMembers.organizationId)).leftJoin(notificationPreferences, eq(notificationPreferences.userId, users.id)).where(and(
+    eq(organizationMembers.organizationId, organizationId), eq(organizations.id, organizationId), eq(organizations.type, "internal"), eq(organizations.isActive, true), eq(users.isActive, true), inArray(organizationMembers.role, INTERNAL_STAFF_ROLES)
+  ))
+  return selectStaffBoardRecipients(rows.filter((row) => row.inAppEnabled !== false), authorId, organizationId)
+}


### PR DESCRIPTION
## Summary
- Add the Staff Board schema, server actions, page, UI, and guarded sidebar entry.
- Bind all Staff Board access to active internal users and active internal organizations.
- Keep notifications organization-scoped and hide Staff Board notification state from unauthorized recipients.
- Use a single D1 batch for post plus notification persistence and atomic organization-scoped pin/delete mutations.

## Verification
- Focused tests: 3 files, 9 passed.
- `bun run lint`: passed with existing warnings only.
- `bun run build`: passed.
- Local migration: `bun run db:migrate:local` applied `0109_staff_board_posts.sql`; `PRAGMA table_info(staff_board_posts)` verified.
- Independent staged-diff security review: passed for hash `014f6a0aa300d682b4af1719b2602b0925a2476691b2e8f1a73a0db9938bdfcb`.

## Known blockers
- Full Vitest suite: 821 passed, 7 pre-existing Buildertrend failures because the environment cannot import `bun:sqlite`.
- Live browser evidence: Chrome remote-debug permission popup was not approved; the isolated local dev server also hit the existing better-sqlite3 Node ABI mismatch. No screenshots or recording are claimed.

Do not merge or deploy from this draft.