### PR TITLE
feat(cutover): attest Buildertrend module coverage

### DIFF
--- a/drizzle/0110_buildertrend_module_attestations.sql
+++ b/drizzle/0110_buildertrend_module_attestations.sql
@@ -1,0 +1,35 @@
+CREATE TABLE `buildertrend_module_attestations` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `project_id` text NOT NULL,
+  `import_run_id` text,
+  `module_key` text NOT NULL,
+  `status` text NOT NULL,
+  `observed_count` integer DEFAULT 0 NOT NULL,
+  `manifest_fingerprint` text NOT NULL,
+  `evidence_drive_file_id` text,
+  `evidence_drive_url` text,
+  `source_label` text NOT NULL,
+  `checked_at` text NOT NULL,
+  `verified_by` text,
+  `notes` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`import_run_id`) REFERENCES `buildertrend_staging_runs`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`verified_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  CONSTRAINT `buildertrend_module_attestations_status_check`
+    CHECK (`status` in ('captured', 'verified_empty', 'partial', 'blocked', 'unavailable')),
+  CONSTRAINT `buildertrend_module_attestations_observed_count_check`
+    CHECK (`observed_count` >= 0)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `buildertrend_module_attestations_org_project_module_unique`
+  ON `buildertrend_module_attestations` (`organization_id`, `project_id`, `module_key`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_module_attestations_org_status_idx`
+  ON `buildertrend_module_attestations` (`organization_id`, `status`);
+--> statement-breakpoint
+CREATE INDEX `buildertrend_module_attestations_run_idx`
+  ON `buildertrend_module_attestations` (`import_run_id`);

--- a/src/app/actions/buildertrend-cutover-coverage.ts
+++ b/src/app/actions/buildertrend-cutover-coverage.ts
@@ -1,0 +1,147 @@
+"use server"
+
+import { and, eq, isNotNull, sql } from "drizzle-orm"
+
+import { getDb } from "@/db"
+import {
+  buildertrendArchiveFiles,
+  buildertrendModuleAttestations,
+  buildertrendSourceRecords,
+} from "@/db/schema-buildertrend"
+import { projects } from "@/db/schema"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import {
+  moduleForArchiveFileType,
+  moduleForSourceRecordType,
+  summarizeBuildertrendModuleCoverage,
+  type BuildertrendCoverageEvidence,
+  type BuildertrendCoverageSummary,
+} from "@/lib/buildertrend/module-coverage"
+import { requireOrg } from "@/lib/org-scope"
+import { canManageProjectRegistry } from "@/lib/permissions"
+
+export type BuildertrendCutoverStatusCount = {
+  readonly status: string
+  readonly count: number
+}
+
+export type BuildertrendCutoverCoverage = BuildertrendCoverageSummary & {
+  readonly generatedAt: string
+  readonly statusCounts: readonly BuildertrendCutoverStatusCount[]
+}
+
+function numberValue(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "string") {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+  return 0
+}
+
+export async function getBuildertrendCutoverCoverage(): Promise<BuildertrendCutoverCoverage> {
+  const user = await requireAuth()
+  if (!canManageProjectRegistry(user)) {
+    throw new Error("Project administration permission is required")
+  }
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+
+  const projectRows = await db
+    .select({ id: projects.id, status: projects.status })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.organizationId, organizationId),
+        isNotNull(projects.buildertrendProjectId)
+      )
+    )
+
+  const sourceGroups = await db
+    .select({
+      projectId: buildertrendSourceRecords.projectId,
+      sourceRecordType: buildertrendSourceRecords.sourceRecordType,
+      recordCount: sql<number>`count(*)`,
+    })
+    .from(buildertrendSourceRecords)
+    .where(
+      and(
+        eq(buildertrendSourceRecords.organizationId, organizationId),
+        isNotNull(buildertrendSourceRecords.projectId)
+      )
+    )
+    .groupBy(
+      buildertrendSourceRecords.projectId,
+      buildertrendSourceRecords.sourceRecordType
+    )
+
+  const fileGroups = await db
+    .select({
+      projectId: buildertrendArchiveFiles.projectId,
+      sourceRecordType: buildertrendArchiveFiles.sourceRecordType,
+      recordCount: sql<number>`count(*)`,
+    })
+    .from(buildertrendArchiveFiles)
+    .where(
+      and(
+        eq(buildertrendArchiveFiles.organizationId, organizationId),
+        isNotNull(buildertrendArchiveFiles.projectId)
+      )
+    )
+    .groupBy(
+      buildertrendArchiveFiles.projectId,
+      buildertrendArchiveFiles.sourceRecordType
+    )
+
+  const evidence: BuildertrendCoverageEvidence[] = []
+  for (const group of sourceGroups) {
+    if (!group.projectId) continue
+    const moduleKey = moduleForSourceRecordType(group.sourceRecordType)
+    if (!moduleKey) continue
+    evidence.push({
+      projectId: group.projectId,
+      moduleKey,
+      recordCount: numberValue(group.recordCount),
+    })
+  }
+  for (const group of fileGroups) {
+    if (!group.projectId) continue
+    const moduleKey = moduleForArchiveFileType(group.sourceRecordType)
+    if (!moduleKey) continue
+    evidence.push({
+      projectId: group.projectId,
+      moduleKey,
+      recordCount: numberValue(group.recordCount),
+    })
+  }
+
+  const attestationRows = await db
+    .select({
+      projectId: buildertrendModuleAttestations.projectId,
+      moduleKey: buildertrendModuleAttestations.moduleKey,
+      status: buildertrendModuleAttestations.status,
+      observedCount: buildertrendModuleAttestations.observedCount,
+    })
+    .from(buildertrendModuleAttestations)
+    .where(eq(buildertrendModuleAttestations.organizationId, organizationId))
+
+  const summary = summarizeBuildertrendModuleCoverage(
+    projectRows.map((project) => ({ id: project.id })),
+    evidence,
+    attestationRows
+  )
+  const statusCounts = new Map<string, number>()
+  for (const project of projectRows) {
+    statusCounts.set(project.status, (statusCounts.get(project.status) ?? 0) + 1)
+  }
+
+  return {
+    ...summary,
+    generatedAt: new Date().toISOString(),
+    statusCounts: [...statusCounts.entries()]
+      .map(([status, count]) => ({ status, count }))
+      .sort((left, right) => left.status.localeCompare(right.status)),
+  }
+}

--- a/src/app/dashboard/office-maintenance/buildertrend-cutover/page.tsx
+++ b/src/app/dashboard/office-maintenance/buildertrend-cutover/page.tsx
@@ -1,0 +1,142 @@
+export const dynamic = "force-dynamic"
+
+import Link from "next/link"
+import { IconArrowLeft, IconDatabase } from "@tabler/icons-react"
+
+import { getBuildertrendCutoverCoverage } from "@/app/actions/buildertrend-cutover-coverage"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+
+function generatedLabel(value: string): string {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString()
+}
+
+export default async function BuildertrendCutoverPage(): Promise<React.ReactElement> {
+  const coverage = await getBuildertrendCutoverCoverage()
+
+  return (
+    <main className="mx-auto w-full max-w-6xl space-y-6 p-4 lg:p-6">
+      <header className="border-b pb-4">
+        <Button asChild variant="ghost" size="sm" className="-ml-3 mb-2">
+          <Link href="/dashboard">
+            <IconArrowLeft className="size-4" />
+            Dashboard
+          </Link>
+        </Button>
+        <div className="flex items-center gap-2">
+          <IconDatabase className="size-6 text-muted-foreground" />
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Buildertrend cutover coverage
+          </h1>
+        </div>
+        <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+          A module is complete only when its captured count is attested, or a
+          signed capture confirms that Buildertrend contained zero records.
+          Existing records without that final check remain partial.
+        </p>
+      </header>
+
+      <section className="grid gap-px border bg-border sm:grid-cols-4">
+        <div className="bg-background p-4">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Mapped projects
+          </p>
+          <p className="mt-1 text-2xl font-semibold">{coverage.projectCount}</p>
+        </div>
+        <div className="bg-background p-4">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Required modules
+          </p>
+          <p className="mt-1 text-2xl font-semibold">{coverage.moduleCount}</p>
+        </div>
+        <div className="bg-background p-4">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Verified checks
+          </p>
+          <p className="mt-1 text-2xl font-semibold">
+            {coverage.verifiedChecks} / {coverage.totalChecks}
+          </p>
+        </div>
+        <div className="bg-background p-4">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Evidence complete
+          </p>
+          <p className="mt-1 text-2xl font-semibold">
+            {coverage.completionPercent}%
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="text-lg font-semibold">Project lifecycle inventory</h2>
+        <div className="flex flex-wrap gap-2">
+          {coverage.statusCounts.map((item) => (
+            <Badge key={item.status} variant="outline">
+              {item.status} {item.count}
+            </Badge>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-lg font-semibold">Module evidence</h2>
+          <p className="text-sm text-muted-foreground">
+            “Partial” includes captured records that have not received a
+            matching completeness attestation. “Conflict” means the attested
+            count no longer matches staged evidence.
+          </p>
+        </div>
+        <div className="overflow-x-auto border">
+          <table className="w-full min-w-[860px] text-sm">
+            <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-3 py-3 font-medium">Module</th>
+                <th className="px-3 py-3 text-right font-medium">Captured</th>
+                <th className="px-3 py-3 text-right font-medium">Empty</th>
+                <th className="px-3 py-3 text-right font-medium">Partial</th>
+                <th className="px-3 py-3 text-right font-medium">
+                  Blocked / unavailable
+                </th>
+                <th className="px-3 py-3 text-right font-medium">Conflict</th>
+                <th className="px-3 py-3 text-right font-medium">Missing</th>
+                <th className="px-3 py-3 text-right font-medium">Complete</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {coverage.modules.map((module) => (
+                <tr key={module.key}>
+                  <th className="px-3 py-3 text-left font-medium">
+                    {module.label}
+                  </th>
+                  <td className="px-3 py-3 text-right">
+                    {module.verifiedCapturedCount}
+                  </td>
+                  <td className="px-3 py-3 text-right">
+                    {module.verifiedEmptyCount}
+                  </td>
+                  <td className="px-3 py-3 text-right">{module.partialCount}</td>
+                  <td className="px-3 py-3 text-right">
+                    {module.blockedCount + module.unavailableCount}
+                  </td>
+                  <td className="px-3 py-3 text-right">
+                    {module.conflictCount}
+                  </td>
+                  <td className="px-3 py-3 text-right">{module.missingCount}</td>
+                  <td className="px-3 py-3 text-right font-medium">
+                    {module.completionPercent}%
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Generated {generatedLabel(coverage.generatedAt)}. This screen is
+          read-only and does not promote records or grant portal access.
+        </p>
+      </section>
+    </main>
+  )
+}

--- a/src/components/projects/office-maintenance-drawer.tsx
+++ b/src/components/projects/office-maintenance-drawer.tsx
@@ -2,7 +2,12 @@
 
 import Link from "next/link"
 import { useState } from "react"
-import { IconMailForward, IconSettings, IconTemplate } from "@tabler/icons-react"
+import {
+  IconDatabase,
+  IconMailForward,
+  IconSettings,
+  IconTemplate,
+} from "@tabler/icons-react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -127,6 +132,12 @@ export function OfficeMaintenanceDrawer({
             <Link href="/dashboard/office-maintenance/inbound-email">
               <IconMailForward className="size-4" />
               Review inbound messages
+            </Link>
+          </Button>
+          <Button asChild variant="outline" className="w-full justify-start">
+            <Link href="/dashboard/office-maintenance/buildertrend-cutover">
+              <IconDatabase className="size-4" />
+              Buildertrend cutover coverage
             </Link>
           </Button>
           <div className="space-y-2 border p-3">

--- a/src/db/schema-buildertrend.ts
+++ b/src/db/schema-buildertrend.ts
@@ -289,6 +289,57 @@ export const buildertrendImportObservations = sqliteTable(
   ]
 )
 
+export const buildertrendModuleAttestations = sqliteTable(
+  "buildertrend_module_attestations",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    importRunId: text("import_run_id").references(
+      () => buildertrendImportRuns.id,
+      { onDelete: "set null" }
+    ),
+    moduleKey: text("module_key").notNull(),
+    status: text("status").notNull(),
+    observedCount: integer("observed_count").notNull().default(0),
+    manifestFingerprint: text("manifest_fingerprint").notNull(),
+    evidenceDriveFileId: text("evidence_drive_file_id"),
+    evidenceDriveUrl: text("evidence_drive_url"),
+    sourceLabel: text("source_label").notNull(),
+    checkedAt: text("checked_at").notNull(),
+    verifiedBy: text("verified_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    notes: text("notes"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("buildertrend_module_attestations_org_project_module_unique").on(
+      table.organizationId,
+      table.projectId,
+      table.moduleKey
+    ),
+    index("buildertrend_module_attestations_org_status_idx").on(
+      table.organizationId,
+      table.status
+    ),
+    index("buildertrend_module_attestations_run_idx").on(table.importRunId),
+    check(
+      "buildertrend_module_attestations_status_check",
+      sql`${table.status} in ('captured', 'verified_empty', 'partial', 'blocked', 'unavailable')`
+    ),
+    check(
+      "buildertrend_module_attestations_observed_count_check",
+      sql`${table.observedCount} >= 0`
+    ),
+  ]
+)
+
 export const buildertrendIdentityReviewRuns = sqliteTable(
   "buildertrend_staging_identity_review_runs",
   {
@@ -452,6 +503,10 @@ export type BuildertrendImportObservation =
   typeof buildertrendImportObservations.$inferSelect
 export type NewBuildertrendImportObservation =
   typeof buildertrendImportObservations.$inferInsert
+export type BuildertrendModuleAttestation =
+  typeof buildertrendModuleAttestations.$inferSelect
+export type NewBuildertrendModuleAttestation =
+  typeof buildertrendModuleAttestations.$inferInsert
 export type BuildertrendIdentityReviewRun =
   typeof buildertrendIdentityReviewRuns.$inferSelect
 export type NewBuildertrendIdentityReviewRun =

--- a/src/lib/buildertrend/__tests__/module-coverage.test.ts
+++ b/src/lib/buildertrend/__tests__/module-coverage.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  moduleForArchiveFileType,
+  moduleForSourceRecordType,
+  summarizeBuildertrendModuleCoverage,
+  type BuildertrendModuleCoverageRow,
+} from "@/lib/buildertrend/module-coverage"
+
+function moduleRow(
+  rows: readonly BuildertrendModuleCoverageRow[],
+  key: BuildertrendModuleCoverageRow["key"]
+): BuildertrendModuleCoverageRow {
+  const row = rows.find((candidate) => candidate.key === key)
+  if (!row) throw new Error(`Missing coverage row for ${key}`)
+  return row
+}
+
+describe("Buildertrend module coverage", () => {
+  it("does not treat source records alone as complete evidence", () => {
+    const summary = summarizeBuildertrendModuleCoverage(
+      [{ id: "project-a" }, { id: "project-b" }],
+      [{ projectId: "project-a", moduleKey: "daily_logs", recordCount: 4 }],
+      []
+    )
+
+    const dailyLogs = moduleRow(summary.modules, "daily_logs")
+    expect(dailyLogs.partialCount).toBe(1)
+    expect(dailyLogs.missingCount).toBe(1)
+    expect(dailyLogs.verifiedCount).toBe(0)
+  })
+
+  it("counts matching captures and explicit empty checks as verified", () => {
+    const summary = summarizeBuildertrendModuleCoverage(
+      [{ id: "project-a" }, { id: "project-b" }],
+      [{ projectId: "project-a", moduleKey: "rfis", recordCount: 3 }],
+      [
+        {
+          projectId: "project-a",
+          moduleKey: "rfis",
+          status: "captured",
+          observedCount: 3,
+        },
+        {
+          projectId: "project-b",
+          moduleKey: "rfis",
+          status: "verified_empty",
+          observedCount: 0,
+        },
+      ]
+    )
+
+    const rfis = moduleRow(summary.modules, "rfis")
+    expect(rfis.verifiedCapturedCount).toBe(1)
+    expect(rfis.verifiedEmptyCount).toBe(1)
+    expect(rfis.completionPercent).toBe(100)
+  })
+
+  it("flags count mismatches instead of accepting stale attestations", () => {
+    const summary = summarizeBuildertrendModuleCoverage(
+      [{ id: "project-a" }],
+      [{ projectId: "project-a", moduleKey: "tasks", recordCount: 5 }],
+      [
+        {
+          projectId: "project-a",
+          moduleKey: "tasks",
+          status: "captured",
+          observedCount: 4,
+        },
+      ]
+    )
+
+    expect(moduleRow(summary.modules, "tasks").conflictCount).toBe(1)
+  })
+
+  it("maps staging record and file types to the audited modules", () => {
+    expect(moduleForSourceRecordType("estimate_line_item")).toBe("estimates")
+    expect(moduleForSourceRecordType("message_claim_detail")).toBe(
+      "warranty_claims"
+    )
+    expect(moduleForArchiveFileType("owner_update_photo")).toBe("photos")
+    expect(moduleForArchiveFileType("document")).toBe("files")
+    expect(moduleForSourceRecordType("job")).toBeNull()
+  })
+})

--- a/src/lib/buildertrend/module-coverage.ts
+++ b/src/lib/buildertrend/module-coverage.ts
@@ -1,0 +1,258 @@
+export type BuildertrendModuleKey =
+  | "daily_logs"
+  | "photos"
+  | "videos"
+  | "messages"
+  | "schedules"
+  | "tasks"
+  | "rfis"
+  | "rfqs"
+  | "purchase_orders"
+  | "owner_updates"
+  | "finish_selections"
+  | "files"
+  | "estimates"
+  | "owner_invoices"
+  | "payments"
+  | "change_orders"
+  | "warranty_claims"
+
+export type BuildertrendCoverageStatus =
+  | "verified_captured"
+  | "verified_empty"
+  | "partial"
+  | "blocked"
+  | "unavailable"
+  | "conflict"
+  | "missing"
+
+export type BuildertrendModuleDefinition = {
+  readonly key: BuildertrendModuleKey
+  readonly label: string
+}
+
+export const BUILDERTREND_MODULES: readonly BuildertrendModuleDefinition[] = [
+  { key: "daily_logs", label: "Daily logs" },
+  { key: "photos", label: "Photos" },
+  { key: "videos", label: "Videos" },
+  { key: "messages", label: "Messages" },
+  { key: "schedules", label: "Schedules" },
+  { key: "tasks", label: "To-dos" },
+  { key: "rfis", label: "RFIs" },
+  { key: "rfqs", label: "RFQs" },
+  { key: "purchase_orders", label: "Purchase orders" },
+  { key: "owner_updates", label: "Owner updates" },
+  { key: "finish_selections", label: "Finish selections" },
+  { key: "files", label: "Files and documents" },
+  { key: "estimates", label: "Estimates and proposals" },
+  { key: "owner_invoices", label: "Owner invoices" },
+  { key: "payments", label: "Payments" },
+  { key: "change_orders", label: "Change orders" },
+  { key: "warranty_claims", label: "Warranty claims" },
+]
+
+export type BuildertrendCoverageProject = {
+  readonly id: string
+}
+
+export type BuildertrendCoverageEvidence = {
+  readonly projectId: string
+  readonly moduleKey: BuildertrendModuleKey
+  readonly recordCount: number
+}
+
+export type BuildertrendCoverageAttestation = {
+  readonly projectId: string
+  readonly moduleKey: string
+  readonly status: string
+  readonly observedCount: number
+}
+
+export type BuildertrendModuleCoverageRow = {
+  readonly key: BuildertrendModuleKey
+  readonly label: string
+  readonly projectCount: number
+  readonly verifiedCapturedCount: number
+  readonly verifiedEmptyCount: number
+  readonly partialCount: number
+  readonly blockedCount: number
+  readonly unavailableCount: number
+  readonly conflictCount: number
+  readonly missingCount: number
+  readonly verifiedCount: number
+  readonly completionPercent: number
+}
+
+export type BuildertrendCoverageSummary = {
+  readonly projectCount: number
+  readonly moduleCount: number
+  readonly totalChecks: number
+  readonly verifiedChecks: number
+  readonly completionPercent: number
+  readonly modules: readonly BuildertrendModuleCoverageRow[]
+}
+
+function coverageKey(projectId: string, moduleKey: string): string {
+  return `${projectId}\u0000${moduleKey}`
+}
+
+function normalizedCount(value: number): number {
+  if (!Number.isFinite(value) || value < 0) return 0
+  return Math.floor(value)
+}
+
+function attestedStatus(
+  evidenceCount: number,
+  attestation: BuildertrendCoverageAttestation | undefined
+): BuildertrendCoverageStatus {
+  if (!attestation) return evidenceCount > 0 ? "partial" : "missing"
+
+  const observedCount = normalizedCount(attestation.observedCount)
+  if (attestation.status === "captured") {
+    return observedCount === evidenceCount && evidenceCount > 0
+      ? "verified_captured"
+      : "conflict"
+  }
+  if (attestation.status === "verified_empty") {
+    return observedCount === 0 && evidenceCount === 0
+      ? "verified_empty"
+      : "conflict"
+  }
+  if (attestation.status === "partial") return "partial"
+  if (attestation.status === "blocked") return "blocked"
+  if (attestation.status === "unavailable") return "unavailable"
+  return "conflict"
+}
+
+function countStatuses(
+  statuses: readonly BuildertrendCoverageStatus[],
+  status: BuildertrendCoverageStatus
+): number {
+  return statuses.filter((candidate) => candidate === status).length
+}
+
+export function summarizeBuildertrendModuleCoverage(
+  projects: readonly BuildertrendCoverageProject[],
+  evidence: readonly BuildertrendCoverageEvidence[],
+  attestations: readonly BuildertrendCoverageAttestation[]
+): BuildertrendCoverageSummary {
+  const evidenceByKey = new Map<string, number>()
+  for (const item of evidence) {
+    const key = coverageKey(item.projectId, item.moduleKey)
+    evidenceByKey.set(
+      key,
+      (evidenceByKey.get(key) ?? 0) + normalizedCount(item.recordCount)
+    )
+  }
+
+  const attestationByKey = new Map<string, BuildertrendCoverageAttestation>()
+  for (const attestation of attestations) {
+    attestationByKey.set(
+      coverageKey(attestation.projectId, attestation.moduleKey),
+      attestation
+    )
+  }
+
+  const modules = BUILDERTREND_MODULES.map((module) => {
+    const statuses = projects.map((project) => {
+      const key = coverageKey(project.id, module.key)
+      return attestedStatus(
+        evidenceByKey.get(key) ?? 0,
+        attestationByKey.get(key)
+      )
+    })
+    const verifiedCapturedCount = countStatuses(statuses, "verified_captured")
+    const verifiedEmptyCount = countStatuses(statuses, "verified_empty")
+    const verifiedCount = verifiedCapturedCount + verifiedEmptyCount
+    return {
+      key: module.key,
+      label: module.label,
+      projectCount: projects.length,
+      verifiedCapturedCount,
+      verifiedEmptyCount,
+      partialCount: countStatuses(statuses, "partial"),
+      blockedCount: countStatuses(statuses, "blocked"),
+      unavailableCount: countStatuses(statuses, "unavailable"),
+      conflictCount: countStatuses(statuses, "conflict"),
+      missingCount: countStatuses(statuses, "missing"),
+      verifiedCount,
+      completionPercent:
+        projects.length === 0
+          ? 100
+          : Math.round((verifiedCount / projects.length) * 100),
+    }
+  })
+  const totalChecks = projects.length * modules.length
+  const verifiedChecks = modules.reduce(
+    (total, module) => total + module.verifiedCount,
+    0
+  )
+
+  return {
+    projectCount: projects.length,
+    moduleCount: modules.length,
+    totalChecks,
+    verifiedChecks,
+    completionPercent:
+      totalChecks === 0 ? 100 : Math.round((verifiedChecks / totalChecks) * 100),
+    modules,
+  }
+}
+
+export function moduleForSourceRecordType(
+  sourceRecordType: string
+): BuildertrendModuleKey | null {
+  if (sourceRecordType === "daily_log") return "daily_logs"
+  if (sourceRecordType === "photo_folder") return "photos"
+  if (sourceRecordType === "video") return "videos"
+  if (sourceRecordType === "message") return "messages"
+  if (sourceRecordType === "schedule_item" || sourceRecordType === "schedule_summary") {
+    return "schedules"
+  }
+  if (sourceRecordType === "task") return "tasks"
+  if (sourceRecordType === "rfi") return "rfis"
+  if (sourceRecordType === "rfq") return "rfqs"
+  if (sourceRecordType === "purchase_order") return "purchase_orders"
+  if (sourceRecordType === "owner_update") return "owner_updates"
+  if (sourceRecordType === "finish_selection") return "finish_selections"
+  if (sourceRecordType === "document_folder") return "files"
+  if (
+    sourceRecordType === "estimate" ||
+    sourceRecordType === "estimate_category" ||
+    sourceRecordType === "estimate_line_item" ||
+    sourceRecordType === "lead_proposal"
+  ) {
+    return "estimates"
+  }
+  if (sourceRecordType === "owner_invoice") return "owner_invoices"
+  if (sourceRecordType === "payment") return "payments"
+  if (sourceRecordType === "change_order") return "change_orders"
+  if (
+    sourceRecordType === "warranty_claim" ||
+    sourceRecordType === "message_claim_detail"
+  ) {
+    return "warranty_claims"
+  }
+  return null
+}
+
+export function moduleForArchiveFileType(
+  sourceRecordType: string
+): BuildertrendModuleKey | null {
+  if (
+    sourceRecordType === "photo" ||
+    sourceRecordType === "daily_log_photo" ||
+    sourceRecordType === "owner_update_photo" ||
+    sourceRecordType === "photo_panorama_pointer"
+  ) {
+    return "photos"
+  }
+  if (sourceRecordType === "daily_log_video" || sourceRecordType === "video") {
+    return "videos"
+  }
+  if (sourceRecordType === "document") return "files"
+  if (sourceRecordType === "lead_proposal") return "estimates"
+  if (sourceRecordType === "owner_invoice_attachment") return "owner_invoices"
+  if (sourceRecordType === "message_claim_photo") return "warranty_claims"
+  return null
+}


### PR DESCRIPTION
## What changed

- adds durable per-project, per-module Buildertrend capture attestations
- distinguishes verified captured data, verified empty modules, partial captures, blocked modules, count conflicts, and missing evidence
- adds a read-only Buildertrend cutover coverage screen under Office Maintenance
- keeps imported records partial until a completeness attestation matches the staged count

## Why

An uncaptured Buildertrend module and a verified zero-record module previously looked identical. That made it impossible to prove full cutover coverage without guessing. The new attestation ledger makes zero-record audits count as evidence while preserving real gaps.

## Validation

- `bun test src/lib/buildertrend/__tests__/module-coverage.test.ts`
- focused ESLint on all changed TypeScript/TSX files
- `bun lint` (0 errors; existing repository warnings only)
- `bun run build`
- `git diff --check`

The external autoreview helper was not used because its sandbox approval correctly blocked transmission of the uncommitted source bundle. Per the standing Compass release instruction, the independent-review gate is bypassed; local tests, lint, TypeScript, and production build remain required.
