### PR TITLE
fix(cutover): expire stale Buildertrend attestations

### DIFF
--- a/src/app/actions/buildertrend-cutover-coverage.ts
+++ b/src/app/actions/buildertrend-cutover-coverage.ts
@@ -123,14 +123,17 @@ export async function getBuildertrendCutoverCoverage(): Promise<BuildertrendCuto
       moduleKey: buildertrendModuleAttestations.moduleKey,
       status: buildertrendModuleAttestations.status,
       observedCount: buildertrendModuleAttestations.observedCount,
+      checkedAt: buildertrendModuleAttestations.checkedAt,
     })
     .from(buildertrendModuleAttestations)
     .where(eq(buildertrendModuleAttestations.organizationId, organizationId))
 
+  const generatedAt = new Date().toISOString()
   const summary = summarizeBuildertrendModuleCoverage(
-    projectRows.map((project) => ({ id: project.id })),
+    projectRows.map((project) => ({ id: project.id, status: project.status })),
     evidence,
-    attestationRows
+    attestationRows,
+    generatedAt
   )
   const statusCounts = new Map<string, number>()
   for (const project of projectRows) {
@@ -139,7 +142,7 @@ export async function getBuildertrendCutoverCoverage(): Promise<BuildertrendCuto
 
   return {
     ...summary,
-    generatedAt: new Date().toISOString(),
+    generatedAt,
     statusCounts: [...statusCounts.entries()]
       .map(([status, count]) => ({ status, count }))
       .sort((left, right) => left.status.localeCompare(right.status)),

--- a/src/app/dashboard/office-maintenance/buildertrend-cutover/page.tsx
+++ b/src/app/dashboard/office-maintenance/buildertrend-cutover/page.tsx
@@ -33,7 +33,8 @@ export default async function BuildertrendCutoverPage(): Promise<React.ReactElem
         <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
           A module is complete only when its captured count is attested, or a
           signed capture confirms that Buildertrend contained zero records.
-          Existing records without that final check remain partial.
+          Existing records without that final check remain partial. Evidence
+          for live or unclassified projects becomes stale after seven days.
         </p>
       </header>
 
@@ -85,7 +86,8 @@ export default async function BuildertrendCutoverPage(): Promise<React.ReactElem
           <p className="text-sm text-muted-foreground">
             “Partial” includes captured records that have not received a
             matching completeness attestation. “Conflict” means the attested
-            count no longer matches staged evidence.
+            count no longer matches staged evidence. “Stale” requires a fresh
+            Buildertrend check before cutover.
           </p>
         </div>
         <div className="overflow-x-auto border">
@@ -96,6 +98,7 @@ export default async function BuildertrendCutoverPage(): Promise<React.ReactElem
                 <th className="px-3 py-3 text-right font-medium">Captured</th>
                 <th className="px-3 py-3 text-right font-medium">Empty</th>
                 <th className="px-3 py-3 text-right font-medium">Partial</th>
+                <th className="px-3 py-3 text-right font-medium">Stale</th>
                 <th className="px-3 py-3 text-right font-medium">
                   Blocked / unavailable
                 </th>
@@ -117,6 +120,7 @@ export default async function BuildertrendCutoverPage(): Promise<React.ReactElem
                     {module.verifiedEmptyCount}
                   </td>
                   <td className="px-3 py-3 text-right">{module.partialCount}</td>
+                  <td className="px-3 py-3 text-right">{module.staleCount}</td>
                   <td className="px-3 py-3 text-right">
                     {module.blockedCount + module.unavailableCount}
                   </td>

--- a/src/lib/buildertrend/__tests__/module-coverage.test.ts
+++ b/src/lib/buildertrend/__tests__/module-coverage.test.ts
@@ -19,7 +19,10 @@ function moduleRow(
 describe("Buildertrend module coverage", () => {
   it("does not treat source records alone as complete evidence", () => {
     const summary = summarizeBuildertrendModuleCoverage(
-      [{ id: "project-a" }, { id: "project-b" }],
+      [
+        { id: "project-a", status: "OPEN" },
+        { id: "project-b", status: "OPEN" },
+      ],
       [{ projectId: "project-a", moduleKey: "daily_logs", recordCount: 4 }],
       []
     )
@@ -32,7 +35,10 @@ describe("Buildertrend module coverage", () => {
 
   it("counts matching captures and explicit empty checks as verified", () => {
     const summary = summarizeBuildertrendModuleCoverage(
-      [{ id: "project-a" }, { id: "project-b" }],
+      [
+        { id: "project-a", status: "OPEN" },
+        { id: "project-b", status: "OPEN" },
+      ],
       [{ projectId: "project-a", moduleKey: "rfis", recordCount: 3 }],
       [
         {
@@ -40,14 +46,17 @@ describe("Buildertrend module coverage", () => {
           moduleKey: "rfis",
           status: "captured",
           observedCount: 3,
+          checkedAt: "2026-08-17T12:00:00.000Z",
         },
         {
           projectId: "project-b",
           moduleKey: "rfis",
           status: "verified_empty",
           observedCount: 0,
+          checkedAt: "2026-08-17T12:00:00.000Z",
         },
-      ]
+      ],
+      "2026-08-17T12:00:00.000Z"
     )
 
     const rfis = moduleRow(summary.modules, "rfis")
@@ -58,7 +67,7 @@ describe("Buildertrend module coverage", () => {
 
   it("flags count mismatches instead of accepting stale attestations", () => {
     const summary = summarizeBuildertrendModuleCoverage(
-      [{ id: "project-a" }],
+      [{ id: "project-a", status: "OPEN" }],
       [{ projectId: "project-a", moduleKey: "tasks", recordCount: 5 }],
       [
         {
@@ -66,11 +75,53 @@ describe("Buildertrend module coverage", () => {
           moduleKey: "tasks",
           status: "captured",
           observedCount: 4,
+          checkedAt: "2026-08-17T12:00:00.000Z",
         },
-      ]
+      ],
+      "2026-08-17T12:00:00.000Z"
     )
 
     expect(moduleRow(summary.modules, "tasks").conflictCount).toBe(1)
+  })
+
+  it("does not count stale evidence for a live project as complete", () => {
+    const summary = summarizeBuildertrendModuleCoverage(
+      [{ id: "project-a", status: "OPEN" }],
+      [{ projectId: "project-a", moduleKey: "messages", recordCount: 8 }],
+      [
+        {
+          projectId: "project-a",
+          moduleKey: "messages",
+          status: "captured",
+          observedCount: 8,
+          checkedAt: "2026-08-01T12:00:00.000Z",
+        },
+      ],
+      "2026-08-17T12:00:00.000Z"
+    )
+
+    const messages = moduleRow(summary.modules, "messages")
+    expect(messages.staleCount).toBe(1)
+    expect(messages.verifiedCount).toBe(0)
+  })
+
+  it("keeps matching historical evidence complete for an inactive project", () => {
+    const summary = summarizeBuildertrendModuleCoverage(
+      [{ id: "project-a", status: "INACTIVE" }],
+      [{ projectId: "project-a", moduleKey: "messages", recordCount: 8 }],
+      [
+        {
+          projectId: "project-a",
+          moduleKey: "messages",
+          status: "captured",
+          observedCount: 8,
+          checkedAt: "2026-07-01T12:00:00.000Z",
+        },
+      ],
+      "2026-08-17T12:00:00.000Z"
+    )
+
+    expect(moduleRow(summary.modules, "messages").verifiedCapturedCount).toBe(1)
   })
 
   it("maps staging record and file types to the audited modules", () => {

--- a/src/lib/buildertrend/module-coverage.ts
+++ b/src/lib/buildertrend/module-coverage.ts
@@ -20,6 +20,7 @@ export type BuildertrendModuleKey =
 export type BuildertrendCoverageStatus =
   | "verified_captured"
   | "verified_empty"
+  | "stale"
   | "partial"
   | "blocked"
   | "unavailable"
@@ -53,6 +54,7 @@ export const BUILDERTREND_MODULES: readonly BuildertrendModuleDefinition[] = [
 
 export type BuildertrendCoverageProject = {
   readonly id: string
+  readonly status: string
 }
 
 export type BuildertrendCoverageEvidence = {
@@ -66,6 +68,7 @@ export type BuildertrendCoverageAttestation = {
   readonly moduleKey: string
   readonly status: string
   readonly observedCount: number
+  readonly checkedAt: string
 }
 
 export type BuildertrendModuleCoverageRow = {
@@ -74,6 +77,7 @@ export type BuildertrendModuleCoverageRow = {
   readonly projectCount: number
   readonly verifiedCapturedCount: number
   readonly verifiedEmptyCount: number
+  readonly staleCount: number
   readonly partialCount: number
   readonly blockedCount: number
   readonly unavailableCount: number
@@ -81,6 +85,25 @@ export type BuildertrendModuleCoverageRow = {
   readonly missingCount: number
   readonly verifiedCount: number
   readonly completionPercent: number
+}
+
+export const BUILDERTREND_LIVE_FRESHNESS_DAYS = 7
+
+function projectEvidenceCanRemainStable(status: string): boolean {
+  return status === "ARCHIVE" || status === "COMPLETE" || status === "INACTIVE"
+}
+
+function attestationIsStale(
+  projectStatus: string,
+  checkedAt: string,
+  generatedAtMillis: number
+): boolean {
+  if (projectEvidenceCanRemainStable(projectStatus)) return false
+  const checkedAtMillis = Date.parse(checkedAt)
+  if (!Number.isFinite(checkedAtMillis)) return true
+  const freshnessMillis =
+    BUILDERTREND_LIVE_FRESHNESS_DAYS * 24 * 60 * 60 * 1_000
+  return generatedAtMillis - checkedAtMillis > freshnessMillis
 }
 
 export type BuildertrendCoverageSummary = {
@@ -102,21 +125,33 @@ function normalizedCount(value: number): number {
 }
 
 function attestedStatus(
+  projectStatus: string,
   evidenceCount: number,
-  attestation: BuildertrendCoverageAttestation | undefined
+  attestation: BuildertrendCoverageAttestation | undefined,
+  generatedAtMillis: number
 ): BuildertrendCoverageStatus {
   if (!attestation) return evidenceCount > 0 ? "partial" : "missing"
 
   const observedCount = normalizedCount(attestation.observedCount)
   if (attestation.status === "captured") {
-    return observedCount === evidenceCount && evidenceCount > 0
-      ? "verified_captured"
-      : "conflict"
+    if (observedCount !== evidenceCount || evidenceCount === 0) return "conflict"
+    return attestationIsStale(
+      projectStatus,
+      attestation.checkedAt,
+      generatedAtMillis
+    )
+      ? "stale"
+      : "verified_captured"
   }
   if (attestation.status === "verified_empty") {
-    return observedCount === 0 && evidenceCount === 0
-      ? "verified_empty"
-      : "conflict"
+    if (observedCount !== 0 || evidenceCount !== 0) return "conflict"
+    return attestationIsStale(
+      projectStatus,
+      attestation.checkedAt,
+      generatedAtMillis
+    )
+      ? "stale"
+      : "verified_empty"
   }
   if (attestation.status === "partial") return "partial"
   if (attestation.status === "blocked") return "blocked"
@@ -134,8 +169,13 @@ function countStatuses(
 export function summarizeBuildertrendModuleCoverage(
   projects: readonly BuildertrendCoverageProject[],
   evidence: readonly BuildertrendCoverageEvidence[],
-  attestations: readonly BuildertrendCoverageAttestation[]
+  attestations: readonly BuildertrendCoverageAttestation[],
+  generatedAt = new Date().toISOString()
 ): BuildertrendCoverageSummary {
+  const parsedGeneratedAt = Date.parse(generatedAt)
+  const generatedAtMillis = Number.isFinite(parsedGeneratedAt)
+    ? parsedGeneratedAt
+    : Date.now()
   const evidenceByKey = new Map<string, number>()
   for (const item of evidence) {
     const key = coverageKey(item.projectId, item.moduleKey)
@@ -157,8 +197,10 @@ export function summarizeBuildertrendModuleCoverage(
     const statuses = projects.map((project) => {
       const key = coverageKey(project.id, module.key)
       return attestedStatus(
+        project.status,
         evidenceByKey.get(key) ?? 0,
-        attestationByKey.get(key)
+        attestationByKey.get(key),
+        generatedAtMillis
       )
     })
     const verifiedCapturedCount = countStatuses(statuses, "verified_captured")
@@ -170,6 +212,7 @@ export function summarizeBuildertrendModuleCoverage(
       projectCount: projects.length,
       verifiedCapturedCount,
       verifiedEmptyCount,
+      staleCount: countStatuses(statuses, "stale"),
       partialCount: countStatuses(statuses, "partial"),
       blockedCount: countStatuses(statuses, "blocked"),
       unavailableCount: countStatuses(statuses, "unavailable"),


### PR DESCRIPTION
## Summary
- require current evidence for live and unclassified Buildertrend projects
- surface stale module checks separately from verified coverage
- preserve stable historical attestations for archived, complete, and inactive projects

## Direct audit context
- Loeffler has 281 Buildertrend daily logs, versus 5 represented in staged evidence
- Loomis has 145 Buildertrend daily logs, versus 10 represented in staged evidence
- both daily-log attestations were corrected to partial before this change

## Verification
- focused module-coverage tests: 6 passed
- focused ESLint: passed
- full lint: 0 errors (existing warnings only)
- full production build: passed