### PR TITLE
fix(profile): persist scoped desk photos

### DIFF
--- a/drizzle/0109_user_workspace_photo_scopes.sql
+++ b/drizzle/0109_user_workspace_photo_scopes.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `users`
+  ADD COLUMN `dashboard_desk_photo_organization_id` text;
+--> statement-breakpoint
+ALTER TABLE `users`
+  ADD COLUMN `sidebar_desk_photo_organization_id` text;

--- a/src/app/actions/profile.ts
+++ b/src/app/actions/profile.ts
@@ -3,10 +3,16 @@
 import { getWorkOS, signOut } from "@workos-inc/authkit-nextjs"
 import { getCloudflareContext } from "@/lib/db"
 import { getDb } from "@/db"
-import { users } from "@/db/schema"
-import { eq } from "drizzle-orm"
+import { organizationMembers, organizations, users } from "@/db/schema"
+import { and, eq } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { requireAuth } from "@/lib/auth"
+import { isDemoUser } from "@/lib/demo"
+import { isInternalStaffRole } from "@/lib/user-roles"
+import {
+  canManageWorkspacePhoto,
+  WORKSPACE_PHOTO_REMOVED,
+} from "@/lib/workspace-photo-policy"
 import {
   updateProfileSchema,
   changePasswordSchema,
@@ -18,7 +24,6 @@ type ActionResult<T = undefined> =
   | { success: true; data?: T }
   | { success: false; error: string }
 
-const HIDDEN_WORKSPACE_PHOTO = "__hidden__"
 const MAX_WORKSPACE_PHOTO_LENGTH = 680_000
 const SAFE_IMAGE_DATA_URL =
   /^data:image\/(?:jpeg|png|webp);base64,[a-z0-9+/]+={0,2}$/i
@@ -32,10 +37,21 @@ export async function updateWorkspacePhoto(
       return { success: false, error: "Select a valid workspace photo." }
     }
     const currentUser = await requireAuth()
-    const normalized = value?.trim() || null
     if (
-      normalized !== null &&
-      normalized !== HIDDEN_WORKSPACE_PHOTO &&
+      !currentUser.organizationId ||
+      !currentUser.isActive ||
+      currentUser.organizationType !== "internal" ||
+      isDemoUser(currentUser.id) ||
+      !isInternalStaffRole(currentUser.role)
+    ) {
+      return {
+        success: false,
+        error: "Desk photos are available to internal staff only.",
+      }
+    }
+    const normalized = value?.trim() || WORKSPACE_PHOTO_REMOVED
+    if (
+      normalized !== WORKSPACE_PHOTO_REMOVED &&
       (
         normalized.length > MAX_WORKSPACE_PHOTO_LENGTH ||
         !SAFE_IMAGE_DATA_URL.test(normalized)
@@ -49,12 +65,59 @@ export async function updateWorkspacePhoto(
 
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
+    const membership = await db
+      .select({
+        id: organizationMembers.id,
+        organizationIsActive: organizations.isActive,
+      })
+      .from(organizationMembers)
+      .innerJoin(
+        organizations,
+        eq(organizations.id, organizationMembers.organizationId)
+      )
+      .where(
+        and(
+          eq(organizationMembers.userId, currentUser.id),
+          eq(organizationMembers.organizationId, currentUser.organizationId)
+        )
+      )
+      .limit(1)
+      .get()
+    if (
+      !membership ||
+      !membership.organizationIsActive ||
+      !canManageWorkspacePhoto({
+        actor: {
+          userId: currentUser.id,
+          organizationId: currentUser.organizationId,
+          organizationType: currentUser.organizationType,
+          role: currentUser.role,
+          isActive: currentUser.isActive,
+          isDemo: isDemoUser(currentUser.id),
+        },
+        photo: {
+          userId: currentUser.id,
+          organizationId: currentUser.organizationId,
+        },
+      })
+    ) {
+      return {
+        success: false,
+        error: "Desk photos are not available for this account.",
+      }
+    }
     await db
       .update(users)
       .set({
         ...(slot === "dashboard"
-          ? { dashboardDeskPhotoUrl: normalized }
-          : { sidebarDeskPhotoUrl: normalized }),
+          ? {
+              dashboardDeskPhotoUrl: normalized,
+              dashboardDeskPhotoOrganizationId: currentUser.organizationId,
+            }
+          : {
+              sidebarDeskPhotoUrl: normalized,
+              sidebarDeskPhotoOrganizationId: currentUser.organizationId,
+            }),
         updatedAt: new Date().toISOString(),
       })
       .where(eq(users.id, currentUser.id))

--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -7,6 +7,7 @@ import {
   dailyLogPhotos,
   dailyLogs,
   organizationMembers,
+  organizations,
   ownerProjectUpdates,
   projectContacts,
   projectMembers,
@@ -19,6 +20,7 @@ import {
 } from "@/db/schema"
 import { channelMembers, channels } from "@/db/schema-conversations"
 import { requireAuth } from "@/lib/auth"
+import { isDemoUser } from "@/lib/demo"
 import { getCloudflareContext } from "@/lib/db"
 import { requirePermission } from "@/lib/permissions"
 import { assertProjectAccess } from "@/lib/project-access"
@@ -139,6 +141,7 @@ export type ProjectAudiencePreview = {
   readonly viewerIsInternal: boolean
   readonly viewer: {
     readonly id: string
+    readonly organizationId: string | null
     readonly name: string
     readonly email: string
     readonly avatarUrl: string | null
@@ -172,6 +175,7 @@ async function verifyProjectAccess(
   readonly viewerIsInternal: boolean
   readonly viewer: {
     readonly id: string
+    readonly organizationId: string | null
     readonly name: string
     readonly email: string
     readonly avatarUrl: string | null
@@ -188,7 +192,43 @@ async function verifyProjectAccess(
   if (!project.organizationId) {
     throw new Error("Project organization is missing")
   }
-  const viewerIsInternal = isInternalStaffRole(user.role)
+  const activeOrganization = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(
+      and(
+        eq(organizations.id, project.organizationId),
+        eq(organizations.isActive, true)
+      )
+    )
+    .get()
+  if (!activeOrganization) {
+    throw new Error("Project organization is inactive")
+  }
+  const viewerIsInternal =
+    user.isActive &&
+    user.organizationType === "internal" &&
+    user.organizationId === project.organizationId &&
+    !isDemoUser(user.id) &&
+    isInternalStaffRole(user.role)
+  if (viewerIsInternal) {
+    const activeOrganization = await db
+      .select({ id: organizations.id })
+      .from(organizationMembers)
+      .innerJoin(
+        organizations,
+        eq(organizations.id, organizationMembers.organizationId)
+      )
+      .where(
+        and(
+          eq(organizationMembers.userId, user.id),
+          eq(organizationMembers.organizationId, project.organizationId),
+          eq(organizations.isActive, true)
+        )
+      )
+      .get()
+    if (!activeOrganization) throw new Error("Project not found")
+  }
   if (!viewerIsInternal) {
     const membership = await db
       .select({ role: projectMembers.role })
@@ -211,10 +251,15 @@ async function verifyProjectAccess(
     viewerIsInternal,
     viewer: {
       id: user.id,
+      organizationId: viewerIsInternal ? project.organizationId : null,
       name: user.displayName ?? user.email.split("@")[0] ?? "Compass user",
       email: user.email,
       avatarUrl: user.avatarUrl,
-      sidebarPhotoUrl: user.sidebarDeskPhotoUrl ?? null,
+      sidebarPhotoUrl:
+        viewerIsInternal &&
+        user.sidebarDeskPhotoOrganizationId === project.organizationId
+          ? user.sidebarDeskPhotoUrl ?? null
+          : null,
     },
   }
 }

--- a/src/components/dashboard/dashboard-launchpad.tsx
+++ b/src/components/dashboard/dashboard-launchpad.tsx
@@ -4,7 +4,6 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
   useTransition,
 } from "react"
@@ -79,6 +78,11 @@ import {
   type TeamAvailabilityMember,
 } from "@/lib/dashboard/office-status"
 import { dashboardDeskPhotoStorageKey } from "@/lib/user-photo-storage"
+import {
+  canManageWorkspacePhoto,
+  resolveWorkspacePhoto,
+  WORKSPACE_PHOTO_REMOVED,
+} from "@/lib/workspace-photo-policy"
 import { isProjectTodoRecordType } from "@/lib/project-todos"
 import {
   compareOfficeCalendarPriority,
@@ -115,27 +119,57 @@ export type DashboardOfficeEvent = {
   readonly startTime: string
 }
 
-const MARTINE_DEFAULT_DESK_PHOTO = "/user-desk-photos/martine-desk-photo.jpeg"
-const HIDDEN_DESK_PHOTO = "__hidden__"
 const TEAM_AVAILABILITY_REFRESH_MS = 10_000
 
-function deskPhotoForUser(user: SidebarUser | null): string | null {
-  if (!user) return null
-  if (user.dashboardDeskPhoto === HIDDEN_DESK_PHOTO) return null
-  if (user.dashboardDeskPhoto) return user.dashboardDeskPhoto
+function canManageDeskPhoto(user: SidebarUser | null): boolean {
+  return (
+    user !== null &&
+    canManageWorkspacePhoto({
+      actor: {
+        userId: user.id,
+        organizationId: user.organizationId,
+        organizationType: user.organizationType,
+        role: user.role,
+        isActive: user.isActive,
+        isDemo: user.isDemo,
+      },
+      photo: {
+        userId: user.id,
+        organizationId: user.organizationId ?? "",
+      },
+    })
+  )
+}
 
-  try {
-    const storedPhoto = window.localStorage.getItem(
-      dashboardDeskPhotoStorageKey(user.email)
-    )
-    if (storedPhoto === HIDDEN_DESK_PHOTO) return null
-    if (storedPhoto) return storedPhoto
-  } catch {
-    // The default photo still works when browser storage is unavailable.
+function deskPhotoScopeForUser(user: SidebarUser | null): string | null {
+  return user !== null && canManageDeskPhoto(user) && user.organizationId
+    ? `${user.organizationId}:${user.id}`
+    : null
+}
+
+function deskPhotoForUser(user: SidebarUser | null): string | null {
+  if (!user || !canManageDeskPhoto(user)) return null
+  if (!user.organizationId) return null
+  const durablePhoto = user.dashboardDeskPhoto
+  let cachedPhoto: string | null = null
+
+  if (user.organizationId) {
+    try {
+      const scope = { organizationId: user.organizationId, userId: user.id }
+      const storedPhoto = window.localStorage.getItem(
+        dashboardDeskPhotoStorageKey(scope)
+      )
+      cachedPhoto = storedPhoto
+    } catch {
+      cachedPhoto = null
+    }
   }
 
-  const identity = `${user.name} ${user.email}`.toLowerCase()
-  return identity.includes("martine") ? MARTINE_DEFAULT_DESK_PHOTO : null
+  return resolveWorkspacePhoto({
+    durablePhoto,
+    cachedPhoto,
+    allowCache: true,
+  })
 }
 
 function readFileAsDataUrl(file: File): Promise<string> {
@@ -181,13 +215,27 @@ function resizeDeskPhoto(dataUrl: string): Promise<string> {
 }
 
 function saveDeskPhoto(user: SidebarUser, dataUrl: string): void {
+  if (!canManageDeskPhoto(user) || !user.organizationId) return
   try {
     window.localStorage.setItem(
-      dashboardDeskPhotoStorageKey(user.email),
+      dashboardDeskPhotoStorageKey({
+        organizationId: user.organizationId,
+        userId: user.id,
+      }),
       dataUrl
     )
   } catch {
     // The updated image still remains available for the current session.
+  }
+}
+
+function resetDeskPhoto(user: SidebarUser): void {
+  if (!canManageDeskPhoto(user) || !user.organizationId) return
+  try {
+    const scope = { organizationId: user.organizationId, userId: user.id }
+    window.localStorage.removeItem(dashboardDeskPhotoStorageKey(scope))
+  } catch {
+    // The durable profile reset still applies when browser storage is unavailable.
   }
 }
 
@@ -453,35 +501,17 @@ function DeskHero({
 }): React.ReactElement {
   const [deskPhotoFailed, setDeskPhotoFailed] = useState(false)
   const [deskPhotoUrl, setDeskPhotoUrl] = useState<string | null>(null)
+  const [deskPhotoScope, setDeskPhotoScope] = useState<string | null>(null)
   const [deskPhotoMessage, setDeskPhotoMessage] = useState<string | null>(null)
   const [statusMessage, setStatusMessage] = useState<string | null>(null)
   const [isStatusPending, startStatusTransition] = useTransition()
-  const migratedLegacyPhotoFor = useRef<string | null>(null)
   const firstName = user?.firstName ?? user?.name.split(" ")[0] ?? "there"
 
   useEffect(() => {
     setDeskPhotoFailed(false)
     setDeskPhotoUrl(deskPhotoForUser(user))
+    setDeskPhotoScope(deskPhotoScopeForUser(user))
 
-    if (
-      !user ||
-      user.dashboardDeskPhoto ||
-      migratedLegacyPhotoFor.current === user.email
-    ) {
-      return
-    }
-
-    try {
-      const legacyPhoto = window.localStorage.getItem(
-        dashboardDeskPhotoStorageKey(user.email)
-      )
-      if (!legacyPhoto) return
-
-      migratedLegacyPhotoFor.current = user.email
-      void updateWorkspacePhoto("dashboard", legacyPhoto)
-    } catch {
-      // Keep the browser-local photo when storage is unavailable.
-    }
   }, [user])
 
   function handleStatusChange(nextStatus: DeskStatus): void {
@@ -505,7 +535,7 @@ function DeskHero({
     event: React.ChangeEvent<HTMLInputElement>
   ): Promise<void> {
     const file = event.currentTarget.files?.[0]
-    if (!file || !user) return
+    if (!file || !user || !canManageDeskPhoto(user)) return
     event.currentTarget.value = ""
 
     if (!file.type.startsWith("image/")) {
@@ -524,18 +554,44 @@ function DeskHero({
       saveDeskPhoto(user, resizedDataUrl)
       setDeskPhotoFailed(false)
       setDeskPhotoUrl(resizedDataUrl)
+      setDeskPhotoScope(deskPhotoScopeForUser(user))
       setDeskPhotoMessage("Desk photo updated.")
     } catch {
       setDeskPhotoMessage("Could not update the desk photo.")
     }
   }
 
+  async function handleDeskPhotoReset(): Promise<void> {
+    if (!user) return
+    const result = await updateWorkspacePhoto(
+      "dashboard",
+      WORKSPACE_PHOTO_REMOVED
+    )
+    if (!result.success) {
+      setDeskPhotoMessage(result.error)
+      return
+    }
+    resetDeskPhoto(user)
+    setDeskPhotoFailed(false)
+    setDeskPhotoUrl(null)
+    setDeskPhotoScope(null)
+    setDeskPhotoMessage("Desk photo removed.")
+  }
+
+  const visibleDeskPhoto =
+    user !== null &&
+    user !== undefined &&
+    canManageDeskPhoto(user) &&
+    deskPhotoScopeForUser(user) === deskPhotoScope
+      ? deskPhotoUrl
+      : null
+
   return (
     <section className="grid min-h-52 overflow-hidden border-y border-border/70 bg-background sm:grid-cols-[minmax(10rem,0.8fr)_minmax(0,1.2fr)]">
       <div className="relative min-h-40 overflow-hidden bg-muted">
-        {deskPhotoUrl && !deskPhotoFailed ? (
+        {visibleDeskPhoto && !deskPhotoFailed ? (
           <Image
-            src={deskPhotoUrl}
+            src={visibleDeskPhoto}
             alt={`${firstName}'s desk`}
             fill
             sizes="(min-width: 1024px) 260px, 50vw"
@@ -548,17 +604,26 @@ function DeskHero({
             <IconHome2 className="size-10 text-[#2f5963]/60" />
           </div>
         )}
-        {user ? (
-          <label className="absolute bottom-3 left-3 flex cursor-pointer items-center gap-1.5 border border-white/40 bg-black/55 px-2.5 py-1.5 text-xs font-medium text-white backdrop-blur-sm transition hover:bg-black/70">
-            <IconPhotoEdit className="size-3.5" />
-            Change desk photo
-            <input
-              type="file"
-              accept="image/*"
-              className="sr-only"
-              onChange={handleDeskPhotoUpload}
-            />
-          </label>
+        {canManageDeskPhoto(user) ? (
+          <div className="absolute bottom-3 left-3 flex items-center gap-1.5">
+            <label className="flex cursor-pointer items-center gap-1.5 border border-white/40 bg-black/55 px-2.5 py-1.5 text-xs font-medium text-white backdrop-blur-sm transition hover:bg-black/70">
+              <IconPhotoEdit className="size-3.5" />
+              Change desk photo
+              <input
+                type="file"
+                accept="image/*"
+                className="sr-only"
+                onChange={handleDeskPhotoUpload}
+              />
+            </label>
+            <button
+              type="button"
+              onClick={() => void handleDeskPhotoReset()}
+              className="border border-white/40 bg-black/55 px-2.5 py-1.5 text-xs font-medium text-white backdrop-blur-sm transition hover:bg-black/70"
+            >
+              Remove
+            </button>
+          </div>
         ) : null}
       </div>
 

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -52,6 +52,37 @@ import { sidebarDeskPhotoStorageKey } from "@/lib/user-photo-storage"
 import { cn } from "@/lib/utils"
 import { getInitials } from "@/lib/utils"
 import type { SidebarUser } from "@/lib/auth"
+import {
+  canManageWorkspacePhoto,
+  resolveWorkspacePhoto,
+  WORKSPACE_PHOTO_REMOVED,
+} from "@/lib/workspace-photo-policy"
+
+function canManageSidebarPhoto(user: SidebarUser | null): boolean {
+  return (
+    user !== null &&
+    canManageWorkspacePhoto({
+      actor: {
+        userId: user.id,
+        organizationId: user.organizationId,
+        organizationType: user.organizationType,
+        role: user.role,
+        isActive: user.isActive,
+        isDemo: user.isDemo,
+      },
+      photo: {
+        userId: user.id,
+        organizationId: user.organizationId ?? "",
+      },
+    })
+  )
+}
+
+function sidebarPhotoScopeForUser(user: SidebarUser | null): string | null {
+  return user !== null && canManageSidebarPhoto(user) && user.organizationId
+    ? `${user.organizationId}:${user.id}`
+    : null
+}
 
 function stopEvent(e: React.MouseEvent | React.PointerEvent): void {
   e.stopPropagation()
@@ -67,21 +98,31 @@ function defaultSidebarPhoto(user: SidebarUser): string | null {
 }
 
 function loadSidebarPhoto(user: SidebarUser): string | null {
-  if (user.sidebarDeskPhoto) return user.sidebarDeskPhoto
-  try {
-    return (
-      window.localStorage.getItem(sidebarDeskPhotoStorageKey(user.email)) ??
-      defaultSidebarPhoto(user)
-    )
-  } catch {
-    return defaultSidebarPhoto(user)
+  if (!canManageSidebarPhoto(user)) return null
+  let cachedPhoto: string | null = null
+  if (user.organizationId) {
+    try {
+      const scope = { organizationId: user.organizationId, userId: user.id }
+      cachedPhoto = window.localStorage.getItem(sidebarDeskPhotoStorageKey(scope))
+    } catch {
+      cachedPhoto = null
+    }
   }
+  return resolveWorkspacePhoto({
+    durablePhoto: user.sidebarDeskPhoto,
+    cachedPhoto,
+    allowCache: true,
+  })
 }
 
 function saveSidebarPhoto(user: SidebarUser, dataUrl: string): void {
+  if (!canManageSidebarPhoto(user) || !user.organizationId) return
   try {
     window.localStorage.setItem(
-      sidebarDeskPhotoStorageKey(user.email),
+      sidebarDeskPhotoStorageKey({
+        organizationId: user.organizationId,
+        userId: user.id,
+      }),
       dataUrl
     )
   } catch {
@@ -90,8 +131,10 @@ function saveSidebarPhoto(user: SidebarUser, dataUrl: string): void {
 }
 
 function resetSidebarPhoto(user: SidebarUser): void {
+  if (!canManageSidebarPhoto(user) || !user.organizationId) return
   try {
-    window.localStorage.removeItem(sidebarDeskPhotoStorageKey(user.email))
+    const scope = { organizationId: user.organizationId, userId: user.id }
+    window.localStorage.removeItem(sidebarDeskPhotoStorageKey(scope))
   } catch {
     // The reset still applies for this browser session.
   }
@@ -151,10 +194,13 @@ export function NavUser({
   const [sidebarPhotoUrl, setSidebarPhotoUrl] = React.useState<string | null>(
     null
   )
+  const [sidebarPhotoScope, setSidebarPhotoScope] = React.useState<string | null>(
+    null
+  )
   const [sidebarPhotoFailed, setSidebarPhotoFailed] = React.useState(false)
   const [isLoggingOut, startLogoutTransition] = React.useTransition()
   const photoInputRef = React.useRef<HTMLInputElement>(null)
-  const migratedLegacyPhotoFor = React.useRef<string | null>(null)
+
   const {
     isMuted,
     isDeafened,
@@ -171,23 +217,8 @@ export function NavUser({
   React.useEffect(() => {
     if (!user) return
     setSidebarPhotoFailed(false)
-    setSidebarPhotoUrl(loadSidebarPhoto(user))
-
-    if (user.sidebarDeskPhoto || migratedLegacyPhotoFor.current === user.email) {
-      return
-    }
-
-    try {
-      const legacyPhoto = window.localStorage.getItem(
-        sidebarDeskPhotoStorageKey(user.email)
-      )
-      if (!legacyPhoto) return
-
-      migratedLegacyPhotoFor.current = user.email
-      void updateWorkspacePhoto("sidebar", legacyPhoto)
-    } catch {
-      // Keep the browser-local photo when storage is unavailable.
-    }
+    setSidebarPhotoUrl(loadSidebarPhoto(user) ?? defaultSidebarPhoto(user))
+    setSidebarPhotoScope(sidebarPhotoScopeForUser(user))
   }, [user])
 
   if (!user) {
@@ -205,6 +236,7 @@ export function NavUser({
   async function handleSidebarPhotoUpload(
     event: React.ChangeEvent<HTMLInputElement>
   ): Promise<void> {
+    if (!canManageSidebarPhoto(user)) return
     const file = event.currentTarget.files?.[0]
     event.currentTarget.value = ""
     if (!file || !user) return
@@ -225,6 +257,7 @@ export function NavUser({
       saveSidebarPhoto(user, resizedDataUrl)
       setSidebarPhotoFailed(false)
       setSidebarPhotoUrl(resizedDataUrl)
+      setSidebarPhotoScope(sidebarPhotoScopeForUser(user))
       toast.success("Sidebar photo updated.")
     } catch {
       toast.error("Could not update the sidebar photo.")
@@ -234,7 +267,10 @@ export function NavUser({
   async function handleSidebarPhotoReset(): Promise<void> {
     if (!user) return
 
-    const result = await updateWorkspacePhoto("sidebar", null)
+    const result = await updateWorkspacePhoto(
+      "sidebar",
+      WORKSPACE_PHOTO_REMOVED
+    )
     if (!result.success) {
       toast.error(result.error)
       return
@@ -242,8 +278,15 @@ export function NavUser({
     resetSidebarPhoto(user)
     setSidebarPhotoFailed(false)
     setSidebarPhotoUrl(defaultSidebarPhoto(user))
+    setSidebarPhotoScope(null)
     toast.success("Sidebar photo reset.")
   }
+
+  const visibleSidebarPhoto =
+    canManageSidebarPhoto(user) &&
+    sidebarPhotoScopeForUser(user) === sidebarPhotoScope
+      ? sidebarPhotoUrl
+      : defaultSidebarPhoto(user)
 
   return (
     <SidebarMenu>
@@ -266,9 +309,9 @@ export function NavUser({
               )}
             >
               <span className="relative h-24 min-w-0 flex-1 overflow-hidden rounded-sm border border-sidebar-border bg-sidebar-accent group-data-[collapsible=icon]:size-7! group-data-[collapsible=icon]:flex-none">
-                {sidebarPhotoUrl && !sidebarPhotoFailed ? (
+                {visibleSidebarPhoto && !sidebarPhotoFailed ? (
                   <Image
-                    src={sidebarPhotoUrl}
+                    src={visibleSidebarPhoto}
                     alt={`${user.name}'s sidebar photo`}
                     fill
                     sizes="220px"
@@ -347,21 +390,25 @@ export function NavUser({
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
-              <DropdownMenuItem
-                onSelect={(event) => {
-                  event.preventDefault()
-                  photoInputRef.current?.click()
-                }}
-              >
-                <IconPhotoEdit />
-                Change sidebar photo
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => void handleSidebarPhotoReset()}
-              >
-                <IconRefresh />
-                Reset sidebar photo
-              </DropdownMenuItem>
+              {canManageSidebarPhoto(user) ? (
+                <>
+                  <DropdownMenuItem
+                    onSelect={(event) => {
+                      event.preventDefault()
+                      photoInputRef.current?.click()
+                    }}
+                  >
+                    <IconPhotoEdit />
+                    Change sidebar photo
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={() => void handleSidebarPhotoReset()}
+                  >
+                    <IconRefresh />
+                    Reset sidebar photo
+                  </DropdownMenuItem>
+                </>
+              ) : null}
               <DropdownMenuSeparator />
               <DropdownMenuItem onSelect={() => setAccountOpen(true)}>
                 <IconUserCircle />
@@ -393,14 +440,16 @@ export function NavUser({
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-        <input
-          ref={photoInputRef}
-          type="file"
-          accept="image/*"
-          className="sr-only"
-          aria-label="Choose sidebar photo"
-          onChange={handleSidebarPhotoUpload}
-        />
+        {canManageSidebarPhoto(user) ? (
+          <input
+            ref={photoInputRef}
+            type="file"
+            accept="image/*"
+            className="sr-only"
+            aria-label="Choose sidebar photo"
+            onChange={handleSidebarPhotoUpload}
+          />
+        ) : null}
       </SidebarMenuItem>
       <AccountModal
         open={accountOpen}

--- a/src/components/projects/project-audience-preview-shell.tsx
+++ b/src/components/projects/project-audience-preview-shell.tsx
@@ -156,6 +156,8 @@ export function ProjectAudiencePreviewShell({
   readonly projectNumber: string | null
   readonly projectOptions: readonly AudienceProjectOption[]
   readonly viewer: {
+    readonly id: string
+    readonly organizationId: string | null
     readonly name: string
     readonly email: string
     readonly avatarUrl: string | null
@@ -279,7 +281,12 @@ export function ProjectAudiencePreviewShell({
           ))}
         </nav>
 
-        <ProjectAudienceSidebarProfile viewer={viewer} />
+        <ProjectAudienceSidebarProfile
+          viewer={{
+            ...viewer,
+            canManagePhoto: viewerIsInternal,
+          }}
+        />
       </aside>
 
       <div

--- a/src/components/projects/project-audience-sidebar-profile.tsx
+++ b/src/components/projects/project-audience-sidebar-profile.tsx
@@ -20,15 +20,18 @@ import {
 } from "@/components/ui/popover"
 import { useCompassTheme, useTheme } from "@/components/theme-provider"
 import { THEME_PRESETS } from "@/lib/theme/presets"
-import { sidebarDeskPhotoStorageKey } from "@/lib/user-photo-storage"
+import { resolveWorkspacePhoto } from "@/lib/workspace-photo-policy"
 import { cn } from "@/lib/utils"
 import { ProjectAudienceNotificationSettings } from "@/components/projects/project-audience-notification-settings"
 
 type AudienceViewer = {
+  readonly id: string
+  readonly organizationId: string | null
   readonly name: string
   readonly email: string
   readonly avatarUrl: string | null
   readonly sidebarPhotoUrl: string | null
+  readonly canManagePhoto: boolean
 }
 
 function readFileAsDataUrl(file: File): Promise<string> {
@@ -81,38 +84,55 @@ export function ProjectAudienceSidebarProfile({
   const { theme, setTheme } = useTheme()
   const { activeThemeId, setVisualTheme } = useCompassTheme()
   const [photoUrl, setPhotoUrl] = React.useState<string | null>(
-    viewer.sidebarPhotoUrl ?? viewer.avatarUrl
+    viewer.canManagePhoto
+      ? resolveWorkspacePhoto({
+          durablePhoto: viewer.sidebarPhotoUrl,
+          cachedPhoto: null,
+          allowCache: false,
+        }) ?? viewer.avatarUrl
+      : viewer.avatarUrl
+  )
+  const [photoScope, setPhotoScope] = React.useState<string | null>(
+    viewer.canManagePhoto && viewer.organizationId
+      ? `${viewer.organizationId}:${viewer.id}`
+      : null
   )
   const inputRef = React.useRef<HTMLInputElement>(null)
-  const migratedLegacyPhotoFor = React.useRef<string | null>(null)
 
   React.useEffect(() => {
-    try {
-      const legacyPhoto = window.localStorage.getItem(
-        sidebarDeskPhotoStorageKey(viewer.email)
-      )
-      setPhotoUrl(
-        viewer.sidebarPhotoUrl ??
-          legacyPhoto ??
-          viewer.avatarUrl
-      )
+    setPhotoUrl(
+      viewer.canManagePhoto
+        ? resolveWorkspacePhoto({
+            durablePhoto: viewer.sidebarPhotoUrl,
+            cachedPhoto: null,
+            allowCache: false,
+          }) ?? viewer.avatarUrl
+        : viewer.avatarUrl
+    )
+    setPhotoScope(
+      viewer.canManagePhoto && viewer.organizationId
+        ? `${viewer.organizationId}:${viewer.id}`
+        : null
+    )
+  }, [
+    viewer.avatarUrl,
+    viewer.canManagePhoto,
+    viewer.id,
+    viewer.organizationId,
+    viewer.sidebarPhotoUrl,
+  ])
 
-      if (
-        !viewer.sidebarPhotoUrl &&
-        legacyPhoto &&
-        migratedLegacyPhotoFor.current !== viewer.email
-      ) {
-        migratedLegacyPhotoFor.current = viewer.email
-        void updateWorkspacePhoto("sidebar", legacyPhoto)
-      }
-    } catch {
-      setPhotoUrl(viewer.avatarUrl)
-    }
-  }, [viewer.avatarUrl, viewer.email, viewer.sidebarPhotoUrl])
+  const visiblePhoto =
+    viewer.canManagePhoto &&
+    viewer.organizationId !== null &&
+    photoScope === `${viewer.organizationId}:${viewer.id}`
+      ? photoUrl
+      : viewer.avatarUrl
 
   async function handlePhoto(
     event: React.ChangeEvent<HTMLInputElement>
   ): Promise<void> {
+    if (!viewer.canManagePhoto) return
     const file = event.currentTarget.files?.[0]
     event.currentTarget.value = ""
     if (!file) return
@@ -128,11 +148,10 @@ export function ProjectAudienceSidebarProfile({
         toast.error(result.error)
         return
       }
-      window.localStorage.setItem(
-        sidebarDeskPhotoStorageKey(viewer.email),
-        photo
-      )
       setPhotoUrl(photo)
+      setPhotoScope(
+        viewer.organizationId ? `${viewer.organizationId}:${viewer.id}` : null
+      )
       toast.success("Sidebar photo updated.")
     } catch {
       toast.error("Could not update the sidebar photo.")
@@ -141,22 +160,29 @@ export function ProjectAudienceSidebarProfile({
 
   return (
     <div className="space-y-2 border-t border-sidebar-border p-3">
-      <input
-        ref={inputRef}
-        type="file"
-        accept="image/*"
-        className="hidden"
-        onChange={handlePhoto}
-      />
+      {viewer.canManagePhoto ? (
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={handlePhoto}
+        />
+      ) : null}
       <button
         type="button"
-        onClick={() => inputRef.current?.click()}
-        className="group relative block h-24 w-full overflow-hidden rounded-md border border-sidebar-border bg-sidebar-accent text-left"
-        aria-label="Change sidebar photo"
+        onClick={() => {
+          if (viewer.canManagePhoto) inputRef.current?.click()
+        }}
+        className={cn(
+          "group relative block h-24 w-full overflow-hidden rounded-md border border-sidebar-border bg-sidebar-accent text-left",
+          !viewer.canManagePhoto && "cursor-default"
+        )}
+        aria-label={viewer.canManagePhoto ? "Change sidebar photo" : "Profile photo"}
       >
-        {photoUrl ? (
+        {visiblePhoto ? (
           <Image
-            src={photoUrl}
+            src={visiblePhoto}
             alt={`${viewer.name}'s sidebar photo`}
             fill
             sizes="240px"
@@ -168,10 +194,12 @@ export function ProjectAudienceSidebarProfile({
             Add your photo
           </span>
         )}
-        <span className="absolute inset-x-0 bottom-0 flex items-center justify-between bg-black/55 px-2 py-1 text-[11px] text-white opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
-          Change photo
-          <IconCamera className="size-3.5" />
-        </span>
+        {viewer.canManagePhoto ? (
+          <span className="absolute inset-x-0 bottom-0 flex items-center justify-between bg-black/55 px-2 py-1 text-[11px] text-white opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+            Change photo
+            <IconCamera className="size-3.5" />
+          </span>
+        ) : null}
       </button>
 
       <ProjectAudienceNotificationSettings />

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -16,7 +16,9 @@ export const users = sqliteTable("users", {
   displayName: text("display_name"),
   avatarUrl: text("avatar_url"),
   dashboardDeskPhotoUrl: text("dashboard_desk_photo_url"),
+  dashboardDeskPhotoOrganizationId: text("dashboard_desk_photo_organization_id"),
   sidebarDeskPhotoUrl: text("sidebar_desk_photo_url"),
+  sidebarDeskPhotoOrganizationId: text("sidebar_desk_photo_organization_id"),
   role: text("role").notNull().default("office"), // admin, office, field, client
   googleEmail: text("google_email"), // override for google workspace impersonation
   isActive: integer("is_active", { mode: "boolean" }).notNull().default(true),

--- a/src/lib/__tests__/user-photo-storage.test.ts
+++ b/src/lib/__tests__/user-photo-storage.test.ts
@@ -7,16 +7,19 @@ import {
 
 describe("user photo storage", () => {
   it("keeps dashboard and sidebar photos independent", () => {
-    const email = "person@example.com"
+    const scope = {
+      organizationId: "org-1",
+      userId: "user-1",
+    }
 
-    expect(dashboardDeskPhotoStorageKey(email)).toBe(
-      "compass-desk-photo:person@example.com"
+    expect(dashboardDeskPhotoStorageKey(scope)).toBe(
+      "compass-workspace-photo:org-1:user-1:dashboard"
     )
-    expect(sidebarDeskPhotoStorageKey(email)).toBe(
-      "compass-sidebar-desk-photo:person@example.com"
+    expect(sidebarDeskPhotoStorageKey(scope)).toBe(
+      "compass-workspace-photo:org-1:user-1:sidebar"
     )
-    expect(sidebarDeskPhotoStorageKey(email)).not.toBe(
-      dashboardDeskPhotoStorageKey(email)
+    expect(sidebarDeskPhotoStorageKey(scope)).not.toBe(
+      dashboardDeskPhotoStorageKey(scope)
     )
   })
 })

--- a/src/lib/__tests__/workspace-photo-policy.test.ts
+++ b/src/lib/__tests__/workspace-photo-policy.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  canManageWorkspacePhoto,
+  resolveWorkspacePhoto,
+  WORKSPACE_PHOTO_REMOVED,
+  type WorkspacePhotoActor,
+} from "@/lib/workspace-photo-policy"
+
+const internalActor: WorkspacePhotoActor = {
+  userId: "user-1",
+  organizationId: "org-1",
+  organizationType: "internal",
+  role: "office",
+  isActive: true,
+  isDemo: false,
+}
+
+const ownPhoto = {
+  userId: "user-1",
+  organizationId: "org-1",
+}
+
+describe("workspace photo policy", () => {
+  it("allows only the current internal user in the active organization", () => {
+    expect(canManageWorkspacePhoto({ actor: internalActor, photo: ownPhoto })).toBe(true)
+    expect(
+      canManageWorkspacePhoto({
+        actor: internalActor,
+        photo: { userId: "user-2", organizationId: "org-1" },
+      })
+    ).toBe(false)
+    expect(
+      canManageWorkspacePhoto({
+        actor: internalActor,
+        photo: { userId: "user-1", organizationId: "org-2" },
+      })
+    ).toBe(false)
+  })
+
+  it("rejects demo and external users even when their identifiers match", () => {
+    expect(
+      canManageWorkspacePhoto({
+        actor: { ...internalActor, isDemo: true },
+        photo: ownPhoto,
+      })
+    ).toBe(false)
+    expect(
+      canManageWorkspacePhoto({
+        actor: { ...internalActor, role: "client" },
+        photo: ownPhoto,
+      })
+    ).toBe(false)
+    expect(
+      canManageWorkspacePhoto({
+        actor: { ...internalActor, isActive: false },
+        photo: ownPhoto,
+      })
+    ).toBe(false)
+    expect(
+      canManageWorkspacePhoto({
+        actor: { ...internalActor, organizationType: "client" },
+        photo: ownPhoto,
+      })
+    ).toBe(false)
+  })
+
+  it("uses durable profile data before a browser cache", () => {
+    expect(
+      resolveWorkspacePhoto({
+        durablePhoto: "durable-photo",
+        cachedPhoto: "cached-photo",
+        allowCache: true,
+      })
+    ).toBe("durable-photo")
+    expect(
+      resolveWorkspacePhoto({
+        durablePhoto: null,
+        cachedPhoto: "cached-photo",
+        allowCache: true,
+      })
+    ).toBe("cached-photo")
+  })
+
+  it("does not restore cached or removed photos outside the authorized path", () => {
+    expect(
+      resolveWorkspacePhoto({
+        durablePhoto: null,
+        cachedPhoto: "stale-photo",
+        allowCache: false,
+      })
+    ).toBeNull()
+    expect(
+      resolveWorkspacePhoto({
+        durablePhoto: null,
+        cachedPhoto: null,
+        allowCache: false,
+      })
+    ).toBeNull()
+    expect(
+      resolveWorkspacePhoto({
+        durablePhoto: WORKSPACE_PHOTO_REMOVED,
+        cachedPhoto: "stale-photo",
+        allowCache: true,
+      })
+    ).toBeNull()
+  })
+})

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -11,14 +11,13 @@ import {
 import type { User } from "@/db/schema"
 import { and, desc, eq, sql } from "drizzle-orm"
 import { cookies } from "next/headers"
-import { DEMO_USER } from "@/lib/demo"
+import { DEMO_USER, isDemoUser } from "@/lib/demo"
 import {
   isDevAuthFallbackAllowed,
   isWorkOSConfigured,
 } from "@/lib/auth-config"
-import {
-  isExternalProjectRole,
-} from "@/lib/user-roles"
+import { isExternalProjectRole } from "@/lib/user-roles"
+import { canManageWorkspacePhoto } from "@/lib/workspace-photo-policy"
 import { ensureProjectAudienceConversation } from "@/lib/project-audience-conversations"
 import { recordActivityEvent } from "@/lib/activity-log"
 
@@ -30,7 +29,9 @@ export type AuthUser = {
   readonly displayName: string | null
   readonly avatarUrl: string | null
   readonly dashboardDeskPhotoUrl?: string | null
+  readonly dashboardDeskPhotoOrganizationId?: string | null
   readonly sidebarDeskPhotoUrl?: string | null
+  readonly sidebarDeskPhotoOrganizationId?: string | null
   readonly role: string
   readonly googleEmail: string | null
   readonly isActive: boolean
@@ -49,6 +50,11 @@ export type SidebarUser = Readonly<{
   id: string
   name: string
   email: string
+  organizationId: string | null
+  organizationType: string | null
+  role: string
+  isActive: boolean
+  isDemo: boolean
   avatar: string | null
   dashboardDeskPhoto: string | null
   sidebarDeskPhoto: string | null
@@ -60,13 +66,43 @@ export type SidebarUser = Readonly<{
  * Convert AuthUser to SidebarUser for UI components
  */
 export function toSidebarUser(user: AuthUser): SidebarUser {
+  const canExposeWorkspacePhoto = canManageWorkspacePhoto({
+    actor: {
+      userId: user.id,
+      organizationId: user.organizationId,
+      organizationType: user.organizationType,
+      role: user.role,
+      isActive: user.isActive,
+      isDemo: isDemoUser(user.id),
+    },
+    photo: {
+      userId: user.id,
+      organizationId: user.organizationId ?? "",
+    },
+  })
+  const dashboardPhotoIsScoped =
+    user.dashboardDeskPhotoOrganizationId === user.organizationId
+  const sidebarPhotoIsScoped =
+    user.sidebarDeskPhotoOrganizationId === user.organizationId
+
   return {
     id: user.id,
     name: user.displayName ?? user.email.split("@")[0] ?? "User",
     email: user.email,
+    organizationId: user.organizationId,
+    organizationType: user.organizationType,
+    role: user.role,
+    isActive: user.isActive,
+    isDemo: isDemoUser(user.id),
     avatar: user.avatarUrl,
-    dashboardDeskPhoto: user.dashboardDeskPhotoUrl ?? null,
-    sidebarDeskPhoto: user.sidebarDeskPhotoUrl ?? null,
+    dashboardDeskPhoto:
+      canExposeWorkspacePhoto && dashboardPhotoIsScoped
+        ? user.dashboardDeskPhotoUrl ?? null
+        : null,
+    sidebarDeskPhoto:
+      canExposeWorkspacePhoto && sidebarPhotoIsScoped
+        ? user.sidebarDeskPhotoUrl ?? null
+        : null,
     firstName: user.firstName,
     lastName: user.lastName,
   }
@@ -434,6 +470,7 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
         orgId: organizations.id,
         orgName: organizations.name,
         orgType: organizations.type,
+        orgIsActive: organizations.isActive,
         memberRole: organizationMembers.role,
       })
       .from(organizationMembers)
@@ -443,6 +480,10 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
       )
       .where(eq(organizationMembers.userId, dbUser.id))
 
+    const activeOrgMemberships = orgMemberships.filter(
+      (membership) => membership.orgIsActive
+    )
+
     let activeOrg: {
       readonly orgId: string
       readonly orgName: string
@@ -450,15 +491,15 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
       readonly memberRole: string
     } | null = null
 
-    if (orgMemberships.length > 0) {
+    if (activeOrgMemberships.length > 0) {
       // check for cookie preference
       try {
         const cookieStore = await cookies()
         const preferredOrg = cookieStore.get("compass-active-org")?.value
-        const match = orgMemberships.find((m) => m.orgId === preferredOrg)
-        activeOrg = match ?? orgMemberships[0]
+        const match = activeOrgMemberships.find((m) => m.orgId === preferredOrg)
+        activeOrg = match ?? activeOrgMemberships[0]
       } catch {
-        activeOrg = orgMemberships[0]
+        activeOrg = activeOrgMemberships[0]
       }
     }
 
@@ -468,7 +509,7 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
       .where(eq(projectMembers.userId, dbUser.id))
       .limit(1)
       .get()
-    const hasInternalStaffOrganization = orgMemberships.some(
+    const hasInternalStaffOrganization = activeOrgMemberships.some(
       (membership) =>
         membership.orgType === "internal" &&
         !isExternalProjectRole(membership.memberRole)
@@ -485,7 +526,7 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
       isExternalProjectRole(projectMembership.role)
     ) {
       activeOrg =
-        orgMemberships.find(
+        activeOrgMemberships.find(
           (membership) =>
             membership.orgType === "internal" &&
             isExternalProjectRole(membership.memberRole)
@@ -520,7 +561,11 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
       displayName: dbUser.displayName,
       avatarUrl: dbUser.avatarUrl,
       dashboardDeskPhotoUrl: dbUser.dashboardDeskPhotoUrl,
+      dashboardDeskPhotoOrganizationId:
+        dbUser.dashboardDeskPhotoOrganizationId ?? null,
       sidebarDeskPhotoUrl: dbUser.sidebarDeskPhotoUrl,
+      sidebarDeskPhotoOrganizationId:
+        dbUser.sidebarDeskPhotoOrganizationId ?? null,
       role: effectiveRole,
       googleEmail: dbUser.googleEmail ?? null,
       isActive: dbUser.isActive,

--- a/src/lib/user-photo-storage.ts
+++ b/src/lib/user-photo-storage.ts
@@ -1,7 +1,23 @@
-export function dashboardDeskPhotoStorageKey(email: string): string {
-  return `compass-desk-photo:${email}`
+export type WorkspacePhotoCacheScope = Readonly<{
+  organizationId: string
+  userId: string
+}>
+
+function workspacePhotoStorageKey(
+  slot: "dashboard" | "sidebar",
+  scope: WorkspacePhotoCacheScope
+): string {
+  return `compass-workspace-photo:${scope.organizationId}:${scope.userId}:${slot}`
 }
 
-export function sidebarDeskPhotoStorageKey(email: string): string {
-  return `compass-sidebar-desk-photo:${email}`
+export function dashboardDeskPhotoStorageKey(
+  scope: WorkspacePhotoCacheScope
+): string {
+  return workspacePhotoStorageKey("dashboard", scope)
+}
+
+export function sidebarDeskPhotoStorageKey(
+  scope: WorkspacePhotoCacheScope
+): string {
+  return workspacePhotoStorageKey("sidebar", scope)
 }

--- a/src/lib/workspace-photo-policy.ts
+++ b/src/lib/workspace-photo-policy.ts
@@ -1,0 +1,53 @@
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+export type WorkspacePhotoActor = Readonly<{
+  userId: string
+  organizationId: string | null
+  organizationType: string | null
+  role: string
+  isActive: boolean
+  isDemo: boolean
+}>
+
+export type WorkspacePhotoOwner = Readonly<{
+  userId: string
+  organizationId: string
+}>
+
+type WorkspacePhotoAccessInput = Readonly<{
+  actor: WorkspacePhotoActor
+  photo: WorkspacePhotoOwner
+}>
+
+type WorkspacePhotoResolutionInput = Readonly<{
+  durablePhoto: string | null
+  cachedPhoto: string | null
+  allowCache: boolean
+}>
+
+export const WORKSPACE_PHOTO_REMOVED = "__hidden__"
+
+export function canManageWorkspacePhoto(
+  input: WorkspacePhotoAccessInput
+): boolean {
+  return (
+    !input.actor.isDemo &&
+    input.actor.isActive &&
+    input.actor.organizationId !== null &&
+    input.actor.organizationType === "internal" &&
+    isInternalStaffRole(input.actor.role) &&
+    input.actor.userId === input.photo.userId &&
+    input.actor.organizationId === input.photo.organizationId
+  )
+}
+
+export function resolveWorkspacePhoto(
+  input: WorkspacePhotoResolutionInput
+): string | null {
+  if (input.durablePhoto === WORKSPACE_PHOTO_REMOVED) return null
+  if (input.durablePhoto) return input.durablePhoto
+  if (input.allowCache && input.cachedPhoto !== WORKSPACE_PHOTO_REMOVED) {
+    return input.cachedPhoto
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- Persist personal dashboard/sidebar desk photos through the durable user profile fields instead of email-keyed localStorage.
- Scope stored photos to the current user and organization, with active internal-staff authorization and closed DTO projection for external/demo users.
- Keep browser storage only as an org/user-scoped cache, add authoritative removal sentinel handling, and use a neutral placeholder when no photo is configured.
- Add schema migration `0109_user_workspace_photo_scopes.sql` for per-photo organization scope.

Fixes #107

## Verification
- `bun test src/lib/__tests__/user-photo-storage.test.ts src/lib/__tests__/workspace-photo-policy.test.ts` — 5 passed.
- `bun run lint` — passed with existing warnings only.
- `bun run build` — passed.
- Full `bun test` — 879 passed, 53 failed, 4 errors due existing Bun/native/environment failures; no issue-specific failures observed.
- Independent staged-diff review passed before commit.

## UI evidence
- Live local dashboard placeholder and reset control screenshots are attached in the Kanban task.
- Upload/second-device persistence could not be completed in the local environment because the local D1 database lacks the existing `organization_members` schema; the action failed closed rather than fabricating success.

## Review notes
- Draft only; do not merge or deploy from this PR.
- Apply the new D1 migration before exercising persistence against a migrated environment.
