### PR TITLE
feat(sage): add writer diagnostics and enable bridge

### DIFF
--- a/scripts/Sage.100.Contractor.CompassClientProjectWriter.cs
+++ b/scripts/Sage.100.Contractor.CompassClientProjectWriter.cs
@@ -118,9 +118,15 @@ namespace CompassSageClientProjectWriter
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             bool once = args.Length > 0 && String.Equals(args[0], "--once", StringComparison.OrdinalIgnoreCase);
+            bool diagnose = args.Length > 0 && String.Equals(args[0], "--diagnose", StringComparison.OrdinalIgnoreCase);
             try
             {
-                RequireConfiguration();
+                RequireConfiguration(!diagnose);
+                if (diagnose)
+                {
+                    RunDiagnostics();
+                    return 0;
+                }
                 do
                 {
                     PollOnce();
@@ -135,17 +141,42 @@ namespace CompassSageClientProjectWriter
             }
         }
 
-        private static void RequireConfiguration()
+        private static void RequireConfiguration(bool requireWriteSwitch)
         {
             Required("COMPASS_BASE_URL"); Required("SAGE_BRIDGE_SECRET");
             Required("SAGE_API_USER"); Required("SAGE_API_PASSWORD");
             string database = Environment.GetEnvironmentVariable("SAGE_SQL_DATABASE") ?? TargetCompany;
             if (!String.Equals(database.Trim(), TargetCompany, StringComparison.Ordinal))
                 throw new InvalidOperationException("SAGE_SQL_DATABASE must be exactly " + TargetCompany + ".");
-            if (!String.Equals(Environment.GetEnvironmentVariable("SAGE_CLIENT_PROJECT_WRITES_ENABLED"), "true", StringComparison.OrdinalIgnoreCase))
+            if (requireWriteSwitch && !String.Equals(Environment.GetEnvironmentVariable("SAGE_CLIENT_PROJECT_WRITES_ENABLED"), "true", StringComparison.OrdinalIgnoreCase))
                 throw new InvalidOperationException("Local Sage write switch is disabled.");
             if (!File.Exists(ApiDllPath) || !File.Exists(XsdPath))
                 throw new FileNotFoundException("The Sage API DLL or mbxml.xsd is missing.");
+        }
+
+        private static void RunDiagnostics()
+        {
+            string[] clientStatuses = new string[] { "Current", "Warranty", "Complete", "Inactive", "Archive", "Other" };
+            for (int index = 0; index < clientStatuses.Length; index++)
+            {
+                int actual = ResolveCatalog("clnsts", "stsnme", clientStatuses[index]);
+                int expected = index + 1;
+                if (actual != expected)
+                    throw new InvalidOperationException("Client status mismatch: expected " + expected + " " + clientStatuses[index] + ", but Sage resolved " + actual + ".");
+            }
+            int jobStatuses = CatalogCount("jobsts");
+            int jobTypes = CatalogCount("jobtyp");
+            if (jobStatuses < 1 || jobTypes < 1)
+                throw new InvalidOperationException("Sage job status and job type catalogs must not be empty.");
+            using (new ApiSession(Required("SAGE_API_USER"), Required("SAGE_API_PASSWORD"))) { }
+            Console.WriteLine("DIAGNOSTIC_OK company=" + TargetCompany + " clientStatuses=6 jobStatuses=" + jobStatuses + " jobTypes=" + jobTypes + " apiUser=" + Required("SAGE_API_USER"));
+        }
+
+        private static int CatalogCount(string table)
+        {
+            using (SqlConnection connection = OpenSql())
+            using (SqlCommand command = new SqlCommand("SELECT COUNT(*) FROM dbo." + table, connection))
+                return Convert.ToInt32(command.ExecuteScalar());
         }
 
         private static void PollOnce()

--- a/src/lib/sage/__tests__/client-project-worker-source.test.ts
+++ b/src/lib/sage/__tests__/client-project-worker-source.test.ts
@@ -31,4 +31,15 @@ describe("Sage client/project worker source boundary", () => {
       source.indexOf('Invoke("submitXML"')
     )
   })
+
+  it("has a read-only diagnostic path that verifies Sage without claiming work", () => {
+    expect(source).toContain('"--diagnose"')
+    expect(source).toContain("RunDiagnostics()")
+    expect(source).toContain(
+      'new string[] { "Current", "Warranty", "Complete", "Inactive", "Archive", "Other" }'
+    )
+    expect(source).toContain(
+      'using (new ApiSession(Required("SAGE_API_USER"), Required("SAGE_API_PASSWORD")))'
+    )
+  })
 })

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -84,6 +84,6 @@
 		"REALTIMEKIT_APP_ID": "3e31a97a-54ce-4940-ac53-c593db8d5c25",
 		"WORKOS_REDIRECT_URI": "https://compass.openrangeconstruction.ltd/callback",
 		"JARVIS_AGENT_BRIDGE_ENABLED": "true",
-		"SAGE_CLIENT_PROJECT_WRITES_ENABLED": "false"
+		"SAGE_CLIENT_PROJECT_WRITES_ENABLED": "true"
 	}
 }


### PR DESCRIPTION
## What

- add a read-only `--diagnose` mode to the HPS Sage client/project writer
- verify the exact HPS company, all six client statuses, Sage job catalogs, and `jarvis.api` authentication without claiming queue work
- enable the production Compass client/project write feature flag after signed bridge validation

## Security and rollout

- Compass authorization remains restricted to the six approved users
- the writer remains hard-pinned to `High Performance Structures Inc`
- the existing Compass and NUC dual-gate design remains intact
- the NUC machine-level write switch remains disabled pending the controlled first Sage write
- the signed production empty-queue bridge test returned `EXIT=0`

## Verification

- `bun test src/lib/sage/__tests__/client-project-worker-source.test.ts` — 4 passed
- pre-ship autoreview — clean, no actionable findings
- production Next.js build — passed (TypeScript and 59 static pages)
- NUC diagnostic — `DIAGNOSTIC_OK company=High Performance Structures Inc clientStatuses=6 jobStatuses=35 jobTypes=2 apiUser=jarvis.api`
- Cloudflare deployment with the feature flag enabled completed successfully