### PR TITLE
feat(projects): extend client interaction types

### DIFF
--- a/src/app/actions/project-profile.ts
+++ b/src/app/actions/project-profile.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { and, asc, desc, eq, isNull, sql } from "drizzle-orm"
+import { and, asc, desc, eq, isNull, like, sql } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
@@ -58,8 +58,11 @@ import {
   isSupportedProjectJobStatusLabel,
   legacyProjectStatusAfterClientUpdate,
   normalizeProjectJobStatusLabel,
+  projectInteractionTypeLabel,
+  projectInteractionTypeOptions,
   projectNumberParts,
   type ProjectClientStatus,
+  type ProjectInteractionTypeOption,
 } from "@/lib/project-profile"
 import { clientFollowUpState } from "@/lib/project-follow-up"
 import { getProjectAccessRecord } from "@/lib/project-access"
@@ -89,6 +92,7 @@ export type ProjectProfileNote = {
 export type ProjectProfileInteraction = {
   readonly id: string
   readonly interactionType: string
+  readonly interactionTypeLabel: string
   readonly direction: string
   readonly summary: string
   readonly source: string
@@ -114,6 +118,7 @@ export type ProjectInformation = {
     readonly status: string
   }
   readonly jobStatuses: readonly ProjectProfileJobStatus[]
+  readonly interactionTypes: readonly ProjectInteractionTypeOption[]
   readonly clientContacts: readonly {
     readonly id: string
     readonly displayName: string
@@ -376,7 +381,7 @@ export async function getProjectInformation(
     const project = projectRows[0]
     if (!project) return null
 
-    const [customStatuses, notes, interactions, followUps, operations, aliases, clientContacts] = await Promise.all([
+    const [customStatuses, customInteractionTypes, notes, interactions, followUps, operations, aliases, clientContacts] = await Promise.all([
       db
         .select({
           id: projectJobStatuses.id,
@@ -393,6 +398,17 @@ export async function getProjectInformation(
           ),
         )
         .orderBy(asc(projectJobStatuses.sortOrder), asc(projectJobStatuses.label)),
+      db
+        .selectDistinct({ interactionType: projectInteractions.interactionType })
+        .from(projectInteractions)
+        .where(
+          and(
+            eq(projectInteractions.organizationId, organizationId),
+            eq(projectInteractions.source, "manual"),
+            like(projectInteractions.interactionType, "custom:%"),
+          ),
+        )
+        .orderBy(asc(projectInteractions.interactionType)),
       db
         .select({
           id: projectNotes.id,
@@ -479,10 +495,16 @@ export async function getProjectInformation(
     return {
       project: { ...project, clientStatus },
       jobStatuses: jobStatusOptions(customStatuses),
+      interactionTypes: projectInteractionTypeOptions(
+        customInteractionTypes.map((item) => item.interactionType),
+      ),
       clientContacts,
       projectNumberAliases: aliases.map((alias) => alias.projectNumber),
       notes,
-      interactions,
+      interactions: interactions.map((interaction) => ({
+        ...interaction,
+        interactionTypeLabel: projectInteractionTypeLabel(interaction.interactionType),
+      })),
       followUp: followUps[0] ?? null,
       syncOperations: operations,
     }

--- a/src/components/projects/project-information-workspace.tsx
+++ b/src/components/projects/project-information-workspace.tsx
@@ -22,6 +22,9 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import { customProjectInteractionType } from "@/lib/project-profile"
+
+const CUSTOM_INTERACTION_TYPE_OPTION = "__custom__"
 
 function suffixFromProjectNumber(projectNumber: string | null): string {
   if (!projectNumber) return ""
@@ -65,6 +68,7 @@ export function ProjectInformationWorkspace({
   const [propagateMailingAddress, setPropagateMailingAddress] = useState(false)
   const [note, setNote] = useState("")
   const [interactionType, setInteractionType] = useState("call")
+  const [customInteractionTypeLabel, setCustomInteractionTypeLabel] = useState("")
   const [interactionContactId, setInteractionContactId] = useState(
     information.clientContacts[0]?.id ?? "",
   )
@@ -116,16 +120,27 @@ export function ProjectInformationWorkspace({
 
   function saveInteraction(event: FormEvent<HTMLFormElement>): void {
     event.preventDefault()
+    const selectedInteractionType = interactionType === CUSTOM_INTERACTION_TYPE_OPTION
+      ? customProjectInteractionType(customInteractionTypeLabel)
+      : interactionType
+    if (!selectedInteractionType) {
+      setMessage("Enter a unique custom interaction type using 1–60 standard characters.")
+      return
+    }
     startTransition(async () => {
       const result = await createProjectInteraction({
         projectId: information.project.id,
-        interactionType,
+        interactionType: selectedInteractionType,
         direction,
         summary: interactionSummary,
         occurredAt: interactionTime,
         contactId: interactionContactId || null,
       })
-      if (result.success) setInteractionSummary("")
+      if (result.success) {
+        setInteractionSummary("")
+        setCustomInteractionTypeLabel("")
+        setInteractionType(selectedInteractionType)
+      }
       refreshAfter(result)
     })
   }
@@ -313,7 +328,7 @@ export function ProjectInformationWorkspace({
 
         <section className="rounded-lg border bg-card p-4 sm:p-5">
           <h2 className="font-semibold">Log client interaction</h2>
-          <p className="mt-1 text-sm text-muted-foreground">Calls, emails, meetings, site visits, and client-facing sends count as meaningful contact.</p>
+          <p className="mt-1 text-sm text-muted-foreground">Calls, emails, texts, meetings, site visits, documents/submittals sent to clients, and custom interaction types count as meaningful contact.</p>
           <form className="mt-4 grid gap-3" onSubmit={saveInteraction}>
             <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
               <div className="space-y-2">
@@ -323,10 +338,11 @@ export function ProjectInformationWorkspace({
                   {information.clientContacts.map((contact) => <option key={contact.id} value={contact.id}>{contact.displayName}</option>)}
                 </select>
               </div>
-              <div className="space-y-2"><Label htmlFor="interaction-type">Type</Label><select id="interaction-type" className="flex h-9 w-full rounded-md border bg-background px-3 text-sm" value={interactionType} onChange={(event) => setInteractionType(event.target.value)}><option value="call">Call</option><option value="email">Email</option><option value="meeting">Meeting</option><option value="site_visit">Site visit</option><option value="client_send">Client-facing send</option></select></div>
+              <div className="space-y-2"><Label htmlFor="interaction-type">Type</Label><select id="interaction-type" className="flex h-9 w-full rounded-md border bg-background px-3 text-sm" value={interactionType} onChange={(event) => setInteractionType(event.target.value)}>{information.interactionTypes.map((type) => <option key={type.id} value={type.id}>{type.label}</option>)}<option value={CUSTOM_INTERACTION_TYPE_OPTION}>Add another interaction type…</option></select></div>
               <div className="space-y-2"><Label htmlFor="interaction-direction">Direction</Label><select id="interaction-direction" className="flex h-9 w-full rounded-md border bg-background px-3 text-sm" value={direction} onChange={(event) => setDirection(event.target.value === "inbound" ? "inbound" : "outbound")}><option value="outbound">Outbound</option><option value="inbound">Inbound</option></select></div>
               <div className="space-y-2"><Label htmlFor="interaction-time">When</Label><Input id="interaction-time" type="datetime-local" value={interactionTime} onChange={(event) => setInteractionTime(event.target.value)} required /></div>
             </div>
+            {interactionType === CUSTOM_INTERACTION_TYPE_OPTION && <div className="space-y-2"><Label htmlFor="custom-interaction-type">Custom interaction type</Label><Input id="custom-interaction-type" value={customInteractionTypeLabel} onChange={(event) => setCustomInteractionTypeLabel(event.target.value)} maxLength={60} placeholder="For example: Design review" aria-describedby="custom-interaction-type-help" required /><p id="custom-interaction-type-help" className="text-xs text-muted-foreground">After the first logged interaction, this choice becomes available on every project in your organization.</p></div>}
             <div className="space-y-2"><Label htmlFor="interaction-summary">Outcome / summary</Label><Textarea id="interaction-summary" value={interactionSummary} onChange={(event) => setInteractionSummary(event.target.value)} rows={3} required /></div>
             <div><Button type="submit" disabled={pending}>Log interaction</Button></div>
           </form>
@@ -341,7 +357,7 @@ export function ProjectInformationWorkspace({
         </section>
         <section className="rounded-lg border bg-card p-4 sm:p-5">
           <h2 className="font-semibold">Meaningful interaction history</h2>
-          <div className="mt-4 space-y-3">{information.interactions.length === 0 ? <p className="text-sm text-muted-foreground">No meaningful client interaction recorded yet.</p> : information.interactions.map((item) => <article className="rounded-md border p-3" key={item.id}><div className="flex items-start justify-between gap-3"><div><Badge variant="outline">{item.direction} · {item.interactionType}</Badge><p className="mt-2 whitespace-pre-wrap text-sm">{item.summary}</p></div><Button type="button" size="sm" variant="ghost" disabled={pending} onClick={() => removeInteraction(item.id)}>Delete</Button></div><p className="mt-2 text-xs text-muted-foreground">{item.authorName ?? "Unknown"} · {new Date(item.occurredAt).toLocaleString()} · {item.source}</p></article>)}</div>
+          <div className="mt-4 space-y-3">{information.interactions.length === 0 ? <p className="text-sm text-muted-foreground">No meaningful client interaction recorded yet.</p> : information.interactions.map((item) => <article className="rounded-md border p-3" key={item.id}><div className="flex items-start justify-between gap-3"><div><Badge variant="outline">{item.direction} · {item.interactionTypeLabel}</Badge><p className="mt-2 whitespace-pre-wrap text-sm">{item.summary}</p></div><Button type="button" size="sm" variant="ghost" disabled={pending} onClick={() => removeInteraction(item.id)}>Delete</Button></div><p className="mt-2 text-xs text-muted-foreground">{item.authorName ?? "Unknown"} · {new Date(item.occurredAt).toLocaleString()} · {item.source}</p></article>)}</div>
         </section>
       </div>
 

--- a/src/lib/__tests__/project-profile.test.ts
+++ b/src/lib/__tests__/project-profile.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  customProjectInteractionType,
   FOLLOW_UP_EXCLUDED_JOB_STATUSES,
   PROJECT_CLIENT_STATUSES,
   PROJECT_JOB_STATUS_DEFINITIONS,
@@ -14,6 +15,8 @@ import {
   legacyProjectStatusAfterClientUpdate,
   normalizeProjectJobStatusLabel,
   projectClientStatusLabel,
+  projectInteractionTypeLabel,
+  projectInteractionTypeOptions,
   projectJobStatusBucket,
   projectJobStatusLabel,
   projectNumberParts,
@@ -163,6 +166,39 @@ describe("project profile rules", () => {
     expect(
       isMeaningfulClientInteraction({ interactionType: "email", direction: "outbound", source: "background_sync" }),
     ).toBe(false)
+  })
+
+  it("labels the built-in text and document/submittal interaction choices", () => {
+    expect(projectInteractionTypeLabel("sms")).toBe("Text")
+    expect(projectInteractionTypeLabel("client_send")).toBe("Document/Submittal to Client")
+    expect(
+      isMeaningfulClientInteraction({ interactionType: "sms", direction: "outbound", source: "manual" }),
+    ).toBe(true)
+  })
+
+  it("adds valid custom interaction types to the reusable organization list", () => {
+    const designReview = customProjectInteractionType("Design review")
+    expect(designReview).toBe("custom:Design review")
+    expect(customProjectInteractionType("Call")).toBeNull()
+    expect(customProjectInteractionType("x".repeat(61))).toBeNull()
+    expect(
+      isMeaningfulClientInteraction({
+        interactionType: designReview ?? "",
+        direction: "outbound",
+        source: "manual",
+      }),
+    ).toBe(true)
+    expect(projectInteractionTypeOptions([
+      "custom:Warranty consultation",
+      "custom:Design review",
+      "custom:design review",
+      "not-custom",
+    ])).toEqual(expect.arrayContaining([
+      { id: "sms", label: "Text" },
+      { id: "client_send", label: "Document/Submittal to Client" },
+      { id: "custom:Design review", label: "Design review" },
+      { id: "custom:Warranty consultation", label: "Warranty consultation" },
+    ]))
   })
 
   it("allows follow-up owners only when they are active internal members", () => {

--- a/src/lib/project-profile.ts
+++ b/src/lib/project-profile.ts
@@ -2,13 +2,80 @@ import { isInternalStaffRole } from "@/lib/user-roles"
 
 export const PROJECT_CLIENT_STATUSES = ["lead", "customer"] as const
 
-const MANUAL_MEANINGFUL_INTERACTION_TYPES = new Set([
-  "call",
-  "email",
-  "meeting",
-  "site_visit",
-  "client_send",
-])
+export type ProjectInteractionTypeOption = {
+  readonly id: string
+  readonly label: string
+}
+
+export const PROJECT_INTERACTION_TYPE_DEFINITIONS = [
+  { id: "call", label: "Call" },
+  { id: "email", label: "Email" },
+  { id: "sms", label: "Text" },
+  { id: "meeting", label: "Meeting" },
+  { id: "site_visit", label: "Site visit" },
+  { id: "client_send", label: "Document/Submittal to Client" },
+] as const satisfies readonly { readonly id: string; readonly label: string }[]
+
+const CUSTOM_INTERACTION_TYPE_PREFIX = "custom:"
+const CUSTOM_INTERACTION_TYPE_PATTERN = /^[\x20-\x7E]{1,60}$/
+const MANUAL_MEANINGFUL_INTERACTION_TYPES = new Set<string>(
+  PROJECT_INTERACTION_TYPE_DEFINITIONS.map((type) => type.id),
+)
+
+function normalizeInteractionTypeLabel(label: string): string {
+  return label.trim().toLowerCase()
+}
+
+export function customProjectInteractionType(label: string): string | null {
+  const trimmed = label.trim()
+  if (!CUSTOM_INTERACTION_TYPE_PATTERN.test(trimmed)) return null
+  const normalized = normalizeInteractionTypeLabel(trimmed)
+  if (
+    PROJECT_INTERACTION_TYPE_DEFINITIONS.some(
+      (type) => normalizeInteractionTypeLabel(type.label) === normalized,
+    )
+  ) {
+    return null
+  }
+  return `${CUSTOM_INTERACTION_TYPE_PREFIX}${trimmed}`
+}
+
+function customProjectInteractionTypeLabel(interactionType: string): string | null {
+  if (!interactionType.startsWith(CUSTOM_INTERACTION_TYPE_PREFIX)) return null
+  const label = interactionType.slice(CUSTOM_INTERACTION_TYPE_PREFIX.length)
+  return customProjectInteractionType(label) === interactionType ? label : null
+}
+
+export function projectInteractionTypeLabel(interactionType: string): string {
+  const builtIn = PROJECT_INTERACTION_TYPE_DEFINITIONS.find(
+    (type) => type.id === interactionType,
+  )
+  if (builtIn) return builtIn.label
+  return customProjectInteractionTypeLabel(interactionType) ?? interactionType
+}
+
+export function projectInteractionTypeOptions(
+  interactionTypes: readonly string[],
+): readonly ProjectInteractionTypeOption[] {
+  const options: ProjectInteractionTypeOption[] = PROJECT_INTERACTION_TYPE_DEFINITIONS.map(
+    (type) => ({ ...type }),
+  )
+  const labels = new Set(options.map((option) => normalizeInteractionTypeLabel(option.label)))
+  const customOptions = interactionTypes
+    .map((interactionType) => ({
+      id: interactionType,
+      label: customProjectInteractionTypeLabel(interactionType),
+    }))
+    .filter((option): option is { readonly id: string; readonly label: string } => {
+      if (!option.label) return false
+      const normalized = normalizeInteractionTypeLabel(option.label)
+      if (labels.has(normalized)) return false
+      labels.add(normalized)
+      return true
+    })
+    .sort((left, right) => left.label.localeCompare(right.label))
+  return [...options, ...customOptions]
+}
 
 export function isMeaningfulClientInteraction(input: {
   readonly interactionType: string
@@ -18,7 +85,10 @@ export function isMeaningfulClientInteraction(input: {
   if (input.source === "manual") {
     return (
       (input.direction === "inbound" || input.direction === "outbound")
-      && MANUAL_MEANINGFUL_INTERACTION_TYPES.has(input.interactionType)
+      && (
+        MANUAL_MEANINGFUL_INTERACTION_TYPES.has(input.interactionType)
+        || customProjectInteractionTypeLabel(input.interactionType) !== null
+      )
     )
   }
   return (


### PR DESCRIPTION
## Summary

- rename the existing client-facing send choice to **Document/Submittal to Client** without changing stored identifiers
- add **Text** as a manual meaningful client interaction type
- allow staff to add validated custom interaction types that become reusable across the organization
- display friendly interaction labels in history

## Safety

- no database migration
- no Sage import, export, or synchronization code changes
- all custom interaction lookups remain organization-scoped

## Validation

- `bun test src/lib/__tests__/project-profile.test.ts` (15 passed)
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit`
- changed-file ESLint
- `git diff --check`

Structured autoreview could not initialize because the sandbox could not write Codex's local state database, and host escalation was denied for source-bundle privacy. The diff was manually reviewed for organization isolation, input validation, backward compatibility, and Sage separation.
