### PR TITLE
perf(d1): reduce query waterfalls and harden RFI writes

### DIFF
--- a/docs/architecture/data-layer.md
+++ b/docs/architecture/data-layer.md
@@ -189,6 +189,29 @@ const db = getDb(env.DB)
 The `getDb()` function is called per-request -- it creates a new Drizzle instance each time. This is intentional. Cloudflare Workers are stateless isolates; there's no persistent connection to reuse. The cost of creating the Drizzle wrapper is negligible compared to the query itself.
 
 
+atomic writes and asynchronous work
+---
+
+D1 calls are asynchronous, but an awaited call is still part of the request's
+critical path. Authorization reads, response-dependent reads, primary writes,
+and durable operation records must remain awaited.
+
+Use `db.batch()` when multiple D1 statements maintain one local invariant. D1
+batches commit all statements or roll them all back, so code must not model a
+transaction as an async callback containing separate queries. The shared
+`DatabaseProvider` intentionally does not expose a callback `transaction()` API.
+
+A JavaScript timeout such as `Promise.race()` only stops waiting for a query; it
+does not prove that D1 canceled or rolled back a write. Retriable write workflows
+therefore need stable operation IDs, uniqueness constraints, and reconciliation
+before retry.
+
+Reserve `waitUntil()` for short, best-effort work that is safe to lose. Durable,
+long-running, or external side effects belong in Cloudflare Queues or Workflows
+with idempotent consumers. Persist and await the queue or operation record before
+returning success to the caller.
+
+
 migration workflow
 ---
 

--- a/src/app/actions/dashboard-overview.ts
+++ b/src/app/actions/dashboard-overview.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { asc, desc, eq } from "drizzle-orm"
+import { asc, desc, eq, sql } from "drizzle-orm"
 
 import { getDb } from "@/db"
 import {
@@ -203,6 +203,21 @@ function averageProgress(
   return Math.round(total / rows.length)
 }
 
+function groupByProjectId<T extends { readonly projectId: string }>(
+  rows: readonly T[]
+): ReadonlyMap<string, readonly T[]> {
+  const grouped = new Map<string, T[]>()
+  for (const row of rows) {
+    const projectRows = grouped.get(row.projectId)
+    if (projectRows) {
+      projectRows.push(row)
+    } else {
+      grouped.set(row.projectId, [row])
+    }
+  }
+  return grouped
+}
+
 export async function getDashboardOverview(): Promise<DashboardOverview> {
   try {
     const user = await requireAuth()
@@ -217,20 +232,145 @@ export async function getDashboardOverview(): Promise<DashboardOverview> {
     const db = getDb(env.DB)
     const today = new Date().toISOString().slice(0, 10)
 
-    const projectRows = await db
+    const rankedDailyLogs = db
       .select({
-        id: projects.id,
-        name: projects.name,
-        projectNumber: projects.projectNumber,
-        clientName: projects.clientName,
-        status: projects.status,
-        sageJobId: projects.sageJobId,
-        sageJobNumber: projects.sageJobNumber,
-        googleDriveFolderId: projects.googleDriveFolderId,
+        projectId: dailyLogs.projectId,
+        logDate: dailyLogs.logDate,
+        sourceSystem: dailyLogs.sourceSystem,
+        reviewStatus: dailyLogs.reviewStatus,
+        rank: sql<number>`row_number() over (
+          partition by ${dailyLogs.projectId}
+          order by ${dailyLogs.logDate} desc
+        )`.as("rank"),
       })
-      .from(projects)
+      .from(dailyLogs)
+      .innerJoin(projects, eq(dailyLogs.projectId, projects.id))
       .where(eq(projects.organizationId, orgId))
-      .orderBy(asc(projects.projectNumber), asc(projects.name))
+      .as("ranked_daily_logs")
+
+    // Load each dashboard dataset once for the organization. The previous
+    // per-project loop issued seven sequential D1 queries per project, making
+    // dashboard latency grow linearly with both project count and network RTT.
+    const [
+      projectRows,
+      allTaskRows,
+      allPhotoRows,
+      allLogRows,
+      allOwnerUpdateRows,
+      allOperationRows,
+      allRfiRows,
+    ] = await db.batch([
+      db
+        .select({
+          id: projects.id,
+          name: projects.name,
+          projectNumber: projects.projectNumber,
+          clientName: projects.clientName,
+          status: projects.status,
+          sageJobId: projects.sageJobId,
+          sageJobNumber: projects.sageJobNumber,
+          googleDriveFolderId: projects.googleDriveFolderId,
+        })
+        .from(projects)
+        .where(eq(projects.organizationId, orgId))
+        .orderBy(asc(projects.projectNumber), asc(projects.name)),
+      db
+        .select({
+          projectId: scheduleTasks.projectId,
+          id: scheduleTasks.id,
+          title: scheduleTasks.title,
+          startDate: scheduleTasks.startDate,
+          endDate: scheduleTasks.endDateCalculated,
+          assignedTo: scheduleTasks.assignedTo,
+          status: scheduleTasks.status,
+          percentComplete: scheduleTasks.percentComplete,
+        })
+        .from(scheduleTasks)
+        .innerJoin(projects, eq(scheduleTasks.projectId, projects.id))
+        .where(eq(projects.organizationId, orgId))
+        .orderBy(asc(scheduleTasks.startDate), asc(scheduleTasks.sortOrder)),
+      db
+        .select({
+          projectId: dailyLogPhotos.projectId,
+          id: dailyLogPhotos.id,
+          fileName: dailyLogPhotos.fileName,
+          driveFileId: dailyLogPhotos.driveFileId,
+          driveUrl: dailyLogPhotos.driveUrl,
+          thumbnailUrl: dailyLogPhotos.thumbnailUrl,
+          caption: dailyLogPhotos.caption,
+          capturedAt: dailyLogPhotos.capturedAt,
+          mimeType: dailyLogPhotos.mimeType,
+          photoKind: dailyLogPhotos.photoKind,
+          createdAt: dailyLogPhotos.createdAt,
+          reviewStatus: dailyLogPhotos.reviewStatus,
+          ownerVisible: dailyLogPhotos.ownerVisible,
+        })
+        .from(dailyLogPhotos)
+        .innerJoin(projects, eq(dailyLogPhotos.projectId, projects.id))
+        .where(eq(projects.organizationId, orgId))
+        .orderBy(desc(dailyLogPhotos.capturedAt), desc(dailyLogPhotos.createdAt)),
+      db
+        .select({
+          projectId: rankedDailyLogs.projectId,
+          logDate: rankedDailyLogs.logDate,
+          sourceSystem: rankedDailyLogs.sourceSystem,
+          reviewStatus: rankedDailyLogs.reviewStatus,
+        })
+        .from(rankedDailyLogs)
+        .where(eq(rankedDailyLogs.rank, 1)),
+      db
+        .select({
+          projectId: ownerProjectUpdates.projectId,
+          id: ownerProjectUpdates.id,
+          title: ownerProjectUpdates.title,
+          status: ownerProjectUpdates.status,
+          updateDate: ownerProjectUpdates.updateDate,
+        })
+        .from(ownerProjectUpdates)
+        .innerJoin(projects, eq(ownerProjectUpdates.projectId, projects.id))
+        .where(eq(projects.organizationId, orgId))
+        .orderBy(desc(ownerProjectUpdates.updateDate)),
+      db
+        .select({
+          projectId: projectOperations.projectId,
+          id: projectOperations.id,
+          sourceRecordType: projectOperations.sourceRecordType,
+          sourceRecordNumber: projectOperations.sourceRecordNumber,
+          title: projectOperations.title,
+          status: projectOperations.status,
+          dueDate: projectOperations.dueDate,
+          amount: projectOperations.amount,
+          sourceSystem: projectOperations.sourceSystem,
+          lastSyncedAt: projectOperations.lastSyncedAt,
+          assigneeName: projectOperations.assigneeName,
+          companyName: projectOperations.companyName,
+        })
+        .from(projectOperations)
+        .innerJoin(projects, eq(projectOperations.projectId, projects.id))
+        .where(eq(projects.organizationId, orgId))
+        .orderBy(asc(projectOperations.dueDate), asc(projectOperations.title)),
+      db
+        .select({
+          projectId: projectRfis.projectId,
+          id: projectRfis.id,
+          rfiNumber: projectRfis.rfiNumber,
+          subject: projectRfis.subject,
+          priority: projectRfis.priority,
+          status: projectRfis.status,
+          dueDate: projectRfis.dueDate,
+        })
+        .from(projectRfis)
+        .innerJoin(projects, eq(projectRfis.projectId, projects.id))
+        .where(eq(projects.organizationId, orgId))
+        .orderBy(asc(projectRfis.dueDate), asc(projectRfis.rfiNumber)),
+    ])
+
+    const tasksByProject = groupByProjectId(allTaskRows)
+    const photosByProject = groupByProjectId(allPhotoRows)
+    const logsByProject = groupByProjectId(allLogRows)
+    const ownerUpdatesByProject = groupByProjectId(allOwnerUpdateRows)
+    const operationsByProject = groupByProjectId(allOperationRows)
+    const rfisByProject = groupByProjectId(allRfiRows)
 
     const dashboardProjects: DashboardProject[] = []
     const upcomingTasks: DashboardTask[] = []
@@ -250,19 +390,7 @@ export async function getDashboardOverview(): Promise<DashboardOverview> {
         mappedProjectCount += 1
       }
 
-      const taskRows = await db
-        .select({
-          id: scheduleTasks.id,
-          title: scheduleTasks.title,
-          startDate: scheduleTasks.startDate,
-          endDate: scheduleTasks.endDateCalculated,
-          assignedTo: scheduleTasks.assignedTo,
-          status: scheduleTasks.status,
-          percentComplete: scheduleTasks.percentComplete,
-        })
-        .from(scheduleTasks)
-        .where(eq(scheduleTasks.projectId, project.id))
-        .orderBy(asc(scheduleTasks.startDate), asc(scheduleTasks.sortOrder))
+      const taskRows = tasksByProject.get(project.id) ?? []
 
       const activeTasks = taskRows.filter((task) => !isClosedStatus(task.status))
       const nextTaskRow =
@@ -282,24 +410,7 @@ export async function getDashboardOverview(): Promise<DashboardOverview> {
 
       if (nextTask) upcomingTasks.push(nextTask)
 
-      const photoRows = await db
-        .select({
-          id: dailyLogPhotos.id,
-          fileName: dailyLogPhotos.fileName,
-          driveFileId: dailyLogPhotos.driveFileId,
-          driveUrl: dailyLogPhotos.driveUrl,
-          thumbnailUrl: dailyLogPhotos.thumbnailUrl,
-          caption: dailyLogPhotos.caption,
-          capturedAt: dailyLogPhotos.capturedAt,
-          mimeType: dailyLogPhotos.mimeType,
-          photoKind: dailyLogPhotos.photoKind,
-          createdAt: dailyLogPhotos.createdAt,
-          reviewStatus: dailyLogPhotos.reviewStatus,
-          ownerVisible: dailyLogPhotos.ownerVisible,
-        })
-        .from(dailyLogPhotos)
-        .where(eq(dailyLogPhotos.projectId, project.id))
-        .orderBy(desc(dailyLogPhotos.capturedAt), desc(dailyLogPhotos.createdAt))
+      const photoRows = photosByProject.get(project.id) ?? []
 
       const projectPhotosToReview = photoRows.filter(
         (photo) => photo.reviewStatus === "needs_review"
@@ -336,55 +447,14 @@ export async function getDashboardOverview(): Promise<DashboardOverview> {
         })
       }
 
-      const latestLogRows = await db
-        .select({
-          logDate: dailyLogs.logDate,
-          sourceSystem: dailyLogs.sourceSystem,
-          reviewStatus: dailyLogs.reviewStatus,
-        })
-        .from(dailyLogs)
-        .where(eq(dailyLogs.projectId, project.id))
-        .orderBy(desc(dailyLogs.logDate))
-        .limit(1)
-
-      const latestOwnerUpdateRows = await db
-        .select({
-          id: ownerProjectUpdates.id,
-          title: ownerProjectUpdates.title,
-          status: ownerProjectUpdates.status,
-          updateDate: ownerProjectUpdates.updateDate,
-        })
-        .from(ownerProjectUpdates)
-        .where(eq(ownerProjectUpdates.projectId, project.id))
-        .orderBy(desc(ownerProjectUpdates.updateDate))
-        .limit(1)
-
-      const ownerUpdateRows = await db
-        .select({ status: ownerProjectUpdates.status })
-        .from(ownerProjectUpdates)
-        .where(eq(ownerProjectUpdates.projectId, project.id))
+      const latestLogRows = logsByProject.get(project.id) ?? []
+      const ownerUpdateRows = ownerUpdatesByProject.get(project.id) ?? []
       const projectDraftOwnerUpdates = ownerUpdateRows.filter(
         (update) => update.status === "draft"
       ).length
       draftOwnerUpdates += projectDraftOwnerUpdates
 
-      const operationRows = await db
-        .select({
-          id: projectOperations.id,
-          sourceRecordType: projectOperations.sourceRecordType,
-          sourceRecordNumber: projectOperations.sourceRecordNumber,
-          title: projectOperations.title,
-          status: projectOperations.status,
-          dueDate: projectOperations.dueDate,
-          amount: projectOperations.amount,
-          sourceSystem: projectOperations.sourceSystem,
-          lastSyncedAt: projectOperations.lastSyncedAt,
-          assigneeName: projectOperations.assigneeName,
-          companyName: projectOperations.companyName,
-        })
-        .from(projectOperations)
-        .where(eq(projectOperations.projectId, project.id))
-        .orderBy(asc(projectOperations.dueDate), asc(projectOperations.title))
+      const operationRows = operationsByProject.get(project.id) ?? []
 
       const activeOperations = operationRows.filter(
         (operation) => !isClosedStatus(operation.status)
@@ -425,18 +495,7 @@ export async function getDashboardOverview(): Promise<DashboardOverview> {
         })
       }
 
-      const rfiRows = await db
-        .select({
-          id: projectRfis.id,
-          rfiNumber: projectRfis.rfiNumber,
-          subject: projectRfis.subject,
-          priority: projectRfis.priority,
-          status: projectRfis.status,
-          dueDate: projectRfis.dueDate,
-        })
-        .from(projectRfis)
-        .where(eq(projectRfis.projectId, project.id))
-        .orderBy(asc(projectRfis.dueDate), asc(projectRfis.rfiNumber))
+      const rfiRows = rfisByProject.get(project.id) ?? []
 
       const projectOpenRfis = rfiRows.filter(
         (rfi) => !isClosedStatus(rfi.status)
@@ -469,7 +528,7 @@ export async function getDashboardOverview(): Promise<DashboardOverview> {
         photosToReview: projectPhotosToReview,
         ownerVisiblePhotos,
         latestLog: latestLogRows[0] ?? null,
-        latestOwnerUpdate: latestOwnerUpdateRows[0] ?? null,
+        latestOwnerUpdate: ownerUpdateRows[0] ?? null,
         openPoCount: openPoRows.length,
         openPoAmount: projectOpenPoAmount,
         activeCommitmentCount: activeOperations.length,

--- a/src/app/actions/project-rfis.ts
+++ b/src/app/actions/project-rfis.ts
@@ -420,7 +420,6 @@ export async function createProjectRfi(
       updatedAt: now,
     }
 
-    await db.insert(projectRfis).values(inserted)
     const attachmentRows = input.attachments.map((attachment) => ({
       id: crypto.randomUUID(),
       projectId,
@@ -437,13 +436,14 @@ export async function createProjectRfi(
     }))
 
     if (attachmentRows.length > 0) {
-      try {
-        await db.insert(projectRfiAttachments).values(attachmentRows)
-      } catch (error) {
-        if (!isMissingAttachmentTableError(error)) {
-          throw error
-        }
-      }
+      // D1 batches are atomic: the RFI and its attachment metadata either both
+      // commit or both roll back. A timeout/error must never leave a partial RFI.
+      await db.batch([
+        db.insert(projectRfis).values(inserted),
+        db.insert(projectRfiAttachments).values(attachmentRows),
+      ])
+    } else {
+      await db.insert(projectRfis).values(inserted)
     }
 
     revalidatePath(`/dashboard/projects/${projectId}`)
@@ -675,21 +675,8 @@ export async function deleteProjectRfi(
       return { success: false, error: "RFI not found." }
     }
 
-    try {
-      await db
-        .delete(projectRfiAttachments)
-        .where(
-          and(
-            eq(projectRfiAttachments.rfiId, rfiId),
-            eq(projectRfiAttachments.projectId, projectId)
-          )
-        )
-    } catch (error) {
-      if (!isMissingAttachmentTableError(error)) {
-        throw error
-      }
-    }
-
+    // The attachment foreign key uses ON DELETE CASCADE, so one statement is
+    // both faster and atomic. A failed delete cannot strip attachment metadata.
     await db
       .delete(projectRfis)
       .where(and(eq(projectRfis.id, rfiId), eq(projectRfis.projectId, projectId)))

--- a/src/app/dashboard/projects/[id]/page.tsx
+++ b/src/app/dashboard/projects/[id]/page.tsx
@@ -105,6 +105,18 @@ function normalizeContactIdentity(value: string | null): string {
     : ""
 }
 
+async function loadOptionalSummary<T>(
+  label: string,
+  load: () => Promise<T>
+): Promise<T | null> {
+  try {
+    return await load()
+  } catch (error) {
+    console.warn(`[project-summary] ${label} unavailable`, error)
+    return null
+  }
+}
+
 export default async function ProjectSummaryPage({
   params,
 }: {
@@ -259,15 +271,42 @@ export default async function ProjectSummaryPage({
         }
       }
     }
-    if (canEditRegistry) {
-      registry = await getProjectRegistry(id)
-      sageSyncQueue = await getProjectSageSyncQueue(id)
-    }
-    fieldSummary = await getProjectFieldSummary(id)
-    budgetSummary = await getProjectBudgetSummary(id, "internal")
-    contactsSummary = await getProjectContactsSummary(id, "internal")
-    operationsSummary = await getProjectOperationsSummary(id)
-    rfiSummary = await getProjectRfiSummary(id)
+    // These panels are independent. Resolve them concurrently so a project
+    // page pays for the slowest summary instead of the sum of every D1 roundtrip.
+    const [
+      loadedRegistry,
+      loadedSageSyncQueue,
+      loadedFieldSummary,
+      loadedBudgetSummary,
+      loadedContactsSummary,
+      loadedOperationsSummary,
+      loadedRfiSummary,
+    ] = await Promise.all([
+      canEditRegistry
+        ? loadOptionalSummary("registry", () => getProjectRegistry(id))
+        : Promise.resolve(null),
+      canEditRegistry
+        ? loadOptionalSummary("Sage sync queue", () => getProjectSageSyncQueue(id))
+        : Promise.resolve(null),
+      loadOptionalSummary("field summary", () => getProjectFieldSummary(id)),
+      loadOptionalSummary("budget summary", () =>
+        getProjectBudgetSummary(id, "internal")
+      ),
+      loadOptionalSummary("contacts summary", () =>
+        getProjectContactsSummary(id, "internal")
+      ),
+      loadOptionalSummary("operations summary", () =>
+        getProjectOperationsSummary(id)
+      ),
+      loadOptionalSummary("RFI summary", () => getProjectRfiSummary(id)),
+    ])
+    registry = loadedRegistry
+    sageSyncQueue = loadedSageSyncQueue
+    fieldSummary = loadedFieldSummary
+    budgetSummary = loadedBudgetSummary
+    contactsSummary = loadedContactsSummary
+    operationsSummary = loadedOperationsSummary
+    rfiSummary = loadedRfiSummary
   } catch (error) {
     if (
       hasDigest(error) &&

--- a/src/db/provider/__tests__/interface.test.ts
+++ b/src/db/provider/__tests__/interface.test.ts
@@ -102,50 +102,6 @@ describe.each(providerFactories)("%s", (name, createProvider) => {
     })
   })
 
-  describe("transaction", () => {
-    beforeEach(async () => {
-      await provider.execute(`
-        CREATE TABLE IF NOT EXISTS txn_test (
-          id TEXT PRIMARY KEY,
-          value INTEGER
-        )
-      `)
-    })
-
-    // Note: better-sqlite3's transaction() doesn't support async callbacks.
-    // The MemoryProvider's transaction implementation needs to be refactored
-    // to properly handle async functions. These tests are skipped until then.
-    // The interface is correct, but the implementation has a limitation.
-
-    it.skip("commits successful transaction", async () => {
-      await provider.transaction(async () => {
-        await provider.execute("INSERT INTO txn_test (id, value) VALUES ('a', 1)")
-        await provider.execute("INSERT INTO txn_test (id, value) VALUES ('b', 2)")
-      })
-
-      // Note: Cannot verify with db.execute due to Drizzle type limitations
-      // The transaction would have committed the inserts
-      const db = await provider.getDb()
-      expect(db).toBeDefined()
-    })
-
-    it.skip("returns transaction result", async () => {
-      const result = await provider.transaction(async () => {
-        return "transaction-result"
-      })
-
-      expect(result).toBe("transaction-result")
-    })
-
-    it.skip("provides db parameter for drizzle operations", async () => {
-      await provider.transaction(async (db) => {
-        expect(db).toBeDefined()
-        expect(typeof db.select).toBe("function")
-        return Promise.resolve("success")
-      })
-    })
-  })
-
   describe("close", () => {
     it("can be called multiple times safely", async () => {
       if (!provider.close) {
@@ -184,7 +140,6 @@ describe("DatabaseProvider interface compliance", () => {
     expect(provider.type).toBeDefined()
     expect(typeof provider.getDb).toBe("function")
     expect(typeof provider.execute).toBe("function")
-    expect(typeof provider.transaction).toBe("function")
     expect(typeof provider.close).toBe("function")
   })
 })

--- a/src/db/provider/d1-provider.ts
+++ b/src/db/provider/d1-provider.ts
@@ -59,14 +59,6 @@ export function createD1Provider(config: D1ProviderConfig): DatabaseProvider {
       }
     },
 
-    async transaction<T>(fn: (db: DrizzleDB) => Promise<T>): Promise<T> {
-      const db = await this.getDb()
-      // D1 batch provides transaction-like semantics
-      // For true transactions, we need to use db.batch()
-      // This is a simplified version - full transaction support
-      // requires the batch API
-      return fn(db)
-    },
   }
 }
 

--- a/src/db/provider/electron-provider.ts
+++ b/src/db/provider/electron-provider.ts
@@ -22,11 +22,6 @@ export function createElectronProvider(config?: ElectronProviderConfig): Databas
       throw new Error("Electron desktop does not expose raw SQL IPC")
     },
 
-    async transaction<T>(fn: (db: DrizzleDB) => Promise<T>): Promise<T> {
-      void fn
-      throw new Error("Electron desktop does not expose raw SQL IPC")
-    },
-
     async close(): Promise<void> {
       return
     },

--- a/src/db/provider/interface.ts
+++ b/src/db/provider/interface.ts
@@ -12,7 +12,6 @@ export interface DatabaseProvider {
   readonly type: ProviderType
   getDb(): Promise<DrizzleDB>
   execute(sql: string, params?: unknown[]): Promise<void>
-  transaction<T>(fn: (db: DrizzleDB) => Promise<T>): Promise<T>
   close?(): Promise<void>
 }
 

--- a/src/db/provider/memory-provider.ts
+++ b/src/db/provider/memory-provider.ts
@@ -102,11 +102,6 @@ export function createMemoryProvider(config?: MemoryProviderConfig): DatabasePro
       }
     },
 
-    async transaction<T>(fn: (db: DrizzleDB) => Promise<T>): Promise<T> {
-      const { sqlite: initializedSqlite, db: initializedDb } = await initialize()
-      return initializedSqlite.transaction(() => fn(initializedDb as DrizzleDB))()
-    },
-
     async close(): Promise<void> {
       if (sqlite) {
         sqlite.close()


### PR DESCRIPTION
## What changed

- collapse the dashboard overview's per-project D1 waterfall into one fixed seven-statement D1 batch
- load independent project-summary panels concurrently and degrade each panel independently
- atomically create RFIs with attachment metadata and rely on the existing cascade for atomic deletion
- remove the provider callback transaction API that was not a real D1 transaction
- document D1 async, batching, timeout, idempotency, `waitUntil`, Queue, and Workflow boundaries

## Why

The dashboard performed `1 + 7N` D1 statements for N projects. Coupled RFI writes could also partially commit, and the shared transaction abstraction implied guarantees D1 did not provide.

## Impact

Organizations with larger project lists should see substantially fewer D1 round trips on the dashboard. Project-summary panels no longer form a serial waterfall, and one failed optional panel no longer blanks the others. Coupled RFI metadata writes are all-or-nothing.

## Validation

- production Next.js build
- TypeScript `--noEmit`
- ESLint: zero errors
- focused provider, UI discipline, and Buildertrend coverage tests
- full suite: 823 tests passed; one resource-contention timeout passed when rerun alone
- rebased onto current main with no overlapping Hermes-visible branch paths
