### PR TITLE
fix(purchase-orders): batch D1 line inserts

### DIFF
--- a/src/app/actions/project-operations.ts
+++ b/src/app/actions/project-operations.ts
@@ -1858,9 +1858,8 @@ export async function createPurchaseOrderRequest(
       updatedAt: now,
     }
 
-    await db.insert(projectOperations).values(inserted)
-    await db.insert(projectPurchaseOrderLines).values(
-      lines.map((line) => ({
+    const lineInserts = lines.map((line) =>
+      db.insert(projectPurchaseOrderLines).values({
         id: crypto.randomUUID(),
         operationId: id,
         projectId,
@@ -1879,8 +1878,15 @@ export async function createPurchaseOrderRequest(
         syncStatus: "pending_sage",
         createdAt: now,
         updatedAt: now,
-      }))
+      })
     )
+
+    // D1 permits at most 100 bound parameters per statement. Keep each line in
+    // its own statement and batch the header plus lines so the write is atomic.
+    await db.batch([
+      db.insert(projectOperations).values(inserted),
+      ...lineInserts,
+    ])
     revalidatePath(`/dashboard/projects/${projectId}`)
     revalidatePath(`/dashboard/projects/${projectId}/purchase-orders`)
     revalidatePath("/dashboard/purchase-orders")


### PR DESCRIPTION
## Summary

- insert each purchase-order line in its own D1 statement
- batch the PO header and all lines atomically
- prevent D1's 100-bound-parameter limit from rejecting multi-line POs
- prevent header-only drafts when a line insert fails

## Root cause

The PO action generated one multi-row insert for all line items. Each row binds 18 values, so the reported 13-line PO attempted 234 bound parameters in a single D1 statement, above D1's limit of 100. The PO header was written first in a separate statement, leaving an orphaned draft when the line insert failed.

## Validation

- `bunx eslint src/app/actions/project-operations.ts`
- `bunx tsc --noEmit --pretty false`
- 13-line D1 query-shape reproduction: 14 atomic batch statements; 31 header parameters; 18 parameters per line
- `git diff --check`

## User impact

Multi-line PO requests can be saved without re-entry, and future insert failures roll back the entire request instead of leaving incomplete PO headers.
