### PR TITLE
fix(portal): align audience visibility and PO responses

### DIFF
--- a/src/app/actions/project-audience-preview.ts
+++ b/src/app/actions/project-audience-preview.ts
@@ -6,15 +6,14 @@ import { getDb } from "@/db"
 import {
   dailyLogPhotos,
   dailyLogs,
-  organizationMembers,
   ownerProjectUpdates,
+  projectContacts,
   projectMembers,
   projectOperations,
   projectRfis,
   projects,
   schedulePublications,
   scheduleTasks,
-  users,
 } from "@/db/schema"
 import { channelMembers, channels } from "@/db/schema-conversations"
 import { requireAuth } from "@/lib/auth"
@@ -27,8 +26,15 @@ import {
 } from "@/lib/project-audience-access"
 import { ensureProjectAudienceConversation } from "@/lib/project-audience-conversations"
 import { getProjectAudienceViewerContact } from "@/lib/project-audience-viewer-contact"
-import { isAssignedVisibleAudienceTeamMember } from "@/lib/project-audience-team"
+import { getProjectAudienceStaff } from "@/lib/project-audience-staff"
+import { selectProjectAudienceScheduleItems } from "@/lib/project-audience-schedule-visibility"
 import { isInternalStaffRole } from "@/lib/user-roles"
+import {
+  isPortalVisiblePurchaseOrderStatus,
+  parsePortalPurchaseOrderPayload,
+  portalPurchaseOrderMatchesRecipient,
+  type PortalPurchaseOrderAcknowledgement,
+} from "@/lib/purchase-orders/portal-response"
 import {
   isOwnerScheduleView,
   summarizeOwnerScheduleByPhase,
@@ -82,12 +88,15 @@ export type AudienceOperationItem = {
   readonly sourceRecordType: string
   readonly sourceRecordNumber: string | null
   readonly title: string
+  readonly description: string | null
   readonly status: string
   readonly priority: string
   readonly assigneeName: string | null
   readonly companyName: string | null
   readonly startDate: string | null
   readonly dueDate: string | null
+  readonly amount: number | null
+  readonly acknowledgement: PortalPurchaseOrderAcknowledgement | null
 }
 
 export type AudienceOwnerUpdate = {
@@ -254,6 +263,7 @@ function isActiveStatus(value: string): boolean {
 
 function isSubVendorOperation(value: string): boolean {
   return [
+    "purchase_order",
     "subcontractor_task",
     "supplier_task",
     "schedule_task",
@@ -275,10 +285,6 @@ function photoDate(value: {
   if (value.capturedAt) return value.capturedAt.slice(0, 10)
   if (value.logDate) return value.logDate
   return value.createdAt.slice(0, 10)
-}
-
-function normalizeVisibleName(value: string | null): string {
-  return value?.trim().toLowerCase() ?? ""
 }
 
 export async function getProjectAudiencePreview(
@@ -527,6 +533,7 @@ export async function getProjectAudiencePreview(
             startDate: projectOperations.startDate,
             dueDate: projectOperations.dueDate,
             amount: projectOperations.amount,
+            sageVendorName: projectOperations.sageVendorName,
             sagePayloadJson: projectOperations.sagePayloadJson,
           })
           .from(projectOperations)
@@ -610,79 +617,53 @@ export async function getProjectAudiencePreview(
     )
     .orderBy(asc(channels.sortOrder), asc(channels.name))
 
-  const internalTeamRows = await db
-    .select({
-      id: users.id,
-      userId: users.id,
-      displayName: users.displayName,
-      email: users.email,
-      organizationRole: organizationMembers.role,
-      projectRole: projectMembers.role,
-      projectAssignedAt: projectMembers.assignedAt,
-    })
-    .from(projectMembers)
-    .innerJoin(users, eq(users.id, projectMembers.userId))
-    .innerJoin(
-      organizationMembers,
-      and(
-        eq(organizationMembers.userId, projectMembers.userId),
-        eq(organizationMembers.organizationId, organizationId)
-      )
-    )
-    .where(
-      and(
-        eq(projectMembers.projectId, projectId),
-        eq(users.isActive, true)
-      )
-    )
-    .orderBy(desc(projectMembers.assignedAt), asc(users.displayName))
-
-  // Audience workspaces expose the authoritative internal team only. Internal
-  // previewers receive the same directory that an owner or partner will see.
-  const visibleContactRows = Array.from(
-    new Map(
-      internalTeamRows
-        .filter((member) =>
-          isAssignedVisibleAudienceTeamMember({
-            userId: member.userId,
-            email: member.email,
-            organizationRole: member.organizationRole,
-            projectRole: member.projectRole,
-          })
-        )
-        .map((member) => [member.userId, member])
-    ).values()
-  ).map((member) => ({
-    id: member.id,
+  const internalTeamRows = await getProjectAudienceStaff(db, {
+    projectId,
+    organizationId,
+    audience,
+  })
+  const visibleContactRows: readonly AudienceContact[] = internalTeamRows.map((member) => ({
+    id: member.contactId,
     userId: member.userId,
     contactType: "internal",
-    displayName: member.displayName ?? member.email,
-    companyName: null,
-    role: member.projectRole,
-    trade: null,
-    csiDivision: null,
-    csiDivisionName: null,
+    displayName: member.displayName,
+    companyName: member.companyName,
+    role: member.role,
+    trade: member.trade,
+    csiDivision: member.csiDivision,
+    csiDivisionName: member.csiDivisionName,
     email: member.email,
-    phone: null,
-    primaryContact: false,
+    phone: member.phone,
+    primaryContact: member.primaryContact,
   }))
-  const visibleContactNames = new Set(
-    visibleContactRows
-      .flatMap((contact) => [
-        normalizeVisibleName(contact.displayName),
-        normalizeVisibleName(contact.companyName),
-      ])
-      .filter((value) => value.length > 0)
-  )
+  const externalContactRows =
+    audience === "sub_vendor"
+      ? await db
+          .select({
+            id: projectContacts.id,
+            displayName: projectContacts.displayName,
+            companyName: projectContacts.companyName,
+            email: projectContacts.email,
+          })
+          .from(projectContacts)
+          .where(
+            and(
+              eq(projectContacts.projectId, projectId),
+              eq(projectContacts.active, true),
+              or(
+                eq(projectContacts.contactType, "supplier"),
+                eq(projectContacts.contactType, "subcontractor")
+              )
+            )
+          )
+      : []
   const ownerScheduleView =
     audience === "owner" && isOwnerScheduleView(project.ownerScheduleView)
       ? project.ownerScheduleView
       : "items"
-  const audienceScheduleRows = scheduleRows.filter((item) =>
-    audience === "owner"
-      ? item.ownerVisible !== false
-      : item.subVendorVisible ??
-        visibleContactNames.has(normalizeVisibleName(item.assignedTo))
+  const audienceScheduleRows = selectProjectAudienceScheduleItems(
+    scheduleRows,
+    audience
   )
   const visibleScheduleItem = (
     item: (typeof audienceScheduleRows)[number]
@@ -754,6 +735,56 @@ export async function getProjectAudiencePreview(
       }
     })
 
+  const portalOperationContacts = viewerIsInternal
+    ? externalContactRows
+    : viewerContact
+      ? [viewerContact]
+      : []
+  const audienceOperations: readonly AudienceOperationItem[] = operationRows
+    .filter((operation) => {
+      if (!isSubVendorOperation(operation.sourceRecordType)) return false
+      if (operation.sourceRecordType === "purchase_order") {
+        if (!isPortalVisiblePurchaseOrderStatus(operation.status)) return false
+      } else if (!isActiveStatus(operation.status)) {
+        return false
+      }
+      const payload = parsePortalPurchaseOrderPayload(operation.sagePayloadJson)
+      return portalOperationContacts.some((contact) =>
+        portalPurchaseOrderMatchesRecipient({
+          // Internal previews represent the contact assignment, while a signed-in
+          // vendor must also satisfy any explicit delivery email on the PO.
+          recipientEmails: viewerIsInternal ? [] : payload.recipientEmails,
+          companyName: operation.companyName,
+          assigneeName: operation.assigneeName,
+          vendorName: operation.sageVendorName,
+          viewerEmail: viewerIsInternal ? contact.email ?? "" : viewer.email,
+          viewerCompanyName: contact.companyName,
+          viewerDisplayName: contact.displayName,
+        })
+      )
+    })
+    .map((operation) => {
+      const payload = parsePortalPurchaseOrderPayload(operation.sagePayloadJson)
+      return {
+        id: operation.id,
+        sourceRecordType: operation.sourceRecordType,
+        sourceRecordNumber: operation.sourceRecordNumber,
+        title: operation.title,
+        description: operation.description,
+        status: operation.status,
+        priority: operation.priority,
+        assigneeName: operation.assigneeName,
+        companyName: operation.companyName,
+        startDate: operation.startDate,
+        dueDate: operation.dueDate,
+        amount: operation.amount,
+        acknowledgement:
+          operation.sourceRecordType === "purchase_order"
+            ? payload.acknowledgement
+            : null,
+      }
+    })
+
   return {
     audience,
     viewerIsInternal,
@@ -798,15 +829,7 @@ export async function getProjectAudiencePreview(
       }
     }),
     scheduleItems: audienceScheduleItems,
-    operations: operationRows
-      .filter(
-        (operation) =>
-          isSubVendorOperation(operation.sourceRecordType) &&
-          isActiveStatus(operation.status) &&
-          (visibleContactNames.has(normalizeVisibleName(operation.companyName)) ||
-            visibleContactNames.has(normalizeVisibleName(operation.assigneeName)))
-      )
-      .slice(0, 10),
+    operations: audienceOperations,
     rfis: rfiRows,
     rfqs: audienceRfqs,
     messageChannels: messageChannelRows,

--- a/src/app/actions/project-audience-sub-vendor.ts
+++ b/src/app/actions/project-audience-sub-vendor.ts
@@ -5,11 +5,9 @@ import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
 import {
-  organizationMembers,
   projectMembers,
   projectOperations,
   projectRfis,
-  users,
 } from "@/db/schema"
 import { requireAuth, type AuthUser } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
@@ -20,7 +18,13 @@ import {
 import { assertProjectAccess } from "@/lib/project-access"
 import type { ProjectAudienceViewerContact } from "@/lib/project-audience-viewer-contact"
 import { getProjectAudienceViewerContact } from "@/lib/project-audience-viewer-contact"
-import { isAssignedVisibleAudienceTeamMember } from "@/lib/project-audience-team"
+import { getProjectAudienceStaff } from "@/lib/project-audience-staff"
+import {
+  parsePortalPurchaseOrderPayload,
+  portalPurchaseOrderCanReceiveResponse,
+  portalPurchaseOrderMatchesRecipient,
+  withPortalPurchaseOrderAcknowledgement,
+} from "@/lib/purchase-orders/portal-response"
 import {
   parsePortalRfqPayload,
   portalRfqCanReceiveResponse,
@@ -47,6 +51,17 @@ export type SubmitSubVendorRfqResponseInput = {
   readonly validUntil: string | null
   readonly notes: string | null
 }
+
+export type RespondSubVendorPurchaseOrderInput =
+  | {
+      readonly decision: "acknowledge"
+      readonly note: string | null
+    }
+  | {
+      readonly decision: "question"
+      readonly question: string
+      readonly recipientUserId: string
+    }
 
 type SubVendorWriteContext = {
   readonly db: ReturnType<typeof getDb>
@@ -144,8 +159,10 @@ function revalidateSubVendorWorkspace(projectId: string): void {
   revalidatePath(`/preview/projects/${projectId}/sub-vendor`)
   revalidatePath(`/preview/projects/${projectId}/sub-vendor/rfis`)
   revalidatePath(`/preview/projects/${projectId}/sub-vendor/rfqs`)
+  revalidatePath(`/preview/projects/${projectId}/sub-vendor/commitments`)
   revalidatePath(`/dashboard/projects/${projectId}/rfis`)
   revalidatePath(`/dashboard/projects/${projectId}/rfqs`)
+  revalidatePath(`/dashboard/projects/${projectId}/purchase-orders`)
   revalidatePath("/dashboard/rfis")
 }
 
@@ -158,42 +175,19 @@ export async function createSubVendorRfi(
     const priority = validRfiPriority(input.priority)
     if (!priority) return { success: false, error: "Choose a valid priority." }
 
-    const recipient = await context.db
-      .select({
-        id: users.id,
-        email: users.email,
-        displayName: users.displayName,
-        organizationRole: organizationMembers.role,
-        projectRole: projectMembers.role,
-      })
-      .from(projectMembers)
-      .innerJoin(users, eq(users.id, projectMembers.userId))
-      .innerJoin(
-        organizationMembers,
-        and(
-          eq(organizationMembers.userId, users.id),
-          eq(organizationMembers.organizationId, context.organizationId)
-        )
-      )
-      .where(
-        and(
-          eq(projectMembers.projectId, projectId),
-          eq(projectMembers.userId, input.recipientUserId),
-          eq(users.isActive, true)
-        )
-      )
-      .limit(1)
-      .then((rows) => rows[0] ?? null)
-    if (
-      !recipient ||
-      !isAssignedVisibleAudienceTeamMember({
-        userId: recipient.id,
-        email: recipient.email,
-        organizationRole: recipient.organizationRole,
-        projectRole: recipient.projectRole,
-      })
-    ) {
-      return { success: false, error: "Choose an assigned project team member." }
+    const audienceStaff = await getProjectAudienceStaff(context.db, {
+      projectId,
+      organizationId: context.organizationId,
+      audience: "sub_vendor",
+    })
+    const recipient = audienceStaff.find(
+      (member) => member.userId === input.recipientUserId
+    )
+    if (!recipient) {
+      return {
+        success: false,
+        error: "Choose a staff member selected for the sub/vendor workspace.",
+      }
     }
 
     const rows = await context.db
@@ -213,7 +207,7 @@ export async function createSubVendorRfi(
       priority,
       audience: "sub_vendor",
       requesterName: context.user.displayName ?? context.user.email,
-      assignedToName: recipient.displayName ?? recipient.email,
+      assignedToName: recipient.displayName,
       companyName: context.viewerContact.companyName,
       submittedAt: now,
       createdAt: now,
@@ -241,6 +235,169 @@ export async function createSubVendorRfi(
     return {
       success: false,
       error: error instanceof Error ? error.message : "Unable to send the RFI.",
+    }
+  }
+}
+
+export async function respondToSubVendorPurchaseOrder(
+  projectId: string,
+  purchaseOrderId: string,
+  input: RespondSubVendorPurchaseOrderInput
+): Promise<SubVendorActionResult> {
+  try {
+    const context = await getSubVendorWriteContext(projectId)
+    const purchaseOrder = await context.db
+      .select({
+        id: projectOperations.id,
+        sourceRecordNumber: projectOperations.sourceRecordNumber,
+        title: projectOperations.title,
+        status: projectOperations.status,
+        assigneeName: projectOperations.assigneeName,
+        companyName: projectOperations.companyName,
+        sageVendorName: projectOperations.sageVendorName,
+        sagePayloadJson: projectOperations.sagePayloadJson,
+        updatedAt: projectOperations.updatedAt,
+      })
+      .from(projectOperations)
+      .where(
+        and(
+          eq(projectOperations.id, purchaseOrderId),
+          eq(projectOperations.projectId, projectId),
+          eq(projectOperations.sourceRecordType, "purchase_order")
+        )
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!purchaseOrder) {
+      return { success: false, error: "Purchase order not found." }
+    }
+    if (!portalPurchaseOrderCanReceiveResponse(purchaseOrder.status)) {
+      return {
+        success: false,
+        error: "This purchase order is no longer accepting responses.",
+      }
+    }
+
+    const payload = parsePortalPurchaseOrderPayload(
+      purchaseOrder.sagePayloadJson
+    )
+    if (
+      !portalPurchaseOrderMatchesRecipient({
+        recipientEmails: payload.recipientEmails,
+        companyName: purchaseOrder.companyName,
+        assigneeName: purchaseOrder.assigneeName,
+        vendorName: purchaseOrder.sageVendorName,
+        viewerEmail: context.user.email,
+        viewerCompanyName: context.viewerContact.companyName,
+        viewerDisplayName: context.viewerContact.displayName,
+      })
+    ) {
+      return {
+        success: false,
+        error: "This purchase order was assigned to another vendor.",
+      }
+    }
+
+    const now = new Date().toISOString()
+    if (input.decision === "acknowledge") {
+      const updateResult = await context.db
+        .update(projectOperations)
+        .set({
+          sagePayloadJson: withPortalPurchaseOrderAcknowledgement(
+            purchaseOrder.sagePayloadJson,
+            {
+              responderUserId: context.user.id,
+              responderName: context.user.displayName ?? context.user.email,
+              responderCompany: context.viewerContact.companyName,
+              note: cleanText(input.note, 2_000),
+              submittedAt: now,
+            }
+          ),
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(projectOperations.id, purchaseOrderId),
+            eq(projectOperations.projectId, projectId),
+            eq(projectOperations.status, purchaseOrder.status),
+            eq(projectOperations.updatedAt, purchaseOrder.updatedAt)
+          )
+        )
+        .run()
+      if ((updateResult.meta.changes ?? 0) !== 1) {
+        return {
+          success: false,
+          error:
+            "The purchase order changed. Refresh the page before responding.",
+        }
+      }
+      revalidateSubVendorWorkspace(projectId)
+      return { success: true, id: purchaseOrderId }
+    }
+
+    const audienceStaff = await getProjectAudienceStaff(context.db, {
+      projectId,
+      organizationId: context.organizationId,
+      audience: "sub_vendor",
+    })
+    const recipient = audienceStaff.find(
+      (member) => member.userId === input.recipientUserId
+    )
+    if (!recipient) {
+      return {
+        success: false,
+        error: "Choose a staff member selected for the sub/vendor workspace.",
+      }
+    }
+
+    const rows = await context.db
+      .select({ id: projectRfis.id })
+      .from(projectRfis)
+      .where(eq(projectRfis.projectId, projectId))
+    const rfiId = crypto.randomUUID()
+    const poReference = purchaseOrder.sourceRecordNumber ?? purchaseOrder.title
+    const inserted: typeof projectRfis.$inferInsert = {
+      id: rfiId,
+      projectId,
+      sourceSystem: "compass_portal",
+      rfiNumber: rfiNumber(context.projectNumber, rows.length, rfiId),
+      subject: `Question about PO ${poReference}`.slice(0, 240),
+      question: requireText(input.question, "Question", 10_000),
+      status: "new",
+      priority: "normal",
+      audience: "sub_vendor",
+      requesterName: context.user.displayName ?? context.user.email,
+      assignedToName: recipient.displayName,
+      companyName: context.viewerContact.companyName,
+      submittedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }
+    await context.db.insert(projectRfis).values(inserted)
+    revalidateSubVendorWorkspace(projectId)
+
+    try {
+      await notifyRfiCreated({
+        organizationId: context.organizationId,
+        projectId,
+        rfiId,
+        rfiNumber: inserted.rfiNumber,
+        subject: inserted.subject,
+        assignedToName: inserted.assignedToName ?? null,
+        createdBy: context.user,
+      })
+    } catch (notificationError) {
+      console.error("[sub-vendor-po-question] notification error", notificationError)
+    }
+
+    return { success: true, id: rfiId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to respond to the purchase order.",
     }
   }
 }

--- a/src/app/actions/project-operations.ts
+++ b/src/app/actions/project-operations.ts
@@ -33,7 +33,13 @@ import {
 import {
   isPurchaseOrderStatus,
   isRfqStatus,
+  purchaseOrderStatusAfterEmail,
 } from "@/lib/project-operations/status"
+import {
+  parsePortalPurchaseOrderPayload,
+  type PortalPurchaseOrderAcknowledgement,
+  withPortalPurchaseOrderRecipients,
+} from "@/lib/purchase-orders/portal-response"
 import {
   parsePortalRfqPayload,
   type PortalRfqVendorResponse,
@@ -91,6 +97,7 @@ export type ProjectPurchaseOrderLineItem = {
 export type ProjectPurchaseOrderItem = ProjectOperationItem & {
   readonly lines: readonly ProjectPurchaseOrderLineItem[]
   readonly vendorEmail: string | null
+  readonly vendorAcknowledgement: PortalPurchaseOrderAcknowledgement | null
 }
 
 export type ProjectPurchaseOrderPhaseOption = {
@@ -1557,6 +1564,8 @@ export async function getProjectPurchaseOrders(
     ...toOperationItem(row),
     lines: linesByOperation.get(row.id) ?? [],
     vendorEmail: purchaseOrderVendorEmail(row, contactRows, vendorRows),
+    vendorAcknowledgement: parsePortalPurchaseOrderPayload(row.sagePayloadJson)
+      .acknowledgement,
   }))
 }
 
@@ -2731,6 +2740,9 @@ export async function sendPurchaseOrderEmail(
       ...toOperationItem(operation),
       lines: lineRows.map(toPurchaseOrderLineItem),
       vendorEmail: null,
+      vendorAcknowledgement: parsePortalPurchaseOrderPayload(
+        operation.sagePayloadJson
+      ).acknowledgement,
     }
     const senderName = user.displayName ?? user.email
     const emailInput = {
@@ -2759,7 +2771,11 @@ export async function sendPurchaseOrderEmail(
     await db
       .update(projectOperations)
       .set({
-        status: "sent",
+        status: purchaseOrderStatusAfterEmail(operation.status),
+        sagePayloadJson: withPortalPurchaseOrderRecipients(
+          operation.sagePayloadJson,
+          [...to, ...cc]
+        ),
         updatedAt: now,
       })
       .where(eq(projectOperations.id, purchaseOrderId))

--- a/src/app/dashboard/projects/[id]/purchase-orders/page.tsx
+++ b/src/app/dashboard/projects/[id]/purchase-orders/page.tsx
@@ -68,6 +68,7 @@ const PURCHASE_ORDER_FILTERS: readonly {
   { value: "open", label: "Open" },
   { value: "draft", label: "Draft" },
   { value: "approved", label: "Approved" },
+  { value: "sent", label: "Sent" },
   { value: "ordered", label: "Ordered" },
   { value: "partially_received", label: "Partially received" },
   { value: "received", label: "Received" },
@@ -193,6 +194,21 @@ function PurchaseOrderCard({
           <span>{formatDate(order.dueDate)}</span>
         </div>
         <p className="mt-3 text-sm font-medium">{money(order.amount)}</p>
+        {order.vendorAcknowledgement && (
+          <div className="mt-3 rounded-md border border-green-200 bg-green-50 p-3 text-sm text-green-900">
+            <p className="font-medium">
+              Vendor acknowledged receipt · {order.vendorAcknowledgement.responderName}
+            </p>
+            <p className="mt-1 text-xs">
+              {new Date(
+                order.vendorAcknowledgement.submittedAt
+              ).toLocaleString("en-US")}
+              {order.vendorAcknowledgement.note
+                ? ` · ${order.vendorAcknowledgement.note}`
+                : ""}
+            </p>
+          </div>
+        )}
         <div className="mt-3 rounded-md border bg-muted/20 p-3">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <p className="text-xs font-medium uppercase text-muted-foreground">

--- a/src/components/projects/project-audience-preview.tsx
+++ b/src/components/projects/project-audience-preview.tsx
@@ -39,6 +39,7 @@ import { ProjectEmailAddressCard } from "@/components/projects/project-email-add
 import { ProjectAudienceMessageLauncher } from "@/components/projects/project-audience-message-launcher"
 import { ProjectAudiencePhotoGallery } from "@/components/projects/project-audience-photo-gallery"
 import { ProjectAudiencePreviewShell } from "@/components/projects/project-audience-preview-shell"
+import { ProjectAudiencePurchaseOrderResponseDialog } from "@/components/projects/project-audience-purchase-order-response-dialog"
 import { ProjectAudienceRfiCreateDialog } from "@/components/projects/project-audience-rfi-create-dialog"
 import { ProjectAudienceRfqResponseDialog } from "@/components/projects/project-audience-rfq-response-dialog"
 import { ProjectAudienceSchedule } from "@/components/projects/project-audience-schedule"
@@ -49,7 +50,10 @@ import {
   projectAudienceSectionHref,
   type ProjectAudienceWorkspaceSection,
 } from "@/lib/project-audience-preview-routes"
-import { projectAudienceMessageShortcut } from "@/lib/project-audience-direct-message"
+import {
+  projectAudienceMessageShortcut,
+  type ProjectAudienceMessageRecipient,
+} from "@/lib/project-audience-direct-message"
 import { selectUpcomingScheduleItems } from "@/lib/project-audience-schedule-selection"
 
 function formatDate(value: string | null): string {
@@ -117,8 +121,14 @@ function operationReferenceLabel(item: AudienceOperationItem): string {
 
 function OperationRow({
   item,
+  projectId,
+  recipients,
+  viewerIsInternal,
 }: {
   readonly item: AudienceOperationItem
+  readonly projectId: string
+  readonly recipients: readonly ProjectAudienceMessageRecipient[]
+  readonly viewerIsInternal: boolean
 }): React.ReactElement {
   return (
     <div className="rounded-md border bg-background p-3">
@@ -136,13 +146,37 @@ function OperationRow({
             {item.assigneeName ? ` · ${item.assigneeName}` : ""}
           </p>
         </div>
-        <Badge variant="secondary">{statusLabel(item.status)}</Badge>
+        <div className="flex flex-wrap items-center gap-2">
+          {item.acknowledgement && (
+            <Badge variant="outline">Acknowledged</Badge>
+          )}
+          <Badge variant="secondary">{statusLabel(item.status)}</Badge>
+        </div>
       </div>
+      {item.description && (
+        <p className="mt-2 line-clamp-3 text-sm text-muted-foreground">
+          {item.description}
+        </p>
+      )}
       <p className="mt-2 text-xs text-muted-foreground">
         {formatDate(item.startDate)}
         {" - "}
         {formatDate(item.dueDate)}
       </p>
+      {item.sourceRecordType === "purchase_order" && (
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-2 border-t pt-3">
+          <span className="text-sm font-medium">{formatMoney(item.amount)}</span>
+          <ProjectAudiencePurchaseOrderResponseDialog
+            projectId={projectId}
+            purchaseOrderId={item.id}
+            purchaseOrderLabel={item.sourceRecordNumber ?? item.title}
+            status={item.status}
+            acknowledgement={item.acknowledgement}
+            recipients={recipients}
+            viewerIsInternal={viewerIsInternal}
+          />
+        </div>
+      )}
     </div>
   )
 }
@@ -1077,7 +1111,13 @@ export function ProjectAudiencePreview({
             {data.operations.length > 0 ? (
               <div className="mt-4 grid gap-3">
                 {data.operations.map((item) => (
-                  <OperationRow key={item.id} item={item} />
+                  <OperationRow
+                    key={item.id}
+                    item={item}
+                    projectId={data.project.id}
+                    recipients={messageShortcut?.recipients ?? []}
+                    viewerIsInternal={data.viewerIsInternal}
+                  />
                 ))}
               </div>
             ) : (

--- a/src/components/projects/project-audience-purchase-order-response-dialog.tsx
+++ b/src/components/projects/project-audience-purchase-order-response-dialog.tsx
@@ -1,0 +1,237 @@
+"use client"
+
+import * as React from "react"
+import { IconClipboardCheck, IconQuestionMark } from "@tabler/icons-react"
+import { useRouter } from "next/navigation"
+
+import { respondToSubVendorPurchaseOrder } from "@/app/actions/project-audience-sub-vendor"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import type { ProjectAudienceMessageRecipient } from "@/lib/project-audience-direct-message"
+import type { PortalPurchaseOrderAcknowledgement } from "@/lib/purchase-orders/portal-response"
+import { portalPurchaseOrderCanReceiveResponse } from "@/lib/purchase-orders/portal-response"
+
+type ResponseKind = "acknowledge" | "question"
+
+function acknowledgementLabel(
+  acknowledgement: PortalPurchaseOrderAcknowledgement
+): string {
+  const date = new Date(acknowledgement.submittedAt).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+  return `Acknowledged by ${acknowledgement.responderName} on ${date}`
+}
+
+export function ProjectAudiencePurchaseOrderResponseDialog({
+  projectId,
+  purchaseOrderId,
+  purchaseOrderLabel,
+  status,
+  acknowledgement,
+  recipients,
+  viewerIsInternal,
+}: {
+  readonly projectId: string
+  readonly purchaseOrderId: string
+  readonly purchaseOrderLabel: string
+  readonly status: string
+  readonly acknowledgement: PortalPurchaseOrderAcknowledgement | null
+  readonly recipients: readonly ProjectAudienceMessageRecipient[]
+  readonly viewerIsInternal: boolean
+}): React.ReactElement {
+  const router = useRouter()
+  const [open, setOpen] = React.useState(false)
+  const [pending, startTransition] = React.useTransition()
+  const [kind, setKind] = React.useState<ResponseKind>(
+    acknowledgement ? "question" : "acknowledge"
+  )
+  const [note, setNote] = React.useState("")
+  const [question, setQuestion] = React.useState("")
+  const [recipientUserId, setRecipientUserId] = React.useState(
+    recipients[0]?.userId ?? ""
+  )
+  const [error, setError] = React.useState<string | null>(null)
+  const acceptsResponse = portalPurchaseOrderCanReceiveResponse(status)
+
+  function changeKind(value: string): void {
+    if (value === "acknowledge" || value === "question") setKind(value)
+  }
+
+  function submit(event: React.FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    setError(null)
+    if (viewerIsInternal) {
+      setError(
+        "Preview mode shows the vendor response flow, but only the assigned sub/vendor can submit it."
+      )
+      return
+    }
+    if (kind === "question" && !recipientUserId) {
+      setError("Choose an internal project team member.")
+      return
+    }
+    startTransition(async () => {
+      const result =
+        kind === "acknowledge"
+          ? await respondToSubVendorPurchaseOrder(projectId, purchaseOrderId, {
+              decision: "acknowledge",
+              note,
+            })
+          : await respondToSubVendorPurchaseOrder(projectId, purchaseOrderId, {
+              decision: "question",
+              question,
+              recipientUserId,
+            })
+      if (!result.success) {
+        setError(result.error)
+        return
+      }
+      setOpen(false)
+      setNote("")
+      setQuestion("")
+      router.refresh()
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button type="button" size="sm" disabled={!acceptsResponse}>
+          {acknowledgement ? (
+            <IconQuestionMark className="size-4" />
+          ) : (
+            <IconClipboardCheck className="size-4" />
+          )}
+          {acknowledgement ? "Ask a question" : "Review & respond"}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-xl">
+        <form onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>Respond to {purchaseOrderLabel}</DialogTitle>
+            <DialogDescription>
+              Confirm that the purchase order was received or route a question
+              to the internal project team before it is processed.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="mt-5 grid gap-4">
+            {acknowledgement && (
+              <p className="border bg-muted/40 p-3 text-sm">
+                {acknowledgementLabel(acknowledgement)}
+                {acknowledgement.note ? ` · ${acknowledgement.note}` : ""}
+              </p>
+            )}
+            {viewerIsInternal && (
+              <p className="border bg-muted/40 p-3 text-sm text-muted-foreground">
+                Preview mode: this is the response flow available to the assigned
+                sub/vendor. Submitting is blocked for internal accounts.
+              </p>
+            )}
+            <label className="grid gap-1.5 text-sm font-medium">
+              Response
+              <Select value={kind} onValueChange={changeKind}>
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {!acknowledgement && (
+                    <SelectItem value="acknowledge">Acknowledge receipt</SelectItem>
+                  )}
+                  <SelectItem value="question">Ask a question</SelectItem>
+                </SelectContent>
+              </Select>
+            </label>
+            {kind === "acknowledge" ? (
+              <label className="grid gap-1.5 text-sm font-medium">
+                Note (optional)
+                <Textarea
+                  value={note}
+                  onChange={(event) => setNote(event.currentTarget.value)}
+                  maxLength={2_000}
+                  placeholder="Example: Received and under review."
+                />
+              </label>
+            ) : (
+              <>
+                <label className="grid gap-1.5 text-sm font-medium">
+                  Send to
+                  <Select
+                    value={recipientUserId}
+                    onValueChange={setRecipientUserId}
+                  >
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="Choose a project team member" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {recipients.map((recipient) => (
+                        <SelectItem
+                          key={recipient.userId}
+                          value={recipient.userId}
+                        >
+                          {recipient.displayName}
+                          {recipient.role ? ` · ${recipient.role}` : ""}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </label>
+                <label className="grid gap-1.5 text-sm font-medium">
+                  Question
+                  <Textarea
+                    value={question}
+                    onChange={(event) => setQuestion(event.currentTarget.value)}
+                    maxLength={10_000}
+                    className="min-h-32"
+                    placeholder="What does the project team need to clarify?"
+                    required
+                  />
+                </label>
+              </>
+            )}
+            {error && (
+              <p role="alert" className="text-sm text-destructive">
+                {error}
+              </p>
+            )}
+          </div>
+          <DialogFooter className="mt-5">
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={
+                pending ||
+                (kind === "question" && recipients.length === 0)
+              }
+            >
+              {pending
+                ? "Submitting..."
+                : kind === "acknowledge"
+                  ? "Acknowledge received"
+                  : "Send question"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/projects/project-audience-rfi-create-dialog.tsx
+++ b/src/components/projects/project-audience-rfi-create-dialog.tsx
@@ -49,7 +49,7 @@ export function ProjectAudienceRfiCreateDialog({
     recipients[0]?.userId ?? ""
   )
   const [state, setState] = React.useState<SubmitState>({ kind: "idle" })
-  const unavailable = viewerIsInternal || recipients.length === 0
+  const unavailable = recipients.length === 0
 
   function reset(): void {
     setSubject("")
@@ -62,6 +62,14 @@ export function ProjectAudienceRfiCreateDialog({
   function submit(event: React.FormEvent<HTMLFormElement>): void {
     event.preventDefault()
     setState({ kind: "idle" })
+    if (viewerIsInternal) {
+      setState({
+        kind: "error",
+        message:
+          "Preview mode shows the partner form, but only an assigned sub/vendor can create the live RFI.",
+      })
+      return
+    }
     startTransition(async () => {
       const result = await createSubVendorRfi(projectId, {
         subject,
@@ -86,10 +94,10 @@ export function ProjectAudienceRfiCreateDialog({
           type="button"
           disabled={unavailable}
           title={
-            viewerIsInternal
-              ? "Sign in as the assigned sub/vendor to send an RFI."
-              : recipients.length === 0
-                ? "Assign an internal project team member first."
+            recipients.length === 0
+              ? "Add an active internal staff member first."
+              : viewerIsInternal
+                ? "Preview the RFI form an assigned sub/vendor can send."
                 : undefined
           }
         >
@@ -107,6 +115,13 @@ export function ProjectAudienceRfiCreateDialog({
             </DialogDescription>
           </DialogHeader>
           <div className="mt-5 grid gap-4">
+            {viewerIsInternal && (
+              <p className="border bg-muted/40 p-3 text-sm text-muted-foreground">
+                Preview mode: this is the form an assigned sub/vendor can send.
+                Submitting is blocked here so an internal staff account cannot be
+                recorded as the external requester.
+              </p>
+            )}
             <label className="grid gap-1.5 text-sm font-medium">
               Send to
               <Select value={recipientUserId} onValueChange={setRecipientUserId}>

--- a/src/lib/__tests__/project-audience-schedule-visibility.test.ts
+++ b/src/lib/__tests__/project-audience-schedule-visibility.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import { selectProjectAudienceScheduleItems } from "@/lib/project-audience-schedule-visibility"
+
+const rows = [
+  { id: "owner-and-partner", ownerVisible: true, subVendorVisible: true },
+  { id: "owner-only", ownerVisible: true, subVendorVisible: false },
+  { id: "internal", ownerVisible: false, subVendorVisible: false },
+] as const
+
+describe("project audience schedule visibility", () => {
+  it("keeps owner visibility authoritative for owner workspaces", () => {
+    expect(
+      selectProjectAudienceScheduleItems(rows, "owner").map((item) => item.id)
+    ).toEqual(["owner-and-partner", "owner-only"])
+  })
+
+  it("uses explicit partner selections when the schedule has them", () => {
+    expect(
+      selectProjectAudienceScheduleItems(rows, "sub_vendor").map(
+        (item) => item.id
+      )
+    ).toEqual(["owner-and-partner"])
+  })
+
+  it("falls back to owner-approved rows for legacy schedules", () => {
+    const legacyRows = rows.map((item) => ({
+      ...item,
+      subVendorVisible: false,
+    }))
+    expect(
+      selectProjectAudienceScheduleItems(legacyRows, "sub_vendor").map(
+        (item) => item.id
+      )
+    ).toEqual(["owner-and-partner", "owner-only"])
+  })
+})

--- a/src/lib/__tests__/purchase-order-portal-response.test.ts
+++ b/src/lib/__tests__/purchase-order-portal-response.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isPortalVisiblePurchaseOrderStatus,
+  parsePortalPurchaseOrderPayload,
+  portalPurchaseOrderCanReceiveResponse,
+  portalPurchaseOrderMatchesRecipient,
+  withPortalPurchaseOrderAcknowledgement,
+  withPortalPurchaseOrderRecipients,
+} from "@/lib/purchase-orders/portal-response"
+
+describe("purchase order portal response", () => {
+  it("preserves the Sage payload while adding delivery and acknowledgement data", () => {
+    const delivered = withPortalPurchaseOrderRecipients(
+      JSON.stringify({ source: "compass_po_request", header: { vendorId: "12" } }),
+      ["Purchasing@Vendor.com"]
+    )
+    const acknowledged = withPortalPurchaseOrderAcknowledgement(delivered, {
+      responderUserId: "user-1",
+      responderName: "Pat Vendor",
+      responderCompany: "Vendor Co",
+      note: "Received",
+      submittedAt: "2026-08-19T18:00:00.000Z",
+    })
+    const raw: unknown = JSON.parse(acknowledged)
+    expect(raw).toMatchObject({
+      source: "compass_po_request",
+      header: { vendorId: "12" },
+    })
+    expect(parsePortalPurchaseOrderPayload(acknowledged)).toEqual({
+      recipientEmails: ["purchasing@vendor.com"],
+      acknowledgement: {
+        responderUserId: "user-1",
+        responderName: "Pat Vendor",
+        responderCompany: "Vendor Co",
+        note: "Received",
+        submittedAt: "2026-08-19T18:00:00.000Z",
+      },
+    })
+  })
+
+  it("treats explicit delivery emails as authoritative", () => {
+    expect(
+      portalPurchaseOrderMatchesRecipient({
+        recipientEmails: ["orders@vendor.com"],
+        companyName: "Vendor Co",
+        assigneeName: null,
+        vendorName: "Vendor Co",
+        viewerEmail: "someone@vendor.com",
+        viewerCompanyName: "Vendor Co",
+        viewerDisplayName: "Someone",
+      })
+    ).toBe(false)
+  })
+
+  it("falls back to the assigned company for legacy purchase orders", () => {
+    expect(
+      portalPurchaseOrderMatchesRecipient({
+        recipientEmails: [],
+        companyName: "Vendor Co., LLC",
+        assigneeName: null,
+        vendorName: null,
+        viewerEmail: "someone@vendor.com",
+        viewerCompanyName: "Vendor Co LLC",
+        viewerDisplayName: "Someone",
+      })
+    ).toBe(true)
+  })
+
+  it("exposes only issued POs and stops responses after receipt", () => {
+    expect(isPortalVisiblePurchaseOrderStatus("draft")).toBe(false)
+    expect(isPortalVisiblePurchaseOrderStatus("approved")).toBe(false)
+    expect(isPortalVisiblePurchaseOrderStatus("sent")).toBe(true)
+    expect(portalPurchaseOrderCanReceiveResponse("ordered")).toBe(true)
+    expect(portalPurchaseOrderCanReceiveResponse("received")).toBe(false)
+  })
+})

--- a/src/lib/project-audience-conversations.ts
+++ b/src/lib/project-audience-conversations.ts
@@ -2,7 +2,6 @@ import { and, eq, inArray, isNull } from "drizzle-orm"
 
 import type { getDb } from "@/db"
 import {
-  organizationMembers,
   projectAccessInvitations,
   projectMembers,
   projects,
@@ -17,7 +16,7 @@ import {
   canUseProjectAudience,
   type ProjectAudience,
 } from "@/lib/project-audience-access"
-import { isAssignedVisibleAudienceTeamMember } from "@/lib/project-audience-team"
+import { getProjectAudienceStaff } from "@/lib/project-audience-staff"
 
 type Db = ReturnType<typeof getDb>
 type ConversationMemberRole = "owner" | "moderator" | "member"
@@ -196,48 +195,16 @@ async function ensureMembers(
   }
 }
 
-async function organizationStaffUserIds(
+async function audienceStaffUserIds(
   db: Db,
-  organizationId: string,
-  projectId: string
+  input: {
+    readonly projectId: string
+    readonly organizationId: string
+    readonly audience: ProjectAudience
+  }
 ): Promise<readonly string[]> {
-  const memberRows = await db
-    .select({
-      userId: organizationMembers.userId,
-      email: users.email,
-      organizationRole: organizationMembers.role,
-      projectRole: projectMembers.role,
-    })
-    .from(projectMembers)
-    .innerJoin(users, eq(users.id, projectMembers.userId))
-    .innerJoin(
-      organizationMembers,
-      and(
-        eq(organizationMembers.userId, projectMembers.userId),
-        eq(organizationMembers.organizationId, organizationId)
-      )
-    )
-    .where(
-      and(
-        eq(projectMembers.projectId, projectId),
-        eq(users.isActive, true)
-      )
-    )
-
-  return Array.from(
-    new Set(
-      memberRows
-        .filter((row) =>
-          isAssignedVisibleAudienceTeamMember({
-            userId: row.userId,
-            email: row.email,
-            organizationRole: row.organizationRole,
-            projectRole: row.projectRole,
-          })
-        )
-        .map((row) => row.userId)
-    )
-  )
+  const staff = await getProjectAudienceStaff(db, input)
+  return Array.from(new Set(staff.map((member) => member.userId)))
 }
 
 async function externalParticipantUserIds(input: {
@@ -327,11 +294,11 @@ export async function ensureProjectAudienceConversation(input: {
 
   if (!project) throw new Error("Project not found")
 
-  const staffIds = await organizationStaffUserIds(
-    input.db,
-    input.organizationId,
-    input.projectId
-  )
+  const staffIds = await audienceStaffUserIds(input.db, {
+    projectId: input.projectId,
+    organizationId: input.organizationId,
+    audience: input.audience,
+  })
   const externalParticipantIds = await externalParticipantUserIds({
     db: input.db,
     projectId: input.projectId,

--- a/src/lib/project-audience-schedule-visibility.ts
+++ b/src/lib/project-audience-schedule-visibility.ts
@@ -1,0 +1,29 @@
+import type { ProjectAudience } from "@/lib/project-audience-access"
+
+type AudienceScheduleVisibility = {
+  readonly ownerVisible: boolean | null | undefined
+  readonly subVendorVisible: boolean | null | undefined
+}
+
+/**
+ * Existing schedules predate sub/vendor visibility flags. Until a project
+ * explicitly curates partner-visible tasks, give partners the same published
+ * schedule rows already approved for owners. Once any task is explicitly
+ * shared with partners, the explicit partner selection becomes authoritative.
+ */
+export function selectProjectAudienceScheduleItems<
+  T extends AudienceScheduleVisibility,
+>(items: readonly T[], audience: ProjectAudience): readonly T[] {
+  if (audience === "owner") {
+    return items.filter((item) => item.ownerVisible !== false)
+  }
+
+  const hasExplicitPartnerSelection = items.some(
+    (item) => item.subVendorVisible === true
+  )
+  return items.filter((item) =>
+    hasExplicitPartnerSelection
+      ? item.subVendorVisible === true
+      : item.ownerVisible !== false
+  )
+}

--- a/src/lib/project-audience-staff.ts
+++ b/src/lib/project-audience-staff.ts
@@ -1,0 +1,111 @@
+import { and, asc, eq } from "drizzle-orm"
+
+import type { getDb } from "@/db"
+import {
+  organizationMembers,
+  projectContacts,
+  users,
+} from "@/db/schema"
+import type { ProjectAudience } from "@/lib/project-audience-access"
+import { isVisibleAudienceTeamMember } from "@/lib/project-audience-team"
+
+export type ProjectAudienceStaffMember = {
+  readonly contactId: string
+  readonly userId: string
+  readonly displayName: string
+  readonly email: string
+  readonly companyName: string | null
+  readonly role: string | null
+  readonly trade: string | null
+  readonly csiDivision: string | null
+  readonly csiDivisionName: string | null
+  readonly phone: string | null
+  readonly primaryContact: boolean
+}
+
+/**
+ * Returns only linked internal contacts explicitly selected for this audience.
+ * The project-contact visibility checkboxes are the source of truth for portal
+ * team lists and communication recipients.
+ */
+export async function getProjectAudienceStaff(
+  db: ReturnType<typeof getDb>,
+  input: {
+    readonly projectId: string
+    readonly organizationId: string
+    readonly audience: ProjectAudience
+  }
+): Promise<readonly ProjectAudienceStaffMember[]> {
+  const audienceVisibility =
+    input.audience === "owner"
+      ? eq(projectContacts.ownerPortalVisible, true)
+      : eq(projectContacts.subVendorPortalVisible, true)
+  const rows = await db
+    .select({
+      contactId: projectContacts.id,
+      userId: users.id,
+      contactDisplayName: projectContacts.displayName,
+      userDisplayName: users.displayName,
+      email: users.email,
+      companyName: projectContacts.companyName,
+      contactRole: projectContacts.role,
+      organizationRole: organizationMembers.role,
+      trade: projectContacts.trade,
+      csiDivision: projectContacts.csiDivision,
+      csiDivisionName: projectContacts.csiDivisionName,
+      phone: projectContacts.phone,
+      primaryContact: projectContacts.primaryContact,
+    })
+    .from(projectContacts)
+    .innerJoin(
+      users,
+      and(
+        eq(projectContacts.sourceEntityType, "user"),
+        eq(projectContacts.sourceEntityId, users.id)
+      )
+    )
+    .innerJoin(
+      organizationMembers,
+      and(
+        eq(organizationMembers.userId, users.id),
+        eq(organizationMembers.organizationId, input.organizationId)
+      )
+    )
+    .where(
+      and(
+        eq(projectContacts.projectId, input.projectId),
+        eq(projectContacts.contactType, "internal"),
+        eq(projectContacts.active, true),
+        eq(users.isActive, true),
+        audienceVisibility
+      )
+    )
+    .orderBy(
+      asc(projectContacts.sortOrder),
+      asc(projectContacts.displayName),
+      asc(users.email)
+    )
+
+  return rows
+    .filter((row) =>
+      isVisibleAudienceTeamMember({
+        userId: row.userId,
+        email: row.email,
+        role: row.organizationRole,
+      })
+    )
+    .map((row) => ({
+      contactId: row.contactId,
+      userId: row.userId,
+      displayName:
+        row.contactDisplayName.trim() || row.userDisplayName?.trim() || row.email,
+      email: row.email,
+      companyName: row.companyName,
+      role: row.contactRole ?? row.organizationRole,
+      trade: row.trade,
+      csiDivision: row.csiDivision,
+      csiDivisionName: row.csiDivisionName,
+      phone: row.phone,
+      primaryContact: row.primaryContact,
+    }))
+}

--- a/src/lib/project-operations/__tests__/status.test.ts
+++ b/src/lib/project-operations/__tests__/status.test.ts
@@ -6,6 +6,7 @@ import {
   isRfqStatus,
   parseProjectOperationStatusFilter,
   projectOperationMatchesStatusFilter,
+  purchaseOrderStatusAfterEmail,
   statusLabel,
 } from "@/lib/project-operations/status"
 
@@ -33,6 +34,13 @@ describe("project operation statuses", () => {
     expect(isPurchaseOrderStatus("response_received")).toBe(false)
     expect(isRfqStatus("response_received")).toBe(true)
     expect(isRfqStatus("partially_received")).toBe(false)
+  })
+
+  it("marks newly issued POs sent without downgrading later lifecycle states", () => {
+    expect(purchaseOrderStatusAfterEmail("draft")).toBe("sent")
+    expect(purchaseOrderStatusAfterEmail("approved")).toBe("sent")
+    expect(purchaseOrderStatusAfterEmail("ordered")).toBe("ordered")
+    expect(purchaseOrderStatusAfterEmail("received")).toBe("received")
   })
 
   it("defaults filters to open and accepts query arrays", () => {

--- a/src/lib/project-operations/status.ts
+++ b/src/lib/project-operations/status.ts
@@ -1,6 +1,7 @@
 export type PurchaseOrderStatus =
   | "draft"
   | "approved"
+  | "sent"
   | "ordered"
   | "partially_received"
   | "received"
@@ -26,6 +27,7 @@ export const PURCHASE_ORDER_STATUS_OPTIONS: readonly {
 }[] = [
   { value: "draft", label: "Draft" },
   { value: "approved", label: "Approved" },
+  { value: "sent", label: "Sent" },
   { value: "ordered", label: "Ordered" },
   { value: "partially_received", label: "Partially received" },
   { value: "received", label: "Received" },
@@ -89,6 +91,11 @@ export function isRfqStatus(status: string): status is RfqStatus {
     RFQ_STATUS_OPTIONS.some((option) => option.value === normalized) &&
     status === normalized
   )
+}
+
+export function purchaseOrderStatusAfterEmail(status: string): string {
+  const normalized = normalizedStatus(status)
+  return normalized === "draft" || normalized === "approved" ? "sent" : status
 }
 
 export function parseProjectOperationStatusFilter(

--- a/src/lib/purchase-orders/portal-response.ts
+++ b/src/lib/purchase-orders/portal-response.ts
@@ -1,0 +1,157 @@
+export type PortalPurchaseOrderAcknowledgement = {
+  readonly responderUserId: string
+  readonly responderName: string
+  readonly responderCompany: string | null
+  readonly note: string | null
+  readonly submittedAt: string
+}
+
+export type PortalPurchaseOrderPayload = {
+  readonly recipientEmails: readonly string[]
+  readonly acknowledgement: PortalPurchaseOrderAcknowledgement | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function parseRecord(value: string | null): Record<string, unknown> {
+  if (!value) return {}
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return isRecord(parsed) ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+function textValue(value: Record<string, unknown>, key: string): string | null {
+  const candidate = value[key]
+  return typeof candidate === "string" && candidate.trim().length > 0
+    ? candidate.trim()
+    : null
+}
+
+function normalizedEmail(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+function parseRecipientEmails(
+  payload: Record<string, unknown>
+): readonly string[] {
+  const multiple = payload.recipientEmails
+  if (Array.isArray(multiple)) {
+    return Array.from(
+      new Set(
+        multiple
+          .filter((value): value is string => typeof value === "string")
+          .map(normalizedEmail)
+          .filter((value) => value.length > 0)
+      )
+    )
+  }
+  const single = textValue(payload, "recipientEmail")
+  return single ? [normalizedEmail(single)] : []
+}
+
+function parseAcknowledgement(
+  payload: Record<string, unknown>
+): PortalPurchaseOrderAcknowledgement | null {
+  const raw = payload.vendorAcknowledgement
+  if (!isRecord(raw)) return null
+  const responderUserId = textValue(raw, "responderUserId")
+  const responderName = textValue(raw, "responderName")
+  const submittedAt = textValue(raw, "submittedAt")
+  if (!responderUserId || !responderName || !submittedAt) return null
+  return {
+    responderUserId,
+    responderName,
+    responderCompany: textValue(raw, "responderCompany"),
+    note: textValue(raw, "note"),
+    submittedAt,
+  }
+}
+
+export function parsePortalPurchaseOrderPayload(
+  value: string | null
+): PortalPurchaseOrderPayload {
+  const payload = parseRecord(value)
+  return {
+    recipientEmails: parseRecipientEmails(payload),
+    acknowledgement: parseAcknowledgement(payload),
+  }
+}
+
+function normalizedName(value: string | null): string {
+  return (value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+}
+
+export function portalPurchaseOrderMatchesRecipient(input: {
+  readonly recipientEmails: readonly string[]
+  readonly companyName: string | null
+  readonly assigneeName: string | null
+  readonly vendorName: string | null
+  readonly viewerEmail: string
+  readonly viewerCompanyName: string | null
+  readonly viewerDisplayName: string
+}): boolean {
+  if (input.recipientEmails.length > 0) {
+    return input.recipientEmails.includes(normalizedEmail(input.viewerEmail))
+  }
+
+  const viewerNames = new Set(
+    [input.viewerCompanyName, input.viewerDisplayName]
+      .map(normalizedName)
+      .filter((value) => value.length > 0)
+  )
+  return [input.companyName, input.assigneeName, input.vendorName]
+    .map(normalizedName)
+    .some((value) => value.length > 0 && viewerNames.has(value))
+}
+
+export function isPortalVisiblePurchaseOrderStatus(status: string): boolean {
+  return [
+    "sent",
+    "ordered",
+    "partially_received",
+    "received",
+    "complete",
+    "completed",
+    "closed",
+  ].includes(status.trim().toLowerCase())
+}
+
+export function portalPurchaseOrderCanReceiveResponse(status: string): boolean {
+  return ["sent", "ordered", "partially_received"].includes(
+    status.trim().toLowerCase()
+  )
+}
+
+export function withPortalPurchaseOrderRecipients(
+  value: string | null,
+  recipientEmails: readonly string[]
+): string {
+  return JSON.stringify({
+    ...parseRecord(value),
+    recipientEmails: Array.from(
+      new Set(
+        recipientEmails
+          .map(normalizedEmail)
+          .filter((email) => email.length > 0)
+      )
+    ),
+  })
+}
+
+export function withPortalPurchaseOrderAcknowledgement(
+  value: string | null,
+  acknowledgement: PortalPurchaseOrderAcknowledgement
+): string {
+  return JSON.stringify({
+    ...parseRecord(value),
+    vendorAcknowledgement: acknowledgement,
+  })
+}


### PR DESCRIPTION
## Summary
- use project contact Owner/Sub workspace visibility selections for each audience's team, messaging, and RFI recipients
- restore legacy sub/vendor schedule visibility while preserving explicit partner selections
- show issued purchase orders assigned to the signed-in vendor and support acknowledgment or RFI questions
- preserve PO lifecycle state and surface vendor acknowledgments to internal staff

## Verification
- `bun test` focused portal/status suites: 22 passing
- `./node_modules/.bin/tsc --noEmit`
- `bun lint` (0 errors; existing warnings only)
- `bun run build`
- autoreview clean: no accepted/actionable findings

## Notes
The broad `bun test` command still encounters existing repository harness issues (Playwright specs collected by Bun and unsupported `better-sqlite3` under Bun). Focused affected suites pass.
