### PR TITLE
fix(dashboard): open alerts across projects

### DIFF
--- a/src/app/actions/dashboard-overview.ts
+++ b/src/app/actions/dashboard-overview.ts
@@ -180,6 +180,7 @@ function isClosedStatus(status: string): boolean {
     normalized === "completed" ||
     normalized === "done" ||
     normalized === "closed" ||
+    normalized === "void" ||
     normalized === "inactive" ||
     normalized === "archive" ||
     normalized === "archived" ||

--- a/src/app/actions/office-alerts.ts
+++ b/src/app/actions/office-alerts.ts
@@ -1,0 +1,285 @@
+"use server"
+
+import { and, asc, desc, eq, inArray } from "drizzle-orm"
+
+import { getDb } from "@/db"
+import {
+  dailyLogPhotos,
+  ownerProjectUpdates,
+  projectMembers,
+  projectRfis,
+  projects,
+} from "@/db/schema"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { requireOrg } from "@/lib/org-scope"
+import { canFeature } from "@/lib/permission-enforcement"
+import { canUseOrganizationProjectScopeRole } from "@/lib/user-roles"
+
+export type OfficeAlertRfi = {
+  readonly id: string
+  readonly projectId: string
+  readonly projectLabel: string
+  readonly projectName: string
+  readonly rfiNumber: string
+  readonly subject: string
+  readonly priority: string
+  readonly status: string
+  readonly dueDate: string | null
+  readonly assignedToName: string | null
+}
+
+export type OfficeAlertPhoto = {
+  readonly id: string
+  readonly projectId: string
+  readonly projectLabel: string
+  readonly projectName: string
+  readonly fileName: string
+  readonly caption: string | null
+  readonly photoKind: string
+  readonly capturedAt: string | null
+  readonly createdAt: string
+}
+
+export type OfficeAlertOwnerUpdate = {
+  readonly id: string
+  readonly projectId: string
+  readonly projectLabel: string
+  readonly projectName: string
+  readonly title: string
+  readonly updateDate: string
+  readonly updatedAt: string
+}
+
+export type OfficeAlertQueue = {
+  readonly rfis: readonly OfficeAlertRfi[]
+  readonly photos: readonly OfficeAlertPhoto[]
+  readonly ownerUpdates: readonly OfficeAlertOwnerUpdate[]
+}
+
+type AccessibleProject = {
+  readonly id: string
+  readonly name: string
+  readonly projectNumber: string | null
+}
+
+type OfficeAlertRfiRow = Omit<
+  OfficeAlertRfi,
+  "projectLabel" | "projectName"
+>
+
+type OfficeAlertPhotoRow = Omit<
+  OfficeAlertPhoto,
+  "projectLabel" | "projectName"
+>
+
+type OfficeAlertOwnerUpdateRow = Omit<
+  OfficeAlertOwnerUpdate,
+  "projectLabel" | "projectName"
+>
+
+const EMPTY_QUEUE: OfficeAlertQueue = {
+  rfis: [],
+  photos: [],
+  ownerUpdates: [],
+}
+
+function isClosedStatus(status: string): boolean {
+  const normalized = status.toLowerCase()
+  return (
+    normalized === "complete" ||
+    normalized === "completed" ||
+    normalized === "done" ||
+    normalized === "closed" ||
+    normalized === "void" ||
+    normalized === "inactive" ||
+    normalized === "archive" ||
+    normalized === "archived" ||
+    normalized === "cancelled" ||
+    normalized === "canceled"
+  )
+}
+
+function projectLabel(project: AccessibleProject): string {
+  return project.projectNumber ?? project.name
+}
+
+export async function getOfficeAlertQueue(): Promise<OfficeAlertQueue> {
+  const user = await requireAuth()
+  const orgId = requireOrg(user)
+  if (user.organizationType !== "internal") return EMPTY_QUEUE
+
+  const { env } = await getCloudflareContext()
+  if (!env?.DB) return EMPTY_QUEUE
+
+  const db = getDb(env.DB)
+  const hasOrganizationScope = canUseOrganizationProjectScopeRole(user.role)
+
+  const accessibleProjects: readonly AccessibleProject[] = hasOrganizationScope
+    ? await db
+        .select({
+          id: projects.id,
+          name: projects.name,
+          projectNumber: projects.projectNumber,
+        })
+        .from(projects)
+        .where(eq(projects.organizationId, orgId))
+        .orderBy(asc(projects.projectNumber), asc(projects.name))
+    : await db
+        .select({
+          id: projects.id,
+          name: projects.name,
+          projectNumber: projects.projectNumber,
+        })
+        .from(projectMembers)
+        .innerJoin(projects, eq(projectMembers.projectId, projects.id))
+        .where(
+          and(
+            eq(projectMembers.userId, user.id),
+            eq(projects.organizationId, orgId)
+          )
+        )
+        .orderBy(asc(projects.projectNumber), asc(projects.name))
+
+  if (accessibleProjects.length === 0) return EMPTY_QUEUE
+
+  const projectIds = accessibleProjects.map((project) => project.id)
+  const projectsById = new Map(
+    accessibleProjects.map((project) => [project.id, project])
+  )
+  const [canReadRfis, canReadPhotos, canReadOwnerUpdates] = await Promise.all([
+    canFeature(user, "rfis", "read"),
+    canFeature(user, "project-photos", "read"),
+    canFeature(user, "owner-updates", "read"),
+  ])
+
+  const rfiRows: OfficeAlertRfiRow[] = []
+  const photoRows: OfficeAlertPhotoRow[] = []
+  const ownerUpdateRows: OfficeAlertOwnerUpdateRow[] = []
+  const projectBatchSize = 80
+
+  // D1 has a low parameter ceiling, and imported organizations can contain
+  // hundreds of projects. Keep every cross-project IN predicate bounded.
+  for (let index = 0; index < projectIds.length; index += projectBatchSize) {
+    const batchProjectIds = projectIds.slice(index, index + projectBatchSize)
+    const [rfiBatch, photoBatch, ownerUpdateBatch] = await Promise.all([
+      canReadRfis
+        ? db
+            .select({
+              id: projectRfis.id,
+              projectId: projectRfis.projectId,
+              rfiNumber: projectRfis.rfiNumber,
+              subject: projectRfis.subject,
+              priority: projectRfis.priority,
+              status: projectRfis.status,
+              dueDate: projectRfis.dueDate,
+              assignedToName: projectRfis.assignedToName,
+            })
+            .from(projectRfis)
+            .where(inArray(projectRfis.projectId, batchProjectIds))
+            .orderBy(asc(projectRfis.dueDate), asc(projectRfis.rfiNumber))
+        : Promise.resolve([]),
+      canReadPhotos
+        ? db
+            .select({
+              id: dailyLogPhotos.id,
+              projectId: dailyLogPhotos.projectId,
+              fileName: dailyLogPhotos.fileName,
+              caption: dailyLogPhotos.caption,
+              photoKind: dailyLogPhotos.photoKind,
+              capturedAt: dailyLogPhotos.capturedAt,
+              createdAt: dailyLogPhotos.createdAt,
+            })
+            .from(dailyLogPhotos)
+            .where(
+              and(
+                inArray(dailyLogPhotos.projectId, batchProjectIds),
+                eq(dailyLogPhotos.reviewStatus, "needs_review")
+              )
+            )
+            .orderBy(
+              desc(dailyLogPhotos.capturedAt),
+              desc(dailyLogPhotos.createdAt)
+            )
+        : Promise.resolve([]),
+      canReadOwnerUpdates
+        ? db
+            .select({
+              id: ownerProjectUpdates.id,
+              projectId: ownerProjectUpdates.projectId,
+              title: ownerProjectUpdates.title,
+              updateDate: ownerProjectUpdates.updateDate,
+              updatedAt: ownerProjectUpdates.updatedAt,
+            })
+            .from(ownerProjectUpdates)
+            .where(
+              and(
+                inArray(ownerProjectUpdates.projectId, batchProjectIds),
+                eq(ownerProjectUpdates.status, "draft")
+              )
+            )
+            .orderBy(
+              desc(ownerProjectUpdates.updateDate),
+              desc(ownerProjectUpdates.updatedAt)
+            )
+        : Promise.resolve([]),
+    ])
+
+    rfiRows.push(...rfiBatch)
+    photoRows.push(...photoBatch)
+    ownerUpdateRows.push(...ownerUpdateBatch)
+  }
+
+  rfiRows.sort(
+    (left, right) =>
+      (left.dueDate ?? "9999-12-31").localeCompare(
+        right.dueDate ?? "9999-12-31"
+      ) || left.rfiNumber.localeCompare(right.rfiNumber)
+  )
+  photoRows.sort((left, right) =>
+    (right.capturedAt ?? right.createdAt).localeCompare(
+      left.capturedAt ?? left.createdAt
+    )
+  )
+  ownerUpdateRows.sort(
+    (left, right) =>
+      right.updateDate.localeCompare(left.updateDate) ||
+      right.updatedAt.localeCompare(left.updatedAt)
+  )
+
+  const rfis: OfficeAlertRfi[] = []
+  for (const rfi of rfiRows) {
+    if (isClosedStatus(rfi.status)) continue
+    const project = projectsById.get(rfi.projectId)
+    if (!project) continue
+    rfis.push({
+      ...rfi,
+      projectLabel: projectLabel(project),
+      projectName: project.name,
+    })
+  }
+
+  const photos: OfficeAlertPhoto[] = []
+  for (const photo of photoRows) {
+    const project = projectsById.get(photo.projectId)
+    if (!project) continue
+    photos.push({
+      ...photo,
+      projectLabel: projectLabel(project),
+      projectName: project.name,
+    })
+  }
+
+  const ownerUpdates: OfficeAlertOwnerUpdate[] = []
+  for (const update of ownerUpdateRows) {
+    const project = projectsById.get(update.projectId)
+    if (!project) continue
+    ownerUpdates.push({
+      ...update,
+      projectLabel: projectLabel(project),
+      projectName: project.name,
+    })
+  }
+
+  return { rfis, photos, ownerUpdates }
+}

--- a/src/app/dashboard/office-alerts/page.tsx
+++ b/src/app/dashboard/office-alerts/page.tsx
@@ -1,0 +1,253 @@
+import Link from "next/link"
+import {
+  IconArrowRight,
+  IconClipboardText,
+  IconMessageCircleQuestion,
+  IconPhoto,
+} from "@tabler/icons-react"
+
+import {
+  getOfficeAlertQueue,
+  type OfficeAlertQueue,
+} from "@/app/actions/office-alerts"
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+
+type AlertQueue = "rfis" | "photos" | "owner-updates"
+
+type AlertTab = {
+  readonly id: AlertQueue
+  readonly label: string
+  readonly count: number
+  readonly href: string
+}
+
+function alertQueueFrom(value: string | undefined): AlertQueue {
+  if (value === "photos" || value === "owner-updates") return value
+  return "rfis"
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "No date"
+  const date = /^\d{4}-\d{2}-\d{2}$/.test(value)
+    ? new Date(`${value}T00:00:00`)
+    : new Date(value)
+  if (Number.isNaN(date.getTime())) return "No date"
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date)
+}
+
+function statusLabel(value: string): string {
+  return value
+    .split("_")
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ")
+}
+
+function EmptyQueue({ queue }: { readonly queue: AlertQueue }): React.ReactElement {
+  const copy = {
+    rfis: "There are no open RFIs across your projects.",
+    photos: "There are no field photos waiting for review.",
+    "owner-updates": "There are no draft owner updates waiting for review.",
+  }
+
+  return (
+    <div className="border-y bg-background px-5 py-14 text-center">
+      <p className="text-sm font-medium">This queue is clear</p>
+      <p className="mt-1 text-sm text-muted-foreground">{copy[queue]}</p>
+    </div>
+  )
+}
+
+function RfiQueue({ queue }: { readonly queue: OfficeAlertQueue }): React.ReactElement {
+  if (queue.rfis.length === 0) return <EmptyQueue queue="rfis" />
+
+  return (
+    <div className="divide-y border-y bg-background">
+      {queue.rfis.map((rfi) => (
+        <Link
+          key={rfi.id}
+          href={`/dashboard/projects/${rfi.projectId}/rfis`}
+          className="group grid gap-2 px-4 py-3 transition-colors hover:bg-muted/50 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+        >
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm font-semibold">{rfi.rfiNumber}</span>
+              <Badge variant="outline">{statusLabel(rfi.priority)}</Badge>
+              <Badge variant="secondary">{statusLabel(rfi.status)}</Badge>
+            </div>
+            <p className="mt-1 truncate text-sm">{rfi.subject}</p>
+            <p className="mt-1 truncate text-xs text-muted-foreground">
+              {rfi.projectLabel} · {rfi.projectName}
+              {rfi.assignedToName ? ` · Assigned to ${rfi.assignedToName}` : ""}
+            </p>
+          </div>
+          <div className="flex items-center gap-3 text-xs text-muted-foreground sm:justify-end">
+            <span>{rfi.dueDate ? `Due ${formatDate(rfi.dueDate)}` : "No due date"}</span>
+            <IconArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+          </div>
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+function PhotoQueue({ queue }: { readonly queue: OfficeAlertQueue }): React.ReactElement {
+  if (queue.photos.length === 0) return <EmptyQueue queue="photos" />
+
+  return (
+    <div className="divide-y border-y bg-background">
+      {queue.photos.map((photo) => (
+        <Link
+          key={photo.id}
+          href={`/dashboard/projects/${photo.projectId}/photos`}
+          className="group grid gap-2 px-4 py-3 transition-colors hover:bg-muted/50 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+        >
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="truncate text-sm font-semibold">
+                {photo.caption ?? photo.fileName}
+              </span>
+              <Badge variant="outline">{statusLabel(photo.photoKind)}</Badge>
+            </div>
+            <p className="mt-1 truncate text-xs text-muted-foreground">
+              {photo.projectLabel} · {photo.projectName}
+            </p>
+          </div>
+          <div className="flex items-center gap-3 text-xs text-muted-foreground sm:justify-end">
+            <span>{formatDate(photo.capturedAt ?? photo.createdAt)}</span>
+            <IconArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+          </div>
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+function OwnerUpdateQueue({
+  queue,
+}: {
+  readonly queue: OfficeAlertQueue
+}): React.ReactElement {
+  if (queue.ownerUpdates.length === 0) {
+    return <EmptyQueue queue="owner-updates" />
+  }
+
+  return (
+    <div className="divide-y border-y bg-background">
+      {queue.ownerUpdates.map((update) => (
+        <Link
+          key={update.id}
+          href={`/dashboard/projects/${update.projectId}/owner-updates/${update.id}`}
+          className="group grid gap-2 px-4 py-3 transition-colors hover:bg-muted/50 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+        >
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="truncate text-sm font-semibold">{update.title}</span>
+              <Badge variant="secondary">Draft</Badge>
+            </div>
+            <p className="mt-1 truncate text-xs text-muted-foreground">
+              {update.projectLabel} · {update.projectName}
+            </p>
+          </div>
+          <div className="flex items-center gap-3 text-xs text-muted-foreground sm:justify-end">
+            <span>{formatDate(update.updateDate)}</span>
+            <IconArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+          </div>
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+export default async function OfficeAlertsPage({
+  searchParams,
+}: {
+  readonly searchParams: Promise<{ readonly queue?: string }>
+}): Promise<React.ReactElement> {
+  const [{ queue: requestedQueue }, alerts] = await Promise.all([
+    searchParams,
+    getOfficeAlertQueue(),
+  ])
+  const activeQueue = alertQueueFrom(requestedQueue)
+  const tabs: readonly AlertTab[] = [
+    {
+      id: "rfis",
+      label: "Open RFIs",
+      count: alerts.rfis.length,
+      href: "/dashboard/office-alerts?queue=rfis",
+    },
+    {
+      id: "photos",
+      label: "Photos to review",
+      count: alerts.photos.length,
+      href: "/dashboard/office-alerts?queue=photos",
+    },
+    {
+      id: "owner-updates",
+      label: "Draft owner updates",
+      count: alerts.ownerUpdates.length,
+      href: "/dashboard/office-alerts?queue=owner-updates",
+    },
+  ]
+
+  return (
+    <main className="mx-auto w-full max-w-6xl space-y-5 p-3 sm:p-4 lg:p-5">
+      <header className="border-b pb-4">
+        <div className="flex items-center gap-2">
+          {activeQueue === "rfis" ? (
+            <IconMessageCircleQuestion className="size-5 text-[#9d832c]" />
+          ) : activeQueue === "photos" ? (
+            <IconPhoto className="size-5 text-[#2f5963]" />
+          ) : (
+            <IconClipboardText className="size-5 text-[#3f7d4d]" />
+          )}
+          <h1 className="text-2xl font-semibold tracking-tight">Office alerts</h1>
+        </div>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Review outstanding items across every project you can access.
+        </p>
+      </header>
+
+      <nav className="grid gap-px border bg-border sm:grid-cols-3" aria-label="Office alert queues">
+        {tabs.map((tab) => (
+          <Link
+            key={tab.id}
+            href={tab.href}
+            aria-current={activeQueue === tab.id ? "page" : undefined}
+            className={cn(
+              "flex items-center justify-between gap-3 bg-background px-4 py-3 text-sm transition-colors hover:bg-muted/50",
+              activeQueue === tab.id && "bg-muted font-semibold"
+            )}
+          >
+            <span>{tab.label}</span>
+            <Badge variant={activeQueue === tab.id ? "default" : "secondary"}>
+              {tab.count}
+            </Badge>
+          </Link>
+        ))}
+      </nav>
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-sm font-semibold">
+            {tabs.find((tab) => tab.id === activeQueue)?.label}
+          </h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Select an item to open it in the correct project workspace.
+          </p>
+        </div>
+        {activeQueue === "rfis" ? (
+          <RfiQueue queue={alerts} />
+        ) : activeQueue === "photos" ? (
+          <PhotoQueue queue={alerts} />
+        ) : (
+          <OwnerUpdateQueue queue={alerts} />
+        )}
+      </section>
+    </main>
+  )
+}

--- a/src/components/dashboard/dashboard-launchpad.tsx
+++ b/src/components/dashboard/dashboard-launchpad.tsx
@@ -763,7 +763,7 @@ function OfficeTaskList({
             id: "draft-owner-updates",
             title: `Review ${overview.metrics.draftOwnerUpdates} draft owner update${overview.metrics.draftOwnerUpdates === 1 ? "" : "s"}`,
             detail: "Publication queue",
-            href: "/dashboard/projects",
+            href: "/dashboard/office-alerts?queue=owner-updates",
             category: "Owner update",
           }]
         : []
@@ -773,7 +773,7 @@ function OfficeTaskList({
             id: "field-photo-review",
             title: `Review ${overview.metrics.photosToReview} field photo${overview.metrics.photosToReview === 1 ? "" : "s"}`,
             detail: "Visibility decisions",
-            href: "/dashboard/projects/select?target=photos",
+            href: "/dashboard/office-alerts?queue=photos",
             category: "Field review",
           }]
         : []
@@ -968,19 +968,19 @@ function OfficeAlerts({
     {
       label: "Open RFIs",
       value: overview.metrics.openRfis,
-      href: "/dashboard/rfis",
+      href: "/dashboard/office-alerts?queue=rfis",
       icon: <IconMessageCircleQuestion className="size-4" />,
     },
     {
       label: "Draft owner updates",
       value: overview.metrics.draftOwnerUpdates,
-      href: "/dashboard/projects",
+      href: "/dashboard/office-alerts?queue=owner-updates",
       icon: <IconClipboardText className="size-4" />,
     },
     {
       label: "Photos to review",
       value: overview.metrics.photosToReview,
-      href: "/dashboard/projects/select?target=photos",
+      href: "/dashboard/office-alerts?queue=photos",
       icon: <IconPhoto className="size-4" />,
     },
   ]


### PR DESCRIPTION
## What changed

- Added one all-project Office Alerts workspace for open RFIs, photos awaiting review, and draft owner updates.
- Updated dashboard alert and priority links to open the matching aggregate queue instead of a current-project picker.
- Preserved project context on every result and deep-links each row into the correct project.
- Scoped queues to internal staff, feature permissions, and accessible projects.
- Batched cross-project D1 queries and excluded terminal RFI statuses.

## Why

Dashboard alert totals are organization-wide, but their previous links depended on the current project. Users could see an alert count without being able to see the records represented by it.

## Validation

- `bun lint` (passes; existing warnings only)
- `bun run build` (passes, including TypeScript and `/dashboard/office-alerts` route generation)
- Codex autoreview: clean, no actionable findings
