### PR TITLE
feat(purchase-orders): restore draft editing

### DIFF
--- a/src/app/actions/project-operations.ts
+++ b/src/app/actions/project-operations.ts
@@ -35,6 +35,7 @@ import {
   isRfqStatus,
   purchaseOrderStatusAfterEmail,
 } from "@/lib/project-operations/status"
+import { canEditPurchaseOrderDraft } from "@/lib/purchase-orders/draft-edit"
 import {
   parsePortalPurchaseOrderPayload,
   type PortalPurchaseOrderAcknowledgement,
@@ -224,6 +225,11 @@ export type CreatePurchaseOrderRequestInput = {
   readonly priority: string
   readonly lines: readonly CreatePurchaseOrderLineInput[]
 }
+
+export type UpdatePurchaseOrderRequestInput =
+  CreatePurchaseOrderRequestInput & {
+    readonly expectedUpdatedAt: string
+  }
 
 export type CreatePurchaseOrderLineInput = {
   readonly description: string | null
@@ -1910,6 +1916,158 @@ export async function createPurchaseOrderRequest(
         error instanceof Error
           ? error.message
           : "Failed to create purchase order request",
+    }
+  }
+}
+
+export async function updatePurchaseOrderRequest(
+  projectId: string,
+  purchaseOrderId: string,
+  input: UpdatePurchaseOrderRequestInput
+): Promise<ProjectOperationActionResult> {
+  try {
+    const db = await verifyProjectUpdateAccess(
+      projectId,
+      "purchase-orders"
+    )
+    const [existing] = await db
+      .select()
+      .from(projectOperations)
+      .where(
+        and(
+          eq(projectOperations.id, purchaseOrderId),
+          eq(projectOperations.projectId, projectId),
+          eq(projectOperations.sourceRecordType, "purchase_order")
+        )
+      )
+      .limit(1)
+
+    if (!existing) {
+      throw new Error("Purchase order not found")
+    }
+    if (!canEditPurchaseOrderDraft(existing)) {
+      throw new Error(
+        "This purchase order can no longer be edited because it was sent or queued for Sage."
+      )
+    }
+    if (existing.updatedAt !== input.expectedUpdatedAt) {
+      throw new Error(
+        "This purchase order changed after you opened it. Refresh and try again."
+      )
+    }
+    if (!existing.sourceRecordNumber) {
+      throw new Error("Purchase order number is missing")
+    }
+
+    const now = new Date().toISOString()
+    const title = requireText(input.title, "Title")
+    const description = cleanText(input.description)
+    const companyName = cleanText(input.companyName)
+    const sageVendorId = cleanText(input.sageVendorId)
+    const shipTo = cleanText(input.shipTo)
+    const orderDate = cleanDate(input.orderDate, "P.O. date")
+    const dueDate = cleanDate(input.dueDate, "Required date")
+    const lines = normalizePurchaseOrderLines(input.lines, description ?? title)
+    const amount = lines.reduce((total, line) => total + line.amount, 0)
+    const headerCostCode = lines.length === 1 ? lines[0]?.costCode ?? null : null
+    const headerPhaseCode = lines.length === 1 ? lines[0]?.phaseCode ?? null : null
+    const headerTaxGroup = lines.length === 1 ? lines[0]?.taxGroup ?? null : null
+    const sagePayloadJson = JSON.stringify(
+      buildSagePurchaseOrderPayload({
+        project: {
+          sageJobId: existing.sageJobId,
+          sageJobNumber: existing.sageJobNumber,
+        },
+        sourceRecordNumber: existing.sourceRecordNumber,
+        title,
+        description,
+        companyName,
+        sageVendorId,
+        shipTo,
+        orderDate,
+        dueDate,
+        lines,
+      })
+    )
+
+    const lineInserts = lines.map((line) =>
+      db.insert(projectPurchaseOrderLines).values({
+        id: crypto.randomUUID(),
+        operationId: purchaseOrderId,
+        projectId,
+        sourceSystem: "compass",
+        sourceRecordId: null,
+        lineNumber: line.lineNumber,
+        costCode: line.costCode,
+        phaseCode: line.phaseCode,
+        description: line.description,
+        quantity: line.quantity,
+        unitCost: line.unitCost,
+        unit: line.unit,
+        amount: line.amount,
+        taxGroup: line.taxGroup,
+        sagePayloadJson: JSON.stringify(line),
+        syncStatus: "pending_sage",
+        createdAt: now,
+        updatedAt: now,
+      })
+    )
+
+    await db.batch([
+      db
+        .update(projectOperations)
+        .set({
+          title,
+          description,
+          priority: input.priority,
+          assigneeName: cleanText(input.assigneeName),
+          companyName,
+          costCode: headerCostCode,
+          dueDate,
+          amount,
+          sageVendorId,
+          sageVendorName: companyName,
+          sagePhaseCode: headerPhaseCode,
+          sageCostCode: headerCostCode,
+          sageTaxGroup: headerTaxGroup,
+          sageShipTo: shipTo,
+          sageOrderDate: orderDate,
+          sageRequiredDate: dueDate,
+          sagePayloadJson,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(projectOperations.id, purchaseOrderId),
+            eq(projectOperations.projectId, projectId),
+            eq(projectOperations.updatedAt, input.expectedUpdatedAt)
+          )
+        ),
+      db
+        .delete(projectPurchaseOrderLines)
+        .where(
+          and(
+            eq(projectPurchaseOrderLines.operationId, purchaseOrderId),
+            eq(projectPurchaseOrderLines.projectId, projectId)
+          )
+        ),
+      ...lineInserts,
+    ])
+
+    revalidatePath(`/dashboard/projects/${projectId}`)
+    revalidatePath(`/dashboard/projects/${projectId}/purchase-orders`)
+    revalidatePath("/dashboard/purchase-orders")
+    revalidatePath("/dashboard/financials")
+    revalidatePath("/dashboard/schedule")
+
+    return { success: true, id: purchaseOrderId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to update purchase order request",
     }
   }
 }

--- a/src/app/dashboard/projects/[id]/purchase-orders/page.tsx
+++ b/src/app/dashboard/projects/[id]/purchase-orders/page.tsx
@@ -12,11 +12,17 @@ import {
   getProjectPurchaseOrders,
   type ProjectPurchaseOrderItem,
 } from "@/app/actions/project-operations"
-import { getProjectTaskAssigneeOptions } from "@/app/actions/project-contacts"
+import {
+  getProjectTaskAssigneeOptions,
+  type ProjectTaskAssigneeOption,
+} from "@/app/actions/project-contacts"
 import { getProjects } from "@/app/actions/projects"
 import { ProjectPurchaseOrderDeleteButton } from "@/components/projects/project-purchase-order-delete-button"
 import { ProjectPurchaseOrderEmailButton } from "@/components/projects/project-purchase-order-email-button"
-import { ProjectPurchaseOrderCreateForm } from "@/components/projects/project-purchase-order-create-form"
+import {
+  ProjectPurchaseOrderCreateForm,
+  ProjectPurchaseOrderEditForm,
+} from "@/components/projects/project-purchase-order-create-form"
 import { ProjectPurchaseOrderPrintButton } from "@/components/projects/project-purchase-order-print-button"
 import { ProjectOperationStatusSelect } from "@/components/projects/project-operation-status-select"
 import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
@@ -31,6 +37,7 @@ import {
   projectOperationMatchesStatusFilter,
   type ProjectOperationStatusFilter,
 } from "@/lib/project-operations/status"
+import { canEditPurchaseOrderDraft } from "@/lib/purchase-orders/draft-edit"
 import {
   projectBrandFor,
   type ProjectBrand,
@@ -108,6 +115,8 @@ function PurchaseOrderCard({
   isCreated,
   isFocused,
   taskAssigneeOptions,
+  phaseOptions,
+  costCodeOptions,
 }: {
   readonly brand: ProjectBrand
   readonly order: ProjectPurchaseOrderItem
@@ -115,9 +124,13 @@ function PurchaseOrderCard({
   readonly projectLabel: string
   readonly isCreated: boolean
   readonly isFocused: boolean
-  readonly taskAssigneeOptions: React.ComponentProps<
-    typeof ProjectTaskCreateButton
-  >["assigneeOptions"]
+  readonly taskAssigneeOptions: readonly ProjectTaskAssigneeOption[]
+  readonly phaseOptions: React.ComponentProps<
+    typeof ProjectPurchaseOrderEditForm
+  >["phaseOptions"]
+  readonly costCodeOptions: React.ComponentProps<
+    typeof ProjectPurchaseOrderEditForm
+  >["costCodeOptions"]
 }): React.ReactElement {
   return (
     <article
@@ -150,6 +163,15 @@ function PurchaseOrderCard({
             <Badge variant="outline">{label(order.syncStatus)}</Badge>
             {order.priority === "high" && (
               <Badge variant="destructive">High</Badge>
+            )}
+            {canEditPurchaseOrderDraft(order) && (
+              <ProjectPurchaseOrderEditForm
+                projectId={projectId}
+                purchaseOrder={order}
+                contactOptions={taskAssigneeOptions}
+                phaseOptions={phaseOptions}
+                costCodeOptions={costCodeOptions}
+              />
             )}
             <ProjectPurchaseOrderEmailButton
               projectId={projectId}
@@ -519,6 +541,8 @@ export default async function ProjectPurchaseOrdersPage({
               isCreated={order.id === createdPurchaseOrderId}
               isFocused={order.id === focusedPurchaseOrderId}
               taskAssigneeOptions={taskAssignees}
+              phaseOptions={purchaseOrderCodingOptions.phases}
+              costCodeOptions={purchaseOrderCodingOptions.costCodes}
             />
           ))
         ) : (

--- a/src/components/projects/project-purchase-order-create-form.tsx
+++ b/src/components/projects/project-purchase-order-create-form.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation"
 import {
   IconCheck,
   IconChevronDown,
+  IconPencil,
   IconPlus,
   IconShoppingCart,
   IconTrash,
@@ -13,8 +14,10 @@ import {
 import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
 import {
   createPurchaseOrderRequest,
+  updatePurchaseOrderRequest,
   type CreatePurchaseOrderLineInput,
   type ProjectPurchaseOrderCostCodeOption,
+  type ProjectPurchaseOrderItem,
   type ProjectPurchaseOrderPhaseOption,
 } from "@/app/actions/project-operations"
 import { ProjectAssigneePicker } from "@/components/projects/project-assignee-picker"
@@ -213,6 +216,33 @@ function newLine(): DraftPurchaseOrderLine {
   }
 }
 
+function textFromNumber(value: number): string {
+  return Number.isFinite(value) ? String(value) : ""
+}
+
+function draftLinesFromPurchaseOrder(
+  purchaseOrder: ProjectPurchaseOrderItem | null
+): readonly DraftPurchaseOrderLine[] {
+  if (purchaseOrder === null || purchaseOrder.lines.length === 0) {
+    return [newLine()]
+  }
+
+  return purchaseOrder.lines.map((line) => ({
+    id: line.id,
+    description: line.description,
+    phaseCode: line.phaseCode ?? "",
+    costCode: line.costCode ?? "",
+    quantity: textFromNumber(line.quantity),
+    unitCost: textFromNumber(line.unitCost),
+    unit: line.unit ?? "",
+    amount:
+      line.amount === line.quantity * line.unitCost
+        ? ""
+        : textFromNumber(line.amount),
+    taxGroup: line.taxGroup ?? "",
+  }))
+}
+
 function numberFromText(value: string): number | null {
   const trimmed = value.replaceAll(",", "").trim()
   if (trimmed.length === 0) return null
@@ -270,25 +300,41 @@ function Field({
   )
 }
 
-export function ProjectPurchaseOrderCreateForm({
-  projectId,
-  contactOptions,
-  phaseOptions,
-  costCodeOptions,
-}: {
+type SharedPurchaseOrderFormProps = {
   readonly projectId: string
   readonly contactOptions: readonly ProjectTaskAssigneeOption[]
   readonly phaseOptions: readonly ProjectPurchaseOrderPhaseOption[]
   readonly costCodeOptions: readonly ProjectPurchaseOrderCostCodeOption[]
-}): React.ReactElement {
+}
+
+type PurchaseOrderFormProps = SharedPurchaseOrderFormProps &
+  (
+    | { readonly kind: "create" }
+    | {
+        readonly kind: "edit"
+        readonly purchaseOrder: ProjectPurchaseOrderItem
+      }
+  )
+
+function ProjectPurchaseOrderForm(
+  props: PurchaseOrderFormProps
+): React.ReactElement {
+  const { projectId, contactOptions, phaseOptions, costCodeOptions } = props
+  const purchaseOrder = props.kind === "edit" ? props.purchaseOrder : null
   const router = useRouter()
   const formRef = React.useRef<HTMLFormElement>(null)
-  const [lines, setLines] = React.useState<readonly DraftPurchaseOrderLine[]>([
-    newLine(),
-  ])
-  const [sageVendorId, setSageVendorId] = React.useState("")
-  const [companyName, setCompanyName] = React.useState("")
-  const [assigneeName, setAssigneeName] = React.useState("")
+  const [lines, setLines] = React.useState<readonly DraftPurchaseOrderLine[]>(
+    () => draftLinesFromPurchaseOrder(purchaseOrder)
+  )
+  const [sageVendorId, setSageVendorId] = React.useState(
+    purchaseOrder?.sageVendorId ?? ""
+  )
+  const [companyName, setCompanyName] = React.useState(
+    purchaseOrder?.companyName ?? ""
+  )
+  const [assigneeName, setAssigneeName] = React.useState(
+    purchaseOrder?.assigneeName ?? ""
+  )
   const [submitting, setSubmitting] = React.useState(false)
   const [message, setMessage] = React.useState<string | null>(null)
   const [open, setOpen] = React.useState(false)
@@ -334,6 +380,19 @@ export function ProjectPurchaseOrderCreateForm({
     )
   }
 
+  function handleOpenChange(nextOpen: boolean): void {
+    if (nextOpen) {
+      setMessage(null)
+      if (purchaseOrder !== null) {
+        setLines(draftLinesFromPurchaseOrder(purchaseOrder))
+        setSageVendorId(purchaseOrder.sageVendorId ?? "")
+        setCompanyName(purchaseOrder.companyName ?? "")
+        setAssigneeName(purchaseOrder.assigneeName ?? "")
+      }
+    }
+    setOpen(nextOpen)
+  }
+
   async function handleSubmit(
     event: React.FormEvent<HTMLFormElement>
   ): Promise<void> {
@@ -346,7 +405,7 @@ export function ProjectPurchaseOrderCreateForm({
 
     try {
       const formData = new FormData(form)
-      const result = await createPurchaseOrderRequest(projectId, {
+      const request = {
         title: String(formData.get("title") ?? ""),
         description: cleanText(String(formData.get("description") ?? "")),
         companyName: cleanText(companyName),
@@ -357,30 +416,47 @@ export function ProjectPurchaseOrderCreateForm({
         dueDate: cleanText(String(formData.get("dueDate") ?? "")),
         priority: String(formData.get("priority") ?? "normal"),
         lines: lines.map(toLineInput),
-      })
+      }
+      const result =
+        purchaseOrder === null
+          ? await createPurchaseOrderRequest(projectId, request)
+          : await updatePurchaseOrderRequest(projectId, purchaseOrder.id, {
+              ...request,
+              expectedUpdatedAt: purchaseOrder.updatedAt,
+            })
 
       if (!result.success) {
         throw new Error(result.error)
       }
 
-      form.reset()
-      setLines([newLine()])
-      setSageVendorId("")
-      setCompanyName("")
-      setAssigneeName("")
-      setMessage("P.O. request saved in Compass.")
-      setOpen(false)
-      router.push(
-        `/dashboard/projects/${projectId}/purchase-orders?created=${encodeURIComponent(
-          result.id
-        )}`
+      if (purchaseOrder === null) {
+        form.reset()
+        setLines([newLine()])
+        setSageVendorId("")
+        setCompanyName("")
+        setAssigneeName("")
+      }
+      setMessage(
+        purchaseOrder === null
+          ? "P.O. request saved in Compass."
+          : "Purchase order draft updated."
       )
+      setOpen(false)
+      if (purchaseOrder === null) {
+        router.push(
+          `/dashboard/projects/${projectId}/purchase-orders?created=${encodeURIComponent(
+            result.id
+          )}`
+        )
+      }
       router.refresh()
     } catch (error) {
       setMessage(
         error instanceof Error
           ? error.message
-          : "Could not stage the P.O. request."
+          : purchaseOrder === null
+            ? "Could not stage the P.O. request."
+            : "Could not update the purchase order draft."
       )
     } finally {
       setSubmitting(false)
@@ -388,19 +464,32 @@ export function ProjectPurchaseOrderCreateForm({
   }
 
   return (
-    <Sheet open={open} onOpenChange={setOpen}>
+    <Sheet open={open} onOpenChange={handleOpenChange}>
       <SheetTrigger asChild>
-        <Button type="button">
-          <IconPlus className="size-4" />
-          New PO
+        <Button
+          type="button"
+          variant={purchaseOrder === null ? "default" : "outline"}
+          size={purchaseOrder === null ? "default" : "sm"}
+        >
+          {purchaseOrder === null ? (
+            <IconPlus className="size-4" />
+          ) : (
+            <IconPencil className="size-4" />
+          )}
+          {purchaseOrder === null ? "New PO" : "Edit draft"}
         </Button>
       </SheetTrigger>
       <SheetContent className="w-[min(96vw,1180px)] overflow-y-auto sm:max-w-none">
         <SheetHeader className="border-b px-5 py-4">
-          <SheetTitle>Request Purchase Order</SheetTitle>
+          <SheetTitle>
+            {purchaseOrder === null
+              ? "Request Purchase Order"
+              : `Edit ${purchaseOrder.sourceRecordNumber ?? "Purchase Order"}`}
+          </SheetTitle>
           <SheetDescription>
-            Enter the vendor once, then code each purchase line for job tracking,
-            printing, supplier email, and optional accounting sync.
+            {purchaseOrder === null
+              ? "Enter the vendor once, then code each purchase line for job tracking, printing, supplier email, and optional accounting sync."
+              : "Update the draft header, delivery details, and individual line items before sending or accounting sync."}
           </SheetDescription>
         </SheetHeader>
         <form
@@ -419,6 +508,7 @@ export function ProjectPurchaseOrderCreateForm({
             <Input
               name="title"
               placeholder="ICF bracing rental"
+              defaultValue={purchaseOrder?.title ?? ""}
               required
               className={DOCUMENT_INPUT_CLASS}
             />
@@ -427,6 +517,7 @@ export function ProjectPurchaseOrderCreateForm({
             <Textarea
               name="description"
               placeholder="Overall scope, delivery notes, or billing context"
+              defaultValue={purchaseOrder?.description ?? ""}
               className={`min-h-24 ${DOCUMENT_INPUT_CLASS}`}
             />
           </Field>
@@ -463,6 +554,7 @@ export function ProjectPurchaseOrderCreateForm({
             <Field label="Ship to / delivery location">
               <Input
                 name="shipTo"
+                defaultValue={purchaseOrder?.sageShipTo ?? ""}
                 placeholder="Jobsite, office, or pickup"
                 className={DOCUMENT_INPUT_CLASS}
               />
@@ -471,6 +563,7 @@ export function ProjectPurchaseOrderCreateForm({
               <Input
                 name="orderDate"
                 type="date"
+                defaultValue={purchaseOrder?.sageOrderDate ?? ""}
                 className={DOCUMENT_INPUT_CLASS}
               />
             </Field>
@@ -478,13 +571,14 @@ export function ProjectPurchaseOrderCreateForm({
               <Input
                 name="dueDate"
                 type="date"
+                defaultValue={purchaseOrder?.dueDate ?? ""}
                 className={DOCUMENT_INPUT_CLASS}
               />
             </Field>
             <Field label="Priority">
               <select
                 name="priority"
-                defaultValue="normal"
+                defaultValue={purchaseOrder?.priority ?? "normal"}
                 className={DOCUMENT_SELECT_CLASS}
               >
                 <option value="normal">Normal priority</option>
@@ -653,11 +747,31 @@ export function ProjectPurchaseOrderCreateForm({
         <div className="flex justify-end">
           <Button type="submit" disabled={submitting}>
             <IconShoppingCart className="size-4" />
-            {submitting ? "Staging PO..." : "Create PO Request"}
+            {submitting
+              ? purchaseOrder === null
+                ? "Staging PO..."
+                : "Saving changes..."
+              : purchaseOrder === null
+                ? "Create PO Request"
+                : "Save changes"}
           </Button>
         </div>
       </form>
       </SheetContent>
     </Sheet>
   )
+}
+
+export function ProjectPurchaseOrderCreateForm(
+  props: SharedPurchaseOrderFormProps
+): React.ReactElement {
+  return <ProjectPurchaseOrderForm {...props} kind="create" />
+}
+
+export function ProjectPurchaseOrderEditForm(
+  props: SharedPurchaseOrderFormProps & {
+    readonly purchaseOrder: ProjectPurchaseOrderItem
+  }
+): React.ReactElement {
+  return <ProjectPurchaseOrderForm {...props} kind="edit" />
 }

--- a/src/lib/purchase-orders/__tests__/draft-edit.test.ts
+++ b/src/lib/purchase-orders/__tests__/draft-edit.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+
+import { canEditPurchaseOrderDraft } from "../draft-edit"
+
+const EDITABLE_DRAFT = {
+  sourceSystem: "compass",
+  status: "draft",
+  syncStatus: "pending_sage",
+  sageWriteStatus: "draft_ready",
+} as const
+
+describe("canEditPurchaseOrderDraft", () => {
+  it("allows an unsent Compass draft", () => {
+    expect(canEditPurchaseOrderDraft(EDITABLE_DRAFT)).toBe(true)
+  })
+
+  it.each([
+    { ...EDITABLE_DRAFT, sourceSystem: "sage" },
+    { ...EDITABLE_DRAFT, status: "sent" },
+    { ...EDITABLE_DRAFT, syncStatus: "queued_sage" },
+    { ...EDITABLE_DRAFT, syncStatus: "syncing" },
+    { ...EDITABLE_DRAFT, syncStatus: "synced" },
+    { ...EDITABLE_DRAFT, sageWriteStatus: "queued" },
+  ])("locks a PO after it leaves the editable draft state", (purchaseOrder) => {
+    expect(canEditPurchaseOrderDraft(purchaseOrder)).toBe(false)
+  })
+})

--- a/src/lib/purchase-orders/draft-edit.ts
+++ b/src/lib/purchase-orders/draft-edit.ts
@@ -1,0 +1,19 @@
+export type PurchaseOrderDraftState = {
+  readonly sourceSystem: string
+  readonly status: string
+  readonly syncStatus: string
+  readonly sageWriteStatus: string
+}
+
+export function canEditPurchaseOrderDraft(
+  purchaseOrder: PurchaseOrderDraftState
+): boolean {
+  return (
+    purchaseOrder.sourceSystem === "compass" &&
+    purchaseOrder.status === "draft" &&
+    purchaseOrder.sageWriteStatus === "draft_ready" &&
+    !["queued_sage", "syncing", "synced"].includes(
+      purchaseOrder.syncStatus
+    )
+  )
+}


### PR DESCRIPTION
## Summary
- restore editing for unsent Compass purchase-order drafts
- prefill and edit ship-to, vendor, owner, dates, priority, and every line item
- atomically replace draft lines and rebuild the Sage payload without exceeding D1 statement limits
- lock editing after the PO is sent, queued, syncing, or synced
- reject stale edits when the draft changed after the editor opened

## Validation
- `bunx eslint` on all changed files
- `bunx tsc --noEmit --pretty false`
- `bunx vitest run src/lib/purchase-orders/__tests__/draft-edit.test.ts` (7 passing)
- `bun run build` after rebasing onto main
- required pre-push production build
- `git diff --check origin/main...HEAD`

## Context
Follow-up to #437. The recovered Wes Jones PO remains a Compass draft and will become editable immediately after deployment.
