### PR TITLE
fix(sage): prefix job names and avoid exclusive access

### DIFF
--- a/scripts/Sage.100.Contractor.CompassClientProjectWriter.cs
+++ b/scripts/Sage.100.Contractor.CompassClientProjectWriter.cs
@@ -27,7 +27,7 @@ namespace CompassSageClientProjectWriter
         private static Type ImbxmlType;
         private static Type GlobalType;
         private static object ApiInstance;
-        private static bool ExclusiveAccess;
+        private static bool ApiInitialized;
 
         public sealed class Envelope { public WriteRequest[] requests { get; set; } }
         public sealed class WriteRequest
@@ -81,37 +81,41 @@ namespace CompassSageClientProjectWriter
         {
             public ApiSession(string user, string password)
             {
-                Directory.SetCurrentDirectory(Path.GetDirectoryName(ApiDllPath));
-                Assembly assembly = Assembly.LoadFrom(ApiDllPath);
-                ImbxmlType = assembly.GetType("Sage.SMB.API.IMBXML", true);
-                GlobalType = assembly.GetType("Sage.SMB.API.mbAPIGlobal", true);
-                ApiInstance = Activator.CreateInstance(ImbxmlType);
-                InvokeStatic("SetRqDataSource", new object[] { DataSource() });
-                Invoke("SetDataSource", new object[] { DataSource() });
-                Invoke("IntializeAPI", new object[0]);
-                InvokeStatic("SetRqDataSource", new object[] { DataSource() });
-                InvokeStatic("ResetRqAcceptState", new object[0]);
-                InvokeStatic("EnableAcceptRq", new object[] { true });
-                Invoke("SetDataSource", new object[] { DataSource() });
-                Invoke("EnableRequests", new object[0]);
-                object allowed = Invoke("IsApplicationAllowed", new object[] { user, password });
-                if (!(allowed is int) || (int)allowed != 0) throw new InvalidOperationException("The Sage API application is not allowed (code " + Convert.ToString(allowed) + ").");
-                object valid = Invoke("IsValidUser", new object[] { TargetCompany, user, password });
-                if (!(valid is bool) || !(bool)valid) throw new InvalidOperationException("jarvis.api is not a valid Sage API user for the target company.");
-                object exclusive = Invoke("GetExclusiveAccess", new object[] { TargetCompany, user, password });
-                if (!(exclusive is int) || (int)exclusive != 0) throw new InvalidOperationException("Sage exclusive access is unavailable (code " + Convert.ToString(exclusive) + ").");
-                ExclusiveAccess = true;
-            }
-            public void Dispose()
-            {
-                try { if (ExclusiveAccess) Invoke("ReleaseExclusiveAccess", new object[0]); }
-                finally
+                try
                 {
-                    ExclusiveAccess = false;
-                    try { Invoke("DeIntializeAPI", new object[0]); } catch { }
-                    ApiInstance = null;
+                    Directory.SetCurrentDirectory(Path.GetDirectoryName(ApiDllPath));
+                    Assembly assembly = Assembly.LoadFrom(ApiDllPath);
+                    ImbxmlType = assembly.GetType("Sage.SMB.API.IMBXML", true);
+                    GlobalType = assembly.GetType("Sage.SMB.API.mbAPIGlobal", true);
+                    ApiInstance = Activator.CreateInstance(ImbxmlType);
+                    InvokeStatic("SetRqDataSource", new object[] { DataSource() });
+                    Invoke("SetDataSource", new object[] { DataSource() });
+                    Invoke("IntializeAPI", new object[0]);
+                    ApiInitialized = true;
+                    InvokeStatic("SetRqDataSource", new object[] { DataSource() });
+                    InvokeStatic("ResetRqAcceptState", new object[0]);
+                    InvokeStatic("EnableAcceptRq", new object[] { true });
+                    Invoke("SetDataSource", new object[] { DataSource() });
+                    Invoke("EnableRequests", new object[0]);
+                    object allowed = Invoke("IsApplicationAllowed", new object[] { user, password });
+                    if (!(allowed is int) || (int)allowed != 0) throw new InvalidOperationException("The Sage API application is not allowed (code " + Convert.ToString(allowed) + ").");
+                    object valid = Invoke("IsValidUser", new object[] { TargetCompany, user, password });
+                    if (!(valid is bool) || !(bool)valid) throw new InvalidOperationException("jarvis.api is not a valid Sage API user for the target company.");
+                }
+                catch
+                {
+                    ResetApi();
+                    throw;
                 }
             }
+            public void Dispose() { ResetApi(); }
+        }
+
+        private static void ResetApi()
+        {
+            try { if (ApiInitialized && ApiInstance != null) Invoke("DeIntializeAPI", new object[0]); }
+            catch { }
+            finally { ApiInitialized = false; ApiInstance = null; }
         }
 
         public static int Main(string[] args)
@@ -553,8 +557,19 @@ namespace CompassSageClientProjectWriter
             }
         }
 
-        private static object Invoke(string name, object[] args) { return FindMethod(ImbxmlType, name, args.Length, false).Invoke(ApiInstance, args); }
-        private static object InvokeStatic(string name, object[] args) { return FindMethod(GlobalType, name, args.Length, true).Invoke(null, args); }
+        private static object Invoke(string name, object[] args) { return InvokeMethod(FindMethod(ImbxmlType, name, args.Length, false), ApiInstance, args); }
+        private static object InvokeStatic(string name, object[] args) { return InvokeMethod(FindMethod(GlobalType, name, args.Length, true), null, args); }
+        private static object InvokeMethod(MethodInfo method, object target, object[] args)
+        {
+            try { return method.Invoke(target, args); }
+            catch (TargetInvocationException error)
+            {
+                Exception inner = error.InnerException;
+                if (inner == null) throw;
+                string message = String.IsNullOrWhiteSpace(inner.Message) ? inner.GetType().FullName : inner.Message;
+                throw new InvalidOperationException(message, inner);
+            }
+        }
         private static MethodInfo FindMethod(Type type, string name, int count, bool isStatic)
         {
             BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | (isStatic ? BindingFlags.Static : BindingFlags.Instance);

--- a/src/app/actions/projects.ts
+++ b/src/app/actions/projects.ts
@@ -57,6 +57,7 @@ import {
   parseSageClientStatusId,
   parseSageJobTypeId,
   sageClientStatusName,
+  sageJobName,
   sageJobTypeName,
   sageShortName,
   type SageClientStatusId,
@@ -544,6 +545,7 @@ export async function createProjectIntake(
       createdAt: now,
       updatedAt: now,
     }
+    const fullSageJobName = sageJobName(projectNumber, projectName)
     const sageWritePayload = {
       operationType: "ensure_client_and_job" as const,
       company: "High Performance Structures Inc" as const,
@@ -565,8 +567,8 @@ export async function createProjectIntake(
       job: {
         compassProjectId: projectId,
         compassProjectNumber: projectNumber,
-        name: projectName,
-        shortName: sageShortName(projectName),
+        name: fullSageJobName,
+        shortName: sageShortName(fullSageJobName),
         address: joinedAddress(input),
         statusName: sageJobStatus.label,
         typeName: sageJobTypeName(sageJobType),
@@ -1274,6 +1276,7 @@ export async function createProjectShell(
       .get()
     const customerId = customerMatch?.id ?? crypto.randomUUID()
     const address = cleanText(input.address)
+    const fullSageJobName = sageJobName(projectNumber, name)
     const payload = {
       operationType: "ensure_client_and_job" as const,
       company: "High Performance Structures Inc" as const,
@@ -1295,8 +1298,8 @@ export async function createProjectShell(
       job: {
         compassProjectId: id,
         compassProjectNumber: projectNumber,
-        name,
-        shortName: sageShortName(name),
+        name: fullSageJobName,
+        shortName: sageShortName(fullSageJobName),
         address,
         statusName: sageJobStatus.label,
         typeName: sageJobTypeName(sageJobType),

--- a/src/lib/sage/__tests__/client-project-worker-source.test.ts
+++ b/src/lib/sage/__tests__/client-project-worker-source.test.ts
@@ -68,4 +68,16 @@ describe("Sage client/project worker source boundary", () => {
       "A Sage client matches the requested name but not the requested email; no write was attempted."
     )
   })
+
+  it("does not require exclusive company access for normal API writes", () => {
+    expect(source).not.toContain("GetExclusiveAccess")
+    expect(source).not.toContain("ReleaseExclusiveAccess")
+  })
+
+  it("cleans up failed API initialization and exposes Sage errors", () => {
+    expect(source).toContain("catch\n                {\n                    ResetApi()")
+    expect(source).toContain("if (ApiInitialized && ApiInstance != null)")
+    expect(source).toContain("catch (TargetInvocationException error)")
+    expect(source).toContain("error.InnerException")
+  })
 })

--- a/src/lib/sage/__tests__/client-project-write.test.ts
+++ b/src/lib/sage/__tests__/client-project-write.test.ts
@@ -6,6 +6,7 @@ import {
   sageClientProjectWritePayloadSchema,
   sageClientProjectWriteResultSchema,
   sageClientStatusName,
+  sageJobName,
   sageJobTypeName,
   sageShortName,
 } from "@/lib/sage/client-project-write"
@@ -30,6 +31,16 @@ describe("Sage client/project write contract", () => {
   it("caps Sage short names at the database limit", () => {
     expect(sageShortName("  High   Performance Structures Incorporated "))
       .toBe("High Performance Structures In")
+  })
+
+  it("prefixes the Sage job name with the full Compass project number", () => {
+    expect(sageJobName("H-434-595", "Luke Loeffler Earthwork")).toBe(
+      "H-434-595-Luke Loeffler Earthwork"
+    )
+    expect(sageJobName(null, "  Internal   Operations  ")).toBe(
+      "Internal Operations"
+    )
+    expect(sageJobName("O-123-456", "x".repeat(80))).toHaveLength(75)
   })
 
   it("validates the exact target company and required job selections", () => {

--- a/src/lib/sage/client-project-write.ts
+++ b/src/lib/sage/client-project-write.ts
@@ -123,6 +123,18 @@ export function sageShortName(value: string): string {
   return value.trim().replace(/\s+/g, " ").slice(0, 30)
 }
 
+export function sageJobName(
+  projectNumber: string | null,
+  projectName: string
+): string {
+  const normalizedName = projectName.trim().replace(/\s+/g, " ")
+  const normalizedNumber = projectNumber?.trim().replace(/\s+/g, " ") ?? ""
+  const fullName = normalizedNumber
+    ? `${normalizedNumber}-${normalizedName}`
+    : normalizedName
+  return fullName.slice(0, 75)
+}
+
 export async function isSageWriteApproved(
   db: ReturnType<typeof getDb>,
   organizationId: string,


### PR DESCRIPTION
## Summary

- format new Sage job names as `<full Compass project number>-<project name>`
- stop requesting Sage database exclusive access for ordinary client/project API writes
- preserve Sage API deinitialization and surface inner reflection errors clearly

## Validation

- `bun test src/lib/sage/__tests__/client-project-write.test.ts src/lib/sage/__tests__/client-project-worker-source.test.ts`
- `bunx eslint src/lib/sage/client-project-write.ts src/app/actions/projects.ts src/lib/sage/__tests__/client-project-write.test.ts src/lib/sage/__tests__/client-project-worker-source.test.ts`
- `/Users/martine/.agents/skills/autoreview/scripts/autoreview --mode local`

## Production follow-up

- deploy the merged Worker for the job-name payload change
- reinstall the Windows Sage writer and diagnose it while the Sage company is open
