### PR TITLE
feat(office): add simple staff message desk

### DIFF
--- a/drizzle/0109_staff_message_records.sql
+++ b/drizzle/0109_staff_message_records.sql
@@ -1,0 +1,26 @@
+CREATE TABLE `staff_message_records` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL REFERENCES `organizations`(`id`) ON DELETE CASCADE,
+  `source_type` text NOT NULL CHECK (`source_type` IN ('call', 'message')),
+  `goto_inbound_event_id` text REFERENCES `goto_inbound_events`(`id`) ON DELETE SET NULL,
+  `caller_name` text NOT NULL,
+  `caller_company` text,
+  `caller_phone` text,
+  `caller_email` text,
+  `subject` text NOT NULL,
+  `body` text NOT NULL,
+  `assignee_user_id` text NOT NULL REFERENCES `users`(`id`),
+  `created_by` text REFERENCES `users`(`id`) ON DELETE SET NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `staff_message_records_goto_event_unique`
+  ON `staff_message_records` (`goto_inbound_event_id`)
+  WHERE `goto_inbound_event_id` IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX `staff_message_records_org_created_idx`
+  ON `staff_message_records` (`organization_id`, `created_at`);
+--> statement-breakpoint
+CREATE INDEX `staff_message_records_assignee_created_idx`
+  ON `staff_message_records` (`assignee_user_id`, `created_at`);

--- a/src/app/actions/staff-message-desk.ts
+++ b/src/app/actions/staff-message-desk.ts
@@ -1,0 +1,534 @@
+"use server"
+
+import { and, asc, desc, eq, isNull, ne } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import {
+  gotoInboundEvents,
+  organizations,
+  organizationMembers,
+  staffMessageRecords,
+  users,
+} from "@/db/schema"
+import { requireAuth, type AuthUser } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import {
+  buildGotoStaffMessageDraft,
+  buildStaffMessageAssignmentNotification,
+  isEligibleStaffMessageAssignee,
+  isStaffMessageDeskUser,
+  type StaffMessageDeskUser,
+} from "@/lib/staff-message-desk"
+import { createNotificationEvent } from "@/lib/notifications/create-event"
+import { requireOrg } from "@/lib/org-scope"
+import { canManageProjectRegistry } from "@/lib/permissions"
+
+const MESSAGE_DESK_PATH = "/dashboard/office-maintenance/message-desk"
+
+type ActionFailure = { readonly success: false; readonly error: string }
+type ActionSuccess<T> = { readonly success: true; readonly data: T }
+type ActionResult<T> = ActionFailure | ActionSuccess<T>
+
+type StaffDeskUserRow = {
+  readonly id: string
+  readonly email: string
+  readonly firstName: string | null
+  readonly lastName: string | null
+  readonly displayName: string | null
+  readonly isActive: boolean
+  readonly memberRole: string
+}
+
+export type StaffMessageDeskRecordDto = Readonly<{
+  readonly id: string
+  readonly sourceType: "call" | "message"
+  readonly gotoInboundEventId: string | null
+  readonly callerName: string
+  readonly callerCompany: string | null
+  readonly callerPhone: string | null
+  readonly callerEmail: string | null
+  readonly subject: string
+  readonly body: string
+  readonly assigneeUserId: string
+  readonly assigneeName: string
+  readonly createdBy: string | null
+  readonly createdAt: string
+  readonly updatedAt: string
+}>
+
+export type StaffMessageAssigneeDto = Readonly<{
+  readonly id: string
+  readonly name: string
+  readonly email: string
+}>
+
+export type StaffMessageInboundTextDto = Readonly<{
+  readonly id: string
+  readonly senderPhone: string
+  readonly messageBody: string | null
+  readonly receivedAt: string
+}>
+
+export type StaffMessageDeskData = Readonly<{
+  readonly records: readonly StaffMessageDeskRecordDto[]
+  readonly assignees: readonly StaffMessageAssigneeDto[]
+  readonly inboundTexts: readonly StaffMessageInboundTextDto[]
+}>
+
+function failure(error: unknown): ActionFailure {
+  return {
+    success: false,
+    error: error instanceof Error ? error.message : "Staff message action failed",
+  }
+}
+
+function value(formData: FormData, key: string): string | null {
+  const candidate = formData.get(key)
+  if (typeof candidate !== "string") return null
+  const trimmed = candidate.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function requiredValue(formData: FormData, key: string): string {
+  const candidate = value(formData, key)
+  if (!candidate) throw new Error(`${key} is required`)
+  return candidate
+}
+
+function deskUser(user: {
+  readonly id: string
+  readonly isActive: boolean
+  readonly organizationId: string | null
+  readonly organizationType: string | null
+  readonly role: string
+}): StaffMessageDeskUser {
+  return {
+    id: user.id,
+    isActive: user.isActive,
+    organizationId: user.organizationId,
+    organizationType: user.organizationType,
+    role: user.role,
+  }
+}
+
+async function staffMessageContext(): Promise<{
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string
+  readonly user: AuthUser
+}> {
+  const user = await requireAuth()
+  if (!isStaffMessageDeskUser(deskUser(user))) {
+    throw new Error("Staff Message Desk access is restricted to active internal staff")
+  }
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const organization = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(
+      and(
+        eq(organizations.id, organizationId),
+        eq(organizations.type, "internal"),
+        eq(organizations.isActive, true)
+      )
+    )
+    .get()
+  if (!organization) throw new Error("Active internal organization is required")
+  return { db, organizationId, user }
+}
+
+async function staffReviewContext(): Promise<{
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string
+  readonly user: AuthUser
+}> {
+  const context = await staffMessageContext()
+  if (!canManageProjectRegistry(context.user)) {
+    throw new Error("Project administration permission is required")
+  }
+  return context
+}
+
+function displayName(row: Pick<StaffDeskUserRow, "displayName" | "firstName" | "lastName" | "email">): string {
+  const named = row.displayName?.trim()
+  if (named) return named
+  const fullName = [row.firstName, row.lastName]
+    .filter((part): part is string => Boolean(part?.trim()))
+    .join(" ")
+    .trim()
+  return fullName || row.email
+}
+
+async function assigneeFor(
+  db: ReturnType<typeof getDb>,
+  organizationId: string,
+  creatorUserId: string,
+  assigneeUserId: string
+): Promise<StaffDeskUserRow> {
+  const row = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      firstName: users.firstName,
+      lastName: users.lastName,
+      displayName: users.displayName,
+      isActive: users.isActive,
+      memberRole: organizationMembers.role,
+    })
+    .from(users)
+    .innerJoin(organizationMembers, eq(organizationMembers.userId, users.id))
+    .innerJoin(organizations, eq(organizations.id, organizationMembers.organizationId))
+    .where(
+      and(
+        eq(users.id, assigneeUserId),
+        ne(users.id, creatorUserId),
+        eq(users.isActive, true),
+        eq(organizationMembers.organizationId, organizationId),
+        eq(organizations.type, "internal"),
+        eq(organizations.isActive, true)
+      )
+    )
+    .get()
+  if (!row) throw new Error("Choose one other active internal staff member")
+  if (
+    !isEligibleStaffMessageAssignee(
+      deskUser({
+        id: row.id,
+        isActive: row.isActive,
+        organizationId,
+        organizationType: "internal",
+        role: row.memberRole,
+      }),
+      organizationId,
+      creatorUserId
+    )
+  ) {
+    throw new Error("Assignee must be another active internal staff member")
+  }
+  return row
+}
+
+async function activeAssignees(
+  db: ReturnType<typeof getDb>,
+  organizationId: string,
+  creatorUserId: string
+): Promise<readonly StaffMessageAssigneeDto[]> {
+  const rows = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      firstName: users.firstName,
+      lastName: users.lastName,
+      displayName: users.displayName,
+      isActive: users.isActive,
+      memberRole: organizationMembers.role,
+    })
+    .from(users)
+    .innerJoin(organizationMembers, eq(organizationMembers.userId, users.id))
+    .innerJoin(organizations, eq(organizations.id, organizationMembers.organizationId))
+    .where(
+      and(
+        ne(users.id, creatorUserId),
+        eq(users.isActive, true),
+        eq(organizationMembers.organizationId, organizationId),
+        eq(organizations.type, "internal"),
+        eq(organizations.isActive, true)
+      )
+    )
+    .orderBy(asc(users.displayName), asc(users.email))
+  return rows
+    .filter((row) =>
+      isEligibleStaffMessageAssignee(
+        deskUser({
+          id: row.id,
+          isActive: row.isActive,
+          organizationId,
+          organizationType: "internal",
+          role: row.memberRole,
+        }),
+        organizationId,
+        creatorUserId
+      )
+    )
+    .map((row) => ({ id: row.id, name: displayName(row), email: row.email }))
+}
+
+export async function getStaffMessageAssignees(): Promise<
+  ActionResult<readonly StaffMessageAssigneeDto[]>
+> {
+  try {
+    const { db, organizationId, user } = await staffMessageContext()
+    return {
+      success: true,
+      data: await activeAssignees(db, organizationId, user.id),
+    }
+  } catch (error) {
+    return failure(error)
+  }
+}
+
+async function notifyAssignment(input: {
+  readonly organizationId: string
+  readonly recordId: string
+  readonly subject: string
+  readonly assignee: StaffDeskUserRow
+  readonly actor: AuthUser
+}): Promise<void> {
+  const notification = buildStaffMessageAssignmentNotification({
+    organizationId: input.organizationId,
+    recordId: input.recordId,
+    subject: input.subject,
+    assigneeUserId: input.assignee.id,
+  })
+  await createNotificationEvent({
+    organizationId: notification.organizationId,
+    projectId: null,
+    eventType: "staff_message.assigned",
+    sourceType: "staff_message_record",
+    sourceId: notification.recordId,
+    title: notification.title,
+    body: `${input.actor.displayName ?? input.actor.email} assigned this message to you.`,
+    href: notification.href,
+    priority: "normal",
+    audience: "assignee",
+    createdBy: input.actor.id,
+    recipients: [{ userId: input.assignee.id, email: input.assignee.email }],
+    delivery: { inApp: true, email: false, push: false },
+  })
+}
+
+function sourceType(valueToCheck: string): "call" | "message" {
+  if (valueToCheck === "call" || valueToCheck === "message") return valueToCheck
+  throw new Error("Source type must be call or message")
+}
+
+export async function getStaffMessageDesk(): Promise<ActionResult<StaffMessageDeskData>> {
+  try {
+    const { db, organizationId, user } = await staffMessageContext()
+    const rows = await db
+      .select({
+        id: staffMessageRecords.id,
+        sourceType: staffMessageRecords.sourceType,
+        gotoInboundEventId: staffMessageRecords.gotoInboundEventId,
+        callerName: staffMessageRecords.callerName,
+        callerCompany: staffMessageRecords.callerCompany,
+        callerPhone: staffMessageRecords.callerPhone,
+        callerEmail: staffMessageRecords.callerEmail,
+        subject: staffMessageRecords.subject,
+        body: staffMessageRecords.body,
+        assigneeUserId: staffMessageRecords.assigneeUserId,
+        createdBy: staffMessageRecords.createdBy,
+        createdAt: staffMessageRecords.createdAt,
+        updatedAt: staffMessageRecords.updatedAt,
+        assigneeDisplayName: users.displayName,
+        assigneeFirstName: users.firstName,
+        assigneeLastName: users.lastName,
+        assigneeEmail: users.email,
+      })
+      .from(staffMessageRecords)
+      .innerJoin(users, eq(users.id, staffMessageRecords.assigneeUserId))
+      .where(eq(staffMessageRecords.organizationId, organizationId))
+      .orderBy(desc(staffMessageRecords.updatedAt))
+    const inboundRows = await db
+      .select({
+        id: gotoInboundEvents.id,
+        senderPhone: gotoInboundEvents.senderPhone,
+        messageBody: gotoInboundEvents.messageBody,
+        receivedAt: gotoInboundEvents.receivedAt,
+      })
+      .from(gotoInboundEvents)
+      .leftJoin(
+        staffMessageRecords,
+        eq(staffMessageRecords.gotoInboundEventId, gotoInboundEvents.id)
+      )
+      .where(
+        and(
+          eq(gotoInboundEvents.organizationId, organizationId),
+          eq(gotoInboundEvents.status, "needs_review"),
+          isNull(staffMessageRecords.id)
+        )
+      )
+      .orderBy(desc(gotoInboundEvents.receivedAt))
+    return {
+      success: true,
+      data: {
+        records: rows.map((row) => ({
+          id: row.id,
+          sourceType: sourceType(row.sourceType),
+          gotoInboundEventId: row.gotoInboundEventId,
+          callerName: row.callerName,
+          callerCompany: row.callerCompany,
+          callerPhone: row.callerPhone,
+          callerEmail: row.callerEmail,
+          subject: row.subject,
+          body: row.body,
+          assigneeUserId: row.assigneeUserId,
+          assigneeName: displayName({
+            displayName: row.assigneeDisplayName,
+            firstName: row.assigneeFirstName,
+            lastName: row.assigneeLastName,
+            email: row.assigneeEmail,
+          }),
+          createdBy: row.createdBy,
+          createdAt: row.createdAt,
+          updatedAt: row.updatedAt,
+        })),
+        assignees: await activeAssignees(db, organizationId, user.id),
+        inboundTexts: inboundRows.map((row) => ({
+          id: row.id,
+          senderPhone: row.senderPhone,
+          messageBody: row.messageBody,
+          receivedAt: row.receivedAt,
+        })),
+      },
+    }
+  } catch (error) {
+    return failure(error)
+  }
+}
+
+async function insertStaffMessage(input: {
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string
+  readonly user: AuthUser
+  readonly assignee: StaffDeskUserRow
+  readonly sourceType: "call" | "message"
+  readonly gotoInboundEventId: string | null
+  readonly callerName: string
+  readonly callerCompany: string | null
+  readonly callerPhone: string | null
+  readonly callerEmail: string | null
+  readonly subject: string
+  readonly body: string
+}): Promise<string> {
+  const now = new Date().toISOString()
+  const id = crypto.randomUUID()
+  await input.db.insert(staffMessageRecords).values({
+    id,
+    organizationId: input.organizationId,
+    sourceType: input.sourceType,
+    gotoInboundEventId: input.gotoInboundEventId,
+    callerName: input.callerName,
+    callerCompany: input.callerCompany,
+    callerPhone: input.callerPhone,
+    callerEmail: input.callerEmail,
+    subject: input.subject,
+    body: input.body,
+    assigneeUserId: input.assignee.id,
+    createdBy: input.user.id,
+    createdAt: now,
+    updatedAt: now,
+  })
+  try {
+    await notifyAssignment({
+      organizationId: input.organizationId,
+      recordId: id,
+      subject: input.subject,
+      assignee: input.assignee,
+      actor: input.user,
+    })
+  } catch (error) {
+    console.error("[staff-message-desk] assignment notification error", error)
+  }
+  return id
+}
+
+export async function createStaffMessage(
+  formData: FormData
+): Promise<ActionResult<{ readonly id: string }>> {
+  try {
+    const { db, organizationId, user } = await staffMessageContext()
+    const assignee = await assigneeFor(
+      db,
+      organizationId,
+      user.id,
+      requiredValue(formData, "assigneeUserId")
+    )
+    const id = await insertStaffMessage({
+      db,
+      organizationId,
+      user,
+      assignee,
+      sourceType: sourceType(requiredValue(formData, "sourceType")),
+      gotoInboundEventId: null,
+      callerName: requiredValue(formData, "callerName"),
+      callerCompany: value(formData, "callerCompany"),
+      callerPhone: value(formData, "callerPhone"),
+      callerEmail: value(formData, "callerEmail"),
+      subject: requiredValue(formData, "subject"),
+      body: requiredValue(formData, "body"),
+    })
+    revalidatePath(MESSAGE_DESK_PATH)
+    return { success: true, data: { id } }
+  } catch (error) {
+    return failure(error)
+  }
+}
+
+export async function routeGotoTextToMessageDesk(
+  formData: FormData
+): Promise<ActionResult<{ readonly id: string }>> {
+  try {
+    const { db, organizationId, user } = await staffReviewContext()
+    const eventId = requiredValue(formData, "eventId")
+    const assignee = await assigneeFor(
+      db,
+      organizationId,
+      user.id,
+      requiredValue(formData, "assigneeUserId")
+    )
+    const event = await db
+      .select({
+        id: gotoInboundEvents.id,
+        senderPhone: gotoInboundEvents.senderPhone,
+        messageBody: gotoInboundEvents.messageBody,
+      })
+      .from(gotoInboundEvents)
+      .where(
+        and(
+          eq(gotoInboundEvents.id, eventId),
+          eq(gotoInboundEvents.organizationId, organizationId),
+          eq(gotoInboundEvents.status, "needs_review")
+        )
+      )
+      .get()
+    if (!event) throw new Error("Inbound text is no longer awaiting review")
+    const draft = buildGotoStaffMessageDraft({
+      eventId: event.id,
+      senderPhone: event.senderPhone,
+      messageBody: event.messageBody,
+      assigneeUserId: assignee.id,
+    })
+    const id = await insertStaffMessage({
+      db,
+      organizationId,
+      user,
+      assignee,
+      sourceType: draft.sourceType,
+      gotoInboundEventId: draft.gotoInboundEventId,
+      callerName: draft.callerName,
+      callerCompany: null,
+      callerPhone: draft.callerPhone,
+      callerEmail: null,
+      subject: draft.subject,
+      body: draft.body,
+    })
+    revalidatePath(MESSAGE_DESK_PATH)
+    revalidatePath("/dashboard/office-maintenance/inbound-email")
+    return { success: true, data: { id } }
+  } catch (error) {
+    return failure(error)
+  }
+}
+
+export async function submitCreateStaffMessage(formData: FormData): Promise<void> {
+  await createStaffMessage(formData)
+}
+
+export async function submitRouteGotoTextToMessageDesk(
+  formData: FormData
+): Promise<void> {
+  await routeGotoTextToMessageDesk(formData)
+}

--- a/src/app/dashboard/office-maintenance/inbound-email/page.tsx
+++ b/src/app/dashboard/office-maintenance/inbound-email/page.tsx
@@ -9,6 +9,10 @@ import {
 } from "@tabler/icons-react"
 
 import {
+  getStaffMessageAssignees,
+  submitRouteGotoTextToMessageDesk,
+} from "@/app/actions/staff-message-desk"
+import {
   dismissInboundEmail,
   getInboundEmailReviewQueue,
   routeInboundEmailToRfi,
@@ -32,8 +36,11 @@ function suggestedTitle(value: string | null): string {
 }
 
 export default async function InboundEmailReviewPage(): Promise<React.ReactElement> {
-  const queue = await getInboundEmailReviewQueue()
-  const smsQueue = await getInboundSmsReviewQueue()
+  const [queue, smsQueue, staffAssignees] = await Promise.all([
+    getInboundEmailReviewQueue(),
+    getInboundSmsReviewQueue(),
+    getStaffMessageAssignees(),
+  ])
 
   return (
     <main className="mx-auto w-full max-w-5xl space-y-5 p-4 lg:p-6">
@@ -172,6 +179,31 @@ export default async function InboundEmailReviewPage(): Promise<React.ReactEleme
                 <input type="hidden" name="eventId" value={item.id} />
                 <Button type="submit" variant="outline">Dismiss</Button>
               </form>
+              {staffAssignees.success && staffAssignees.data.length > 0 ? (
+                <form
+                  action={submitRouteGotoTextToMessageDesk}
+                  className="mt-2 flex flex-col gap-2 border-t pt-3 sm:flex-row sm:items-end sm:justify-end"
+                >
+                  <input type="hidden" name="eventId" value={item.id} />
+                  <label className="flex flex-1 flex-col gap-1 text-sm font-medium sm:max-w-sm">
+                    Route to Message Desk
+                    <select
+                      name="assigneeUserId"
+                      required
+                      defaultValue=""
+                      className="h-10 border bg-background px-3 font-normal"
+                    >
+                      <option value="" disabled>Select one staff recipient…</option>
+                      {staffAssignees.data.map((assignee) => (
+                        <option key={assignee.id} value={assignee.id}>
+                          {assignee.name} · {assignee.email}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <Button type="submit" variant="outline">Route to Message Desk</Button>
+                </form>
+              ) : null}
             </article>
           ))
         )}

--- a/src/app/dashboard/office-maintenance/message-desk/page.tsx
+++ b/src/app/dashboard/office-maintenance/message-desk/page.tsx
@@ -1,0 +1,182 @@
+export const dynamic = "force-dynamic"
+
+import Link from "next/link"
+import { IconArrowLeft, IconInbox, IconPhone } from "@tabler/icons-react"
+
+import {
+  getStaffMessageDesk,
+  submitCreateStaffMessage,
+  submitRouteGotoTextToMessageDesk,
+} from "@/app/actions/staff-message-desk"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+
+function fieldClassName(): string {
+  return "h-10 border bg-background px-3 text-sm"
+}
+
+function timestamp(value: string): string {
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toLocaleString()
+}
+
+export default async function StaffMessageDeskPage(): Promise<React.ReactElement> {
+  const result = await getStaffMessageDesk()
+  if (!result.success) {
+    return (
+      <main className="mx-auto w-full max-w-3xl p-6">
+        <h1 className="text-2xl font-semibold">Staff Message Desk unavailable</h1>
+        <p className="mt-2 text-sm text-muted-foreground">{result.error}</p>
+      </main>
+    )
+  }
+  const { records, assignees, inboundTexts } = result.data
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6 overflow-y-auto p-4 lg:p-6">
+      <header className="border-b pb-5">
+        <Button asChild variant="ghost" size="sm" className="-ml-3 mb-2">
+          <Link href="/dashboard/projects">
+            <IconArrowLeft className="size-4" />
+            Office maintenance
+          </Link>
+        </Button>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-2">
+              <IconPhone className="size-6 text-muted-foreground" />
+              <h1 className="text-2xl font-semibold tracking-tight">Staff Message Desk</h1>
+            </div>
+            <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+              Capture a call for one accountable staff member, or manually route an inbound text after review.
+            </p>
+          </div>
+          <Badge variant="secondary">{records.length} messages</Badge>
+        </div>
+      </header>
+
+      <section className="border-b pb-6" aria-labelledby="new-staff-message">
+        <h2 id="new-staff-message" className="text-lg font-semibold">New call or message</h2>
+        {assignees.length === 0 ? (
+          <p className="mt-3 text-sm text-muted-foreground">No other active internal staff member is available to receive a message.</p>
+        ) : (
+          <form action={submitCreateStaffMessage} className="mt-4 grid gap-3 md:grid-cols-2">
+            <label className="flex flex-col gap-1 text-sm font-medium">
+              Source
+              <select name="sourceType" required defaultValue="call" className={fieldClassName()}>
+                <option value="call">Incoming call</option>
+                <option value="message">Incoming message</option>
+              </select>
+            </label>
+            <label className="flex flex-col gap-1 text-sm font-medium">
+              Assign to one staff member
+              <select name="assigneeUserId" required defaultValue="" className={fieldClassName()}>
+                <option value="" disabled>Select a recipient…</option>
+                {assignees.map((assignee) => (
+                  <option key={assignee.id} value={assignee.id}>{assignee.name} · {assignee.email}</option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1 text-sm font-medium">
+              Caller / contact name
+              <input name="callerName" required className={fieldClassName()} />
+            </label>
+            <label className="flex flex-col gap-1 text-sm font-medium">
+              Company
+              <input name="callerCompany" className={fieldClassName()} />
+            </label>
+            <label className="flex flex-col gap-1 text-sm font-medium">
+              Phone
+              <input name="callerPhone" type="tel" className={fieldClassName()} />
+            </label>
+            <label className="flex flex-col gap-1 text-sm font-medium">
+              Email
+              <input name="callerEmail" type="email" className={fieldClassName()} />
+            </label>
+            <label className="flex flex-col gap-1 text-sm font-medium md:col-span-2">
+              Subject
+              <input name="subject" required className={fieldClassName()} />
+            </label>
+            <label className="flex flex-col gap-1 text-sm font-medium md:col-span-2">
+              Message details
+              <textarea name="body" required className="min-h-28 border bg-background p-3 text-sm" />
+            </label>
+            <div className="flex justify-end md:col-span-2">
+              <Button type="submit">Create message and notify recipient</Button>
+            </div>
+          </form>
+        )}
+      </section>
+
+      <section className="space-y-4" aria-labelledby="active-staff-messages">
+        <div className="flex items-center gap-2 border-b pb-2">
+          <IconInbox className="size-5 text-muted-foreground" />
+          <h2 id="active-staff-messages" className="text-lg font-semibold">Message Desk records</h2>
+        </div>
+        {records.length === 0 ? (
+          <div className="border border-dashed p-8 text-center text-sm text-muted-foreground">No message records yet.</div>
+        ) : records.map((record) => (
+          <article id={`message-${record.id}`} key={record.id} className="border bg-background p-4 shadow-sm">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3 className="text-lg font-semibold">{record.subject}</h3>
+                  <Badge variant="outline">{record.sourceType === "call" ? "Call" : "Message"}</Badge>
+                </div>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {record.callerName}
+                  {record.callerCompany ? ` · ${record.callerCompany}` : ""}
+                  {record.callerPhone ? ` · ${record.callerPhone}` : ""}
+                  {record.callerEmail ? ` · ${record.callerEmail}` : ""}
+                </p>
+              </div>
+              <p className="text-xs text-muted-foreground">Assigned to {record.assigneeName} · {timestamp(record.createdAt)}</p>
+            </div>
+            <p className="mt-4 whitespace-pre-wrap border-l-2 pl-3 text-sm leading-6">{record.body}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="space-y-4 border-t pt-6" aria-labelledby="inbound-text-routing">
+        <div className="flex items-center gap-2 border-b pb-2">
+          <IconInbox className="size-5 text-muted-foreground" />
+          <div>
+            <h2 id="inbound-text-routing" className="text-lg font-semibold">Inbound texts awaiting review</h2>
+            <p className="text-sm text-muted-foreground">Routing is manual. Creating a Desk record does not claim or process the GoTo event.</p>
+          </div>
+        </div>
+        {inboundTexts.length === 0 ? (
+          <div className="border border-dashed p-8 text-center text-sm text-muted-foreground">No unhandled inbound texts.</div>
+        ) : inboundTexts.map((item) => (
+          <article key={item.id} className="border bg-background p-4 shadow-sm">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <h3 className="font-semibold">Text sender ending {item.senderPhone.replace(/\D/g, "").slice(-4) || "unknown"}</h3>
+                <p className="text-sm text-muted-foreground">{timestamp(item.receivedAt)}</p>
+              </div>
+              <Badge variant="secondary">Needs review</Badge>
+            </div>
+            <p className="mt-4 whitespace-pre-wrap border-l-2 pl-3 text-sm leading-6">
+              {item.messageBody ?? "No message body was retained."}
+            </p>
+            {assignees.length > 0 ? (
+              <form action={submitRouteGotoTextToMessageDesk} className="mt-4 flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-end">
+                <input type="hidden" name="eventId" value={item.id} />
+                <label className="flex flex-1 flex-col gap-1 text-sm font-medium">
+                  Route to one staff member
+                  <select name="assigneeUserId" required defaultValue="" className={fieldClassName()}>
+                    <option value="" disabled>Select a recipient…</option>
+                    {assignees.map((assignee) => (
+                      <option key={assignee.id} value={assignee.id}>{assignee.name} · {assignee.email}</option>
+                    ))}
+                  </select>
+                </label>
+                <Button type="submit">Route to Message Desk</Button>
+              </form>
+            ) : null}
+          </article>
+        ))}
+      </section>
+    </main>
+  )
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -19,6 +19,7 @@ import {
   IconMessageCircleQuestion,
   IconMessageReport,
   IconPalette,
+  IconPhone,
   IconPhoto,
   IconReceipt,
   IconShoppingCart,
@@ -79,6 +80,12 @@ const NAV_MAIN = [
     title: "Activity",
     url: "/dashboard/activity",
     icon: IconActivity,
+    internalOnly: true,
+  },
+  {
+    title: "Staff Message Desk",
+    url: "/dashboard/office-maintenance/message-desk",
+    icon: IconPhone,
     internalOnly: true,
   },
   {

--- a/src/components/projects/office-maintenance-drawer.tsx
+++ b/src/components/projects/office-maintenance-drawer.tsx
@@ -2,7 +2,12 @@
 
 import Link from "next/link"
 import { useState } from "react"
-import { IconMailForward, IconSettings, IconTemplate } from "@tabler/icons-react"
+import {
+  IconMailForward,
+  IconPhone,
+  IconSettings,
+  IconTemplate,
+} from "@tabler/icons-react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -127,6 +132,12 @@ export function OfficeMaintenanceDrawer({
             <Link href="/dashboard/office-maintenance/inbound-email">
               <IconMailForward className="size-4" />
               Review inbound messages
+            </Link>
+          </Button>
+          <Button asChild variant="outline" className="w-full justify-start">
+            <Link href="/dashboard/office-maintenance/message-desk">
+              <IconPhone className="size-4" />
+              Open Staff Message Desk
             </Link>
           </Button>
           <div className="space-y-2 border p-3">

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm"
 import {
   index,
   sqliteTable,
@@ -719,6 +720,53 @@ export const activityEvents = sqliteTable(
 
 export type ActivityEvent = typeof activityEvents.$inferSelect
 export type NewActivityEvent = typeof activityEvents.$inferInsert
+
+export const staffMessageRecords = sqliteTable(
+  "staff_message_records",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    sourceType: text("source_type").notNull(),
+    gotoInboundEventId: text("goto_inbound_event_id").references(
+      () => gotoInboundEvents.id,
+      { onDelete: "set null" }
+    ),
+    callerName: text("caller_name").notNull(),
+    callerCompany: text("caller_company"),
+    callerPhone: text("caller_phone"),
+    callerEmail: text("caller_email"),
+    subject: text("subject").notNull(),
+    body: text("body").notNull(),
+    assigneeUserId: text("assignee_user_id")
+      .notNull()
+      .references(() => users.id),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("staff_message_records_goto_event_unique")
+      .on(table.gotoInboundEventId)
+      .where(
+        sql`${table.gotoInboundEventId} IS NOT NULL`
+      ),
+    index("staff_message_records_org_created_idx").on(
+      table.organizationId,
+      table.createdAt
+    ),
+    index("staff_message_records_assignee_created_idx").on(
+      table.assigneeUserId,
+      table.createdAt
+    ),
+  ]
+)
+
+export type StaffMessageRecord = typeof staffMessageRecords.$inferSelect
+export type NewStaffMessageRecord = typeof staffMessageRecords.$inferInsert
 
 export const gotoInboundEvents = sqliteTable(
   "goto_inbound_events",

--- a/src/lib/__tests__/staff-message-desk.test.ts
+++ b/src/lib/__tests__/staff-message-desk.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildGotoStaffMessageDraft,
+  buildStaffMessageAssignmentNotification,
+  isEligibleStaffMessageAssignee,
+  isStaffMessageDeskUser,
+  type StaffMessageDeskUser,
+} from "@/lib/staff-message-desk"
+
+const internalStaff: StaffMessageDeskUser = {
+  id: "staff-1",
+  isActive: true,
+  organizationId: "org-internal",
+  organizationType: "internal",
+  role: "office",
+}
+
+describe("Staff Message Desk authorization", () => {
+  it("allows only active internal staff in an active organization", () => {
+    expect(isStaffMessageDeskUser(internalStaff)).toBe(true)
+    expect(isStaffMessageDeskUser({ ...internalStaff, isActive: false })).toBe(false)
+    expect(isStaffMessageDeskUser({ ...internalStaff, organizationType: "client" })).toBe(false)
+    expect(isStaffMessageDeskUser({ ...internalStaff, role: "developer" })).toBe(false)
+    expect(isStaffMessageDeskUser({ ...internalStaff, organizationId: null })).toBe(false)
+  })
+
+  it("requires the selected recipient to be active internal staff in the current organization and not the caller", () => {
+    expect(isEligibleStaffMessageAssignee(internalStaff, "org-internal", "staff-2")).toBe(true)
+    expect(isEligibleStaffMessageAssignee(internalStaff, "org-other", "staff-2")).toBe(false)
+    expect(isEligibleStaffMessageAssignee(internalStaff, "org-internal", "staff-1")).toBe(false)
+    expect(
+      isEligibleStaffMessageAssignee(
+        { ...internalStaff, role: "client" },
+        "org-internal",
+        "staff-2"
+      )
+    ).toBe(false)
+  })
+})
+
+describe("Staff Message Desk routing contracts", () => {
+  it("targets exactly the selected recipient for the in-app assignment notification", () => {
+    expect(
+      buildStaffMessageAssignmentNotification({
+        organizationId: "org-internal",
+        recordId: "record-1",
+        subject: "Call from supplier",
+        assigneeUserId: "staff-2",
+      })
+    ).toEqual({
+      organizationId: "org-internal",
+      recordId: "record-1",
+      recipientUserId: "staff-2",
+      title: "Staff message assigned: Call from supplier",
+      href: "/dashboard/office-maintenance/message-desk#message-record-1",
+    })
+  })
+
+  it("builds a prefilled manual GoTo draft without claiming the source event", () => {
+    expect(
+      buildGotoStaffMessageDraft({
+        eventId: "goto-1",
+        senderPhone: "+1 (303) 555-0100",
+        messageBody: "Please call me back\nabout the estimate.",
+        assigneeUserId: "staff-2",
+      })
+    ).toEqual({
+      sourceType: "message",
+      gotoInboundEventId: "goto-1",
+      callerName: "Inbound text caller",
+      callerPhone: "+1 (303) 555-0100",
+      subject: "Please call me back",
+      body: "Please call me back\nabout the estimate.",
+      assigneeUserId: "staff-2",
+      sourceEventMutation: null,
+    })
+  })
+})

--- a/src/lib/buildertrend/__tests__/legacy-reconciliation.test.ts
+++ b/src/lib/buildertrend/__tests__/legacy-reconciliation.test.ts
@@ -28,11 +28,17 @@ function isTestDatabaseModule(value: unknown): value is TestDatabaseModule {
 }
 
 async function createDatabase(): Promise<TestDatabase> {
-  const sqliteModule: unknown = await import("bun:sqlite")
-  if (!isTestDatabaseModule(sqliteModule)) {
-    throw new Error("bun:sqlite did not provide a Database constructor")
+  if ("Bun" in globalThis) {
+    const bunSqliteSpecifier = "bun:sqlite"
+    const sqliteModule: unknown = await import(bunSqliteSpecifier)
+    if (!isTestDatabaseModule(sqliteModule)) {
+      throw new Error("bun:sqlite did not provide a Database constructor")
+    }
+    return new sqliteModule.Database(":memory:")
   }
-  return new sqliteModule.Database(":memory:")
+
+  const { default: Database } = await import("better-sqlite3")
+  return new Database(":memory:")
 }
 
 const guardedMigrationSql = readFileSync(

--- a/src/lib/staff-message-desk.ts
+++ b/src/lib/staff-message-desk.ts
@@ -1,0 +1,87 @@
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+export type StaffMessageDeskUser = Readonly<{
+  readonly id: string
+  readonly isActive: boolean
+  readonly organizationId: string | null
+  readonly organizationType: string | null
+  readonly role: string
+}>
+
+export function isStaffMessageDeskUser(
+  user: StaffMessageDeskUser | null
+): boolean {
+  return (
+    user !== null &&
+    user.isActive &&
+    user.organizationId !== null &&
+    user.organizationType === "internal" &&
+    isInternalStaffRole(user.role)
+  )
+}
+
+export function isEligibleStaffMessageAssignee(
+  user: StaffMessageDeskUser,
+  organizationId: string,
+  creatorUserId: string
+): boolean {
+  return (
+    isStaffMessageDeskUser(user) &&
+    user.organizationId === organizationId &&
+    user.id !== creatorUserId
+  )
+}
+
+export type StaffMessageAssignmentNotification = Readonly<{
+  readonly organizationId: string
+  readonly recordId: string
+  readonly recipientUserId: string
+  readonly title: string
+  readonly href: string
+}>
+
+export function buildStaffMessageAssignmentNotification(input: {
+  readonly organizationId: string
+  readonly recordId: string
+  readonly subject: string
+  readonly assigneeUserId: string
+}): StaffMessageAssignmentNotification {
+  return {
+    organizationId: input.organizationId,
+    recordId: input.recordId,
+    recipientUserId: input.assigneeUserId,
+    title: `Staff message assigned: ${input.subject}`,
+    href: `/dashboard/office-maintenance/message-desk#message-${encodeURIComponent(input.recordId)}`,
+  }
+}
+
+export type GotoStaffMessageDraft = Readonly<{
+  readonly sourceType: "message"
+  readonly gotoInboundEventId: string
+  readonly callerName: string
+  readonly callerPhone: string
+  readonly subject: string
+  readonly body: string
+  readonly assigneeUserId: string
+  readonly sourceEventMutation: null
+}>
+
+export function buildGotoStaffMessageDraft(input: {
+  readonly eventId: string
+  readonly senderPhone: string
+  readonly messageBody: string | null
+  readonly assigneeUserId: string
+}): GotoStaffMessageDraft {
+  const body = input.messageBody?.trim() ?? ""
+  const subject = body.split(/\r?\n/, 1)[0]?.trim().slice(0, 120) || "Inbound text"
+  return {
+    sourceType: "message",
+    gotoInboundEventId: input.eventId,
+    callerName: "Inbound text caller",
+    callerPhone: input.senderPhone,
+    subject,
+    body: body || "No message body was retained.",
+    assigneeUserId: input.assigneeUserId,
+    sourceEventMutation: null,
+  }
+}


### PR DESCRIPTION
## Summary
- add a narrow Staff Message Desk for recording incoming calls/messages to one other active internal staff member
- create an in-app assignment notification targeted only at the selected recipient
- add an explicit manual GoTo inbound-text route that creates a prefilled Desk record without changing the source event
- add the minimum D1 table and internal-staff UI entry points

## Verification
- focused Staff Message Desk tests: pass (4)
- focused schema and Staff Message Desk tests: pass (10)
- lint: pass with existing repository warnings only
- production build: pass
- local D1 migration replay: pass, including 0109
- full test suite: 815 passed, 8 pre-existing Buildertrend failures because this environment lacks bun:sqlite
- typecheck: only the same pre-existing bun:sqlite declaration error remains

Draft only. Do not merge, deploy, or run production migrations.