### PR TITLE
feat(portal): add sub-vendor workflow parity

### DIFF
--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -8,7 +8,6 @@ import {
   dailyLogs,
   organizationMembers,
   ownerProjectUpdates,
-  projectContacts,
   projectMembers,
   projectOperations,
   projectRfis,
@@ -27,6 +26,7 @@ import {
   type ProjectAudience,
 } from "@/lib/project-audience-access"
 import { ensureProjectAudienceConversation } from "@/lib/project-audience-conversations"
+import { getProjectAudienceViewerContact } from "@/lib/project-audience-viewer-contact"
 import { isAssignedVisibleAudienceTeamMember } from "@/lib/project-audience-team"
 import { isInternalStaffRole } from "@/lib/user-roles"
 import {
@@ -38,6 +38,14 @@ import { parsePublishedScheduleSnapshot } from "@/lib/schedule/publications"
 import { projectAudiencePhotoUrl } from "@/lib/photo-sources"
 import { canViewerConfirmScheduleTask } from "@/lib/schedule/confirmation"
 import { isWarrantyProjectStage } from "@/lib/warranty/status"
+import {
+  isPortalVisibleRfqStatus,
+  parsePortalRfqPayload,
+  portalRfqMatchesRecipient,
+  type PortalRfqDocumentLink,
+  type PortalRfqScopeItem,
+  type PortalRfqVendorResponse,
+} from "@/lib/rfqs/portal-response"
 
 export type { ProjectAudience } from "@/lib/project-audience-access"
 
@@ -113,6 +121,22 @@ export type AudienceRfi = {
   readonly answeredAt: string | null
 }
 
+export type AudienceRfq = {
+  readonly id: string
+  readonly number: string | null
+  readonly title: string
+  readonly description: string | null
+  readonly status: string
+  readonly priority: string
+  readonly companyName: string | null
+  readonly vendorCategory: string | null
+  readonly dueDate: string | null
+  readonly amount: number | null
+  readonly scopeItems: readonly PortalRfqScopeItem[]
+  readonly documentLinks: readonly PortalRfqDocumentLink[]
+  readonly vendorResponse: PortalRfqVendorResponse | null
+}
+
 export type AudienceMessageChannel = {
   readonly id: string
   readonly name: string
@@ -161,6 +185,7 @@ export type ProjectAudiencePreview = {
   readonly scheduleItems: readonly AudienceScheduleItem[]
   readonly operations: readonly AudienceOperationItem[]
   readonly rfis: readonly AudienceRfi[]
+  readonly rfqs: readonly AudienceRfq[]
   readonly messageChannels: readonly AudienceMessageChannel[]
   readonly contacts: readonly AudienceContact[]
 }
@@ -322,6 +347,14 @@ export async function getProjectAudiencePreview(
             }))
         )
 
+  const viewerContact =
+    audience === "sub_vendor" && !viewerIsInternal
+      ? await getProjectAudienceViewerContact(db, projectId, {
+          id: viewer.id,
+          email: viewer.email,
+        })
+      : null
+
   const visibilityFilter =
     audience === "owner"
       ? or(
@@ -454,37 +487,6 @@ export async function getProjectAudiencePreview(
       left.id.localeCompare(right.id)
   )
 
-  const contactRows = await db
-    .select({
-      id: projectContacts.id,
-      userId: projectContacts.sourceEntityId,
-      contactType: projectContacts.contactType,
-      displayName: projectContacts.displayName,
-      companyName: projectContacts.companyName,
-      role: projectContacts.role,
-      trade: projectContacts.trade,
-      csiDivision: projectContacts.csiDivision,
-      csiDivisionName: projectContacts.csiDivisionName,
-      email: projectContacts.email,
-      phone: projectContacts.phone,
-      primaryContact: projectContacts.primaryContact,
-    })
-    .from(projectContacts)
-    .where(
-      audience === "owner"
-        ? and(
-            eq(projectContacts.projectId, projectId),
-            eq(projectContacts.active, true),
-            eq(projectContacts.ownerPortalVisible, true)
-          )
-        : and(
-            eq(projectContacts.projectId, projectId),
-            eq(projectContacts.active, true),
-            eq(projectContacts.subVendorPortalVisible, true)
-          )
-    )
-    .orderBy(asc(projectContacts.sortOrder), asc(projectContacts.displayName))
-
   const ownerUpdateRows =
     audience === "owner"
       ? await db
@@ -521,8 +523,11 @@ export async function getProjectAudiencePreview(
             priority: projectOperations.priority,
             assigneeName: projectOperations.assigneeName,
             companyName: projectOperations.companyName,
+            description: projectOperations.description,
             startDate: projectOperations.startDate,
             dueDate: projectOperations.dueDate,
+            amount: projectOperations.amount,
+            sagePayloadJson: projectOperations.sagePayloadJson,
           })
           .from(projectOperations)
           .where(eq(projectOperations.projectId, projectId))
@@ -560,7 +565,7 @@ export async function getProjectAudiencePreview(
   const audienceContactId =
     viewerIsInternal
       ? null
-      : contactRows.find((contact) => contact.userId === viewer.id)?.id ?? null
+      : viewerContact?.id ?? null
   if (
     audience === "owner" ||
     (!viewerIsInternal && audienceContactId !== null)
@@ -710,6 +715,45 @@ export async function getProjectAudiencePreview(
         }))
       : audienceScheduleRows.map(visibleScheduleItem)
 
+  const audienceRfqs: readonly AudienceRfq[] = operationRows
+    .filter((operation) => {
+      if (
+        operation.sourceRecordType !== "rfq" ||
+        !isPortalVisibleRfqStatus(operation.status)
+      ) {
+        return false
+      }
+      if (viewerIsInternal) return true
+      if (!viewerContact) return false
+      const payload = parsePortalRfqPayload(operation.sagePayloadJson)
+      return portalRfqMatchesRecipient({
+        recipientEmail: payload.recipientEmail,
+        companyName: operation.companyName,
+        assigneeName: operation.assigneeName,
+        viewerEmail: viewer.email,
+        viewerCompanyName: viewerContact.companyName,
+        viewerDisplayName: viewerContact.displayName,
+      })
+    })
+    .map((operation) => {
+      const payload = parsePortalRfqPayload(operation.sagePayloadJson)
+      return {
+        id: operation.id,
+        number: operation.sourceRecordNumber,
+        title: operation.title,
+        description: operation.description,
+        status: operation.status,
+        priority: operation.priority,
+        companyName: operation.companyName,
+        vendorCategory: payload.vendorCategory,
+        dueDate: operation.dueDate,
+        amount: operation.amount,
+        scopeItems: payload.scopeItems,
+        documentLinks: payload.documentLinks,
+        vendorResponse: payload.vendorResponse,
+      }
+    })
+
   return {
     audience,
     viewerIsInternal,
@@ -764,6 +808,7 @@ export async function getProjectAudiencePreview(
       )
       .slice(0, 10),
     rfis: rfiRows,
+    rfqs: audienceRfqs,
     messageChannels: messageChannelRows,
     contacts: visibleContactRows,
   }

--- a/src/app/actions/project-audience-sub-vendor.ts
+++ b/src/app/actions/project-audience-sub-vendor.ts
@@ -1,0 +1,367 @@
+"use server"
+
+import { and, eq, inArray } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import {
+  organizationMembers,
+  projectMembers,
+  projectOperations,
+  projectRfis,
+  users,
+} from "@/db/schema"
+import { requireAuth, type AuthUser } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import {
+  notifyRfiCreated,
+  notifyRfqResponseReceived,
+} from "@/lib/notifications/events"
+import { assertProjectAccess } from "@/lib/project-access"
+import type { ProjectAudienceViewerContact } from "@/lib/project-audience-viewer-contact"
+import { getProjectAudienceViewerContact } from "@/lib/project-audience-viewer-contact"
+import { isAssignedVisibleAudienceTeamMember } from "@/lib/project-audience-team"
+import {
+  parsePortalRfqPayload,
+  portalRfqCanReceiveResponse,
+  portalRfqMatchesRecipient,
+  withPortalRfqVendorResponse,
+} from "@/lib/rfqs/portal-response"
+import { validRfiPriority } from "@/lib/rfis/status"
+
+type SubVendorActionResult =
+  | { readonly success: true; readonly id: string }
+  | { readonly success: false; readonly error: string }
+
+export type CreateSubVendorRfiInput = {
+  readonly subject: string
+  readonly question: string
+  readonly priority: string
+  readonly recipientUserId: string
+}
+
+export type SubmitSubVendorRfqResponseInput = {
+  readonly decision: "quote" | "decline"
+  readonly amount: number | null
+  readonly leadTime: string | null
+  readonly validUntil: string | null
+  readonly notes: string | null
+}
+
+type SubVendorWriteContext = {
+  readonly db: ReturnType<typeof getDb>
+  readonly user: AuthUser
+  readonly organizationId: string
+  readonly projectNumber: string | null
+  readonly viewerContact: ProjectAudienceViewerContact
+}
+
+function cleanText(value: string | null, maximumLength = 10_000): string | null {
+  const trimmed = value?.trim() ?? ""
+  if (!trimmed) return null
+  if (trimmed.length > maximumLength) {
+    throw new Error(`Text must be ${maximumLength.toLocaleString()} characters or fewer.`)
+  }
+  return trimmed
+}
+
+function requireText(
+  value: string,
+  label: string,
+  maximumLength: number
+): string {
+  const cleaned = cleanText(value, maximumLength)
+  if (!cleaned) throw new Error(`${label} is required.`)
+  return cleaned
+}
+
+function validDate(value: string | null): string | null {
+  const cleaned = cleanText(value, 10)
+  if (!cleaned) return null
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(cleaned)) {
+    throw new Error("Valid until must be a valid date.")
+  }
+  return cleaned
+}
+
+async function getSubVendorWriteContext(
+  projectId: string
+): Promise<SubVendorWriteContext> {
+  const user = await requireAuth()
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const project = await assertProjectAccess(db, user, projectId)
+  if (!project.organizationId) throw new Error("Project organization is missing.")
+
+  const membership = await db
+    .select({ role: projectMembers.role })
+    .from(projectMembers)
+    .where(
+      and(
+        eq(projectMembers.projectId, projectId),
+        eq(projectMembers.userId, user.id)
+      )
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  if (
+    membership?.role !== "subcontractor" &&
+    membership?.role !== "supplier"
+  ) {
+    throw new Error("Only an assigned sub/vendor can use this action.")
+  }
+
+  const viewerContact = await getProjectAudienceViewerContact(db, projectId, {
+    id: user.id,
+    email: user.email,
+  })
+  if (!viewerContact) {
+    throw new Error("Your project contact record could not be verified.")
+  }
+
+  return {
+    db,
+    user,
+    organizationId: project.organizationId,
+    projectNumber: project.projectNumber,
+    viewerContact,
+  }
+}
+
+function rfiNumber(
+  projectNumber: string | null,
+  existingCount: number,
+  id: string
+): string {
+  const sequence = String(existingCount + 1).padStart(3, "0")
+  const prefix = projectNumber?.trim() ?? ""
+  return prefix
+    ? `${prefix}-RFI-${sequence}`
+    : `RFI-${sequence}-${id.slice(0, 6).toUpperCase()}`
+}
+
+function revalidateSubVendorWorkspace(projectId: string): void {
+  revalidatePath(`/preview/projects/${projectId}/sub-vendor`)
+  revalidatePath(`/preview/projects/${projectId}/sub-vendor/rfis`)
+  revalidatePath(`/preview/projects/${projectId}/sub-vendor/rfqs`)
+  revalidatePath(`/dashboard/projects/${projectId}/rfis`)
+  revalidatePath(`/dashboard/projects/${projectId}/rfqs`)
+  revalidatePath("/dashboard/rfis")
+}
+
+export async function createSubVendorRfi(
+  projectId: string,
+  input: CreateSubVendorRfiInput
+): Promise<SubVendorActionResult> {
+  try {
+    const context = await getSubVendorWriteContext(projectId)
+    const priority = validRfiPriority(input.priority)
+    if (!priority) return { success: false, error: "Choose a valid priority." }
+
+    const recipient = await context.db
+      .select({
+        id: users.id,
+        email: users.email,
+        displayName: users.displayName,
+        organizationRole: organizationMembers.role,
+        projectRole: projectMembers.role,
+      })
+      .from(projectMembers)
+      .innerJoin(users, eq(users.id, projectMembers.userId))
+      .innerJoin(
+        organizationMembers,
+        and(
+          eq(organizationMembers.userId, users.id),
+          eq(organizationMembers.organizationId, context.organizationId)
+        )
+      )
+      .where(
+        and(
+          eq(projectMembers.projectId, projectId),
+          eq(projectMembers.userId, input.recipientUserId),
+          eq(users.isActive, true)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (
+      !recipient ||
+      !isAssignedVisibleAudienceTeamMember({
+        userId: recipient.id,
+        email: recipient.email,
+        organizationRole: recipient.organizationRole,
+        projectRole: recipient.projectRole,
+      })
+    ) {
+      return { success: false, error: "Choose an assigned project team member." }
+    }
+
+    const rows = await context.db
+      .select({ id: projectRfis.id })
+      .from(projectRfis)
+      .where(eq(projectRfis.projectId, projectId))
+    const now = new Date().toISOString()
+    const id = crypto.randomUUID()
+    const inserted: typeof projectRfis.$inferInsert = {
+      id,
+      projectId,
+      sourceSystem: "compass_portal",
+      rfiNumber: rfiNumber(context.projectNumber, rows.length, id),
+      subject: requireText(input.subject, "Subject", 240),
+      question: requireText(input.question, "Question", 10_000),
+      status: "new",
+      priority,
+      audience: "sub_vendor",
+      requesterName: context.user.displayName ?? context.user.email,
+      assignedToName: recipient.displayName ?? recipient.email,
+      companyName: context.viewerContact.companyName,
+      submittedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }
+    await context.db.insert(projectRfis).values(inserted)
+    revalidateSubVendorWorkspace(projectId)
+
+    try {
+      await notifyRfiCreated({
+        organizationId: context.organizationId,
+        projectId,
+        rfiId: id,
+        rfiNumber: inserted.rfiNumber,
+        subject: inserted.subject,
+        assignedToName: inserted.assignedToName ?? null,
+        createdBy: context.user,
+      })
+    } catch (notificationError) {
+      console.error("[sub-vendor-rfi] notification error", notificationError)
+    }
+
+    return { success: true, id }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unable to send the RFI.",
+    }
+  }
+}
+
+export async function submitSubVendorRfqResponse(
+  projectId: string,
+  rfqId: string,
+  input: SubmitSubVendorRfqResponseInput
+): Promise<SubVendorActionResult> {
+  try {
+    const context = await getSubVendorWriteContext(projectId)
+    if (input.decision !== "quote" && input.decision !== "decline") {
+      return { success: false, error: "Choose quote or decline." }
+    }
+    const amount =
+      input.amount === null || !Number.isFinite(input.amount)
+        ? null
+        : Math.round(input.amount * 100) / 100
+    if (input.decision === "quote" && (amount === null || amount < 0)) {
+      return { success: false, error: "Enter a valid quote amount." }
+    }
+
+    const rfq = await context.db
+      .select()
+      .from(projectOperations)
+      .where(
+        and(
+          eq(projectOperations.id, rfqId),
+          eq(projectOperations.projectId, projectId),
+          eq(projectOperations.sourceRecordType, "rfq")
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!rfq) return { success: false, error: "RFQ not found." }
+    if (!portalRfqCanReceiveResponse(rfq.status)) {
+      return { success: false, error: "This RFQ is not accepting responses." }
+    }
+
+    const payload = parsePortalRfqPayload(rfq.sagePayloadJson)
+    if (
+      !portalRfqMatchesRecipient({
+        recipientEmail: payload.recipientEmail,
+        companyName: rfq.companyName,
+        assigneeName: rfq.assigneeName,
+        viewerEmail: context.user.email,
+        viewerCompanyName: context.viewerContact.companyName,
+        viewerDisplayName: context.viewerContact.displayName,
+      })
+    ) {
+      return { success: false, error: "This RFQ was assigned to another vendor." }
+    }
+
+    const now = new Date().toISOString()
+    const responseStatus =
+      input.decision === "decline" ? "declined" : "response_received"
+    await context.db
+      .update(projectOperations)
+      .set({
+        status: responseStatus,
+        amount: input.decision === "quote" ? amount : null,
+        sagePayloadJson: withPortalRfqVendorResponse(rfq.sagePayloadJson, {
+          decision: input.decision,
+          amount: input.decision === "quote" ? amount : null,
+          leadTime: cleanText(input.leadTime, 240),
+          validUntil: validDate(input.validUntil),
+          notes: cleanText(input.notes, 10_000),
+          responderUserId: context.user.id,
+          responderName: context.user.displayName ?? context.user.email,
+          responderCompany: context.viewerContact.companyName,
+          submittedAt: now,
+        }),
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(projectOperations.id, rfqId),
+          eq(projectOperations.projectId, projectId),
+          inArray(projectOperations.status, ["sent", "response_received"])
+        )
+      )
+    const updatedRfq = await context.db
+      .select({ status: projectOperations.status })
+      .from(projectOperations)
+      .where(
+        and(
+          eq(projectOperations.id, rfqId),
+          eq(projectOperations.projectId, projectId)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (updatedRfq?.status !== responseStatus) {
+      return {
+        success: false,
+        error: "The RFQ status changed. Refresh the page before responding.",
+      }
+    }
+    revalidateSubVendorWorkspace(projectId)
+
+    try {
+      await notifyRfqResponseReceived({
+        organizationId: context.organizationId,
+        projectId,
+        rfqId,
+        rfqNumber: rfq.sourceRecordNumber,
+        title: rfq.title,
+        decision: input.decision,
+        amount: input.decision === "quote" ? amount : null,
+        respondedBy: context.user,
+      })
+    } catch (notificationError) {
+      console.error("[sub-vendor-rfq] notification error", notificationError)
+    }
+
+    return { success: true, id: rfqId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Unable to submit the RFQ response.",
+    }
+  }
+}

--- a/src/app/actions/project-operations.ts
+++ b/src/app/actions/project-operations.ts
@@ -34,6 +34,10 @@ import {
   isPurchaseOrderStatus,
   isRfqStatus,
 } from "@/lib/project-operations/status"
+import {
+  parsePortalRfqPayload,
+  type PortalRfqVendorResponse,
+} from "@/lib/rfqs/portal-response"
 
 export type ProjectOperationKind = "purchase_order" | "rfq"
 
@@ -130,6 +134,7 @@ export type ProjectRfqItem = ProjectOperationItem & {
     readonly unresolvedPlaceholders: readonly string[]
     readonly requiresDocumentPackage: boolean
   } | null
+  readonly vendorResponse: PortalRfqVendorResponse | null
 }
 
 export type NextScheduleItem = {
@@ -896,6 +901,7 @@ function toRfqItem(
   recipientEmail: string | null
 ): ProjectRfqItem {
   const payload = parseJsonRecord(row.sagePayloadJson)
+  const portalPayload = parsePortalRfqPayload(row.sagePayloadJson)
 
   return {
     ...toOperationItem(row),
@@ -905,6 +911,7 @@ function toRfqItem(
     scopeItems: parseRfqScopeItems(payload, row.description),
     documentLinks: parseRfqDocumentLinks(payload),
     templateReview: parseRfqTemplateReview(payload),
+    vendorResponse: portalPayload.vendorResponse,
   }
 }
 
@@ -1741,6 +1748,9 @@ export async function updateProjectOperationStatus(
     revalidatePath("/dashboard/financials")
     revalidatePath("/dashboard/schedule")
     revalidatePath("/dashboard")
+    if (operationKind === "rfq") {
+      revalidatePath(`/preview/projects/${projectId}/sub-vendor/rfqs`)
+    }
 
     return { success: true, id: operationId }
   } catch (error) {
@@ -2116,6 +2126,9 @@ export async function updateRfqRequest(
     )
     const documentLinks = normalizeRfqDocumentLinks(input.documentLinks)
     const existingPayload = parseJsonRecord(existing[0].sagePayloadJson)
+    const existingVendorResponse = parsePortalRfqPayload(
+      existing[0].sagePayloadJson
+    ).vendorResponse
     const existingTemplateReview = parseRfqTemplateReview(existingPayload)
     const unresolvedPlaceholders = existingTemplateReview
       ? findTemplatePlaceholders(
@@ -2157,6 +2170,7 @@ export async function updateRfqRequest(
       scope: description,
       scopeItems,
       documentLinks,
+      vendorResponse: existingVendorResponse,
       templateReview:
         templateReview &&
         (templateReview.unresolvedPlaceholders.length > 0 ||

--- a/src/app/dashboard/projects/[id]/rfqs/page.tsx
+++ b/src/app/dashboard/projects/[id]/rfqs/page.tsx
@@ -157,6 +157,7 @@ function RfqCard({
 }): React.ReactElement {
   return (
     <article
+      id={`rfq-${rfq.id}`}
       data-rfq-id={rfq.id}
       className={cn(
         "border-l-2 border-y border-r bg-background px-4 py-3",
@@ -233,6 +234,43 @@ function RfqCard({
           {rfq.templateReview.requiresDocumentPackage && (
             <p className="mt-1 text-muted-foreground">
               Add the project plans/specifications package. Sharing stays disabled until review is complete.
+            </p>
+          )}
+        </div>
+      )}
+
+      {rfq.vendorResponse && (
+        <div className="mt-3 border-l-2 border-brand-hps-primary bg-muted/30 px-3 py-3 text-sm">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="font-medium">
+              {rfq.vendorResponse.decision === "decline"
+                ? "Vendor declined to quote"
+                : `Vendor quote: ${new Intl.NumberFormat("en-US", {
+                    style: "currency",
+                    currency: "USD",
+                  }).format(rfq.vendorResponse.amount ?? 0)}`}
+            </p>
+            <span className="text-xs text-muted-foreground">
+              {new Date(rfq.vendorResponse.submittedAt).toLocaleString("en-US")}
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Submitted by {rfq.vendorResponse.responderName}
+            {rfq.vendorResponse.responderCompany
+              ? ` · ${rfq.vendorResponse.responderCompany}`
+              : ""}
+          </p>
+          <div className="mt-2 flex flex-wrap gap-3 text-xs text-muted-foreground">
+            {rfq.vendorResponse.leadTime && (
+              <span>Lead time: {rfq.vendorResponse.leadTime}</span>
+            )}
+            {rfq.vendorResponse.validUntil && (
+              <span>Valid through {formatDate(rfq.vendorResponse.validUntil)}</span>
+            )}
+          </div>
+          {rfq.vendorResponse.notes && (
+            <p className="mt-2 whitespace-pre-wrap text-muted-foreground">
+              {rfq.vendorResponse.notes}
             </p>
           )}
         </div>

--- a/src/app/preview/projects/[id]/sub-vendor/rfqs/page.tsx
+++ b/src/app/preview/projects/[id]/sub-vendor/rfqs/page.tsx
@@ -1,0 +1,20 @@
+export const dynamic = "force-dynamic"
+
+import type * as React from "react"
+
+import { ProjectAudienceWorkspaceRoute } from "@/components/projects/project-audience-workspace-route"
+
+export default async function PartnerRfqsPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  return (
+    <ProjectAudienceWorkspaceRoute
+      projectId={id}
+      audience="sub_vendor"
+      section="rfqs"
+    />
+  )
+}

--- a/src/components/projects/project-audience-message-launcher.tsx
+++ b/src/components/projects/project-audience-message-launcher.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import { IconMessageCircle } from "@tabler/icons-react"
+
+import { Button } from "@/components/ui/button"
+import { ProjectAudienceDirectMessageDialog } from "@/components/projects/project-audience-direct-message-dialog"
+import type { ProjectAudienceMessageShortcut } from "@/lib/project-audience-direct-message"
+
+export function ProjectAudienceMessageLauncher({
+  shortcut,
+  className,
+}: {
+  readonly shortcut: ProjectAudienceMessageShortcut | null
+  readonly className?: string
+}): React.ReactElement | null {
+  const [open, setOpen] = React.useState(false)
+  if (!shortcut) return null
+
+  return (
+    <>
+      <Button type="button" variant="outline" className={className} onClick={() => setOpen(true)}>
+        <IconMessageCircle className="size-4" />
+        Message project team
+      </Button>
+      <ProjectAudienceDirectMessageDialog
+        open={open}
+        onOpenChange={setOpen}
+        shortcut={shortcut}
+      />
+    </>
+  )
+}

--- a/src/components/projects/project-audience-preview-shell.tsx
+++ b/src/components/projects/project-audience-preview-shell.tsx
@@ -12,6 +12,7 @@ import {
   IconMessageCircle,
   IconPhoto,
   IconQuestionMark,
+  IconShoppingCartQuestion,
   IconUsers,
   IconShieldCheck,
 } from "@tabler/icons-react"
@@ -105,6 +106,11 @@ const SUB_VENDOR_NAVIGATION: readonly PreviewNavigationItem[] = [
     label: "RFIs",
     section: "rfis",
     icon: <IconQuestionMark className="size-4" />,
+  },
+  {
+    label: "RFQs",
+    section: "rfqs",
+    icon: <IconShoppingCartQuestion className="size-4" />,
   },
   {
     label: "Change Orders",

--- a/src/components/projects/project-audience-preview.tsx
+++ b/src/components/projects/project-audience-preview.tsx
@@ -5,9 +5,11 @@ import {
   IconCalendarStats,
   IconChevronDown,
   IconClipboardCheck,
+  IconExternalLink,
   IconFolder,
   IconMessageCircle,
   IconQuestionMark,
+  IconShoppingCartQuestion,
   IconSparkles,
   IconUsers,
 } from "@tabler/icons-react"
@@ -19,6 +21,7 @@ import type {
   AudienceOwnerUpdate,
   AudienceProjectOption,
   AudienceRfi,
+  AudienceRfq,
   AudienceScheduleItem,
   ProjectAudience,
   ProjectAudiencePreview as ProjectAudiencePreviewData,
@@ -33,8 +36,11 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { OwnerCoverPhotoControl } from "@/components/projects/owner-cover-photo-control"
 import { ProjectEmailAddressCard } from "@/components/projects/project-email-address-card"
+import { ProjectAudienceMessageLauncher } from "@/components/projects/project-audience-message-launcher"
 import { ProjectAudiencePhotoGallery } from "@/components/projects/project-audience-photo-gallery"
 import { ProjectAudiencePreviewShell } from "@/components/projects/project-audience-preview-shell"
+import { ProjectAudienceRfiCreateDialog } from "@/components/projects/project-audience-rfi-create-dialog"
+import { ProjectAudienceRfqResponseDialog } from "@/components/projects/project-audience-rfq-response-dialog"
 import { ProjectAudienceSchedule } from "@/components/projects/project-audience-schedule"
 import {
   ownerUpdatePreviewHref,
@@ -60,6 +66,15 @@ function statusLabel(value: string): string {
     .split("_")
     .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
     .join(" ")
+}
+
+function formatMoney(value: number | null): string {
+  if (value === null) return "Not submitted"
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(value)
 }
 
 function projectLabel(data: ProjectAudiencePreviewData): string {
@@ -172,6 +187,125 @@ function RfiRow({
         {item.assignedToName && <span>Assigned: {item.assignedToName}</span>}
         {item.dueDate && <span>Due {formatDate(item.dueDate)}</span>}
       </div>
+    </article>
+  )
+}
+
+function RfqRow({
+  item,
+  projectId,
+  viewerIsInternal,
+}: {
+  readonly item: AudienceRfq
+  readonly projectId: string
+  readonly viewerIsInternal: boolean
+}): React.ReactElement {
+  return (
+    <article id={`rfq-${item.id}`} className="scroll-mt-24 border bg-background p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-xs font-medium text-muted-foreground">
+            {item.number ?? "Request for quote"}
+          </p>
+          <h3 className="mt-1 text-base font-semibold">{item.title}</h3>
+          <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+            {item.vendorCategory && <span>{item.vendorCategory}</span>}
+            {item.dueDate && <span>Response due {formatDate(item.dueDate)}</span>}
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant={item.status === "sent" ? "secondary" : "outline"}>
+            {statusLabel(item.status)}
+          </Badge>
+          <ProjectAudienceRfqResponseDialog
+            projectId={projectId}
+            rfqId={item.id}
+            rfqTitle={item.title}
+            status={item.status}
+            response={item.vendorResponse}
+            viewerIsInternal={viewerIsInternal}
+          />
+        </div>
+      </div>
+
+      {item.description && (
+        <p className="mt-4 whitespace-pre-wrap text-sm text-muted-foreground">
+          {item.description}
+        </p>
+      )}
+
+      {item.scopeItems.length > 0 && (
+        <div className="mt-4 overflow-hidden border">
+          <div className="grid grid-cols-[2.5rem_minmax(0,1fr)] gap-2 border-b bg-muted/40 px-3 py-2 text-xs font-medium text-muted-foreground sm:grid-cols-[2.5rem_minmax(0,1fr)_6rem_7rem]">
+            <span>#</span>
+            <span>Scope</span>
+            <span className="hidden sm:block">Phase</span>
+            <span className="hidden sm:block">Cost code</span>
+          </div>
+          {item.scopeItems.map((line) => (
+            <div
+              key={`${item.id}-${line.lineNumber}`}
+              className="grid grid-cols-[2.5rem_minmax(0,1fr)] gap-2 border-b px-3 py-2 text-xs last:border-b-0 sm:grid-cols-[2.5rem_minmax(0,1fr)_6rem_7rem]"
+            >
+              <span className="font-medium">{line.lineNumber}</span>
+              <span>
+                {line.description}
+                {line.notes && (
+                  <span className="mt-1 block text-muted-foreground">{line.notes}</span>
+                )}
+              </span>
+              <span className="hidden sm:block">{line.phaseCode ?? "-"}</span>
+              <span className="hidden sm:block">{line.costCode ?? "-"}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {item.documentLinks.length > 0 && (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {item.documentLinks.map((document) => (
+            <Button
+              key={`${item.id}-document-${document.lineNumber}`}
+              asChild
+              variant="outline"
+              size="sm"
+            >
+              <a href={document.url} target="_blank" rel="noreferrer">
+                {document.label}
+                <IconExternalLink className="size-3" />
+              </a>
+            </Button>
+          ))}
+        </div>
+      )}
+
+      {item.vendorResponse && (
+        <div className="mt-4 border-l-2 border-primary bg-primary/5 px-3 py-3 text-sm">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="font-medium">
+              {item.vendorResponse.decision === "decline"
+                ? "Declined to quote"
+                : `Quote submitted · ${formatMoney(item.vendorResponse.amount)}`}
+            </p>
+            <span className="text-xs text-muted-foreground">
+              {new Date(item.vendorResponse.submittedAt).toLocaleDateString("en-US")}
+            </span>
+          </div>
+          <div className="mt-2 flex flex-wrap gap-3 text-xs text-muted-foreground">
+            {item.vendorResponse.leadTime && (
+              <span>Lead time: {item.vendorResponse.leadTime}</span>
+            )}
+            {item.vendorResponse.validUntil && (
+              <span>Valid through {formatDate(item.vendorResponse.validUntil)}</span>
+            )}
+          </div>
+          {item.vendorResponse.notes && (
+            <p className="mt-2 whitespace-pre-wrap text-muted-foreground">
+              {item.vendorResponse.notes}
+            </p>
+          )}
+        </div>
+      )}
     </article>
   )
 }
@@ -411,10 +545,10 @@ function AudienceMetricStrip({
       icon: <IconClipboardCheck className="size-4" />,
     },
     {
-      label: "Messages",
-      value: String(data.messageChannels.length),
-      detail: "project channels",
-      icon: <IconMessageCircle className="size-4" />,
+      label: "RFQs",
+      value: String(data.rfqs.length),
+      detail: "quote requests",
+      icon: <IconShoppingCartQuestion className="size-4" />,
     },
   ]
 
@@ -807,6 +941,43 @@ export function ProjectAudiencePreview({
         )}
 
         {section === "overview" && (
+          <section className="border bg-background p-4 sm:p-5">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div className="max-w-2xl">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Compass partner workspace
+                </p>
+                <h2 className="mt-1 text-lg font-semibold">Project command center</h2>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Keep questions, quotes, schedules, files, and project-team
+                  conversations together in one secure workspace.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <ProjectAudienceRfiCreateDialog
+                  projectId={data.project.id}
+                  recipients={messageShortcut?.recipients ?? []}
+                  viewerIsInternal={data.viewerIsInternal}
+                />
+                <Button asChild variant="outline">
+                  <Link
+                    href={projectAudienceSectionHref(
+                      data.project.id,
+                      "sub-vendor",
+                      "rfqs"
+                    )}
+                  >
+                    <IconShoppingCartQuestion className="size-4" />
+                    Review RFQs
+                  </Link>
+                </Button>
+                <ProjectAudienceMessageLauncher shortcut={messageShortcut} />
+              </div>
+            </div>
+          </section>
+        )}
+
+        {section === "overview" && (
           <section className="rounded-lg border bg-background/80 px-3 py-2">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div className="flex min-w-0 items-center gap-2">
@@ -928,7 +1099,14 @@ export function ProjectAudiencePreview({
                   <IconQuestionMark className="size-4 text-muted-foreground" />
                   <h2 className="text-sm font-semibold">RFIs</h2>
                 </div>
-                <Badge variant="outline">{data.rfis.length} visible</Badge>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="outline">{data.rfis.length} visible</Badge>
+                  <ProjectAudienceRfiCreateDialog
+                    projectId={data.project.id}
+                    recipients={messageShortcut?.recipients ?? []}
+                    viewerIsInternal={data.viewerIsInternal}
+                  />
+                </div>
               </div>
               {data.rfis.length > 0 ? (
                 <div className="mt-4 grid gap-3">
@@ -942,6 +1120,40 @@ export function ProjectAudiencePreview({
                 </p>
               )}
             </div>
+          </section>
+        )}
+
+        {section === "rfqs" && (
+          <section className="space-y-3">
+            <div className="flex flex-wrap items-end justify-between gap-3 border-y py-3">
+              <div>
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Pricing requests
+                </p>
+                <h1 className="mt-1 text-xl font-semibold">Requests for quote</h1>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Review assigned scopes and send pricing directly to the
+                  internal project team.
+                </p>
+              </div>
+              <Badge variant="outline">{data.rfqs.length} assigned</Badge>
+            </div>
+            {data.rfqs.length > 0 ? (
+              <div className="grid gap-3">
+                {data.rfqs.map((item) => (
+                  <RfqRow
+                    key={item.id}
+                    item={item}
+                    projectId={data.project.id}
+                    viewerIsInternal={data.viewerIsInternal}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className="border bg-background p-5 text-sm text-muted-foreground">
+                No RFQs are currently assigned to your company.
+              </p>
+            )}
           </section>
         )}
 

--- a/src/components/projects/project-audience-rfi-create-dialog.tsx
+++ b/src/components/projects/project-audience-rfi-create-dialog.tsx
@@ -1,0 +1,178 @@
+"use client"
+
+import * as React from "react"
+import { IconQuestionMark } from "@tabler/icons-react"
+import { useRouter } from "next/navigation"
+
+import { createSubVendorRfi } from "@/app/actions/project-audience-sub-vendor"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import type { ProjectAudienceMessageRecipient } from "@/lib/project-audience-direct-message"
+
+type SubmitState =
+  | { readonly kind: "idle" }
+  | { readonly kind: "error"; readonly message: string }
+
+export function ProjectAudienceRfiCreateDialog({
+  projectId,
+  recipients,
+  viewerIsInternal,
+}: {
+  readonly projectId: string
+  readonly recipients: readonly ProjectAudienceMessageRecipient[]
+  readonly viewerIsInternal: boolean
+}): React.ReactElement {
+  const router = useRouter()
+  const [open, setOpen] = React.useState(false)
+  const [pending, startTransition] = React.useTransition()
+  const [subject, setSubject] = React.useState("")
+  const [question, setQuestion] = React.useState("")
+  const [priority, setPriority] = React.useState("normal")
+  const [recipientUserId, setRecipientUserId] = React.useState(
+    recipients[0]?.userId ?? ""
+  )
+  const [state, setState] = React.useState<SubmitState>({ kind: "idle" })
+  const unavailable = viewerIsInternal || recipients.length === 0
+
+  function reset(): void {
+    setSubject("")
+    setQuestion("")
+    setPriority("normal")
+    setRecipientUserId(recipients[0]?.userId ?? "")
+    setState({ kind: "idle" })
+  }
+
+  function submit(event: React.FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    setState({ kind: "idle" })
+    startTransition(async () => {
+      const result = await createSubVendorRfi(projectId, {
+        subject,
+        question,
+        priority,
+        recipientUserId,
+      })
+      if (!result.success) {
+        setState({ kind: "error", message: result.error })
+        return
+      }
+      setOpen(false)
+      reset()
+      router.refresh()
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          disabled={unavailable}
+          title={
+            viewerIsInternal
+              ? "Sign in as the assigned sub/vendor to send an RFI."
+              : recipients.length === 0
+                ? "Assign an internal project team member first."
+                : undefined
+          }
+        >
+          <IconQuestionMark className="size-4" />
+          Send an RFI
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-xl">
+        <form onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>Send a request for information</DialogTitle>
+            <DialogDescription>
+              Route a project question directly to an assigned internal team
+              member. The response will remain visible in this workspace.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="mt-5 grid gap-4">
+            <label className="grid gap-1.5 text-sm font-medium">
+              Send to
+              <Select value={recipientUserId} onValueChange={setRecipientUserId}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Choose a project team member" />
+                </SelectTrigger>
+                <SelectContent>
+                  {recipients.map((recipient) => (
+                    <SelectItem key={recipient.userId} value={recipient.userId}>
+                      {recipient.displayName}
+                      {recipient.role ? ` · ${recipient.role}` : ""}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </label>
+            <label className="grid gap-1.5 text-sm font-medium">
+              Subject
+              <Input
+                value={subject}
+                onChange={(event) => setSubject(event.currentTarget.value)}
+                maxLength={240}
+                placeholder="Example: Roof curb detail at grid C4"
+                required
+              />
+            </label>
+            <label className="grid gap-1.5 text-sm font-medium">
+              Question
+              <Textarea
+                value={question}
+                onChange={(event) => setQuestion(event.currentTarget.value)}
+                maxLength={10_000}
+                className="min-h-32"
+                placeholder="Describe the decision or clarification your team needs."
+                required
+              />
+            </label>
+            <label className="grid gap-1.5 text-sm font-medium">
+              Priority
+              <Select value={priority} onValueChange={setPriority}>
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="low">Low</SelectItem>
+                  <SelectItem value="normal">Normal</SelectItem>
+                  <SelectItem value="high">High</SelectItem>
+                </SelectContent>
+              </Select>
+            </label>
+            {state.kind === "error" && (
+              <p role="alert" className="text-sm text-destructive">
+                {state.message}
+              </p>
+            )}
+          </div>
+          <DialogFooter className="mt-5">
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={pending || !recipientUserId}>
+              {pending ? "Sending..." : "Send RFI"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/projects/project-audience-rfq-response-dialog.tsx
+++ b/src/components/projects/project-audience-rfq-response-dialog.tsx
@@ -1,0 +1,191 @@
+"use client"
+
+import * as React from "react"
+import { IconSend } from "@tabler/icons-react"
+import { useRouter } from "next/navigation"
+
+import { submitSubVendorRfqResponse } from "@/app/actions/project-audience-sub-vendor"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import type { PortalRfqVendorResponse } from "@/lib/rfqs/portal-response"
+import { portalRfqCanReceiveResponse } from "@/lib/rfqs/portal-response"
+
+type Decision = "quote" | "decline"
+
+export function ProjectAudienceRfqResponseDialog({
+  projectId,
+  rfqId,
+  rfqTitle,
+  status,
+  response,
+  viewerIsInternal,
+}: {
+  readonly projectId: string
+  readonly rfqId: string
+  readonly rfqTitle: string
+  readonly status: string
+  readonly response: PortalRfqVendorResponse | null
+  readonly viewerIsInternal: boolean
+}): React.ReactElement {
+  const router = useRouter()
+  const [open, setOpen] = React.useState(false)
+  const [pending, startTransition] = React.useTransition()
+  const [decision, setDecision] = React.useState<Decision>(
+    response?.decision ?? "quote"
+  )
+  const [amount, setAmount] = React.useState(
+    response?.amount === null || response?.amount === undefined
+      ? ""
+      : String(response.amount)
+  )
+  const [leadTime, setLeadTime] = React.useState(response?.leadTime ?? "")
+  const [validUntil, setValidUntil] = React.useState(response?.validUntil ?? "")
+  const [notes, setNotes] = React.useState(response?.notes ?? "")
+  const [error, setError] = React.useState<string | null>(null)
+  const acceptsResponse = portalRfqCanReceiveResponse(status)
+
+  function changeDecision(value: string): void {
+    if (value === "quote" || value === "decline") setDecision(value)
+  }
+
+  function submit(event: React.FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    setError(null)
+    const parsedAmount = amount.trim().length > 0 ? Number(amount) : null
+    startTransition(async () => {
+      const result = await submitSubVendorRfqResponse(projectId, rfqId, {
+        decision,
+        amount: parsedAmount,
+        leadTime,
+        validUntil,
+        notes,
+      })
+      if (!result.success) {
+        setError(result.error)
+        return
+      }
+      setOpen(false)
+      router.refresh()
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          size="sm"
+          disabled={viewerIsInternal || !acceptsResponse}
+          title={
+            viewerIsInternal
+              ? "Sign in as the assigned vendor to submit a response."
+              : !acceptsResponse
+                ? "This RFQ is not accepting responses."
+                : undefined
+          }
+        >
+          <IconSend className="size-4" />
+          {response ? "Revise response" : "Respond"}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-xl">
+        <form onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>Respond to {rfqTitle}</DialogTitle>
+            <DialogDescription>
+              Submit pricing and delivery notes to the internal project team.
+              You can revise the response while the RFQ remains open.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="mt-5 grid gap-4 sm:grid-cols-2">
+            <label className="grid gap-1.5 text-sm font-medium sm:col-span-2">
+              Response
+              <Select value={decision} onValueChange={changeDecision}>
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="quote">Submit a quote</SelectItem>
+                  <SelectItem value="decline">Decline to quote</SelectItem>
+                </SelectContent>
+              </Select>
+            </label>
+            {decision === "quote" && (
+              <label className="grid gap-1.5 text-sm font-medium">
+                Quote amount
+                <Input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={amount}
+                  onChange={(event) => setAmount(event.currentTarget.value)}
+                  placeholder="0.00"
+                  required
+                />
+              </label>
+            )}
+            <label className="grid gap-1.5 text-sm font-medium">
+              Lead time
+              <Input
+                value={leadTime}
+                onChange={(event) => setLeadTime(event.currentTarget.value)}
+                maxLength={240}
+                placeholder="Example: 3 weeks"
+              />
+            </label>
+            {decision === "quote" && (
+              <label className="grid gap-1.5 text-sm font-medium sm:col-span-2">
+                Quote valid until
+                <Input
+                  type="date"
+                  value={validUntil}
+                  onChange={(event) => setValidUntil(event.currentTarget.value)}
+                />
+              </label>
+            )}
+            <label className="grid gap-1.5 text-sm font-medium sm:col-span-2">
+              Notes, exclusions, and clarifications
+              <Textarea
+                value={notes}
+                onChange={(event) => setNotes(event.currentTarget.value)}
+                maxLength={10_000}
+                className="min-h-32"
+                placeholder="Include assumptions, alternates, exclusions, or questions."
+              />
+            </label>
+            {error && (
+              <p role="alert" className="text-sm text-destructive sm:col-span-2">
+                {error}
+              </p>
+            )}
+          </div>
+          <DialogFooter className="mt-5">
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={pending}>
+              {pending ? "Submitting..." : "Submit response"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/projects/project-rfq-share-actions.tsx
+++ b/src/components/projects/project-rfq-share-actions.tsx
@@ -8,8 +8,12 @@ import {
   IconPrinter,
   IconSparkles,
 } from "@tabler/icons-react"
+import { useRouter } from "next/navigation"
 
-import type { ProjectRfqItem } from "@/app/actions/project-operations"
+import {
+  type ProjectRfqItem,
+  updateProjectOperationStatus,
+} from "@/app/actions/project-operations"
 import { Button } from "@/components/ui/button"
 import type { ProjectBrand } from "@/lib/project-branding"
 
@@ -29,9 +33,10 @@ function plainText(value: string | null): string {
 }
 
 function rfqLink(projectId: string, rfqId: string): string {
-  return `/dashboard/projects/${projectId}/rfqs?created=${encodeURIComponent(
-    rfqId
-  )}`
+  return (
+    `/preview/projects/${encodeURIComponent(projectId)}/sub-vendor/rfqs` +
+    `?rfq=${encodeURIComponent(rfqId)}#rfq-${encodeURIComponent(rfqId)}`
+  )
 }
 
 function rfqRows(rfq: ProjectRfqItem): string {
@@ -144,8 +149,27 @@ export function ProjectRfqShareActions({
   readonly projectLabel: string
   readonly rfq: ProjectRfqItem
 }): React.ReactElement {
+  const router = useRouter()
   const [copied, setCopied] = React.useState<CopiedState>(null)
+  const [shareError, setShareError] = React.useState<string | null>(null)
   const requiresTemplateReview = rfq.templateReview !== null
+
+  async function prepareForSharing(): Promise<boolean> {
+    setShareError(null)
+    if (rfq.status !== "draft") return true
+    const result = await updateProjectOperationStatus(
+      projectId,
+      rfq.id,
+      "rfq",
+      "sent"
+    )
+    if (!result.success) {
+      setShareError(result.error)
+      return false
+    }
+    router.refresh()
+    return true
+  }
 
   function absoluteUrl(): string {
     return new URL(rfqLink(projectId, rfq.id), window.location.origin).toString()
@@ -202,16 +226,19 @@ export function ProjectRfqShareActions({
   }
 
   async function copyLink(): Promise<void> {
+    if (!(await prepareForSharing())) return
     await navigator.clipboard.writeText(absoluteUrl())
     setCopied("link")
   }
 
   async function copyEmail(): Promise<void> {
+    if (!(await prepareForSharing())) return
     await navigator.clipboard.writeText(plainEmail())
     setCopied("email")
   }
 
   async function copyHtmlEmail(): Promise<void> {
+    if (!(await prepareForSharing())) return
     const html = htmlEmail()
     const plain = plainEmail()
     if ("ClipboardItem" in window) {
@@ -281,6 +308,11 @@ export function ProjectRfqShareActions({
         )}
         HTML
       </Button>
+      {shareError && (
+        <span role="alert" className="basis-full text-xs text-destructive">
+          {shareError}
+        </span>
+      )}
     </div>
   )
 }

--- a/src/lib/notifications/events.ts
+++ b/src/lib/notifications/events.ts
@@ -51,6 +51,17 @@ type RfiUpdatedNotificationInput = {
   readonly updatedBy: AuthUser
 }
 
+type RfqResponseNotificationInput = {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly rfqId: string
+  readonly rfqNumber: string | null
+  readonly title: string
+  readonly decision: "quote" | "decline"
+  readonly amount: number | null
+  readonly respondedBy: AuthUser
+}
+
 type ProjectAssignmentNotificationInput = {
   readonly organizationId: string
   readonly projectId: string
@@ -263,10 +274,12 @@ export async function notifyRfiCreated(
     .then((rows) => rows[0] ?? null)
 
   const recipients = new Map<string, NotificationRecipientInput>()
-  recipients.set(input.createdBy.id, {
-    userId: input.createdBy.id,
-    email: input.createdBy.email,
-  })
+  if (isInternalStaffRole(input.createdBy.role)) {
+    recipients.set(input.createdBy.id, {
+      userId: input.createdBy.id,
+      email: input.createdBy.email,
+    })
+  }
 
   const assignedRecipients = await projectAssignmentRecipients(
     db,
@@ -372,6 +385,69 @@ export async function notifyRfiUpdated(
       email: true,
       push: true,
     },
+  })
+}
+
+export async function notifyRfqResponseReceived(
+  input: RfqResponseNotificationInput
+): Promise<void> {
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const members = await db
+    .select({
+      userId: users.id,
+      email: users.email,
+      googleEmail: users.googleEmail,
+      role: users.role,
+    })
+    .from(projectMembers)
+    .innerJoin(users, eq(users.id, projectMembers.userId))
+    .where(
+      and(
+        eq(projectMembers.projectId, input.projectId),
+        eq(users.isActive, true)
+      )
+    )
+  const recipients = members
+    .filter(
+      (member) =>
+        member.userId !== input.respondedBy.id &&
+        isInternalStaffRole(member.role)
+    )
+    .map((member) => ({
+      userId: member.userId,
+      email: member.googleEmail?.trim() || member.email,
+    }))
+  if (recipients.length === 0) return
+
+  const responseLabel =
+    input.decision === "decline"
+      ? "declined the request"
+      : `submitted a quote${
+          input.amount === null
+            ? ""
+            : ` for ${new Intl.NumberFormat("en-US", {
+                style: "currency",
+                currency: "USD",
+              }).format(input.amount)}`
+        }`
+  const responder = input.respondedBy.displayName ?? input.respondedBy.email
+  await createNotificationEvent({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    eventType: "rfq.response_received",
+    sourceType: "rfq",
+    sourceId: input.rfqId,
+    title: `${input.rfqNumber ?? "RFQ"}: ${input.title}`,
+    body: `${responder} ${responseLabel}.`,
+    href:
+      `/dashboard/projects/${input.projectId}/rfqs?status=response_received` +
+      `#rfq-${encodeURIComponent(input.rfqId)}`,
+    priority: "normal",
+    audience: "project_team",
+    createdBy: input.respondedBy.id,
+    recipients,
+    delivery: { inApp: true, email: true, push: true },
   })
 }
 

--- a/src/lib/project-audience-preview-routes.ts
+++ b/src/lib/project-audience-preview-routes.ts
@@ -6,6 +6,7 @@ export type ProjectAudienceWorkspaceSection =
   | "budget"
   | "commitments"
   | "rfis"
+  | "rfqs"
   | "change-orders"
   | "conversations"
   | "photos"

--- a/src/lib/project-audience-viewer-contact.ts
+++ b/src/lib/project-audience-viewer-contact.ts
@@ -1,0 +1,75 @@
+import { and, desc, eq, sql } from "drizzle-orm"
+
+import type { getDb } from "@/db"
+import {
+  projectAccessInvitations,
+  projectContacts,
+} from "@/db/schema"
+
+export type ProjectAudienceViewerContact = {
+  readonly id: string
+  readonly contactType: string
+  readonly displayName: string
+  readonly companyName: string | null
+  readonly email: string | null
+}
+
+const VIEWER_CONTACT_SELECTION = {
+  id: projectContacts.id,
+  contactType: projectContacts.contactType,
+  displayName: projectContacts.displayName,
+  companyName: projectContacts.companyName,
+  email: projectContacts.email,
+}
+
+export async function getProjectAudienceViewerContact(
+  db: ReturnType<typeof getDb>,
+  projectId: string,
+  viewer: { readonly id: string; readonly email: string }
+): Promise<ProjectAudienceViewerContact | null> {
+  const acceptedInvitation = await db
+    .select({ projectContactId: projectAccessInvitations.projectContactId })
+    .from(projectAccessInvitations)
+    .where(
+      and(
+        eq(projectAccessInvitations.projectId, projectId),
+        eq(projectAccessInvitations.acceptedBy, viewer.id),
+        eq(projectAccessInvitations.status, "accepted")
+      )
+    )
+    .orderBy(desc(projectAccessInvitations.acceptedAt))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+
+  if (acceptedInvitation?.projectContactId) {
+    const invitedContact = await db
+      .select(VIEWER_CONTACT_SELECTION)
+      .from(projectContacts)
+      .where(
+        and(
+          eq(projectContacts.id, acceptedInvitation.projectContactId),
+          eq(projectContacts.projectId, projectId),
+          eq(projectContacts.active, true)
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (invitedContact) return invitedContact
+  }
+
+  const normalizedEmail = viewer.email.trim().toLowerCase()
+  if (!normalizedEmail) return null
+
+  return db
+    .select(VIEWER_CONTACT_SELECTION)
+    .from(projectContacts)
+    .where(
+      and(
+        eq(projectContacts.projectId, projectId),
+        eq(projectContacts.active, true),
+        sql`lower(trim(${projectContacts.email})) = ${normalizedEmail}`
+      )
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+}

--- a/src/lib/rfqs/__tests__/portal-response.test.ts
+++ b/src/lib/rfqs/__tests__/portal-response.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isPortalVisibleRfqStatus,
+  parsePortalRfqPayload,
+  portalRfqMatchesRecipient,
+  withPortalRfqVendorResponse,
+} from "@/lib/rfqs/portal-response"
+
+describe("sub/vendor RFQ portal", () => {
+  it("fails closed when an RFQ targets another vendor", () => {
+    expect(
+      portalRfqMatchesRecipient({
+        recipientEmail: "quotes@other.example",
+        companyName: "Other Electric",
+        assigneeName: "Other Electric",
+        viewerEmail: "estimating@acme.example",
+        viewerCompanyName: "Acme Framing",
+        viewerDisplayName: "Alex Vendor",
+      })
+    ).toBe(false)
+  })
+
+  it("treats an explicit recipient email as authoritative", () => {
+    expect(
+      portalRfqMatchesRecipient({
+        recipientEmail: "another-estimator@acme.example",
+        companyName: "Acme Framing",
+        assigneeName: "Acme Framing",
+        viewerEmail: "alex@acme.example",
+        viewerCompanyName: "Acme Framing",
+        viewerDisplayName: "Alex Vendor",
+      })
+    ).toBe(false)
+  })
+
+  it("matches a targeted vendor by email or company", () => {
+    expect(
+      portalRfqMatchesRecipient({
+        recipientEmail: "estimating@acme.example",
+        companyName: null,
+        assigneeName: null,
+        viewerEmail: "estimating@acme.example",
+        viewerCompanyName: "Acme Framing",
+        viewerDisplayName: "Alex Vendor",
+      })
+    ).toBe(true)
+    expect(
+      portalRfqMatchesRecipient({
+        recipientEmail: null,
+        companyName: "Acme Framing, LLC",
+        assigneeName: null,
+        viewerEmail: "alex@acme.example",
+        viewerCompanyName: "Acme Framing LLC",
+        viewerDisplayName: "Alex Vendor",
+      })
+    ).toBe(true)
+  })
+
+  it("keeps draft RFQs private", () => {
+    expect(isPortalVisibleRfqStatus("draft")).toBe(false)
+    expect(isPortalVisibleRfqStatus("sent")).toBe(true)
+    expect(isPortalVisibleRfqStatus("response_received")).toBe(true)
+  })
+
+  it("preserves the RFQ package when a vendor submits a response", () => {
+    const original = JSON.stringify({
+      vendorCategory: "Framing",
+      scopeItems: [{ lineNumber: 1, description: "Frame the garage" }],
+    })
+    const updated = withPortalRfqVendorResponse(original, {
+      decision: "quote",
+      amount: 12500,
+      leadTime: "3 weeks",
+      validUntil: "2026-09-30",
+      notes: "Includes crane time.",
+      responderUserId: "user-vendor",
+      responderName: "Alex Vendor",
+      responderCompany: "Acme Framing",
+      submittedAt: "2026-08-19T12:00:00.000Z",
+    })
+    const parsed = parsePortalRfqPayload(updated)
+
+    expect(parsed.vendorCategory).toBe("Framing")
+    expect(parsed.scopeItems[0]?.description).toBe("Frame the garage")
+    expect(parsed.vendorResponse?.amount).toBe(12500)
+  })
+})

--- a/src/lib/rfqs/portal-response.ts
+++ b/src/lib/rfqs/portal-response.ts
@@ -1,0 +1,213 @@
+export type PortalRfqScopeItem = {
+  readonly lineNumber: number
+  readonly description: string
+  readonly phaseCode: string | null
+  readonly costCode: string | null
+  readonly notes: string | null
+}
+
+export type PortalRfqDocumentLink = {
+  readonly lineNumber: number
+  readonly label: string
+  readonly url: string
+  readonly notes: string | null
+}
+
+export type PortalRfqVendorResponse = {
+  readonly decision: "quote" | "decline"
+  readonly amount: number | null
+  readonly leadTime: string | null
+  readonly validUntil: string | null
+  readonly notes: string | null
+  readonly responderUserId: string
+  readonly responderName: string
+  readonly responderCompany: string | null
+  readonly submittedAt: string
+}
+
+export type PortalRfqPayload = {
+  readonly vendorCategory: string | null
+  readonly recipientEmail: string | null
+  readonly scopeItems: readonly PortalRfqScopeItem[]
+  readonly documentLinks: readonly PortalRfqDocumentLink[]
+  readonly vendorResponse: PortalRfqVendorResponse | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function parseRecord(value: string | null): Record<string, unknown> {
+  if (!value) return {}
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return isRecord(parsed) ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+function textValue(
+  value: Record<string, unknown>,
+  key: string
+): string | null {
+  const candidate = value[key]
+  return typeof candidate === "string" && candidate.trim().length > 0
+    ? candidate.trim()
+    : null
+}
+
+function numberValue(
+  value: Record<string, unknown>,
+  key: string
+): number | null {
+  const candidate = value[key]
+  return typeof candidate === "number" && Number.isFinite(candidate)
+    ? candidate
+    : null
+}
+
+function parseScopeItems(
+  value: Record<string, unknown>
+): readonly PortalRfqScopeItem[] {
+  const items = value.scopeItems
+  if (!Array.isArray(items)) return []
+
+  return items.flatMap((item, index) => {
+    if (!isRecord(item)) return []
+    const description = textValue(item, "description")
+    if (!description) return []
+    return [
+      {
+        lineNumber: numberValue(item, "lineNumber") ?? index + 1,
+        description,
+        phaseCode: textValue(item, "phaseCode"),
+        costCode: textValue(item, "costCode"),
+        notes: textValue(item, "notes"),
+      },
+    ]
+  })
+}
+
+function parseDocumentLinks(
+  value: Record<string, unknown>
+): readonly PortalRfqDocumentLink[] {
+  const links = value.documentLinks
+  if (!Array.isArray(links)) return []
+
+  return links.flatMap((link, index) => {
+    if (!isRecord(link)) return []
+    const url = textValue(link, "url")
+    if (!url) return []
+    try {
+      const parsedUrl = new URL(url)
+      if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
+        return []
+      }
+    } catch {
+      return []
+    }
+    return [
+      {
+        lineNumber: numberValue(link, "lineNumber") ?? index + 1,
+        label: textValue(link, "label") ?? `Document ${index + 1}`,
+        url,
+        notes: textValue(link, "notes"),
+      },
+    ]
+  })
+}
+
+function parseVendorResponse(
+  value: Record<string, unknown>
+): PortalRfqVendorResponse | null {
+  const response = value.vendorResponse
+  if (!isRecord(response)) return null
+  const decision = textValue(response, "decision")
+  const responderUserId = textValue(response, "responderUserId")
+  const responderName = textValue(response, "responderName")
+  const submittedAt = textValue(response, "submittedAt")
+  if (
+    (decision !== "quote" && decision !== "decline") ||
+    !responderUserId ||
+    !responderName ||
+    !submittedAt
+  ) {
+    return null
+  }
+
+  return {
+    decision,
+    amount: numberValue(response, "amount"),
+    leadTime: textValue(response, "leadTime"),
+    validUntil: textValue(response, "validUntil"),
+    notes: textValue(response, "notes"),
+    responderUserId,
+    responderName,
+    responderCompany: textValue(response, "responderCompany"),
+    submittedAt,
+  }
+}
+
+export function parsePortalRfqPayload(value: string | null): PortalRfqPayload {
+  const payload = parseRecord(value)
+  return {
+    vendorCategory: textValue(payload, "vendorCategory"),
+    recipientEmail: textValue(payload, "recipientEmail"),
+    scopeItems: parseScopeItems(payload),
+    documentLinks: parseDocumentLinks(payload),
+    vendorResponse: parseVendorResponse(payload),
+  }
+}
+
+function normalizedName(value: string | null): string {
+  return (value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+}
+
+export function portalRfqMatchesRecipient(input: {
+  readonly recipientEmail: string | null
+  readonly companyName: string | null
+  readonly assigneeName: string | null
+  readonly viewerEmail: string
+  readonly viewerCompanyName: string | null
+  readonly viewerDisplayName: string
+}): boolean {
+  const recipientEmail = input.recipientEmail?.trim().toLowerCase() ?? ""
+  if (recipientEmail.length > 0) {
+    // An explicit RFQ email is authoritative. Do not fall back to a broad
+    // company-name match when the request names a different mailbox.
+    return recipientEmail === input.viewerEmail.trim().toLowerCase()
+  }
+
+  const viewerNames = new Set(
+    [input.viewerCompanyName, input.viewerDisplayName]
+      .map(normalizedName)
+      .filter((value) => value.length > 0)
+  )
+  return [input.companyName, input.assigneeName]
+    .map(normalizedName)
+    .some((value) => value.length > 0 && viewerNames.has(value))
+}
+
+export function isPortalVisibleRfqStatus(status: string): boolean {
+  return !["draft", "void", "cancelled", "canceled"].includes(
+    status.trim().toLowerCase()
+  )
+}
+
+export function portalRfqCanReceiveResponse(status: string): boolean {
+  return ["sent", "response_received"].includes(status.trim().toLowerCase())
+}
+
+export function withPortalRfqVendorResponse(
+  value: string | null,
+  response: PortalRfqVendorResponse
+): string {
+  return JSON.stringify({
+    ...parseRecord(value),
+    vendorResponse: response,
+  })
+}


### PR DESCRIPTION
## Summary

- bring the sub/vendor portal to owner-portal workflow parity
- let external partners send RFIs, respond to or decline RFQs, and revise responses
- add project-team and internal-staff messaging through the recipient dropdown
- align the external portal with Compass's internal command-center experience

## Impact

Subcontractors and vendors can now complete core project communication and procurement workflows without leaving their portal. Internal teams receive targeted messages and RFQ/RFI notifications while external access remains scoped to the intended project and contact.

## Validation

- 14 focused unit tests passing
- TypeScript check passing
- production Next.js build passing
- full lint completed with no errors; existing warnings remain
