### PR TITLE
fix: persist workspace desk photos

### DIFF
--- a/drizzle/0109_workspace_photo_scope.sql
+++ b/drizzle/0109_workspace_photo_scope.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users ADD COLUMN dashboard_desk_photo_organization_id TEXT;
+ALTER TABLE users ADD COLUMN sidebar_desk_photo_organization_id TEXT;

--- a/src/app/actions/profile.ts
+++ b/src/app/actions/profile.ts
@@ -191,7 +191,12 @@ export async function updateWorkspacePhoto(
       return { success: false, error: "Invalid desk-photo slot." }
     }
     const currentUser = await requireAuth()
-    if (isDemoUser(currentUser.id) || !isInternalStaffRole(currentUser.role)) {
+    if (
+      isDemoUser(currentUser.id) ||
+      !currentUser.isActive ||
+      currentUser.organizationType !== "internal" ||
+      !isInternalStaffRole(currentUser.role)
+    ) {
       return { success: false, error: "Desk photos are not available here." }
     }
     const organizationId = requireOrg(currentUser)
@@ -209,6 +214,7 @@ export async function updateWorkspacePhoto(
           organizations,
           eq(organizations.id, organizationMembers.organizationId)
         )
+        .innerJoin(users, eq(users.id, organizationMembers.userId))
         .where(
           and(
             eq(organizationMembers.userId, currentUser.id),

--- a/src/app/actions/profile.ts
+++ b/src/app/actions/profile.ts
@@ -3,10 +3,29 @@
 import { getWorkOS, signOut } from "@workos-inc/authkit-nextjs"
 import { getCloudflareContext } from "@/lib/db"
 import { getDb } from "@/db"
-import { users } from "@/db/schema"
-import { eq } from "drizzle-orm"
+import { organizationMembers, organizations, users } from "@/db/schema"
+import { googleAuth } from "@/db/schema-google"
+import { and, eq, exists } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { requireAuth } from "@/lib/auth"
+import { decrypt } from "@/lib/crypto"
+import { isDemoUser } from "@/lib/demo"
+import { DriveClient } from "@/lib/google/client/drive-client"
+import type { DriveFile } from "@/lib/google/client/types"
+import {
+  getGoogleConfig,
+  getGoogleCryptoSalt,
+  parseServiceAccountKey,
+} from "@/lib/google/config"
+import { requireOrg } from "@/lib/org-scope"
+import { isInternalStaffRole } from "@/lib/user-roles"
+import {
+  controlledDeskPhotoUrl,
+  HIDDEN_DESK_PHOTO,
+  isDeskPhotoSlot,
+  parseImageDataUrl,
+  type DeskPhotoSlot,
+} from "@/lib/user-photo-storage"
 import {
   updateProfileSchema,
   changePasswordSchema,
@@ -18,50 +37,269 @@ type ActionResult<T = undefined> =
   | { success: true; data?: T }
   | { success: false; error: string }
 
-const HIDDEN_WORKSPACE_PHOTO = "__hidden__"
-const MAX_WORKSPACE_PHOTO_LENGTH = 680_000
-const SAFE_IMAGE_DATA_URL =
-  /^data:image\/(?:jpeg|png|webp);base64,[a-z0-9+/]+={0,2}$/i
+const WORKSPACE_PHOTO_FOLDER_NAME = "Compass Workspace Photos"
+const MAX_WORKSPACE_PHOTO_BYTES = 500_000
+const GOOGLE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
+
+type WorkspacePhotoData = {
+  readonly url: string | null
+}
+
+async function requireWorkspacePhotoAccess(
+  userId: string,
+  organizationId: string,
+  role: string
+): Promise<void> {
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const membership = await db
+    .select({ id: organizationMembers.id })
+    .from(organizationMembers)
+    .innerJoin(users, eq(users.id, organizationMembers.userId))
+    .innerJoin(organizations, eq(organizations.id, organizationMembers.organizationId))
+    .where(
+      and(
+        eq(organizationMembers.userId, userId),
+        eq(organizationMembers.organizationId, organizationId),
+        eq(organizationMembers.role, role),
+        eq(users.isActive, true),
+        eq(organizations.isActive, true),
+        eq(organizations.type, "internal")
+      )
+    )
+    .limit(1)
+    .get()
+
+  if (!membership) throw new Error("Workspace membership is required")
+}
+
+async function workspaceDrive(input: {
+  readonly db: ReturnType<typeof getDb>
+  readonly environment: unknown
+  readonly organizationId: string
+}): Promise<{
+  readonly client: DriveClient
+  readonly googleEmail: string
+  readonly driveId: string | null
+}> {
+  const auth = await input.db
+    .select({
+      serviceAccountKeyEncrypted: googleAuth.serviceAccountKeyEncrypted,
+      sharedDriveId: googleAuth.sharedDriveId,
+      connectorGoogleEmail: users.googleEmail,
+      connectorEmail: users.email,
+    })
+    .from(googleAuth)
+    .innerJoin(users, eq(users.id, googleAuth.connectedBy))
+    .innerJoin(organizations, eq(organizations.id, googleAuth.organizationId))
+    .where(
+      and(
+        eq(googleAuth.organizationId, input.organizationId),
+        eq(organizations.isActive, true),
+        eq(organizations.type, "internal")
+      )
+    )
+    .limit(1)
+    .get()
+
+  if (!auth) throw new Error("Google Workspace storage is not connected")
+  const driveId = auth.sharedDriveId?.trim()
+  if (!driveId) throw new Error("A Shared Drive is required for workspace photos")
+
+  const config = getGoogleConfig(input.environment)
+  const keyJson = await decrypt(
+    auth.serviceAccountKeyEncrypted,
+    config.encryptionKey,
+    getGoogleCryptoSalt()
+  )
+
+  return {
+    client: new DriveClient({
+      serviceAccountKey: parseServiceAccountKey(keyJson),
+    }),
+    googleEmail: auth.connectorGoogleEmail ?? auth.connectorEmail,
+    driveId,
+  }
+}
+
+async function workspacePhotoFolder(input: {
+  readonly client: DriveClient
+  readonly googleEmail: string
+  readonly driveId: string | null
+}): Promise<string> {
+  const parentId = input.driveId ?? "root"
+  const existing = await input.client.listFiles(input.googleEmail, {
+    folderId: parentId,
+    driveId: input.driveId ?? undefined,
+    pageSize: 10,
+    query:
+      `mimeType = '${GOOGLE_FOLDER_MIME_TYPE}' and ` +
+      `name = '${WORKSPACE_PHOTO_FOLDER_NAME}'`,
+  })
+  const folder = existing.files[0]
+  if (folder) return folder.id
+
+  const created = await input.client.createFolder(input.googleEmail, {
+    name: WORKSPACE_PHOTO_FOLDER_NAME,
+    parentId,
+    driveId: input.driveId ?? undefined,
+  })
+  return created.id
+}
+
+function workspacePhotoValue(
+  value: string
+): { readonly url: string | null; readonly data: ReturnType<typeof parseImageDataUrl> } {
+  if (value === HIDDEN_DESK_PHOTO) return { url: HIDDEN_DESK_PHOTO, data: null }
+
+  const data = parseImageDataUrl(value)
+  if (!data || data.bytes.byteLength > MAX_WORKSPACE_PHOTO_BYTES) {
+    throw new Error("Use a JPEG, PNG, or WebP image under 500 KB.")
+  }
+  return { url: null, data }
+}
+
+function isOwnedWorkspacePhoto(
+  metadata: DriveFile,
+  input: {
+    readonly organizationId: string
+    readonly userId: string
+    readonly slot: DeskPhotoSlot
+    readonly driveId: string | null
+  }
+): boolean {
+  const properties = metadata.appProperties
+  return (
+    metadata.trashed !== true &&
+    (metadata.mimeType === "image/jpeg" ||
+      metadata.mimeType === "image/png" ||
+      metadata.mimeType === "image/webp") &&
+    (!input.driveId ? !metadata.driveId : metadata.driveId === input.driveId) &&
+    properties?.compassResource === "workspace-desk-photo" &&
+    properties.organizationId === input.organizationId &&
+    properties.userId === input.userId &&
+    properties.slot === input.slot
+  )
+}
 
 export async function updateWorkspacePhoto(
-  slot: "dashboard" | "sidebar",
-  value: string | null
-): Promise<ActionResult> {
+  slot: DeskPhotoSlot,
+  value: string
+): Promise<ActionResult<WorkspacePhotoData>> {
   try {
-    if (slot !== "dashboard" && slot !== "sidebar") {
-      return { success: false, error: "Select a valid workspace photo." }
+    if (!isDeskPhotoSlot(slot)) {
+      return { success: false, error: "Invalid desk-photo slot." }
     }
     const currentUser = await requireAuth()
-    const normalized = value?.trim() || null
-    if (
-      normalized !== null &&
-      normalized !== HIDDEN_WORKSPACE_PHOTO &&
-      (
-        normalized.length > MAX_WORKSPACE_PHOTO_LENGTH ||
-        !SAFE_IMAGE_DATA_URL.test(normalized)
-      )
-    ) {
-      return {
-        success: false,
-        error: "Use a JPEG, PNG, or WebP image under 500 KB.",
-      }
+    if (isDemoUser(currentUser.id) || !isInternalStaffRole(currentUser.role)) {
+      return { success: false, error: "Desk photos are not available here." }
     }
+    const organizationId = requireOrg(currentUser)
 
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
-    await db
+    await requireWorkspacePhotoAccess(currentUser.id, organizationId, currentUser.role)
+
+    const photo = workspacePhotoValue(value.trim() || HIDDEN_DESK_PHOTO)
+    const authorizedUser = exists(
+      db
+        .select({ id: organizationMembers.id })
+        .from(organizationMembers)
+        .innerJoin(
+          organizations,
+          eq(organizations.id, organizationMembers.organizationId)
+        )
+        .where(
+          and(
+            eq(organizationMembers.userId, currentUser.id),
+            eq(organizationMembers.organizationId, organizationId),
+            eq(organizationMembers.role, currentUser.role),
+            eq(users.isActive, true),
+            eq(organizations.isActive, true),
+            eq(organizations.type, "internal")
+          )
+        )
+    )
+    let nextValue = photo.url
+    let uploadedFileId: string | null = null
+    let drive: Awaited<ReturnType<typeof workspaceDrive>> | null = null
+
+    if (photo.data) {
+      drive = await workspaceDrive({
+        db,
+        environment: env,
+        organizationId,
+      })
+      const folderId = await workspacePhotoFolder(drive)
+      const uploaded = await drive.client.uploadFile(drive.googleEmail, {
+        name: `compass-${slot}-${crypto.randomUUID()}.${photo.data.mimeType.slice(6)}`,
+        parentId: folderId,
+        driveId: drive.driveId ?? undefined,
+        mimeType: photo.data.mimeType,
+        size: photo.data.bytes.byteLength,
+        data: new Blob([photo.data.bytes], { type: photo.data.mimeType }),
+        appProperties: {
+          compassResource: "workspace-desk-photo",
+          organizationId,
+          userId: currentUser.id,
+          slot,
+        },
+      })
+      uploadedFileId = uploaded.id
+      nextValue = controlledDeskPhotoUrl(slot, uploaded.id)
+    }
+
+    const photoOrganizationId = nextValue === null ? null : organizationId
+    const discardUploadedPhoto = async (): Promise<void> => {
+      if (!uploadedFileId || !drive) return
+      try {
+        const uploaded = await drive.client.getFile(
+          drive.googleEmail,
+          uploadedFileId
+        )
+        if (
+          isOwnedWorkspacePhoto(uploaded, {
+            organizationId,
+            userId: currentUser.id,
+            slot,
+            driveId: drive.driveId,
+          })
+        ) {
+          await drive.client.trashFile(drive.googleEmail, uploadedFileId)
+        }
+      } catch (cleanupError: unknown) {
+        console.warn("Unable to trash an uncommitted workspace photo", cleanupError)
+      }
+    }
+
+    const updateResult = await db
       .update(users)
       .set({
         ...(slot === "dashboard"
-          ? { dashboardDeskPhotoUrl: normalized }
-          : { sidebarDeskPhotoUrl: normalized }),
+          ? {
+              dashboardDeskPhotoUrl: nextValue,
+              dashboardDeskPhotoOrganizationId: photoOrganizationId,
+            }
+          : {
+              sidebarDeskPhotoUrl: nextValue,
+              sidebarDeskPhotoOrganizationId: photoOrganizationId,
+            }),
         updatedAt: new Date().toISOString(),
       })
-      .where(eq(users.id, currentUser.id))
+      .where(and(eq(users.id, currentUser.id), authorizedUser))
       .run()
+      .catch(async (error: unknown) => {
+        await discardUploadedPhoto()
+        throw error
+      })
+
+    if ((updateResult.meta.changes ?? 0) !== 1) {
+      await discardUploadedPhoto()
+      throw new Error("Workspace photo was not saved")
+    }
 
     revalidatePath("/dashboard", "layout")
-    return { success: true }
+    return { success: true, data: { url: nextValue === HIDDEN_DESK_PHOTO ? null : nextValue } }
   } catch (error) {
     return {
       success: false,

--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -201,7 +201,11 @@ async function verifyProjectAccess(
     db,
     organizationId: project.organizationId,
     viewerIsInternal,
-    viewer: toProjectAudienceViewer(user, viewerIsInternal),
+    viewer: toProjectAudienceViewer(
+      user,
+      viewerIsInternal,
+      project.organizationId
+    ),
   }
 }
 

--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -214,7 +214,7 @@ async function verifyProjectAccess(
       name: user.displayName ?? user.email.split("@")[0] ?? "Compass user",
       email: user.email,
       avatarUrl: user.avatarUrl,
-      sidebarPhotoUrl: user.sidebarDeskPhotoUrl ?? null,
+      sidebarPhotoUrl: null,
     },
   }
 }

--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -37,6 +37,10 @@ import {
 import { parsePublishedScheduleSnapshot } from "@/lib/schedule/publications"
 import { projectAudiencePhotoUrl } from "@/lib/photo-sources"
 import { canViewerConfirmScheduleTask } from "@/lib/schedule/confirmation"
+import {
+  toProjectAudienceViewer,
+  type ProjectAudienceViewer,
+} from "@/lib/project-audience-viewer"
 
 export type { ProjectAudience } from "@/lib/project-audience-access"
 
@@ -137,13 +141,7 @@ export type AudienceContact = {
 export type ProjectAudiencePreview = {
   readonly audience: ProjectAudience
   readonly viewerIsInternal: boolean
-  readonly viewer: {
-    readonly id: string
-    readonly name: string
-    readonly email: string
-    readonly avatarUrl: string | null
-    readonly sidebarPhotoUrl: string | null
-  }
+  readonly viewer: ProjectAudienceViewer
   readonly projectOptions: readonly AudienceProjectOption[]
   readonly project: {
     readonly id: string
@@ -170,13 +168,7 @@ async function verifyProjectAccess(
   readonly db: ReturnType<typeof getDb>
   readonly organizationId: string
   readonly viewerIsInternal: boolean
-  readonly viewer: {
-    readonly id: string
-    readonly name: string
-    readonly email: string
-    readonly avatarUrl: string | null
-    readonly sidebarPhotoUrl: string | null
-  }
+  readonly viewer: ProjectAudienceViewer
 }> {
   const user = await requireAuth()
   requirePermission(user, "project", "read")
@@ -209,13 +201,7 @@ async function verifyProjectAccess(
     db,
     organizationId: project.organizationId,
     viewerIsInternal,
-    viewer: {
-      id: user.id,
-      name: user.displayName ?? user.email.split("@")[0] ?? "Compass user",
-      email: user.email,
-      avatarUrl: user.avatarUrl,
-      sidebarPhotoUrl: null,
-    },
+    viewer: toProjectAudienceViewer(user, viewerIsInternal),
   }
 }
 

--- a/src/app/api/users/desk-photo/route.ts
+++ b/src/app/api/users/desk-photo/route.ts
@@ -108,8 +108,10 @@ export async function GET(request: NextRequest): Promise<Response> {
   const user = await getCurrentUser()
   if (
     !user ||
+    !user.isActive ||
     isDemoUser(user.id) ||
     !isInternalStaffRole(user.role) ||
+    user.organizationType !== "internal" ||
     !user.organizationId
   ) {
     return notFound()

--- a/src/app/api/users/desk-photo/route.ts
+++ b/src/app/api/users/desk-photo/route.ts
@@ -1,0 +1,198 @@
+import { and, eq } from "drizzle-orm"
+import { NextRequest } from "next/server"
+
+import { getDb } from "@/db"
+import { organizationMembers, organizations, users } from "@/db/schema"
+import { googleAuth } from "@/db/schema-google"
+import { getCurrentUser } from "@/lib/auth"
+import { decrypt } from "@/lib/crypto"
+import { isDemoUser } from "@/lib/demo"
+import { getCloudflareContext } from "@/lib/db"
+import { DriveClient } from "@/lib/google/client/drive-client"
+import type { DriveFile } from "@/lib/google/client/types"
+import {
+  getGoogleConfig,
+  getGoogleCryptoSalt,
+  parseServiceAccountKey,
+} from "@/lib/google/config"
+import { requireOrg } from "@/lib/org-scope"
+import { isInternalStaffRole } from "@/lib/user-roles"
+import {
+  controlledDeskPhotoUrl,
+  parseControlledDeskPhoto,
+  type DeskPhotoSlot,
+} from "@/lib/user-photo-storage"
+
+function requestedSlot(value: string | null): DeskPhotoSlot | null {
+  return value === "dashboard" || value === "sidebar" ? value : null
+}
+
+function notFound(): Response {
+  return new Response("Not found", {
+    status: 404,
+    headers: { "Cache-Control": "no-store" },
+  })
+}
+
+async function loadWorkspaceDrive(organizationId: string): Promise<{
+  readonly client: DriveClient
+  readonly googleEmail: string
+  readonly driveId: string | null
+}> {
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const auth = await db
+    .select({
+      serviceAccountKeyEncrypted: googleAuth.serviceAccountKeyEncrypted,
+      sharedDriveId: googleAuth.sharedDriveId,
+      connectorGoogleEmail: users.googleEmail,
+      connectorEmail: users.email,
+    })
+    .from(googleAuth)
+    .innerJoin(users, eq(users.id, googleAuth.connectedBy))
+    .innerJoin(organizations, eq(organizations.id, googleAuth.organizationId))
+    .where(
+      and(
+        eq(googleAuth.organizationId, organizationId),
+        eq(organizations.isActive, true),
+        eq(organizations.type, "internal")
+      )
+    )
+    .limit(1)
+    .get()
+
+  if (!auth) throw new Error("Google Workspace storage is not connected")
+  const driveId = auth.sharedDriveId?.trim()
+  if (!driveId) throw new Error("A Shared Drive is required for workspace photos")
+
+  const config = getGoogleConfig(env)
+  const keyJson = await decrypt(
+    auth.serviceAccountKeyEncrypted,
+    config.encryptionKey,
+    getGoogleCryptoSalt()
+  )
+
+  return {
+    client: new DriveClient({
+      serviceAccountKey: parseServiceAccountKey(keyJson),
+    }),
+    googleEmail: auth.connectorGoogleEmail ?? auth.connectorEmail,
+    driveId,
+  }
+}
+
+function isOwnedWorkspacePhoto(
+  metadata: DriveFile,
+  input: {
+    readonly organizationId: string
+    readonly userId: string
+    readonly slot: DeskPhotoSlot
+    readonly driveId: string | null
+  }
+): boolean {
+  const properties = metadata.appProperties
+  return (
+    metadata.trashed !== true &&
+    (metadata.mimeType === "image/jpeg" ||
+      metadata.mimeType === "image/png" ||
+      metadata.mimeType === "image/webp") &&
+    (!input.driveId ? !metadata.driveId : metadata.driveId === input.driveId) &&
+    properties?.compassResource === "workspace-desk-photo" &&
+    properties.organizationId === input.organizationId &&
+    properties.userId === input.userId &&
+    properties.slot === input.slot
+  )
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const user = await getCurrentUser()
+  if (
+    !user ||
+    isDemoUser(user.id) ||
+    !isInternalStaffRole(user.role) ||
+    !user.organizationId
+  ) {
+    return notFound()
+  }
+
+  const slot = requestedSlot(request.nextUrl.searchParams.get("slot"))
+  const fileId = request.nextUrl.searchParams.get("file")
+  if (!slot || !fileId || parseControlledDeskPhoto(
+    controlledDeskPhotoUrl(slot, fileId),
+    slot
+  ) === null) {
+    return notFound()
+  }
+
+  try {
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const photo = await db
+      .select({
+        value:
+          slot === "dashboard"
+            ? users.dashboardDeskPhotoUrl
+            : users.sidebarDeskPhotoUrl,
+        organizationId:
+          slot === "dashboard"
+            ? users.dashboardDeskPhotoOrganizationId
+            : users.sidebarDeskPhotoOrganizationId,
+      })
+      .from(users)
+      .innerJoin(
+        organizationMembers,
+        and(
+          eq(organizationMembers.userId, users.id),
+          eq(organizationMembers.organizationId, organizationId),
+          eq(organizationMembers.role, user.role)
+        )
+      )
+      .innerJoin(
+        organizations,
+        eq(organizations.id, organizationMembers.organizationId)
+      )
+      .where(
+        and(
+          eq(users.id, user.id),
+          eq(users.isActive, true),
+          eq(organizations.isActive, true),
+          eq(organizations.type, "internal")
+        )
+      )
+      .limit(1)
+      .get()
+
+    const expectedUrl = controlledDeskPhotoUrl(slot, fileId)
+    if (photo?.value !== expectedUrl || photo.organizationId !== organizationId) {
+      return notFound()
+    }
+
+    const drive = await loadWorkspaceDrive(organizationId)
+    const metadata = await drive.client.getFile(drive.googleEmail, fileId)
+    if (
+      !isOwnedWorkspacePhoto(metadata, {
+        organizationId,
+        userId: user.id,
+        slot,
+        driveId: drive.driveId,
+      })
+    ) {
+      return notFound()
+    }
+
+    const response = await drive.client.downloadFile(drive.googleEmail, fileId)
+    if (!response.ok) return notFound()
+
+    return new Response(response.body, {
+      headers: {
+        "Cache-Control": "private, no-store",
+        "Content-Type": metadata.mimeType,
+        ...(metadata.size ? { "Content-Length": metadata.size } : {}),
+      },
+    })
+  } catch (error: unknown) {
+    console.error("Unable to load workspace photo", error)
+    return notFound()
+  }
+}

--- a/src/components/dashboard/dashboard-launchpad.tsx
+++ b/src/components/dashboard/dashboard-launchpad.tsx
@@ -79,8 +79,10 @@ import {
   type TeamAvailabilityMember,
 } from "@/lib/dashboard/office-status"
 import {
+  authorizedWorkspacePhotoUrl,
   dashboardDeskPhotoStorageKey,
   HIDDEN_DESK_PHOTO,
+  workspacePhotoStateKey,
 } from "@/lib/user-photo-storage"
 import { isProjectTodoRecordType } from "@/lib/project-todos"
 import {
@@ -129,7 +131,7 @@ function deskPhotoForUser(user: SidebarUser | null): string | null {
 
   try {
     const storedPhoto = window.localStorage.getItem(
-      dashboardDeskPhotoStorageKey(user.email, user.organizationId)
+      dashboardDeskPhotoStorageKey(user.id, user.organizationId)
     )
     if (storedPhoto === HIDDEN_DESK_PHOTO) return null
     if (storedPhoto) return storedPhoto
@@ -187,7 +189,7 @@ function saveDeskPhoto(user: SidebarUser, dataUrl: string): void {
   if (!user.organizationId) return
   try {
     window.localStorage.setItem(
-      dashboardDeskPhotoStorageKey(user.email, user.organizationId),
+      dashboardDeskPhotoStorageKey(user.id, user.organizationId),
       dataUrl
     )
   } catch {
@@ -204,11 +206,11 @@ function clearDeskPhotoCache(
   try {
     if (value === null) {
       window.localStorage.removeItem(
-        dashboardDeskPhotoStorageKey(user.email, user.organizationId)
+        dashboardDeskPhotoStorageKey(user.id, user.organizationId)
       )
     } else {
       window.localStorage.setItem(
-        dashboardDeskPhotoStorageKey(user.email, user.organizationId),
+        dashboardDeskPhotoStorageKey(user.id, user.organizationId),
         value
       )
     }
@@ -486,7 +488,13 @@ function DeskHero({
   const migratedLegacyPhotoFor = useRef<string | null>(null)
   const firstName = user?.firstName ?? user?.name.split(" ")[0] ?? "there"
   const currentDeskPhotoScope = user
-    ? `${user.id}:${user.organizationId ?? "none"}:${user.dashboardDeskPhoto ?? "none"}`
+    ? workspacePhotoStateKey({
+        userId: user.id,
+        organizationId: user.organizationId,
+        slot: "dashboard",
+        canUseWorkspacePhotos: user.canUseWorkspacePhotos,
+        serverPhotoUrl: user.dashboardDeskPhoto,
+      })
     : "no-user"
 
   useEffect(() => {
@@ -498,7 +506,7 @@ function DeskHero({
     if (!user) return
     if (!user.canUseWorkspacePhotos) return
     if (!user.organizationId) return
-    const migrationKey = `${user.email}:${user.organizationId ?? "none"}`
+    const migrationKey = `${user.id}:${user.organizationId}:dashboard`
     if (
       serverPhoto !== null ||
       migratedLegacyPhotoFor.current === migrationKey
@@ -508,7 +516,7 @@ function DeskHero({
 
     try {
       const legacyPhoto = window.localStorage.getItem(
-        dashboardDeskPhotoStorageKey(user.email, user.organizationId)
+        dashboardDeskPhotoStorageKey(user.id, user.organizationId)
       )
       if (!legacyPhoto) return
 
@@ -523,8 +531,12 @@ function DeskHero({
     }
   }, [currentDeskPhotoScope, user])
 
-  const renderedDeskPhotoUrl =
-    deskPhotoScope === currentDeskPhotoScope ? deskPhotoUrl : null
+  const renderedDeskPhotoUrl = authorizedWorkspacePhotoUrl({
+    canUseWorkspacePhotos: user?.canUseWorkspacePhotos === true,
+    currentScope: currentDeskPhotoScope,
+    loadedScope: deskPhotoScope,
+    photoUrl: deskPhotoUrl,
+  })
 
   function handleStatusChange(nextStatus: DeskStatus): void {
     const previousStatus = status

--- a/src/components/dashboard/dashboard-launchpad.tsx
+++ b/src/components/dashboard/dashboard-launchpad.tsx
@@ -78,7 +78,10 @@ import {
   type DeskStatus,
   type TeamAvailabilityMember,
 } from "@/lib/dashboard/office-status"
-import { dashboardDeskPhotoStorageKey } from "@/lib/user-photo-storage"
+import {
+  dashboardDeskPhotoStorageKey,
+  HIDDEN_DESK_PHOTO,
+} from "@/lib/user-photo-storage"
 import { isProjectTodoRecordType } from "@/lib/project-todos"
 import {
   compareOfficeCalendarPriority,
@@ -115,27 +118,25 @@ export type DashboardOfficeEvent = {
   readonly startTime: string
 }
 
-const MARTINE_DEFAULT_DESK_PHOTO = "/user-desk-photos/martine-desk-photo.jpeg"
-const HIDDEN_DESK_PHOTO = "__hidden__"
 const TEAM_AVAILABILITY_REFRESH_MS = 10_000
 
 function deskPhotoForUser(user: SidebarUser | null): string | null {
   if (!user) return null
+  if (!user.organizationId) return null
   if (user.dashboardDeskPhoto === HIDDEN_DESK_PHOTO) return null
   if (user.dashboardDeskPhoto) return user.dashboardDeskPhoto
 
   try {
     const storedPhoto = window.localStorage.getItem(
-      dashboardDeskPhotoStorageKey(user.email)
+      dashboardDeskPhotoStorageKey(user.email, user.organizationId)
     )
     if (storedPhoto === HIDDEN_DESK_PHOTO) return null
     if (storedPhoto) return storedPhoto
   } catch {
-    // The default photo still works when browser storage is unavailable.
+    // The neutral placeholder still works when browser storage is unavailable.
   }
 
-  const identity = `${user.name} ${user.email}`.toLowerCase()
-  return identity.includes("martine") ? MARTINE_DEFAULT_DESK_PHOTO : null
+  return null
 }
 
 function readFileAsDataUrl(file: File): Promise<string> {
@@ -181,13 +182,35 @@ function resizeDeskPhoto(dataUrl: string): Promise<string> {
 }
 
 function saveDeskPhoto(user: SidebarUser, dataUrl: string): void {
+  if (!user.organizationId) return
   try {
     window.localStorage.setItem(
-      dashboardDeskPhotoStorageKey(user.email),
+      dashboardDeskPhotoStorageKey(user.email, user.organizationId),
       dataUrl
     )
   } catch {
     // The updated image still remains available for the current session.
+  }
+}
+
+function clearDeskPhotoCache(
+  user: SidebarUser,
+  value: typeof HIDDEN_DESK_PHOTO | null
+): void {
+  if (!user.organizationId) return
+  try {
+    if (value === null) {
+      window.localStorage.removeItem(
+        dashboardDeskPhotoStorageKey(user.email, user.organizationId)
+      )
+    } else {
+      window.localStorage.setItem(
+        dashboardDeskPhotoStorageKey(user.email, user.organizationId),
+        value
+      )
+    }
+  } catch {
+    // The server remains the source of truth when browser storage is unavailable.
   }
 }
 
@@ -453,36 +476,51 @@ function DeskHero({
 }): React.ReactElement {
   const [deskPhotoFailed, setDeskPhotoFailed] = useState(false)
   const [deskPhotoUrl, setDeskPhotoUrl] = useState<string | null>(null)
+  const [deskPhotoScope, setDeskPhotoScope] = useState<string | null>(null)
   const [deskPhotoMessage, setDeskPhotoMessage] = useState<string | null>(null)
   const [statusMessage, setStatusMessage] = useState<string | null>(null)
   const [isStatusPending, startStatusTransition] = useTransition()
   const migratedLegacyPhotoFor = useRef<string | null>(null)
   const firstName = user?.firstName ?? user?.name.split(" ")[0] ?? "there"
+  const currentDeskPhotoScope = user
+    ? `${user.id}:${user.organizationId ?? "none"}:${user.dashboardDeskPhoto ?? "none"}`
+    : "no-user"
 
   useEffect(() => {
+    setDeskPhotoScope(currentDeskPhotoScope)
     setDeskPhotoFailed(false)
     setDeskPhotoUrl(deskPhotoForUser(user))
 
+    const serverPhoto = user?.dashboardDeskPhoto ?? null
+    if (!user) return
+    if (!user.organizationId) return
+    const migrationKey = `${user.email}:${user.organizationId ?? "none"}`
     if (
-      !user ||
-      user.dashboardDeskPhoto ||
-      migratedLegacyPhotoFor.current === user.email
+      serverPhoto !== null ||
+      migratedLegacyPhotoFor.current === migrationKey
     ) {
       return
     }
 
     try {
       const legacyPhoto = window.localStorage.getItem(
-        dashboardDeskPhotoStorageKey(user.email)
+        dashboardDeskPhotoStorageKey(user.email, user.organizationId)
       )
       if (!legacyPhoto) return
 
-      migratedLegacyPhotoFor.current = user.email
-      void updateWorkspacePhoto("dashboard", legacyPhoto)
+      migratedLegacyPhotoFor.current = migrationKey
+      void updateWorkspacePhoto("dashboard", legacyPhoto).then((result) => {
+        if (result.success && result.data?.url) {
+          setDeskPhotoUrl(result.data.url)
+        }
+      })
     } catch {
       // Keep the browser-local photo when storage is unavailable.
     }
-  }, [user])
+  }, [currentDeskPhotoScope, user])
+
+  const renderedDeskPhotoUrl =
+    deskPhotoScope === currentDeskPhotoScope ? deskPhotoUrl : null
 
   function handleStatusChange(nextStatus: DeskStatus): void {
     const previousStatus = status
@@ -523,19 +561,45 @@ function DeskHero({
       }
       saveDeskPhoto(user, resizedDataUrl)
       setDeskPhotoFailed(false)
-      setDeskPhotoUrl(resizedDataUrl)
+      setDeskPhotoUrl(result.data?.url ?? resizedDataUrl)
       setDeskPhotoMessage("Desk photo updated.")
     } catch {
       setDeskPhotoMessage("Could not update the desk photo.")
     }
   }
 
+  async function handleDeskPhotoReset(): Promise<void> {
+    if (!user) return
+    const result = await updateWorkspacePhoto("dashboard", HIDDEN_DESK_PHOTO)
+    if (!result.success) {
+      setDeskPhotoMessage(result.error)
+      return
+    }
+    clearDeskPhotoCache(user, HIDDEN_DESK_PHOTO)
+    setDeskPhotoFailed(false)
+    setDeskPhotoUrl(null)
+    setDeskPhotoMessage("Desk photo reset.")
+  }
+
+  async function handleDeskPhotoRemove(): Promise<void> {
+    if (!user) return
+    const result = await updateWorkspacePhoto("dashboard", HIDDEN_DESK_PHOTO)
+    if (!result.success) {
+      setDeskPhotoMessage(result.error)
+      return
+    }
+    clearDeskPhotoCache(user, HIDDEN_DESK_PHOTO)
+    setDeskPhotoFailed(false)
+    setDeskPhotoUrl(null)
+    setDeskPhotoMessage("Desk photo removed.")
+  }
+
   return (
     <section className="grid min-h-52 overflow-hidden border-y border-border/70 bg-background sm:grid-cols-[minmax(10rem,0.8fr)_minmax(0,1.2fr)]">
       <div className="relative min-h-40 overflow-hidden bg-muted">
-        {deskPhotoUrl && !deskPhotoFailed ? (
+        {renderedDeskPhotoUrl && !deskPhotoFailed ? (
           <Image
-            src={deskPhotoUrl}
+            src={renderedDeskPhotoUrl}
             alt={`${firstName}'s desk`}
             fill
             sizes="(min-width: 1024px) 260px, 50vw"
@@ -549,16 +613,32 @@ function DeskHero({
           </div>
         )}
         {user ? (
-          <label className="absolute bottom-3 left-3 flex cursor-pointer items-center gap-1.5 border border-white/40 bg-black/55 px-2.5 py-1.5 text-xs font-medium text-white backdrop-blur-sm transition hover:bg-black/70">
-            <IconPhotoEdit className="size-3.5" />
-            Change desk photo
-            <input
-              type="file"
-              accept="image/*"
-              className="sr-only"
-              onChange={handleDeskPhotoUpload}
-            />
-          </label>
+          <div className="absolute bottom-3 left-3 flex flex-wrap gap-1.5">
+            <label className="flex cursor-pointer items-center gap-1.5 border border-white/40 bg-black/55 px-2.5 py-1.5 text-xs font-medium text-white backdrop-blur-sm transition hover:bg-black/70">
+              <IconPhotoEdit className="size-3.5" />
+              Change desk photo
+              <input
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                className="sr-only"
+                onChange={handleDeskPhotoUpload}
+              />
+            </label>
+            <button
+              type="button"
+              onClick={() => void handleDeskPhotoReset()}
+              className="border border-white/40 bg-black/55 px-2.5 py-1.5 text-xs font-medium text-white backdrop-blur-sm transition hover:bg-black/70"
+            >
+              Reset
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleDeskPhotoRemove()}
+              className="border border-white/40 bg-black/55 px-2.5 py-1.5 text-xs font-medium text-white backdrop-blur-sm transition hover:bg-black/70"
+            >
+              Remove
+            </button>
+          </div>
         ) : null}
       </div>
 

--- a/src/components/dashboard/dashboard-launchpad.tsx
+++ b/src/components/dashboard/dashboard-launchpad.tsx
@@ -122,6 +122,7 @@ const TEAM_AVAILABILITY_REFRESH_MS = 10_000
 
 function deskPhotoForUser(user: SidebarUser | null): string | null {
   if (!user) return null
+  if (!user.canUseWorkspacePhotos) return null
   if (!user.organizationId) return null
   if (user.dashboardDeskPhoto === HIDDEN_DESK_PHOTO) return null
   if (user.dashboardDeskPhoto) return user.dashboardDeskPhoto
@@ -182,6 +183,7 @@ function resizeDeskPhoto(dataUrl: string): Promise<string> {
 }
 
 function saveDeskPhoto(user: SidebarUser, dataUrl: string): void {
+  if (!user.canUseWorkspacePhotos) return
   if (!user.organizationId) return
   try {
     window.localStorage.setItem(
@@ -197,6 +199,7 @@ function clearDeskPhotoCache(
   user: SidebarUser,
   value: typeof HIDDEN_DESK_PHOTO | null
 ): void {
+  if (!user.canUseWorkspacePhotos) return
   if (!user.organizationId) return
   try {
     if (value === null) {
@@ -493,6 +496,7 @@ function DeskHero({
 
     const serverPhoto = user?.dashboardDeskPhoto ?? null
     if (!user) return
+    if (!user.canUseWorkspacePhotos) return
     if (!user.organizationId) return
     const migrationKey = `${user.email}:${user.organizationId ?? "none"}`
     if (
@@ -612,7 +616,7 @@ function DeskHero({
             <IconHome2 className="size-10 text-[#2f5963]/60" />
           </div>
         )}
-        {user ? (
+        {user?.canUseWorkspacePhotos ? (
           <div className="absolute bottom-3 left-3 flex flex-wrap gap-1.5">
             <label className="flex cursor-pointer items-center gap-1.5 border border-white/40 bg-black/55 px-2.5 py-1.5 text-xs font-medium text-white backdrop-blur-sm transition hover:bg-black/70">
               <IconPhotoEdit className="size-3.5" />

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -49,8 +49,10 @@ import { AccountModal } from "@/components/account-modal"
 import { DevicePicker } from "@/components/voice/device-picker"
 import { useVoiceState } from "@/hooks/use-voice-state"
 import {
+  authorizedWorkspacePhotoUrl,
   HIDDEN_DESK_PHOTO,
   sidebarDeskPhotoStorageKey,
+  workspacePhotoStateKey,
 } from "@/lib/user-photo-storage"
 import { cn } from "@/lib/utils"
 import { getInitials } from "@/lib/utils"
@@ -76,7 +78,7 @@ function loadSidebarPhoto(user: SidebarUser): string | null {
   if (user.sidebarDeskPhoto) return user.sidebarDeskPhoto
   try {
     const storedPhoto = window.localStorage.getItem(
-      sidebarDeskPhotoStorageKey(user.email, user.organizationId)
+      sidebarDeskPhotoStorageKey(user.id, user.organizationId)
     )
     return storedPhoto === HIDDEN_DESK_PHOTO
       ? null
@@ -91,7 +93,7 @@ function saveSidebarPhoto(user: SidebarUser, dataUrl: string): void {
   if (!user.organizationId) return
   try {
     window.localStorage.setItem(
-      sidebarDeskPhotoStorageKey(user.email, user.organizationId),
+      sidebarDeskPhotoStorageKey(user.id, user.organizationId),
       dataUrl
     )
   } catch {
@@ -104,7 +106,7 @@ function resetSidebarPhoto(user: SidebarUser): void {
   if (!user.organizationId) return
   try {
     window.localStorage.setItem(
-      sidebarDeskPhotoStorageKey(user.email, user.organizationId),
+      sidebarDeskPhotoStorageKey(user.id, user.organizationId),
       HIDDEN_DESK_PHOTO
     )
   } catch {
@@ -174,7 +176,13 @@ export function NavUser({
   const photoInputRef = React.useRef<HTMLInputElement>(null)
   const migratedLegacyPhotoFor = React.useRef<string | null>(null)
   const currentSidebarPhotoScope = user
-    ? `${user.id}:${user.organizationId ?? "none"}:${user.sidebarDeskPhoto ?? "none"}`
+    ? workspacePhotoStateKey({
+        userId: user.id,
+        organizationId: user.organizationId,
+        slot: "sidebar",
+        canUseWorkspacePhotos: user.canUseWorkspacePhotos,
+        serverPhotoUrl: user.sidebarDeskPhoto,
+      })
     : "no-user"
   const {
     isMuted,
@@ -198,7 +206,7 @@ export function NavUser({
 
     const serverPhoto = user.sidebarDeskPhoto
     if (!user.canUseWorkspacePhotos) return
-    const migrationKey = `${user.email}:${user.organizationId ?? "none"}`
+    const migrationKey = `${user.id}:${user.organizationId}:sidebar`
     if (
       serverPhoto !== null ||
       migratedLegacyPhotoFor.current === migrationKey
@@ -208,7 +216,7 @@ export function NavUser({
 
     try {
       const legacyPhoto = window.localStorage.getItem(
-        sidebarDeskPhotoStorageKey(user.email, user.organizationId)
+        sidebarDeskPhotoStorageKey(user.id, user.organizationId)
       )
       if (!legacyPhoto) return
 
@@ -223,8 +231,12 @@ export function NavUser({
     }
   }, [currentSidebarPhotoScope, user])
 
-  const renderedSidebarPhotoUrl =
-    sidebarPhotoScope === currentSidebarPhotoScope ? sidebarPhotoUrl : null
+  const renderedSidebarPhotoUrl = authorizedWorkspacePhotoUrl({
+    canUseWorkspacePhotos: user?.canUseWorkspacePhotos === true,
+    currentScope: currentSidebarPhotoScope,
+    loadedScope: sidebarPhotoScope,
+    photoUrl: sidebarPhotoUrl,
+  })
 
   if (!user) {
     return null

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -70,6 +70,7 @@ function defaultSidebarPhoto(user: SidebarUser): string | null {
 }
 
 function loadSidebarPhoto(user: SidebarUser): string | null {
+  if (!user.canUseWorkspacePhotos) return null
   if (!user.organizationId) return null
   if (user.sidebarDeskPhoto === HIDDEN_DESK_PHOTO) return null
   if (user.sidebarDeskPhoto) return user.sidebarDeskPhoto
@@ -86,6 +87,7 @@ function loadSidebarPhoto(user: SidebarUser): string | null {
 }
 
 function saveSidebarPhoto(user: SidebarUser, dataUrl: string): void {
+  if (!user.canUseWorkspacePhotos) return
   if (!user.organizationId) return
   try {
     window.localStorage.setItem(
@@ -98,6 +100,7 @@ function saveSidebarPhoto(user: SidebarUser, dataUrl: string): void {
 }
 
 function resetSidebarPhoto(user: SidebarUser): void {
+  if (!user.canUseWorkspacePhotos) return
   if (!user.organizationId) return
   try {
     window.localStorage.setItem(
@@ -194,6 +197,7 @@ export function NavUser({
     setSidebarPhotoUrl(loadSidebarPhoto(user))
 
     const serverPhoto = user.sidebarDeskPhoto
+    if (!user.canUseWorkspacePhotos) return
     const migrationKey = `${user.email}:${user.organizationId ?? "none"}`
     if (
       serverPhoto !== null ||
@@ -379,21 +383,25 @@ export function NavUser({
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
-              <DropdownMenuItem
-                onSelect={(event) => {
-                  event.preventDefault()
-                  photoInputRef.current?.click()
-                }}
-              >
-                <IconPhotoEdit />
-                Change sidebar photo
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => void handleSidebarPhotoReset()}
-              >
-                <IconRefresh />
-                Reset sidebar photo
-              </DropdownMenuItem>
+              {user.canUseWorkspacePhotos ? (
+                <>
+                  <DropdownMenuItem
+                    onSelect={(event) => {
+                      event.preventDefault()
+                      photoInputRef.current?.click()
+                    }}
+                  >
+                    <IconPhotoEdit />
+                    Change sidebar photo
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={() => void handleSidebarPhotoReset()}
+                  >
+                    <IconRefresh />
+                    Reset sidebar photo
+                  </DropdownMenuItem>
+                </>
+              ) : null}
               <DropdownMenuSeparator />
               <DropdownMenuItem onSelect={() => setAccountOpen(true)}>
                 <IconUserCircle />
@@ -425,14 +433,16 @@ export function NavUser({
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-        <input
-          ref={photoInputRef}
-          type="file"
-          accept="image/jpeg,image/png,image/webp"
-          className="sr-only"
-          aria-label="Choose sidebar photo"
-          onChange={handleSidebarPhotoUpload}
-        />
+        {user.canUseWorkspacePhotos ? (
+          <input
+            ref={photoInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            className="sr-only"
+            aria-label="Choose sidebar photo"
+            onChange={handleSidebarPhotoUpload}
+          />
+        ) : null}
       </SidebarMenuItem>
       <AccountModal
         open={accountOpen}

--- a/src/components/nav-user.tsx
+++ b/src/components/nav-user.tsx
@@ -48,7 +48,10 @@ import {
 import { AccountModal } from "@/components/account-modal"
 import { DevicePicker } from "@/components/voice/device-picker"
 import { useVoiceState } from "@/hooks/use-voice-state"
-import { sidebarDeskPhotoStorageKey } from "@/lib/user-photo-storage"
+import {
+  HIDDEN_DESK_PHOTO,
+  sidebarDeskPhotoStorageKey,
+} from "@/lib/user-photo-storage"
 import { cn } from "@/lib/utils"
 import { getInitials } from "@/lib/utils"
 import type { SidebarUser } from "@/lib/auth"
@@ -67,21 +70,26 @@ function defaultSidebarPhoto(user: SidebarUser): string | null {
 }
 
 function loadSidebarPhoto(user: SidebarUser): string | null {
+  if (!user.organizationId) return null
+  if (user.sidebarDeskPhoto === HIDDEN_DESK_PHOTO) return null
   if (user.sidebarDeskPhoto) return user.sidebarDeskPhoto
   try {
-    return (
-      window.localStorage.getItem(sidebarDeskPhotoStorageKey(user.email)) ??
-      defaultSidebarPhoto(user)
+    const storedPhoto = window.localStorage.getItem(
+      sidebarDeskPhotoStorageKey(user.email, user.organizationId)
     )
+    return storedPhoto === HIDDEN_DESK_PHOTO
+      ? null
+      : storedPhoto ?? defaultSidebarPhoto(user)
   } catch {
     return defaultSidebarPhoto(user)
   }
 }
 
 function saveSidebarPhoto(user: SidebarUser, dataUrl: string): void {
+  if (!user.organizationId) return
   try {
     window.localStorage.setItem(
-      sidebarDeskPhotoStorageKey(user.email),
+      sidebarDeskPhotoStorageKey(user.email, user.organizationId),
       dataUrl
     )
   } catch {
@@ -90,8 +98,12 @@ function saveSidebarPhoto(user: SidebarUser, dataUrl: string): void {
 }
 
 function resetSidebarPhoto(user: SidebarUser): void {
+  if (!user.organizationId) return
   try {
-    window.localStorage.removeItem(sidebarDeskPhotoStorageKey(user.email))
+    window.localStorage.setItem(
+      sidebarDeskPhotoStorageKey(user.email, user.organizationId),
+      HIDDEN_DESK_PHOTO
+    )
   } catch {
     // The reset still applies for this browser session.
   }
@@ -152,9 +164,15 @@ export function NavUser({
     null
   )
   const [sidebarPhotoFailed, setSidebarPhotoFailed] = React.useState(false)
+  const [sidebarPhotoScope, setSidebarPhotoScope] = React.useState<string | null>(
+    null
+  )
   const [isLoggingOut, startLogoutTransition] = React.useTransition()
   const photoInputRef = React.useRef<HTMLInputElement>(null)
   const migratedLegacyPhotoFor = React.useRef<string | null>(null)
+  const currentSidebarPhotoScope = user
+    ? `${user.id}:${user.organizationId ?? "none"}:${user.sidebarDeskPhoto ?? "none"}`
+    : "no-user"
   const {
     isMuted,
     isDeafened,
@@ -170,25 +188,39 @@ export function NavUser({
 
   React.useEffect(() => {
     if (!user) return
+    if (!user.organizationId) return
+    setSidebarPhotoScope(currentSidebarPhotoScope)
     setSidebarPhotoFailed(false)
     setSidebarPhotoUrl(loadSidebarPhoto(user))
 
-    if (user.sidebarDeskPhoto || migratedLegacyPhotoFor.current === user.email) {
+    const serverPhoto = user.sidebarDeskPhoto
+    const migrationKey = `${user.email}:${user.organizationId ?? "none"}`
+    if (
+      serverPhoto !== null ||
+      migratedLegacyPhotoFor.current === migrationKey
+    ) {
       return
     }
 
     try {
       const legacyPhoto = window.localStorage.getItem(
-        sidebarDeskPhotoStorageKey(user.email)
+        sidebarDeskPhotoStorageKey(user.email, user.organizationId)
       )
       if (!legacyPhoto) return
 
-      migratedLegacyPhotoFor.current = user.email
-      void updateWorkspacePhoto("sidebar", legacyPhoto)
+      migratedLegacyPhotoFor.current = migrationKey
+      void updateWorkspacePhoto("sidebar", legacyPhoto).then((result) => {
+        if (result.success && result.data?.url) {
+          setSidebarPhotoUrl(result.data.url)
+        }
+      })
     } catch {
       // Keep the browser-local photo when storage is unavailable.
     }
-  }, [user])
+  }, [currentSidebarPhotoScope, user])
+
+  const renderedSidebarPhotoUrl =
+    sidebarPhotoScope === currentSidebarPhotoScope ? sidebarPhotoUrl : null
 
   if (!user) {
     return null
@@ -224,7 +256,7 @@ export function NavUser({
       }
       saveSidebarPhoto(user, resizedDataUrl)
       setSidebarPhotoFailed(false)
-      setSidebarPhotoUrl(resizedDataUrl)
+      setSidebarPhotoUrl(result.data?.url ?? resizedDataUrl)
       toast.success("Sidebar photo updated.")
     } catch {
       toast.error("Could not update the sidebar photo.")
@@ -234,7 +266,7 @@ export function NavUser({
   async function handleSidebarPhotoReset(): Promise<void> {
     if (!user) return
 
-    const result = await updateWorkspacePhoto("sidebar", null)
+    const result = await updateWorkspacePhoto("sidebar", HIDDEN_DESK_PHOTO)
     if (!result.success) {
       toast.error(result.error)
       return
@@ -266,9 +298,9 @@ export function NavUser({
               )}
             >
               <span className="relative h-24 min-w-0 flex-1 overflow-hidden rounded-sm border border-sidebar-border bg-sidebar-accent group-data-[collapsible=icon]:size-7! group-data-[collapsible=icon]:flex-none">
-                {sidebarPhotoUrl && !sidebarPhotoFailed ? (
+                {renderedSidebarPhotoUrl && !sidebarPhotoFailed ? (
                   <Image
-                    src={sidebarPhotoUrl}
+                    src={renderedSidebarPhotoUrl}
                     alt={`${user.name}'s sidebar photo`}
                     fill
                     sizes="220px"
@@ -396,7 +428,7 @@ export function NavUser({
         <input
           ref={photoInputRef}
           type="file"
-          accept="image/*"
+          accept="image/jpeg,image/png,image/webp"
           className="sr-only"
           aria-label="Choose sidebar photo"
           onChange={handleSidebarPhotoUpload}

--- a/src/components/personal-desk-photo.tsx
+++ b/src/components/personal-desk-photo.tsx
@@ -6,42 +6,43 @@ import { IconPhotoEdit, IconUpload, IconX } from "@tabler/icons-react"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { updateWorkspacePhoto } from "@/app/actions/profile"
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
 import type { SidebarUser } from "@/lib/auth"
+import {
+  dashboardDeskPhotoStorageKey,
+  HIDDEN_DESK_PHOTO,
+} from "@/lib/user-photo-storage"
 
-const MARTINE_DEFAULT_DESK_PHOTO = "/user-desk-photos/martine-desk-photo.jpeg"
-const HIDDEN_DESK_PHOTO = "__hidden__"
-
-function storageKey(user: SidebarUser): string {
-  return `compass-desk-photo:${user.email}`
-}
-
-function defaultDeskPhoto(user: SidebarUser): string | null {
-  const identity = `${user.name} ${user.email}`.toLowerCase()
-
-  return identity.includes("martine") ? MARTINE_DEFAULT_DESK_PHOTO : null
+function storageKey(user: SidebarUser): string | null {
+  if (!user.organizationId) return null
+  return dashboardDeskPhotoStorageKey(user.email, user.organizationId)
 }
 
 function readStoredPhoto(user: SidebarUser): string | null | typeof HIDDEN_DESK_PHOTO {
+  const key = storageKey(user)
+  if (!key) return null
   try {
-    return window.localStorage.getItem(storageKey(user))
+    return window.localStorage.getItem(key)
   } catch {
     return null
   }
 }
 
 function saveStoredPhoto(user: SidebarUser, value: string | null): void {
+  const key = storageKey(user)
+  if (!key) return
   try {
     if (value === null) {
-      window.localStorage.removeItem(storageKey(user))
+      window.localStorage.removeItem(key)
       return
     }
 
-    window.localStorage.setItem(storageKey(user), value)
+    window.localStorage.setItem(key, value)
   } catch {
     // The preview can still update for this session if storage is unavailable.
   }
@@ -100,20 +101,38 @@ export function PersonalDeskPhoto({
   readonly user: SidebarUser | null
 }): React.ReactElement | null {
   const [photoUrl, setPhotoUrl] = React.useState<string | null>(null)
+  const [photoScope, setPhotoScope] = React.useState<string | null>(null)
   const [message, setMessage] = React.useState<string | null>(null)
+  const currentPhotoScope = user
+    ? `${user.id}:${user.organizationId ?? "none"}:${user.dashboardDeskPhoto ?? "none"}`
+    : "no-user"
 
   React.useEffect(() => {
     if (!user) return
+    setPhotoScope(currentPhotoScope)
 
+    const serverPhoto = user.dashboardDeskPhoto
     const storedPhoto = readStoredPhoto(user)
     setPhotoUrl(
-      storedPhoto === HIDDEN_DESK_PHOTO
-        ? null
-        : storedPhoto ?? defaultDeskPhoto(user)
+      serverPhoto === HIDDEN_DESK_PHOTO ? null : serverPhoto ?? storedPhoto
     )
-  }, [user])
 
-  if (!user || photoUrl === null) {
+    if (serverPhoto !== null || !storedPhoto) return
+    const legacyPhoto = storedPhoto
+    if (!legacyPhoto) return
+    if (legacyPhoto === HIDDEN_DESK_PHOTO) {
+      void updateWorkspacePhoto("dashboard", HIDDEN_DESK_PHOTO)
+      return
+    }
+
+    void updateWorkspacePhoto("dashboard", legacyPhoto).then((result) => {
+      if (result.success && result.data?.url) setPhotoUrl(result.data.url)
+    })
+  }, [currentPhotoScope, user])
+
+  const renderedPhotoUrl = photoScope === currentPhotoScope ? photoUrl : null
+
+  if (!user || renderedPhotoUrl === null) {
     return null
   }
 
@@ -132,26 +151,41 @@ export function PersonalDeskPhoto({
 
     const dataUrl = await readFileAsDataUrl(file)
     const resizedDataUrl = await resizeImageDataUrl(dataUrl)
-    setPhotoUrl(resizedDataUrl)
+    const result = await updateWorkspacePhoto("dashboard", resizedDataUrl)
+    if (!result.success) {
+      setMessage(result.error)
+      return
+    }
+    setPhotoUrl(result.data?.url ?? resizedDataUrl)
     saveStoredPhoto(user, resizedDataUrl)
     setMessage("Desk photo updated.")
     event.currentTarget.value = ""
   }
 
-  function handleReset(): void {
+  async function handleReset(): Promise<void> {
     if (!user) return
 
-    const fallback = defaultDeskPhoto(user)
-    setPhotoUrl(fallback)
+    const result = await updateWorkspacePhoto("dashboard", HIDDEN_DESK_PHOTO)
+    if (!result.success) {
+      setMessage(result.error)
+      return
+    }
+    setPhotoUrl(null)
     saveStoredPhoto(user, null)
-    setMessage(fallback ? "Desk photo reset." : null)
+    setMessage("Desk photo reset.")
   }
 
-  function handleRemove(): void {
+  async function handleRemove(): Promise<void> {
     if (!user) return
 
+    const result = await updateWorkspacePhoto("dashboard", HIDDEN_DESK_PHOTO)
+    if (!result.success) {
+      setMessage(result.error)
+      return
+    }
     setPhotoUrl(null)
     saveStoredPhoto(user, HIDDEN_DESK_PHOTO)
+    setMessage("Desk photo removed.")
   }
 
   return (
@@ -165,7 +199,7 @@ export function PersonalDeskPhoto({
           >
             <div className="relative aspect-[16/10] overflow-hidden rounded-sm bg-sidebar-accent">
               <Image
-                src={photoUrl}
+                src={renderedPhotoUrl}
                 alt={`${user.name}'s desk photo`}
                 fill
                 sizes="240px"
@@ -189,7 +223,7 @@ export function PersonalDeskPhoto({
             </div>
             <div className="relative aspect-[16/10] overflow-hidden rounded-md border bg-muted">
               <Image
-                src={photoUrl}
+                src={renderedPhotoUrl}
                 alt={`${user.name}'s desk photo preview`}
                 fill
                 sizes="288px"
@@ -210,10 +244,18 @@ export function PersonalDeskPhoto({
               </p>
             )}
             <div className="flex justify-between gap-2">
-              <Button variant="outline" size="sm" onClick={handleReset}>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void handleReset()}
+              >
                 Reset
               </Button>
-              <Button variant="ghost" size="sm" onClick={handleRemove}>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => void handleRemove()}
+              >
                 <IconX className="size-4" />
                 Hide
               </Button>

--- a/src/components/personal-desk-photo.tsx
+++ b/src/components/personal-desk-photo.tsx
@@ -14,14 +14,16 @@ import {
 } from "@/components/ui/popover"
 import type { SidebarUser } from "@/lib/auth"
 import {
+  authorizedWorkspacePhotoUrl,
   dashboardDeskPhotoStorageKey,
   HIDDEN_DESK_PHOTO,
+  workspacePhotoStateKey,
 } from "@/lib/user-photo-storage"
 
 function storageKey(user: SidebarUser): string | null {
   if (!user.canUseWorkspacePhotos) return null
   if (!user.organizationId) return null
-  return dashboardDeskPhotoStorageKey(user.email, user.organizationId)
+  return dashboardDeskPhotoStorageKey(user.id, user.organizationId)
 }
 
 function readStoredPhoto(user: SidebarUser): string | null | typeof HIDDEN_DESK_PHOTO {
@@ -105,7 +107,13 @@ export function PersonalDeskPhoto({
   const [photoScope, setPhotoScope] = React.useState<string | null>(null)
   const [message, setMessage] = React.useState<string | null>(null)
   const currentPhotoScope = user
-    ? `${user.id}:${user.organizationId ?? "none"}:${user.dashboardDeskPhoto ?? "none"}`
+    ? workspacePhotoStateKey({
+        userId: user.id,
+        organizationId: user.organizationId,
+        slot: "dashboard",
+        canUseWorkspacePhotos: user.canUseWorkspacePhotos,
+        serverPhotoUrl: user.dashboardDeskPhoto,
+      })
     : "no-user"
 
   React.useEffect(() => {
@@ -135,7 +143,12 @@ export function PersonalDeskPhoto({
     })
   }, [currentPhotoScope, user])
 
-  const renderedPhotoUrl = photoScope === currentPhotoScope ? photoUrl : null
+  const renderedPhotoUrl = authorizedWorkspacePhotoUrl({
+    canUseWorkspacePhotos: user?.canUseWorkspacePhotos === true,
+    currentScope: currentPhotoScope,
+    loadedScope: photoScope,
+    photoUrl,
+  })
 
   if (!user || renderedPhotoUrl === null) {
     return null

--- a/src/components/personal-desk-photo.tsx
+++ b/src/components/personal-desk-photo.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/user-photo-storage"
 
 function storageKey(user: SidebarUser): string | null {
+  if (!user.canUseWorkspacePhotos) return null
   if (!user.organizationId) return null
   return dashboardDeskPhotoStorageKey(user.email, user.organizationId)
 }
@@ -110,6 +111,10 @@ export function PersonalDeskPhoto({
   React.useEffect(() => {
     if (!user) return
     setPhotoScope(currentPhotoScope)
+    if (!user.canUseWorkspacePhotos) {
+      setPhotoUrl(null)
+      return
+    }
 
     const serverPhoto = user.dashboardDeskPhoto
     const storedPhoto = readStoredPhoto(user)

--- a/src/components/projects/project-audience-sidebar-profile.tsx
+++ b/src/components/projects/project-audience-sidebar-profile.tsx
@@ -11,7 +11,6 @@ import {
 } from "@tabler/icons-react"
 import { toast } from "sonner"
 
-import { updateWorkspacePhoto } from "@/app/actions/profile"
 import { Button } from "@/components/ui/button"
 import {
   Popover,
@@ -20,7 +19,6 @@ import {
 } from "@/components/ui/popover"
 import { useCompassTheme, useTheme } from "@/components/theme-provider"
 import { THEME_PRESETS } from "@/lib/theme/presets"
-import { sidebarDeskPhotoStorageKey } from "@/lib/user-photo-storage"
 import { cn } from "@/lib/utils"
 import { ProjectAudienceNotificationSettings } from "@/components/projects/project-audience-notification-settings"
 
@@ -83,32 +81,16 @@ export function ProjectAudienceSidebarProfile({
   const [photoUrl, setPhotoUrl] = React.useState<string | null>(
     viewer.sidebarPhotoUrl ?? viewer.avatarUrl
   )
+  const [photoScope, setPhotoScope] = React.useState<string | null>(null)
+  const currentPhotoScope = `${viewer.email}:${viewer.avatarUrl ?? "none"}:${viewer.sidebarPhotoUrl ?? "none"}`
   const inputRef = React.useRef<HTMLInputElement>(null)
-  const migratedLegacyPhotoFor = React.useRef<string | null>(null)
 
   React.useEffect(() => {
-    try {
-      const legacyPhoto = window.localStorage.getItem(
-        sidebarDeskPhotoStorageKey(viewer.email)
-      )
-      setPhotoUrl(
-        viewer.sidebarPhotoUrl ??
-          legacyPhoto ??
-          viewer.avatarUrl
-      )
+    setPhotoScope(currentPhotoScope)
+    setPhotoUrl(viewer.sidebarPhotoUrl ?? viewer.avatarUrl)
+  }, [currentPhotoScope, viewer.avatarUrl, viewer.sidebarPhotoUrl])
 
-      if (
-        !viewer.sidebarPhotoUrl &&
-        legacyPhoto &&
-        migratedLegacyPhotoFor.current !== viewer.email
-      ) {
-        migratedLegacyPhotoFor.current = viewer.email
-        void updateWorkspacePhoto("sidebar", legacyPhoto)
-      }
-    } catch {
-      setPhotoUrl(viewer.avatarUrl)
-    }
-  }, [viewer.avatarUrl, viewer.email, viewer.sidebarPhotoUrl])
+  const renderedPhotoUrl = photoScope === currentPhotoScope ? photoUrl : null
 
   async function handlePhoto(
     event: React.ChangeEvent<HTMLInputElement>
@@ -123,17 +105,8 @@ export function ProjectAudienceSidebarProfile({
 
     try {
       const photo = await resizeSidebarPhoto(await readFileAsDataUrl(file))
-      const result = await updateWorkspacePhoto("sidebar", photo)
-      if (!result.success) {
-        toast.error(result.error)
-        return
-      }
-      window.localStorage.setItem(
-        sidebarDeskPhotoStorageKey(viewer.email),
-        photo
-      )
       setPhotoUrl(photo)
-      toast.success("Sidebar photo updated.")
+      toast.success("Sidebar photo applied for this session.")
     } catch {
       toast.error("Could not update the sidebar photo.")
     }
@@ -154,9 +127,9 @@ export function ProjectAudienceSidebarProfile({
         className="group relative block h-24 w-full overflow-hidden rounded-md border border-sidebar-border bg-sidebar-accent text-left"
         aria-label="Change sidebar photo"
       >
-        {photoUrl ? (
+        {renderedPhotoUrl ? (
           <Image
-            src={photoUrl}
+            src={renderedPhotoUrl}
             alt={`${viewer.name}'s sidebar photo`}
             fill
             sizes="240px"

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -16,7 +16,9 @@ export const users = sqliteTable("users", {
   displayName: text("display_name"),
   avatarUrl: text("avatar_url"),
   dashboardDeskPhotoUrl: text("dashboard_desk_photo_url"),
+  dashboardDeskPhotoOrganizationId: text("dashboard_desk_photo_organization_id"),
   sidebarDeskPhotoUrl: text("sidebar_desk_photo_url"),
+  sidebarDeskPhotoOrganizationId: text("sidebar_desk_photo_organization_id"),
   role: text("role").notNull().default("office"), // admin, office, field, client
   googleEmail: text("google_email"), // override for google workspace impersonation
   isActive: integer("is_active", { mode: "boolean" }).notNull().default(true),

--- a/src/lib/__tests__/project-audience-viewer.test.ts
+++ b/src/lib/__tests__/project-audience-viewer.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+
+import { toProjectAudienceViewer } from "@/lib/project-audience-viewer"
+
+const photoUrl = "https://drive.google.com/file/d/drive-photo-id/view"
+
+function sourceUser(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "user-1",
+    displayName: "Example User",
+    email: "person@example.com",
+    avatarUrl: photoUrl,
+    role: "client",
+    isActive: true,
+    organizationType: "client",
+    ...overrides,
+  }
+}
+
+describe("project audience viewer projection", () => {
+  it("does not serialize profile photo URLs for external viewers", () => {
+    expect(toProjectAudienceViewer(sourceUser(), false)).toEqual({
+      id: "user-1",
+      name: "Example User",
+      email: "person@example.com",
+      avatarUrl: null,
+      sidebarPhotoUrl: null,
+    })
+  })
+
+  it("does not serialize profile photo URLs for inactive or demo viewers", () => {
+    expect(
+      toProjectAudienceViewer(
+        sourceUser({ id: "staff-1", role: "admin", organizationType: "internal", isActive: false }),
+        true
+      ).avatarUrl
+    ).toBeNull()
+    expect(
+      toProjectAudienceViewer(
+        sourceUser({ id: "demo-user-001", role: "admin", organizationType: "internal" }),
+        true
+      ).avatarUrl
+    ).toBeNull()
+  })
+
+  it("keeps an active internal staff avatar only in internal preview mode", () => {
+    expect(
+      toProjectAudienceViewer(
+        sourceUser({ id: "staff-1", role: "admin", organizationType: "internal" }),
+        true
+      ).avatarUrl
+    ).toBe(photoUrl)
+  })
+})

--- a/src/lib/__tests__/project-audience-viewer.test.ts
+++ b/src/lib/__tests__/project-audience-viewer.test.ts
@@ -12,6 +12,7 @@ function sourceUser(overrides: Record<string, unknown> = {}) {
     avatarUrl: photoUrl,
     role: "client",
     isActive: true,
+    organizationId: "org-1",
     organizationType: "client",
     ...overrides,
   }
@@ -19,7 +20,7 @@ function sourceUser(overrides: Record<string, unknown> = {}) {
 
 describe("project audience viewer projection", () => {
   it("does not serialize profile photo URLs for external viewers", () => {
-    expect(toProjectAudienceViewer(sourceUser(), false)).toEqual({
+    expect(toProjectAudienceViewer(sourceUser(), false, "org-1")).toEqual({
       id: "user-1",
       name: "Example User",
       email: "person@example.com",
@@ -32,13 +33,15 @@ describe("project audience viewer projection", () => {
     expect(
       toProjectAudienceViewer(
         sourceUser({ id: "staff-1", role: "admin", organizationType: "internal", isActive: false }),
-        true
+        true,
+        "org-1"
       ).avatarUrl
     ).toBeNull()
     expect(
       toProjectAudienceViewer(
         sourceUser({ id: "demo-user-001", role: "admin", organizationType: "internal" }),
-        true
+        true,
+        "org-1"
       ).avatarUrl
     ).toBeNull()
   })
@@ -47,8 +50,26 @@ describe("project audience viewer projection", () => {
     expect(
       toProjectAudienceViewer(
         sourceUser({ id: "staff-1", role: "admin", organizationType: "internal" }),
-        true
+        true,
+        "org-1"
       ).avatarUrl
     ).toBe(photoUrl)
+  })
+
+  it("redacts raw profile photos when an internal viewer previews another organization", () => {
+    const viewer = toProjectAudienceViewer(
+      sourceUser({
+        id: "staff-1",
+        role: "admin",
+        organizationType: "internal",
+        organizationId: "org-1",
+      }),
+      true,
+      "org-2"
+    )
+
+    expect(viewer.avatarUrl).toBeNull()
+    expect(viewer.sidebarPhotoUrl).toBeNull()
+    expect(JSON.stringify(viewer)).not.toContain(photoUrl)
   })
 })

--- a/src/lib/__tests__/user-photo-access.test.ts
+++ b/src/lib/__tests__/user-photo-access.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+
+import { toSidebarUser, type AuthUser } from "@/lib/auth"
+import { controlledDeskPhotoUrl } from "@/lib/user-photo-storage"
+
+function user(overrides: Partial<AuthUser> = {}): AuthUser {
+  return {
+    id: "user-1",
+    email: "person@example.com",
+    firstName: "Example",
+    lastName: "Person",
+    displayName: "Example Person",
+    avatarUrl: "https://drive.google.com/uc?id=avatar-drive-id",
+    dashboardDeskPhotoUrl: controlledDeskPhotoUrl("dashboard", "dashboard-drive-id"),
+    dashboardDeskPhotoOrganizationId: "org-internal",
+    sidebarDeskPhotoUrl: controlledDeskPhotoUrl("sidebar", "sidebar-drive-id"),
+    sidebarDeskPhotoOrganizationId: "org-internal",
+    role: "client",
+    googleEmail: null,
+    isActive: true,
+    lastLoginAt: null,
+    organizationId: "org-internal",
+    organizationName: "Client organization",
+    organizationType: "client",
+    createdAt: "2026-08-17T00:00:00.000Z",
+    updatedAt: "2026-08-17T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+describe("workspace photo delivery policy", () => {
+  it("removes profile and desk photo capabilities from external sidebar props", () => {
+    const sidebarUser = toSidebarUser(user())
+
+    expect(sidebarUser.canUseWorkspacePhotos).toBe(false)
+    expect(sidebarUser.avatar).toBeNull()
+    expect(sidebarUser.dashboardDeskPhoto).toBeNull()
+    expect(sidebarUser.sidebarDeskPhoto).toBeNull()
+  })
+
+  it("removes every photo capability from demo and inactive sidebar props", () => {
+    const demoUser = toSidebarUser(
+      user({ id: "demo-user-001", role: "admin", organizationType: "internal" })
+    )
+    const inactiveUser = toSidebarUser(
+      user({
+        id: "staff-1",
+        role: "admin",
+        organizationType: "internal",
+        isActive: false,
+      })
+    )
+
+    expect(demoUser.avatar).toBeNull()
+    expect(demoUser.canUseWorkspacePhotos).toBe(false)
+    expect(demoUser.dashboardDeskPhoto).toBeNull()
+    expect(demoUser.sidebarDeskPhoto).toBeNull()
+    expect(inactiveUser.avatar).toBeNull()
+    expect(inactiveUser.canUseWorkspacePhotos).toBe(false)
+    expect(inactiveUser.dashboardDeskPhoto).toBeNull()
+    expect(inactiveUser.sidebarDeskPhoto).toBeNull()
+  })
+
+  it("keeps only current-organization controlled photos for active internal staff", () => {
+    const sidebarUser = toSidebarUser(
+      user({
+        id: "staff-1",
+        role: "admin",
+        organizationType: "internal",
+        dashboardDeskPhotoOrganizationId: "org-internal",
+        sidebarDeskPhotoOrganizationId: "org-other",
+      })
+    )
+
+    expect(sidebarUser.avatar).toBe("https://drive.google.com/uc?id=avatar-drive-id")
+    expect(sidebarUser.canUseWorkspacePhotos).toBe(true)
+    expect(sidebarUser.dashboardDeskPhoto).toBe(
+      controlledDeskPhotoUrl("dashboard", "dashboard-drive-id")
+    )
+    expect(sidebarUser.sidebarDeskPhoto).toBeNull()
+  })
+})

--- a/src/lib/__tests__/user-photo-storage.test.ts
+++ b/src/lib/__tests__/user-photo-storage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  authorizedWorkspacePhotoUrl,
   controlledDeskPhotoUrl,
   dashboardDeskPhotoStorageKey,
   isLegacyDeskPhotoValue,
@@ -8,21 +9,77 @@ import {
   parseControlledDeskPhoto,
   parseImageDataUrl,
   sidebarDeskPhotoStorageKey,
+  workspacePhotoStateKey,
 } from "@/lib/user-photo-storage"
 
 describe("user photo storage", () => {
   it("keeps dashboard and sidebar photos independent", () => {
-    const email = "person@example.com"
+    const userId = "user-123"
 
-    expect(dashboardDeskPhotoStorageKey(email, "org-123")).toBe(
-      `compass-desk-photo:org-123:${email}`
+    expect(dashboardDeskPhotoStorageKey(userId, "org-123")).toBe(
+      "compass-desk-photo:user-123:org-123:dashboard"
     )
-    expect(sidebarDeskPhotoStorageKey(email, "org-123")).toBe(
-      "compass-sidebar-desk-photo:org-123:person@example.com"
+    expect(sidebarDeskPhotoStorageKey(userId, "org-123")).toBe(
+      "compass-desk-photo:user-123:org-123:sidebar"
     )
-    expect(sidebarDeskPhotoStorageKey(email, "org-123")).not.toBe(
-      dashboardDeskPhotoStorageKey(email, "org-123")
+    expect(sidebarDeskPhotoStorageKey(userId, "org-123")).not.toBe(
+      dashboardDeskPhotoStorageKey(userId, "org-123")
     )
+  })
+
+  it("does not share a cache key when an email address is reused by another user", () => {
+    expect(dashboardDeskPhotoStorageKey("user-123", "org-123")).not.toBe(
+      dashboardDeskPhotoStorageKey("user-456", "org-123")
+    )
+  })
+
+  it.each(["dashboard", "sidebar"] as const)(
+    "synchronously redacts stale %s photo state after authorization is removed",
+    (slot) => {
+      const authorizedScope = workspacePhotoStateKey({
+        userId: "user-123",
+        organizationId: "org-123",
+        slot,
+        canUseWorkspacePhotos: true,
+        serverPhotoUrl: null,
+      })
+      const unauthorizedScope = workspacePhotoStateKey({
+        userId: "user-123",
+        organizationId: "org-123",
+        slot,
+        canUseWorkspacePhotos: false,
+        serverPhotoUrl: null,
+      })
+
+      expect(unauthorizedScope).not.toBe(authorizedScope)
+      expect(
+        authorizedWorkspacePhotoUrl({
+          canUseWorkspacePhotos: false,
+          currentScope: unauthorizedScope,
+          loadedScope: authorizedScope,
+          photoUrl: "data:image/png;base64,AQID",
+        })
+      ).toBeNull()
+    }
+  )
+
+  it("keeps an authorized photo visible only in its current state scope", () => {
+    const scope = workspacePhotoStateKey({
+      userId: "user-123",
+      organizationId: "org-123",
+      slot: "dashboard",
+      canUseWorkspacePhotos: true,
+      serverPhotoUrl: "/api/users/desk-photo?slot=dashboard&file=file-1",
+    })
+
+    expect(
+      authorizedWorkspacePhotoUrl({
+        canUseWorkspacePhotos: true,
+        currentScope: scope,
+        loadedScope: scope,
+        photoUrl: "/api/users/desk-photo?slot=dashboard&file=file-1",
+      })
+    ).toBe("/api/users/desk-photo?slot=dashboard&file=file-1")
   })
 
   it("round-trips only controlled, slot-specific photo URLs", () => {

--- a/src/lib/__tests__/user-photo-storage.test.ts
+++ b/src/lib/__tests__/user-photo-storage.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  controlledDeskPhotoUrl,
   dashboardDeskPhotoStorageKey,
+  isLegacyDeskPhotoValue,
+  isDeskPhotoSlot,
+  parseControlledDeskPhoto,
+  parseImageDataUrl,
   sidebarDeskPhotoStorageKey,
 } from "@/lib/user-photo-storage"
 
@@ -9,14 +14,60 @@ describe("user photo storage", () => {
   it("keeps dashboard and sidebar photos independent", () => {
     const email = "person@example.com"
 
-    expect(dashboardDeskPhotoStorageKey(email)).toBe(
-      "compass-desk-photo:person@example.com"
+    expect(dashboardDeskPhotoStorageKey(email, "org-123")).toBe(
+      `compass-desk-photo:org-123:${email}`
     )
-    expect(sidebarDeskPhotoStorageKey(email)).toBe(
-      "compass-sidebar-desk-photo:person@example.com"
+    expect(sidebarDeskPhotoStorageKey(email, "org-123")).toBe(
+      "compass-sidebar-desk-photo:org-123:person@example.com"
     )
-    expect(sidebarDeskPhotoStorageKey(email)).not.toBe(
-      dashboardDeskPhotoStorageKey(email)
+    expect(sidebarDeskPhotoStorageKey(email, "org-123")).not.toBe(
+      dashboardDeskPhotoStorageKey(email, "org-123")
     )
+  })
+
+  it("round-trips only controlled, slot-specific photo URLs", () => {
+    const url = controlledDeskPhotoUrl("dashboard", "drive-file-123")
+
+    expect(parseControlledDeskPhoto(url, "dashboard")).toEqual({
+      fileId: "drive-file-123",
+    })
+    expect(parseControlledDeskPhoto(url, "sidebar")).toBeNull()
+    expect(
+      parseControlledDeskPhoto(
+        "https://drive.google.com/file/d/drive-file-123/view",
+        "dashboard"
+      )
+    ).toBeNull()
+    expect(
+      parseControlledDeskPhoto(
+        "/api/users/desk-photo?slot=dashboard&file=other-file",
+        "dashboard"
+      )
+    ).toEqual({ fileId: "other-file" })
+  })
+
+  it("decodes only supported image data URLs for legacy migration", () => {
+    expect(parseImageDataUrl("data:image/jpeg;base64,AQID")).toEqual({
+      mimeType: "image/jpeg",
+      bytes: new Uint8Array([1, 2, 3]),
+    })
+    expect(parseImageDataUrl("data:text/plain;base64,AQID")).toBeNull()
+    expect(parseImageDataUrl("not-an-image")).toBeNull()
+  })
+
+  it("recognizes legacy image values without treating controlled URLs as cache data", () => {
+    expect(isLegacyDeskPhotoValue("data:image/png;base64,AQID")).toBe(true)
+    expect(
+      isLegacyDeskPhotoValue(
+        controlledDeskPhotoUrl("sidebar", "drive-file-123")
+      )
+    ).toBe(false)
+    expect(isLegacyDeskPhotoValue("__hidden__")).toBe(false)
+  })
+
+  it("rejects unknown photo slots at runtime", () => {
+    expect(isDeskPhotoSlot("dashboard")).toBe(true)
+    expect(isDeskPhotoSlot("sidebar")).toBe(true)
+    expect(isDeskPhotoSlot("profile")).toBe(false)
   })
 })

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -51,6 +51,7 @@ export type AuthUser = {
 export type SidebarUser = Readonly<{
   id: string
   organizationId: string | null
+  canUseWorkspacePhotos: boolean
   name: string
   email: string
   avatar: string | null
@@ -74,9 +75,10 @@ export function toSidebarUser(user: AuthUser): SidebarUser {
   return {
     id: user.id,
     organizationId: user.organizationId,
+    canUseWorkspacePhotos,
     name: user.displayName ?? user.email.split("@")[0] ?? "User",
     email: user.email,
-    avatar: user.avatarUrl,
+    avatar: canUseWorkspacePhotos ? user.avatarUrl : null,
     dashboardDeskPhoto:
       canUseWorkspacePhotos &&
       user.dashboardDeskPhotoOrganizationId === user.organizationId
@@ -517,6 +519,12 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
         ) ?? activeOrg
     }
 
+    const canUseWorkspacePhotos =
+      dbUser.isActive &&
+      !isDemoUser(dbUser.id) &&
+      activeOrg?.orgType === "internal" &&
+      isInternalStaffRole(effectiveRole)
+
     if (activatedPendingAccount && activeOrg) {
       await recordActivityEvent({
         db,
@@ -543,12 +551,19 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
       firstName: dbUser.firstName,
       lastName: dbUser.lastName,
       displayName: dbUser.displayName,
-      avatarUrl: dbUser.avatarUrl,
-      dashboardDeskPhotoUrl: dbUser.dashboardDeskPhotoUrl,
+      avatarUrl: canUseWorkspacePhotos ? dbUser.avatarUrl : null,
+      dashboardDeskPhotoUrl: canUseWorkspacePhotos
+        ? dbUser.dashboardDeskPhotoUrl
+        : null,
       dashboardDeskPhotoOrganizationId:
-        dbUser.dashboardDeskPhotoOrganizationId,
-      sidebarDeskPhotoUrl: dbUser.sidebarDeskPhotoUrl,
-      sidebarDeskPhotoOrganizationId: dbUser.sidebarDeskPhotoOrganizationId,
+        canUseWorkspacePhotos
+          ? dbUser.dashboardDeskPhotoOrganizationId
+          : null,
+      sidebarDeskPhotoUrl: canUseWorkspacePhotos
+        ? dbUser.sidebarDeskPhotoUrl
+        : null,
+      sidebarDeskPhotoOrganizationId:
+        canUseWorkspacePhotos ? dbUser.sidebarDeskPhotoOrganizationId : null,
       role: effectiveRole,
       googleEmail: dbUser.googleEmail ?? null,
       isActive: dbUser.isActive,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -11,13 +11,14 @@ import {
 import type { User } from "@/db/schema"
 import { and, desc, eq, sql } from "drizzle-orm"
 import { cookies } from "next/headers"
-import { DEMO_USER } from "@/lib/demo"
+import { DEMO_USER, isDemoUser } from "@/lib/demo"
 import {
   isDevAuthFallbackAllowed,
   isWorkOSConfigured,
 } from "@/lib/auth-config"
 import {
   isExternalProjectRole,
+  isInternalStaffRole,
 } from "@/lib/user-roles"
 import { ensureProjectAudienceConversation } from "@/lib/project-audience-conversations"
 import { recordActivityEvent } from "@/lib/activity-log"
@@ -30,7 +31,9 @@ export type AuthUser = {
   readonly displayName: string | null
   readonly avatarUrl: string | null
   readonly dashboardDeskPhotoUrl?: string | null
+  readonly dashboardDeskPhotoOrganizationId?: string | null
   readonly sidebarDeskPhotoUrl?: string | null
+  readonly sidebarDeskPhotoOrganizationId?: string | null
   readonly role: string
   readonly googleEmail: string | null
   readonly isActive: boolean
@@ -47,6 +50,7 @@ export type AuthUser = {
  */
 export type SidebarUser = Readonly<{
   id: string
+  organizationId: string | null
   name: string
   email: string
   avatar: string | null
@@ -60,13 +64,29 @@ export type SidebarUser = Readonly<{
  * Convert AuthUser to SidebarUser for UI components
  */
 export function toSidebarUser(user: AuthUser): SidebarUser {
+  const canUseWorkspacePhotos =
+    user.isActive &&
+    user.organizationId !== null &&
+    user.organizationType === "internal" &&
+    isInternalStaffRole(user.role) &&
+    !isDemoUser(user.id)
+
   return {
     id: user.id,
+    organizationId: user.organizationId,
     name: user.displayName ?? user.email.split("@")[0] ?? "User",
     email: user.email,
     avatar: user.avatarUrl,
-    dashboardDeskPhoto: user.dashboardDeskPhotoUrl ?? null,
-    sidebarDeskPhoto: user.sidebarDeskPhotoUrl ?? null,
+    dashboardDeskPhoto:
+      canUseWorkspacePhotos &&
+      user.dashboardDeskPhotoOrganizationId === user.organizationId
+        ? user.dashboardDeskPhotoUrl ?? null
+        : null,
+    sidebarDeskPhoto:
+      canUseWorkspacePhotos &&
+      user.sidebarDeskPhotoOrganizationId === user.organizationId
+        ? user.sidebarDeskPhotoUrl ?? null
+        : null,
     firstName: user.firstName,
     lastName: user.lastName,
   }
@@ -441,7 +461,12 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
         organizations,
         eq(organizations.id, organizationMembers.organizationId)
       )
-      .where(eq(organizationMembers.userId, dbUser.id))
+      .where(
+        and(
+          eq(organizationMembers.userId, dbUser.id),
+          eq(organizations.isActive, true)
+        )
+      )
 
     let activeOrg: {
       readonly orgId: string
@@ -520,7 +545,10 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
       displayName: dbUser.displayName,
       avatarUrl: dbUser.avatarUrl,
       dashboardDeskPhotoUrl: dbUser.dashboardDeskPhotoUrl,
+      dashboardDeskPhotoOrganizationId:
+        dbUser.dashboardDeskPhotoOrganizationId,
       sidebarDeskPhotoUrl: dbUser.sidebarDeskPhotoUrl,
+      sidebarDeskPhotoOrganizationId: dbUser.sidebarDeskPhotoOrganizationId,
       role: effectiveRole,
       googleEmail: dbUser.googleEmail ?? null,
       isActive: dbUser.isActive,

--- a/src/lib/buildertrend/__tests__/legacy-reconciliation.test.ts
+++ b/src/lib/buildertrend/__tests__/legacy-reconciliation.test.ts
@@ -15,24 +15,24 @@ type TestDatabase = {
 }
 
 type TestDatabaseModule = {
-  readonly Database: new (filename: string) => TestDatabase
+  readonly DatabaseSync: new (filename: string) => TestDatabase
 }
 
 function isTestDatabaseModule(value: unknown): value is TestDatabaseModule {
   return (
     value !== null &&
     typeof value === "object" &&
-    "Database" in value &&
-    typeof value.Database === "function"
+    "DatabaseSync" in value &&
+    typeof value.DatabaseSync === "function"
   )
 }
 
 async function createDatabase(): Promise<TestDatabase> {
-  const sqliteModule: unknown = await import("bun:sqlite")
+  const sqliteModule: unknown = await import("node:sqlite")
   if (!isTestDatabaseModule(sqliteModule)) {
-    throw new Error("bun:sqlite did not provide a Database constructor")
+    throw new Error("node:sqlite did not provide a DatabaseSync constructor")
   }
-  return new sqliteModule.Database(":memory:")
+  return new sqliteModule.DatabaseSync(":memory:")
 }
 
 const guardedMigrationSql = readFileSync(

--- a/src/lib/google/client/types.ts
+++ b/src/lib/google/client/types.ts
@@ -32,6 +32,7 @@ export type DriveFile = {
   readonly iconLink?: string
   readonly thumbnailLink?: string
   readonly driveId?: string
+  readonly appProperties?: Readonly<Record<string, string>>
 }
 
 export type DriveFileList = {
@@ -89,7 +90,7 @@ export type UploadFileOptions = UploadOptions & {
 export const DRIVE_FILE_FIELDS =
   "id,name,mimeType,size,createdTime,modifiedTime,owners," +
   "parents,permissions,shared,trashed,webViewLink," +
-  "webContentLink,iconLink,thumbnailLink,driveId"
+  "webContentLink,iconLink,thumbnailLink,driveId,appProperties"
 
 export const DRIVE_LIST_FIELDS =
   `nextPageToken,files(${DRIVE_FILE_FIELDS})`

--- a/src/lib/project-audience-viewer.ts
+++ b/src/lib/project-audience-viewer.ts
@@ -12,16 +12,25 @@ export type ProjectAudienceViewer = {
 
 type ProjectAudienceViewerSource = Pick<
   AuthUser,
-  "id" | "displayName" | "email" | "avatarUrl" | "role" | "isActive" | "organizationType"
+  | "id"
+  | "displayName"
+  | "email"
+  | "avatarUrl"
+  | "role"
+  | "isActive"
+  | "organizationId"
+  | "organizationType"
 >
 
 export function toProjectAudienceViewer(
   user: ProjectAudienceViewerSource,
-  viewerIsInternal: boolean
+  viewerIsInternal: boolean,
+  projectOrganizationId: string
 ): ProjectAudienceViewer {
   const canShareProfilePhoto =
     viewerIsInternal &&
     user.isActive &&
+    user.organizationId === projectOrganizationId &&
     user.organizationType === "internal" &&
     isInternalStaffRole(user.role) &&
     !isDemoUser(user.id)

--- a/src/lib/project-audience-viewer.ts
+++ b/src/lib/project-audience-viewer.ts
@@ -1,0 +1,36 @@
+import { isDemoUser } from "@/lib/demo"
+import type { AuthUser } from "@/lib/auth"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+export type ProjectAudienceViewer = {
+  readonly id: string
+  readonly name: string
+  readonly email: string
+  readonly avatarUrl: string | null
+  readonly sidebarPhotoUrl: string | null
+}
+
+type ProjectAudienceViewerSource = Pick<
+  AuthUser,
+  "id" | "displayName" | "email" | "avatarUrl" | "role" | "isActive" | "organizationType"
+>
+
+export function toProjectAudienceViewer(
+  user: ProjectAudienceViewerSource,
+  viewerIsInternal: boolean
+): ProjectAudienceViewer {
+  const canShareProfilePhoto =
+    viewerIsInternal &&
+    user.isActive &&
+    user.organizationType === "internal" &&
+    isInternalStaffRole(user.role) &&
+    !isDemoUser(user.id)
+
+  return {
+    id: user.id,
+    name: user.displayName ?? user.email.split("@")[0] ?? "Compass user",
+    email: user.email,
+    avatarUrl: canShareProfilePhoto ? user.avatarUrl : null,
+    sidebarPhotoUrl: null,
+  }
+}

--- a/src/lib/user-photo-storage.ts
+++ b/src/lib/user-photo-storage.ts
@@ -1,7 +1,94 @@
-export function dashboardDeskPhotoStorageKey(email: string): string {
-  return `compass-desk-photo:${email}`
+export function dashboardDeskPhotoStorageKey(
+  email: string,
+  organizationId: string
+): string {
+  return `compass-desk-photo:${organizationId}:${email}`
 }
 
-export function sidebarDeskPhotoStorageKey(email: string): string {
-  return `compass-sidebar-desk-photo:${email}`
+export function sidebarDeskPhotoStorageKey(
+  email: string,
+  organizationId: string
+): string {
+  return `compass-sidebar-desk-photo:${organizationId}:${email}`
+}
+
+export const HIDDEN_DESK_PHOTO = "__hidden__"
+
+export const DESK_PHOTO_SLOTS = ["dashboard", "sidebar"] as const
+export type DeskPhotoSlot = (typeof DESK_PHOTO_SLOTS)[number]
+
+export function isDeskPhotoSlot(value: string): value is DeskPhotoSlot {
+  return value === DESK_PHOTO_SLOTS[0] || value === DESK_PHOTO_SLOTS[1]
+}
+
+const DESK_PHOTO_PATH = "/api/users/desk-photo"
+const CONTROLLED_URL_ORIGIN = "https://compass.invalid"
+
+export function controlledDeskPhotoUrl(
+  slot: DeskPhotoSlot,
+  fileId: string
+): string {
+  const params = new URLSearchParams({ slot, file: fileId })
+  return `${DESK_PHOTO_PATH}?${params.toString()}`
+}
+
+export function parseControlledDeskPhoto(
+  value: string | null,
+  slot: DeskPhotoSlot
+): { readonly fileId: string } | null {
+  if (!value || !value.startsWith("/")) return null
+
+  try {
+    const parsed = new URL(value, CONTROLLED_URL_ORIGIN)
+    if (
+      parsed.origin !== CONTROLLED_URL_ORIGIN ||
+      parsed.pathname !== DESK_PHOTO_PATH ||
+      parsed.searchParams.get("slot") !== slot
+    ) {
+      return null
+    }
+
+    const fileId = parsed.searchParams.get("file")
+    return fileId && /^[A-Za-z0-9_-]+$/.test(fileId) ? { fileId } : null
+  } catch {
+    return null
+  }
+}
+
+export function parseImageDataUrl(
+  value: string
+): {
+  readonly mimeType: "image/jpeg" | "image/png" | "image/webp"
+  readonly bytes: Uint8Array<ArrayBuffer>
+} | null {
+  const match = value.match(
+    /^data:(image\/(?:jpeg|png|webp));base64,([A-Za-z0-9+/]+={0,2})$/i
+  )
+  if (!match) return null
+
+  const mimeType = match[1]?.toLowerCase()
+  const encoded = match[2]
+  if (
+    (mimeType !== "image/jpeg" &&
+      mimeType !== "image/png" &&
+      mimeType !== "image/webp") ||
+    !encoded
+  ) {
+    return null
+  }
+
+  try {
+    const binary = atob(encoded)
+    const bytes = new Uint8Array(new ArrayBuffer(binary.length))
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index)
+    }
+    return { mimeType, bytes }
+  } catch {
+    return null
+  }
+}
+
+export function isLegacyDeskPhotoValue(value: string | null): boolean {
+  return value !== null && parseImageDataUrl(value) !== null
 }

--- a/src/lib/user-photo-storage.ts
+++ b/src/lib/user-photo-storage.ts
@@ -1,21 +1,47 @@
 export function dashboardDeskPhotoStorageKey(
-  email: string,
+  userId: string,
   organizationId: string
 ): string {
-  return `compass-desk-photo:${organizationId}:${email}`
+  return `compass-desk-photo:${userId}:${organizationId}:dashboard`
 }
 
 export function sidebarDeskPhotoStorageKey(
-  email: string,
+  userId: string,
   organizationId: string
 ): string {
-  return `compass-sidebar-desk-photo:${organizationId}:${email}`
+  return `compass-desk-photo:${userId}:${organizationId}:sidebar`
 }
 
 export const HIDDEN_DESK_PHOTO = "__hidden__"
 
 export const DESK_PHOTO_SLOTS = ["dashboard", "sidebar"] as const
 export type DeskPhotoSlot = (typeof DESK_PHOTO_SLOTS)[number]
+
+export function workspacePhotoStateKey(input: {
+  readonly userId: string
+  readonly organizationId: string | null
+  readonly slot: DeskPhotoSlot
+  readonly canUseWorkspacePhotos: boolean
+  readonly serverPhotoUrl: string | null
+}): string {
+  return [
+    input.userId,
+    input.organizationId ?? "none",
+    input.slot,
+    input.canUseWorkspacePhotos ? "authorized" : "unauthorized",
+    input.serverPhotoUrl ?? "none",
+  ].join(":")
+}
+
+export function authorizedWorkspacePhotoUrl(input: {
+  readonly canUseWorkspacePhotos: boolean
+  readonly currentScope: string
+  readonly loadedScope: string | null
+  readonly photoUrl: string | null
+}): string | null {
+  if (!input.canUseWorkspacePhotos) return null
+  return input.loadedScope === input.currentScope ? input.photoUrl : null
+}
 
 export function isDeskPhotoSlot(value: string): value is DeskPhotoSlot {
   return value === DESK_PHOTO_SLOTS[0] || value === DESK_PHOTO_SLOTS[1]


### PR DESCRIPTION
## Summary
- Persist dashboard and sidebar desk photos as organization-scoped Google Drive files with controlled Compass delivery URLs.
- Enforce active internal-staff authorization, organization/user scoping, Drive ownership metadata, and fail-closed direct delivery.
- Add durable hidden/reset handling, scoped disposable cache keys, and neutral placeholder behavior.

## Verification
- Targeted photo-storage tests: 5 passed.
- `bun run lint`: passed with 81 pre-existing warnings.
- `bun run build`: passed.
- `bunx tsc --noEmit`: baseline failure remains in `src/lib/buildertrend/__tests__/legacy-reconciliation.test.ts` because `bun:sqlite` types are unavailable.
- Playwright UI checks: demo placeholder rendered; demo upload/remove attempts were rejected without persistence. Authenticated Drive upload/reset/reload evidence is blocked by unavailable real credentials and Shared Drive configuration in this environment.

Independent security review: passed.