### PR TITLE
fix(contacts): restore project contact controls

### DIFF
--- a/src/lib/__tests__/contact-identity-ownership.test.ts
+++ b/src/lib/__tests__/contact-identity-ownership.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { contactIdentityChanged } from "@/lib/contact-identity-ownership"
+import {
+  contactIdentityChanged,
+  requestedDirectoryIdentityKeys,
+} from "@/lib/contact-identity-ownership"
 import { updateProfileSchema } from "@/lib/validations/profile"
 
 describe("contact identity ownership", () => {
@@ -37,6 +40,28 @@ describe("contact identity ownership", () => {
     expect(
       contactIdentityChanged(current, { ...current, address: "20 Main Street" })
     ).toBe(true)
+  })
+
+  it("filters active identities for directories larger than D1's parameter limit", () => {
+    const entityIds = Array.from(
+      { length: 540 },
+      (_, index) => `directory-${index}`
+    )
+
+    const result = requestedDirectoryIdentityKeys({
+      entityIds,
+      rows: [
+        { entityType: "customer", entityId: "directory-10" },
+        { entityType: "vendor", entityId: "directory-539" },
+        { entityType: "vendor", entityId: "outside-directory" },
+        { entityType: "customer", entityId: null },
+      ],
+    })
+
+    expect(Array.from(result)).toEqual([
+      "customer:directory-10",
+      "vendor:directory-539",
+    ])
   })
 })
 

--- a/src/lib/contact-identity-ownership.ts
+++ b/src/lib/contact-identity-ownership.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, or } from "drizzle-orm"
+import { and, eq, or } from "drizzle-orm"
 
 import type { getDb } from "@/db"
 import {
@@ -15,6 +15,11 @@ export type ContactIdentityFields = {
 }
 
 type DirectoryEntityType = "customer" | "vendor"
+
+type DirectoryIdentityRow = {
+  readonly entityType: string
+  readonly entityId: string | null
+}
 
 function normalizedIdentityValue(
   value: string | null | undefined,
@@ -35,6 +40,21 @@ export function contactIdentityChanged(
       normalizedIdentityValue(next.phone, false) ||
     normalizedIdentityValue(current.address, false) !==
       normalizedIdentityValue(next.address, false)
+  )
+}
+
+export function requestedDirectoryIdentityKeys(input: {
+  readonly entityIds: readonly string[]
+  readonly rows: readonly DirectoryIdentityRow[]
+}): ReadonlySet<string> {
+  const requestedIds = new Set(input.entityIds.filter(Boolean))
+
+  return new Set(
+    input.rows.flatMap((row) =>
+      row.entityId && requestedIds.has(row.entityId)
+        ? [`${row.entityType}:${row.entityId}`]
+        : []
+    )
   )
 }
 
@@ -79,6 +99,10 @@ export async function activeDirectoryIdentityKeys(input: {
   const entityIds = Array.from(new Set(input.entityIds.filter(Boolean)))
   if (entityIds.length === 0) return new Set<string>()
 
+  // D1 allows at most 100 bound parameters per query. Organizations can have
+  // hundreds of directory records, so query the small set of accepted active
+  // identities for the organization and filter it in memory instead of using
+  // one bound parameter for every customer and vendor ID.
   const rows = await input.db
     .select({
       entityType: projectContacts.sourceEntityType,
@@ -99,7 +123,6 @@ export async function activeDirectoryIdentityKeys(input: {
       and(
         eq(projects.organizationId, input.organizationId),
         eq(users.isActive, true),
-        inArray(projectContacts.sourceEntityId, entityIds),
         or(
           eq(projectContacts.sourceEntityType, "customer"),
           eq(projectContacts.sourceEntityType, "vendor")
@@ -107,9 +130,5 @@ export async function activeDirectoryIdentityKeys(input: {
       )
     )
 
-  return new Set(
-    rows.flatMap((row) =>
-      row.entityId ? [`${row.entityType}:${row.entityId}`] : []
-    )
-  )
+  return requestedDirectoryIdentityKeys({ entityIds, rows })
 }


### PR DESCRIPTION
## Summary
- restore the Project Contacts pencil and Add contact controls for organizations with large customer/vendor directories
- avoid exceeding Cloudflare D1's 100-bound-parameter limit during active-user ownership lookup
- preserve active-user identity ownership by filtering the organization-scoped accepted identities in memory

## Root cause
Production has 540 customer/vendor directory records. The ownership query introduced in #427 attempted to bind every directory ID in one D1 query. The directory action failed, and the contacts page intentionally fell back to read-only mode, hiding both controls.

## Verification
- 18 focused contact and project-access tests passed
- regression coverage uses 540 directory IDs
- changed-file ESLint passed
- full TypeScript check passed with an 8 GB heap
- no database migration required

## Review note
The structured autoreview helper could not initialize because its local Codex state SQLite database is read-only in this environment. Manual review and the checks above completed successfully.
