### PR TITLE
feat(office): add Staff Message Desk

### DIFF
--- a/drizzle/0109_staff_message_desk.sql
+++ b/drizzle/0109_staff_message_desk.sql
@@ -1,0 +1,168 @@
+CREATE TABLE `staff_message_records` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL REFERENCES `organizations`(`id`) ON DELETE CASCADE,
+  `source_type` text NOT NULL CHECK (`source_type` IN ('call', 'message')),
+  `goto_inbound_event_id` text REFERENCES `goto_inbound_events`(`id`) ON DELETE SET NULL,
+  `caller_name` text NOT NULL,
+  `caller_company` text,
+  `caller_phone` text,
+  `caller_email` text,
+  `subject` text NOT NULL,
+  `body` text NOT NULL,
+  `status` text NOT NULL DEFAULT 'New' CHECK (`status` IN ('New', 'Assigned', 'In Progress', 'Waiting', 'Completed')),
+  `assignee_user_id` text NOT NULL REFERENCES `users`(`id`),
+  `follow_up_due_date` text,
+  `completion_outcome` text,
+  `created_by` text REFERENCES `users`(`id`) ON DELETE SET NULL,
+  `completed_at` text,
+  `deleted_at` text,
+  `deleted_by` text REFERENCES `users`(`id`) ON DELETE SET NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `staff_message_records_goto_event_unique`
+  ON `staff_message_records` (`goto_inbound_event_id`);
+--> statement-breakpoint
+CREATE INDEX `staff_message_records_org_status_idx`
+  ON `staff_message_records` (`organization_id`, `status`, `updated_at`);
+--> statement-breakpoint
+CREATE INDEX `staff_message_records_assignee_status_idx`
+  ON `staff_message_records` (`assignee_user_id`, `status`, `updated_at`);
+--> statement-breakpoint
+CREATE TRIGGER `staff_message_record_assignee_guard_insert`
+BEFORE INSERT ON `staff_message_records`
+BEGIN
+  SELECT RAISE(ABORT, 'Staff message records require an active internal staff assignee')
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM `users` AS u
+    INNER JOIN `organization_members` AS om ON om.user_id = u.id
+    INNER JOIN `organizations` AS o ON o.id = om.organization_id
+    WHERE u.id = NEW.assignee_user_id
+      AND om.organization_id = NEW.organization_id
+      AND u.is_active = 1
+      AND o.is_active = 1
+      AND o.type = 'internal'
+      AND om.role IN (
+        'admin', 'secondary_admin', 'executive', 'project_manager',
+        'project_administrator', 'assistant_project_manager', 'accounting',
+        'office_manager', 'office', 'field_superintendent', 'field_crew',
+        'architectural_designer', 'drafter', 'lead_estimator',
+        'assistant_estimator', 'coordinator', 'field'
+      )
+  );
+END;
+--> statement-breakpoint
+CREATE TRIGGER `staff_message_record_assignee_guard_update`
+BEFORE UPDATE OF `assignee_user_id`, `organization_id` ON `staff_message_records`
+BEGIN
+  SELECT RAISE(ABORT, 'Staff message records require an active internal staff assignee')
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM `users` AS u
+    INNER JOIN `organization_members` AS om ON om.user_id = u.id
+    INNER JOIN `organizations` AS o ON o.id = om.organization_id
+    WHERE u.id = NEW.assignee_user_id
+      AND om.organization_id = NEW.organization_id
+      AND u.is_active = 1
+      AND o.is_active = 1
+      AND o.type = 'internal'
+      AND om.role IN (
+        'admin', 'secondary_admin', 'executive', 'project_manager',
+        'project_administrator', 'assistant_project_manager', 'accounting',
+        'office_manager', 'office', 'field_superintendent', 'field_crew',
+        'architectural_designer', 'drafter', 'lead_estimator',
+        'assistant_estimator', 'coordinator', 'field'
+      )
+  );
+END;
+--> statement-breakpoint
+CREATE TRIGGER `staff_message_record_user_active_guard`
+BEFORE UPDATE OF `is_active` ON `users`
+WHEN NEW.is_active = 0
+BEGIN
+  SELECT RAISE(ABORT, 'Reassign active staff message records before deactivating a user')
+  WHERE EXISTS (
+    SELECT 1
+    FROM `staff_message_records`
+    WHERE `staff_message_records`.`assignee_user_id` = NEW.id
+      AND `staff_message_records`.`deleted_at` IS NULL
+  );
+END;
+--> statement-breakpoint
+CREATE TRIGGER `staff_message_record_member_role_guard`
+BEFORE UPDATE OF `role`, `organization_id`, `user_id` ON `organization_members`
+BEGIN
+  SELECT RAISE(ABORT, 'Reassign active staff message records before changing staff membership')
+  WHERE EXISTS (
+    SELECT 1
+    FROM `staff_message_records` AS smr
+    WHERE smr.assignee_user_id = NEW.user_id
+      AND smr.organization_id = OLD.organization_id
+      AND smr.deleted_at IS NULL
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `users` AS u
+    INNER JOIN `organizations` AS o ON o.id = NEW.organization_id
+    WHERE u.id = NEW.user_id
+      AND NEW.organization_id = OLD.organization_id
+      AND u.is_active = 1
+      AND o.is_active = 1
+      AND o.type = 'internal'
+      AND NEW.role IN (
+        'admin', 'secondary_admin', 'executive', 'project_manager',
+        'project_administrator', 'assistant_project_manager', 'accounting',
+        'office_manager', 'office', 'field_superintendent', 'field_crew',
+        'architectural_designer', 'drafter', 'lead_estimator',
+        'assistant_estimator', 'coordinator', 'field'
+      )
+  );
+END;
+--> statement-breakpoint
+CREATE TRIGGER `staff_message_record_organization_active_guard`
+BEFORE UPDATE OF `is_active`, `type` ON `organizations`
+WHEN NEW.is_active = 0 OR NEW.type <> 'internal'
+BEGIN
+  SELECT RAISE(ABORT, 'Reassign active staff message records before deactivating an organization')
+  WHERE EXISTS (
+    SELECT 1
+    FROM `staff_message_records`
+    WHERE `staff_message_records`.`organization_id` = NEW.id
+      AND `staff_message_records`.`deleted_at` IS NULL
+  );
+END;
+--> statement-breakpoint
+CREATE TABLE `staff_message_history` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL REFERENCES `organizations`(`id`) ON DELETE CASCADE,
+  `record_id` text NOT NULL REFERENCES `staff_message_records`(`id`) ON DELETE CASCADE,
+  `actor_user_id` text REFERENCES `users`(`id`) ON DELETE SET NULL,
+  `action` text NOT NULL,
+  `from_status` text,
+  `to_status` text,
+  `from_assignee_user_id` text,
+  `to_assignee_user_id` text,
+  `note` text,
+  `metadata` text,
+  `created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `staff_message_history_record_created_idx`
+  ON `staff_message_history` (`record_id`, `created_at`);
+--> statement-breakpoint
+CREATE INDEX `staff_message_history_org_created_idx`
+  ON `staff_message_history` (`organization_id`, `created_at`);
+--> statement-breakpoint
+CREATE TRIGGER `staff_message_history_no_update`
+BEFORE UPDATE ON `staff_message_history`
+BEGIN
+  SELECT RAISE(ABORT, 'Staff message history is immutable');
+END;
+--> statement-breakpoint
+CREATE TRIGGER `staff_message_history_no_delete`
+BEFORE DELETE ON `staff_message_history`
+BEGIN
+  SELECT RAISE(ABORT, 'Staff message history is immutable');
+END;

--- a/drizzle/0110_staff_message_desk_integrity.sql
+++ b/drizzle/0110_staff_message_desk_integrity.sql
@@ -1,0 +1,78 @@
+DROP TRIGGER IF EXISTS `staff_message_record_member_role_guard`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `staff_message_records_goto_event_unique`;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `staff_message_records_goto_event_active_unique`
+  ON `staff_message_records` (`goto_inbound_event_id`)
+  WHERE `goto_inbound_event_id` IS NOT NULL
+    AND `deleted_at` IS NULL;
+--> statement-breakpoint
+CREATE TRIGGER `staff_message_record_member_update_guard`
+BEFORE UPDATE OF `role`, `organization_id`, `user_id` ON `organization_members`
+BEGIN
+  SELECT RAISE(ABORT, 'Reassign active staff message records before changing staff membership')
+  WHERE EXISTS (
+    SELECT 1
+    FROM `staff_message_records` AS smr
+    WHERE smr.assignee_user_id = OLD.user_id
+      AND smr.organization_id = OLD.organization_id
+      AND smr.deleted_at IS NULL
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `users` AS u
+    INNER JOIN `organization_members` AS om ON om.user_id = OLD.user_id
+    INNER JOIN `organizations` AS o ON o.id = om.organization_id
+    WHERE u.id = OLD.user_id
+      AND om.organization_id = OLD.organization_id
+      AND u.is_active = 1
+      AND o.is_active = 1
+      AND o.type = 'internal'
+      AND (
+        om.id <> OLD.id
+        OR (
+          NEW.user_id = OLD.user_id
+          AND NEW.organization_id = OLD.organization_id
+          AND NEW.role IN (
+            'admin', 'secondary_admin', 'executive', 'project_manager',
+            'project_administrator', 'assistant_project_manager', 'accounting',
+            'office_manager', 'office', 'field_superintendent', 'field_crew',
+            'architectural_designer', 'drafter', 'lead_estimator',
+            'assistant_estimator', 'coordinator', 'field'
+          )
+        )
+      )
+  );
+END;
+--> statement-breakpoint
+CREATE TRIGGER `staff_message_record_member_delete_guard`
+BEFORE DELETE ON `organization_members`
+BEGIN
+  SELECT RAISE(ABORT, 'Reassign active staff message records before changing staff membership')
+  WHERE EXISTS (
+    SELECT 1
+    FROM `staff_message_records` AS smr
+    WHERE smr.assignee_user_id = OLD.user_id
+      AND smr.organization_id = OLD.organization_id
+      AND smr.deleted_at IS NULL
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `users` AS u
+    INNER JOIN `organization_members` AS om ON om.user_id = OLD.user_id
+    INNER JOIN `organizations` AS o ON o.id = om.organization_id
+    WHERE u.id = OLD.user_id
+      AND om.organization_id = OLD.organization_id
+      AND om.id <> OLD.id
+      AND u.is_active = 1
+      AND o.is_active = 1
+      AND o.type = 'internal'
+      AND om.role IN (
+        'admin', 'secondary_admin', 'executive', 'project_manager',
+        'project_administrator', 'assistant_project_manager', 'accounting',
+        'office_manager', 'office', 'field_superintendent', 'field_crew',
+        'architectural_designer', 'drafter', 'lead_estimator',
+        'assistant_estimator', 'coordinator', 'field'
+      )
+  );
+END;

--- a/src/app/actions/staff-message-desk.ts
+++ b/src/app/actions/staff-message-desk.ts
@@ -1,0 +1,714 @@
+"use server"
+
+import { and, asc, desc, eq, isNull } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import {
+  gotoInboundEvents,
+  organizations,
+  organizationMembers,
+  staffMessageHistory,
+  staffMessageRecords,
+  users,
+} from "@/db/schema"
+import { requireAuth, type AuthUser } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import {
+  canTransitionStaffMessageStatus,
+  isEligibleStaffMessageAssignee,
+  isStaffMessageDeskUser,
+  isStaffMessageStatus,
+  type StaffMessageDeskUser,
+  type StaffMessageStatus,
+} from "@/lib/staff-message-desk"
+import { createNotificationEvent } from "@/lib/notifications/create-event"
+import { requireOrg } from "@/lib/org-scope"
+import { canManageUserAccessRole } from "@/lib/user-roles"
+
+const MESSAGE_DESK_PATH = "/dashboard/office-maintenance/message-desk"
+
+type ActionFailure = { readonly success: false; readonly error: string }
+type ActionSuccess<T> = { readonly success: true; readonly data: T }
+type ActionResult<T> = ActionFailure | ActionSuccess<T>
+
+type AssigneeRow = {
+  readonly id: string
+  readonly email: string
+  readonly firstName: string | null
+  readonly lastName: string | null
+  readonly displayName: string | null
+  readonly isActive: boolean
+  readonly memberRole: string
+}
+
+export type StaffMessageRecordDto = Readonly<{
+  readonly id: string
+  readonly sourceType: "call" | "message"
+  readonly gotoInboundEventId: string | null
+  readonly callerName: string
+  readonly callerCompany: string | null
+  readonly callerPhone: string | null
+  readonly callerEmail: string | null
+  readonly subject: string
+  readonly body: string
+  readonly status: StaffMessageStatus
+  readonly assigneeUserId: string
+  readonly assigneeName: string
+  readonly followUpDueDate: string | null
+  readonly completionOutcome: string | null
+  readonly createdBy: string | null
+  readonly completedAt: string | null
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly history: readonly StaffMessageHistoryDto[]
+}>
+
+export type StaffMessageHistoryDto = Readonly<{
+  readonly id: string
+  readonly action: string
+  readonly fromStatus: string | null
+  readonly toStatus: string | null
+  readonly fromAssigneeUserId: string | null
+  readonly toAssigneeUserId: string | null
+  readonly note: string | null
+  readonly createdAt: string
+  readonly actorName: string
+}>
+
+export type StaffMessageAssigneeDto = Readonly<{
+  readonly id: string
+  readonly name: string
+  readonly email: string
+}>
+
+export type StaffMessageInboundTextDto = Readonly<{
+  readonly id: string
+  readonly senderPhone: string
+  readonly messageBody: string | null
+  readonly receivedAt: string
+}>
+
+export type StaffMessageDeskData = Readonly<{
+  readonly records: readonly StaffMessageRecordDto[]
+  readonly assignees: readonly StaffMessageAssigneeDto[]
+  readonly inboundTexts: readonly StaffMessageInboundTextDto[]
+  readonly canDelete: boolean
+}>
+
+function failure(error: unknown): ActionFailure {
+  return {
+    success: false,
+    error: error instanceof Error ? error.message : "Staff message action failed",
+  }
+}
+
+function value(formData: FormData, key: string): string | null {
+  const candidate = formData.get(key)
+  if (typeof candidate !== "string") return null
+  const trimmed = candidate.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function requiredValue(formData: FormData, key: string): string {
+  const candidate = value(formData, key)
+  if (!candidate) throw new Error(`${key} is required`)
+  return candidate
+}
+
+function sourceType(valueToCheck: string): "call" | "message" {
+  if (valueToCheck === "call" || valueToCheck === "message") return valueToCheck
+  throw new Error("Source type must be call or message")
+}
+
+function parseStatus(valueToCheck: string): StaffMessageStatus {
+  if (isStaffMessageStatus(valueToCheck)) return valueToCheck
+  throw new Error("Choose a governed staff message status")
+}
+
+function parseDueDate(valueToCheck: string | null): string | null {
+  if (valueToCheck === null) return null
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(valueToCheck)) {
+    throw new Error("Follow-up due date must use YYYY-MM-DD")
+  }
+  return valueToCheck
+}
+
+function staffDeskUser(user: AuthUser): StaffMessageDeskUser {
+  return {
+    id: user.id,
+    isActive: user.isActive,
+    organizationId: user.organizationId,
+    organizationType: user.organizationType,
+    role: user.role,
+  }
+}
+
+async function staffMessageContext(): Promise<{
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string
+  readonly user: AuthUser
+}> {
+  const user = await requireAuth()
+  if (!isStaffMessageDeskUser(staffDeskUser(user))) {
+    throw new Error("Staff Message Desk access is restricted to active internal staff")
+  }
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const organization = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(
+      and(
+        eq(organizations.id, organizationId),
+        eq(organizations.type, "internal"),
+        eq(organizations.isActive, true)
+      )
+    )
+    .get()
+  if (!organization) throw new Error("Active internal organization is required")
+  return { db, organizationId, user }
+}
+
+async function assigneeFor(
+  db: ReturnType<typeof getDb>,
+  organizationId: string,
+  userId: string
+): Promise<AssigneeRow> {
+  const row = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      firstName: users.firstName,
+      lastName: users.lastName,
+      displayName: users.displayName,
+      isActive: users.isActive,
+      memberRole: organizationMembers.role,
+    })
+    .from(users)
+    .innerJoin(organizationMembers, eq(organizationMembers.userId, users.id))
+    .where(
+      and(
+        eq(users.id, userId),
+        eq(organizationMembers.organizationId, organizationId)
+      )
+    )
+    .get()
+  if (!row) throw new Error("Assignee is not a member of the active organization")
+  const candidate: StaffMessageDeskUser = {
+    id: row.id,
+    isActive: row.isActive,
+    organizationId,
+    organizationType: "internal",
+    role: row.memberRole,
+  }
+  if (!isEligibleStaffMessageAssignee(candidate, organizationId)) {
+    throw new Error("Assignee must be active internal staff")
+  }
+  return row
+}
+
+function assigneeName(row: Pick<AssigneeRow, "displayName" | "firstName" | "lastName" | "email">): string {
+  const displayName = row.displayName?.trim()
+  if (displayName) return displayName
+  const fullName = [row.firstName, row.lastName]
+    .filter((part): part is string => Boolean(part?.trim()))
+    .join(" ")
+    .trim()
+  return fullName || row.email
+}
+
+async function activeAssignees(
+  db: ReturnType<typeof getDb>,
+  organizationId: string
+): Promise<readonly StaffMessageAssigneeDto[]> {
+  const rows = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      firstName: users.firstName,
+      lastName: users.lastName,
+      displayName: users.displayName,
+      isActive: users.isActive,
+      memberRole: organizationMembers.role,
+    })
+    .from(users)
+    .innerJoin(organizationMembers, eq(organizationMembers.userId, users.id))
+    .where(
+      and(
+        eq(organizationMembers.organizationId, organizationId),
+        eq(users.isActive, true)
+      )
+    )
+    .orderBy(asc(users.displayName), asc(users.email))
+  return rows
+    .filter((row) =>
+      isEligibleStaffMessageAssignee(
+        {
+          id: row.id,
+          isActive: row.isActive,
+          organizationId,
+          organizationType: "internal",
+          role: row.memberRole,
+        },
+        organizationId
+      )
+    )
+    .map((row) => ({ id: row.id, name: assigneeName(row), email: row.email }))
+}
+
+async function appendHistory(input: {
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string
+  readonly recordId: string
+  readonly actorUserId: string
+  readonly action: string
+  readonly fromStatus: string | null
+  readonly toStatus: string | null
+  readonly fromAssigneeUserId?: string | null
+  readonly toAssigneeUserId?: string | null
+  readonly note?: string | null
+  readonly createdAt: string
+}): Promise<void> {
+  await input.db
+    .insert(staffMessageHistory)
+    .values({
+      id: crypto.randomUUID(),
+      organizationId: input.organizationId,
+      recordId: input.recordId,
+      actorUserId: input.actorUserId,
+      action: input.action,
+      fromStatus: input.fromStatus,
+      toStatus: input.toStatus,
+      fromAssigneeUserId: input.fromAssigneeUserId ?? null,
+      toAssigneeUserId: input.toAssigneeUserId ?? null,
+      note: input.note ?? null,
+      metadata: null,
+      createdAt: input.createdAt,
+    })
+    .run()
+}
+
+async function notifyAssignment(input: {
+  readonly organizationId: string
+  readonly recordId: string
+  readonly subject: string
+  readonly assignee: AssigneeRow
+  readonly actor: AuthUser
+}): Promise<void> {
+  try {
+    await createNotificationEvent({
+      organizationId: input.organizationId,
+      projectId: null,
+      eventType: "staff_message.assigned",
+      sourceType: "staff_message_record",
+      sourceId: input.recordId,
+      title: `Staff message assigned: ${input.subject}`,
+      body: `${input.actor.displayName ?? input.actor.email} assigned this message to you.`,
+      href: `${MESSAGE_DESK_PATH}#message-${encodeURIComponent(input.recordId)}`,
+      priority: "normal",
+      audience: "assignee",
+      createdBy: input.actor.id,
+      recipients: [{ userId: input.assignee.id, email: input.assignee.email }],
+      delivery: { inApp: true, email: true, push: true },
+    })
+  } catch (error) {
+    console.error("[staff-message-desk] assignment notification error", error)
+  }
+}
+
+export async function getStaffMessageDesk(): Promise<ActionResult<StaffMessageDeskData>> {
+  try {
+    const { db, organizationId, user } = await staffMessageContext()
+    const rows = await db
+      .select({
+        id: staffMessageRecords.id,
+        sourceType: staffMessageRecords.sourceType,
+        gotoInboundEventId: staffMessageRecords.gotoInboundEventId,
+        callerName: staffMessageRecords.callerName,
+        callerCompany: staffMessageRecords.callerCompany,
+        callerPhone: staffMessageRecords.callerPhone,
+        callerEmail: staffMessageRecords.callerEmail,
+        subject: staffMessageRecords.subject,
+        body: staffMessageRecords.body,
+        status: staffMessageRecords.status,
+        assigneeUserId: staffMessageRecords.assigneeUserId,
+        followUpDueDate: staffMessageRecords.followUpDueDate,
+        completionOutcome: staffMessageRecords.completionOutcome,
+        createdBy: staffMessageRecords.createdBy,
+        completedAt: staffMessageRecords.completedAt,
+        createdAt: staffMessageRecords.createdAt,
+        updatedAt: staffMessageRecords.updatedAt,
+        assigneeDisplayName: users.displayName,
+        assigneeFirstName: users.firstName,
+        assigneeLastName: users.lastName,
+        assigneeEmail: users.email,
+      })
+      .from(staffMessageRecords)
+      .innerJoin(users, eq(users.id, staffMessageRecords.assigneeUserId))
+      .where(
+        and(
+          eq(staffMessageRecords.organizationId, organizationId),
+          isNull(staffMessageRecords.deletedAt)
+        )
+      )
+      .orderBy(desc(staffMessageRecords.updatedAt))
+    const historyRows = await db
+      .select({
+        id: staffMessageHistory.id,
+        recordId: staffMessageHistory.recordId,
+        action: staffMessageHistory.action,
+        fromStatus: staffMessageHistory.fromStatus,
+        toStatus: staffMessageHistory.toStatus,
+        fromAssigneeUserId: staffMessageHistory.fromAssigneeUserId,
+        toAssigneeUserId: staffMessageHistory.toAssigneeUserId,
+        note: staffMessageHistory.note,
+        createdAt: staffMessageHistory.createdAt,
+        actorDisplayName: users.displayName,
+        actorFirstName: users.firstName,
+        actorLastName: users.lastName,
+        actorEmail: users.email,
+      })
+      .from(staffMessageHistory)
+      .leftJoin(users, eq(users.id, staffMessageHistory.actorUserId))
+      .where(eq(staffMessageHistory.organizationId, organizationId))
+      .orderBy(desc(staffMessageHistory.createdAt))
+    const inboundRows = await db
+      .select({
+        id: gotoInboundEvents.id,
+        senderPhone: gotoInboundEvents.senderPhone,
+        messageBody: gotoInboundEvents.messageBody,
+        receivedAt: gotoInboundEvents.receivedAt,
+      })
+      .from(gotoInboundEvents)
+      .leftJoin(
+        staffMessageRecords,
+        and(
+          eq(staffMessageRecords.gotoInboundEventId, gotoInboundEvents.id),
+          isNull(staffMessageRecords.deletedAt)
+        )
+      )
+      .where(
+        and(
+          eq(gotoInboundEvents.organizationId, organizationId),
+          eq(gotoInboundEvents.status, "needs_review"),
+          isNull(staffMessageRecords.id)
+        )
+      )
+      .orderBy(desc(gotoInboundEvents.receivedAt))
+    const historyByRecord = new Map<string, StaffMessageHistoryDto[]>()
+    for (const row of historyRows) {
+      const list = historyByRecord.get(row.recordId) ?? []
+      list.push({
+        id: row.id,
+        action: row.action,
+        fromStatus: row.fromStatus,
+        toStatus: row.toStatus,
+        fromAssigneeUserId: row.fromAssigneeUserId,
+        toAssigneeUserId: row.toAssigneeUserId,
+        note: row.note,
+        createdAt: row.createdAt,
+        actorName:
+          row.actorDisplayName ??
+          ([row.actorFirstName, row.actorLastName]
+            .filter((part): part is string => Boolean(part?.trim()))
+            .join(" ")
+            .trim() ||
+            row.actorEmail ||
+            "Compass"),
+      })
+      historyByRecord.set(row.recordId, list)
+    }
+    const records: StaffMessageRecordDto[] = rows.flatMap((row) => {
+      if (!isStaffMessageStatus(row.status)) return []
+      return [
+        {
+          id: row.id,
+          sourceType: sourceType(row.sourceType),
+          gotoInboundEventId: row.gotoInboundEventId,
+          callerName: row.callerName,
+          callerCompany: row.callerCompany,
+          callerPhone: row.callerPhone,
+          callerEmail: row.callerEmail,
+          subject: row.subject,
+          body: row.body,
+          status: row.status,
+          assigneeUserId: row.assigneeUserId,
+          assigneeName: assigneeName({
+            displayName: row.assigneeDisplayName,
+            firstName: row.assigneeFirstName,
+            lastName: row.assigneeLastName,
+            email: row.assigneeEmail,
+          }),
+          followUpDueDate: row.followUpDueDate,
+          completionOutcome: row.completionOutcome,
+          createdBy: row.createdBy,
+          completedAt: row.completedAt,
+          createdAt: row.createdAt,
+          updatedAt: row.updatedAt,
+          history: historyByRecord.get(row.id) ?? [],
+        },
+      ]
+    })
+    return {
+      success: true,
+      data: {
+        records,
+        assignees: await activeAssignees(db, organizationId),
+        inboundTexts: inboundRows,
+        canDelete: canManageUserAccessRole(user.role),
+      },
+    }
+  } catch (error) {
+    return failure(error)
+  }
+}
+
+export async function createStaffMessageRecord(
+  formData: FormData
+): Promise<ActionResult<{ readonly id: string }>> {
+  try {
+    const { db, organizationId, user } = await staffMessageContext()
+    const assignee = await assigneeFor(
+      db,
+      organizationId,
+      requiredValue(formData, "assigneeUserId")
+    )
+    const linkedEventId = value(formData, "gotoInboundEventId")
+    if (linkedEventId) {
+      const event = await db
+        .select({ id: gotoInboundEvents.id })
+        .from(gotoInboundEvents)
+        .where(
+          and(
+            eq(gotoInboundEvents.id, linkedEventId),
+            eq(gotoInboundEvents.organizationId, organizationId),
+            eq(gotoInboundEvents.status, "needs_review")
+          )
+        )
+        .get()
+      if (!event) throw new Error("GoTo text is not available for linking")
+    }
+    const now = new Date().toISOString()
+    const id = crypto.randomUUID()
+    await db
+      .insert(staffMessageRecords)
+      .values({
+        id,
+        organizationId,
+        sourceType: sourceType(requiredValue(formData, "sourceType")),
+        gotoInboundEventId: linkedEventId,
+        callerName: requiredValue(formData, "callerName"),
+        callerCompany: value(formData, "callerCompany"),
+        callerPhone: value(formData, "callerPhone"),
+        callerEmail: value(formData, "callerEmail"),
+        subject: requiredValue(formData, "subject"),
+        body: requiredValue(formData, "body"),
+        status: "New",
+        assigneeUserId: assignee.id,
+        followUpDueDate: parseDueDate(value(formData, "followUpDueDate")),
+        completionOutcome: null,
+        createdBy: user.id,
+        completedAt: null,
+        deletedAt: null,
+        deletedBy: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run()
+    await appendHistory({
+      db,
+      organizationId,
+      recordId: id,
+      actorUserId: user.id,
+      action: "created",
+      fromStatus: null,
+      toStatus: "New",
+      toAssigneeUserId: assignee.id,
+      note: value(formData, "note"),
+      createdAt: now,
+    })
+    await notifyAssignment({
+      organizationId,
+      recordId: id,
+      subject: requiredValue(formData, "subject"),
+      assignee,
+      actor: user,
+    })
+    revalidatePath(MESSAGE_DESK_PATH)
+    return { success: true, data: { id } }
+  } catch (error) {
+    return failure(error)
+  }
+}
+
+export async function updateStaffMessageRecord(
+  formData: FormData
+): Promise<ActionResult<{ readonly id: string }>> {
+  try {
+    const { db, organizationId, user } = await staffMessageContext()
+    const recordId = requiredValue(formData, "recordId")
+    const existing = await db
+      .select()
+      .from(staffMessageRecords)
+      .where(
+        and(
+          eq(staffMessageRecords.id, recordId),
+          eq(staffMessageRecords.organizationId, organizationId),
+          isNull(staffMessageRecords.deletedAt)
+        )
+      )
+      .get()
+    if (!existing) throw new Error("Staff message record not found")
+    if (!isStaffMessageStatus(existing.status)) {
+      throw new Error("Stored staff message has an invalid status")
+    }
+    const nextStatus = parseStatus(requiredValue(formData, "status"))
+    if (!canTransitionStaffMessageStatus(existing.status, nextStatus)) {
+      throw new Error(`Cannot move ${existing.status} to ${nextStatus}`)
+    }
+    const requestedAssigneeId = requiredValue(formData, "assigneeUserId")
+    if (
+      requestedAssigneeId !== existing.assigneeUserId &&
+      user.id !== existing.assigneeUserId &&
+      !canManageUserAccessRole(user.role)
+    ) {
+      throw new Error("Only the current assignee or an administrator may reassign")
+    }
+    const assignee = await assigneeFor(db, organizationId, requestedAssigneeId)
+    const outcome = value(formData, "completionOutcome")
+    if (nextStatus === "Completed" && !outcome) {
+      throw new Error("Completion outcome is required before completing a record")
+    }
+    const now = new Date().toISOString()
+    const dueDate = parseDueDate(value(formData, "followUpDueDate"))
+    await db
+      .update(staffMessageRecords)
+      .set({
+        status: nextStatus,
+        assigneeUserId: assignee.id,
+        followUpDueDate: dueDate,
+        completionOutcome: outcome,
+        completedAt: nextStatus === "Completed" ? existing.completedAt ?? now : null,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(staffMessageRecords.id, recordId),
+          eq(staffMessageRecords.organizationId, organizationId),
+          isNull(staffMessageRecords.deletedAt)
+        )
+      )
+      .run()
+    const changed =
+      existing.status !== nextStatus ||
+      existing.assigneeUserId !== assignee.id ||
+      existing.followUpDueDate !== dueDate ||
+      existing.completionOutcome !== outcome
+    if (changed) {
+      await appendHistory({
+        db,
+        organizationId,
+        recordId,
+        actorUserId: user.id,
+        action:
+          existing.assigneeUserId !== assignee.id
+            ? "reassigned"
+            : existing.status !== nextStatus
+              ? "status_changed"
+              : "updated",
+        fromStatus: existing.status,
+        toStatus: nextStatus,
+        fromAssigneeUserId: existing.assigneeUserId,
+        toAssigneeUserId: assignee.id,
+        note: value(formData, "note"),
+        createdAt: now,
+      })
+    }
+    if (existing.assigneeUserId !== assignee.id) {
+      await notifyAssignment({
+        organizationId,
+        recordId,
+        subject: existing.subject,
+        assignee,
+        actor: user,
+      })
+    }
+    revalidatePath(MESSAGE_DESK_PATH)
+    return { success: true, data: { id: recordId } }
+  } catch (error) {
+    return failure(error)
+  }
+}
+
+export async function deleteStaffMessageRecord(
+  formData: FormData
+): Promise<ActionResult<{ readonly id: string }>> {
+  try {
+    const { db, organizationId, user } = await staffMessageContext()
+    if (!canManageUserAccessRole(user.role)) {
+      throw new Error("Administrator permission is required to delete a record")
+    }
+    const recordId = requiredValue(formData, "recordId")
+    const existing = await db
+      .select({ id: staffMessageRecords.id, status: staffMessageRecords.status, assigneeUserId: staffMessageRecords.assigneeUserId })
+      .from(staffMessageRecords)
+      .where(
+        and(
+          eq(staffMessageRecords.id, recordId),
+          eq(staffMessageRecords.organizationId, organizationId),
+          isNull(staffMessageRecords.deletedAt)
+        )
+      )
+      .get()
+    if (!existing) throw new Error("Staff message record not found")
+    const now = new Date().toISOString()
+    await db
+      .update(staffMessageRecords)
+      .set({ deletedAt: now, deletedBy: user.id, updatedAt: now })
+      .where(
+        and(
+          eq(staffMessageRecords.id, recordId),
+          eq(staffMessageRecords.organizationId, organizationId),
+          isNull(staffMessageRecords.deletedAt)
+        )
+      )
+      .run()
+    await appendHistory({
+      db,
+      organizationId,
+      recordId,
+      actorUserId: user.id,
+      action: "deleted",
+      fromStatus: existing.status,
+      toStatus: existing.status,
+      fromAssigneeUserId: existing.assigneeUserId,
+      toAssigneeUserId: existing.assigneeUserId,
+      note: value(formData, "note"),
+      createdAt: now,
+    })
+    revalidatePath(MESSAGE_DESK_PATH)
+    return { success: true, data: { id: recordId } }
+  } catch (error) {
+    return failure(error)
+  }
+}
+
+export async function submitCreateStaffMessageRecord(
+  formData: FormData
+): Promise<void> {
+  await createStaffMessageRecord(formData)
+}
+
+export async function submitUpdateStaffMessageRecord(
+  formData: FormData
+): Promise<void> {
+  await updateStaffMessageRecord(formData)
+}
+
+export async function submitDeleteStaffMessageRecord(
+  formData: FormData
+): Promise<void> {
+  await deleteStaffMessageRecord(formData)
+}

--- a/src/app/actions/staff-message-desk.ts
+++ b/src/app/actions/staff-message-desk.ts
@@ -15,10 +15,12 @@ import {
 import { requireAuth, type AuthUser } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import {
+  archivedStaffMessageGotoEventState,
   canTransitionStaffMessageStatus,
   isEligibleStaffMessageAssignee,
   isStaffMessageDeskUser,
   isStaffMessageStatus,
+  linkedStaffMessageGotoEventState,
   type StaffMessageDeskUser,
   type StaffMessageStatus,
 } from "@/lib/staff-message-desk"
@@ -492,7 +494,7 @@ export async function createStaffMessageRecord(
     }
     const now = new Date().toISOString()
     const id = crypto.randomUUID()
-    await db
+    const recordInsert = db
       .insert(staffMessageRecords)
       .values({
         id,
@@ -516,7 +518,23 @@ export async function createStaffMessageRecord(
         createdAt: now,
         updatedAt: now,
       })
-      .run()
+    if (linkedEventId) {
+      await db.batch([
+        recordInsert,
+        db
+          .update(gotoInboundEvents)
+          .set(linkedStaffMessageGotoEventState(now))
+          .where(
+            and(
+              eq(gotoInboundEvents.id, linkedEventId),
+              eq(gotoInboundEvents.organizationId, organizationId),
+              eq(gotoInboundEvents.status, "needs_review")
+            )
+          ),
+      ])
+    } else {
+      await db.batch([recordInsert])
+    }
     await appendHistory({
       db,
       organizationId,
@@ -652,7 +670,12 @@ export async function deleteStaffMessageRecord(
     }
     const recordId = requiredValue(formData, "recordId")
     const existing = await db
-      .select({ id: staffMessageRecords.id, status: staffMessageRecords.status, assigneeUserId: staffMessageRecords.assigneeUserId })
+      .select({
+        id: staffMessageRecords.id,
+        status: staffMessageRecords.status,
+        assigneeUserId: staffMessageRecords.assigneeUserId,
+        gotoInboundEventId: staffMessageRecords.gotoInboundEventId,
+      })
       .from(staffMessageRecords)
       .where(
         and(
@@ -664,7 +687,7 @@ export async function deleteStaffMessageRecord(
       .get()
     if (!existing) throw new Error("Staff message record not found")
     const now = new Date().toISOString()
-    await db
+    const recordArchive = db
       .update(staffMessageRecords)
       .set({ deletedAt: now, deletedBy: user.id, updatedAt: now })
       .where(
@@ -674,7 +697,22 @@ export async function deleteStaffMessageRecord(
           isNull(staffMessageRecords.deletedAt)
         )
       )
-      .run()
+    if (existing.gotoInboundEventId) {
+      await db.batch([
+        recordArchive,
+        db
+          .update(gotoInboundEvents)
+          .set(archivedStaffMessageGotoEventState(now))
+          .where(
+            and(
+              eq(gotoInboundEvents.id, existing.gotoInboundEventId),
+              eq(gotoInboundEvents.organizationId, organizationId)
+            )
+          ),
+      ])
+    } else {
+      await db.batch([recordArchive])
+    }
     await appendHistory({
       db,
       organizationId,

--- a/src/app/dashboard/office-maintenance/message-desk/page.tsx
+++ b/src/app/dashboard/office-maintenance/message-desk/page.tsx
@@ -1,0 +1,210 @@
+export const dynamic = "force-dynamic"
+
+import Link from "next/link"
+import { redirect } from "next/navigation"
+import { IconArrowLeft, IconInbox, IconPhone, IconTrash } from "@tabler/icons-react"
+
+import {
+  getStaffMessageDesk,
+  submitCreateStaffMessageRecord,
+  submitDeleteStaffMessageRecord,
+  submitUpdateStaffMessageRecord,
+} from "@/app/actions/staff-message-desk"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { STAFF_MESSAGE_STATUSES } from "@/lib/staff-message-desk"
+
+function timestamp(value: string): string {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString()
+}
+
+function statusVariant(
+  status: string
+): "default" | "secondary" | "outline" {
+  if (status === "Completed") return "secondary"
+  if (status === "In Progress") return "default"
+  return "outline"
+}
+
+function fieldClassName(): string {
+  return "h-10 border bg-background px-3 text-sm"
+}
+
+export default async function StaffMessageDeskPage(): Promise<React.ReactElement> {
+  const result = await getStaffMessageDesk()
+  if (!result.success) redirect("/dashboard/access-restricted")
+  const { records, assignees, inboundTexts, canDelete } = result.data
+
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 overflow-y-auto p-4 lg:p-6">
+      <header className="border-b pb-5">
+        <Button asChild variant="ghost" size="sm" className="-ml-3 mb-2">
+          <Link href="/dashboard/projects">
+            <IconArrowLeft className="size-4" />
+            Office maintenance
+          </Link>
+        </Button>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-2">
+              <IconPhone className="size-6 text-muted-foreground" />
+              <h1 className="text-2xl font-semibold tracking-tight">Staff Message Desk</h1>
+            </div>
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+              Capture incoming calls and messages, give each item one accountable staff owner, and keep the handoff history intact.
+            </p>
+          </div>
+          <Badge variant="secondary">{records.length} active records</Badge>
+        </div>
+      </header>
+
+      <section className="border-b pb-6" aria-labelledby="new-staff-message">
+        <h2 id="new-staff-message" className="text-lg font-semibold">New intake</h2>
+        <form action={submitCreateStaffMessageRecord} className="mt-4 grid gap-3 md:grid-cols-2">
+          <label className="flex flex-col gap-1 text-sm font-medium">
+            Source
+            <select name="sourceType" required defaultValue="call" className={fieldClassName()}>
+              <option value="call">Incoming call</option>
+              <option value="message">Incoming message</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium">
+            Assign to
+            <select name="assigneeUserId" required defaultValue="" className={fieldClassName()}>
+              <option value="" disabled>Select one active staff member…</option>
+              {assignees.map((assignee) => (
+                <option key={assignee.id} value={assignee.id}>{assignee.name} · {assignee.email}</option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium">
+            Caller / contact name
+            <input name="callerName" required className={fieldClassName()} />
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium">
+            Company
+            <input name="callerCompany" className={fieldClassName()} />
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium">
+            Phone
+            <input name="callerPhone" type="tel" className={fieldClassName()} />
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium">
+            Email
+            <input name="callerEmail" type="email" className={fieldClassName()} />
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium md:col-span-2">
+            Subject
+            <input name="subject" required className={fieldClassName()} />
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium md:col-span-2">
+            Message details
+            <textarea name="body" required className="min-h-28 border bg-background p-3 text-sm" />
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium">
+            Follow-up due
+            <input name="followUpDueDate" type="date" className={fieldClassName()} />
+          </label>
+          <label className="flex flex-col gap-1 text-sm font-medium">
+            Link GoTo text review
+            <select name="gotoInboundEventId" defaultValue="" className={fieldClassName()}>
+              <option value="">No linked text</option>
+              {inboundTexts.map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.senderPhone} · {timestamp(item.receivedAt)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="flex justify-end md:col-span-2">
+            <Button type="submit">Create staff message record</Button>
+          </div>
+        </form>
+      </section>
+
+      <section className="space-y-4" aria-labelledby="active-staff-messages">
+        <div className="flex items-center gap-2 border-b pb-2">
+          <IconInbox className="size-5 text-muted-foreground" />
+          <h2 id="active-staff-messages" className="text-lg font-semibold">Active message records</h2>
+        </div>
+        {records.length === 0 ? (
+          <div className="border border-dashed p-8 text-center text-sm text-muted-foreground">
+            No active staff message records.
+          </div>
+        ) : records.map((record) => (
+          <article id={`message-${record.id}`} key={record.id} className="border bg-background p-4 shadow-sm">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3 className="text-lg font-semibold">{record.subject}</h3>
+                  <Badge variant={statusVariant(record.status)}>{record.status}</Badge>
+                  <Badge variant="outline">{record.sourceType === "call" ? "Call" : "Message"}</Badge>
+                </div>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {record.callerName}{record.callerCompany ? ` · ${record.callerCompany}` : ""}
+                  {record.callerPhone ? ` · ${record.callerPhone}` : ""}
+                  {record.callerEmail ? ` · ${record.callerEmail}` : ""}
+                </p>
+              </div>
+              <p className="text-xs text-muted-foreground">Updated {timestamp(record.updatedAt)}</p>
+            </div>
+            <p className="mt-4 whitespace-pre-wrap border-l-2 pl-3 text-sm leading-6">{record.body}</p>
+            <form action={submitUpdateStaffMessageRecord} className="mt-4 grid gap-3 border-t pt-4 md:grid-cols-4">
+              <input type="hidden" name="recordId" value={record.id} />
+              <label className="flex flex-col gap-1 text-sm font-medium">
+                Status
+                <select name="status" defaultValue={record.status} className={fieldClassName()}>
+                  {STAFF_MESSAGE_STATUSES.map((status) => <option key={status} value={status}>{status}</option>)}
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-sm font-medium">
+                Assignee
+                <select name="assigneeUserId" required defaultValue={record.assigneeUserId} className={fieldClassName()}>
+                  {assignees.map((assignee) => <option key={assignee.id} value={assignee.id}>{assignee.name}</option>)}
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-sm font-medium">
+                Follow-up due
+                <input name="followUpDueDate" type="date" defaultValue={record.followUpDueDate ?? ""} className={fieldClassName()} />
+              </label>
+              <label className="flex flex-col gap-1 text-sm font-medium">
+                Completion outcome
+                <input name="completionOutcome" defaultValue={record.completionOutcome ?? ""} className={fieldClassName()} />
+              </label>
+              <label className="flex flex-col gap-1 text-sm font-medium md:col-span-3">
+                Update note
+                <input name="note" className={fieldClassName()} placeholder="Why did this change?" />
+              </label>
+              <div className="flex items-end justify-end">
+                <Button type="submit">Save update</Button>
+              </div>
+            </form>
+            <div className="mt-4 border-t pt-4">
+              <h4 className="text-sm font-semibold">Immutable activity history</h4>
+              <ol className="mt-2 space-y-2 text-xs text-muted-foreground">
+                {record.history.map((event) => (
+                  <li key={event.id}>
+                    <span className="font-medium text-foreground">{event.actorName}</span>{" "}
+                    {event.action.replaceAll("_", " ")} · {timestamp(event.createdAt)}
+                    {event.note ? ` · ${event.note}` : ""}
+                  </li>
+                ))}
+              </ol>
+            </div>
+            {canDelete ? (
+              <form action={submitDeleteStaffMessageRecord} className="mt-4 flex justify-end border-t pt-3">
+                <input type="hidden" name="recordId" value={record.id} />
+                <input type="hidden" name="note" value="Administrator archived this record from the active desk." />
+                <Button type="submit" variant="outline">
+                  <IconTrash className="size-4" />
+                  Archive record
+                </Button>
+              </form>
+            ) : null}
+          </article>
+        ))}
+      </section>
+    </main>
+  )
+}

--- a/src/app/dashboard/office-maintenance/message-desk/page.tsx
+++ b/src/app/dashboard/office-maintenance/message-desk/page.tsx
@@ -2,16 +2,16 @@ export const dynamic = "force-dynamic"
 
 import Link from "next/link"
 import { redirect } from "next/navigation"
-import { IconArrowLeft, IconInbox, IconPhone, IconTrash } from "@tabler/icons-react"
+import { IconArrowLeft, IconInbox, IconPhone } from "@tabler/icons-react"
 
 import {
   getStaffMessageDesk,
   submitCreateStaffMessageRecord,
-  submitDeleteStaffMessageRecord,
   submitUpdateStaffMessageRecord,
 } from "@/app/actions/staff-message-desk"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { StaffMessageArchiveDialog } from "@/components/office/staff-message-archive-dialog"
 import { STAFF_MESSAGE_STATUSES } from "@/lib/staff-message-desk"
 
 function timestamp(value: string): string {
@@ -193,14 +193,9 @@ export default async function StaffMessageDeskPage(): Promise<React.ReactElement
               </ol>
             </div>
             {canDelete ? (
-              <form action={submitDeleteStaffMessageRecord} className="mt-4 flex justify-end border-t pt-3">
-                <input type="hidden" name="recordId" value={record.id} />
-                <input type="hidden" name="note" value="Administrator archived this record from the active desk." />
-                <Button type="submit" variant="outline">
-                  <IconTrash className="size-4" />
-                  Archive record
-                </Button>
-              </form>
+              <div className="mt-4 flex justify-end border-t pt-3">
+                <StaffMessageArchiveDialog recordId={record.id} />
+              </div>
             ) : null}
           </article>
         ))}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -19,6 +19,7 @@ import {
   IconMessageCircleQuestion,
   IconMessageReport,
   IconPalette,
+  IconPhone,
   IconPhoto,
   IconReceipt,
   IconShoppingCart,
@@ -79,6 +80,12 @@ const NAV_MAIN = [
     title: "Activity",
     url: "/dashboard/activity",
     icon: IconActivity,
+    internalOnly: true,
+  },
+  {
+    title: "Staff Message Desk",
+    url: "/dashboard/office-maintenance/message-desk",
+    icon: IconPhone,
     internalOnly: true,
   },
   {

--- a/src/components/office/staff-message-archive-dialog.test.ts
+++ b/src/components/office/staff-message-archive-dialog.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+describe("Staff Message Desk archive control", () => {
+  it("uses a confirmation dialog with explicit archive and cancel choices", () => {
+    const component = readFileSync(
+      resolve(process.cwd(), "src/components/office/staff-message-archive-dialog.tsx"),
+      "utf8"
+    )
+    const page = readFileSync(
+      resolve(
+        process.cwd(),
+        "src/app/dashboard/office-maintenance/message-desk/page.tsx"
+      ),
+      "utf8"
+    )
+
+    expect(page).toContain("StaffMessageArchiveDialog")
+    expect(component).toContain("AlertDialogTitle")
+    expect(component).toContain("Archive this staff message?")
+    expect(component).toContain("This removes the record from the active desk")
+    expect(component).toContain("Keep record")
+    expect(component).toContain("Archive record")
+  })
+})

--- a/src/components/office/staff-message-archive-dialog.tsx
+++ b/src/components/office/staff-message-archive-dialog.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { useState, useTransition } from "react"
+
+import { deleteStaffMessageRecord } from "@/app/actions/staff-message-desk"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+
+export type StaffMessageArchiveDialogProps = Readonly<{
+  readonly recordId: string
+}>
+
+export function StaffMessageArchiveDialog({
+  recordId,
+}: StaffMessageArchiveDialogProps): React.ReactElement {
+  const [open, setOpen] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function handleConfirm(event: React.MouseEvent<HTMLButtonElement>): void {
+    event.preventDefault()
+    setError(null)
+    const formData = new FormData()
+    formData.set("recordId", recordId)
+    formData.set("note", "Administrator archived this record from the active desk.")
+    startTransition(() => {
+      void deleteStaffMessageRecord(formData).then((result) => {
+        if (result.success) {
+          setOpen(false)
+          return
+        }
+        setError(result.error)
+      })
+    })
+  }
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!isPending) {
+          setOpen(nextOpen)
+          if (nextOpen) setError(null)
+        }
+      }}
+    >
+      <AlertDialogTrigger asChild>
+        <Button type="button" variant="outline">
+          Archive record
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Archive this staff message?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This removes the record from the active desk. A linked GoTo text will
+            return to the review queue so it can be relinked later.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {error ? <p role="alert" className="text-sm text-destructive">{error}</p> : null}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Keep record</AlertDialogCancel>
+          <AlertDialogAction onClick={handleConfirm} disabled={isPending}>
+            {isPending ? "Archiving…" : "Archive record"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/components/projects/office-maintenance-drawer.tsx
+++ b/src/components/projects/office-maintenance-drawer.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { useState } from "react"
-import { IconMailForward, IconSettings, IconTemplate } from "@tabler/icons-react"
+import { IconMailForward, IconPhone, IconSettings, IconTemplate } from "@tabler/icons-react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -127,6 +127,12 @@ export function OfficeMaintenanceDrawer({
             <Link href="/dashboard/office-maintenance/inbound-email">
               <IconMailForward className="size-4" />
               Review inbound messages
+            </Link>
+          </Button>
+          <Button asChild variant="outline" className="w-full justify-start">
+            <Link href="/dashboard/office-maintenance/message-desk">
+              <IconPhone className="size-4" />
+              Open Staff Message Desk
             </Link>
           </Button>
           <div className="space-y-2 border p-3">

--- a/src/db/__tests__/staff-message-desk-migration.test.ts
+++ b/src/db/__tests__/staff-message-desk-migration.test.ts
@@ -3,10 +3,18 @@ import { resolve } from "node:path"
 
 import { describe, expect, it } from "vitest"
 
-const migration = readFileSync(
-  resolve(process.cwd(), "drizzle/0109_staff_message_desk.sql"),
-  "utf8"
-).replaceAll("--> statement-breakpoint", "")
+const migration = [
+  readFileSync(
+    resolve(process.cwd(), "drizzle/0109_staff_message_desk.sql"),
+    "utf8"
+  ),
+  readFileSync(
+    resolve(process.cwd(), "drizzle/0110_staff_message_desk_integrity.sql"),
+    "utf8"
+  ),
+]
+  .join("\n")
+  .replaceAll("--> statement-breakpoint", "")
 
 describe("Staff Message Desk migration", () => {
   it("enforces active internal assignees, governed statuses, and immutable history", async () => {
@@ -29,11 +37,22 @@ describe("Staff Message Desk migration", () => {
           user_id TEXT NOT NULL,
           role TEXT NOT NULL
         );
-        CREATE TABLE goto_inbound_events (id TEXT PRIMARY KEY);
+        CREATE TABLE goto_inbound_events (
+          id TEXT PRIMARY KEY,
+          status TEXT NOT NULL DEFAULT 'needs_review',
+          review_reason TEXT,
+          processed_at TEXT
+        );
         INSERT INTO organizations VALUES ('org-internal', 'internal', 1), ('org-client', 'client', 1);
-        INSERT INTO users VALUES ('staff', 1), ('inactive', 0), ('external', 1);
+        INSERT INTO users VALUES
+          ('staff', 1), ('replacement', 1), ('role-staff', 1),
+          ('moved-staff', 1), ('user-staff', 1), ('inactive', 0), ('external', 1);
         INSERT INTO organization_members VALUES
           ('member-staff', 'org-internal', 'staff', 'office'),
+          ('member-replacement', 'org-internal', 'replacement', 'office'),
+          ('member-role-staff', 'org-internal', 'role-staff', 'office'),
+          ('member-moved-staff', 'org-internal', 'moved-staff', 'office'),
+          ('member-user-staff', 'org-internal', 'user-staff', 'office'),
           ('member-inactive', 'org-internal', 'inactive', 'office'),
           ('member-external', 'org-client', 'external', 'client');
       `)
@@ -41,17 +60,64 @@ describe("Staff Message Desk migration", () => {
       const insert = database.prepare(`
         INSERT INTO staff_message_records (
           id, organization_id, source_type, caller_name, subject, body,
-          status, assignee_user_id, created_at, updated_at
-        ) VALUES (?, ?, 'call', 'Caller', 'Subject', 'Body', ?, ?, '2026-08-16', '2026-08-16')
+          status, assignee_user_id, goto_inbound_event_id, deleted_at,
+          created_at, updated_at
+        ) VALUES (?, ?, 'call', 'Caller', 'Subject', 'Body', ?, ?, ?, ?, '2026-08-16', '2026-08-16')
       `)
-      insert.run("record-1", "org-internal", "New", "staff")
+      insert.run("record-1", "org-internal", "New", "staff", null, null)
       expect(() =>
         database.prepare("UPDATE users SET is_active = 0 WHERE id = 'staff'").run()
       ).toThrow(/Reassign active staff message records/)
-      expect(() => insert.run("record-2", "org-internal", "New", "inactive")).toThrow(
+      expect(() =>
+        database.prepare("DELETE FROM organization_members WHERE id = 'member-staff'").run()
+      ).toThrow(/Reassign active staff message records/)
+      expect(() =>
+        database.prepare("UPDATE organization_members SET role = 'client' WHERE id = 'member-staff'").run()
+      ).toThrow(/Reassign active staff message records/)
+      database.prepare("UPDATE staff_message_records SET assignee_user_id = 'replacement' WHERE id = 'record-1'").run()
+      database.prepare("DELETE FROM organization_members WHERE id = 'member-staff'").run()
+
+      expect(() => insert.run("record-2", "org-internal", "New", "inactive", null, null)).toThrow(
         /active internal staff assignee/
       )
-      expect(() => insert.run("record-3", "org-internal", "Not a status", "staff")).toThrow()
+      insert.run("record-3", "org-internal", "New", "role-staff", null, null)
+      expect(() =>
+        database.prepare("UPDATE organization_members SET role = 'client' WHERE id = 'member-role-staff'").run()
+      ).toThrow(/Reassign active staff message records/)
+      database.prepare("UPDATE staff_message_records SET assignee_user_id = 'replacement' WHERE id = 'record-3'").run()
+      database.prepare("UPDATE organization_members SET role = 'client' WHERE id = 'member-role-staff'").run()
+
+      insert.run("record-4", "org-internal", "New", "moved-staff", null, null)
+      expect(() =>
+        database.prepare("UPDATE organization_members SET organization_id = 'org-client' WHERE id = 'member-moved-staff'").run()
+      ).toThrow(/Reassign active staff message records/)
+      database.prepare("UPDATE staff_message_records SET assignee_user_id = 'replacement' WHERE id = 'record-4'").run()
+      database.prepare("UPDATE organization_members SET organization_id = 'org-client' WHERE id = 'member-moved-staff'").run()
+
+      insert.run("record-5", "org-internal", "New", "user-staff", null, null)
+      expect(() =>
+        database.prepare("UPDATE organization_members SET user_id = 'replacement' WHERE id = 'member-user-staff'").run()
+      ).toThrow(/Reassign active staff message records/)
+      database.prepare("UPDATE staff_message_records SET assignee_user_id = 'replacement' WHERE id = 'record-5'").run()
+      database.prepare("UPDATE organization_members SET user_id = 'replacement' WHERE id = 'member-user-staff'").run()
+
+      expect(() => insert.run("record-6", "org-internal", "Not a status", "replacement", null, null)).toThrow()
+
+      database.prepare("INSERT INTO goto_inbound_events (id) VALUES ('goto-1')").run()
+      insert.run("linked-1", "org-internal", "New", "replacement", "goto-1", null)
+      expect(() => insert.run("linked-2", "org-internal", "New", "replacement", "goto-1", null)).toThrow()
+      database.prepare("UPDATE goto_inbound_events SET status = 'processed', processed_at = '2026-08-17T12:00:00.000Z' WHERE id = 'goto-1'").run()
+      expect(database.prepare("SELECT status, processed_at FROM goto_inbound_events WHERE id = 'goto-1'").get()).toEqual({
+        status: "processed",
+        processed_at: "2026-08-17T12:00:00.000Z",
+      })
+      database.prepare("UPDATE staff_message_records SET deleted_at = '2026-08-17' WHERE id = 'linked-1'").run()
+      database.prepare("UPDATE goto_inbound_events SET status = 'needs_review', processed_at = NULL WHERE id = 'goto-1'").run()
+      expect(database.prepare("SELECT status, processed_at FROM goto_inbound_events WHERE id = 'goto-1'").get()).toEqual({
+        status: "needs_review",
+        processed_at: null,
+      })
+      insert.run("linked-2", "org-internal", "New", "replacement", "goto-1", null)
       database.prepare(`
         INSERT INTO staff_message_history (
           id, organization_id, record_id, actor_user_id, action, to_status, created_at
@@ -71,7 +137,10 @@ describe("Staff Message Desk migration", () => {
 
 type TestDatabase = {
   readonly exec: (sql: string) => unknown
-  readonly prepare: (sql: string) => { readonly run: (...values: unknown[]) => unknown }
+  readonly prepare: (sql: string) => {
+    readonly run: (...values: unknown[]) => unknown
+    readonly get: (...values: unknown[]) => unknown
+  }
   readonly close: () => void
 }
 

--- a/src/db/__tests__/staff-message-desk-migration.test.ts
+++ b/src/db/__tests__/staff-message-desk-migration.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const migration = readFileSync(
+  resolve(process.cwd(), "drizzle/0109_staff_message_desk.sql"),
+  "utf8"
+).replaceAll("--> statement-breakpoint", "")
+
+describe("Staff Message Desk migration", () => {
+  it("enforces active internal assignees, governed statuses, and immutable history", async () => {
+    const database = await openDatabase()
+    try {
+      database.exec(`
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE organizations (
+          id TEXT PRIMARY KEY,
+          type TEXT NOT NULL,
+          is_active INTEGER NOT NULL
+        );
+        CREATE TABLE users (
+          id TEXT PRIMARY KEY,
+          is_active INTEGER NOT NULL
+        );
+        CREATE TABLE organization_members (
+          id TEXT PRIMARY KEY,
+          organization_id TEXT NOT NULL,
+          user_id TEXT NOT NULL,
+          role TEXT NOT NULL
+        );
+        CREATE TABLE goto_inbound_events (id TEXT PRIMARY KEY);
+        INSERT INTO organizations VALUES ('org-internal', 'internal', 1), ('org-client', 'client', 1);
+        INSERT INTO users VALUES ('staff', 1), ('inactive', 0), ('external', 1);
+        INSERT INTO organization_members VALUES
+          ('member-staff', 'org-internal', 'staff', 'office'),
+          ('member-inactive', 'org-internal', 'inactive', 'office'),
+          ('member-external', 'org-client', 'external', 'client');
+      `)
+      database.exec(migration)
+      const insert = database.prepare(`
+        INSERT INTO staff_message_records (
+          id, organization_id, source_type, caller_name, subject, body,
+          status, assignee_user_id, created_at, updated_at
+        ) VALUES (?, ?, 'call', 'Caller', 'Subject', 'Body', ?, ?, '2026-08-16', '2026-08-16')
+      `)
+      insert.run("record-1", "org-internal", "New", "staff")
+      expect(() =>
+        database.prepare("UPDATE users SET is_active = 0 WHERE id = 'staff'").run()
+      ).toThrow(/Reassign active staff message records/)
+      expect(() => insert.run("record-2", "org-internal", "New", "inactive")).toThrow(
+        /active internal staff assignee/
+      )
+      expect(() => insert.run("record-3", "org-internal", "Not a status", "staff")).toThrow()
+      database.prepare(`
+        INSERT INTO staff_message_history (
+          id, organization_id, record_id, actor_user_id, action, to_status, created_at
+        ) VALUES ('history-1', 'org-internal', 'record-1', 'staff', 'created', 'New', '2026-08-16')
+      `).run()
+      expect(() =>
+        database.prepare("UPDATE staff_message_history SET note = 'tampered' WHERE id = 'history-1'").run()
+      ).toThrow(/immutable/)
+      expect(() =>
+        database.prepare("DELETE FROM staff_message_history WHERE id = 'history-1'").run()
+      ).toThrow(/immutable/)
+    } finally {
+      database.close()
+    }
+  })
+})
+
+type TestDatabase = {
+  readonly exec: (sql: string) => unknown
+  readonly prepare: (sql: string) => { readonly run: (...values: unknown[]) => unknown }
+  readonly close: () => void
+}
+
+type BunDatabaseModule = {
+  readonly Database: new (filename: string) => TestDatabase
+}
+
+function isBunDatabaseModule(value: unknown): value is BunDatabaseModule {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "Database" in value &&
+    typeof value.Database === "function"
+  )
+}
+
+async function openDatabase(): Promise<TestDatabase> {
+  if ("Bun" in globalThis) {
+    const bunSqliteSpecifier = "bun:sqlite"
+    const sqliteModule: unknown = await import(bunSqliteSpecifier)
+    if (!isBunDatabaseModule(sqliteModule)) {
+      throw new Error("bun:sqlite did not provide a Database constructor")
+    }
+    return new sqliteModule.Database(":memory:")
+  }
+  const { default: Database } = await import("better-sqlite3")
+  return new Database(":memory:")
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -6,6 +6,7 @@ import {
   real,
   uniqueIndex,
 } from "drizzle-orm/sqlite-core"
+import { sql } from "drizzle-orm"
 
 // Auth and user management tables
 export const users = sqliteTable("users", {
@@ -756,9 +757,9 @@ export const staffMessageRecords = sqliteTable(
     updatedAt: text("updated_at").notNull(),
   },
   (table) => [
-    uniqueIndex("staff_message_records_goto_event_unique").on(
-      table.gotoInboundEventId
-    ),
+    uniqueIndex("staff_message_records_goto_event_active_unique")
+      .on(table.gotoInboundEventId)
+      .where(sql`${table.gotoInboundEventId} IS NOT NULL AND ${table.deletedAt} IS NULL`),
     index("staff_message_records_org_status_idx").on(
       table.organizationId,
       table.status,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -720,6 +720,92 @@ export const activityEvents = sqliteTable(
 export type ActivityEvent = typeof activityEvents.$inferSelect
 export type NewActivityEvent = typeof activityEvents.$inferInsert
 
+export const staffMessageRecords = sqliteTable(
+  "staff_message_records",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    sourceType: text("source_type").notNull(),
+    gotoInboundEventId: text("goto_inbound_event_id").references(
+      () => gotoInboundEvents.id,
+      { onDelete: "set null" }
+    ),
+    callerName: text("caller_name").notNull(),
+    callerCompany: text("caller_company"),
+    callerPhone: text("caller_phone"),
+    callerEmail: text("caller_email"),
+    subject: text("subject").notNull(),
+    body: text("body").notNull(),
+    status: text("status").notNull().default("New"),
+    assigneeUserId: text("assignee_user_id")
+      .notNull()
+      .references(() => users.id),
+    followUpDueDate: text("follow_up_due_date"),
+    completionOutcome: text("completion_outcome"),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    completedAt: text("completed_at"),
+    deletedAt: text("deleted_at"),
+    deletedBy: text("deleted_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("staff_message_records_goto_event_unique").on(
+      table.gotoInboundEventId
+    ),
+    index("staff_message_records_org_status_idx").on(
+      table.organizationId,
+      table.status,
+      table.updatedAt
+    ),
+    index("staff_message_records_assignee_status_idx").on(
+      table.assigneeUserId,
+      table.status,
+      table.updatedAt
+    ),
+  ]
+)
+
+export const staffMessageHistory = sqliteTable(
+  "staff_message_history",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    recordId: text("record_id")
+      .notNull()
+      .references(() => staffMessageRecords.id, { onDelete: "cascade" }),
+    actorUserId: text("actor_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    action: text("action").notNull(),
+    fromStatus: text("from_status"),
+    toStatus: text("to_status"),
+    fromAssigneeUserId: text("from_assignee_user_id"),
+    toAssigneeUserId: text("to_assignee_user_id"),
+    note: text("note"),
+    metadata: text("metadata"),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    index("staff_message_history_record_created_idx").on(
+      table.recordId,
+      table.createdAt
+    ),
+    index("staff_message_history_org_created_idx").on(
+      table.organizationId,
+      table.createdAt
+    ),
+  ]
+)
+
 export const gotoInboundEvents = sqliteTable(
   "goto_inbound_events",
   {

--- a/src/lib/__tests__/staff-message-desk.test.ts
+++ b/src/lib/__tests__/staff-message-desk.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest"
 import {
   STAFF_MESSAGE_STATUSES,
   canTransitionStaffMessageStatus,
+  archivedStaffMessageGotoEventState,
   isEligibleStaffMessageAssignee,
   isStaffMessageDeskUser,
+  linkedStaffMessageGotoEventState,
   type StaffMessageDeskUser,
 } from "@/lib/staff-message-desk"
 
@@ -86,5 +88,20 @@ describe("Staff Message Desk rules", () => {
     expect(canTransitionStaffMessageStatus("Waiting", "Completed")).toBe(true)
     expect(canTransitionStaffMessageStatus("Completed", "In Progress")).toBe(false)
     expect(canTransitionStaffMessageStatus("New", "Completed")).toBe(false)
+  })
+
+  it("resolves a linked GoTo review event and restores it when archived", () => {
+    expect(linkedStaffMessageGotoEventState("2026-08-17T12:00:00.000Z")).toEqual({
+      status: "processed",
+      reviewReason: null,
+      processedAt: "2026-08-17T12:00:00.000Z",
+      updatedAt: "2026-08-17T12:00:00.000Z",
+    })
+    expect(archivedStaffMessageGotoEventState("2026-08-17T13:00:00.000Z")).toEqual({
+      status: "needs_review",
+      reviewReason: null,
+      processedAt: null,
+      updatedAt: "2026-08-17T13:00:00.000Z",
+    })
   })
 })

--- a/src/lib/__tests__/staff-message-desk.test.ts
+++ b/src/lib/__tests__/staff-message-desk.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  STAFF_MESSAGE_STATUSES,
+  canTransitionStaffMessageStatus,
+  isEligibleStaffMessageAssignee,
+  isStaffMessageDeskUser,
+  type StaffMessageDeskUser,
+} from "@/lib/staff-message-desk"
+
+const internalUser: StaffMessageDeskUser = {
+  id: "user-1",
+  isActive: true,
+  organizationId: "org-internal",
+  organizationType: "internal",
+  role: "office",
+}
+
+describe("Staff Message Desk rules", () => {
+  it("exposes only the governed statuses in workflow order", () => {
+    expect(STAFF_MESSAGE_STATUSES).toEqual([
+      "New",
+      "Assigned",
+      "In Progress",
+      "Waiting",
+      "Completed",
+    ])
+  })
+
+  it("requires an active internal staff user in an active internal organization", () => {
+    expect(isStaffMessageDeskUser(internalUser)).toBe(true)
+    expect(
+      isStaffMessageDeskUser({
+        ...internalUser,
+        isActive: false,
+      })
+    ).toBe(false)
+    expect(
+      isStaffMessageDeskUser({
+        ...internalUser,
+        organizationType: "client",
+      })
+    ).toBe(false)
+    expect(
+      isStaffMessageDeskUser({
+        ...internalUser,
+        role: "developer",
+      })
+    ).toBe(false)
+    expect(
+      isStaffMessageDeskUser({
+        ...internalUser,
+        organizationId: null,
+      })
+    ).toBe(false)
+  })
+
+  it("accepts only active internal staff assignees in the current organization", () => {
+    expect(
+      isEligibleStaffMessageAssignee(internalUser, "org-internal")
+    ).toBe(true)
+    expect(
+      isEligibleStaffMessageAssignee(
+        { ...internalUser, organizationId: "org-other" },
+        "org-internal"
+      )
+    ).toBe(false)
+    expect(
+      isEligibleStaffMessageAssignee(
+        { ...internalUser, role: "client" },
+        "org-internal"
+      )
+    ).toBe(false)
+    expect(
+      isEligibleStaffMessageAssignee(
+        { ...internalUser, isActive: false },
+        "org-internal"
+      )
+    ).toBe(false)
+  })
+
+  it("allows only governed forward status transitions", () => {
+    expect(canTransitionStaffMessageStatus("New", "Assigned")).toBe(true)
+    expect(canTransitionStaffMessageStatus("Assigned", "In Progress")).toBe(true)
+    expect(canTransitionStaffMessageStatus("In Progress", "Waiting")).toBe(true)
+    expect(canTransitionStaffMessageStatus("Waiting", "Completed")).toBe(true)
+    expect(canTransitionStaffMessageStatus("Completed", "In Progress")).toBe(false)
+    expect(canTransitionStaffMessageStatus("New", "Completed")).toBe(false)
+  })
+})

--- a/src/lib/buildertrend/__tests__/legacy-reconciliation.test.ts
+++ b/src/lib/buildertrend/__tests__/legacy-reconciliation.test.ts
@@ -28,11 +28,17 @@ function isTestDatabaseModule(value: unknown): value is TestDatabaseModule {
 }
 
 async function createDatabase(): Promise<TestDatabase> {
-  const sqliteModule: unknown = await import("bun:sqlite")
-  if (!isTestDatabaseModule(sqliteModule)) {
-    throw new Error("bun:sqlite did not provide a Database constructor")
+  if ("Bun" in globalThis) {
+    const bunSqliteSpecifier = "bun:sqlite"
+    const sqliteModule: unknown = await import(bunSqliteSpecifier)
+    if (!isTestDatabaseModule(sqliteModule)) {
+      throw new Error("bun:sqlite did not provide a Database constructor")
+    }
+    return new sqliteModule.Database(":memory:")
   }
-  return new sqliteModule.Database(":memory:")
+
+  const { default: Database } = await import("better-sqlite3")
+  return new Database(":memory:")
 }
 
 const guardedMigrationSql = readFileSync(

--- a/src/lib/staff-message-desk.ts
+++ b/src/lib/staff-message-desk.ts
@@ -10,6 +10,35 @@ export const STAFF_MESSAGE_STATUSES = [
 
 export type StaffMessageStatus = (typeof STAFF_MESSAGE_STATUSES)[number]
 
+export type StaffMessageGotoEventState = Readonly<{
+  readonly status: "needs_review" | "processed"
+  readonly reviewReason: null
+  readonly processedAt: string | null
+  readonly updatedAt: string
+}>
+
+export function linkedStaffMessageGotoEventState(
+  now: string
+): StaffMessageGotoEventState {
+  return {
+    status: "processed",
+    reviewReason: null,
+    processedAt: now,
+    updatedAt: now,
+  }
+}
+
+export function archivedStaffMessageGotoEventState(
+  now: string
+): StaffMessageGotoEventState {
+  return {
+    status: "needs_review",
+    reviewReason: null,
+    processedAt: null,
+    updatedAt: now,
+  }
+}
+
 export type StaffMessageDeskUser = Readonly<{
   readonly id: string
   readonly isActive: boolean

--- a/src/lib/staff-message-desk.ts
+++ b/src/lib/staff-message-desk.ts
@@ -1,0 +1,63 @@
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+export const STAFF_MESSAGE_STATUSES = [
+  "New",
+  "Assigned",
+  "In Progress",
+  "Waiting",
+  "Completed",
+] as const
+
+export type StaffMessageStatus = (typeof STAFF_MESSAGE_STATUSES)[number]
+
+export type StaffMessageDeskUser = Readonly<{
+  readonly id: string
+  readonly isActive: boolean
+  readonly organizationId: string | null
+  readonly organizationType: string | null
+  readonly role: string
+}>
+
+const STATUS_TRANSITIONS: Readonly<
+  Record<StaffMessageStatus, readonly StaffMessageStatus[]>
+> = {
+  New: ["New", "Assigned"],
+  Assigned: ["Assigned", "In Progress", "Waiting"],
+  "In Progress": ["In Progress", "Waiting", "Completed"],
+  Waiting: ["Waiting", "In Progress", "Completed"],
+  Completed: ["Completed"],
+}
+
+export function isStaffMessageDeskUser(
+  user: StaffMessageDeskUser | null
+): boolean {
+  return (
+    user !== null &&
+    user.isActive &&
+    user.organizationId !== null &&
+    user.organizationType === "internal" &&
+    isInternalStaffRole(user.role)
+  )
+}
+
+export function isEligibleStaffMessageAssignee(
+  user: StaffMessageDeskUser,
+  organizationId: string
+): boolean {
+  return (
+    isStaffMessageDeskUser(user) && user.organizationId === organizationId
+  )
+}
+
+export function canTransitionStaffMessageStatus(
+  from: StaffMessageStatus,
+  to: StaffMessageStatus
+): boolean {
+  return STATUS_TRANSITIONS[from].includes(to)
+}
+
+export function isStaffMessageStatus(
+  value: string
+): value is StaffMessageStatus {
+  return (STAFF_MESSAGE_STATUSES as readonly string[]).includes(value)
+}


### PR DESCRIPTION
## Summary
- Add staff-only structured intake for calls and messages with governed statuses, one active internal assignee, due dates, completion outcomes, reassignment rules, and immutable history.
- Add D1 migration 0109 with database assignee/org/user guards, history immutability triggers, and GoTo inbound-text linkage.
- Add assignment notifications, RSC desk route, navigation entry, and Office Maintenance shortcut.
- Repair the Buildertrend reconciliation test SQLite runtime fallback for Bun/Node CI.

## Verification
- `bun test`: 824 passed, 3 skipped
- `bun run lint`: passed (81 pre-existing warnings, 0 errors)
- `bunx tsc --noEmit`: passed
- `bun run build`: passed
- Migration-focused tests: passed

## Review notes
- No live authenticated UI session or external/inactive denial browser evidence was available in this CLI run; those paths are explicitly queued for the independent review child.
- Do not merge, deploy, or run production migrations from this draft PR.