### PR TITLE
fix(projects): connect project status and contact identities

### DIFF
--- a/drizzle/0114_project_customer_legacy_status.sql
+++ b/drizzle/0114_project_customer_legacy_status.sql
@@ -1,0 +1,6 @@
+UPDATE `projects`
+SET
+	`status` = 'OPEN',
+	`updated_at` = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE `client_status` = 'customer'
+	AND upper(trim(`status`)) = 'LEAD';

--- a/drizzle/0115_contact_profile_ownership.sql
+++ b/drizzle/0115_contact_profile_ownership.sql
@@ -1,0 +1,345 @@
+ALTER TABLE `users` ADD `phone` text;
+--> statement-breakpoint
+ALTER TABLE `users` ADD `address` text;
+--> statement-breakpoint
+ALTER TABLE `project_contacts` ADD `address` text;
+--> statement-breakpoint
+
+-- Native project intake historically saved customer and assignee details on
+-- separate records without creating the project-scoped contact links. Repair
+-- only projects proven to have come through that intake path.
+WITH `native_projects` AS (
+  SELECT DISTINCT
+    p.`id`,
+    p.`organization_id`,
+    p.`client_name`,
+    p.`project_manager`,
+    p.`created_at`
+  FROM `projects` p
+  INNER JOIN `project_operations` o
+    ON o.`project_id` = p.`id`
+   AND o.`source_system` = 'compass_project_intake'
+),
+`matched_customers` AS (
+  SELECT
+    n.`id` AS `project_id`,
+    n.`created_at` AS `project_created_at`,
+    c.`id` AS `customer_id`,
+    c.`name`,
+    c.`company`,
+    c.`email`,
+    c.`phone`,
+    c.`address`,
+    ROW_NUMBER() OVER (
+      PARTITION BY n.`id`
+      ORDER BY c.`created_at`, c.`id`
+    ) AS `match_rank`
+  FROM `native_projects` n
+  INNER JOIN `customers` c
+    ON c.`organization_id` = n.`organization_id`
+   AND lower(trim(c.`name`)) = lower(trim(n.`client_name`))
+  WHERE n.`client_name` IS NOT NULL
+    AND trim(n.`client_name`) <> ''
+)
+INSERT INTO `project_contacts` (
+  `id`, `project_id`, `contact_type`, `source_system`, `source_record_id`,
+  `source_entity_type`, `source_entity_id`, `display_name`, `company_name`,
+  `role`, `trade`, `csi_division`, `csi_division_name`, `primary_cost_code`,
+  `email`, `phone`, `address`, `notes`, `owner_portal_visible`,
+  `sub_vendor_portal_visible`, `internal_visible`, `primary_contact`, `active`,
+  `sort_order`, `sync_status`, `last_synced_at`, `created_at`, `updated_at`
+)
+SELECT
+  'intake-owner:' || m.`project_id`,
+  m.`project_id`,
+  'owner',
+  'customer_directory',
+  m.`customer_id`,
+  'customer',
+  m.`customer_id`,
+  m.`name`,
+  m.`company`,
+  'Owner / Client',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  m.`email`,
+  m.`phone`,
+  m.`address`,
+  'Linked automatically from Compass project intake.',
+  1,
+  0,
+  1,
+  1,
+  1,
+  100,
+  'manual',
+  NULL,
+  m.`project_created_at`,
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+FROM `matched_customers` m
+WHERE m.`match_rank` = 1
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `project_contacts` existing
+    WHERE existing.`project_id` = m.`project_id`
+      AND existing.`active` = 1
+      AND existing.`contact_type` = 'owner'
+      AND (
+        (existing.`source_entity_type` = 'customer'
+          AND existing.`source_entity_id` = m.`customer_id`)
+        OR (m.`email` IS NOT NULL AND trim(m.`email`) <> ''
+          AND lower(trim(existing.`email`)) = lower(trim(m.`email`)))
+        OR lower(trim(existing.`display_name`)) = lower(trim(m.`name`))
+      )
+  );
+--> statement-breakpoint
+
+-- If an older native intake has no matching customer-directory record, keep
+-- the recorded client visible as a manual owner contact instead of losing it.
+WITH `native_projects` AS (
+  SELECT DISTINCT
+    p.`id`,
+    p.`client_name`,
+    p.`created_at`
+  FROM `projects` p
+  INNER JOIN `project_operations` o
+    ON o.`project_id` = p.`id`
+   AND o.`source_system` = 'compass_project_intake'
+)
+INSERT INTO `project_contacts` (
+  `id`, `project_id`, `contact_type`, `source_system`, `source_record_id`,
+  `source_entity_type`, `source_entity_id`, `display_name`, `company_name`,
+  `role`, `trade`, `csi_division`, `csi_division_name`, `primary_cost_code`,
+  `email`, `phone`, `address`, `notes`, `owner_portal_visible`,
+  `sub_vendor_portal_visible`, `internal_visible`, `primary_contact`, `active`,
+  `sort_order`, `sync_status`, `last_synced_at`, `created_at`, `updated_at`
+)
+SELECT
+  'intake-owner-manual:' || n.`id`,
+  n.`id`,
+  'owner',
+  'compass_project_intake',
+  n.`id`,
+  'manual',
+  NULL,
+  trim(n.`client_name`),
+  NULL,
+  'Owner / Client',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  'Recovered from the project intake client name; directory details need review.',
+  1,
+  0,
+  1,
+  1,
+  1,
+  100,
+  'manual',
+  NULL,
+  n.`created_at`,
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+FROM `native_projects` n
+WHERE n.`client_name` IS NOT NULL
+  AND trim(n.`client_name`) <> ''
+  AND NOT EXISTS (
+    SELECT 1
+    FROM `project_contacts` existing
+    WHERE existing.`project_id` = n.`id`
+      AND existing.`active` = 1
+      AND existing.`contact_type` = 'owner'
+  );
+--> statement-breakpoint
+
+WITH `matched_assignees` AS (
+  SELECT DISTINCT
+    p.`id` AS `project_id`,
+    p.`created_at` AS `project_created_at`,
+    u.`id` AS `user_id`,
+    COALESCE(
+      NULLIF(trim(u.`display_name`), ''),
+      NULLIF(trim(COALESCE(u.`first_name`, '') || ' ' || COALESCE(u.`last_name`, '')), ''),
+      u.`email`
+    ) AS `display_name`,
+    u.`email`,
+    u.`phone`,
+    u.`address`
+  FROM `projects` p
+  INNER JOIN `project_operations` o
+    ON o.`project_id` = p.`id`
+   AND o.`source_system` = 'compass_project_intake'
+  INNER JOIN `organization_members` om
+    ON om.`organization_id` = p.`organization_id`
+  INNER JOIN `users` u
+    ON u.`id` = om.`user_id`
+   AND u.`is_active` = 1
+  WHERE p.`project_manager` IS NOT NULL
+    AND trim(p.`project_manager`) <> ''
+    AND lower(trim(p.`project_manager`)) = lower(trim(COALESCE(
+      NULLIF(trim(u.`display_name`), ''),
+      NULLIF(trim(COALESCE(u.`first_name`, '') || ' ' || COALESCE(u.`last_name`, '')), ''),
+      u.`email`
+    )))
+)
+INSERT INTO `project_contacts` (
+  `id`, `project_id`, `contact_type`, `source_system`, `source_record_id`,
+  `source_entity_type`, `source_entity_id`, `display_name`, `company_name`,
+  `role`, `trade`, `csi_division`, `csi_division_name`, `primary_cost_code`,
+  `email`, `phone`, `address`, `notes`, `owner_portal_visible`,
+  `sub_vendor_portal_visible`, `internal_visible`, `primary_contact`, `active`,
+  `sort_order`, `sync_status`, `last_synced_at`, `created_at`, `updated_at`
+)
+SELECT
+  'intake-internal:' || m.`project_id` || ':' || m.`user_id`,
+  m.`project_id`,
+  'internal',
+  'organization_directory',
+  m.`user_id`,
+  'user',
+  m.`user_id`,
+  m.`display_name`,
+  NULL,
+  'Project manager',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  m.`email`,
+  m.`phone`,
+  m.`address`,
+  'Linked automatically from the Compass project intake assignment.',
+  1,
+  1,
+  1,
+  1,
+  1,
+  200,
+  'synced',
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+  m.`project_created_at`,
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+FROM `matched_assignees` m
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM `project_contacts` existing
+  WHERE existing.`project_id` = m.`project_id`
+    AND existing.`active` = 1
+    AND existing.`contact_type` = 'internal'
+    AND (
+      (existing.`source_entity_type` = 'user'
+        AND existing.`source_entity_id` = m.`user_id`)
+      OR lower(trim(existing.`email`)) = lower(trim(m.`email`))
+      OR lower(trim(existing.`display_name`)) = lower(trim(m.`display_name`))
+    )
+);
+--> statement-breakpoint
+
+WITH `matched_assignees` AS (
+  SELECT DISTINCT
+    p.`id` AS `project_id`,
+    p.`created_at` AS `project_created_at`,
+    u.`id` AS `user_id`
+  FROM `projects` p
+  INNER JOIN `project_operations` o
+    ON o.`project_id` = p.`id`
+   AND o.`source_system` = 'compass_project_intake'
+  INNER JOIN `organization_members` om
+    ON om.`organization_id` = p.`organization_id`
+  INNER JOIN `users` u
+    ON u.`id` = om.`user_id`
+   AND u.`is_active` = 1
+  WHERE p.`project_manager` IS NOT NULL
+    AND trim(p.`project_manager`) <> ''
+    AND lower(trim(p.`project_manager`)) = lower(trim(COALESCE(
+      NULLIF(trim(u.`display_name`), ''),
+      NULLIF(trim(COALESCE(u.`first_name`, '') || ' ' || COALESCE(u.`last_name`, '')), ''),
+      u.`email`
+    )))
+)
+INSERT INTO `project_members` (
+  `id`, `project_id`, `user_id`, `role`, `assigned_at`
+)
+SELECT
+  'intake-member:' || m.`project_id` || ':' || m.`user_id`,
+  m.`project_id`,
+  m.`user_id`,
+  'project-manager',
+  m.`project_created_at`
+FROM `matched_assignees` m
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM `project_members` existing
+  WHERE existing.`project_id` = m.`project_id`
+    AND existing.`user_id` = m.`user_id`
+);
+--> statement-breakpoint
+
+UPDATE `project_contacts`
+SET `address` = (
+  SELECT c.`address`
+  FROM `customers` c
+  WHERE c.`id` = `project_contacts`.`source_entity_id`
+)
+WHERE `source_entity_type` = 'customer'
+  AND `source_entity_id` IS NOT NULL
+  AND (`address` IS NULL OR trim(`address`) = '');
+--> statement-breakpoint
+
+UPDATE `project_contacts`
+SET `address` = (
+  SELECT v.`address`
+  FROM `vendors` v
+  WHERE v.`id` = `project_contacts`.`source_entity_id`
+)
+WHERE `source_entity_type` = 'vendor'
+  AND `source_entity_id` IS NOT NULL
+  AND (`address` IS NULL OR trim(`address`) = '');
+--> statement-breakpoint
+
+-- Preserve the staff-maintained identity details when an existing invited
+-- contact has already activated their Compass account. Future edits come from
+-- Account Settings and synchronize back to these linked directory records.
+UPDATE `users`
+SET
+  `phone` = COALESCE(
+    NULLIF(trim(`users`.`phone`), ''),
+    (
+      SELECT NULLIF(trim(pc.`phone`), '')
+      FROM `project_access_invitations` invitation
+      INNER JOIN `project_contacts` pc
+        ON pc.`id` = invitation.`project_contact_id`
+      WHERE invitation.`accepted_by` = `users`.`id`
+        AND invitation.`status` = 'accepted'
+        AND pc.`phone` IS NOT NULL
+        AND trim(pc.`phone`) <> ''
+      ORDER BY invitation.`accepted_at` DESC, invitation.`id` DESC
+      LIMIT 1
+    )
+  ),
+  `address` = COALESCE(
+    NULLIF(trim(`users`.`address`), ''),
+    (
+      SELECT NULLIF(trim(pc.`address`), '')
+      FROM `project_access_invitations` invitation
+      INNER JOIN `project_contacts` pc
+        ON pc.`id` = invitation.`project_contact_id`
+      WHERE invitation.`accepted_by` = `users`.`id`
+        AND invitation.`status` = 'accepted'
+        AND pc.`address` IS NOT NULL
+        AND trim(pc.`address`) <> ''
+      ORDER BY invitation.`accepted_at` DESC, invitation.`id` DESC
+      LIMIT 1
+    )
+  )
+WHERE EXISTS (
+  SELECT 1
+  FROM `project_access_invitations` invitation
+  WHERE invitation.`accepted_by` = `users`.`id`
+    AND invitation.`status` = 'accepted'
+);

--- a/src/app/actions/customers.ts
+++ b/src/app/actions/customers.ts
@@ -3,7 +3,7 @@
 import { getCloudflareContext } from "@/lib/db"
 import { eq, and } from "drizzle-orm"
 import { getDb } from "@/db"
-import { customers, type NewCustomer } from "@/db/schema"
+import { customers, projectContacts, type NewCustomer } from "@/db/schema"
 import { sageClientProjectWriteOperations } from "@/db/schema-sage"
 import { requireAuth } from "@/lib/auth"
 import { requirePermission } from "@/lib/permissions"
@@ -17,6 +17,10 @@ import {
   sageShortName,
   type SageClientStatusId,
 } from "@/lib/sage/client-project-write"
+import {
+  contactIdentityChanged,
+  directoryIdentityManagedByActiveUser,
+} from "@/lib/contact-identity-ownership"
 
 export type CreateCustomerInput = {
   readonly name: string
@@ -160,12 +164,56 @@ export async function updateCustomer(
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
 
-    await db
-      .update(customers)
-      .set({ ...data, updatedAt: new Date().toISOString() })
+    const existing = await db
+      .select()
+      .from(customers)
       .where(and(eq(customers.id, id), eq(customers.organizationId, orgId)))
+      .limit(1)
+      .get()
+    if (!existing) return { success: false, error: "Customer not found" }
+
+    const nextIdentity = {
+      email: data.email === undefined ? existing.email : data.email,
+      phone: data.phone === undefined ? existing.phone : data.phone,
+      address: data.address === undefined ? existing.address : data.address,
+    }
+    const identityChanged = contactIdentityChanged(existing, nextIdentity)
+    if (
+      identityChanged &&
+      (await directoryIdentityManagedByActiveUser({
+        db,
+        organizationId: orgId,
+        entityType: "customer",
+        entityId: id,
+      }))
+    ) {
+      return {
+        success: false,
+        error:
+          "This active Compass user manages their own phone, email, and address.",
+      }
+    }
+
+    const updatedAt = new Date().toISOString()
+    await db.batch([
+      db
+        .update(customers)
+        .set({ ...data, updatedAt })
+        .where(and(eq(customers.id, id), eq(customers.organizationId, orgId))),
+      db
+        .update(projectContacts)
+        .set({ ...nextIdentity, updatedAt })
+        .where(
+          and(
+            eq(projectContacts.sourceEntityType, "customer"),
+            eq(projectContacts.sourceEntityId, id)
+          )
+        ),
+    ])
 
     revalidatePath("/dashboard/customers")
+    revalidatePath("/dashboard/contacts")
+    revalidatePath("/dashboard/projects", "layout")
     return { success: true }
   } catch (err) {
     return {

--- a/src/app/actions/profile.ts
+++ b/src/app/actions/profile.ts
@@ -3,8 +3,14 @@
 import { getWorkOS, signOut } from "@workos-inc/authkit-nextjs"
 import { getCloudflareContext } from "@/lib/db"
 import { getDb } from "@/db"
-import { users } from "@/db/schema"
-import { eq } from "drizzle-orm"
+import {
+  customers,
+  projectAccessInvitations,
+  projectContacts,
+  users,
+  vendors,
+} from "@/db/schema"
+import { and, eq, inArray } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { requireAuth } from "@/lib/auth"
 import {
@@ -73,12 +79,24 @@ export async function updateWorkspacePhoto(
   }
 }
 
+type ProfileUpdateResult = {
+  readonly emailVerificationRequired: boolean
+  readonly verificationEmailSent: boolean
+}
+
+function nullableProfileValue(value: string): string | null {
+  const normalized = value.trim()
+  return normalized.length > 0 ? normalized : null
+}
+
 /**
- * Update the current user's profile (first name, last name)
+ * Update the signed-in user's identity in WorkOS and every linked Compass
+ * contact snapshot. Once an account is active, this is the identity source of
+ * truth for customer and vendor directory records linked through invitations.
  */
 export async function updateProfile(
   input: UpdateProfileInput
-): Promise<ActionResult> {
+): Promise<ActionResult<ProfileUpdateResult>> {
   try {
     // Validate input
     const parsed = updateProfileSchema.safeParse(input)
@@ -89,17 +107,22 @@ export async function updateProfile(
       }
     }
 
-    const { firstName, lastName } = parsed.data
+    const { firstName, lastName, email, phone, address } = parsed.data
 
     // Get current authenticated user
     const currentUser = await requireAuth()
 
-    // Update in WorkOS
+    const normalizedCurrentEmail = currentUser.email.trim().toLowerCase()
+    const emailChanged = email !== normalizedCurrentEmail
+
+    // WorkOS remains authoritative for the login email and may reject an
+    // email managed by SSO or directory sync before any local values change.
     const workos = getWorkOS()
     await workos.userManagement.updateUser({
       userId: currentUser.id,
       firstName,
       lastName,
+      ...(emailChanged ? { email } : {}),
     })
 
     // Update in local database
@@ -108,6 +131,51 @@ export async function updateProfile(
       const db = getDb(env.DB)
       const now = new Date().toISOString()
       const displayName = `${firstName} ${lastName}`.trim()
+      const identity = {
+        email,
+        phone: nullableProfileValue(phone),
+        address: nullableProfileValue(address),
+      }
+
+      const acceptedContactRows = await db
+        .select({
+          id: projectContacts.id,
+          sourceEntityType: projectContacts.sourceEntityType,
+          sourceEntityId: projectContacts.sourceEntityId,
+        })
+        .from(projectAccessInvitations)
+        .innerJoin(
+          projectContacts,
+          eq(projectContacts.id, projectAccessInvitations.projectContactId)
+        )
+        .where(
+          and(
+            eq(projectAccessInvitations.acceptedBy, currentUser.id),
+            eq(projectAccessInvitations.status, "accepted")
+          )
+        )
+
+      const acceptedContactIds = Array.from(
+        new Set(acceptedContactRows.map((contact) => contact.id))
+      )
+      const linkedCustomerIds = Array.from(
+        new Set(
+          acceptedContactRows.flatMap((contact) =>
+            contact.sourceEntityType === "customer" && contact.sourceEntityId
+              ? [contact.sourceEntityId]
+              : []
+          )
+        )
+      )
+      const linkedVendorIds = Array.from(
+        new Set(
+          acceptedContactRows.flatMap((contact) =>
+            contact.sourceEntityType === "vendor" && contact.sourceEntityId
+              ? [contact.sourceEntityId]
+              : []
+          )
+        )
+      )
 
       await db
         .update(users)
@@ -115,13 +183,107 @@ export async function updateProfile(
           firstName,
           lastName,
           displayName,
+          ...identity,
           updatedAt: now,
         })
         .where(eq(users.id, currentUser.id))
         .run()
+
+      await db
+        .update(projectContacts)
+        .set({
+          displayName,
+          ...identity,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(projectContacts.sourceEntityType, "user"),
+            eq(projectContacts.sourceEntityId, currentUser.id)
+          )
+        )
+        .run()
+
+      if (acceptedContactIds.length > 0) {
+        await db
+          .update(projectContacts)
+          .set({ ...identity, updatedAt: now })
+          .where(inArray(projectContacts.id, acceptedContactIds))
+          .run()
+      }
+
+      if (linkedCustomerIds.length > 0) {
+        await db
+          .update(customers)
+          .set({ ...identity, updatedAt: now })
+          .where(inArray(customers.id, linkedCustomerIds))
+          .run()
+        await db
+          .update(projectContacts)
+          .set({ ...identity, updatedAt: now })
+          .where(
+            and(
+              eq(projectContacts.sourceEntityType, "customer"),
+              inArray(projectContacts.sourceEntityId, linkedCustomerIds)
+            )
+          )
+          .run()
+      }
+
+      if (linkedVendorIds.length > 0) {
+        await db
+          .update(vendors)
+          .set({ ...identity, updatedAt: now })
+          .where(inArray(vendors.id, linkedVendorIds))
+          .run()
+        await db
+          .update(projectContacts)
+          .set({ ...identity, updatedAt: now })
+          .where(
+            and(
+              eq(projectContacts.sourceEntityType, "vendor"),
+              inArray(projectContacts.sourceEntityId, linkedVendorIds)
+            )
+          )
+          .run()
+      }
+
+      await db
+        .update(projectAccessInvitations)
+        .set({ email, updatedAt: now })
+        .where(
+          and(
+            eq(projectAccessInvitations.acceptedBy, currentUser.id),
+            eq(projectAccessInvitations.status, "accepted")
+          )
+        )
+        .run()
     }
 
-    return { success: true }
+    let verificationEmailSent = !emailChanged
+    if (emailChanged) {
+      try {
+        await workos.userManagement.sendVerificationEmail({
+          userId: currentUser.id,
+        })
+        verificationEmailSent = true
+      } catch (error) {
+        console.warn("Profile email changed, but verification email failed:", error)
+      }
+    }
+
+    revalidatePath("/dashboard", "layout")
+    revalidatePath("/dashboard/contacts")
+    revalidatePath("/dashboard/customers")
+    revalidatePath("/dashboard/vendors")
+    revalidatePath("/dashboard/projects", "layout")
+    return {
+      success: true,
+      data: {
+        emailVerificationRequired: emailChanged,
+        verificationEmailSent,
+      },
+    }
   } catch (error) {
     console.error("Error updating profile:", error)
     return {

--- a/src/app/actions/project-access-invitations.ts
+++ b/src/app/actions/project-access-invitations.ts
@@ -221,6 +221,8 @@ export async function sendProjectAccessInvitation(
         id: users.id,
         role: users.role,
         isActive: users.isActive,
+        phone: users.phone,
+        address: users.address,
       })
       .from(users)
       .where(sql`lower(trim(${users.email})) = ${email}`)
@@ -286,6 +288,20 @@ export async function sendProjectAccessInvitation(
     let accessStatus: "invited" | "access_granted" = "invited"
 
     if (activeExistingUser) {
+      if (
+        (!activeExistingUser.phone && row.contact.phone) ||
+        (!activeExistingUser.address && row.contact.address)
+      ) {
+        await db
+          .update(users)
+          .set({
+            phone: activeExistingUser.phone ?? row.contact.phone,
+            address: activeExistingUser.address ?? row.contact.address,
+            updatedAt: now,
+          })
+          .where(eq(users.id, activeExistingUser.id))
+          .run()
+      }
       if (!verifiedOrganizationMembership) {
         await ensureExternalOrganizationMembership({
           db,

--- a/src/app/actions/project-contacts.ts
+++ b/src/app/actions/project-contacts.ts
@@ -19,6 +19,12 @@ import {
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { isDemoUser } from "@/lib/demo"
+import {
+  activeDirectoryIdentityKeys,
+  contactIdentityChanged,
+  directoryIdentityManagedByActiveUser,
+  type ContactIdentityFields,
+} from "@/lib/contact-identity-ownership"
 import { requireOrg } from "@/lib/org-scope"
 import { requireFeaturePermission } from "@/lib/permission-enforcement"
 import { requirePermission } from "@/lib/permissions"
@@ -52,6 +58,7 @@ export type ProjectContactItem = {
   readonly primaryCostCode: string | null
   readonly email: string | null
   readonly phone: string | null
+  readonly address: string | null
   readonly notes: string | null
   readonly ownerPortalVisible: boolean
   readonly subVendorPortalVisible: boolean
@@ -61,6 +68,7 @@ export type ProjectContactItem = {
   readonly syncStatus: string
   readonly lastSyncedAt: string | null
   readonly accessStatus: ProjectContactAccessStatus
+  readonly identityManagedByActiveUser: boolean
 }
 
 export type ProjectContactGroup = {
@@ -173,7 +181,9 @@ export type ProjectContactDirectoryOption = {
   readonly companyName: string | null
   readonly email: string | null
   readonly phone: string | null
+  readonly address: string | null
   readonly suggestedContactType: ProjectContactType
+  readonly identityManagedByActiveUser: boolean
 }
 
 export type ProjectContactMutationInput = {
@@ -191,6 +201,7 @@ export type ProjectContactMutationInput = {
   readonly primaryCostCode: string
   readonly email: string
   readonly phone: string
+  readonly address: string
   readonly notes: string
   readonly ownerPortalVisible: boolean
   readonly subVendorPortalVisible: boolean
@@ -199,7 +210,11 @@ export type ProjectContactMutationInput = {
 }
 
 export type ProjectContactMutationResult =
-  | { readonly success: true; readonly contactId: string }
+  | {
+      readonly success: true
+      readonly contactId: string
+      readonly warning?: string
+    }
   | { readonly success: false; readonly error: string }
 
 const CONTACT_TYPES: readonly ProjectContactType[] = [
@@ -220,6 +235,12 @@ function contactTypeLabel(type: ProjectContactType): string {
     case "internal":
       return "Internal"
   }
+}
+
+function environmentString(env: unknown, key: string): string | null {
+  if (typeof env !== "object" || env === null) return null
+  const value = Reflect.get(env, key)
+  return typeof value === "string" && value.trim() ? value.trim() : null
 }
 
 function toContactType(value: string): ProjectContactType {
@@ -309,7 +330,8 @@ function requireLinkIds(formData: FormData): readonly string[] {
 
 function toContactItem(
   row: typeof projectContacts.$inferSelect,
-  accessStatus: ProjectContactAccessStatus = "not_invited"
+  accessStatus: ProjectContactAccessStatus = "not_invited",
+  directoryIdentityManaged = false
 ): ProjectContactItem {
   return {
     id: row.id,
@@ -327,6 +349,7 @@ function toContactItem(
     primaryCostCode: row.primaryCostCode,
     email: row.email,
     phone: row.phone,
+    address: row.address,
     notes: row.notes,
     ownerPortalVisible: row.ownerPortalVisible,
     subVendorPortalVisible: row.subVendorPortalVisible,
@@ -336,6 +359,8 @@ function toContactItem(
     syncStatus: row.syncStatus,
     lastSyncedAt: row.lastSyncedAt,
     accessStatus,
+    identityManagedByActiveUser:
+      accessStatus === "active" || directoryIdentityManaged,
   }
 }
 
@@ -578,6 +603,25 @@ export async function getProjectContactsSummary(
       asc(projectContacts.displayName)
     )
 
+  const projectRow = await db
+    .select({ organizationId: projects.organizationId })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .get()
+  const directoryIdentityKeys = projectRow?.organizationId
+    ? await activeDirectoryIdentityKeys({
+        db,
+        organizationId: projectRow.organizationId,
+        entityIds: rows.flatMap((row) =>
+          (row.sourceEntityType === "customer" ||
+            row.sourceEntityType === "vendor") &&
+          row.sourceEntityId
+            ? [row.sourceEntityId]
+            : []
+        ),
+      })
+    : new Set<string>()
+
   const invitationRows = await db
     .select({
       projectContactId: projectAccessInvitations.projectContactId,
@@ -652,7 +696,11 @@ export async function getProjectContactsSummary(
       projectContactAccessStatus({
         activeProjectMember,
         latestInvitation,
-      })
+      }),
+      row.sourceEntityId !== null &&
+        directoryIdentityKeys.has(
+          `${row.sourceEntityType}:${row.sourceEntityId}`
+        )
     )
   })
   const sourceLinks = await db
@@ -738,6 +786,7 @@ export async function getProjectContactDirectoryOptions(
         company: customers.company,
         email: customers.email,
         phone: customers.phone,
+        address: customers.address,
       })
       .from(customers)
       .where(eq(customers.organizationId, orgId)),
@@ -748,6 +797,7 @@ export async function getProjectContactDirectoryOptions(
         category: vendors.category,
         email: vendors.email,
         phone: vendors.phone,
+        address: vendors.address,
       })
       .from(vendors)
       .where(
@@ -763,6 +813,8 @@ export async function getProjectContactDirectoryOptions(
         displayName: users.displayName,
         firstName: users.firstName,
         lastName: users.lastName,
+        phone: users.phone,
+        address: users.address,
       })
       .from(organizationMembers)
       .innerJoin(users, eq(users.id, organizationMembers.userId))
@@ -773,6 +825,13 @@ export async function getProjectContactDirectoryOptions(
         )
       ),
   ])
+  const directoryIdentityKeys = await activeDirectoryIdentityKeys({
+    db,
+    organizationId: orgId,
+    entityIds: customerRows
+      .map((row) => row.id)
+      .concat(vendorRows.map((row) => row.id)),
+  })
 
   const customerOptions: ProjectContactDirectoryOption[] = customerRows
     .filter((row) => !existingSources.has(`customer:${row.id}`))
@@ -783,7 +842,11 @@ export async function getProjectContactDirectoryOptions(
       companyName: row.company,
       email: row.email,
       phone: row.phone,
+      address: row.address,
       suggestedContactType: "owner",
+      identityManagedByActiveUser: directoryIdentityKeys.has(
+        `customer:${row.id}`
+      ),
     }))
   const vendorOptions: ProjectContactDirectoryOption[] = vendorRows
     .filter(
@@ -798,7 +861,11 @@ export async function getProjectContactDirectoryOptions(
       companyName: row.name,
       email: row.email,
       phone: row.phone,
+      address: row.address,
       suggestedContactType: vendorCategoryToContactType(row.category),
+      identityManagedByActiveUser: directoryIdentityKeys.has(
+        `vendor:${row.id}`
+      ),
     }))
   const teamOptions: ProjectContactDirectoryOption[] = teamRows
     .filter((row) => !existingSources.has(`user:${row.id}`))
@@ -812,8 +879,10 @@ export async function getProjectContactDirectoryOptions(
         displayName: row.displayName?.trim() || fullName || row.email,
         companyName: null,
         email: row.email,
-        phone: null,
+        phone: row.phone,
+        address: row.address,
         suggestedContactType: "internal",
+        identityManagedByActiveUser: true,
       }
     })
 
@@ -848,6 +917,9 @@ export async function saveProjectContact(
     let sourceEntityType = "manual"
     let sourceEntityId: string | null = null
     let syncStatus = "manual"
+    let warning: string | undefined
+    let directoryIdentity: ContactIdentityFields | null = null
+    let directoryIdentityManaged = false
 
     if (!contactId && input.directorySourceType && input.directorySourceId) {
       sourceRecordId = input.directorySourceId
@@ -855,7 +927,12 @@ export async function saveProjectContact(
 
       if (input.directorySourceType === "customer") {
         const [directoryRecord] = await db
-          .select({ id: customers.id })
+          .select({
+            id: customers.id,
+            email: customers.email,
+            phone: customers.phone,
+            address: customers.address,
+          })
           .from(customers)
           .where(
             and(
@@ -869,9 +946,23 @@ export async function saveProjectContact(
         }
         sourceSystem = "customer_directory"
         sourceEntityType = "customer"
+        directoryIdentity = directoryRecord
+        directoryIdentityManaged =
+          await directoryIdentityManagedByActiveUser({
+            db,
+            organizationId: orgId,
+            entityType: "customer",
+            entityId: directoryRecord.id,
+          })
       } else if (input.directorySourceType === "vendor") {
         const [directoryRecord] = await db
-          .select({ id: vendors.id, syncStatus: vendors.syncStatus })
+          .select({
+            id: vendors.id,
+            syncStatus: vendors.syncStatus,
+            email: vendors.email,
+            phone: vendors.phone,
+            address: vendors.address,
+          })
           .from(vendors)
           .where(
             and(
@@ -887,9 +978,22 @@ export async function saveProjectContact(
         sourceSystem = "global_directory"
         sourceEntityType = "vendor"
         syncStatus = directoryRecord.syncStatus
+        directoryIdentity = directoryRecord
+        directoryIdentityManaged =
+          await directoryIdentityManagedByActiveUser({
+            db,
+            organizationId: orgId,
+            entityType: "vendor",
+            entityId: directoryRecord.id,
+          })
       } else {
         const [directoryRecord] = await db
-          .select({ id: users.id })
+          .select({
+            id: users.id,
+            email: users.email,
+            phone: users.phone,
+            address: users.address,
+          })
           .from(organizationMembers)
           .innerJoin(users, eq(users.id, organizationMembers.userId))
           .where(
@@ -905,6 +1009,8 @@ export async function saveProjectContact(
         }
         sourceSystem = "organization_directory"
         sourceEntityType = "user"
+        directoryIdentity = directoryRecord
+        directoryIdentityManaged = true
       }
 
       const [existingContact] = await db
@@ -935,6 +1041,7 @@ export async function saveProjectContact(
       primaryCostCode: nullableInput(input.primaryCostCode),
       email: nullableInput(input.email),
       phone: nullableInput(input.phone),
+      address: nullableInput(input.address),
       notes: nullableInput(input.notes),
       ownerPortalVisible: input.ownerPortalVisible,
       subVendorPortalVisible: input.subVendorPortalVisible,
@@ -944,11 +1051,25 @@ export async function saveProjectContact(
       updatedAt: now,
     }
 
+    if (
+      directoryIdentityManaged &&
+      directoryIdentity &&
+      contactIdentityChanged(directoryIdentity, contactValues)
+    ) {
+      return {
+        success: false,
+        error:
+          "Phone, email, and address are managed by this active Compass user. Add the directory contact without changing those fields.",
+      }
+    }
+
     if (contactId) {
       const [existingContact] = await db
         .select({
           id: projectContacts.id,
           email: projectContacts.email,
+          phone: projectContacts.phone,
+          address: projectContacts.address,
           sourceEntityType: projectContacts.sourceEntityType,
           sourceEntityId: projectContacts.sourceEntityId,
         })
@@ -963,24 +1084,59 @@ export async function saveProjectContact(
       if (!existingContact) {
         return { success: false, error: "Project contact not found" }
       }
+      sourceEntityType = existingContact.sourceEntityType
+      sourceEntityId = existingContact.sourceEntityId
       const existingEmail = existingContact.email?.trim().toLowerCase() ?? ""
       const updatedEmail = nullableInput(input.email)?.toLowerCase() ?? ""
-      if (existingEmail !== updatedEmail) {
-        const [invitationRows, organizationUserRows] = await Promise.all([
+      const existingPhone = existingContact.phone?.trim() ?? ""
+      const updatedPhone = nullableInput(input.phone) ?? ""
+      const existingAddress = existingContact.address?.trim() ?? ""
+      const updatedAddress = nullableInput(input.address) ?? ""
+      const identityChanged =
+        existingEmail !== updatedEmail ||
+        existingPhone !== updatedPhone ||
+        existingAddress !== updatedAddress
+      if (identityChanged) {
+        if (
+          (existingContact.sourceEntityType === "customer" ||
+            existingContact.sourceEntityType === "vendor") &&
+          existingContact.sourceEntityId &&
+          (await directoryIdentityManagedByActiveUser({
+            db,
+            organizationId: orgId,
+            entityType: existingContact.sourceEntityType,
+            entityId: existingContact.sourceEntityId,
+          }))
+        ) {
+          return {
+            success: false,
+            error:
+              "Phone, email, and address are managed by this active Compass user. You can still update their project role and visibility.",
+          }
+        }
+        const [activeInvitationRows, organizationUserRows] = await Promise.all([
           db
-            .select({ status: projectAccessInvitations.status })
+            .select({ userId: users.id })
             .from(projectAccessInvitations)
+            .innerJoin(users, eq(users.id, projectAccessInvitations.acceptedBy))
             .where(
               and(
                 eq(projectAccessInvitations.projectId, input.projectId),
-                eq(projectAccessInvitations.projectContactId, contactId)
+                eq(projectAccessInvitations.projectContactId, contactId),
+                eq(projectAccessInvitations.status, "accepted"),
+                eq(users.isActive, true)
               )
             ),
           db
             .select({ id: users.id, email: users.email })
             .from(organizationMembers)
             .innerJoin(users, eq(users.id, organizationMembers.userId))
-            .where(eq(organizationMembers.organizationId, orgId)),
+            .where(
+              and(
+                eq(organizationMembers.organizationId, orgId),
+                eq(users.isActive, true)
+              )
+            ),
         ])
         const linkedUserIds = new Set<string>()
         if (
@@ -1010,14 +1166,63 @@ export async function saveProjectContact(
                 )
                 .limit(1)
             : []
-        const hasActiveInvitation = invitationRows.some((invitation) =>
-          ["sent", "accepted"].includes(invitation.status)
-        )
-        if (hasActiveInvitation || linkedMembership.length > 0) {
+        if (activeInvitationRows.length > 0 || linkedMembership.length > 0) {
           return {
             success: false,
             error:
-              "This contact has Compass access. Remove the contact from the project, then add the correct person so access is revoked safely.",
+              "Phone, email, and address are managed by this active Compass user. You can still update their project role and visibility.",
+          }
+        }
+
+        if (existingEmail !== updatedEmail) {
+          const pendingInvitations = await db
+            .select({
+              id: projectAccessInvitations.id,
+              workosInvitationId: projectAccessInvitations.workosInvitationId,
+            })
+            .from(projectAccessInvitations)
+            .where(
+              and(
+                eq(projectAccessInvitations.projectId, input.projectId),
+                eq(projectAccessInvitations.projectContactId, contactId),
+                eq(projectAccessInvitations.status, "sent")
+              )
+            )
+          const workosInvitationIds = pendingInvitations.flatMap((invitation) =>
+            invitation.workosInvitationId
+              ? [invitation.workosInvitationId]
+              : []
+          )
+          if (workosInvitationIds.length > 0) {
+            const { env } = await getCloudflareContext()
+            const workosApiKey = environmentString(env, "WORKOS_API_KEY")
+            if (!workosApiKey || workosApiKey.includes("placeholder")) {
+              return {
+                success: false,
+                error:
+                  "The pending access invitation must be revoked before changing this email, but WorkOS is not configured.",
+              }
+            }
+            const { WorkOS } = await import("@workos-inc/node")
+            const workos = new WorkOS(workosApiKey)
+            for (const invitationId of workosInvitationIds) {
+              await workos.userManagement.revokeInvitation(invitationId)
+            }
+          }
+          if (pendingInvitations.length > 0) {
+            await db
+              .update(projectAccessInvitations)
+              .set({ status: "revoked", updatedAt: now })
+              .where(
+                and(
+                  eq(projectAccessInvitations.projectId, input.projectId),
+                  eq(projectAccessInvitations.projectContactId, contactId),
+                  eq(projectAccessInvitations.status, "sent")
+                )
+              )
+              .run()
+            warning =
+              "The old pending access invitation was revoked. Send a new invitation to the updated email."
           }
         }
       }
@@ -1069,13 +1274,77 @@ export async function saveProjectContact(
       })
     }
 
+    if (sourceEntityType === "customer" && sourceEntityId) {
+      await db.batch([
+        db
+          .update(customers)
+          .set({
+            email: contactValues.email,
+            phone: contactValues.phone,
+            address: contactValues.address,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(customers.id, sourceEntityId),
+              eq(customers.organizationId, orgId)
+            )
+          ),
+        db
+          .update(projectContacts)
+          .set({
+            email: contactValues.email,
+            phone: contactValues.phone,
+            address: contactValues.address,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(projectContacts.sourceEntityType, "customer"),
+              eq(projectContacts.sourceEntityId, sourceEntityId)
+            )
+          ),
+      ])
+    } else if (sourceEntityType === "vendor" && sourceEntityId) {
+      await db.batch([
+        db
+          .update(vendors)
+          .set({
+            email: contactValues.email,
+            phone: contactValues.phone,
+            address: contactValues.address,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(vendors.id, sourceEntityId),
+              eq(vendors.organizationId, orgId)
+            )
+          ),
+        db
+          .update(projectContacts)
+          .set({
+            email: contactValues.email,
+            phone: contactValues.phone,
+            address: contactValues.address,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(projectContacts.sourceEntityType, "vendor"),
+              eq(projectContacts.sourceEntityId, sourceEntityId)
+            )
+          ),
+      ])
+    }
+
     await queueProjectContactTrackerRefresh({
       db,
       organizationId: orgId,
       projectId: input.projectId,
     })
     revalidateContactPaths(input.projectId)
-    return { success: true, contactId }
+    return { success: true, contactId, ...(warning ? { warning } : {}) }
   } catch (error) {
     console.error("Failed to save project contact", error)
     return { success: false, error: "Failed to save project contact" }

--- a/src/app/actions/project-profile.ts
+++ b/src/app/actions/project-profile.ts
@@ -56,6 +56,7 @@ import {
   isEligibleFollowUpOwner,
   isMeaningfulClientInteraction,
   isSupportedProjectJobStatusLabel,
+  legacyProjectStatusAfterClientUpdate,
   normalizeProjectJobStatusLabel,
   projectNumberParts,
   type ProjectClientStatus,
@@ -825,6 +826,7 @@ export async function updateProjectInformation(input: {
       .select({
         id: projects.id,
         projectNumber: projects.projectNumber,
+        status: projects.status,
         address: projects.address,
         mailingAddress: projects.mailingAddress,
         clientStatus: projects.clientStatus,
@@ -900,10 +902,15 @@ export async function updateProjectInformation(input: {
         )
       : []
     const updatedAt = nowIso()
+    const legacyStatus = legacyProjectStatusAfterClientUpdate({
+      currentStatus: existing.status,
+      clientStatus: input.clientStatus,
+    })
     const projectUpdate = db
       .update(projects)
       .set({
         projectNumber,
+        status: legacyStatus,
         address: projectAddress,
         mailingAddress,
         clientStatus: input.clientStatus,
@@ -932,6 +939,7 @@ export async function updateProjectInformation(input: {
         mailingAddress,
         clientStatus: input.clientStatus,
         jobStatusId: input.jobStatusId,
+        status: legacyStatus,
       }),
       createdAt: updatedAt,
     })

--- a/src/app/actions/projects.ts
+++ b/src/app/actions/projects.ts
@@ -5,6 +5,7 @@ import { getDb } from "@/db"
 import {
   customers,
   organizationMembers,
+  projectContacts,
   projectExternalLinks,
   projectJobStatuses,
   projectMembers,
@@ -15,7 +16,7 @@ import {
 } from "@/db/schema"
 import { sageClientProjectWriteOperations } from "@/db/schema-sage"
 import { googleAuth } from "@/db/schema-google"
-import { and, asc, eq, sql } from "drizzle-orm"
+import { and, asc, eq, or, sql } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { requireAuth } from "@/lib/auth"
 import { decrypt } from "@/lib/crypto"
@@ -45,6 +46,10 @@ import {
 } from "@/lib/google/project-intake-tracker"
 import { resolveProjectIntakeIntegrationEmail } from "@/lib/google/project-intake-identity"
 import { requireOrg } from "@/lib/org-scope"
+import {
+  contactIdentityChanged,
+  directoryIdentityManagedByActiveUser,
+} from "@/lib/contact-identity-ownership"
 import {
   canManageProjectRegistry,
   requirePermission,
@@ -339,6 +344,20 @@ function appendWarning(current: string | null, next: string): string {
   return current ? `${current} ${next}` : next
 }
 
+function intakeAssigneeName(input: {
+  readonly displayName: string | null
+  readonly firstName: string | null
+  readonly lastName: string | null
+  readonly email: string
+}): string {
+  return (
+    cleanText(input.displayName) ??
+    ([cleanText(input.firstName), cleanText(input.lastName)]
+      .filter((value) => value !== null)
+      .join(" ") || input.email)
+  )
+}
+
 function projectDepartment(projectNumber: string | null): ProjectIntakeDepartment | null {
   return normalizedIntakeDepartment(projectNumber?.slice(0, 1) ?? null)
 }
@@ -391,11 +410,7 @@ export async function getProjectIntakeAssignees(): Promise<
 
     return rows.map((row) => ({
       id: row.id,
-      name:
-        cleanText(row.displayName) ??
-        ([cleanText(row.firstName), cleanText(row.lastName)]
-          .filter((value) => value !== null)
-          .join(" ") || row.email),
+      name: intakeAssigneeName(row),
       email: row.email,
     }))
   } catch {
@@ -522,7 +537,10 @@ export async function createProjectIntake(
         and(
           eq(customers.organizationId, organizationId),
           customerEmail
-            ? sql`lower(trim(${customers.email})) = ${customerEmail}`
+            ? or(
+                sql`lower(trim(${customers.email})) = ${customerEmail}`,
+                sql`lower(trim(${customers.name})) = ${clientName.toLowerCase()}`
+              )
             : sql`lower(trim(${customers.name})) = ${clientName.toLowerCase()}`
         )
       )
@@ -530,8 +548,41 @@ export async function createProjectIntake(
       .get()
     const customerId = customerMatch?.id ?? crypto.randomUUID()
 
+    const assignedTo = cleanText(input.assignedTo)
+    const assigneeRows = assignedTo
+      ? await db
+          .select({
+            id: users.id,
+            displayName: users.displayName,
+            firstName: users.firstName,
+            lastName: users.lastName,
+            email: users.email,
+            phone: users.phone,
+            address: users.address,
+          })
+          .from(organizationMembers)
+          .innerJoin(users, eq(users.id, organizationMembers.userId))
+          .where(
+            and(
+              eq(organizationMembers.organizationId, organizationId),
+              eq(users.isActive, true)
+            )
+          )
+      : []
+    const assignee = assignedTo
+      ? assigneeRows.find(
+          (candidate) =>
+            intakeAssigneeName(candidate).toLowerCase() === assignedTo.toLowerCase()
+        ) ?? null
+      : null
+    const projectManagerName = assignee
+      ? intakeAssigneeName(assignee)
+      : assignedTo
+
     const now = new Date().toISOString()
     const projectId = `proj-${slugPart(projectNumber)}-${crypto.randomUUID().slice(0, 8)}`
+    const ownerContactId = crypto.randomUUID()
+    const internalContactId = assignedTo ? crypto.randomUUID() : null
     const operationId = crypto.randomUUID()
     const registryLinkId = crypto.randomUUID()
     const departmentTrackerLinkId = crypto.randomUUID()
@@ -555,14 +606,34 @@ export async function createProjectIntake(
       id: customerId,
       organizationId,
       name: clientName,
-      company: cleanText(input.companyName),
-      email: cleanText(input.contactEmail),
-      phone: cleanText(input.contactPhone),
-      address: cleanText(input.billingAddress) ?? joinedAddress(input),
-      notes: cleanText(input.notes),
+      company: cleanText(input.companyName) ?? customerMatch?.company ?? null,
+      email: cleanText(input.contactEmail) ?? customerMatch?.email ?? null,
+      phone: cleanText(input.contactPhone) ?? customerMatch?.phone ?? null,
+      address:
+        cleanText(input.billingAddress) ??
+        customerMatch?.address ??
+        joinedAddress(input) ??
+        null,
+      notes: cleanText(input.notes) ?? customerMatch?.notes ?? null,
       sageClientStatusId,
       createdAt: now,
       updatedAt: now,
+    }
+    if (
+      customerMatch &&
+      contactIdentityChanged(customerMatch, customerValues) &&
+      (await directoryIdentityManagedByActiveUser({
+        db,
+        organizationId,
+        entityType: "customer",
+        entityId: customerId,
+      }))
+    ) {
+      return {
+        success: false,
+        error:
+          "This active Compass client manages their own phone, email, and address. Use their existing directory details for this project.",
+      }
     }
     const fullSageJobName = sageJobName(projectNumber, projectName)
     const sageWritePayload = {
@@ -608,7 +679,7 @@ export async function createProjectIntake(
           jobStatusId: sageJobStatus.id,
           sageJobStatusName: sageJobStatus.label,
           sageJobTypeName: sageJobTypeName(sageJobType),
-          projectManager: cleanText(input.assignedTo),
+          projectManager: projectManagerName,
           ownerUpdatesEnabled: true,
           ownerUpdateChannel: "compass",
           ownerUpdateCadence: "weekly",
@@ -629,6 +700,77 @@ export async function createProjectIntake(
               })
               .where(eq(customers.id, customerId))
           : db.insert(customers).values(customerValues),
+        db.insert(projectContacts).values({
+          id: ownerContactId,
+          projectId,
+          contactType: "owner",
+          sourceSystem: "customer_directory",
+          sourceRecordId: customerId,
+          sourceEntityType: "customer",
+          sourceEntityId: customerId,
+          displayName: clientName,
+          companyName: customerValues.company,
+          role: "Owner / Client",
+          email: customerValues.email,
+          phone: customerValues.phone,
+          address: customerValues.address,
+          notes: null,
+          ownerPortalVisible: true,
+          subVendorPortalVisible: false,
+          internalVisible: true,
+          primaryContact: true,
+          active: true,
+          sortOrder: 100,
+          syncStatus: "manual",
+          lastSyncedAt: null,
+          createdAt: now,
+          updatedAt: now,
+        }),
+        ...(assignedTo && internalContactId
+          ? [
+              db.insert(projectContacts).values({
+                id: internalContactId,
+                projectId,
+                contactType: "internal",
+                sourceSystem: assignee
+                  ? "organization_directory"
+                  : "compass_project_intake",
+                sourceRecordId: assignee?.id ?? projectId,
+                sourceEntityType: assignee ? "user" : "manual",
+                sourceEntityId: assignee?.id ?? null,
+                displayName: projectManagerName ?? assignedTo,
+                companyName: null,
+                role: "Project manager",
+                email: assignee?.email ?? null,
+                phone: assignee?.phone ?? null,
+                address: assignee?.address ?? null,
+                notes: assignee
+                  ? null
+                  : "Typed project intake assignment; match this contact to an active team member when available.",
+                ownerPortalVisible: true,
+                subVendorPortalVisible: true,
+                internalVisible: true,
+                primaryContact: true,
+                active: true,
+                sortOrder: 200,
+                syncStatus: assignee ? "synced" : "manual",
+                lastSyncedAt: assignee ? now : null,
+                createdAt: now,
+                updatedAt: now,
+              }),
+            ]
+          : []),
+        ...(assignee
+          ? [
+              db.insert(projectMembers).values({
+                id: crypto.randomUUID(),
+                projectId,
+                userId: assignee.id,
+                role: "project-manager",
+                assignedAt: now,
+              }),
+            ]
+          : []),
         db.insert(projectNumberReservations).values({
           id: crypto.randomUUID(),
           organizationId,
@@ -1380,6 +1522,32 @@ export async function createProjectShell(
             createdAt: now,
             updatedAt: now,
           }),
+      db.insert(projectContacts).values({
+        id: crypto.randomUUID(),
+        projectId: id,
+        contactType: "owner",
+        sourceSystem: "customer_directory",
+        sourceRecordId: customerId,
+        sourceEntityType: "customer",
+        sourceEntityId: customerId,
+        displayName: clientName,
+        companyName: customerMatch?.company ?? null,
+        role: "Owner / Client",
+        email: customerMatch?.email ?? null,
+        phone: customerMatch?.phone ?? null,
+        address: customerMatch?.address ?? address,
+        notes: null,
+        ownerPortalVisible: true,
+        subVendorPortalVisible: false,
+        internalVisible: true,
+        primaryContact: true,
+        active: true,
+        sortOrder: 100,
+        syncStatus: "manual",
+        lastSyncedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      }),
       db.insert(projectExternalLinks).values({
         id: crypto.randomUUID(),
         projectId: id,

--- a/src/app/actions/projects.ts
+++ b/src/app/actions/projects.ts
@@ -6,6 +6,7 @@ import {
   customers,
   organizationMembers,
   projectExternalLinks,
+  projectJobStatuses,
   projectMembers,
   projectNumberReservations,
   projectOperations,
@@ -51,6 +52,7 @@ import {
 import { canUseOrganizationProjectScopeRole } from "@/lib/user-roles"
 import {
   PROJECT_JOB_STATUS_DEFINITIONS,
+  projectJobStatusLabel,
 } from "@/lib/project-profile"
 import {
   isSageWriteApproved,
@@ -88,7 +90,24 @@ export type ProjectListItem = {
   readonly clientName: string | null
   readonly googleDriveFolderId: string | null
   readonly status: string
+  readonly clientStatus: string
+  readonly jobStatusId: string
+  readonly jobStatusLabel: string
   readonly createdAt: string
+}
+
+type ProjectListRow = Omit<ProjectListItem, "jobStatusLabel"> & {
+  readonly customJobStatusLabel: string | null
+}
+
+function projectListItems(rows: readonly ProjectListRow[]): ProjectListItem[] {
+  return rows.map(({ customJobStatusLabel, ...project }) => ({
+    ...project,
+    jobStatusLabel: projectJobStatusLabel({
+      jobStatusId: project.jobStatusId,
+      customLabel: customJobStatusLabel,
+    }),
+  }))
 }
 
 export type CreateProjectShellInput = {
@@ -1173,7 +1192,7 @@ export async function getProjects(): Promise<ProjectListItem[]> {
       user.organizationType === "internal" &&
       canUseOrganizationProjectScopeRole(user.role)
     ) {
-      return await db
+      const rows = await db
         .select({
           id: projects.id,
           name: projects.name,
@@ -1181,14 +1200,25 @@ export async function getProjects(): Promise<ProjectListItem[]> {
           clientName: projects.clientName,
           googleDriveFolderId: projects.googleDriveFolderId,
           status: projects.status,
+          clientStatus: projects.clientStatus,
+          jobStatusId: projects.jobStatusId,
+          customJobStatusLabel: projectJobStatuses.label,
           createdAt: projects.createdAt,
         })
         .from(projects)
+        .leftJoin(
+          projectJobStatuses,
+          and(
+            eq(projectJobStatuses.id, projects.jobStatusId),
+            eq(projectJobStatuses.organizationId, projects.organizationId),
+          ),
+        )
         .where(eq(projects.organizationId, user.organizationId))
         .orderBy(asc(projects.projectNumber), asc(projects.name))
+      return projectListItems(rows)
     }
 
-    return await db
+    const rows = await db
       .select({
         id: projects.id,
         name: projects.name,
@@ -1196,12 +1226,23 @@ export async function getProjects(): Promise<ProjectListItem[]> {
         clientName: projects.clientName,
         googleDriveFolderId: projects.googleDriveFolderId,
         status: projects.status,
+        clientStatus: projects.clientStatus,
+        jobStatusId: projects.jobStatusId,
+        customJobStatusLabel: projectJobStatuses.label,
         createdAt: projects.createdAt,
       })
       .from(projectMembers)
       .innerJoin(projects, eq(projects.id, projectMembers.projectId))
+      .leftJoin(
+        projectJobStatuses,
+        and(
+          eq(projectJobStatuses.id, projects.jobStatusId),
+          eq(projectJobStatuses.organizationId, projects.organizationId),
+        ),
+      )
       .where(eq(projectMembers.userId, user.id))
       .orderBy(asc(projects.projectNumber), asc(projects.name))
+    return projectListItems(rows)
   } catch {
     return []
   }

--- a/src/app/actions/vendors.ts
+++ b/src/app/actions/vendors.ts
@@ -14,6 +14,10 @@ import { requirePermission } from "@/lib/permissions"
 import { revalidatePath } from "next/cache"
 import { requireOrg } from "@/lib/org-scope"
 import { isDemoUser } from "@/lib/demo"
+import {
+  contactIdentityChanged,
+  directoryIdentityManagedByActiveUser,
+} from "@/lib/contact-identity-ownership"
 
 export type InternalDirectoryContact = {
   readonly id: string
@@ -344,12 +348,56 @@ export async function updateVendor(
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
 
-    await db
-      .update(vendors)
-      .set({ ...data, updatedAt: new Date().toISOString() })
+    const existing = await db
+      .select()
+      .from(vendors)
       .where(and(eq(vendors.id, id), eq(vendors.organizationId, orgId)))
+      .limit(1)
+      .get()
+    if (!existing) return { success: false, error: "Vendor not found" }
+
+    const nextIdentity = {
+      email: data.email === undefined ? existing.email : data.email,
+      phone: data.phone === undefined ? existing.phone : data.phone,
+      address: data.address === undefined ? existing.address : data.address,
+    }
+    const identityChanged = contactIdentityChanged(existing, nextIdentity)
+    if (
+      identityChanged &&
+      (await directoryIdentityManagedByActiveUser({
+        db,
+        organizationId: orgId,
+        entityType: "vendor",
+        entityId: id,
+      }))
+    ) {
+      return {
+        success: false,
+        error:
+          "This active Compass user manages their own phone, email, and address.",
+      }
+    }
+
+    const updatedAt = new Date().toISOString()
+    await db.batch([
+      db
+        .update(vendors)
+        .set({ ...data, updatedAt })
+        .where(and(eq(vendors.id, id), eq(vendors.organizationId, orgId))),
+      db
+        .update(projectContacts)
+        .set({ ...nextIdentity, updatedAt })
+        .where(
+          and(
+            eq(projectContacts.sourceEntityType, "vendor"),
+            eq(projectContacts.sourceEntityId, id)
+          )
+        ),
+    ])
 
     revalidatePath("/dashboard/vendors")
+    revalidatePath("/dashboard/contacts")
+    revalidatePath("/dashboard/projects", "layout")
     return { success: true }
   } catch (err) {
     return {

--- a/src/app/dashboard/financials/page.tsx
+++ b/src/app/dashboard/financials/page.tsx
@@ -9,7 +9,7 @@ import { useRegisterPageActions } from "@/hooks/use-register-page-actions"
 
 import { getCustomers } from "@/app/actions/customers"
 import { getVendors } from "@/app/actions/vendors"
-import { getProjects } from "@/app/actions/projects"
+import { getProjects, type ProjectListItem } from "@/app/actions/projects"
 import {
   getInvoices,
   createInvoice,
@@ -35,7 +35,7 @@ import {
   deleteCreditMemo,
 } from "@/app/actions/credit-memos"
 
-import type { Customer, Vendor, Project } from "@/db/schema"
+import type { Customer, Vendor } from "@/db/schema"
 import type {
   Invoice,
   VendorBill,
@@ -89,7 +89,7 @@ function FinancialsContent() {
 
   const [customersList, setCustomersList] = React.useState<Customer[]>([])
   const [vendorsList, setVendorsList] = React.useState<Vendor[]>([])
-  const [projectsList, setProjectsList] = React.useState<Project[]>([])
+  const [projectsList, setProjectsList] = React.useState<ProjectListItem[]>([])
 
   const [invoicesList, setInvoicesList] = React.useState<Invoice[]>([])
   const [billsList, setBillsList] = React.useState<VendorBill[]>([])
@@ -125,7 +125,7 @@ function FinancialsContent() {
       ])
       setCustomersList(c)
       setVendorsList(v)
-      setProjectsList(p as Project[])
+      setProjectsList(p)
       setInvoicesList(inv)
       setBillsList(bills)
       setPaymentsList(pay)
@@ -435,7 +435,7 @@ function FinancialsContent() {
         onOpenChange={setInvoiceDialogOpen}
         initialData={editingInvoice}
         customers={customersList}
-        projects={projectsList as Project[]}
+        projects={projectsList}
         onSubmit={handleInvoiceSubmit}
       />
 
@@ -444,7 +444,7 @@ function FinancialsContent() {
         onOpenChange={setBillDialogOpen}
         initialData={editingBill}
         vendors={vendorsList}
-        projects={projectsList as Project[]}
+        projects={projectsList}
         onSubmit={handleBillSubmit}
       />
 
@@ -454,7 +454,7 @@ function FinancialsContent() {
         initialData={editingPayment}
         customers={customersList}
         vendors={vendorsList}
-        projects={projectsList as Project[]}
+        projects={projectsList}
         onSubmit={handlePaymentSubmit}
       />
 
@@ -463,7 +463,7 @@ function FinancialsContent() {
         onOpenChange={setMemoDialogOpen}
         initialData={editingMemo}
         customers={customersList}
-        projects={projectsList as Project[]}
+        projects={projectsList}
         onSubmit={handleMemoSubmit}
       />
     </>

--- a/src/app/dashboard/projects/[id]/page.tsx
+++ b/src/app/dashboard/projects/[id]/page.tsx
@@ -5,6 +5,7 @@ import { getDb } from "@/db"
 import {
   projectContacts,
   projectExternalLinks,
+  projectJobStatuses,
   projectMembers,
   projects,
   scheduleTasks,
@@ -51,6 +52,10 @@ import {
   defaultWorkflowRoleId,
 } from "@/lib/project-workflow-roles"
 import type { ScheduleTask } from "@/db/schema"
+import {
+  projectClientStatusLabel,
+  projectJobStatusLabel,
+} from "@/lib/project-profile"
 
 function getWeekDays(): { date: Date; dayName: string }[] {
   const today = new Date()
@@ -129,6 +134,9 @@ export default async function ProjectSummaryPage({
     projectNumber: string | null
     name: string
     status: string
+    clientStatus: string
+    jobStatusId: string
+    jobStatusLabel: string
     address: string | null
     clientName: string | null
     projectManager: string | null
@@ -180,16 +188,31 @@ export default async function ProjectSummaryPage({
       redirect(projectAudiencePreviewHref(id, "sub-vendor"))
     }
 
-    const [found] = await db
-      .select()
+    const [foundRow] = await db
+      .select({
+        project: projects,
+        customJobStatusLabel: projectJobStatuses.label,
+      })
       .from(projects)
+      .leftJoin(
+        projectJobStatuses,
+        and(
+          eq(projectJobStatuses.id, projects.jobStatusId),
+          eq(projectJobStatuses.organizationId, projects.organizationId),
+        ),
+      )
       .where(eq(projects.id, id))
       .limit(1)
 
+    const found = foundRow?.project
     if (!found) notFound()
+    const jobStatusLabel = projectJobStatusLabel({
+      jobStatusId: found.jobStatusId,
+      customLabel: foundRow.customJobStatusLabel,
+    })
 
     if (found.googleDriveFolderId) {
-      project = found
+      project = { ...found, jobStatusLabel }
     } else {
       const [driveLink] = await db
         .select({
@@ -207,6 +230,7 @@ export default async function ProjectSummaryPage({
 
       project = {
         ...found,
+        jobStatusLabel,
         googleDriveFolderId:
           driveLink?.externalId ??
           driveFolderIdFromUrl(driveLink?.externalUrl ?? null),
@@ -319,7 +343,10 @@ export default async function ProjectSummaryPage({
   }
 
   const projectName = project?.name ?? "Project"
-  const projectStatus = project?.status ?? "OPEN"
+  const projectJobStatus = project?.jobStatusLabel ?? "Unknown job status"
+  const clientStatus = project
+    ? projectClientStatusLabel(project.clientStatus)
+    : "Unknown client status"
   const initialWorkflowRoleId = defaultWorkflowRoleId({
     projectRole,
     userRole,
@@ -366,7 +393,8 @@ export default async function ProjectSummaryPage({
             projectName={projectName}
             projectNumber={project?.projectNumber}
             projectId={id}
-            status={projectStatus}
+            jobStatus={projectJobStatus}
+            clientStatus={clientStatus}
           />
           <ProjectActionsMenu
             projectId={id}

--- a/src/app/dashboard/projects/page.tsx
+++ b/src/app/dashboard/projects/page.tsx
@@ -8,7 +8,7 @@ import {
   getProjects,
 } from "@/app/actions/projects"
 import { getDb } from "@/db"
-import { projectExternalLinks, projects } from "@/db/schema"
+import { projectExternalLinks, projectJobStatuses, projects } from "@/db/schema"
 import { ProjectsHub } from "@/components/projects/projects-hub"
 import { ProjectHubLaunchpad } from "@/components/projects/project-hub-launchpad"
 import { getCurrentUser } from "@/lib/auth"
@@ -17,12 +17,16 @@ import {
   canCreateProject,
   canManageProjectRegistry,
 } from "@/lib/permissions"
+import { projectJobStatusLabel } from "@/lib/project-profile"
 
 export type ProjectsHubProject = {
   readonly id: string
   readonly projectNumber: string | null
   readonly name: string
   readonly status: string
+  readonly clientStatus: string
+  readonly jobStatusId: string
+  readonly jobStatusLabel: string
   readonly address: string | null
   readonly clientName: string | null
   readonly projectManager: string | null
@@ -90,6 +94,9 @@ export default async function ProjectsPage({
         projectNumber: projects.projectNumber,
         name: projects.name,
         status: projects.status,
+        clientStatus: projects.clientStatus,
+        jobStatusId: projects.jobStatusId,
+        customJobStatusLabel: projectJobStatuses.label,
         address: projects.address,
         clientName: projects.clientName,
         projectManager: projects.projectManager,
@@ -106,13 +113,24 @@ export default async function ProjectsPage({
         createdAt: projects.createdAt,
       })
       .from(projects)
+      .leftJoin(
+        projectJobStatuses,
+        and(
+          eq(projectJobStatuses.id, projects.jobStatusId),
+          eq(projectJobStatuses.organizationId, projects.organizationId),
+        ),
+      )
       .orderBy(asc(projects.projectNumber), asc(projects.name))
 
     const loadedProjects = organizationId
       ? await query.where(eq(projects.organizationId, organizationId))
       : await query
-    hubProjects = loadedProjects.map((project) => ({
+    hubProjects = loadedProjects.map(({ customJobStatusLabel, ...project }) => ({
       ...project,
+      jobStatusLabel: projectJobStatusLabel({
+        jobStatusId: project.jobStatusId,
+        customLabel: customJobStatusLabel,
+      }),
       telegramChatId: null,
     }))
 

--- a/src/components/account-modal.tsx
+++ b/src/components/account-modal.tsx
@@ -33,6 +33,9 @@ export function AccountModal({ open, onOpenChange, user }: AccountModalProps) {
   // Profile form state
   const [firstName, setFirstName] = React.useState("")
   const [lastName, setLastName] = React.useState("")
+  const [email, setEmail] = React.useState("")
+  const [phone, setPhone] = React.useState("")
+  const [address, setAddress] = React.useState("")
   const [isSavingProfile, setIsSavingProfile] = React.useState(false)
 
   // Password form state
@@ -46,6 +49,9 @@ export function AccountModal({ open, onOpenChange, user }: AccountModalProps) {
     if (user && open) {
       setFirstName(user.firstName ?? "")
       setLastName(user.lastName ?? "")
+      setEmail(user.email)
+      setPhone(user.phone ?? "")
+      setAddress(user.address ?? "")
       // Clear password fields when opening
       setCurrentPassword("")
       setNewPassword("")
@@ -62,9 +68,28 @@ export function AccountModal({ open, onOpenChange, user }: AccountModalProps) {
   async function handleSaveProfile() {
     setIsSavingProfile(true)
     try {
-      const result = await updateProfile({ firstName, lastName })
+      const result = await updateProfile({
+        firstName,
+        lastName,
+        email,
+        phone,
+        address,
+      })
       if (result.success) {
-        toast.success("Profile updated")
+        if (
+          result.data?.emailVerificationRequired &&
+          !result.data.verificationEmailSent
+        ) {
+          toast.warning(
+            "Profile updated, but the verification email could not be sent. Contact support before signing out."
+          )
+        } else {
+          toast.success(
+            result.data?.emailVerificationRequired
+              ? "Profile updated. Verify your new email before your next sign-in."
+              : "Profile updated"
+          )
+        }
         router.refresh() // Refresh to show updated data
         onOpenChange(false)
       } else {
@@ -112,7 +137,11 @@ export function AccountModal({ open, onOpenChange, user }: AccountModalProps) {
   }
 
   const hasProfileChanges =
-    firstName !== (user.firstName ?? "") || lastName !== (user.lastName ?? "")
+    firstName !== (user.firstName ?? "") ||
+    lastName !== (user.lastName ?? "") ||
+    email.trim().toLowerCase() !== user.email.trim().toLowerCase() ||
+    phone.trim() !== (user.phone ?? "").trim() ||
+    address.trim() !== (user.address ?? "").trim()
 
   const canChangePassword =
     currentPassword.length > 0 &&
@@ -172,14 +201,36 @@ export function AccountModal({ open, onOpenChange, user }: AccountModalProps) {
               <Input
                 id="email"
                 type="email"
-                value={user.email}
-                className="h-9 bg-muted text-muted-foreground"
-                disabled
-                readOnly
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                className="h-9"
+                disabled={isSavingProfile}
               />
               <p className="text-xs text-muted-foreground">
-                Contact support to change your email address.
+                A changed email must be verified. SSO-managed emails may need
+                to be changed by your identity administrator.
               </p>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="phone" className="text-xs">Phone</Label>
+              <Input
+                id="phone"
+                type="tel"
+                value={phone}
+                onChange={(event) => setPhone(event.target.value)}
+                className="h-9"
+                disabled={isSavingProfile}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="address" className="text-xs">Address</Label>
+              <Input
+                id="address"
+                value={address}
+                onChange={(event) => setAddress(event.target.value)}
+                className="h-9"
+                disabled={isSavingProfile}
+              />
             </div>
           </div>
 

--- a/src/components/financials/credit-memo-dialog.tsx
+++ b/src/components/financials/credit-memo-dialog.tsx
@@ -29,7 +29,7 @@ interface CreditMemoDialogProps {
   onOpenChange: (open: boolean) => void
   initialData?: CreditMemo | null
   customers: Customer[]
-  projects: Project[]
+  projects: readonly Pick<Project, "id" | "name">[]
   onSubmit: (data: {
     customerId: string
     projectId: string | null

--- a/src/components/financials/invoice-dialog.tsx
+++ b/src/components/financials/invoice-dialog.tsx
@@ -36,7 +36,7 @@ interface InvoiceDialogProps {
   onOpenChange: (open: boolean) => void
   initialData?: Invoice | null
   customers: Customer[]
-  projects: Project[]
+  projects: readonly Pick<Project, "id" | "name">[]
   onSubmit: (data: {
     customerId: string
     projectId: string | null

--- a/src/components/financials/payment-dialog.tsx
+++ b/src/components/financials/payment-dialog.tsx
@@ -36,7 +36,7 @@ interface PaymentDialogProps {
   initialData?: Payment | null
   customers: Customer[]
   vendors: Vendor[]
-  projects: Project[]
+  projects: readonly Pick<Project, "id" | "name">[]
   onSubmit: (data: {
     paymentType: string
     customerId: string | null

--- a/src/components/financials/vendor-bill-dialog.tsx
+++ b/src/components/financials/vendor-bill-dialog.tsx
@@ -35,7 +35,7 @@ interface VendorBillDialogProps {
   onOpenChange: (open: boolean) => void
   initialData?: VendorBill | null
   vendors: Vendor[]
-  projects: Project[]
+  projects: readonly Pick<Project, "id" | "name">[]
   onSubmit: (data: {
     vendorId: string
     projectId: string | null

--- a/src/components/mobile-project-switcher.tsx
+++ b/src/components/mobile-project-switcher.tsx
@@ -21,7 +21,8 @@ interface MobileProjectSwitcherProps {
   projectName: string
   projectNumber?: string | null
   projectId: string
-  status?: string
+  jobStatus?: string
+  clientStatus?: string
 }
 
 function projectSectionHref(
@@ -54,7 +55,8 @@ export function MobileProjectSwitcher({
   projectName,
   projectNumber = null,
   projectId,
-  status,
+  jobStatus,
+  clientStatus,
 }: MobileProjectSwitcherProps) {
   const isMobile = useIsMobile()
   const router = useRouter()
@@ -77,9 +79,14 @@ export function MobileProjectSwitcher({
             </p>
           )}
         </div>
-        {status && (
+        {jobStatus && (
           <span className="rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
-            {status}
+            {jobStatus}
+          </span>
+        )}
+        {clientStatus && (
+          <span className="rounded-md border px-2 py-0.5 text-xs font-medium text-muted-foreground">
+            {clientStatus}
           </span>
         )}
       </div>
@@ -102,11 +109,18 @@ export function MobileProjectSwitcher({
           </span>
         )}
       </button>
-      {status && (
-        <div>
-          <span className="rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
-            {status}
-          </span>
+      {(jobStatus || clientStatus) && (
+        <div className="flex flex-wrap gap-1.5">
+          {jobStatus && (
+            <span className="rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+              {jobStatus}
+            </span>
+          )}
+          {clientStatus && (
+            <span className="rounded-md border px-2 py-0.5 text-xs font-medium text-muted-foreground">
+              {clientStatus}
+            </span>
+          )}
         </div>
       )}
 

--- a/src/components/projects/project-contact-management.tsx
+++ b/src/components/projects/project-contact-management.tsx
@@ -126,6 +126,7 @@ function initialInput(
     primaryCostCode: contact?.primaryCostCode ?? "",
     email: contact?.email ?? "",
     phone: contact?.phone ?? "",
+    address: contact?.address ?? "",
     notes: contact?.notes ?? "",
     ownerPortalVisible: contact?.ownerPortalVisible ?? false,
     subVendorPortalVisible: contact?.subVendorPortalVisible ?? false,
@@ -274,6 +275,10 @@ export function ProjectContactEditor({
       option.id === input.directorySourceId &&
       option.sourceType === input.directorySourceType
   ) ?? null
+  const identityManagedByActiveUser =
+    contact?.identityManagedByActiveUser ??
+    selectedDirectory?.identityManagedByActiveUser ??
+    false
 
   function updateInput<Key extends keyof ProjectContactMutationInput>(
     key: Key,
@@ -306,6 +311,7 @@ export function ProjectContactEditor({
       companyName: option.companyName ?? "",
       email: option.email ?? "",
       phone: option.phone ?? "",
+      address: option.address ?? "",
       role: projectRole,
       ownerPortalVisible:
         option.suggestedContactType === "internal" || current.ownerPortalVisible,
@@ -325,6 +331,7 @@ export function ProjectContactEditor({
         return
       }
       toast.success(isEditing ? "Project contact updated." : "Project contact added.")
+      if (result.warning) toast.warning(result.warning)
       setOpen(false)
       router.refresh()
     })
@@ -358,7 +365,9 @@ export function ProjectContactEditor({
           <SheetHeader>
             <SheetTitle>{isEditing ? "Edit project contact" : "Add project contact"}</SheetTitle>
             <SheetDescription>
-              Changes apply to this project. The company-wide directory record remains intact.
+              {identityManagedByActiveUser
+                ? "This active Compass user manages their own phone, email, and address. Project role and visibility remain editable here."
+                : "Phone, email, and address stay synchronized with the linked company directory record."}
             </SheetDescription>
           </SheetHeader>
 
@@ -492,6 +501,7 @@ export function ProjectContactEditor({
                   type="email"
                   value={input.email}
                   onChange={(event) => updateInput("email", event.target.value)}
+                  disabled={identityManagedByActiveUser}
                 />
               </div>
               <div className="grid gap-2">
@@ -501,6 +511,16 @@ export function ProjectContactEditor({
                   type="tel"
                   value={input.phone}
                   onChange={(event) => updateInput("phone", event.target.value)}
+                  disabled={identityManagedByActiveUser}
+                />
+              </div>
+              <div className="grid gap-2 sm:col-span-2">
+                <Label htmlFor="project-contact-address">Address</Label>
+                <Input
+                  id="project-contact-address"
+                  value={input.address}
+                  onChange={(event) => updateInput("address", event.target.value)}
+                  disabled={identityManagedByActiveUser}
                 />
               </div>
               <div className="grid gap-2">

--- a/src/components/projects/project-contacts-panel.tsx
+++ b/src/components/projects/project-contacts-panel.tsx
@@ -5,6 +5,7 @@ import {
   IconGitMerge,
   IconHome,
   IconMail,
+  IconMapPin,
   IconPhone,
   IconShieldCheck,
   IconUsers,
@@ -178,6 +179,12 @@ function ContactCard({
             <span className="inline-flex items-center gap-1">
               <IconPhone className="size-3" />
               {contact.phone}
+            </span>
+          )}
+          {contact.address && (
+            <span className="inline-flex items-center gap-1">
+              <IconMapPin className="size-3" />
+              {contact.address}
             </span>
           )}
         </div>

--- a/src/components/projects/project-hub-launchpad.tsx
+++ b/src/components/projects/project-hub-launchpad.tsx
@@ -27,6 +27,10 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { OfficeMaintenanceDrawer } from "@/components/projects/office-maintenance-drawer"
 import { cn } from "@/lib/utils"
+import {
+  projectClientStatusLabel,
+  projectJobStatusBucket,
+} from "@/lib/project-profile"
 
 type DepartmentFilter = "ALL" | "O" | "H" | "N" | "D" | "OTHER"
 type StatusFilter = "active" | "warranty" | "complete" | "all"
@@ -66,24 +70,11 @@ function departmentForProject(project: ProjectListItem): DepartmentFilter {
 }
 
 function statusForProject(project: ProjectListItem): StatusFilter {
-  const status = project.status.trim().toLowerCase().replace(/[^a-z0-9]+/g, " ")
-  if (
-    status === "open" ||
-    status === "active" ||
-    status === "current" ||
-    status === "construction" ||
-    status === "in progress" ||
-    status === "scheduled" ||
-    status === "preconstruction"
-  ) {
-    return "active"
-  }
-  if (status.includes("warranty") || status.includes("service")) {
-    return "warranty"
-  }
-  if (status === "closed" || status === "complete" || status === "completed") {
-    return "complete"
-  }
+  const bucket = projectJobStatusBucket({
+    jobStatusId: project.jobStatusId,
+    jobStatusLabel: project.jobStatusLabel,
+  })
+  if (bucket === "active" || bucket === "warranty" || bucket === "complete") return bucket
   return "all"
 }
 
@@ -181,7 +172,13 @@ function ProjectCard({
             {department === "OTHER" ? "Unassigned department" : department}
           </p>
         </div>
-        <ProjectHealth projectId={project.id} overview={overview} />
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex min-w-0 flex-wrap gap-1.5">
+            <Badge variant="secondary">{project.jobStatusLabel}</Badge>
+            <Badge variant="outline">{projectClientStatusLabel(project.clientStatus)}</Badge>
+          </div>
+          <ProjectHealth projectId={project.id} overview={overview} />
+        </div>
       </Link>
     )
   }
@@ -235,7 +232,13 @@ function ProjectCard({
           {health?.nextTask ? `Next: ${health.nextTask.title}` : project.clientName ?? "No next phase recorded"}
         </p>
         <div className="mt-2">
-          <ProjectHealth projectId={project.id} overview={overview} />
+          <div className="flex flex-wrap items-center gap-1.5">
+            <Badge variant="secondary">{project.jobStatusLabel}</Badge>
+            <Badge variant="outline">{projectClientStatusLabel(project.clientStatus)}</Badge>
+          </div>
+          <div className="mt-2">
+            <ProjectHealth projectId={project.id} overview={overview} />
+          </div>
         </div>
 
         <Button

--- a/src/components/projects/project-hub-launchpad.tsx
+++ b/src/components/projects/project-hub-launchpad.tsx
@@ -8,6 +8,10 @@ import {
   IconBuilding,
   IconBuildingCommunity,
   IconCheck,
+  IconChevronLeft,
+  IconChevronRight,
+  IconChevronsLeft,
+  IconChevronsRight,
   IconLayoutCards,
   IconList,
   IconPaint,
@@ -25,6 +29,13 @@ import { ProjectIntakeDrawer } from "@/components/projects/project-intake-drawer
 import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { OfficeMaintenanceDrawer } from "@/components/projects/office-maintenance-drawer"
 import { cn } from "@/lib/utils"
 import {
@@ -35,6 +46,7 @@ import {
 type DepartmentFilter = "ALL" | "O" | "H" | "N" | "D" | "OTHER"
 type StatusFilter = "active" | "warranty" | "complete" | "all"
 type ProjectLayout = "cards" | "list"
+type ProjectPageSize = 5 | 10 | 25 | 50 | "all"
 
 type DepartmentDefinition = {
   readonly id: DepartmentFilter
@@ -60,6 +72,16 @@ const STATUS_OPTIONS: readonly {
   { value: "complete", label: "Complete" },
   { value: "all", label: "All" },
 ]
+
+const PROJECT_PAGE_SIZES: readonly ProjectPageSize[] = [5, 10, 25, 50, "all"]
+
+function parseProjectPageSize(value: string): ProjectPageSize {
+  if (value === "5") return 5
+  if (value === "25") return 25
+  if (value === "50") return 50
+  if (value === "all") return "all"
+  return 10
+}
 
 function departmentForProject(project: ProjectListItem): DepartmentFilter {
   const prefix = project.projectNumber?.trim().slice(0, 1).toUpperCase()
@@ -272,6 +294,8 @@ export function ProjectHubLaunchpad({
   const [department, setDepartment] = useState<DepartmentFilter>("ALL")
   const [status, setStatus] = useState<StatusFilter>("active")
   const [layout, setLayout] = useState<ProjectLayout>("cards")
+  const [pageSize, setPageSize] = useState<ProjectPageSize>(10)
+  const [pageIndex, setPageIndex] = useState(0)
 
   const statusCounts = useMemo(
     () => ({
@@ -307,6 +331,29 @@ export function ProjectHubLaunchpad({
     [department, projects, status]
   )
 
+  const pageCount =
+    pageSize === "all"
+      ? 1
+      : Math.max(1, Math.ceil(visibleProjects.length / pageSize))
+  const currentPageIndex = Math.min(pageIndex, pageCount - 1)
+  const firstVisibleProjectIndex =
+    visibleProjects.length === 0
+      ? 0
+      : pageSize === "all"
+        ? 1
+        : currentPageIndex * pageSize + 1
+  const lastVisibleProjectIndex =
+    pageSize === "all"
+      ? visibleProjects.length
+      : Math.min((currentPageIndex + 1) * pageSize, visibleProjects.length)
+  const paginatedProjects =
+    pageSize === "all"
+      ? visibleProjects
+      : visibleProjects.slice(
+          currentPageIndex * pageSize,
+          (currentPageIndex + 1) * pageSize
+        )
+
   return (
     <main className="mx-auto w-full max-w-[1500px] space-y-4 p-3 sm:p-4 lg:p-5">
       <header className="flex flex-col gap-3 border-b pb-4 sm:flex-row sm:items-center sm:justify-between">
@@ -338,7 +385,10 @@ export function ProjectHubLaunchpad({
               <button
                 key={item.id}
                 type="button"
-                onClick={() => setDepartment(item.id)}
+                onClick={() => {
+                  setDepartment(item.id)
+                  setPageIndex(0)
+                }}
                 className={cn(
                   "flex h-10 shrink-0 items-center gap-2 bg-background px-3 text-sm font-medium transition-colors hover:bg-muted",
                   department === item.id && "bg-[#2f5963] text-white hover:bg-[#2f5963]"
@@ -371,7 +421,10 @@ export function ProjectHubLaunchpad({
               <button
                 key={value}
                 type="button"
-                onClick={() => setStatus(value)}
+                onClick={() => {
+                  setStatus(value)
+                  setPageIndex(0)
+                }}
                 className={cn(
                   "flex h-8 items-center gap-2 border px-3 text-sm transition-colors hover:bg-muted",
                   status === value && "border-[#2f5963] bg-[#2f5963]/[0.07] font-semibold"
@@ -400,7 +453,7 @@ export function ProjectHubLaunchpad({
               {status === "all" ? "All" : status.charAt(0).toUpperCase() + status.slice(1)} projects
             </h2>
             <p className="text-xs text-muted-foreground">
-              {visibleProjects.length} project{visibleProjects.length === 1 ? "" : "s"} shown · use ⌘K for global search
+              {visibleProjects.length} project{visibleProjects.length === 1 ? "" : "s"} match · use ⌘K for global search
             </p>
           </div>
           <div className="grid grid-cols-2 border p-0.5">
@@ -431,7 +484,7 @@ export function ProjectHubLaunchpad({
               : "divide-y border-y"
           )}
         >
-          {visibleProjects.map((project) => (
+          {paginatedProjects.map((project) => (
             <ProjectCard
               key={project.id}
               project={project}
@@ -449,13 +502,100 @@ export function ProjectHubLaunchpad({
               onClick={() => {
                 setDepartment("ALL")
                 setStatus("all")
+                setPageIndex(0)
               }}
               className="mt-2 text-sm font-medium text-primary hover:underline"
             >
               Clear filters
             </button>
           </div>
-        ) : null}
+        ) : (
+          <div className="mt-4 flex flex-col gap-3 border-t pt-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-muted-foreground" aria-live="polite">
+              Showing {firstVisibleProjectIndex}–{lastVisibleProjectIndex} of{" "}
+              {visibleProjects.length} projects
+            </p>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="flex items-center gap-2">
+                <label htmlFor="projects-per-page" className="text-sm font-medium">
+                  Projects per page
+                </label>
+                <Select
+                  value={String(pageSize)}
+                  onValueChange={(value) => {
+                    setPageSize(parseProjectPageSize(value))
+                    setPageIndex(0)
+                  }}
+                >
+                  <SelectTrigger id="projects-per-page" size="sm" className="w-20">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent side="top">
+                    {PROJECT_PAGE_SIZES.map((size) => (
+                      <SelectItem key={size} value={String(size)}>
+                        {size === "all" ? "All" : size}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <span className="min-w-24 text-center text-sm font-medium">
+                Page {currentPageIndex + 1} of {pageCount}
+              </span>
+
+              <div className="flex items-center gap-1">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="size-8"
+                  onClick={() => setPageIndex(0)}
+                  disabled={currentPageIndex === 0}
+                >
+                  <span className="sr-only">Go to first page</span>
+                  <IconChevronsLeft className="size-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="size-8"
+                  onClick={() => setPageIndex(Math.max(0, currentPageIndex - 1))}
+                  disabled={currentPageIndex === 0}
+                >
+                  <span className="sr-only">Go to previous page</span>
+                  <IconChevronLeft className="size-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="size-8"
+                  onClick={() =>
+                    setPageIndex(Math.min(pageCount - 1, currentPageIndex + 1))
+                  }
+                  disabled={currentPageIndex >= pageCount - 1}
+                >
+                  <span className="sr-only">Go to next page</span>
+                  <IconChevronRight className="size-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="size-8"
+                  onClick={() => setPageIndex(pageCount - 1)}
+                  disabled={currentPageIndex >= pageCount - 1}
+                >
+                  <span className="sr-only">Go to last page</span>
+                  <IconChevronsRight className="size-4" />
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
       </section>
 
       <footer className="flex flex-wrap items-center justify-between gap-2 border-t pt-3 text-xs text-muted-foreground">

--- a/src/components/projects/project-quick-switcher.tsx
+++ b/src/components/projects/project-quick-switcher.tsx
@@ -21,6 +21,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover"
 import { cn } from "@/lib/utils"
+import { projectClientStatusLabel } from "@/lib/project-profile"
 
 type ProjectQuickSwitcherProps = {
   readonly projects: readonly ProjectListItem[]
@@ -41,6 +42,9 @@ function projectSearchValue(project: ProjectListItem): string {
     project.projectNumber,
     project.name,
     project.clientName,
+    projectClientStatusLabel(project.clientStatus),
+    project.jobStatusId,
+    project.jobStatusLabel,
     project.id,
   ]
     .filter((value): value is string => Boolean(value))
@@ -107,7 +111,7 @@ export function ProjectQuickSwitcher({
         className="w-[var(--radix-popover-trigger-width)] p-0"
       >
         <Command>
-          <CommandInput placeholder="Search number, name, or client..." />
+          <CommandInput placeholder="Search number, name, client, or status..." />
           <CommandList>
             <CommandEmpty>No matching projects.</CommandEmpty>
             <CommandGroup>

--- a/src/components/projects/projects-hub.tsx
+++ b/src/components/projects/projects-hub.tsx
@@ -25,7 +25,6 @@ import {
 import type { ProjectsHubProject } from "@/app/dashboard/projects/page"
 import {
   createProjectShell,
-  updateProjectStatus,
   type ProjectStatusValue,
 } from "@/app/actions/projects"
 import { updateProjectRegistry } from "@/app/actions/project-registry"
@@ -51,20 +50,19 @@ import {
   openHpsProjectManagerWorkWindow,
 } from "@/lib/google/project-manager-app"
 import { cn } from "@/lib/utils"
-import { PROJECT_JOB_STATUS_DEFINITIONS } from "@/lib/project-profile"
+import {
+  PROJECT_JOB_STATUS_DEFINITIONS,
+  projectClientStatusLabel,
+  projectJobStatusBucket,
+  type ProjectJobStatusBucket,
+} from "@/lib/project-profile"
 import {
   SAGE_CLIENT_STATUS_OPTIONS,
   SAGE_JOB_TYPE_OPTIONS,
 } from "@/lib/sage/client-project-write"
 
 type DepartmentId = "O" | "H" | "N" | "D" | "UNASSIGNED"
-type ProjectStatusBucket =
-  | "active"
-  | "warranty"
-  | "complete"
-  | "inactive"
-  | "archive"
-  | "other"
+type ProjectStatusBucket = ProjectJobStatusBucket
 
 type ProjectStatusOption = {
   readonly value: ProjectStatusValue
@@ -266,62 +264,11 @@ function projectSubtitle(project: ProjectsHubProject): string {
     .join(" · ")
 }
 
-function statusLabel(status: string): string {
-  const normalized = status.trim().toLowerCase().replace(/[^a-z0-9]+/g, " ")
-  if (normalized === "open") return "Active"
-  if (normalized === "active") return "Active"
-  if (normalized === "in progress") return "Active"
-  if (normalized === "current") return "Active"
-  if (normalized === "construction") return "Active"
-  if (normalized === "warranty") return "Warranty"
-  if (normalized === "warranty service") return "Warranty"
-  if (normalized === "inactive") return "Inactive"
-  if (normalized === "paused") return "Inactive"
-  if (normalized === "archive") return "Archive"
-  if (normalized === "archived") return "Archive"
-  if (normalized === "closed") return "Complete"
-  if (normalized === "complete") return "Complete"
-  if (normalized === "completed") return "Complete"
-  if (normalized === "other") return "Other"
-  return status
-}
-
-function statusBucket(status: string): ProjectStatusBucket {
-  const normalized = status.trim().toLowerCase().replace(/[^a-z0-9]+/g, " ")
-
-  if (
-    normalized === "open" ||
-    normalized === "active" ||
-    normalized === "in progress" ||
-    normalized === "current" ||
-    normalized === "construction" ||
-    normalized === "scheduled" ||
-    normalized === "preconstruction"
-  ) {
-    return "active"
-  }
-
-  if (normalized.includes("warranty") || normalized.includes("service")) {
-    return "warranty"
-  }
-
-  if (normalized === "inactive" || normalized === "paused") {
-    return "inactive"
-  }
-
-  if (normalized === "archive" || normalized === "archived") {
-    return "archive"
-  }
-
-  if (
-    normalized === "closed" ||
-    normalized === "complete" ||
-    normalized === "completed"
-  ) {
-    return "complete"
-  }
-
-  return "other"
+function statusBucket(project: ProjectsHubProject): ProjectStatusBucket {
+  return projectJobStatusBucket({
+    jobStatusId: project.jobStatusId,
+    jobStatusLabel: project.jobStatusLabel,
+  })
 }
 
 function projectStatusValue(status: string): ProjectStatusValue {
@@ -329,7 +276,18 @@ function projectStatusValue(status: string): ProjectStatusValue {
   const option = PROJECT_STATUS_OPTIONS.find((item) => item.value === normalized)
   if (option) return option.value
 
-  const bucket = statusBucket(status)
+  const normalizedStatus = status.trim().toLowerCase()
+  const bucket = normalizedStatus === "warranty"
+    ? "warranty"
+    : normalizedStatus === "complete"
+      ? "complete"
+      : normalizedStatus === "inactive"
+        ? "inactive"
+        : normalizedStatus === "archive"
+          ? "archive"
+          : normalizedStatus === "other"
+            ? "other"
+            : "active"
   const bucketOption = PROJECT_STATUS_OPTIONS.find(
     (item) => item.bucket === bucket
   )
@@ -420,7 +378,7 @@ function countByStatusBucket(
   projects: readonly ProjectsHubProject[],
   bucket: ProjectStatusBucket
 ): number {
-  return projects.filter((project) => statusBucket(project.status) === bucket)
+  return projects.filter((project) => statusBucket(project) === bucket)
     .length
 }
 
@@ -438,6 +396,10 @@ function projectMatchesSearch(
       project.address,
       project.projectManager,
       project.sageJobNumber,
+      projectClientStatusLabel(project.clientStatus),
+      project.clientStatus,
+      project.jobStatusId,
+      project.jobStatusLabel,
     ]
       .filter((value): value is string => Boolean(value))
       .join(" ")
@@ -482,66 +444,6 @@ function DepartmentMark({
     >
       {department.icon}
     </span>
-  )
-}
-
-function ProjectStatusSelect({
-  projectId,
-  currentStatus,
-  projectLabelText,
-}: {
-  readonly projectId: string
-  readonly currentStatus: string
-  readonly projectLabelText: string
-}): React.ReactElement {
-  const router = useRouter()
-  const [statusMessage, setStatusMessage] = React.useState<string | null>(null)
-  const [isUpdatingStatus, startStatusTransition] = React.useTransition()
-
-  function selectProjectStatus(nextStatus: string): void {
-    const statusOption = PROJECT_STATUS_OPTIONS.find(
-      (option) => option.value === nextStatus
-    )
-    if (!statusOption) return
-
-    setStatusMessage(null)
-    startStatusTransition(async () => {
-      const result = await updateProjectStatus(projectId, statusOption.value)
-      if (!result.success) {
-        setStatusMessage(result.error)
-        return
-      }
-
-      router.refresh()
-    })
-  }
-
-  return (
-    <div className="shrink-0">
-      <Select
-        value={projectStatusValue(currentStatus)}
-        onValueChange={selectProjectStatus}
-        disabled={isUpdatingStatus}
-      >
-        <SelectTrigger
-          size="sm"
-          className="h-7 w-[7.5rem] bg-background text-xs"
-          aria-label={`Change status for ${projectLabelText}`}
-        >
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent align="end">
-          {PROJECT_STATUS_OPTIONS.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-      {statusMessage && (
-        <p className="mt-1 text-xs text-destructive">{statusMessage}</p>
-      )}
-    </div>
   )
 }
 
@@ -603,10 +505,8 @@ function RegistrySelectField({
 
 function ProjectCard({
   project,
-  canUpdateStatus,
 }: {
   readonly project: ProjectsHubProject
-  readonly canUpdateStatus: boolean
 }): React.ReactElement {
   const label = projectLabel(project)
   const subtitle = projectSubtitle(project)
@@ -635,17 +535,14 @@ function ProjectCard({
             </p>
           )}
         </div>
-        {canUpdateStatus ? (
-          <ProjectStatusSelect
-            projectId={project.id}
-            currentStatus={project.status}
-            projectLabelText={label}
-          />
-        ) : (
-          <span className="shrink-0 pt-0.5 text-xs font-medium text-muted-foreground">
-            {statusLabel(project.status)}
+        <div className="flex shrink-0 flex-wrap justify-end gap-1.5">
+          <span className="rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+            {project.jobStatusLabel}
           </span>
-        )}
+          <span className="rounded-md border px-2 py-0.5 text-xs font-medium text-muted-foreground">
+            {projectClientStatusLabel(project.clientStatus)}
+          </span>
+        </div>
       </div>
 
       <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2 border-t pt-2">
@@ -689,11 +586,9 @@ function ProjectCard({
 function DepartmentLane({
   group,
   activeDepartment,
-  canUpdateStatus,
 }: {
   readonly group: DepartmentGroup
   readonly activeDepartment: DepartmentId | "ALL"
-  readonly canUpdateStatus: boolean
 }): React.ReactElement {
   const isFiltered = activeDepartment !== "ALL"
   const visibleProjects = isFiltered ? group.projects : group.projects.slice(0, 5)
@@ -739,11 +634,7 @@ function DepartmentLane({
       {visibleProjects.length > 0 ? (
         <div className="grid gap-3 p-3 xl:grid-cols-2">
           {visibleProjects.map((project) => (
-            <ProjectCard
-              key={project.id}
-              project={project}
-              canUpdateStatus={canUpdateStatus}
-            />
+            <ProjectCard key={project.id} project={project} />
           ))}
         </div>
       ) : (
@@ -865,12 +756,10 @@ function DepartmentToolButton({
 
 function DepartmentLanding({
   group,
-  canUpdateStatus,
   canOpenTools,
   onOpenProjectManager,
 }: {
   readonly group: DepartmentGroup
-  readonly canUpdateStatus: boolean
   readonly canOpenTools: boolean
   readonly onOpenProjectManager: () => void
 }): React.ReactElement {
@@ -978,11 +867,7 @@ function DepartmentLanding({
         {group.projects.length > 0 ? (
           <div className="mt-3 grid gap-3 xl:grid-cols-2">
             {group.projects.map((project) => (
-              <ProjectCard
-                key={project.id}
-                project={project}
-                canUpdateStatus={canUpdateStatus}
-              />
+              <ProjectCard key={project.id} project={project} />
             ))}
           </div>
         ) : (
@@ -1332,7 +1217,7 @@ export function ProjectsHub({
     ? projects.find((project) => project.id === selectedRegistryProjectId) ?? null
     : null
   const statusFilteredProjects = projects.filter((project) =>
-    activeStatusFilters.includes(statusBucket(project.status))
+    activeStatusFilters.includes(statusBucket(project))
   )
   const searchedProjects = statusFilteredProjects.filter((project) =>
     projectMatchesSearch(project, normalizedQuery)
@@ -1353,13 +1238,13 @@ export function ProjectsHub({
         )
       : groups.filter((group) => group.id === activeDepartment)
   const activeProjects = projects.filter(
-    (project) => statusBucket(project.status) === "active"
+    (project) => statusBucket(project) === "active"
   )
   const warrantyProjects = projects.filter(
-    (project) => statusBucket(project.status) === "warranty"
+    (project) => statusBucket(project) === "warranty"
   )
   const completeProjects = projects.filter(
-    (project) => statusBucket(project.status) === "complete"
+    (project) => statusBucket(project) === "complete"
   )
   const linkedToSageCount = projects.filter((project) =>
     Boolean(project.sageJobNumber)
@@ -1448,7 +1333,7 @@ export function ProjectsHub({
               placeholder={
                 selectedDepartmentGroup
                   ? `Search ${selectedDepartmentGroup.shortLabel} projects...`
-                  : "Search by project number, client, address, or accounting job..."
+                  : "Search by project number, client, job status, address, or accounting job..."
               }
               className="pl-9"
             />
@@ -1529,7 +1414,7 @@ export function ProjectsHub({
           <span>
             <span className="font-semibold tabular-nums">
               {
-                projects.filter((project) => statusBucket(project.status) === "other")
+                projects.filter((project) => statusBucket(project) === "other")
                   .length
               }
             </span>{" "}
@@ -1753,14 +1638,17 @@ export function ProjectsHub({
                             {projectLabel(project)}
                           </span>
                           <span className="block truncate text-xs text-muted-foreground">
-                            {projectSubtitle(project) || statusLabel(project.status)}
+                            {projectSubtitle(project) || project.jobStatusLabel}
                           </span>
                         </button>
-                        <ProjectStatusSelect
-                          projectId={project.id}
-                          currentStatus={project.status}
-                          projectLabelText={projectLabel(project)}
-                        />
+                        <div className="flex shrink-0 flex-wrap justify-end gap-1.5">
+                          <span className="rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                            {project.jobStatusLabel}
+                          </span>
+                          <span className="rounded-md border px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                            {projectClientStatusLabel(project.clientStatus)}
+                          </span>
+                        </div>
                       </div>
                     ))
                   ) : (
@@ -1816,7 +1704,7 @@ export function ProjectsHub({
                         placeholder="O-### or H-###"
                       />
                       <RegistrySelectField
-                        label="Status"
+                        label="Legacy status"
                         name="status"
                         value={projectStatusValue(selectedRegistryProject.status)}
                         options={PROJECT_STATUS_OPTIONS}
@@ -1939,7 +1827,6 @@ export function ProjectsHub({
         ) : selectedDepartmentGroup ? (
           <DepartmentLanding
             group={selectedDepartmentGroup}
-            canUpdateStatus={canCreateOrUpdateProjects}
             canOpenTools={canCreateOrUpdateProjects}
             onOpenProjectManager={openProjectManager}
           />
@@ -1954,7 +1841,6 @@ export function ProjectsHub({
                 key={group.id}
                 group={group}
                 activeDepartment={activeDepartment}
-                canUpdateStatus={canCreateOrUpdateProjects}
               />
             ))}
           </section>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -15,6 +15,8 @@ export const users = sqliteTable("users", {
   firstName: text("first_name"),
   lastName: text("last_name"),
   displayName: text("display_name"),
+  phone: text("phone"),
+  address: text("address"),
   avatarUrl: text("avatar_url"),
   dashboardDeskPhotoUrl: text("dashboard_desk_photo_url"),
   sidebarDeskPhotoUrl: text("sidebar_desk_photo_url"),
@@ -1777,6 +1779,7 @@ export const projectContacts = sqliteTable("project_contacts", {
   primaryCostCode: text("primary_cost_code"),
   email: text("email"),
   phone: text("phone"),
+  address: text("address"),
   notes: text("notes"),
   ownerPortalVisible: integer("owner_portal_visible", {
     mode: "boolean",

--- a/src/lib/__tests__/contact-identity-ownership.test.ts
+++ b/src/lib/__tests__/contact-identity-ownership.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+
+import { contactIdentityChanged } from "@/lib/contact-identity-ownership"
+import { updateProfileSchema } from "@/lib/validations/profile"
+
+describe("contact identity ownership", () => {
+  it("ignores formatting-only email and whitespace changes", () => {
+    expect(
+      contactIdentityChanged(
+        {
+          email: "Person@Example.com",
+          phone: " 970-555-0100 ",
+          address: " 10 Main Street ",
+        },
+        {
+          email: " person@example.com ",
+          phone: "970-555-0100",
+          address: "10 Main Street",
+        }
+      )
+    ).toBe(false)
+  })
+
+  it("detects phone, email, and address changes", () => {
+    const current = {
+      email: "person@example.com",
+      phone: "970-555-0100",
+      address: "10 Main Street",
+    }
+
+    expect(
+      contactIdentityChanged(current, { ...current, email: "new@example.com" })
+    ).toBe(true)
+    expect(
+      contactIdentityChanged(current, { ...current, phone: "970-555-0199" })
+    ).toBe(true)
+    expect(
+      contactIdentityChanged(current, { ...current, address: "20 Main Street" })
+    ).toBe(true)
+  })
+})
+
+describe("profile identity validation", () => {
+  it("normalizes the email and permits blank optional contact fields", () => {
+    const result = updateProfileSchema.safeParse({
+      firstName: " Brian ",
+      lastName: " Sack ",
+      email: " BRIAN@EXAMPLE.COM ",
+      phone: " ",
+      address: " ",
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data).toEqual({
+      firstName: "Brian",
+      lastName: "Sack",
+      email: "brian@example.com",
+      phone: "",
+      address: "",
+    })
+  })
+
+  it("rejects an invalid account email", () => {
+    const result = updateProfileSchema.safeParse({
+      firstName: "Brian",
+      lastName: "Sack",
+      email: "not-an-email",
+      phone: "555-0100",
+      address: "10 Test St",
+    })
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/lib/__tests__/project-profile.test.ts
+++ b/src/lib/__tests__/project-profile.test.ts
@@ -11,6 +11,7 @@ import {
   isMeaningfulClientInteraction,
   isBuiltInProjectJobStatusLabel,
   isSupportedProjectJobStatusLabel,
+  legacyProjectStatusAfterClientUpdate,
   normalizeProjectJobStatusLabel,
   projectNumberParts,
 } from "@/lib/project-profile"
@@ -18,6 +19,27 @@ import {
 describe("project profile rules", () => {
   it("keeps client status limited to lead and customer", () => {
     expect(PROJECT_CLIENT_STATUSES).toEqual(["lead", "customer"])
+  })
+
+  it("clears the legacy lead status when a project becomes a customer", () => {
+    expect(
+      legacyProjectStatusAfterClientUpdate({
+        currentStatus: "LEAD",
+        clientStatus: "customer",
+      }),
+    ).toBe("OPEN")
+    expect(
+      legacyProjectStatusAfterClientUpdate({
+        currentStatus: "LEAD",
+        clientStatus: "lead",
+      }),
+    ).toBe("LEAD")
+    expect(
+      legacyProjectStatusAfterClientUpdate({
+        currentStatus: "WARRANTY",
+        clientStatus: "customer",
+      }),
+    ).toBe("WARRANTY")
   })
 
   it("keeps the approved Sage-aligned job statuses standardized", () => {

--- a/src/lib/__tests__/project-profile.test.ts
+++ b/src/lib/__tests__/project-profile.test.ts
@@ -13,6 +13,9 @@ import {
   isSupportedProjectJobStatusLabel,
   legacyProjectStatusAfterClientUpdate,
   normalizeProjectJobStatusLabel,
+  projectClientStatusLabel,
+  projectJobStatusBucket,
+  projectJobStatusLabel,
   projectNumberParts,
 } from "@/lib/project-profile"
 
@@ -54,6 +57,54 @@ describe("project profile rules", () => {
         "Bid Refused",
       ]),
     )
+  })
+
+  it("uses the exact approved job status label for project-facing status", () => {
+    expect(
+      projectJobStatusLabel({ jobStatusId: "current", customLabel: null }),
+    ).toBe("Current")
+    expect(
+      projectJobStatusLabel({
+        jobStatusId: "organization-warranty",
+        customLabel: "Extended Warranty",
+      }),
+    ).toBe("Extended Warranty")
+    expect(
+      projectJobStatusLabel({ jobStatusId: "missing", customLabel: null }),
+    ).toBe("Unknown job status")
+  })
+
+  it("keeps client classification separate from job status", () => {
+    expect(projectClientStatusLabel("customer")).toBe("Customer")
+    expect(projectClientStatusLabel("lead")).toBe("Lead")
+    expect(projectClientStatusLabel("unexpected")).toBe("Unknown client status")
+  })
+
+  it("groups project search views from approved job status rather than legacy OPEN", () => {
+    expect(
+      projectJobStatusBucket({
+        jobStatusId: "current",
+        jobStatusLabel: "Current",
+      }),
+    ).toBe("active")
+    expect(
+      projectJobStatusBucket({
+        jobStatusId: "organization-warranty",
+        jobStatusLabel: "Warranty Service",
+      }),
+    ).toBe("warranty")
+    expect(
+      projectJobStatusBucket({
+        jobStatusId: "complete",
+        jobStatusLabel: "Complete",
+      }),
+    ).toBe("complete")
+    expect(
+      projectJobStatusBucket({
+        jobStatusId: "bid_refused",
+        jobStatusLabel: "Bid Refused",
+      }),
+    ).toBe("inactive")
   })
 
   it("recognizes built-in status labels before an administrator creates a custom status", () => {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,6 +6,7 @@ import {
   organizations,
   organizationMembers,
   projectAccessInvitations,
+  projectContacts,
   projectMembers,
 } from "@/db/schema"
 import type { User } from "@/db/schema"
@@ -28,6 +29,8 @@ export type AuthUser = {
   readonly firstName: string | null
   readonly lastName: string | null
   readonly displayName: string | null
+  readonly phone?: string | null
+  readonly address?: string | null
   readonly avatarUrl: string | null
   readonly dashboardDeskPhotoUrl?: string | null
   readonly sidebarDeskPhotoUrl?: string | null
@@ -54,6 +57,8 @@ export type SidebarUser = Readonly<{
   sidebarDeskPhoto: string | null
   firstName: string | null
   lastName: string | null
+  phone: string | null
+  address: string | null
 }>
 
 /**
@@ -69,6 +74,8 @@ export function toSidebarUser(user: AuthUser): SidebarUser {
     sidebarDeskPhoto: user.sidebarDeskPhotoUrl ?? null,
     firstName: user.firstName,
     lastName: user.lastName,
+    phone: user.phone ?? null,
+    address: user.address ?? null,
   }
 }
 
@@ -149,8 +156,14 @@ async function claimProjectAccessInvitations(
       role: projectAccessInvitations.role,
       invitedBy: projectAccessInvitations.invitedBy,
       workosExpiresAt: projectAccessInvitations.workosExpiresAt,
+      contactPhone: projectContacts.phone,
+      contactAddress: projectContacts.address,
     })
     .from(projectAccessInvitations)
+    .leftJoin(
+      projectContacts,
+      eq(projectContacts.id, projectAccessInvitations.projectContactId)
+    )
     .where(
       and(
         eq(projectAccessInvitations.status, "sent"),
@@ -158,6 +171,33 @@ async function claimProjectAccessInvitations(
       )
     )
     .orderBy(desc(projectAccessInvitations.invitedAt))
+
+  const currentIdentity = await db
+    .select({ phone: users.phone, address: users.address })
+    .from(users)
+    .where(eq(users.id, userId))
+    .get()
+  const identityInvitation = invitations.find(
+    (invitation) =>
+      (!invitation.workosExpiresAt || invitation.workosExpiresAt > now) &&
+      (invitation.contactPhone || invitation.contactAddress)
+  )
+  if (
+    currentIdentity &&
+    identityInvitation &&
+    ((!currentIdentity.phone && identityInvitation.contactPhone) ||
+      (!currentIdentity.address && identityInvitation.contactAddress))
+  ) {
+    await db
+      .update(users)
+      .set({
+        phone: currentIdentity.phone ?? identityInvitation.contactPhone,
+        address: currentIdentity.address ?? identityInvitation.contactAddress,
+        updatedAt: now,
+      })
+      .where(eq(users.id, userId))
+      .run()
+  }
 
   let claimedInvitation: {
     readonly organizationId: string
@@ -518,6 +558,8 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
       firstName: dbUser.firstName,
       lastName: dbUser.lastName,
       displayName: dbUser.displayName,
+      phone: dbUser.phone,
+      address: dbUser.address,
       avatarUrl: dbUser.avatarUrl,
       dashboardDeskPhotoUrl: dbUser.dashboardDeskPhotoUrl,
       sidebarDeskPhotoUrl: dbUser.sidebarDeskPhotoUrl,

--- a/src/lib/contact-identity-ownership.ts
+++ b/src/lib/contact-identity-ownership.ts
@@ -1,0 +1,115 @@
+import { and, eq, inArray, or } from "drizzle-orm"
+
+import type { getDb } from "@/db"
+import {
+  projectAccessInvitations,
+  projectContacts,
+  projects,
+  users,
+} from "@/db/schema"
+
+export type ContactIdentityFields = {
+  readonly email: string | null
+  readonly phone: string | null
+  readonly address: string | null
+}
+
+type DirectoryEntityType = "customer" | "vendor"
+
+function normalizedIdentityValue(
+  value: string | null | undefined,
+  lowercase: boolean
+): string {
+  const normalized = value?.trim() ?? ""
+  return lowercase ? normalized.toLowerCase() : normalized
+}
+
+export function contactIdentityChanged(
+  current: ContactIdentityFields,
+  next: ContactIdentityFields
+): boolean {
+  return (
+    normalizedIdentityValue(current.email, true) !==
+      normalizedIdentityValue(next.email, true) ||
+    normalizedIdentityValue(current.phone, false) !==
+      normalizedIdentityValue(next.phone, false) ||
+    normalizedIdentityValue(current.address, false) !==
+      normalizedIdentityValue(next.address, false)
+  )
+}
+
+export async function directoryIdentityManagedByActiveUser(input: {
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string
+  readonly entityType: DirectoryEntityType
+  readonly entityId: string
+}): Promise<boolean> {
+  const row = await input.db
+    .select({ userId: users.id })
+    .from(projectContacts)
+    .innerJoin(projects, eq(projects.id, projectContacts.projectId))
+    .innerJoin(
+      projectAccessInvitations,
+      and(
+        eq(projectAccessInvitations.projectId, projectContacts.projectId),
+        eq(projectAccessInvitations.projectContactId, projectContacts.id),
+        eq(projectAccessInvitations.status, "accepted")
+      )
+    )
+    .innerJoin(users, eq(users.id, projectAccessInvitations.acceptedBy))
+    .where(
+      and(
+        eq(projects.organizationId, input.organizationId),
+        eq(projectContacts.sourceEntityType, input.entityType),
+        eq(projectContacts.sourceEntityId, input.entityId),
+        eq(users.isActive, true)
+      )
+    )
+    .limit(1)
+    .get()
+
+  return row !== undefined
+}
+
+export async function activeDirectoryIdentityKeys(input: {
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string
+  readonly entityIds: readonly string[]
+}): Promise<ReadonlySet<string>> {
+  const entityIds = Array.from(new Set(input.entityIds.filter(Boolean)))
+  if (entityIds.length === 0) return new Set<string>()
+
+  const rows = await input.db
+    .select({
+      entityType: projectContacts.sourceEntityType,
+      entityId: projectContacts.sourceEntityId,
+    })
+    .from(projectContacts)
+    .innerJoin(projects, eq(projects.id, projectContacts.projectId))
+    .innerJoin(
+      projectAccessInvitations,
+      and(
+        eq(projectAccessInvitations.projectId, projectContacts.projectId),
+        eq(projectAccessInvitations.projectContactId, projectContacts.id),
+        eq(projectAccessInvitations.status, "accepted")
+      )
+    )
+    .innerJoin(users, eq(users.id, projectAccessInvitations.acceptedBy))
+    .where(
+      and(
+        eq(projects.organizationId, input.organizationId),
+        eq(users.isActive, true),
+        inArray(projectContacts.sourceEntityId, entityIds),
+        or(
+          eq(projectContacts.sourceEntityType, "customer"),
+          eq(projectContacts.sourceEntityType, "vendor")
+        )
+      )
+    )
+
+  return new Set(
+    rows.flatMap((row) =>
+      row.entityId ? [`${row.entityType}:${row.entityId}`] : []
+    )
+  )
+}

--- a/src/lib/project-profile.ts
+++ b/src/lib/project-profile.ts
@@ -37,6 +37,20 @@ export function isEligibleFollowUpOwner(input: {
 
 export type ProjectClientStatus = (typeof PROJECT_CLIENT_STATUSES)[number]
 
+export function legacyProjectStatusAfterClientUpdate(input: {
+  readonly currentStatus: string
+  readonly clientStatus: ProjectClientStatus
+}): string {
+  if (
+    input.clientStatus === "customer"
+    && input.currentStatus.trim().toUpperCase() === "LEAD"
+  ) {
+    return "OPEN"
+  }
+
+  return input.currentStatus
+}
+
 export type ProjectJobStatusDefinition = {
   readonly id: string
   readonly label: string

--- a/src/lib/project-profile.ts
+++ b/src/lib/project-profile.ts
@@ -156,6 +156,81 @@ export const PROJECT_JOB_STATUS_DEFINITIONS = [
 
 export type ProjectJobStatusId = (typeof PROJECT_JOB_STATUS_DEFINITIONS)[number]["id"]
 
+export type ProjectJobStatusBucket =
+  | "active"
+  | "warranty"
+  | "complete"
+  | "inactive"
+  | "archive"
+  | "other"
+
+export function projectClientStatusLabel(clientStatus: string): string {
+  const normalized = clientStatus.trim().toLowerCase()
+  if (normalized === "lead") return "Lead"
+  if (normalized === "customer") return "Customer"
+  return "Unknown client status"
+}
+
+export function projectJobStatusLabel(input: {
+  readonly jobStatusId: string
+  readonly customLabel: string | null
+}): string {
+  const builtIn = PROJECT_JOB_STATUS_DEFINITIONS.find(
+    (status) => status.id === input.jobStatusId,
+  )
+  if (builtIn) return builtIn.label
+
+  const customLabel = input.customLabel?.trim()
+  return customLabel || "Unknown job status"
+}
+
+export function projectJobStatusBucket(input: {
+  readonly jobStatusId: string
+  readonly jobStatusLabel: string
+}): ProjectJobStatusBucket {
+  const id = input.jobStatusId.trim().toLowerCase()
+  const label = input.jobStatusLabel.trim().toLowerCase()
+
+  if (
+    id.includes("warranty")
+    || label.includes("warranty")
+    || label.includes("service")
+  ) {
+    return "warranty"
+  }
+  if (
+    id === "complete"
+    || id === "closed"
+    || label === "complete"
+    || label === "completed"
+    || label === "closed"
+  ) {
+    return "complete"
+  }
+  if (
+    id === "inactive"
+    || id === "bid_refused"
+    || id === "paused"
+    || label === "inactive"
+    || label === "bid refused"
+    || label === "paused"
+  ) {
+    return "inactive"
+  }
+  if (
+    id === "archive"
+    || id === "archived"
+    || label === "archive"
+    || label === "archived"
+  ) {
+    return "archive"
+  }
+  if (id === "other" || label === "other" || input.jobStatusLabel === "Unknown job status") {
+    return "other"
+  }
+  return "active"
+}
+
 const PROJECT_JOB_STATUS_LABEL_PATTERN = /^[\x20-\x7E]+$/
 
 export function normalizeProjectJobStatusLabel(label: string): string {

--- a/src/lib/validations/profile.ts
+++ b/src/lib/validations/profile.ts
@@ -1,18 +1,32 @@
 import { z } from "zod"
 
 /**
- * Schema for updating user profile (first name, last name)
+ * Schema for identity details managed by the signed-in user.
  */
 export const updateProfileSchema = z.object({
   firstName: z
     .string()
+    .trim()
     .min(1, "First name is required")
-    .max(100, "First name must be 100 characters or less")
-    .trim(),
+    .max(100, "First name must be 100 characters or less"),
   lastName: z
     .string()
+    .trim()
     .min(1, "Last name is required")
-    .max(100, "Last name must be 100 characters or less")
+    .max(100, "Last name must be 100 characters or less"),
+  email: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .email("Enter a valid email address")
+    .max(320, "Email must be 320 characters or less"),
+  phone: z
+    .string()
+    .max(50, "Phone number must be 50 characters or less")
+    .trim(),
+  address: z
+    .string()
+    .max(500, "Address must be 500 characters or less")
     .trim(),
 })
 


### PR DESCRIPTION
## Summary
- classify Project Hub records from the approved job status while keeping customer/lead classification distinct
- add Project Hub pagination and selectable page sizes
- persist intake customer contact details, client project contacts, and selected internal contacts/project managers
- allow staff-managed client/vendor contact details until the linked Compass account becomes active, then make the active user the profile owner
- backfill existing native-intake contact relationships and preserve Sage as server-side/read-only integration behavior

## Verification
- `bunx tsc --noEmit --pretty false`
- ESLint on all changed TypeScript/TSX files
- 37 focused Vitest tests, including Sage write and worker-source tests
- production D1 migration applied and verified for N-995-00
- production Worker deployment smoke-tested with expected authenticated redirect

## Release note
The structured autoreview helper could not initialize because its local Codex state SQLite database is read-only in this environment. Manual review and the checks above completed successfully.
