### PR TITLE
fix(office): restore inbound message review link

### DIFF
--- a/src/app/dashboard/office-maintenance/message-desk/page.tsx
+++ b/src/app/dashboard/office-maintenance/message-desk/page.tsx
@@ -154,7 +154,13 @@ export default async function StaffMessageDeskPage(): Promise<React.ReactElement
                 <h3 className="font-semibold">Text sender ending {item.senderPhone.replace(/\D/g, "").slice(-4) || "unknown"}</h3>
                 <p className="text-sm text-muted-foreground">{timestamp(item.receivedAt)}</p>
               </div>
-              <Badge variant="secondary">Needs review</Badge>
+              <Badge asChild variant="secondary">
+                <Link
+                  href={`/dashboard/office-maintenance/inbound-email#inbound-sms-${encodeURIComponent(item.id)}`}
+                >
+                  Needs review
+                </Link>
+              </Badge>
             </div>
             <p className="mt-4 whitespace-pre-wrap border-l-2 pl-3 text-sm leading-6">
               {item.messageBody ?? "No message body was retained."}


### PR DESCRIPTION
## What changed

- Restores the **Needs review** badge as a link in the Staff Message Desk.
- Routes directly to the matching inbound SMS record on the Review Inbound Messages page.

## Root cause

A later main-branch version rendered the badge as plain text. The earlier deployed link was not preserved in main, so a subsequent deployment reintroduced the regression.

## How to test

- Staff Message Desk tests: 4 passing
- Targeted ESLint: clean
- Production Next.js build: passing
- Production verification: link visible and matching inbound record found
