### PR TITLE
feat(warranty): add guarded claim workflow

### DIFF
--- a/docs/wip/buildertrend-project-data-cutover-status-2026-08-15.md
+++ b/docs/wip/buildertrend-project-data-cutover-status-2026-08-15.md
@@ -1,6 +1,6 @@
 # Buildertrend Project-Data Cutover Status
 
-Updated: 2026-08-15
+Updated: 2026-08-17
 
 This public ledger records the technical state and safety requirements of the
 Buildertrend-to-Compass project-data cutover. Client names, project identifiers,
@@ -28,6 +28,12 @@ details are intentionally excluded.
   removing document thumbnails that had been misclassified as photographs after
   confirming the underlying documents remained in Drive.
 - Imported message attachments use non-Buildertrend storage.
+- User-facing imported messages, daily logs, finish selections, and change
+  orders no longer expose Buildertrend provenance URLs. Internal source IDs are
+  retained for deterministic reconciliation.
+- Historical pay-application package links for the two priority active projects
+  now open the verified complete packages in Google Drive.
+- The identified Sage test vendor bill is quarantined from operational queues.
 - Promoted project records have operational IDs, and no orphaned promotion
   pointers were found.
 - Buildertrend provenance remains in internal archive tables as migration
@@ -43,29 +49,27 @@ details are intentionally excluded.
 - The staged-file inventory is otherwise verified. Unresolved records remain
   explicit rather than being silently blanked.
 
-## Remaining operational-link cleanup
+## Operational-link cleanup
 
-Imported content is present, but some user-facing records still include removable
-Buildertrend provenance:
+The guarded cleanup has been applied to production. It removed only removable
+Buildertrend provenance from:
 
 - final-line links in imported project messages;
 - first-line source URLs in imported daily logs;
 - trailing source URLs in historical finish-selection notes; and
 - source-link fields on imported change orders.
 
-Cleanup must remove only the provenance link or footer. It must not alter
-substantive content, source IDs, authors, recipients, statuses, or timestamps. A
-guarded cleanup script passed an exact-count fixture, but production D1 rejects
-raw SQL transaction statements. The cleanup remains unapplied until it can run
-through an atomic D1 batch or transaction boundary.
+The operation ran through D1's atomic file-execution path with a pre-change Time
+Travel bookmark. Substantive content, source IDs, authors, recipients, statuses,
+and timestamps were preserved.
 
 ## Review-gated project-data gaps
 
 - Open imported to-dos remain staged where dates, assignees, hierarchy, or parent
   relationships are incomplete. Blind promotion would create misleading
   duplicate work.
-- Compass does not yet have a dedicated operational warranty-claim model or
-  warranty-claim staging record type.
+- Historical Buildertrend warranty claims still require review-gated capture and
+  promotion into the new Compass warranty workflow.
 - Executed imported change orders need supporting acceptance documents before
   their remaining source references can be removed.
 - Some owner assignments on active or warranty projects are not yet represented
@@ -81,10 +85,9 @@ through an atomic D1 batch or transaction boundary.
   differences that must be reconciled against source packages and Sage.
 - Sage and Google pay-application baselines differ. The records are a
   reconciliation pair, not disposable duplicates.
-- Complete Drive pay-request packages exist for historical applications whose
-  current Compass links open only an individual form. Exact guarded forward and
-  rollback mappings are prepared but remain unapplied pending an atomic execution
-  path.
+- Complete Drive pay-request packages for the priority projects are linked from
+  their historical Compass applications. Remaining projects still require the
+  same exact-file reconciliation.
 - Imported change orders still need cost-code, phase, budget-ledger, and Sage
   mappings before they can drive G703 values.
 - Broader financial cutover requires verified active-project Sage mappings, a
@@ -100,6 +103,22 @@ Do not bulk-promote:
 - claim and dispute archives retained for evidence;
 - verified empty-source markers; and
 - pointer-only historical panorama records.
+
+## Warranty workflow
+
+Compass now has a first-class, project-scoped warranty workflow with:
+
+- owner submissions available only during Warranty or Service project stages;
+- internal status, priority, assignment, visit, resolution, and deletion controls;
+- owner resolution confirmation;
+- project-Drive evidence uploads delivered through protected Compass downloads;
+- owner-safe history separated from internal notes;
+- activity and opt-in notification events; and
+- a dedicated review-gated staging table for historical Buildertrend claims.
+
+The warranty database migration must be applied before the corresponding
+application release. Historical source records will remain review-gated rather
+than being bulk-promoted.
 
 ## Completion criteria
 

--- a/drizzle/0109_warranty_claims.sql
+++ b/drizzle/0109_warranty_claims.sql
@@ -1,0 +1,127 @@
+CREATE TABLE `project_warranty_claims` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `project_id` text NOT NULL,
+  `source_system` text DEFAULT 'compass' NOT NULL,
+  `source_record_id` text,
+  `claim_number` text NOT NULL,
+  `title` text NOT NULL,
+  `location` text,
+  `category` text NOT NULL,
+  `description` text NOT NULL,
+  `priority` text DEFAULT 'normal' NOT NULL,
+  `status` text DEFAULT 'submitted' NOT NULL,
+  `audience` text DEFAULT 'owner' NOT NULL,
+  `promotion_state` text DEFAULT 'actionable' NOT NULL,
+  `claimant_user_id` text,
+  `claimant_name` text NOT NULL,
+  `assigned_user_id` text,
+  `assigned_name` text,
+  `acknowledged_at` text,
+  `scheduled_for` text,
+  `work_started_at` text,
+  `resolved_at` text,
+  `owner_confirmed_at` text,
+  `resolution_summary` text,
+  `internal_notes` text,
+  `created_by` text,
+  `submitted_at` text NOT NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`claimant_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`assigned_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  CHECK (`priority` IN ('low', 'normal', 'high', 'urgent')),
+  CHECK (`status` IN ('submitted', 'acknowledged', 'visit_scheduled', 'in_progress', 'waiting_on_owner', 'resolved', 'closed', 'rejected')),
+  CHECK (`audience` IN ('internal', 'owner')),
+  CHECK (`promotion_state` IN ('actionable', 'review_required', 'archive_only', 'rejected'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `project_warranty_claims_project_number_uq` ON `project_warranty_claims` (`project_id`,`claim_number`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `project_warranty_claims_source_uq` ON `project_warranty_claims` (`organization_id`,`source_system`,`source_record_id`);
+--> statement-breakpoint
+CREATE INDEX `project_warranty_claims_project_status_idx` ON `project_warranty_claims` (`project_id`,`status`,`updated_at`);
+--> statement-breakpoint
+CREATE INDEX `project_warranty_claims_assignee_idx` ON `project_warranty_claims` (`project_id`,`assigned_user_id`,`status`);
+--> statement-breakpoint
+CREATE TABLE `project_warranty_claim_attachments` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `project_id` text NOT NULL,
+  `claim_id` text NOT NULL,
+  `file_name` text NOT NULL,
+  `mime_type` text,
+  `file_size` integer DEFAULT 0 NOT NULL,
+  `storage_provider` text DEFAULT 'google_drive' NOT NULL,
+  `storage_id` text,
+  `storage_url` text,
+  `owner_visible` integer DEFAULT true NOT NULL,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`claim_id`) REFERENCES `project_warranty_claims`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `project_warranty_claim_attachments_claim_idx` ON `project_warranty_claim_attachments` (`claim_id`,`created_at`);
+--> statement-breakpoint
+CREATE INDEX `project_warranty_claim_attachments_project_idx` ON `project_warranty_claim_attachments` (`project_id`);
+--> statement-breakpoint
+CREATE TABLE `project_warranty_claim_events` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `project_id` text NOT NULL,
+  `claim_id` text NOT NULL,
+  `actor_user_id` text,
+  `actor_name` text NOT NULL,
+  `actor_role` text NOT NULL,
+  `event_type` text NOT NULL,
+  `from_status` text,
+  `to_status` text,
+  `note` text,
+  `owner_visible` integer DEFAULT true NOT NULL,
+  `created_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`claim_id`) REFERENCES `project_warranty_claims`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`actor_user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `project_warranty_claim_events_claim_idx` ON `project_warranty_claim_events` (`claim_id`,`created_at`);
+--> statement-breakpoint
+CREATE TABLE `buildertrend_warranty_claim_staging` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `project_id` text,
+  `source_record_id` text NOT NULL,
+  `source_project_id` text,
+  `source_claim_number` text,
+  `title` text NOT NULL,
+  `description` text,
+  `source_status` text,
+  `source_priority` text,
+  `source_created_at` text,
+  `source_updated_at` text,
+  `source_url` text,
+  `raw_payload_json` text NOT NULL,
+  `review_status` text DEFAULT 'needs_review' NOT NULL,
+  `review_notes` text,
+  `promoted_claim_id` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`promoted_claim_id`) REFERENCES `project_warranty_claims`(`id`) ON UPDATE no action ON DELETE set null,
+  CHECK (`review_status` IN ('needs_review', 'approved', 'archive_only', 'rejected', 'promoted'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `buildertrend_warranty_staging_source_uq` ON `buildertrend_warranty_claim_staging` (`organization_id`,`source_record_id`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_warranty_staging_review_idx` ON `buildertrend_warranty_claim_staging` (`organization_id`,`review_status`,`updated_at`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_warranty_staging_project_idx` ON `buildertrend_warranty_claim_staging` (`project_id`);

--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -37,6 +37,7 @@ import {
 import { parsePublishedScheduleSnapshot } from "@/lib/schedule/publications"
 import { projectAudiencePhotoUrl } from "@/lib/photo-sources"
 import { canViewerConfirmScheduleTask } from "@/lib/schedule/confirmation"
+import { isWarrantyProjectStage } from "@/lib/warranty/status"
 
 export type { ProjectAudience } from "@/lib/project-audience-access"
 
@@ -153,6 +154,7 @@ export type ProjectAudiencePreview = {
     readonly clientName: string | null
     readonly projectManager: string | null
     readonly ownerScheduleView: OwnerScheduleView
+    readonly warrantyEnabled: boolean
   }
   readonly ownerUpdates: readonly AudienceOwnerUpdate[]
   readonly photos: readonly AudiencePhoto[]
@@ -271,6 +273,7 @@ export async function getProjectAudiencePreview(
       projectManager: projects.projectManager,
       ownerScheduleView: projects.ownerScheduleView,
       status: projects.status,
+      jobStatusId: projects.jobStatusId,
     })
     .from(projects)
     .where(eq(projects.id, projectId))
@@ -720,6 +723,10 @@ export async function getProjectAudiencePreview(
       clientName: project.clientName,
       projectManager: project.projectManager,
       ownerScheduleView,
+      warrantyEnabled: isWarrantyProjectStage({
+        status: project.status,
+        jobStatusId: project.jobStatusId,
+      }),
     },
     ownerUpdates: ownerUpdateRows,
     photos: photoRows.filter(isImage).map((photo) => {

--- a/src/app/actions/project-warranty.ts
+++ b/src/app/actions/project-warranty.ts
@@ -1,0 +1,707 @@
+"use server"
+
+import { and, asc, desc, eq } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import { projectMembers, projects } from "@/db/schema"
+import {
+  projectWarrantyClaimAttachments,
+  projectWarrantyClaimEvents,
+  projectWarrantyClaims,
+} from "@/db/schema-warranty"
+import { requireAuth } from "@/lib/auth"
+import type { AuthUser } from "@/lib/auth"
+import { recordActivityEvent } from "@/lib/activity-log"
+import { getCloudflareContext } from "@/lib/db"
+import {
+  canFeature,
+  requireFeaturePermission,
+} from "@/lib/permission-enforcement"
+import { assertProjectAccess } from "@/lib/project-access"
+import { canUseProjectAudience } from "@/lib/project-audience-access"
+import { isInternalStaffRole } from "@/lib/user-roles"
+import {
+  notifyWarrantyClaimCreated,
+  notifyWarrantyClaimUpdated,
+} from "@/lib/notifications/events"
+import {
+  canOwnerDeleteWarrantyClaim,
+  isOwnerVisibleWarrantyClaim,
+  isWarrantyProjectStage,
+  warrantyClaimPriority,
+  warrantyClaimStatus,
+} from "@/lib/warranty/status"
+
+export type WarrantyClaimAttachmentItem = {
+  readonly id: string
+  readonly fileName: string
+  readonly mimeType: string | null
+  readonly fileSize: number
+  readonly ownerVisible: boolean
+  readonly downloadHref: string
+}
+
+export type WarrantyClaimEventItem = {
+  readonly id: string
+  readonly actorName: string
+  readonly eventType: string
+  readonly fromStatus: string | null
+  readonly toStatus: string | null
+  readonly note: string | null
+  readonly createdAt: string
+}
+
+export type WarrantyClaimItem = {
+  readonly id: string
+  readonly claimNumber: string
+  readonly title: string
+  readonly location: string | null
+  readonly category: string
+  readonly description: string
+  readonly priority: string
+  readonly status: string
+  readonly claimantUserId: string | null
+  readonly claimantName: string
+  readonly assignedUserId: string | null
+  readonly assignedName: string | null
+  readonly acknowledgedAt: string | null
+  readonly scheduledFor: string | null
+  readonly workStartedAt: string | null
+  readonly resolvedAt: string | null
+  readonly ownerConfirmedAt: string | null
+  readonly resolutionSummary: string | null
+  readonly internalNotes: string | null
+  readonly submittedAt: string
+  readonly updatedAt: string
+  readonly attachments: readonly WarrantyClaimAttachmentItem[]
+  readonly events: readonly WarrantyClaimEventItem[]
+  readonly viewerCanDelete: boolean
+}
+
+export type WarrantyWorkspace = {
+  readonly project: {
+    readonly id: string
+    readonly name: string
+    readonly projectNumber: string | null
+    readonly googleDriveFolderId: string | null
+    readonly warrantyEnabled: boolean
+  }
+  readonly viewerIsInternal: boolean
+  readonly claims: readonly WarrantyClaimItem[]
+}
+
+export type CreateWarrantyClaimInput = {
+  readonly title: string
+  readonly location: string | null
+  readonly category: string
+  readonly description: string
+  readonly priority: string
+  readonly claimantName: string | null
+}
+
+export type UpdateWarrantyClaimInput = {
+  readonly status: string
+  readonly priority: string
+  readonly assignedUserId: string | null
+  readonly assignedName: string | null
+  readonly scheduledFor: string | null
+  readonly resolutionSummary: string | null
+  readonly internalNotes: string | null
+}
+
+type WarrantyActionResult =
+  | { readonly success: true; readonly id: string }
+  | { readonly success: false; readonly error: string }
+
+type WarrantyContext = {
+  readonly db: ReturnType<typeof getDb>
+  readonly user: AuthUser
+  readonly organizationId: string
+  readonly viewerIsInternal: boolean
+  readonly project: {
+    readonly id: string
+    readonly name: string
+    readonly projectNumber: string | null
+    readonly status: string
+    readonly jobStatusId: string
+    readonly googleDriveFolderId: string | null
+  }
+}
+
+function cleanText(value: string | null): string | null {
+  const trimmed = value?.trim() ?? ""
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function requireText(value: string, label: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) throw new Error(`${label} is required.`)
+  return trimmed
+}
+
+function viewerName(user: AuthUser): string {
+  return user.displayName?.trim() || user.email
+}
+
+async function warrantyContext(projectId: string): Promise<WarrantyContext> {
+  const user = await requireAuth()
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const access = await assertProjectAccess(db, user, projectId)
+  if (!access.organizationId) throw new Error("Project organization is missing.")
+
+  const project = await db
+    .select({
+      id: projects.id,
+      name: projects.name,
+      projectNumber: projects.projectNumber,
+      status: projects.status,
+      jobStatusId: projects.jobStatusId,
+      googleDriveFolderId: projects.googleDriveFolderId,
+    })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.id, projectId),
+        eq(projects.organizationId, access.organizationId)
+      )
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  if (!project) throw new Error("Project not found.")
+
+  const viewerIsInternal = isInternalStaffRole(user.role)
+  if (viewerIsInternal) {
+    await requireFeaturePermission(user, "warranty-claims", "read")
+  } else {
+    const membership = await db
+      .select({ role: projectMembers.role })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.projectId, projectId),
+          eq(projectMembers.userId, user.id)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!canUseProjectAudience(membership?.role ?? null, "owner")) {
+      throw new Error("Project not found.")
+    }
+  }
+
+  return {
+    db,
+    user,
+    organizationId: access.organizationId,
+    viewerIsInternal,
+    project,
+  }
+}
+
+function claimNumberFor(
+  projectNumber: string | null,
+  existingCount: number
+): string {
+  const sequence = String(existingCount + 1).padStart(3, "0")
+  return projectNumber
+    ? `${projectNumber}-W-${sequence}`
+    : `WARRANTY-${sequence}`
+}
+
+function claimRevalidationPaths(projectId: string): readonly string[] {
+  return [
+    `/dashboard/projects/${projectId}`,
+    `/dashboard/projects/${projectId}/warranty`,
+    `/preview/projects/${projectId}/owner`,
+    `/preview/projects/${projectId}/owner/warranty`,
+  ]
+}
+
+function revalidateClaimPaths(projectId: string): void {
+  for (const path of claimRevalidationPaths(projectId)) revalidatePath(path)
+}
+
+async function appendClaimEvent(input: {
+  readonly context: WarrantyContext
+  readonly claimId: string
+  readonly eventType: string
+  readonly fromStatus: string | null
+  readonly toStatus: string | null
+  readonly note: string | null
+  readonly ownerVisible: boolean
+  readonly createdAt: string
+}): Promise<void> {
+  await input.context.db.insert(projectWarrantyClaimEvents).values({
+    id: crypto.randomUUID(),
+    organizationId: input.context.organizationId,
+    projectId: input.context.project.id,
+    claimId: input.claimId,
+    actorUserId: input.context.user.id,
+    actorName: viewerName(input.context.user),
+    actorRole: input.context.user.role,
+    eventType: input.eventType,
+    fromStatus: input.fromStatus,
+    toStatus: input.toStatus,
+    note: input.note,
+    ownerVisible: input.ownerVisible,
+    createdAt: input.createdAt,
+  })
+}
+
+export async function getProjectWarrantyWorkspace(
+  projectId: string
+): Promise<WarrantyWorkspace> {
+  const context = await warrantyContext(projectId)
+  const warrantyEnabled = isWarrantyProjectStage(context.project)
+  if (!context.viewerIsInternal && !warrantyEnabled) {
+    throw new Error("Warranty is not open for this project.")
+  }
+
+  const rows = await context.db
+    .select()
+    .from(projectWarrantyClaims)
+    .where(
+      and(
+        eq(projectWarrantyClaims.projectId, projectId),
+        eq(projectWarrantyClaims.organizationId, context.organizationId)
+      )
+    )
+    .orderBy(desc(projectWarrantyClaims.updatedAt), asc(projectWarrantyClaims.claimNumber))
+  const visibleRows = context.viewerIsInternal
+    ? rows
+    : rows.filter(isOwnerVisibleWarrantyClaim)
+  const internalCanDelete = context.viewerIsInternal
+    ? await canFeature(context.user, "warranty-claims", "delete")
+    : false
+  const claimIds = new Set(visibleRows.map((claim) => claim.id))
+
+  const attachmentRows = await context.db
+    .select()
+    .from(projectWarrantyClaimAttachments)
+    .where(eq(projectWarrantyClaimAttachments.projectId, projectId))
+    .orderBy(asc(projectWarrantyClaimAttachments.createdAt))
+  const eventRows = await context.db
+    .select()
+    .from(projectWarrantyClaimEvents)
+    .where(eq(projectWarrantyClaimEvents.projectId, projectId))
+    .orderBy(asc(projectWarrantyClaimEvents.createdAt))
+
+  return {
+    project: {
+      id: context.project.id,
+      name: context.project.name,
+      projectNumber: context.project.projectNumber,
+      googleDriveFolderId: context.project.googleDriveFolderId,
+      warrantyEnabled,
+    },
+    viewerIsInternal: context.viewerIsInternal,
+    claims: visibleRows.map((claim) => ({
+      id: claim.id,
+      claimNumber: claim.claimNumber,
+      title: claim.title,
+      location: claim.location,
+      category: claim.category,
+      description: claim.description,
+      priority: claim.priority,
+      status: claim.status,
+      claimantUserId: claim.claimantUserId,
+      claimantName: claim.claimantName,
+      assignedUserId: claim.assignedUserId,
+      assignedName: claim.assignedName,
+      acknowledgedAt: claim.acknowledgedAt,
+      scheduledFor: claim.scheduledFor,
+      workStartedAt: claim.workStartedAt,
+      resolvedAt: claim.resolvedAt,
+      ownerConfirmedAt: claim.ownerConfirmedAt,
+      resolutionSummary: claim.resolutionSummary,
+      internalNotes: context.viewerIsInternal ? claim.internalNotes : null,
+      submittedAt: claim.submittedAt,
+      updatedAt: claim.updatedAt,
+      attachments: attachmentRows
+        .filter(
+          (attachment) =>
+            attachment.claimId === claim.id &&
+            (context.viewerIsInternal || attachment.ownerVisible)
+        )
+        .map((attachment) => ({
+          id: attachment.id,
+          fileName: attachment.fileName,
+          mimeType: attachment.mimeType,
+          fileSize: attachment.fileSize,
+          ownerVisible: attachment.ownerVisible,
+          downloadHref:
+            `/api/projects/${encodeURIComponent(projectId)}` +
+            `/warranty/${encodeURIComponent(claim.id)}` +
+            `/attachments/${encodeURIComponent(attachment.id)}/download`,
+        })),
+      events: eventRows
+        .filter(
+          (event) =>
+            claimIds.has(event.claimId) &&
+            event.claimId === claim.id &&
+            (context.viewerIsInternal || event.ownerVisible)
+        )
+        .map((event) => ({
+          id: event.id,
+          actorName: event.actorName,
+          eventType: event.eventType,
+          fromStatus: event.fromStatus,
+          toStatus: event.toStatus,
+          note: event.note,
+          createdAt: event.createdAt,
+        })),
+      viewerCanDelete:
+        internalCanDelete ||
+        canOwnerDeleteWarrantyClaim({
+          status: claim.status,
+          claimantUserId: claim.claimantUserId,
+          viewerUserId: context.user.id,
+        }),
+    })),
+  }
+}
+
+export async function createProjectWarrantyClaim(
+  projectId: string,
+  input: CreateWarrantyClaimInput
+): Promise<WarrantyActionResult> {
+  try {
+    const context = await warrantyContext(projectId)
+    if (!context.viewerIsInternal && !isWarrantyProjectStage(context.project)) {
+      return {
+        success: false,
+        error: "Warranty claims are not open for this project yet.",
+      }
+    }
+    if (context.viewerIsInternal) {
+      await requireFeaturePermission(context.user, "warranty-claims", "create")
+    }
+    const priority = warrantyClaimPriority(input.priority)
+    if (!priority) {
+      return { success: false, error: "Choose a valid warranty priority." }
+    }
+
+    const count = await context.db
+      .select({ id: projectWarrantyClaims.id })
+      .from(projectWarrantyClaims)
+      .where(eq(projectWarrantyClaims.projectId, projectId))
+      .then((rows) => rows.length)
+    const now = new Date().toISOString()
+    const id = crypto.randomUUID()
+    const title = requireText(input.title, "Title")
+    const claimantName = context.viewerIsInternal
+      ? cleanText(input.claimantName) ?? viewerName(context.user)
+      : viewerName(context.user)
+
+    await context.db.insert(projectWarrantyClaims).values({
+      id,
+      organizationId: context.organizationId,
+      projectId,
+      claimNumber: claimNumberFor(context.project.projectNumber, count),
+      title,
+      location: cleanText(input.location),
+      category: requireText(input.category, "Category"),
+      description: requireText(input.description, "Description"),
+      priority,
+      status: "submitted",
+      audience: "owner",
+      promotionState: "actionable",
+      claimantUserId: context.viewerIsInternal ? null : context.user.id,
+      claimantName,
+      createdBy: context.user.id,
+      submittedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    })
+    await appendClaimEvent({
+      context,
+      claimId: id,
+      eventType: "claim_submitted",
+      fromStatus: null,
+      toStatus: "submitted",
+      note: null,
+      ownerVisible: true,
+      createdAt: now,
+    })
+    await recordActivityEvent({
+      db: context.db,
+      organizationId: context.organizationId,
+      projectId,
+      actor: context.user,
+      category: "warranty",
+      action: "warranty.claim_submitted",
+      entityType: "warranty_claim",
+      entityId: id,
+      summary: `Submitted warranty claim: ${title}.`,
+      metadata: { priority, externalSubmission: !context.viewerIsInternal },
+    })
+    try {
+      await notifyWarrantyClaimCreated({
+        organizationId: context.organizationId,
+        projectId,
+        claimId: id,
+        claimNumber: claimNumberFor(context.project.projectNumber, count),
+        title,
+        priority,
+        createdBy: context.user,
+      })
+    } catch (notificationError) {
+      console.error("Warranty creation notification failed", notificationError)
+    }
+    revalidateClaimPaths(projectId)
+    return { success: true, id }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to create warranty claim.",
+    }
+  }
+}
+
+export async function updateProjectWarrantyClaim(
+  projectId: string,
+  claimId: string,
+  input: UpdateWarrantyClaimInput
+): Promise<WarrantyActionResult> {
+  try {
+    const context = await warrantyContext(projectId)
+    if (!context.viewerIsInternal) {
+      return { success: false, error: "Staff access is required." }
+    }
+    await requireFeaturePermission(context.user, "warranty-claims", "update")
+    const status = warrantyClaimStatus(input.status)
+    const priority = warrantyClaimPriority(input.priority)
+    if (!status || !priority) {
+      return { success: false, error: "Choose a valid status and priority." }
+    }
+    const existing = await context.db
+      .select()
+      .from(projectWarrantyClaims)
+      .where(
+        and(
+          eq(projectWarrantyClaims.id, claimId),
+          eq(projectWarrantyClaims.projectId, projectId),
+          eq(projectWarrantyClaims.organizationId, context.organizationId)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!existing) return { success: false, error: "Warranty claim not found." }
+
+    const now = new Date().toISOString()
+    await context.db
+      .update(projectWarrantyClaims)
+      .set({
+        status,
+        priority,
+        assignedUserId: cleanText(input.assignedUserId),
+        assignedName: cleanText(input.assignedName),
+        scheduledFor: cleanText(input.scheduledFor),
+        resolutionSummary: cleanText(input.resolutionSummary),
+        internalNotes: cleanText(input.internalNotes),
+        acknowledgedAt:
+          status !== "submitted" ? existing.acknowledgedAt ?? now : null,
+        workStartedAt:
+          status === "in_progress" ? existing.workStartedAt ?? now : existing.workStartedAt,
+        resolvedAt:
+          status === "resolved" || status === "closed"
+            ? existing.resolvedAt ?? now
+            : null,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(projectWarrantyClaims.id, claimId),
+          eq(projectWarrantyClaims.projectId, projectId)
+        )
+      )
+
+    const statusChanged = existing.status !== status
+    await appendClaimEvent({
+      context,
+      claimId,
+      eventType: statusChanged ? "status_changed" : "claim_updated",
+      fromStatus: existing.status,
+      toStatus: status,
+      note: cleanText(input.resolutionSummary),
+      ownerVisible: true,
+      createdAt: now,
+    })
+    await recordActivityEvent({
+      db: context.db,
+      organizationId: context.organizationId,
+      projectId,
+      actor: context.user,
+      category: "warranty",
+      action: statusChanged ? "warranty.status_changed" : "warranty.claim_updated",
+      entityType: "warranty_claim",
+      entityId: claimId,
+      summary: statusChanged
+        ? `Changed ${existing.claimNumber} from ${existing.status} to ${status}.`
+        : `Updated ${existing.claimNumber}.`,
+      metadata: { status, priority },
+    })
+    if (statusChanged) {
+      try {
+        await notifyWarrantyClaimUpdated({
+          organizationId: context.organizationId,
+          projectId,
+          claimId,
+          claimNumber: existing.claimNumber,
+          title: existing.title,
+          status,
+          claimantUserId: existing.claimantUserId,
+          updatedBy: context.user,
+        })
+      } catch (notificationError) {
+        console.error("Warranty update notification failed", notificationError)
+      }
+    }
+    revalidateClaimPaths(projectId)
+    return { success: true, id: claimId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to update warranty claim.",
+    }
+  }
+}
+
+export async function confirmProjectWarrantyResolution(
+  projectId: string,
+  claimId: string
+): Promise<WarrantyActionResult> {
+  try {
+    const context = await warrantyContext(projectId)
+    if (context.viewerIsInternal) {
+      return { success: false, error: "Open the internal claim workspace to close this claim." }
+    }
+    const existing = await context.db
+      .select()
+      .from(projectWarrantyClaims)
+      .where(
+        and(
+          eq(projectWarrantyClaims.id, claimId),
+          eq(projectWarrantyClaims.projectId, projectId),
+          eq(projectWarrantyClaims.organizationId, context.organizationId),
+          eq(projectWarrantyClaims.audience, "owner"),
+          eq(projectWarrantyClaims.promotionState, "actionable")
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!existing || existing.status !== "resolved") {
+      return { success: false, error: "This claim is not ready for confirmation." }
+    }
+    const now = new Date().toISOString()
+    await context.db
+      .update(projectWarrantyClaims)
+      .set({ status: "closed", ownerConfirmedAt: now, updatedAt: now })
+      .where(
+        and(
+          eq(projectWarrantyClaims.id, claimId),
+          eq(projectWarrantyClaims.projectId, projectId)
+        )
+      )
+    await appendClaimEvent({
+      context,
+      claimId,
+      eventType: "owner_confirmed",
+      fromStatus: "resolved",
+      toStatus: "closed",
+      note: "Owner confirmed the warranty resolution.",
+      ownerVisible: true,
+      createdAt: now,
+    })
+    await recordActivityEvent({
+      db: context.db,
+      organizationId: context.organizationId,
+      projectId,
+      actor: context.user,
+      category: "warranty",
+      action: "warranty.owner_confirmed",
+      entityType: "warranty_claim",
+      entityId: claimId,
+      summary: `Confirmed resolution of ${existing.claimNumber}.`,
+    })
+    revalidateClaimPaths(projectId)
+    return { success: true, id: claimId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to confirm resolution.",
+    }
+  }
+}
+
+export async function deleteProjectWarrantyClaim(
+  projectId: string,
+  claimId: string
+): Promise<WarrantyActionResult> {
+  try {
+    const context = await warrantyContext(projectId)
+    const existing = await context.db
+      .select()
+      .from(projectWarrantyClaims)
+      .where(
+        and(
+          eq(projectWarrantyClaims.id, claimId),
+          eq(projectWarrantyClaims.projectId, projectId),
+          eq(projectWarrantyClaims.organizationId, context.organizationId)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!existing) return { success: false, error: "Warranty claim not found." }
+    if (
+      !context.viewerIsInternal &&
+      !canOwnerDeleteWarrantyClaim({
+        status: existing.status,
+        claimantUserId: existing.claimantUserId,
+        viewerUserId: context.user.id,
+      })
+    ) {
+      return {
+        success: false,
+        error: "Only an unacknowledged claim you submitted can be deleted.",
+      }
+    }
+    if (context.viewerIsInternal) {
+      await requireFeaturePermission(context.user, "warranty-claims", "delete")
+    }
+
+    await context.db
+      .delete(projectWarrantyClaims)
+      .where(
+        and(
+          eq(projectWarrantyClaims.id, claimId),
+          eq(projectWarrantyClaims.projectId, projectId)
+        )
+      )
+    await recordActivityEvent({
+      db: context.db,
+      organizationId: context.organizationId,
+      projectId,
+      actor: context.user,
+      category: "warranty",
+      action: "warranty.claim_deleted",
+      entityType: "warranty_claim",
+      entityId: claimId,
+      summary: `Deleted ${existing.claimNumber}: ${existing.title}.`,
+      metadata: { previousStatus: existing.status },
+    })
+    revalidateClaimPaths(projectId)
+    return { success: true, id: claimId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to delete warranty claim.",
+    }
+  }
+}

--- a/src/app/api/projects/[id]/warranty/[claimId]/attachments/[attachmentId]/download/route.ts
+++ b/src/app/api/projects/[id]/warranty/[claimId]/attachments/[attachmentId]/download/route.ts
@@ -1,0 +1,106 @@
+import { and, eq } from "drizzle-orm"
+import { NextRequest } from "next/server"
+
+import { getDb } from "@/db"
+import { projectMembers } from "@/db/schema"
+import {
+  projectWarrantyClaimAttachments,
+  projectWarrantyClaims,
+} from "@/db/schema-warranty"
+import { getCurrentUser } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { assertProjectAccess } from "@/lib/project-access"
+import { canUseProjectAudience } from "@/lib/project-audience-access"
+import { isInternalStaffRole } from "@/lib/user-roles"
+import { getWarrantyDriveContext } from "@/lib/warranty/google-drive"
+import { isOwnerVisibleWarrantyClaim } from "@/lib/warranty/status"
+
+export async function GET(
+  _request: NextRequest,
+  {
+    params,
+  }: {
+    readonly params: Promise<{
+      readonly id: string
+      readonly claimId: string
+      readonly attachmentId: string
+    }>
+  }
+): Promise<Response> {
+  try {
+    const user = await getCurrentUser()
+    if (!user) return new Response("Unauthorized", { status: 401 })
+    const { id: projectId, claimId, attachmentId } = await params
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    await assertProjectAccess(db, user, projectId)
+    const viewerIsInternal = isInternalStaffRole(user.role)
+    if (!viewerIsInternal) {
+      const membership = await db
+        .select({ role: projectMembers.role })
+        .from(projectMembers)
+        .where(
+          and(
+            eq(projectMembers.projectId, projectId),
+            eq(projectMembers.userId, user.id)
+          )
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null)
+      if (!canUseProjectAudience(membership?.role ?? null, "owner")) {
+        return new Response("File not found", { status: 404 })
+      }
+    }
+    const row = await db
+      .select({
+        fileName: projectWarrantyClaimAttachments.fileName,
+        mimeType: projectWarrantyClaimAttachments.mimeType,
+        storageId: projectWarrantyClaimAttachments.storageId,
+        ownerVisible: projectWarrantyClaimAttachments.ownerVisible,
+        audience: projectWarrantyClaims.audience,
+        promotionState: projectWarrantyClaims.promotionState,
+      })
+      .from(projectWarrantyClaimAttachments)
+      .innerJoin(
+        projectWarrantyClaims,
+        eq(projectWarrantyClaims.id, projectWarrantyClaimAttachments.claimId)
+      )
+      .where(
+        and(
+          eq(projectWarrantyClaimAttachments.id, attachmentId),
+          eq(projectWarrantyClaimAttachments.claimId, claimId),
+          eq(projectWarrantyClaimAttachments.projectId, projectId),
+          eq(projectWarrantyClaims.projectId, projectId)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (
+      !row?.storageId ||
+      (!viewerIsInternal &&
+        (!row.ownerVisible || !isOwnerVisibleWarrantyClaim(row)))
+    ) {
+      return new Response("File not found", { status: 404 })
+    }
+    const drive = await getWarrantyDriveContext({
+      db,
+      env,
+      userEmail: user.email,
+      googleEmail: user.googleEmail,
+    })
+    const response = await drive.client.downloadFile(drive.googleEmail, row.storageId)
+    if (!response.ok) {
+      return new Response("Unable to download file", { status: response.status })
+    }
+    return new Response(response.body, {
+      headers: {
+        "Content-Type": row.mimeType ?? "application/octet-stream",
+        "Content-Disposition": `inline; filename="${encodeURIComponent(row.fileName)}"`,
+        "Cache-Control": "private, max-age=300",
+      },
+    })
+  } catch (error) {
+    console.error("Warranty evidence download failed", error)
+    return new Response("File not found", { status: 404 })
+  }
+}

--- a/src/app/api/projects/[id]/warranty/[claimId]/attachments/route.ts
+++ b/src/app/api/projects/[id]/warranty/[claimId]/attachments/route.ts
@@ -1,0 +1,247 @@
+import { and, eq } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+import { NextRequest, NextResponse } from "next/server"
+
+import { getDb } from "@/db"
+import { projectMembers, projects } from "@/db/schema"
+import {
+  projectWarrantyClaimAttachments,
+  projectWarrantyClaims,
+} from "@/db/schema-warranty"
+import { recordActivityEvent } from "@/lib/activity-log"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import { requireFeaturePermission } from "@/lib/permission-enforcement"
+import { assertProjectAccess } from "@/lib/project-access"
+import { canUseProjectAudience } from "@/lib/project-audience-access"
+import {
+  MAX_PHOTO_UPLOAD_BATCH_BYTES,
+  MAX_PHOTO_UPLOAD_FILE_BYTES,
+  PHOTO_UPLOAD_LIMIT_LABEL,
+} from "@/lib/photos/upload-limits"
+import { isInternalStaffRole } from "@/lib/user-roles"
+import {
+  getWarrantyDriveContext,
+  warrantyClaimFolderId,
+} from "@/lib/warranty/google-drive"
+import { isWarrantyProjectStage } from "@/lib/warranty/status"
+
+type UploadResult =
+  | { readonly success: true; readonly uploadedCount: number }
+  | { readonly success: false; readonly error: string }
+
+function isFile(value: FormDataEntryValue): value is File {
+  return typeof value === "object" && value !== null && "arrayBuffer" in value
+}
+
+function safeFileName(value: string): string {
+  const normalized = value.replace(/[/:\\]/g, "-").trim()
+  return normalized || "warranty-evidence"
+}
+
+export async function POST(
+  request: NextRequest,
+  {
+    params,
+  }: {
+    readonly params: Promise<{
+      readonly id: string
+      readonly claimId: string
+    }>
+  }
+): Promise<NextResponse<UploadResult>> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return NextResponse.json(
+        { success: false, error: "Demo mode is read-only." },
+        { status: 403 }
+      )
+    }
+    const { id: projectId, claimId } = await params
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const access = await assertProjectAccess(db, user, projectId)
+    if (!access.organizationId) {
+      return NextResponse.json(
+        { success: false, error: "Project not found." },
+        { status: 404 }
+      )
+    }
+    const project = await db
+      .select({
+        id: projects.id,
+        status: projects.status,
+        jobStatusId: projects.jobStatusId,
+        googleDriveFolderId: projects.googleDriveFolderId,
+      })
+      .from(projects)
+      .where(
+        and(
+          eq(projects.id, projectId),
+          eq(projects.organizationId, access.organizationId)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!project) {
+      return NextResponse.json(
+        { success: false, error: "Project not found." },
+        { status: 404 }
+      )
+    }
+    const viewerIsInternal = isInternalStaffRole(user.role)
+    if (viewerIsInternal) {
+      await requireFeaturePermission(user, "warranty-claims", "update")
+    }
+    if (!viewerIsInternal) {
+      const membership = await db
+        .select({ role: projectMembers.role })
+        .from(projectMembers)
+        .where(
+          and(
+            eq(projectMembers.projectId, projectId),
+            eq(projectMembers.userId, user.id)
+          )
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null)
+      if (
+        !canUseProjectAudience(membership?.role ?? null, "owner") ||
+        !isWarrantyProjectStage(project)
+      ) {
+        return NextResponse.json(
+          { success: false, error: "Warranty uploads are not available." },
+          { status: 403 }
+        )
+      }
+    }
+    const claim = await db
+      .select()
+      .from(projectWarrantyClaims)
+      .where(
+        and(
+          eq(projectWarrantyClaims.id, claimId),
+          eq(projectWarrantyClaims.projectId, projectId),
+          eq(projectWarrantyClaims.organizationId, access.organizationId)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (
+      !claim ||
+      (!viewerIsInternal && claim.claimantUserId !== user.id) ||
+      (!viewerIsInternal && claim.status !== "submitted")
+    ) {
+      return NextResponse.json(
+        { success: false, error: "Warranty claim not found." },
+        { status: 404 }
+      )
+    }
+
+    const formData = await request.formData()
+    const files = formData.getAll("files").filter(isFile)
+    if (files.length === 0) {
+      return NextResponse.json(
+        { success: false, error: "Choose at least one file." },
+        { status: 400 }
+      )
+    }
+    const oversized = files.find((file) => file.size > MAX_PHOTO_UPLOAD_FILE_BYTES)
+    if (oversized) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `${oversized.name} is larger than 50 MB. ${PHOTO_UPLOAD_LIMIT_LABEL}`,
+        },
+        { status: 400 }
+      )
+    }
+    const totalBytes = files.reduce((total, file) => total + file.size, 0)
+    if (totalBytes > MAX_PHOTO_UPLOAD_BATCH_BYTES) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `The selected files exceed the 90 MB batch limit. ${PHOTO_UPLOAD_LIMIT_LABEL}`,
+        },
+        { status: 400 }
+      )
+    }
+
+    const drive = await getWarrantyDriveContext({
+      db,
+      env,
+      userEmail: user.email,
+      googleEmail: user.googleEmail,
+    })
+    const folderId = await warrantyClaimFolderId({
+      db,
+      projectId,
+      mappedProjectFolderId: project.googleDriveFolderId,
+      claimNumber: claim.claimNumber,
+      drive,
+    })
+    const now = new Date().toISOString()
+    for (const file of files) {
+      const mimeType = file.type || "application/octet-stream"
+      const uploaded = await drive.client.uploadFile(drive.googleEmail, {
+        name: safeFileName(file.name),
+        mimeType,
+        parentId: folderId,
+        driveId: drive.driveId ?? undefined,
+        data: file,
+      })
+      await db.insert(projectWarrantyClaimAttachments).values({
+        id: crypto.randomUUID(),
+        organizationId: access.organizationId,
+        projectId,
+        claimId,
+        fileName: uploaded.name,
+        mimeType: uploaded.mimeType,
+        fileSize: Number(uploaded.size ?? file.size),
+        storageProvider: "google_drive",
+        storageId: uploaded.id,
+        storageUrl: uploaded.webViewLink ?? null,
+        ownerVisible: true,
+        createdBy: user.id,
+        createdAt: now,
+        updatedAt: now,
+      })
+    }
+    await db
+      .update(projectWarrantyClaims)
+      .set({ updatedAt: now })
+      .where(
+        and(
+          eq(projectWarrantyClaims.id, claimId),
+          eq(projectWarrantyClaims.projectId, projectId)
+        )
+      )
+    await recordActivityEvent({
+      db,
+      organizationId: access.organizationId,
+      projectId,
+      actor: user,
+      category: "warranty",
+      action: "warranty.evidence_uploaded",
+      entityType: "warranty_claim",
+      entityId: claimId,
+      summary: `Uploaded ${files.length} evidence ${files.length === 1 ? "file" : "files"} to ${claim.claimNumber}.`,
+      metadata: { fileCount: files.length },
+    })
+    revalidatePath(`/dashboard/projects/${projectId}/warranty`)
+    revalidatePath(`/preview/projects/${projectId}/owner/warranty`)
+    return NextResponse.json({ success: true, uploadedCount: files.length })
+  } catch (error) {
+    console.error("Warranty evidence upload failed", error)
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Unable to upload evidence.",
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/dashboard/activity/page.tsx
+++ b/src/app/dashboard/activity/page.tsx
@@ -21,6 +21,7 @@ const CATEGORY_LABELS: Readonly<Record<ActivityCategory, string>> = {
   financial: "Financial",
   presence: "Availability",
   schedule: "Schedule",
+  warranty: "Warranty",
 }
 
 type ActivityPageProps = {

--- a/src/app/dashboard/projects/[id]/warranty/page.tsx
+++ b/src/app/dashboard/projects/[id]/warranty/page.tsx
@@ -1,0 +1,50 @@
+import type * as React from "react"
+import Link from "next/link"
+import { IconArrowLeft } from "@tabler/icons-react"
+
+import { getProjectTaskAssigneeOptions } from "@/app/actions/project-contacts"
+import { getProjectWarrantyWorkspace } from "@/app/actions/project-warranty"
+import { ProjectWarrantyWorkspace } from "@/components/projects/project-warranty-workspace"
+import { Button } from "@/components/ui/button"
+import { redirectIfFeaturePermissionDenied } from "@/lib/permission-redirect"
+
+export const dynamic = "force-dynamic"
+
+export default async function ProjectWarrantyPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  const [workspace, assigneeOptions] = await Promise.all([
+    getProjectWarrantyWorkspace(id),
+    getProjectTaskAssigneeOptions(id),
+  ]).catch((error: unknown) => {
+    redirectIfFeaturePermissionDenied(error)
+    throw error
+  })
+  const assigneeNames = Array.from(
+    new Set(
+      [
+        ...assigneeOptions.projectContacts,
+        ...assigneeOptions.directoryContacts,
+      ].map((option) => option.name.trim()).filter(Boolean)
+    )
+  ).sort((left, right) => left.localeCompare(right))
+
+  return (
+    <main className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6">
+      <Button asChild variant="ghost" size="sm" className="mb-3">
+        <Link href={`/dashboard/projects/${encodeURIComponent(id)}`}>
+          <IconArrowLeft className="size-4" /> Back to project
+        </Link>
+      </Button>
+      <div className="overflow-hidden rounded-lg border">
+        <ProjectWarrantyWorkspace
+          workspace={workspace}
+          assigneeNames={assigneeNames}
+        />
+      </div>
+    </main>
+  )
+}

--- a/src/app/preview/projects/[id]/owner/budget/page.tsx
+++ b/src/app/preview/projects/[id]/owner/budget/page.tsx
@@ -135,6 +135,7 @@ export default async function OwnerBudgetPage({
       viewerIsInternal={preview.viewerIsInternal}
       messageShortcut={messageShortcut}
       activeSection="budget"
+      warrantyEnabled={preview.project.warrantyEnabled}
     >
       <main className="min-h-screen bg-muted/20 px-4 py-5 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-7xl">

--- a/src/app/preview/projects/[id]/owner/updates/[updateId]/page.tsx
+++ b/src/app/preview/projects/[id]/owner/updates/[updateId]/page.tsx
@@ -77,6 +77,7 @@ export default async function OwnerUpdatePreviewPage({
       viewerIsInternal={preview.viewerIsInternal}
       messageShortcut={messageShortcut}
       activeSection="updates"
+      warrantyEnabled={preview.project.warrantyEnabled}
     >
       <OwnerUpdateDocument
         document={document}

--- a/src/app/preview/projects/[id]/owner/warranty/page.tsx
+++ b/src/app/preview/projects/[id]/owner/warranty/page.tsx
@@ -1,0 +1,14 @@
+import type * as React from "react"
+
+import { ProjectAudienceWarranty } from "@/components/projects/project-audience-warranty"
+
+export const dynamic = "force-dynamic"
+
+export default async function OwnerWarrantyPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  return <ProjectAudienceWarranty projectId={id} />
+}

--- a/src/components/nav-projects.tsx
+++ b/src/components/nav-projects.tsx
@@ -21,6 +21,7 @@ import {
   IconShoppingCartQuestion,
   IconUsers,
   IconVideo,
+  IconShieldCheck,
 } from "@tabler/icons-react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
@@ -51,6 +52,7 @@ type ProjectSectionKey =
   | "rfqs"
   | "purchase-orders"
   | "change-orders"
+  | "warranty"
   | "estimate"
   | "budget"
   | "financials"
@@ -145,6 +147,12 @@ const PROJECT_SECTION_ITEMS: readonly ProjectSectionItem[] = [
     section: "change-orders",
   },
   {
+    title: "Warranty",
+    hrefSuffix: "warranty",
+    icon: IconShieldCheck,
+    section: "warranty",
+  },
+  {
     title: "Estimate",
     hrefSuffix: "estimate",
     icon: IconFileDollar,
@@ -233,6 +241,7 @@ function activeProjectSection(pathname: string | null): ProjectSectionKey {
     case "schedule":
     case "todos":
     case "conversations":
+    case "warranty":
       return section
     default:
       return "overview"

--- a/src/components/projects/project-audience-change-orders.tsx
+++ b/src/components/projects/project-audience-change-orders.tsx
@@ -84,6 +84,7 @@ export async function ProjectAudienceChangeOrders({
       viewerIsInternal={preview.viewerIsInternal}
       messageShortcut={messageShortcut}
       activeSection="change-orders"
+      warrantyEnabled={preview.project.warrantyEnabled}
     >
       <main className="min-h-screen bg-muted/20 px-4 py-5 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-6xl">

--- a/src/components/projects/project-audience-conversation.tsx
+++ b/src/components/projects/project-audience-conversation.tsx
@@ -116,6 +116,7 @@ export async function ProjectAudienceConversation({
       messageShortcut={messageShortcut}
       contentMode="viewport"
       activeSection="conversations"
+      warrantyEnabled={preview.project.warrantyEnabled}
     >
       <main className="min-h-0 flex-1 overflow-hidden bg-background">
         <ConversationsProvider>

--- a/src/components/projects/project-audience-preview-shell.tsx
+++ b/src/components/projects/project-audience-preview-shell.tsx
@@ -13,6 +13,7 @@ import {
   IconPhoto,
   IconQuestionMark,
   IconUsers,
+  IconShieldCheck,
 } from "@tabler/icons-react"
 
 import type { AudienceProjectOption } from "@/app/actions/project-audience-preview"
@@ -127,6 +128,12 @@ const SUB_VENDOR_NAVIGATION: readonly PreviewNavigationItem[] = [
   },
 ]
 
+const OWNER_WARRANTY_NAVIGATION: PreviewNavigationItem = {
+  label: "Warranty",
+  section: "warranty",
+  icon: <IconShieldCheck className="size-4" />,
+}
+
 function audienceRoute(audience: ProjectAudience): "owner" | "sub-vendor" {
   return audience === "owner" ? "owner" : "sub-vendor"
 }
@@ -148,6 +155,7 @@ export function ProjectAudiencePreviewShell({
   messageShortcut,
   contentMode = "document",
   activeSection = "overview",
+  warrantyEnabled = false,
   children,
 }: {
   readonly audience: ProjectAudience
@@ -165,12 +173,17 @@ export function ProjectAudiencePreviewShell({
   readonly messageShortcut: ProjectAudienceMessageShortcut | null
   readonly contentMode?: "document" | "viewport"
   readonly activeSection?: ProjectAudienceWorkspaceSection
+  readonly warrantyEnabled?: boolean
   readonly children: React.ReactNode
 }): React.ReactElement {
   const routeAudience = audienceRoute(audience)
   const homeHref = projectAudiencePreviewHref(projectId, routeAudience)
   const navigation =
-    audience === "owner" ? OWNER_NAVIGATION : SUB_VENDOR_NAVIGATION
+    audience === "owner"
+      ? warrantyEnabled
+        ? [...OWNER_NAVIGATION, OWNER_WARRANTY_NAVIGATION]
+        : OWNER_NAVIGATION
+      : SUB_VENDOR_NAVIGATION
 
   return (
     <div

--- a/src/components/projects/project-audience-preview.tsx
+++ b/src/components/projects/project-audience-preview.tsx
@@ -745,6 +745,7 @@ export function ProjectAudiencePreview({
         viewerIsInternal={data.viewerIsInternal}
         messageShortcut={messageShortcut}
         activeSection={section}
+        warrantyEnabled={data.project.warrantyEnabled}
       >
         <OwnerProjectPreview data={data} section={section} />
       </ProjectAudiencePreviewShell>
@@ -762,6 +763,7 @@ export function ProjectAudiencePreview({
       viewerIsInternal={data.viewerIsInternal}
       messageShortcut={messageShortcut}
       activeSection={section}
+      warrantyEnabled={data.project.warrantyEnabled}
     >
       <main className="min-h-screen bg-muted/30">
         <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-4 sm:px-6 lg:px-8">

--- a/src/components/projects/project-audience-warranty.tsx
+++ b/src/components/projects/project-audience-warranty.tsx
@@ -1,0 +1,58 @@
+import type * as React from "react"
+import { notFound } from "next/navigation"
+
+import { getProjectAudiencePreview } from "@/app/actions/project-audience-preview"
+import { getProjectWarrantyWorkspace } from "@/app/actions/project-warranty"
+import { ProjectAudiencePreviewShell } from "@/components/projects/project-audience-preview-shell"
+import { ProjectWarrantyWorkspace } from "@/components/projects/project-warranty-workspace"
+import { projectAudienceMessageShortcut } from "@/lib/project-audience-direct-message"
+
+function hasDigest(error: unknown): error is { readonly digest: string } {
+  return typeof error === "object" && error !== null && "digest" in error
+}
+
+export async function ProjectAudienceWarranty({
+  projectId,
+}: {
+  readonly projectId: string
+}): Promise<React.ReactElement> {
+  let preview: Awaited<ReturnType<typeof getProjectAudiencePreview>>
+  let workspace: Awaited<ReturnType<typeof getProjectWarrantyWorkspace>>
+  try {
+    ;[preview, workspace] = await Promise.all([
+      getProjectAudiencePreview(projectId, "owner"),
+      getProjectWarrantyWorkspace(projectId),
+    ])
+  } catch (error) {
+    if (hasDigest(error) && error.digest === "NEXT_NOT_FOUND") throw error
+    notFound()
+  }
+  const messageShortcut = projectAudienceMessageShortcut({
+    projectId: preview.project.id,
+    audience: preview.audience,
+    viewerId: preview.viewer.id,
+    contacts: preview.contacts,
+    messageChannels: preview.messageChannels,
+  })
+
+  return (
+    <ProjectAudiencePreviewShell
+      audience="owner"
+      projectId={preview.project.id}
+      projectName={preview.project.name}
+      projectNumber={preview.project.projectNumber}
+      projectOptions={preview.projectOptions}
+      viewer={preview.viewer}
+      viewerIsInternal={preview.viewerIsInternal}
+      messageShortcut={messageShortcut}
+      activeSection="warranty"
+      warrantyEnabled={workspace.project.warrantyEnabled}
+    >
+      <main className="min-h-screen bg-[oklch(0.96_0.018_115)] px-4 py-4 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-6xl overflow-hidden rounded-lg border">
+          <ProjectWarrantyWorkspace workspace={workspace} />
+        </div>
+      </main>
+    </ProjectAudiencePreviewShell>
+  )
+}

--- a/src/components/projects/project-warranty-workspace.tsx
+++ b/src/components/projects/project-warranty-workspace.tsx
@@ -1,0 +1,472 @@
+"use client"
+
+import * as React from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import {
+  IconCalendarEvent,
+  IconCheck,
+  IconDownload,
+  IconHistory,
+  IconPaperclip,
+  IconPlus,
+  IconShieldCheck,
+  IconTrash,
+} from "@tabler/icons-react"
+
+import {
+  confirmProjectWarrantyResolution,
+  createProjectWarrantyClaim,
+  deleteProjectWarrantyClaim,
+  updateProjectWarrantyClaim,
+  type WarrantyClaimItem,
+  type WarrantyWorkspace,
+} from "@/app/actions/project-warranty"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  WARRANTY_CLAIM_PRIORITIES,
+  WARRANTY_CLAIM_STATUSES,
+} from "@/lib/warranty/status"
+
+const CATEGORIES = [
+  "Exterior",
+  "Interior",
+  "Electrical",
+  "Plumbing",
+  "HVAC",
+  "Appliance",
+  "Finish",
+  "Site / drainage",
+  "Other",
+] as const
+
+function formText(formData: FormData, name: string): string {
+  const value = formData.get(name)
+  return typeof value === "string" ? value : ""
+}
+
+function optionalText(value: string): string | null {
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
+
+function label(value: string): string {
+  return value
+    .split("_")
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ")
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "Not scheduled"
+  return new Date(value).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })
+}
+
+function ClaimCreateSheet({
+  projectId,
+  viewerIsInternal,
+}: {
+  readonly projectId: string
+  readonly viewerIsInternal: boolean
+}): React.ReactElement {
+  const router = useRouter()
+  const formRef = React.useRef<HTMLFormElement>(null)
+  const [open, setOpen] = React.useState(false)
+  const [submitting, setSubmitting] = React.useState(false)
+  const [message, setMessage] = React.useState<string | null>(null)
+  const [files, setFiles] = React.useState<readonly File[]>([])
+
+  async function handleSubmit(
+    event: React.FormEvent<HTMLFormElement>
+  ): Promise<void> {
+    event.preventDefault()
+    const form = formRef.current
+    if (!form) return
+    setSubmitting(true)
+    setMessage(null)
+    try {
+      const data = new FormData(form)
+      const result = await createProjectWarrantyClaim(projectId, {
+        title: formText(data, "title"),
+        location: optionalText(formText(data, "location")),
+        category: formText(data, "category"),
+        description: formText(data, "description"),
+        priority: formText(data, "priority"),
+        claimantName: optionalText(formText(data, "claimantName")),
+      })
+      if (!result.success) throw new Error(result.error)
+
+      if (files.length > 0) {
+        const uploadData = new FormData()
+        for (const file of files) uploadData.append("files", file)
+        const response = await fetch(
+          `/api/projects/${encodeURIComponent(projectId)}/warranty/${encodeURIComponent(result.id)}/attachments`,
+          { method: "POST", body: uploadData }
+        )
+        const uploadResult: unknown = await response.json()
+        if (
+          !response.ok ||
+          typeof uploadResult !== "object" ||
+          uploadResult === null ||
+          Reflect.get(uploadResult, "success") !== true
+        ) {
+          const error =
+            typeof uploadResult === "object" &&
+            uploadResult !== null &&
+            typeof Reflect.get(uploadResult, "error") === "string"
+              ? Reflect.get(uploadResult, "error")
+              : "Evidence upload failed."
+          throw new Error(
+            `The claim was saved, but its evidence did not upload: ${error}`
+          )
+        }
+      }
+
+      form.reset()
+      setFiles([])
+      setOpen(false)
+      router.refresh()
+    } catch (error) {
+      setMessage(
+        error instanceof Error ? error.message : "Unable to submit warranty claim."
+      )
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button>
+          <IconPlus className="size-4" />
+          New warranty claim
+        </Button>
+      </SheetTrigger>
+      <SheetContent className="w-[min(96vw,720px)] overflow-y-auto sm:max-w-none">
+        <SheetHeader className="border-b px-5 py-4">
+          <SheetTitle>New warranty claim</SheetTitle>
+          <SheetDescription>
+            Record the location, issue, urgency, and supporting photos, video,
+            or documents.
+          </SheetDescription>
+        </SheetHeader>
+        <form ref={formRef} onSubmit={handleSubmit} className="space-y-4 px-5 pb-6">
+          <Input name="title" placeholder="Short issue title" required />
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Input name="location" placeholder="Location (room or area)" />
+            <select
+              name="category"
+              defaultValue=""
+              required
+              className="flex h-9 w-full rounded-md border bg-background px-3 text-sm"
+            >
+              <option value="" disabled>Choose category</option>
+              {CATEGORIES.map((category) => (
+                <option key={category} value={category}>{category}</option>
+              ))}
+            </select>
+          </div>
+          <Textarea
+            name="description"
+            placeholder="Describe what is happening and when you first noticed it"
+            className="min-h-32"
+            required
+          />
+          <div className="grid gap-3 sm:grid-cols-2">
+            <select
+              name="priority"
+              defaultValue="normal"
+              className="flex h-9 w-full rounded-md border bg-background px-3 text-sm"
+            >
+              {WARRANTY_CLAIM_PRIORITIES.map((priority) => (
+                <option key={priority} value={priority}>{label(priority)} priority</option>
+              ))}
+            </select>
+            {viewerIsInternal && (
+              <Input name="claimantName" placeholder="Owner / claimant name" />
+            )}
+          </div>
+          <div className="border-t pt-4">
+            <label className="flex items-start gap-2 text-sm font-medium">
+              <IconPaperclip className="mt-0.5 size-4" />
+              <span>
+                Evidence files
+                <span className="mt-1 block text-xs font-normal text-muted-foreground">
+                  Images, video, PDFs, and documents; 50 MB each and 90 MB per batch.
+                </span>
+              </span>
+            </label>
+            <Input
+              type="file"
+              multiple
+              accept="image/*,video/*,.pdf,.doc,.docx,.txt"
+              className="mt-3"
+              onChange={(event) =>
+                setFiles(event.currentTarget.files ? Array.from(event.currentTarget.files) : [])
+              }
+            />
+            {files.length > 0 && (
+              <p className="mt-2 text-xs text-muted-foreground">
+                {files.length} {files.length === 1 ? "file" : "files"} selected
+              </p>
+            )}
+          </div>
+          {message && (
+            <p role="alert" className="border-l-2 border-destructive px-3 text-sm text-destructive">
+              {message}
+            </p>
+          )}
+          <div className="flex justify-end">
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Submitting…" : "Submit claim"}
+            </Button>
+          </div>
+        </form>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+function ClaimActions({
+  projectId,
+  claim,
+  viewerIsInternal,
+  assigneeNames,
+}: {
+  readonly projectId: string
+  readonly claim: WarrantyClaimItem
+  readonly viewerIsInternal: boolean
+  readonly assigneeNames: readonly string[]
+}): React.ReactElement {
+  const router = useRouter()
+  const [message, setMessage] = React.useState<string | null>(null)
+  const [submitting, startTransition] = React.useTransition()
+
+  function handleUpdate(formData: FormData): void {
+    startTransition(async () => {
+      const assignedName = optionalText(formText(formData, "assignedName"))
+      const result = await updateProjectWarrantyClaim(projectId, claim.id, {
+        status: formText(formData, "status"),
+        priority: formText(formData, "priority"),
+        assignedUserId: null,
+        assignedName,
+        scheduledFor: optionalText(formText(formData, "scheduledFor")),
+        resolutionSummary: optionalText(formText(formData, "resolutionSummary")),
+        internalNotes: optionalText(formText(formData, "internalNotes")),
+      })
+      setMessage(result.success ? "Claim updated." : result.error)
+      if (result.success) router.refresh()
+    })
+  }
+
+  function handleConfirm(): void {
+    startTransition(async () => {
+      const result = await confirmProjectWarrantyResolution(projectId, claim.id)
+      setMessage(result.success ? "Resolution confirmed." : result.error)
+      if (result.success) router.refresh()
+    })
+  }
+
+  function handleDelete(): void {
+    if (!window.confirm(`Delete ${claim.claimNumber}? This cannot be undone.`)) return
+    startTransition(async () => {
+      const result = await deleteProjectWarrantyClaim(projectId, claim.id)
+      setMessage(result.success ? "Claim deleted." : result.error)
+      if (result.success) router.refresh()
+    })
+  }
+
+  if (viewerIsInternal) {
+    return (
+      <form action={handleUpdate} className="mt-4 space-y-3 border-t pt-4">
+        <div className="grid gap-3 md:grid-cols-3">
+          <label className="space-y-1 text-xs font-medium text-muted-foreground">
+            Status
+            <select name="status" defaultValue={claim.status} className="flex h-9 w-full rounded-md border bg-background px-3 text-sm text-foreground">
+              {WARRANTY_CLAIM_STATUSES.map((status) => (
+                <option key={status} value={status}>{label(status)}</option>
+              ))}
+            </select>
+          </label>
+          <label className="space-y-1 text-xs font-medium text-muted-foreground">
+            Priority
+            <select name="priority" defaultValue={claim.priority} className="flex h-9 w-full rounded-md border bg-background px-3 text-sm text-foreground">
+              {WARRANTY_CLAIM_PRIORITIES.map((priority) => (
+                <option key={priority} value={priority}>{label(priority)}</option>
+              ))}
+            </select>
+          </label>
+          <label className="space-y-1 text-xs font-medium text-muted-foreground">
+            Assigned to
+            <select name="assignedName" defaultValue={claim.assignedName ?? ""} className="flex h-9 w-full rounded-md border bg-background px-3 text-sm text-foreground">
+              <option value="">Unassigned</option>
+              {assigneeNames.map((name) => <option key={name} value={name}>{name}</option>)}
+            </select>
+          </label>
+        </div>
+        <label className="space-y-1 text-xs font-medium text-muted-foreground">
+          Visit / work date
+          <Input name="scheduledFor" type="datetime-local" defaultValue={claim.scheduledFor?.slice(0, 16) ?? ""} className="text-foreground" />
+        </label>
+        <Textarea name="resolutionSummary" defaultValue={claim.resolutionSummary ?? ""} placeholder="Owner-visible resolution or progress note" />
+        <Textarea name="internalNotes" defaultValue={claim.internalNotes ?? ""} placeholder="Internal notes (never shown to owners)" />
+        {message && <p className="text-xs text-muted-foreground">{message}</p>}
+        <div className="flex flex-wrap justify-end gap-2">
+          {claim.viewerCanDelete && (
+            <Button type="button" variant="outline" onClick={handleDelete} disabled={submitting}>
+              <IconTrash className="size-4" /> Delete
+            </Button>
+          )}
+          <Button type="submit" disabled={submitting}>{submitting ? "Saving…" : "Save"}</Button>
+        </div>
+      </form>
+    )
+  }
+
+  return (
+    <div className="mt-4 flex flex-wrap items-center justify-end gap-2 border-t pt-4">
+      {message && <p className="mr-auto text-xs text-muted-foreground">{message}</p>}
+      {claim.status === "resolved" && (
+        <Button onClick={handleConfirm} disabled={submitting}>
+          <IconCheck className="size-4" /> Confirm resolution
+        </Button>
+      )}
+      {claim.viewerCanDelete && (
+        <Button variant="outline" onClick={handleDelete} disabled={submitting}>
+          <IconTrash className="size-4" /> Withdraw claim
+        </Button>
+      )}
+    </div>
+  )
+}
+
+function ClaimRow({
+  projectId,
+  claim,
+  viewerIsInternal,
+  assigneeNames,
+}: {
+  readonly projectId: string
+  readonly claim: WarrantyClaimItem
+  readonly viewerIsInternal: boolean
+  readonly assigneeNames: readonly string[]
+}): React.ReactElement {
+  return (
+    <article id={`warranty-${claim.id}`} className="border-b py-5 last:border-b-0">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-medium text-muted-foreground">{claim.claimNumber}</p>
+          <h2 className="mt-1 text-lg font-semibold">{claim.title}</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {[claim.location, claim.category, `Submitted by ${claim.claimantName}`].filter(Boolean).join(" · ")}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Badge variant={claim.priority === "urgent" || claim.priority === "high" ? "destructive" : "outline"}>{label(claim.priority)}</Badge>
+          <Badge variant={claim.status === "closed" ? "outline" : "secondary"}>{label(claim.status)}</Badge>
+        </div>
+      </div>
+      <p className="mt-4 whitespace-pre-wrap text-sm leading-6">{claim.description}</p>
+      <div className="mt-4 grid gap-2 text-xs text-muted-foreground sm:grid-cols-3">
+        <p><IconCalendarEvent className="mr-1 inline size-4" />Visit: {formatDate(claim.scheduledFor)}</p>
+        <p>Assigned: {claim.assignedName ?? "Not assigned"}</p>
+        <p>Updated: {formatDate(claim.updatedAt)}</p>
+      </div>
+      {claim.resolutionSummary && (
+        <div className="mt-4 border-l-2 border-primary pl-3">
+          <p className="text-xs font-medium uppercase text-muted-foreground">Resolution / progress</p>
+          <p className="mt-1 whitespace-pre-wrap text-sm">{claim.resolutionSummary}</p>
+        </div>
+      )}
+      {claim.attachments.length > 0 && (
+        <div className="mt-4">
+          <p className="flex items-center gap-2 text-xs font-medium uppercase text-muted-foreground"><IconPaperclip className="size-4" />Evidence</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {claim.attachments.map((attachment) => (
+              <Button key={attachment.id} asChild variant="outline" size="sm">
+                <Link href={attachment.downloadHref} target="_blank">
+                  <IconDownload className="size-4" />{attachment.fileName}
+                </Link>
+              </Button>
+            ))}
+          </div>
+        </div>
+      )}
+      {claim.events.length > 0 && (
+        <details className="mt-4 text-sm">
+          <summary className="flex cursor-pointer items-center gap-2 text-xs font-medium text-muted-foreground"><IconHistory className="size-4" />Activity history ({claim.events.length})</summary>
+          <ol className="mt-3 space-y-2 border-l pl-4">
+            {claim.events.map((event) => (
+              <li key={event.id}>
+                <p className="text-xs">{label(event.eventType)} · {event.actorName} · {formatDate(event.createdAt)}</p>
+                {event.note && <p className="mt-1 text-xs text-muted-foreground">{event.note}</p>}
+              </li>
+            ))}
+          </ol>
+        </details>
+      )}
+      <ClaimActions projectId={projectId} claim={claim} viewerIsInternal={viewerIsInternal} assigneeNames={assigneeNames} />
+    </article>
+  )
+}
+
+export function ProjectWarrantyWorkspace({
+  workspace,
+  assigneeNames = [],
+}: {
+  readonly workspace: WarrantyWorkspace
+  readonly assigneeNames?: readonly string[]
+}): React.ReactElement {
+  return (
+    <section className="bg-background">
+      <div className="flex flex-wrap items-start justify-between gap-4 border-b px-4 py-5 sm:px-6">
+        <div>
+          <div className="flex items-center gap-2">
+            <IconShieldCheck className="size-5 text-muted-foreground" />
+            <h1 className="text-2xl font-semibold">Warranty claims</h1>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Submit issues, attach evidence, schedule visits, and track resolution.
+          </p>
+        </div>
+        <ClaimCreateSheet projectId={workspace.project.id} viewerIsInternal={workspace.viewerIsInternal} />
+      </div>
+      {!workspace.project.warrantyEnabled && workspace.viewerIsInternal && (
+        <p className="border-b bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:bg-amber-950 dark:text-amber-50 sm:px-6">
+          Staff can prepare claims, but the owner workspace remains hidden until this project enters Warranty or Service status.
+        </p>
+      )}
+      <div className="px-4 sm:px-6">
+        {workspace.claims.length > 0 ? (
+          workspace.claims.map((claim) => (
+            <ClaimRow key={claim.id} projectId={workspace.project.id} claim={claim} viewerIsInternal={workspace.viewerIsInternal} assigneeNames={assigneeNames} />
+          ))
+        ) : (
+          <div className="py-16 text-center">
+            <IconShieldCheck className="mx-auto size-8 text-muted-foreground" />
+            <p className="mt-3 font-medium">No warranty claims yet</p>
+            <p className="mt-1 text-sm text-muted-foreground">New submissions will appear here with their complete history.</p>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -14,6 +14,7 @@ import * as sageSchema from "./schema-sage"
 import * as buildertrendSchema from "./schema-buildertrend"
 import * as estimatesSchema from "./schema-estimates"
 import * as templateSchema from "./schema-templates"
+import * as warrantySchema from "./schema-warranty"
 
 const allSchemas = {
   ...schema,
@@ -31,6 +32,7 @@ const allSchemas = {
   ...buildertrendSchema,
   ...estimatesSchema,
   ...templateSchema,
+  ...warrantySchema,
 }
 
 // Legacy function - kept for backwards compatibility

--- a/src/db/schema-warranty.ts
+++ b/src/db/schema-warranty.ts
@@ -1,0 +1,194 @@
+import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core"
+
+import { organizations, projects, users } from "./schema"
+
+export const projectWarrantyClaims = sqliteTable(
+  "project_warranty_claims",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    sourceSystem: text("source_system").notNull().default("compass"),
+    sourceRecordId: text("source_record_id"),
+    claimNumber: text("claim_number").notNull(),
+    title: text("title").notNull(),
+    location: text("location"),
+    category: text("category").notNull(),
+    description: text("description").notNull(),
+    priority: text("priority").notNull().default("normal"),
+    status: text("status").notNull().default("submitted"),
+    audience: text("audience").notNull().default("owner"),
+    promotionState: text("promotion_state").notNull().default("actionable"),
+    claimantUserId: text("claimant_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    claimantName: text("claimant_name").notNull(),
+    assignedUserId: text("assigned_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    assignedName: text("assigned_name"),
+    acknowledgedAt: text("acknowledged_at"),
+    scheduledFor: text("scheduled_for"),
+    workStartedAt: text("work_started_at"),
+    resolvedAt: text("resolved_at"),
+    ownerConfirmedAt: text("owner_confirmed_at"),
+    resolutionSummary: text("resolution_summary"),
+    internalNotes: text("internal_notes"),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    submittedAt: text("submitted_at").notNull(),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("project_warranty_claims_project_number_uq").on(
+      table.projectId,
+      table.claimNumber
+    ),
+    uniqueIndex("project_warranty_claims_source_uq").on(
+      table.organizationId,
+      table.sourceSystem,
+      table.sourceRecordId
+    ),
+    index("project_warranty_claims_project_status_idx").on(
+      table.projectId,
+      table.status,
+      table.updatedAt
+    ),
+    index("project_warranty_claims_assignee_idx").on(
+      table.projectId,
+      table.assignedUserId,
+      table.status
+    ),
+  ]
+)
+
+export const projectWarrantyClaimAttachments = sqliteTable(
+  "project_warranty_claim_attachments",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    claimId: text("claim_id")
+      .notNull()
+      .references(() => projectWarrantyClaims.id, { onDelete: "cascade" }),
+    fileName: text("file_name").notNull(),
+    mimeType: text("mime_type"),
+    fileSize: integer("file_size").notNull().default(0),
+    storageProvider: text("storage_provider").notNull().default("google_drive"),
+    storageId: text("storage_id"),
+    storageUrl: text("storage_url"),
+    ownerVisible: integer("owner_visible", { mode: "boolean" })
+      .notNull()
+      .default(true),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    index("project_warranty_claim_attachments_claim_idx").on(
+      table.claimId,
+      table.createdAt
+    ),
+    index("project_warranty_claim_attachments_project_idx").on(table.projectId),
+  ]
+)
+
+export const projectWarrantyClaimEvents = sqliteTable(
+  "project_warranty_claim_events",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    claimId: text("claim_id")
+      .notNull()
+      .references(() => projectWarrantyClaims.id, { onDelete: "cascade" }),
+    actorUserId: text("actor_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    actorName: text("actor_name").notNull(),
+    actorRole: text("actor_role").notNull(),
+    eventType: text("event_type").notNull(),
+    fromStatus: text("from_status"),
+    toStatus: text("to_status"),
+    note: text("note"),
+    ownerVisible: integer("owner_visible", { mode: "boolean" })
+      .notNull()
+      .default(true),
+    createdAt: text("created_at").notNull(),
+  },
+  (table) => [
+    index("project_warranty_claim_events_claim_idx").on(
+      table.claimId,
+      table.createdAt
+    ),
+  ]
+)
+
+export const buildertrendWarrantyClaimStaging = sqliteTable(
+  "buildertrend_warranty_claim_staging",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id").references(() => projects.id, {
+      onDelete: "set null",
+    }),
+    sourceRecordId: text("source_record_id").notNull(),
+    sourceProjectId: text("source_project_id"),
+    sourceClaimNumber: text("source_claim_number"),
+    title: text("title").notNull(),
+    description: text("description"),
+    sourceStatus: text("source_status"),
+    sourcePriority: text("source_priority"),
+    sourceCreatedAt: text("source_created_at"),
+    sourceUpdatedAt: text("source_updated_at"),
+    sourceUrl: text("source_url"),
+    rawPayloadJson: text("raw_payload_json").notNull(),
+    reviewStatus: text("review_status").notNull().default("needs_review"),
+    reviewNotes: text("review_notes"),
+    promotedClaimId: text("promoted_claim_id").references(
+      () => projectWarrantyClaims.id,
+      { onDelete: "set null" }
+    ),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("buildertrend_warranty_staging_source_uq").on(
+      table.organizationId,
+      table.sourceRecordId
+    ),
+    index("buildertrend_warranty_staging_review_idx").on(
+      table.organizationId,
+      table.reviewStatus,
+      table.updatedAt
+    ),
+    index("buildertrend_warranty_staging_project_idx").on(table.projectId),
+  ]
+)
+
+export type ProjectWarrantyClaim = typeof projectWarrantyClaims.$inferSelect
+export type NewProjectWarrantyClaim = typeof projectWarrantyClaims.$inferInsert
+export type ProjectWarrantyClaimAttachment =
+  typeof projectWarrantyClaimAttachments.$inferSelect
+export type ProjectWarrantyClaimEvent =
+  typeof projectWarrantyClaimEvents.$inferSelect
+export type BuildertrendWarrantyClaimStaging =
+  typeof buildertrendWarrantyClaimStaging.$inferSelect

--- a/src/lib/activity-log.ts
+++ b/src/lib/activity-log.ts
@@ -10,6 +10,7 @@ export const ACTIVITY_CATEGORIES = [
   "financial",
   "presence",
   "schedule",
+  "warranty",
 ] as const
 
 export type ActivityCategory = (typeof ACTIVITY_CATEGORIES)[number]

--- a/src/lib/buildertrend/__tests__/legacy-reconciliation.test.ts
+++ b/src/lib/buildertrend/__tests__/legacy-reconciliation.test.ts
@@ -28,11 +28,17 @@ function isTestDatabaseModule(value: unknown): value is TestDatabaseModule {
 }
 
 async function createDatabase(): Promise<TestDatabase> {
-  const sqliteModule: unknown = await import("bun:sqlite")
-  if (!isTestDatabaseModule(sqliteModule)) {
-    throw new Error("bun:sqlite did not provide a Database constructor")
+  if ("Bun" in globalThis) {
+    const bunSqliteSpecifier = "bun:sqlite"
+    const sqliteModule: unknown = await import(bunSqliteSpecifier)
+    if (!isTestDatabaseModule(sqliteModule)) {
+      throw new Error("bun:sqlite did not provide a Database constructor")
+    }
+    return new sqliteModule.Database(":memory:")
   }
-  return new sqliteModule.Database(":memory:")
+
+  const { default: Database } = await import("better-sqlite3")
+  return new Database(":memory:")
 }
 
 const guardedMigrationSql = readFileSync(

--- a/src/lib/notifications/__tests__/sms-policy.test.ts
+++ b/src/lib/notifications/__tests__/sms-policy.test.ts
@@ -45,6 +45,23 @@ describe("SMS notification policy", () => {
     ).toBe(false)
   })
 
+  it("routes live warranty updates through project activity consent", () => {
+    expect(
+      shouldSendSmsNotification(ENABLED_PREFERENCES, {
+        eventType: "warranty.updated",
+        createdBy: "project-manager",
+        occurredAt: new Date("2026-07-30T18:00:00.000Z"),
+      })
+    ).toBe(true)
+    expect(
+      shouldSendSmsNotification(ENABLED_PREFERENCES, {
+        eventType: "warranty.created",
+        createdBy: null,
+        occurredAt: new Date("2026-07-30T18:00:00.000Z"),
+      })
+    ).toBe(false)
+  })
+
   it("requires current consent and the matching category preference", () => {
     expect(
       shouldSendSmsNotification(

--- a/src/lib/notifications/events.ts
+++ b/src/lib/notifications/events.ts
@@ -4,6 +4,7 @@ import { getDb } from "@/db"
 import {
   organizationMembers,
   projectContacts,
+  projectMembers,
   projects,
   users,
 } from "@/db/schema"
@@ -18,6 +19,7 @@ import {
   channelNotificationRecipients,
   type ChannelMessageMention,
 } from "@/lib/notifications/audience"
+import { isInternalStaffRole } from "@/lib/user-roles"
 
 export {
   createNotificationEvent,
@@ -70,6 +72,27 @@ type ChannelMessageNotificationInput = {
   readonly content: string
   readonly sender: AuthUser
   readonly mentions: readonly ChannelMessageMention[]
+}
+
+type WarrantyCreatedNotificationInput = {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly claimId: string
+  readonly claimNumber: string
+  readonly title: string
+  readonly priority: string
+  readonly createdBy: AuthUser
+}
+
+type WarrantyUpdatedNotificationInput = {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly claimId: string
+  readonly claimNumber: string
+  readonly title: string
+  readonly status: string
+  readonly claimantUserId: string | null
+  readonly updatedBy: AuthUser
 }
 
 function normalizeName(value: string | null): string {
@@ -390,5 +413,98 @@ export async function notifyProjectAssignment(
       email: true,
       push: true,
     },
+  })
+}
+
+export async function notifyWarrantyClaimCreated(
+  input: WarrantyCreatedNotificationInput
+): Promise<void> {
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const members = await db
+    .select({
+      userId: users.id,
+      email: users.email,
+      googleEmail: users.googleEmail,
+      role: users.role,
+    })
+    .from(projectMembers)
+    .innerJoin(users, eq(users.id, projectMembers.userId))
+    .where(
+      and(
+        eq(projectMembers.projectId, input.projectId),
+        eq(users.isActive, true)
+      )
+    )
+  const recipients = members
+    .filter(
+      (member) =>
+        member.userId !== input.createdBy.id &&
+        isInternalStaffRole(member.role)
+    )
+    .map((member) => ({
+      userId: member.userId,
+      email: member.googleEmail?.trim() || member.email,
+    }))
+  if (recipients.length === 0) return
+
+  await createNotificationEvent({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    eventType: "warranty.created",
+    sourceType: "warranty_claim",
+    sourceId: input.claimId,
+    title: `${input.claimNumber}: ${input.title}`,
+    body: `${input.createdBy.displayName ?? input.createdBy.email} submitted a ${input.priority} priority warranty claim.`,
+    href:
+      `/dashboard/projects/${input.projectId}/warranty` +
+      `#warranty-${encodeURIComponent(input.claimId)}`,
+    priority: input.priority === "urgent" ? "high" : "normal",
+    audience: "project_team",
+    createdBy: input.createdBy.id,
+    recipients,
+    delivery: { inApp: true, email: true, push: true },
+  })
+}
+
+export async function notifyWarrantyClaimUpdated(
+  input: WarrantyUpdatedNotificationInput
+): Promise<void> {
+  if (!input.claimantUserId || input.claimantUserId === input.updatedBy.id) return
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const claimant = await db
+    .select({
+      userId: users.id,
+      email: users.email,
+      googleEmail: users.googleEmail,
+    })
+    .from(users)
+    .where(and(eq(users.id, input.claimantUserId), eq(users.isActive, true)))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  if (!claimant) return
+
+  await createNotificationEvent({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    eventType: "warranty.updated",
+    sourceType: "warranty_claim",
+    sourceId: input.claimId,
+    title: `${input.claimNumber}: ${input.title}`,
+    body: `Your warranty claim is now ${input.status.replace(/_/g, " ")}.`,
+    href:
+      `/preview/projects/${input.projectId}/owner/warranty` +
+      `#warranty-${encodeURIComponent(input.claimId)}`,
+    priority: "normal",
+    audience: "claimant",
+    createdBy: input.updatedBy.id,
+    recipients: [
+      {
+        userId: claimant.userId,
+        email: claimant.googleEmail?.trim() || claimant.email,
+      },
+    ],
+    delivery: { inApp: true, email: true, push: true },
   })
 }

--- a/src/lib/notifications/sms-policy.ts
+++ b/src/lib/notifications/sms-policy.ts
@@ -86,7 +86,9 @@ export function isProjectActivitySmsEvent(eventType: string): boolean {
   return (
     eventType === "message.channel" ||
     eventType === "message.thread_reply" ||
-    eventType === "message.project"
+    eventType === "message.project" ||
+    eventType === "warranty.created" ||
+    eventType === "warranty.updated"
   )
 }
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -173,6 +173,14 @@ export const PERMISSION_FEATURES: readonly PermissionFeature[] = [
     resource: "document",
   },
   {
+    id: "warranty-claims",
+    group: "Client Experience",
+    label: "Warranty Claims",
+    description:
+      "Project warranty submissions, assignment, visits, evidence, resolution, and owner confirmation.",
+    resource: "project",
+  },
+  {
     id: "owner-preview",
     group: "Client Experience",
     label: "Owner Preview",

--- a/src/lib/project-audience-preview-routes.ts
+++ b/src/lib/project-audience-preview-routes.ts
@@ -9,6 +9,7 @@ export type ProjectAudienceWorkspaceSection =
   | "change-orders"
   | "conversations"
   | "photos"
+  | "warranty"
   | "team"
 
 export function projectAudiencePreviewHref(

--- a/src/lib/warranty/__tests__/status.test.ts
+++ b/src/lib/warranty/__tests__/status.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  canOwnerDeleteWarrantyClaim,
+  isOwnerVisibleWarrantyClaim,
+  isWarrantyProjectStage,
+  warrantyClaimPriority,
+  warrantyClaimStatus,
+} from "@/lib/warranty/status"
+
+describe("warranty claim guardrails", () => {
+  it("recognizes warranty and service stages", () => {
+    expect(isWarrantyProjectStage({ status: "WARRANTY", jobStatusId: "current" })).toBe(true)
+    expect(isWarrantyProjectStage({ status: "OPEN", jobStatusId: "warranty_service" })).toBe(true)
+    expect(isWarrantyProjectStage({ status: "OPEN", jobStatusId: "current" })).toBe(false)
+  })
+
+  it("requires owner audience and an actionable promotion", () => {
+    expect(isOwnerVisibleWarrantyClaim({ audience: "owner", promotionState: "actionable" })).toBe(true)
+    expect(isOwnerVisibleWarrantyClaim({ audience: "internal", promotionState: "actionable" })).toBe(false)
+    expect(isOwnerVisibleWarrantyClaim({ audience: "owner", promotionState: "review_required" })).toBe(false)
+  })
+
+  it("only lets a claimant retract an unacknowledged submission", () => {
+    expect(canOwnerDeleteWarrantyClaim({ status: "submitted", claimantUserId: "user-1", viewerUserId: "user-1" })).toBe(true)
+    expect(canOwnerDeleteWarrantyClaim({ status: "acknowledged", claimantUserId: "user-1", viewerUserId: "user-1" })).toBe(false)
+    expect(canOwnerDeleteWarrantyClaim({ status: "submitted", claimantUserId: "user-2", viewerUserId: "user-1" })).toBe(false)
+  })
+
+  it("rejects unknown statuses and priorities", () => {
+    expect(warrantyClaimStatus("resolved")).toBe("resolved")
+    expect(warrantyClaimStatus("done")).toBeNull()
+    expect(warrantyClaimPriority("urgent")).toBe("urgent")
+    expect(warrantyClaimPriority("critical")).toBeNull()
+  })
+})

--- a/src/lib/warranty/google-drive.ts
+++ b/src/lib/warranty/google-drive.ts
@@ -1,0 +1,147 @@
+import { and, eq } from "drizzle-orm"
+
+import type { getDb } from "@/db"
+import { projectExternalLinks } from "@/db/schema"
+import { googleAuth } from "@/db/schema-google"
+import { decrypt } from "@/lib/crypto"
+import { DriveClient } from "@/lib/google/client/drive-client"
+import {
+  getGoogleConfig,
+  getGoogleCryptoSalt,
+  parseServiceAccountKey,
+} from "@/lib/google/config"
+
+const GOOGLE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
+const DEFAULT_COMPASS_GOOGLE_UPLOAD_USER = "compass@hps-colorado.com"
+
+type Db = ReturnType<typeof getDb>
+
+function envString(env: unknown, key: string): string | null {
+  if (typeof env !== "object" || env === null || !(key in env)) return null
+  const rawValue = Reflect.get(env, key)
+  const value = typeof rawValue === "string" ? rawValue.trim() : ""
+  return value ? value : null
+}
+
+function driveFolderIdFromUrl(value: string | null): string | null {
+  if (!value) return null
+  const folderMatch = value.match(/\/folders\/([^/?#]+)/)
+  if (folderMatch) return folderMatch[1] ?? null
+  const idMatch = value.match(/[?&]id=([^&#]+)/)
+  return idMatch?.[1] ?? null
+}
+
+function escapeDriveQueryValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")
+}
+
+async function findOrCreateFolder(input: {
+  readonly client: DriveClient
+  readonly googleEmail: string
+  readonly parentId: string
+  readonly driveId: string | null
+  readonly name: string
+}): Promise<string> {
+  const result = await input.client.listFiles(input.googleEmail, {
+    folderId: input.parentId,
+    driveId: input.driveId ?? undefined,
+    pageSize: 10,
+    query:
+      `mimeType = '${GOOGLE_FOLDER_MIME_TYPE}' and ` +
+      `name = '${escapeDriveQueryValue(input.name)}'`,
+  })
+  const existing = result.files[0]
+  if (existing) return existing.id
+  const created = await input.client.createFolder(input.googleEmail, {
+    name: input.name,
+    parentId: input.parentId,
+    driveId: input.driveId ?? undefined,
+  })
+  return created.id
+}
+
+async function projectDriveFolderId(
+  db: Db,
+  projectId: string,
+  mappedFolderId: string | null
+): Promise<string | null> {
+  if (mappedFolderId) return mappedFolderId
+  const link = await db
+    .select({
+      externalId: projectExternalLinks.externalId,
+      externalUrl: projectExternalLinks.externalUrl,
+    })
+    .from(projectExternalLinks)
+    .where(
+      and(
+        eq(projectExternalLinks.projectId, projectId),
+        eq(projectExternalLinks.system, "google_drive")
+      )
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  return link?.externalId ?? driveFolderIdFromUrl(link?.externalUrl ?? null)
+}
+
+export type WarrantyDriveContext = {
+  readonly client: DriveClient
+  readonly googleEmail: string
+  readonly driveId: string | null
+}
+
+export async function getWarrantyDriveContext(input: {
+  readonly db: Db
+  readonly env: unknown
+  readonly userEmail: string
+  readonly googleEmail: string | null
+}): Promise<WarrantyDriveContext> {
+  const auth = await input.db
+    .select()
+    .from(googleAuth)
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  if (!auth) throw new Error("Google Drive is not connected.")
+  const config = getGoogleConfig(input.env)
+  const keyJson = await decrypt(
+    auth.serviceAccountKeyEncrypted,
+    config.encryptionKey,
+    getGoogleCryptoSalt()
+  )
+  return {
+    client: new DriveClient({ serviceAccountKey: parseServiceAccountKey(keyJson) }),
+    googleEmail:
+      envString(input.env, "COMPASS_GOOGLE_UPLOAD_USER") ??
+      input.googleEmail ??
+      (input.userEmail.endsWith("@hps-colorado.com")
+        ? input.userEmail
+        : DEFAULT_COMPASS_GOOGLE_UPLOAD_USER),
+    driveId: auth.sharedDriveId,
+  }
+}
+
+export async function warrantyClaimFolderId(input: {
+  readonly db: Db
+  readonly projectId: string
+  readonly mappedProjectFolderId: string | null
+  readonly claimNumber: string
+  readonly drive: WarrantyDriveContext
+}): Promise<string> {
+  const projectFolderId = await projectDriveFolderId(
+    input.db,
+    input.projectId,
+    input.mappedProjectFolderId
+  )
+  if (!projectFolderId) {
+    throw new Error("Map this project to a Google Drive folder before uploading.")
+  }
+  const warrantyFolderId = await findOrCreateFolder({
+    ...input.drive,
+    parentId: projectFolderId,
+    name: "Warranty Claims",
+  })
+  return findOrCreateFolder({
+    ...input.drive,
+    parentId: warrantyFolderId,
+    name: input.claimNumber,
+  })
+}

--- a/src/lib/warranty/status.ts
+++ b/src/lib/warranty/status.ts
@@ -1,0 +1,79 @@
+export const WARRANTY_CLAIM_PRIORITIES = [
+  "low",
+  "normal",
+  "high",
+  "urgent",
+] as const
+
+export type WarrantyClaimPriority =
+  (typeof WARRANTY_CLAIM_PRIORITIES)[number]
+
+export const WARRANTY_CLAIM_STATUSES = [
+  "submitted",
+  "acknowledged",
+  "visit_scheduled",
+  "in_progress",
+  "waiting_on_owner",
+  "resolved",
+  "closed",
+  "rejected",
+] as const
+
+export type WarrantyClaimStatus = (typeof WARRANTY_CLAIM_STATUSES)[number]
+
+export const WARRANTY_PROMOTION_STATES = [
+  "actionable",
+  "review_required",
+  "archive_only",
+  "rejected",
+] as const
+
+export type WarrantyPromotionState =
+  (typeof WARRANTY_PROMOTION_STATES)[number]
+
+export function warrantyClaimPriority(
+  value: string
+): WarrantyClaimPriority | null {
+  return WARRANTY_CLAIM_PRIORITIES.find((priority) => priority === value) ?? null
+}
+
+export function warrantyClaimStatus(value: string): WarrantyClaimStatus | null {
+  return WARRANTY_CLAIM_STATUSES.find((status) => status === value) ?? null
+}
+
+export function warrantyPromotionState(
+  value: string
+): WarrantyPromotionState | null {
+  return WARRANTY_PROMOTION_STATES.find((state) => state === value) ?? null
+}
+
+function normalizedStage(value: string | null): string {
+  return value?.trim().toLowerCase().replace(/[\s_-]+/g, " ") ?? ""
+}
+
+export function isWarrantyProjectStage(input: {
+  readonly status: string | null
+  readonly jobStatusId: string | null
+}): boolean {
+  return [input.status, input.jobStatusId].some((value) => {
+    const normalized = normalizedStage(value)
+    return normalized.includes("warranty") || normalized.includes("service")
+  })
+}
+
+export function isOwnerVisibleWarrantyClaim(input: {
+  readonly audience: string
+  readonly promotionState: string
+}): boolean {
+  return input.audience === "owner" && input.promotionState === "actionable"
+}
+
+export function canOwnerDeleteWarrantyClaim(input: {
+  readonly status: string
+  readonly claimantUserId: string | null
+  readonly viewerUserId: string
+}): boolean {
+  return (
+    input.claimantUserId === input.viewerUserId && input.status === "submitted"
+  )
+}


### PR DESCRIPTION
## Outcome

Adds a first-class, project-scoped Compass warranty workflow for internal staff and owners without creating an operational Buildertrend dependency.

## What changed

- adds warranty claim, attachment, event-history, and Buildertrend review-staging tables
- adds internal create/edit/delete, assignment, visit, resolution, and activity controls
- adds owner submission and resolution-confirmation flows gated to Warranty/Service project stages
- stores evidence in the verified project Google Drive hierarchy and streams it through protected Compass routes
- separates owner-visible history from internal notes
- adds in-app/email/push events and opt-in project-activity SMS routing
- exposes Warranty in internal navigation and conditionally in owner workspaces only
- updates the redacted public cutover ledger

## Release order

1. Create a D1 Time Travel bookmark.
2. Apply `drizzle/0109_warranty_claims.sql` to production.
3. Squash-merge and deploy the application.
4. Verify internal and owner routes plus an evidence upload/download.

Historical Buildertrend claims remain review-gated and are not bulk-promoted by this PR.

## Verification

- `bun test src/lib/warranty/__tests__/status.test.ts src/lib/notifications/__tests__/sms-policy.test.ts`
- `bun lint`
- `bun run build`
- migration executed successfully against in-memory SQLite
- `git diff --check`

## Review note

The repository's structured external reviewer was not run because transmitting the uncommitted source bundle was not authorized. Local source, permission, migration, lint, test, and production-build checks passed.
