### PR TITLE
fix(projects): reconcile project contact access

### DIFF
--- a/drizzle/0117_project_contact_directory_reconciliation.sql
+++ b/drizzle/0117_project_contact_directory_reconciliation.sql
@@ -1,0 +1,157 @@
+-- Buildertrend and other legacy imports can predate directory linking. Attach
+-- only contacts with one unambiguous organization-scoped match so similarly
+-- named people or companies are left for manual review.
+WITH `owner_matches` AS (
+  SELECT pc.`id` AS `project_contact_id`, MIN(c.`id`) AS `directory_id`
+  FROM `project_contacts` pc
+  INNER JOIN `projects` p ON p.`id` = pc.`project_id`
+  INNER JOIN `customers` c
+    ON c.`organization_id` = p.`organization_id`
+   AND (
+     (pc.`email` IS NOT NULL AND trim(pc.`email`) <> ''
+       AND c.`email` IS NOT NULL AND trim(c.`email`) <> ''
+       AND lower(trim(pc.`email`)) = lower(trim(c.`email`)))
+     OR lower(trim(pc.`display_name`)) = lower(trim(c.`name`))
+     OR (pc.`company_name` IS NOT NULL AND trim(pc.`company_name`) <> ''
+       AND lower(trim(pc.`company_name`)) = lower(trim(c.`name`)))
+     OR (c.`company` IS NOT NULL AND trim(c.`company`) <> ''
+       AND lower(trim(COALESCE(pc.`company_name`, pc.`display_name`))) = lower(trim(c.`company`)))
+   )
+  WHERE pc.`active` = 1
+    AND pc.`contact_type` = 'owner'
+    AND (pc.`source_entity_type` <> 'customer' OR pc.`source_entity_id` IS NULL)
+  GROUP BY pc.`id`
+  HAVING COUNT(DISTINCT c.`id`) = 1
+)
+UPDATE `project_contacts`
+SET
+  `source_entity_type` = 'customer',
+  `source_entity_id` = (
+    SELECT m.`directory_id` FROM `owner_matches` m
+    WHERE m.`project_contact_id` = `project_contacts`.`id`
+  ),
+  `updated_at` = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE `id` IN (SELECT `project_contact_id` FROM `owner_matches`);
+--> statement-breakpoint
+
+WITH `vendor_matches` AS (
+  SELECT pc.`id` AS `project_contact_id`, MIN(v.`id`) AS `directory_id`
+  FROM `project_contacts` pc
+  INNER JOIN `projects` p ON p.`id` = pc.`project_id`
+  INNER JOIN `vendors` v
+    ON v.`organization_id` = p.`organization_id`
+   AND (
+     (pc.`email` IS NOT NULL AND trim(pc.`email`) <> ''
+       AND v.`email` IS NOT NULL AND trim(v.`email`) <> ''
+       AND lower(trim(pc.`email`)) = lower(trim(v.`email`)))
+     OR lower(trim(pc.`display_name`)) = lower(trim(v.`name`))
+     OR (pc.`company_name` IS NOT NULL AND trim(pc.`company_name`) <> ''
+       AND lower(trim(pc.`company_name`)) = lower(trim(v.`name`)))
+   )
+  WHERE pc.`active` = 1
+    AND pc.`contact_type` IN ('subcontractor', 'supplier')
+    AND (pc.`source_entity_type` <> 'vendor' OR pc.`source_entity_id` IS NULL)
+  GROUP BY pc.`id`
+  HAVING COUNT(DISTINCT v.`id`) = 1
+)
+UPDATE `project_contacts`
+SET
+  `source_entity_type` = 'vendor',
+  `source_entity_id` = (
+    SELECT m.`directory_id` FROM `vendor_matches` m
+    WHERE m.`project_contact_id` = `project_contacts`.`id`
+  ),
+  `updated_at` = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE `id` IN (SELECT `project_contact_id` FROM `vendor_matches`);
+--> statement-breakpoint
+
+WITH `team_matches` AS (
+  SELECT pc.`id` AS `project_contact_id`, MIN(u.`id`) AS `directory_id`
+  FROM `project_contacts` pc
+  INNER JOIN `projects` p ON p.`id` = pc.`project_id`
+  INNER JOIN `organization_members` om ON om.`organization_id` = p.`organization_id`
+  INNER JOIN `users` u
+    ON u.`id` = om.`user_id`
+   AND u.`is_active` = 1
+   AND u.`role` NOT IN ('client', 'subcontractor', 'supplier', 'guest')
+   AND (
+     (pc.`email` IS NOT NULL AND trim(pc.`email`) <> ''
+       AND lower(trim(pc.`email`)) = lower(trim(u.`email`)))
+     OR lower(trim(pc.`display_name`)) = lower(trim(COALESCE(
+       NULLIF(trim(u.`display_name`), ''),
+       NULLIF(trim(COALESCE(u.`first_name`, '') || ' ' || COALESCE(u.`last_name`, '')), ''),
+       u.`email`
+     )))
+   )
+  WHERE pc.`active` = 1
+    AND pc.`contact_type` = 'internal'
+    AND (pc.`source_entity_type` <> 'user' OR pc.`source_entity_id` IS NULL)
+  GROUP BY pc.`id`
+  HAVING COUNT(DISTINCT u.`id`) = 1
+)
+UPDATE `project_contacts`
+SET
+  `source_entity_type` = 'user',
+  `source_entity_id` = (
+    SELECT m.`directory_id` FROM `team_matches` m
+    WHERE m.`project_contact_id` = `project_contacts`.`id`
+  ),
+  `updated_at` = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE `id` IN (SELECT `project_contact_id` FROM `team_matches`);
+--> statement-breakpoint
+
+-- Keep the project-scoped snapshot synchronized with its canonical linked
+-- directory identity. A blank directory field never erases known project data.
+WITH `customer_identity` AS (
+  SELECT pc.`id` AS `project_contact_id`, c.`email`, c.`phone`, c.`address`
+  FROM `project_contacts` pc
+  INNER JOIN `projects` p ON p.`id` = pc.`project_id`
+  INNER JOIN `customers` c
+    ON c.`id` = pc.`source_entity_id`
+   AND c.`organization_id` = p.`organization_id`
+  WHERE pc.`source_entity_type` = 'customer'
+)
+UPDATE `project_contacts`
+SET
+  `email` = COALESCE((SELECT NULLIF(trim(i.`email`), '') FROM `customer_identity` i WHERE i.`project_contact_id` = `project_contacts`.`id`), `email`),
+  `phone` = COALESCE((SELECT NULLIF(trim(i.`phone`), '') FROM `customer_identity` i WHERE i.`project_contact_id` = `project_contacts`.`id`), `phone`),
+  `address` = COALESCE((SELECT NULLIF(trim(i.`address`), '') FROM `customer_identity` i WHERE i.`project_contact_id` = `project_contacts`.`id`), `address`),
+  `updated_at` = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE `id` IN (SELECT `project_contact_id` FROM `customer_identity`);
+--> statement-breakpoint
+
+WITH `vendor_identity` AS (
+  SELECT pc.`id` AS `project_contact_id`, v.`email`, v.`phone`, v.`address`
+  FROM `project_contacts` pc
+  INNER JOIN `projects` p ON p.`id` = pc.`project_id`
+  INNER JOIN `vendors` v
+    ON v.`id` = pc.`source_entity_id`
+   AND v.`organization_id` = p.`organization_id`
+  WHERE pc.`source_entity_type` = 'vendor'
+)
+UPDATE `project_contacts`
+SET
+  `email` = COALESCE((SELECT NULLIF(trim(i.`email`), '') FROM `vendor_identity` i WHERE i.`project_contact_id` = `project_contacts`.`id`), `email`),
+  `phone` = COALESCE((SELECT NULLIF(trim(i.`phone`), '') FROM `vendor_identity` i WHERE i.`project_contact_id` = `project_contacts`.`id`), `phone`),
+  `address` = COALESCE((SELECT NULLIF(trim(i.`address`), '') FROM `vendor_identity` i WHERE i.`project_contact_id` = `project_contacts`.`id`), `address`),
+  `updated_at` = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE `id` IN (SELECT `project_contact_id` FROM `vendor_identity`);
+--> statement-breakpoint
+
+WITH `team_identity` AS (
+  SELECT DISTINCT pc.`id` AS `project_contact_id`, u.`email`, u.`phone`, u.`address`
+  FROM `project_contacts` pc
+  INNER JOIN `projects` p ON p.`id` = pc.`project_id`
+  INNER JOIN `organization_members` om ON om.`organization_id` = p.`organization_id`
+  INNER JOIN `users` u
+    ON u.`id` = pc.`source_entity_id`
+   AND u.`id` = om.`user_id`
+  WHERE pc.`source_entity_type` = 'user'
+)
+UPDATE `project_contacts`
+SET
+  `email` = COALESCE((SELECT NULLIF(trim(i.`email`), '') FROM `team_identity` i WHERE i.`project_contact_id` = `project_contacts`.`id`), `email`),
+  `phone` = COALESCE((SELECT NULLIF(trim(i.`phone`), '') FROM `team_identity` i WHERE i.`project_contact_id` = `project_contacts`.`id`), `phone`),
+  `address` = COALESCE((SELECT NULLIF(trim(i.`address`), '') FROM `team_identity` i WHERE i.`project_contact_id` = `project_contacts`.`id`), `address`),
+  `updated_at` = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE `id` IN (SELECT `project_contact_id` FROM `team_identity`);

--- a/src/app/actions/project-access-invitations.ts
+++ b/src/app/actions/project-access-invitations.ts
@@ -1,11 +1,12 @@
 "use server"
 
-import { and, eq, sql } from "drizzle-orm"
+import { and, desc, eq, or, sql } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { z } from "zod/v4"
 
 import { getDb } from "@/db"
 import {
+  customers,
   projectAccessInvitations,
   projectContacts,
   projectMembers,
@@ -13,6 +14,7 @@ import {
   organizations,
   projects,
   users,
+  vendors,
 } from "@/db/schema"
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
@@ -21,6 +23,8 @@ import { sendCompassEmail } from "@/lib/email/compass-email"
 import { buildProjectAccessWelcomeHtml } from "@/lib/email/project-access-welcome"
 import { requirePermission } from "@/lib/permissions"
 import { ensureProjectAudienceConversation } from "@/lib/project-audience-conversations"
+import { projectContactAccessStatus } from "@/lib/project-contact-access-status"
+import { resolveProjectContactIdentity } from "@/lib/project-contact-directory-identity"
 import {
   isExternalProjectRole,
   isInternalStaffRole,
@@ -186,9 +190,52 @@ export async function sendProjectAccessInvitation(
         projectName: projects.name,
         projectNumber: projects.projectNumber,
         organizationId: projects.organizationId,
+        customer: {
+          email: customers.email,
+          phone: customers.phone,
+          address: customers.address,
+        },
+        vendor: {
+          email: vendors.email,
+          phone: vendors.phone,
+          address: vendors.address,
+        },
+        teamMember: {
+          email: users.email,
+          phone: users.phone,
+          address: users.address,
+        },
       })
       .from(projectContacts)
       .innerJoin(projects, eq(projects.id, projectContacts.projectId))
+      .leftJoin(
+        customers,
+        and(
+          eq(projectContacts.sourceEntityType, "customer"),
+          eq(projectContacts.sourceEntityId, customers.id),
+          eq(customers.organizationId, projects.organizationId)
+        )
+      )
+      .leftJoin(
+        vendors,
+        and(
+          eq(projectContacts.sourceEntityType, "vendor"),
+          eq(projectContacts.sourceEntityId, vendors.id),
+          eq(vendors.organizationId, projects.organizationId)
+        )
+      )
+      .leftJoin(
+        users,
+        and(
+          eq(projectContacts.sourceEntityType, "user"),
+          eq(projectContacts.sourceEntityId, users.id),
+          sql`exists (
+            select 1 from ${organizationMembers}
+            where ${organizationMembers.userId} = ${users.id}
+              and ${organizationMembers.organizationId} = ${projects.organizationId}
+          )`
+        )
+      )
       .where(
         and(
           eq(projectContacts.id, parsed.data.contactId),
@@ -203,7 +250,23 @@ export async function sendProjectAccessInvitation(
       return { success: false, error: "Project contact not found." }
     }
 
-    const email = row.contact.email?.trim().toLowerCase() ?? ""
+    const directoryIdentity =
+      row.contact.sourceEntityType === "customer"
+        ? row.customer
+        : row.contact.sourceEntityType === "vendor"
+          ? row.vendor
+          : row.contact.sourceEntityType === "user"
+            ? row.teamMember
+            : null
+    const identity = resolveProjectContactIdentity(
+      {
+        email: row.contact.email,
+        phone: row.contact.phone,
+        address: row.contact.address,
+      },
+      directoryIdentity
+    )
+    const email = identity.email?.toLowerCase() ?? ""
     if (!email) {
       return {
         success: false,
@@ -216,6 +279,12 @@ export async function sendProjectAccessInvitation(
     }
 
     const now = new Date().toISOString()
+    await db
+      .update(projectContacts)
+      .set({ ...identity, updatedAt: now })
+      .where(eq(projectContacts.id, row.contact.id))
+      .run()
+
     const existingUser = await db
       .select({
         id: users.id,
@@ -238,6 +307,51 @@ export async function sendProjectAccessInvitation(
         error:
           "This Compass account is deactivated. Reactivate it in People before assigning project access.",
       }
+    }
+    const pendingInvitation = !activeExistingUser
+      ? await db
+          .select({
+            id: projectAccessInvitations.id,
+            workosExpiresAt: projectAccessInvitations.workosExpiresAt,
+          })
+          .from(projectAccessInvitations)
+          .where(
+            and(
+              eq(projectAccessInvitations.projectId, parsed.data.projectId),
+              eq(projectAccessInvitations.status, "sent"),
+              or(
+                eq(projectAccessInvitations.projectContactId, row.contact.id),
+                sql`lower(trim(${projectAccessInvitations.email})) = ${email}`
+              )
+            )
+          )
+          .orderBy(desc(projectAccessInvitations.invitedAt))
+          .get()
+      : null
+    if (pendingInvitation) {
+      const pendingStatus = projectContactAccessStatus({
+        activeProjectMember: false,
+        latestInvitation: {
+          status: "sent",
+          workosExpiresAt: pendingInvitation.workosExpiresAt,
+          acceptedUserActive: null,
+        },
+        now: new Date(now),
+      })
+      if (pendingStatus === "pending") {
+        revalidatePath(`/dashboard/projects/${parsed.data.projectId}/contacts`)
+        return {
+          success: true,
+          accessStatus: "invited",
+          warning: "This contact already has a current invitation.",
+        }
+      }
+
+      await db
+        .update(projectAccessInvitations)
+        .set({ status: "expired", updatedAt: now })
+        .where(eq(projectAccessInvitations.id, pendingInvitation.id))
+        .run()
     }
     const internalMembership = activeExistingUser
       ? await db
@@ -289,14 +403,14 @@ export async function sendProjectAccessInvitation(
 
     if (activeExistingUser) {
       if (
-        (!activeExistingUser.phone && row.contact.phone) ||
-        (!activeExistingUser.address && row.contact.address)
+        (!activeExistingUser.phone && identity.phone) ||
+        (!activeExistingUser.address && identity.address)
       ) {
         await db
           .update(users)
           .set({
-            phone: activeExistingUser.phone ?? row.contact.phone,
-            address: activeExistingUser.address ?? row.contact.address,
+            phone: activeExistingUser.phone ?? identity.phone,
+            address: activeExistingUser.address ?? identity.address,
             updatedAt: now,
           })
           .where(eq(users.id, activeExistingUser.id))

--- a/src/app/actions/project-contacts.ts
+++ b/src/app/actions/project-contacts.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { and, asc, desc, eq, inArray, or } from "drizzle-orm"
+import { and, asc, desc, eq, inArray, or, sql } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
@@ -33,6 +33,7 @@ import {
   type ProjectContactAccessStatus,
   type ProjectContactInvitationSnapshot,
 } from "@/lib/project-contact-access-status"
+import { resolveProjectContactIdentity } from "@/lib/project-contact-directory-identity"
 
 export type ProjectContactType =
   | "owner"
@@ -593,34 +594,99 @@ export async function getProjectContactsSummary(
             )
           )
 
-  const rows = await db
-    .select()
+  const projectRow = await db
+    .select({ organizationId: projects.organizationId })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .get()
+  if (!projectRow?.organizationId) throw new Error("Project not found")
+  const organizationId = projectRow.organizationId
+  const directoryRows = await db
+    .select({
+      contact: projectContacts,
+      customer: {
+        email: customers.email,
+        phone: customers.phone,
+        address: customers.address,
+      },
+      vendor: {
+        email: vendors.email,
+        phone: vendors.phone,
+        address: vendors.address,
+      },
+      teamMember: {
+        email: users.email,
+        phone: users.phone,
+        address: users.address,
+      },
+    })
     .from(projectContacts)
+    .leftJoin(
+      customers,
+      and(
+        eq(projectContacts.sourceEntityType, "customer"),
+        eq(projectContacts.sourceEntityId, customers.id),
+        eq(customers.organizationId, organizationId)
+      )
+    )
+    .leftJoin(
+      vendors,
+      and(
+        eq(projectContacts.sourceEntityType, "vendor"),
+        eq(projectContacts.sourceEntityId, vendors.id),
+        eq(vendors.organizationId, organizationId)
+      )
+    )
+    .leftJoin(
+      users,
+      and(
+        eq(projectContacts.sourceEntityType, "user"),
+        eq(projectContacts.sourceEntityId, users.id),
+        sql`exists (
+          select 1 from ${organizationMembers}
+          where ${organizationMembers.userId} = ${users.id}
+            and ${organizationMembers.organizationId} = ${organizationId}
+        )`
+      )
+    )
     .where(visibilityWhere)
     .orderBy(
       asc(projectContacts.sortOrder),
       asc(projectContacts.contactType),
       asc(projectContacts.displayName)
     )
+  const rows = directoryRows.map((row) => {
+    const directoryIdentity =
+      row.contact.sourceEntityType === "customer"
+        ? row.customer
+        : row.contact.sourceEntityType === "vendor"
+          ? row.vendor
+          : row.contact.sourceEntityType === "user"
+            ? row.teamMember
+            : null
+    const identity = resolveProjectContactIdentity(
+      {
+        email: row.contact.email,
+        phone: row.contact.phone,
+        address: row.contact.address,
+      },
+      directoryIdentity
+    )
 
-  const projectRow = await db
-    .select({ organizationId: projects.organizationId })
-    .from(projects)
-    .where(eq(projects.id, projectId))
-    .get()
-  const directoryIdentityKeys = projectRow?.organizationId
-    ? await activeDirectoryIdentityKeys({
-        db,
-        organizationId: projectRow.organizationId,
-        entityIds: rows.flatMap((row) =>
-          (row.sourceEntityType === "customer" ||
-            row.sourceEntityType === "vendor") &&
-          row.sourceEntityId
-            ? [row.sourceEntityId]
-            : []
-        ),
-      })
-    : new Set<string>()
+    return { ...row.contact, ...identity }
+  })
+
+  const directoryIdentityKeys = await activeDirectoryIdentityKeys({
+    db,
+    organizationId,
+    entityIds: rows.flatMap((row) =>
+      (row.sourceEntityType === "customer" ||
+        row.sourceEntityType === "vendor") &&
+      row.sourceEntityId
+        ? [row.sourceEntityId]
+        : []
+    ),
+  })
 
   const invitationRows = await db
     .select({

--- a/src/components/projects/project-contact-invite-button.tsx
+++ b/src/components/projects/project-contact-invite-button.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import { IconMailForward } from "@tabler/icons-react"
+import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 
 import { sendProjectAccessInvitation } from "@/app/actions/project-access-invitations"
@@ -43,6 +44,7 @@ export function ProjectContactInviteButton({
   readonly contactEmail: string
   readonly contactType: InvitableContactType
 }): React.ReactElement {
+  const router = useRouter()
   const template = projectAccessWelcomeTemplate({
     recipientName: contactName,
     projectLabel,
@@ -85,6 +87,7 @@ export function ProjectContactInviteButton({
         toast.success("Compass invitation and welcome email sent")
       }
       setOpen(false)
+      router.refresh()
     } catch {
       toast.error("Unable to send the Compass invitation")
     } finally {

--- a/src/components/projects/project-contact-invite-launcher.tsx
+++ b/src/components/projects/project-contact-invite-launcher.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import { Check, ChevronsUpDown } from "lucide-react"
+import { useRouter } from "next/navigation"
 import { IconMailForward } from "@tabler/icons-react"
 import { toast } from "sonner"
 
@@ -33,6 +34,7 @@ import {
 } from "@/components/ui/sheet"
 import { Textarea } from "@/components/ui/textarea"
 import { projectAccessWelcomeTemplate } from "@/lib/email/project-access-welcome"
+import { projectContactCanInvite } from "@/lib/project-contact-access-status"
 import { cn } from "@/lib/utils"
 
 type InvitableContact = ProjectContactItem & {
@@ -42,7 +44,10 @@ type InvitableContact = ProjectContactItem & {
 function isInvitableContact(
   contact: ProjectContactItem
 ): contact is InvitableContact {
-  return Boolean(contact.email?.trim())
+  return (
+    Boolean(contact.email?.trim()) &&
+    projectContactCanInvite(contact.accessStatus)
+  )
 }
 
 function accessLabel(contactType: ProjectContactItem["contactType"]): string {
@@ -61,6 +66,7 @@ export function ProjectContactInviteLauncher({
   readonly projectLabel: string
   readonly contacts: readonly ProjectContactItem[]
 }): React.ReactElement | null {
+  const router = useRouter()
   const eligibleContacts = contacts.filter(isInvitableContact)
   const [sheetOpen, setSheetOpen] = React.useState(false)
   const [contactPickerOpen, setContactPickerOpen] = React.useState(false)
@@ -117,6 +123,7 @@ export function ProjectContactInviteLauncher({
         toast.success("Compass invitation and welcome email sent")
       }
       handleOpenChange(false)
+      router.refresh()
     } catch {
       toast.error("Unable to send the Compass invitation")
     } finally {

--- a/src/components/projects/project-contacts-panel.tsx
+++ b/src/components/projects/project-contacts-panel.tsx
@@ -21,6 +21,7 @@ import { ProjectContactEditor } from "@/components/projects/project-contact-mana
 import { ProjectContactInviteButton } from "@/components/projects/project-contact-invite-button"
 import { ProjectContactInviteLauncher } from "@/components/projects/project-contact-invite-launcher"
 import { Badge } from "@/components/ui/badge"
+import { projectContactCanInvite } from "@/lib/project-contact-access-status"
 
 type ProjectContactDisplayGroupId = "customers" | "vendors" | "internal"
 
@@ -94,7 +95,7 @@ function accessStatusLabel(contact: ProjectContactItem): string {
     case "active":
       return "Active"
     case "pending":
-      return "Pending"
+      return "Invited"
     case "expired":
       return "Expired"
     case "inactive":
@@ -196,18 +197,20 @@ function ContactCard({
         </p>
       )}
 
-      {!compact && contact.email && (
-        <div className="mt-3 flex justify-end">
-          <ProjectContactInviteButton
-            projectId={projectId}
-            projectLabel={projectLabel}
-            contactId={contact.id}
-            contactName={contact.displayName}
-            contactEmail={contact.email}
-            contactType={contact.contactType}
-          />
-        </div>
-      )}
+      {!compact &&
+        contact.email &&
+        projectContactCanInvite(contact.accessStatus) && (
+          <div className="mt-3 flex justify-end">
+            <ProjectContactInviteButton
+              projectId={projectId}
+              projectLabel={projectLabel}
+              contactId={contact.id}
+              contactName={contact.displayName}
+              contactEmail={contact.email}
+              contactType={contact.contactType}
+            />
+          </div>
+        )}
     </article>
   )
 }

--- a/src/lib/__tests__/project-contact-access-status.test.ts
+++ b/src/lib/__tests__/project-contact-access-status.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { projectContactAccessStatus } from "@/lib/project-contact-access-status"
+import {
+  projectContactAccessStatus,
+  projectContactCanInvite,
+} from "@/lib/project-contact-access-status"
 
 const NOW = new Date("2026-07-29T20:00:00.000Z")
 
@@ -63,5 +66,15 @@ describe("projectContactAccessStatus", () => {
         now: NOW,
       })
     ).toBe("inactive")
+  })
+})
+
+describe("projectContactCanInvite", () => {
+  it("allows new and expired invitations without duplicating current access", () => {
+    expect(projectContactCanInvite("not_invited")).toBe(true)
+    expect(projectContactCanInvite("expired")).toBe(true)
+    expect(projectContactCanInvite("pending")).toBe(false)
+    expect(projectContactCanInvite("active")).toBe(false)
+    expect(projectContactCanInvite("inactive")).toBe(false)
   })
 })

--- a/src/lib/__tests__/project-contact-directory-identity.test.ts
+++ b/src/lib/__tests__/project-contact-directory-identity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveProjectContactIdentity } from "@/lib/project-contact-directory-identity"
+
+describe("resolveProjectContactIdentity", () => {
+  it("uses linked directory identity as the canonical contact information", () => {
+    expect(
+      resolveProjectContactIdentity(
+        {
+          email: "old@example.com",
+          phone: "303-555-0100",
+          address: "Old address",
+        },
+        {
+          email: " current@example.com ",
+          phone: "303-555-0199",
+          address: "Current address",
+        }
+      )
+    ).toEqual({
+      email: "current@example.com",
+      phone: "303-555-0199",
+      address: "Current address",
+    })
+  })
+
+  it("preserves project snapshots when a linked directory field is blank", () => {
+    expect(
+      resolveProjectContactIdentity(
+        {
+          email: "project@example.com",
+          phone: "303-555-0100",
+          address: null,
+        },
+        { email: "", phone: null, address: "  " }
+      )
+    ).toEqual({
+      email: "project@example.com",
+      phone: "303-555-0100",
+      address: null,
+    })
+  })
+})

--- a/src/lib/project-contact-access-status.ts
+++ b/src/lib/project-contact-access-status.ts
@@ -11,6 +11,12 @@ export type ProjectContactInvitationSnapshot = {
   readonly acceptedUserActive: boolean | null
 }
 
+export function projectContactCanInvite(
+  status: ProjectContactAccessStatus
+): boolean {
+  return status === "not_invited" || status === "expired"
+}
+
 export function projectContactAccessStatus(input: {
   readonly activeProjectMember: boolean
   readonly latestInvitation: ProjectContactInvitationSnapshot | null

--- a/src/lib/project-contact-directory-identity.ts
+++ b/src/lib/project-contact-directory-identity.ts
@@ -1,0 +1,40 @@
+export type ProjectContactIdentity = {
+  readonly email: string | null
+  readonly phone: string | null
+  readonly address: string | null
+}
+
+function preferredValue(
+  directoryValue: string | null,
+  projectValue: string | null
+): string | null {
+  const normalizedDirectoryValue = directoryValue?.trim() ?? ""
+  if (normalizedDirectoryValue) return normalizedDirectoryValue
+
+  const normalizedProjectValue = projectValue?.trim() ?? ""
+  return normalizedProjectValue || null
+}
+
+/**
+ * Linked directory records own contact identity. Project contacts retain a
+ * snapshot so imports and offline reads continue to work when a directory
+ * field is empty or temporarily unavailable.
+ */
+export function resolveProjectContactIdentity(
+  projectIdentity: ProjectContactIdentity,
+  directoryIdentity: ProjectContactIdentity | null
+): ProjectContactIdentity {
+  if (!directoryIdentity) {
+    return {
+      email: preferredValue(null, projectIdentity.email),
+      phone: preferredValue(null, projectIdentity.phone),
+      address: preferredValue(null, projectIdentity.address),
+    }
+  }
+
+  return {
+    email: preferredValue(directoryIdentity.email, projectIdentity.email),
+    phone: preferredValue(directoryIdentity.phone, projectIdentity.phone),
+    address: preferredValue(directoryIdentity.address, projectIdentity.address),
+  }
+}


### PR DESCRIPTION
## what

- Reconcile legacy Buildertrend project contacts with unique organization-scoped customer, vendor, and internal-team directory records.
- Hydrate project contact identity from its linked canonical directory record so eligible contacts expose invitation controls.
- Show current invitations as **Invited**, prevent duplicate invite actions, refresh status after sending, and allow expired invitations to be sent again.

## why

Imported project contacts retained stale or blank snapshots even when they were linked to directory contacts. That hid invitation controls and left already-invited contacts showing another invite action.

## how to test

- `bun run test` — 891 passed
- `bun lint` — 0 errors (80 pre-existing warnings)
- `bunx tsc --noEmit` — passed
- `bun run build` — passed
- Local imported-data migration rehearsal — passed
- Cross-organization migration rehearsal — project data preserved

## notes

Directory hydration fails closed across organizations. Ambiguous legacy contacts remain unchanged for manual review.