### PR TITLE
feat(contacts): link project vendors and people

### DIFF
--- a/drizzle/0118_vendor_company_contacts.sql
+++ b/drizzle/0118_vendor_company_contacts.sql
@@ -1,0 +1,113 @@
+CREATE TABLE `vendor_contacts` (
+  `id` text PRIMARY KEY NOT NULL,
+  `vendor_id` text NOT NULL,
+  `name` text NOT NULL,
+  `title` text,
+  `email` text,
+  `phone` text,
+  `is_primary` integer DEFAULT false NOT NULL,
+  `active` integer DEFAULT true NOT NULL,
+  `source_system` text DEFAULT 'manual' NOT NULL,
+  `source_record_id` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`vendor_id`) REFERENCES `vendors`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `vendor_contacts_vendor_idx` ON `vendor_contacts` (`vendor_id`);
+--> statement-breakpoint
+CREATE INDEX `vendor_contacts_vendor_active_idx` ON `vendor_contacts` (`vendor_id`, `active`);
+--> statement-breakpoint
+ALTER TABLE `project_contacts` ADD `vendor_id` text REFERENCES `vendors`(`id`) ON DELETE set null;
+--> statement-breakpoint
+ALTER TABLE `project_contacts` ADD `vendor_contact_id` text REFERENCES `vendor_contacts`(`id`) ON DELETE set null;
+--> statement-breakpoint
+
+-- Preserve the contact information that was historically flattened onto each
+-- Sage/Compass vendor company as its first contact person. Sage source metadata
+-- supplies the person name when it is available.
+INSERT INTO `vendor_contacts` (
+  `id`, `vendor_id`, `name`, `title`, `email`, `phone`, `is_primary`, `active`,
+  `source_system`, `source_record_id`, `created_at`, `updated_at`
+)
+SELECT
+  'vendor-contact-primary-' || v.`id`,
+  v.`id`,
+  COALESCE(
+    NULLIF(
+      trim(json_extract(
+        CASE WHEN json_valid(v.`source_metadata`) THEN v.`source_metadata` ELSE '{}' END,
+        '$.sage.contact'
+      )),
+      ''
+    ),
+    v.`name`
+  ),
+  NULL,
+  NULLIF(trim(v.`email`), ''),
+  NULLIF(trim(v.`phone`), ''),
+  1,
+  1,
+  v.`source_system`,
+  v.`source_record_id`,
+  COALESCE(v.`created_at`, strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  COALESCE(v.`updated_at`, v.`created_at`, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+FROM `vendors` v
+WHERE (
+  (v.`email` IS NOT NULL AND trim(v.`email`) <> '')
+  OR (v.`phone` IS NOT NULL AND trim(v.`phone`) <> '')
+  OR NULLIF(
+    trim(json_extract(
+      CASE WHEN json_valid(v.`source_metadata`) THEN v.`source_metadata` ELSE '{}' END,
+      '$.sage.contact'
+    )),
+    ''
+  ) IS NOT NULL
+);
+--> statement-breakpoint
+
+-- Existing project vendor rows already identify the canonical company. Keep
+-- that relationship explicit so multiple people can be attached to the same
+-- company without duplicating the company directory record.
+UPDATE `project_contacts`
+SET `vendor_id` = `source_entity_id`
+WHERE `source_entity_type` = 'vendor'
+  AND `source_entity_id` IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM `vendors` v WHERE v.`id` = `project_contacts`.`source_entity_id`
+  );
+--> statement-breakpoint
+
+-- Link a legacy project row to the promoted primary person only when its
+-- identity matches. Company-only project assignments remain company-only.
+UPDATE `project_contacts`
+SET `vendor_contact_id` = (
+  SELECT vc.`id`
+  FROM `vendor_contacts` vc
+  WHERE vc.`vendor_id` = `project_contacts`.`vendor_id`
+    AND vc.`active` = 1
+    AND (
+      (`project_contacts`.`email` IS NOT NULL
+        AND trim(`project_contacts`.`email`) <> ''
+        AND vc.`email` IS NOT NULL
+        AND lower(trim(vc.`email`)) = lower(trim(`project_contacts`.`email`)))
+      OR lower(trim(vc.`name`)) = lower(trim(`project_contacts`.`display_name`))
+    )
+  ORDER BY vc.`is_primary` DESC, vc.`created_at`, vc.`id`
+  LIMIT 1
+)
+WHERE `vendor_id` IS NOT NULL
+  AND `vendor_contact_id` IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM `vendor_contacts` vc
+    WHERE vc.`vendor_id` = `project_contacts`.`vendor_id`
+      AND vc.`active` = 1
+      AND (
+        (`project_contacts`.`email` IS NOT NULL
+          AND trim(`project_contacts`.`email`) <> ''
+          AND vc.`email` IS NOT NULL
+          AND lower(trim(vc.`email`)) = lower(trim(`project_contacts`.`email`)))
+        OR lower(trim(vc.`name`)) = lower(trim(`project_contacts`.`display_name`))
+      )
+  );

--- a/src/app/actions/profile.ts
+++ b/src/app/actions/profile.ts
@@ -8,6 +8,7 @@ import {
   projectAccessInvitations,
   projectContacts,
   users,
+  vendorContacts,
   vendors,
 } from "@/db/schema"
 import { and, eq, inArray } from "drizzle-orm"
@@ -142,6 +143,7 @@ export async function updateProfile(
           id: projectContacts.id,
           sourceEntityType: projectContacts.sourceEntityType,
           sourceEntityId: projectContacts.sourceEntityId,
+          vendorContactId: projectContacts.vendorContactId,
         })
         .from(projectAccessInvitations)
         .innerJoin(
@@ -170,9 +172,23 @@ export async function updateProfile(
       const linkedVendorIds = Array.from(
         new Set(
           acceptedContactRows.flatMap((contact) =>
-            contact.sourceEntityType === "vendor" && contact.sourceEntityId
+            contact.sourceEntityType === "vendor" &&
+            contact.sourceEntityId &&
+            !contact.vendorContactId
               ? [contact.sourceEntityId]
               : []
+          )
+        )
+      )
+      const linkedVendorContactIds = Array.from(
+        new Set(
+          acceptedContactRows.flatMap((contact) =>
+            contact.vendorContactId
+              ? [contact.vendorContactId]
+              : contact.sourceEntityType === "vendor_contact" &&
+                  contact.sourceEntityId
+                ? [contact.sourceEntityId]
+                : []
           )
         )
       )
@@ -245,6 +261,24 @@ export async function updateProfile(
               inArray(projectContacts.sourceEntityId, linkedVendorIds)
             )
           )
+          .run()
+      }
+
+      if (linkedVendorContactIds.length > 0) {
+        await db
+          .update(vendorContacts)
+          .set({
+            name: displayName,
+            email: identity.email,
+            phone: identity.phone,
+            updatedAt: now,
+          })
+          .where(inArray(vendorContacts.id, linkedVendorContactIds))
+          .run()
+        await db
+          .update(projectContacts)
+          .set({ displayName, ...identity, updatedAt: now })
+          .where(inArray(projectContacts.vendorContactId, linkedVendorContactIds))
           .run()
       }
 

--- a/src/app/actions/project-access-invitations.ts
+++ b/src/app/actions/project-access-invitations.ts
@@ -14,6 +14,7 @@ import {
   organizations,
   projects,
   users,
+  vendorContacts,
   vendors,
 } from "@/db/schema"
 import { requireAuth } from "@/lib/auth"
@@ -200,6 +201,10 @@ export async function sendProjectAccessInvitation(
           phone: vendors.phone,
           address: vendors.address,
         },
+        vendorContact: {
+          email: vendorContacts.email,
+          phone: vendorContacts.phone,
+        },
         teamMember: {
           email: users.email,
           phone: users.phone,
@@ -219,9 +224,22 @@ export async function sendProjectAccessInvitation(
       .leftJoin(
         vendors,
         and(
-          eq(projectContacts.sourceEntityType, "vendor"),
-          eq(projectContacts.sourceEntityId, vendors.id),
+          or(
+            eq(projectContacts.vendorId, vendors.id),
+            and(
+              eq(projectContacts.sourceEntityType, "vendor"),
+              eq(projectContacts.sourceEntityId, vendors.id)
+            )
+          ),
           eq(vendors.organizationId, projects.organizationId)
+        )
+      )
+      .leftJoin(
+        vendorContacts,
+        and(
+          eq(projectContacts.vendorContactId, vendorContacts.id),
+          eq(vendorContacts.vendorId, vendors.id),
+          eq(vendorContacts.active, true)
         )
       )
       .leftJoin(
@@ -251,7 +269,13 @@ export async function sendProjectAccessInvitation(
     }
 
     const directoryIdentity =
-      row.contact.sourceEntityType === "customer"
+      row.contact.vendorContactId
+        ? {
+            email: row.vendorContact?.email ?? null,
+            phone: row.vendorContact?.phone ?? null,
+            address: null,
+          }
+        : row.contact.sourceEntityType === "customer"
         ? row.customer
         : row.contact.sourceEntityType === "vendor"
           ? row.vendor

--- a/src/app/actions/project-contacts.ts
+++ b/src/app/actions/project-contacts.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { and, asc, desc, eq, inArray, or, sql } from "drizzle-orm"
+import { and, asc, desc, eq, inArray, isNull, or, sql } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
@@ -14,6 +14,7 @@ import {
   projectMembers,
   projects,
   users,
+  vendorContacts,
   vendors,
 } from "@/db/schema"
 import { requireAuth } from "@/lib/auth"
@@ -34,6 +35,7 @@ import {
   type ProjectContactInvitationSnapshot,
 } from "@/lib/project-contact-access-status"
 import { resolveProjectContactIdentity } from "@/lib/project-contact-directory-identity"
+import { isInternalStaffRole } from "@/lib/user-roles"
 
 export type ProjectContactType =
   | "owner"
@@ -50,6 +52,8 @@ export type ProjectContactItem = {
   readonly sourceRecordId: string | null
   readonly sourceEntityType: string
   readonly sourceEntityId: string | null
+  readonly vendorId: string | null
+  readonly vendorContactId: string | null
   readonly displayName: string
   readonly companyName: string | null
   readonly role: string | null
@@ -185,6 +189,17 @@ export type ProjectContactDirectoryOption = {
   readonly address: string | null
   readonly suggestedContactType: ProjectContactType
   readonly identityManagedByActiveUser: boolean
+  readonly vendorContacts: readonly ProjectVendorContactOption[]
+}
+
+export type ProjectVendorContactOption = {
+  readonly id: string
+  readonly name: string
+  readonly title: string | null
+  readonly email: string | null
+  readonly phone: string | null
+  readonly isPrimary: boolean
+  readonly identityManagedByActiveUser: boolean
 }
 
 export type ProjectContactMutationInput = {
@@ -192,6 +207,8 @@ export type ProjectContactMutationInput = {
   readonly contactId: string | null
   readonly directorySourceType: ProjectContactDirectorySource | null
   readonly directorySourceId: string | null
+  readonly vendorId: string | null
+  readonly vendorContactId: string | null
   readonly contactType: ProjectContactType
   readonly displayName: string
   readonly companyName: string
@@ -341,6 +358,8 @@ function toContactItem(
     sourceRecordId: row.sourceRecordId,
     sourceEntityType: row.sourceEntityType,
     sourceEntityId: row.sourceEntityId,
+    vendorId: row.vendorId,
+    vendorContactId: row.vendorContactId,
     displayName: row.displayName,
     companyName: row.companyName,
     role: row.role,
@@ -614,6 +633,10 @@ export async function getProjectContactsSummary(
         phone: vendors.phone,
         address: vendors.address,
       },
+      vendorContact: {
+        email: vendorContacts.email,
+        phone: vendorContacts.phone,
+      },
       teamMember: {
         email: users.email,
         phone: users.phone,
@@ -632,9 +655,22 @@ export async function getProjectContactsSummary(
     .leftJoin(
       vendors,
       and(
-        eq(projectContacts.sourceEntityType, "vendor"),
-        eq(projectContacts.sourceEntityId, vendors.id),
+        or(
+          eq(projectContacts.vendorId, vendors.id),
+          and(
+            eq(projectContacts.sourceEntityType, "vendor"),
+            eq(projectContacts.sourceEntityId, vendors.id)
+          )
+        ),
         eq(vendors.organizationId, organizationId)
+      )
+    )
+    .leftJoin(
+      vendorContacts,
+      and(
+        eq(projectContacts.vendorContactId, vendorContacts.id),
+        eq(vendorContacts.vendorId, vendors.id),
+        eq(vendorContacts.active, true)
       )
     )
     .leftJoin(
@@ -657,13 +693,19 @@ export async function getProjectContactsSummary(
     )
   const rows = directoryRows.map((row) => {
     const directoryIdentity =
-      row.contact.sourceEntityType === "customer"
-        ? row.customer
-        : row.contact.sourceEntityType === "vendor"
-          ? row.vendor
-          : row.contact.sourceEntityType === "user"
-            ? row.teamMember
-            : null
+      row.contact.vendorContactId
+        ? {
+            email: row.vendorContact?.email ?? null,
+            phone: row.vendorContact?.phone ?? null,
+            address: null,
+          }
+        : row.contact.sourceEntityType === "customer"
+          ? row.customer
+          : row.contact.sourceEntityType === "vendor"
+            ? row.vendor
+            : row.contact.sourceEntityType === "user"
+              ? row.teamMember
+              : null
     const identity = resolveProjectContactIdentity(
       {
         email: row.contact.email,
@@ -679,13 +721,19 @@ export async function getProjectContactsSummary(
   const directoryIdentityKeys = await activeDirectoryIdentityKeys({
     db,
     organizationId,
-    entityIds: rows.flatMap((row) =>
-      (row.sourceEntityType === "customer" ||
-        row.sourceEntityType === "vendor") &&
-      row.sourceEntityId
-        ? [row.sourceEntityId]
-        : []
-    ),
+    entityIds: rows.flatMap((row) => {
+      const ids: string[] = []
+      if (
+        (row.sourceEntityType === "customer" ||
+          row.sourceEntityType === "vendor" ||
+          row.sourceEntityType === "vendor_contact") &&
+        row.sourceEntityId
+      ) {
+        ids.push(row.sourceEntityId)
+      }
+      if (row.vendorContactId) ids.push(row.vendorContactId)
+      return ids
+    }),
   })
 
   const invitationRows = await db
@@ -763,10 +811,12 @@ export async function getProjectContactsSummary(
         activeProjectMember,
         latestInvitation,
       }),
-      row.sourceEntityId !== null &&
+      (row.sourceEntityId !== null &&
         directoryIdentityKeys.has(
           `${row.sourceEntityType}:${row.sourceEntityId}`
-        )
+        )) ||
+        (row.vendorContactId !== null &&
+          directoryIdentityKeys.has(`vendor_contact:${row.vendorContactId}`))
     )
   })
   const sourceLinks = await db
@@ -843,8 +893,7 @@ export async function getProjectContactDirectoryOptions(
       )
       .map((row) => `${row.sourceEntityType}:${row.sourceEntityId}`)
   )
-
-  const [customerRows, vendorRows, teamRows] = await Promise.all([
+  const [customerRows, vendorRows, vendorContactRows, teamRows] = await Promise.all([
     db
       .select({
         id: customers.id,
@@ -874,6 +923,25 @@ export async function getProjectContactDirectoryOptions(
       ),
     db
       .select({
+        id: vendorContacts.id,
+        vendorId: vendorContacts.vendorId,
+        name: vendorContacts.name,
+        title: vendorContacts.title,
+        email: vendorContacts.email,
+        phone: vendorContacts.phone,
+        isPrimary: vendorContacts.isPrimary,
+      })
+      .from(vendorContacts)
+      .innerJoin(vendors, eq(vendors.id, vendorContacts.vendorId))
+      .where(
+        and(
+          eq(vendors.organizationId, orgId),
+          eq(vendors.directoryStatus, "active"),
+          eq(vendorContacts.active, true)
+        )
+      ),
+    db
+      .select({
         id: users.id,
         email: users.email,
         displayName: users.displayName,
@@ -881,6 +949,7 @@ export async function getProjectContactDirectoryOptions(
         lastName: users.lastName,
         phone: users.phone,
         address: users.address,
+        role: organizationMembers.role,
       })
       .from(organizationMembers)
       .innerJoin(users, eq(users.id, organizationMembers.userId))
@@ -896,8 +965,26 @@ export async function getProjectContactDirectoryOptions(
     organizationId: orgId,
     entityIds: customerRows
       .map((row) => row.id)
-      .concat(vendorRows.map((row) => row.id)),
+      .concat(vendorRows.map((row) => row.id))
+      .concat(vendorContactRows.map((row) => row.id)),
   })
+  const contactsByVendor = new Map<string, ProjectVendorContactOption[]>()
+  for (const contact of vendorContactRows) {
+    const option: ProjectVendorContactOption = {
+      id: contact.id,
+      name: contact.name,
+      title: contact.title,
+      email: contact.email,
+      phone: contact.phone,
+      isPrimary: contact.isPrimary,
+      identityManagedByActiveUser: directoryIdentityKeys.has(
+        `vendor_contact:${contact.id}`
+      ),
+    }
+    const current = contactsByVendor.get(contact.vendorId) ?? []
+    current.push(option)
+    contactsByVendor.set(contact.vendorId, current)
+  }
 
   const customerOptions: ProjectContactDirectoryOption[] = customerRows
     .filter((row) => !existingSources.has(`customer:${row.id}`))
@@ -913,13 +1000,10 @@ export async function getProjectContactDirectoryOptions(
       identityManagedByActiveUser: directoryIdentityKeys.has(
         `customer:${row.id}`
       ),
+      vendorContacts: [],
     }))
   const vendorOptions: ProjectContactDirectoryOption[] = vendorRows
-    .filter(
-      (row) =>
-        isDirectoryAssignable(row.category) &&
-        !existingSources.has(`vendor:${row.id}`)
-    )
+    .filter((row) => !row.category.toLowerCase().includes("internal"))
     .map((row) => ({
       id: row.id,
       sourceType: "vendor",
@@ -932,9 +1016,17 @@ export async function getProjectContactDirectoryOptions(
       identityManagedByActiveUser: directoryIdentityKeys.has(
         `vendor:${row.id}`
       ),
+      vendorContacts: (contactsByVendor.get(row.id) ?? []).sort((left, right) =>
+        Number(right.isPrimary) - Number(left.isPrimary) ||
+        left.name.localeCompare(right.name)
+      ),
     }))
   const teamOptions: ProjectContactDirectoryOption[] = teamRows
-    .filter((row) => !existingSources.has(`user:${row.id}`))
+    .filter(
+      (row) =>
+        isInternalStaffRole(row.role) &&
+        !existingSources.has(`user:${row.id}`)
+    )
     .map((row) => {
       const fullName = [row.firstName, row.lastName]
         .filter((part): part is string => part !== null && part.trim().length > 0)
@@ -949,6 +1041,7 @@ export async function getProjectContactDirectoryOptions(
         address: row.address,
         suggestedContactType: "internal",
         identityManagedByActiveUser: true,
+        vendorContacts: [],
       }
     })
 
@@ -982,12 +1075,27 @@ export async function saveProjectContact(
     let sourceRecordId: string | null = null
     let sourceEntityType = "manual"
     let sourceEntityId: string | null = null
+    let vendorId: string | null = input.vendorId
+    let vendorContactId: string | null = input.vendorContactId
     let syncStatus = "manual"
     let warning: string | undefined
     let directoryIdentity: ContactIdentityFields | null = null
     let directoryIdentityManaged = false
 
-    if (!contactId && input.directorySourceType && input.directorySourceId) {
+    const requiresVendorCompany =
+      input.contactType === "subcontractor" || input.contactType === "supplier"
+    if (
+      !contactId &&
+      requiresVendorCompany &&
+      (input.directorySourceType !== "vendor" || !input.directorySourceId)
+    ) {
+      return {
+        success: false,
+        error: "Choose a vendor company for this project contact.",
+      }
+    }
+
+    if (input.directorySourceType && input.directorySourceId) {
       sourceRecordId = input.directorySourceId
       sourceEntityId = input.directorySourceId
 
@@ -1024,6 +1132,7 @@ export async function saveProjectContact(
         const [directoryRecord] = await db
           .select({
             id: vendors.id,
+            name: vendors.name,
             syncStatus: vendors.syncStatus,
             email: vendors.email,
             phone: vendors.phone,
@@ -1042,16 +1151,52 @@ export async function saveProjectContact(
           return { success: false, error: "Vendor directory record not found" }
         }
         sourceSystem = "global_directory"
-        sourceEntityType = "vendor"
         syncStatus = directoryRecord.syncStatus
-        directoryIdentity = directoryRecord
-        directoryIdentityManaged =
-          await directoryIdentityManagedByActiveUser({
-            db,
-            organizationId: orgId,
-            entityType: "vendor",
-            entityId: directoryRecord.id,
-          })
+        vendorId = directoryRecord.id
+        vendorContactId = input.vendorContactId
+        if (vendorContactId) {
+          const contactRecord = await db
+            .select({
+              id: vendorContacts.id,
+              email: vendorContacts.email,
+              phone: vendorContacts.phone,
+            })
+            .from(vendorContacts)
+            .where(
+              and(
+                eq(vendorContacts.id, vendorContactId),
+                eq(vendorContacts.vendorId, directoryRecord.id),
+                eq(vendorContacts.active, true)
+              )
+            )
+            .get()
+          if (!contactRecord) {
+            return { success: false, error: "Vendor contact not found" }
+          }
+          sourceRecordId = contactRecord.id
+          sourceEntityType = "vendor_contact"
+          sourceEntityId = contactRecord.id
+          directoryIdentity = { ...contactRecord, address: null }
+          directoryIdentityManaged =
+            await directoryIdentityManagedByActiveUser({
+              db,
+              organizationId: orgId,
+              entityType: "vendor_contact",
+              entityId: contactRecord.id,
+            })
+        } else {
+          sourceRecordId = directoryRecord.id
+          sourceEntityType = "vendor"
+          sourceEntityId = directoryRecord.id
+          directoryIdentity = directoryRecord
+          directoryIdentityManaged =
+            await directoryIdentityManagedByActiveUser({
+              db,
+              organizationId: orgId,
+              entityType: "vendor",
+              entityId: directoryRecord.id,
+            })
+        }
       } else {
         const [directoryRecord] = await db
           .select({
@@ -1079,6 +1224,10 @@ export async function saveProjectContact(
         directoryIdentityManaged = true
       }
 
+      if (!sourceEntityId) {
+        return { success: false, error: "Directory contact not found" }
+      }
+
       const [existingContact] = await db
         .select({ id: projectContacts.id, active: projectContacts.active })
         .from(projectContacts)
@@ -1086,14 +1235,14 @@ export async function saveProjectContact(
           and(
             eq(projectContacts.projectId, input.projectId),
             eq(projectContacts.sourceEntityType, sourceEntityType),
-            eq(projectContacts.sourceEntityId, input.directorySourceId)
+            eq(projectContacts.sourceEntityId, sourceEntityId)
           )
         )
         .limit(1)
-      if (existingContact?.active) {
+      if (existingContact?.active && existingContact.id !== contactId) {
         return { success: false, error: "This contact is already on the project" }
       }
-      if (existingContact) contactId = existingContact.id
+      if (!contactId && existingContact) contactId = existingContact.id
     }
 
     const contactValues = {
@@ -1138,6 +1287,11 @@ export async function saveProjectContact(
           address: projectContacts.address,
           sourceEntityType: projectContacts.sourceEntityType,
           sourceEntityId: projectContacts.sourceEntityId,
+          sourceSystem: projectContacts.sourceSystem,
+          sourceRecordId: projectContacts.sourceRecordId,
+          syncStatus: projectContacts.syncStatus,
+          vendorId: projectContacts.vendorId,
+          vendorContactId: projectContacts.vendorContactId,
         })
         .from(projectContacts)
         .where(
@@ -1150,8 +1304,15 @@ export async function saveProjectContact(
       if (!existingContact) {
         return { success: false, error: "Project contact not found" }
       }
-      sourceEntityType = existingContact.sourceEntityType
-      sourceEntityId = existingContact.sourceEntityId
+      if (!input.directorySourceType) {
+        sourceSystem = existingContact.sourceSystem
+        sourceRecordId = existingContact.sourceRecordId
+        sourceEntityType = existingContact.sourceEntityType
+        sourceEntityId = existingContact.sourceEntityId
+        syncStatus = existingContact.syncStatus
+        vendorId = existingContact.vendorId
+        vendorContactId = existingContact.vendorContactId
+      }
       const existingEmail = existingContact.email?.trim().toLowerCase() ?? ""
       const updatedEmail = nullableInput(input.email)?.toLowerCase() ?? ""
       const existingPhone = existingContact.phone?.trim() ?? ""
@@ -1163,15 +1324,22 @@ export async function saveProjectContact(
         existingPhone !== updatedPhone ||
         existingAddress !== updatedAddress
       if (identityChanged) {
+        const existingDirectoryEntityType = existingContact.vendorContactId
+          ? "vendor_contact"
+          : existingContact.sourceEntityType === "customer" ||
+              existingContact.sourceEntityType === "vendor"
+            ? existingContact.sourceEntityType
+            : null
+        const existingDirectoryEntityId =
+          existingContact.vendorContactId ?? existingContact.sourceEntityId
         if (
-          (existingContact.sourceEntityType === "customer" ||
-            existingContact.sourceEntityType === "vendor") &&
-          existingContact.sourceEntityId &&
+          existingDirectoryEntityType &&
+          existingDirectoryEntityId &&
           (await directoryIdentityManagedByActiveUser({
             db,
             organizationId: orgId,
-            entityType: existingContact.sourceEntityType,
-            entityId: existingContact.sourceEntityId,
+            entityType: existingDirectoryEntityType,
+            entityId: existingDirectoryEntityId,
           }))
         ) {
           return {
@@ -1305,7 +1473,16 @@ export async function saveProjectContact(
       }
       await db
         .update(projectContacts)
-        .set(contactValues)
+        .set({
+          ...contactValues,
+          sourceSystem,
+          sourceRecordId,
+          sourceEntityType,
+          sourceEntityId,
+          vendorId,
+          vendorContactId,
+          syncStatus,
+        })
         .where(
           and(
             eq(projectContacts.id, contactId),
@@ -1332,6 +1509,8 @@ export async function saveProjectContact(
         sourceRecordId,
         sourceEntityType,
         sourceEntityId,
+        vendorId,
+        vendorContactId,
         sortOrder: 800,
         syncStatus,
         lastSyncedAt: null,
@@ -1371,7 +1550,28 @@ export async function saveProjectContact(
             )
           ),
       ])
-    } else if (sourceEntityType === "vendor" && sourceEntityId) {
+    } else if (vendorContactId) {
+      await db.batch([
+        db
+          .update(vendorContacts)
+          .set({
+            name: contactValues.displayName,
+            email: contactValues.email,
+            phone: contactValues.phone,
+            updatedAt: now,
+          })
+          .where(eq(vendorContacts.id, vendorContactId)),
+        db
+          .update(projectContacts)
+          .set({
+            displayName: contactValues.displayName,
+            email: contactValues.email,
+            phone: contactValues.phone,
+            updatedAt: now,
+          })
+          .where(eq(projectContacts.vendorContactId, vendorContactId)),
+      ])
+    } else if (vendorId) {
       await db.batch([
         db
           .update(vendors)
@@ -1383,7 +1583,7 @@ export async function saveProjectContact(
           })
           .where(
             and(
-              eq(vendors.id, sourceEntityId),
+              eq(vendors.id, vendorId),
               eq(vendors.organizationId, orgId)
             )
           ),
@@ -1396,9 +1596,16 @@ export async function saveProjectContact(
             updatedAt: now,
           })
           .where(
-            and(
-              eq(projectContacts.sourceEntityType, "vendor"),
-              eq(projectContacts.sourceEntityId, sourceEntityId)
+            or(
+              and(
+                eq(projectContacts.vendorId, vendorId),
+                isNull(projectContacts.vendorContactId)
+              ),
+              and(
+                eq(projectContacts.sourceEntityType, "vendor"),
+                eq(projectContacts.sourceEntityId, vendorId),
+                isNull(projectContacts.vendorContactId)
+              )
             )
           ),
       ])
@@ -1627,7 +1834,8 @@ export async function getProjectTaskAssigneeOptions(
   const projectSourceVendorIds = new Set(
     projectContactItems
       .map((contact) =>
-        contact.sourceEntityType === "vendor" ? contact.sourceEntityId : null
+        contact.vendorId ??
+        (contact.sourceEntityType === "vendor" ? contact.sourceEntityId : null)
       )
       .filter((value): value is string => value !== null)
   )
@@ -1829,6 +2037,8 @@ export async function addIndependentContactToProjectFromReview(
         sourceRecordId: vendor.id,
         sourceEntityType: "vendor",
         sourceEntityId: vendor.id,
+        vendorId: vendor.id,
+        vendorContactId: null,
         displayName: vendor.name,
         companyName: vendor.name,
         role: contactType === "supplier" ? "Supplier" : "Subcontractor",
@@ -1949,6 +2159,8 @@ export async function addDirectoryContactToProjectForTask(
       sourceRecordId: vendor.id,
       sourceEntityType: "vendor",
       sourceEntityId: vendor.id,
+      vendorId: vendor.id,
+      vendorContactId: null,
       displayName: vendor.name,
       companyName: vendor.name,
       role,

--- a/src/app/actions/vendors.ts
+++ b/src/app/actions/vendors.ts
@@ -1,13 +1,15 @@
 "use server"
 
 import { getCloudflareContext } from "@/lib/db"
-import { eq, and } from "drizzle-orm"
+import { eq, and, asc, desc, inArray, isNull, or } from "drizzle-orm"
 import { getDb } from "@/db"
 import {
   projectContacts,
-  projects,
+  organizationMembers,
+  users,
+  vendorContacts,
   vendors,
-  type NewVendor,
+  type Vendor,
 } from "@/db/schema"
 import { requireAuth } from "@/lib/auth"
 import { requirePermission } from "@/lib/permissions"
@@ -18,6 +20,8 @@ import {
   contactIdentityChanged,
   directoryIdentityManagedByActiveUser,
 } from "@/lib/contact-identity-ownership"
+import { userRoleLabel } from "@/lib/user-roles"
+import { uniqueInternalStaffMembers } from "@/lib/internal-contact-directory"
 
 export type InternalDirectoryContact = {
   readonly id: string
@@ -29,144 +33,91 @@ export type InternalDirectoryContact = {
   readonly sourceLabel: string
 }
 
-const DEFAULT_INTERNAL_DIRECTORY_CONTACTS: readonly InternalDirectoryContact[] = [
-  {
-    id: "internal-department-hps",
-    name: "High Performance Structures Inc.",
-    company: "High Performance Structures Inc.",
-    role: "Internal department",
-    email: null,
-    phone: null,
-    sourceLabel: "Compass seed",
-  },
-  {
-    id: "internal-department-orc",
-    name: "Open Range Construction",
-    company: "Open Range Construction",
-    role: "Internal department",
-    email: null,
-    phone: null,
-    sourceLabel: "Compass seed",
-  },
-  {
-    id: "internal-department-nutech",
-    name: "Nu-Tech Systems",
-    company: "Nu-Tech Systems",
-    role: "ICF sales and bracing rental",
-    email: null,
-    phone: null,
-    sourceLabel: "Compass seed",
-  },
-  {
-    id: "internal-employee-martine-vogel",
-    name: "Martine Vogel",
-    company: "High Performance Structures",
-    role: "Admin-owner",
-    email: null,
-    phone: null,
-    sourceLabel: "Sage roster",
-  },
-  {
-    id: "internal-employee-daniel-vogel",
-    name: "Daniel Vogel",
-    company: "High Performance Structures",
-    role: "Project Manager / Field production",
-    email: null,
-    phone: null,
-    sourceLabel: "Sage roster",
-  },
-  {
-    id: "internal-employee-sarah-cowman",
-    name: "Sarah Cowman",
-    company: "High Performance Structures",
-    role: "Senior Field Crew",
-    email: null,
-    phone: null,
-    sourceLabel: "Sage roster",
-  },
-  {
-    id: "internal-employee-stanley-platt",
-    name: "Stanley Platt",
-    company: "High Performance Structures",
-    role: "Field Superintendent",
-    email: null,
-    phone: null,
-    sourceLabel: "Sage roster",
-  },
-  {
-    id: "internal-employee-sylvi-vogel",
-    name: "Sylvi Vogel",
-    company: "High Performance Structures",
-    role: "Architectural Designer / Design & Print",
-    email: null,
-    phone: null,
-    sourceLabel: "Sage roster",
-  },
-  {
-    id: "internal-employee-cassandra-rodriguez-v",
-    name: "Cassandra Rodriguez-V",
-    company: "High Performance Structures",
-    role: "Project Administrator / Accounting Coordinator",
-    email: null,
-    phone: null,
-    sourceLabel: "Sage roster",
-  },
-  {
-    id: "internal-employee-wesley-jones",
-    name: "Wesley Jones",
-    company: "High Performance Structures",
-    role: "Assistant Project Manager",
-    email: null,
-    phone: null,
-    sourceLabel: "Sage roster",
-  },
-  {
-    id: "internal-employee-rebekah-jones",
-    name: "Rebekah Jones",
-    company: "High Performance Structures",
-    role: "Office Manager / Business Development",
-    email: null,
-    phone: null,
-    sourceLabel: "Sage roster",
-  },
-  {
-    id: "internal-employee-isabel-araguz",
-    name: "Isabel Araguz",
-    company: "High Performance Structures",
-    role: "Field Crew",
-    email: null,
-    phone: null,
-    sourceLabel: "Sage roster",
-  },
-]
-
-function normalizeInternalContactKey(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/&/g, "and")
-    .replace(/[^a-z0-9]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
+export type VendorContactItem = {
+  readonly id: string
+  readonly vendorId: string
+  readonly name: string
+  readonly title: string | null
+  readonly email: string | null
+  readonly phone: string | null
+  readonly isPrimary: boolean
+  readonly active: boolean
+  readonly sourceSystem: string
 }
 
-function internalSourceLabel(sourceSystem: string): string {
-  if (sourceSystem.includes("sage")) return "Sage"
-  if (sourceSystem === "buildertrend") return "Buildertrend"
-  return "Compass"
+export type VendorDirectoryCompany = Vendor & {
+  readonly contacts: readonly VendorContactItem[]
 }
 
-function isSeededInternalDepartmentName(value: string): boolean {
-  const normalized = normalizeInternalContactKey(value)
-  return (
-    normalized === "hps subcontractor" ||
-    normalized.includes("high performance structures") ||
-    normalized.includes("open range construction") ||
-    normalized.includes("nu tech")
-  )
+export type VendorContactMutationInput = {
+  readonly id: string | null
+  readonly name: string
+  readonly title: string
+  readonly email: string
+  readonly phone: string
+  readonly isPrimary: boolean
 }
 
-export async function getVendors() {
+export type VendorCompanyMutationInput = {
+  readonly name: string
+  readonly category: string
+  readonly email: string
+  readonly phone: string
+  readonly address: string
+  readonly contacts?: readonly VendorContactMutationInput[]
+}
+
+export type VendorCompanyUpdateInput = {
+  readonly name?: string
+  readonly category?: string
+  readonly email?: string | null
+  readonly phone?: string | null
+  readonly address?: string | null
+  readonly contacts?: readonly VendorContactMutationInput[]
+}
+
+export type VendorMutationResult =
+  | { readonly success: true; readonly id: string }
+  | { readonly success: false; readonly error: string }
+
+export type VendorUpdateResult =
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string }
+
+export type VendorContactMutationResult =
+  | { readonly success: true; readonly contact: VendorContactItem }
+  | { readonly success: false; readonly error: string }
+
+function nullableText(value: string): string | null {
+  const normalized = value.trim()
+  return normalized.length > 0 ? normalized : null
+}
+
+function nullableOptionalText(value: string | null | undefined): string | null {
+  return value ? nullableText(value) : null
+}
+
+function normalizedContactInputs(
+  contacts: readonly VendorContactMutationInput[]
+): readonly VendorContactMutationInput[] {
+  const normalized = contacts
+    .map((contact) => ({
+      ...contact,
+      name: contact.name.trim(),
+      title: contact.title.trim(),
+      email: contact.email.trim().toLowerCase(),
+      phone: contact.phone.trim(),
+    }))
+    .filter((contact) => contact.name.length > 0)
+  const primaryIndex = normalized.findIndex((contact) => contact.isPrimary)
+
+  return normalized.map((contact, index) => ({
+    ...contact,
+    isPrimary: primaryIndex >= 0 ? index === primaryIndex : index === 0,
+  }))
+}
+
+export async function getVendors(): Promise<VendorDirectoryCompany[]> {
   const user = await requireAuth()
   requirePermission(user, "vendor", "read")
   const orgId = requireOrg(user)
@@ -174,12 +125,55 @@ export async function getVendors() {
   const { env } = await getCloudflareContext()
   const db = getDb(env.DB)
 
-  return db
-    .select()
-    .from(vendors)
-    .where(
-      and(eq(vendors.organizationId, orgId), eq(vendors.directoryStatus, "active"))
-    )
+  const [vendorRows, contactRows] = await Promise.all([
+    db
+      .select()
+      .from(vendors)
+      .where(
+        and(
+          eq(vendors.organizationId, orgId),
+          eq(vendors.directoryStatus, "active")
+        )
+      )
+      .orderBy(asc(vendors.name)),
+    db
+      .select({
+        id: vendorContacts.id,
+        vendorId: vendorContacts.vendorId,
+        name: vendorContacts.name,
+        title: vendorContacts.title,
+        email: vendorContacts.email,
+        phone: vendorContacts.phone,
+        isPrimary: vendorContacts.isPrimary,
+        active: vendorContacts.active,
+        sourceSystem: vendorContacts.sourceSystem,
+      })
+      .from(vendorContacts)
+      .innerJoin(vendors, eq(vendors.id, vendorContacts.vendorId))
+      .where(
+        and(
+          eq(vendors.organizationId, orgId),
+          eq(vendors.directoryStatus, "active"),
+          eq(vendorContacts.active, true)
+        )
+      )
+      .orderBy(
+        asc(vendorContacts.vendorId),
+        desc(vendorContacts.isPrimary),
+        asc(vendorContacts.name)
+      ),
+  ])
+  const contactsByVendor = new Map<string, VendorContactItem[]>()
+  for (const contact of contactRows) {
+    const current = contactsByVendor.get(contact.vendorId) ?? []
+    current.push(contact)
+    contactsByVendor.set(contact.vendorId, current)
+  }
+
+  return vendorRows.map((vendor) => ({
+    ...vendor,
+    contacts: contactsByVendor.get(vendor.id) ?? [],
+  }))
 }
 
 export async function getInternalDirectoryContacts(): Promise<
@@ -192,92 +186,42 @@ export async function getInternalDirectoryContacts(): Promise<
   const { env } = await getCloudflareContext()
   const db = getDb(env.DB)
 
-  const internalVendors = await db
+  const teamRows = await db
     .select({
-      id: vendors.id,
-      name: vendors.name,
-      category: vendors.category,
-      email: vendors.email,
-      phone: vendors.phone,
-      sourceSystem: vendors.sourceSystem,
+      id: users.id,
+      email: users.email,
+      displayName: users.displayName,
+      firstName: users.firstName,
+      lastName: users.lastName,
+      phone: users.phone,
+      role: organizationMembers.role,
     })
-    .from(vendors)
+    .from(organizationMembers)
+    .innerJoin(users, eq(users.id, organizationMembers.userId))
     .where(
       and(
-        eq(vendors.organizationId, orgId),
-        eq(vendors.directoryStatus, "active"),
-        eq(vendors.category, "Internal")
+        eq(organizationMembers.organizationId, orgId),
+        eq(users.isActive, true)
       )
     )
 
-  const internalProjectContacts = await db
-    .select({
-      id: projectContacts.id,
-      name: projectContacts.displayName,
-      company: projectContacts.companyName,
-      role: projectContacts.role,
-      email: projectContacts.email,
-      phone: projectContacts.phone,
-      sourceSystem: projectContacts.sourceSystem,
-    })
-    .from(projectContacts)
-    .innerJoin(projects, eq(projects.id, projectContacts.projectId))
-    .where(
-      and(
-        eq(projects.organizationId, orgId),
-        eq(projectContacts.contactType, "internal"),
-        eq(projectContacts.active, true)
-      )
-    )
-
-  const contacts = new Map<string, InternalDirectoryContact>()
-
-  for (const contact of DEFAULT_INTERNAL_DIRECTORY_CONTACTS) {
-    const key = normalizeInternalContactKey(
-      [contact.name, contact.company ?? "", contact.email ?? ""].join("|")
-    )
-    contacts.set(key, contact)
-  }
-
-  for (const vendor of internalVendors) {
-    if (isSeededInternalDepartmentName(vendor.name)) continue
-
-    const key = normalizeInternalContactKey(
-      [vendor.name, vendor.email ?? ""].join("|")
-    )
-    contacts.set(key, {
-      id: `vendor-${vendor.id}`,
-      name: vendor.name,
-      company: vendor.name,
-      role: vendor.category,
-      email: vendor.email,
-      phone: vendor.phone,
-      sourceLabel: internalSourceLabel(vendor.sourceSystem),
+  const contacts: InternalDirectoryContact[] = []
+  for (const member of uniqueInternalStaffMembers(teamRows)) {
+    const fullName = [member.firstName, member.lastName]
+      .filter((part): part is string => Boolean(part?.trim()))
+      .join(" ")
+    contacts.push({
+      id: member.id,
+      name: member.displayName?.trim() || fullName || member.email,
+      company: null,
+      role: userRoleLabel(member.role),
+      email: member.email,
+      phone: member.phone,
+      sourceLabel: "Settings team",
     })
   }
 
-  for (const contact of internalProjectContacts) {
-    if (isSeededInternalDepartmentName(contact.name)) continue
-
-    const key = normalizeInternalContactKey(
-      [contact.name, contact.company ?? "", contact.email ?? ""].join("|")
-    )
-    if (contacts.has(key)) continue
-
-    contacts.set(key, {
-      id: `project-contact-${contact.id}`,
-      name: contact.name,
-      company: contact.company,
-      role: contact.role,
-      email: contact.email,
-      phone: contact.phone,
-      sourceLabel: internalSourceLabel(contact.sourceSystem),
-    })
-  }
-
-  return Array.from(contacts.values()).sort((left, right) =>
-    left.name.localeCompare(right.name)
-  )
+  return contacts.sort((left, right) => left.name.localeCompare(right.name))
 }
 
 export async function getVendor(id: string) {
@@ -298,8 +242,8 @@ export async function getVendor(id: string) {
 }
 
 export async function createVendor(
-  data: Omit<NewVendor, "id" | "createdAt" | "updatedAt" | "organizationId">
-) {
+  data: VendorCompanyMutationInput
+): Promise<VendorMutationResult> {
   try {
     const user = await requireAuth()
     if (isDemoUser(user.id)) {
@@ -311,18 +255,46 @@ export async function createVendor(
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
 
+    const name = data.name.trim()
+    const category = data.category.trim()
+    if (!name) return { success: false, error: "Vendor company name is required" }
+    if (!category) return { success: false, error: "Vendor category is required" }
+
     const now = new Date().toISOString()
     const id = crypto.randomUUID()
+    const contactInputs = normalizedContactInputs(data.contacts ?? [])
 
     await db.insert(vendors).values({
       id,
       organizationId: orgId,
-      ...data,
+      name,
+      category,
+      email: nullableText(data.email),
+      phone: nullableText(data.phone),
+      address: nullableText(data.address),
       createdAt: now,
       updatedAt: now,
     })
+    for (const contact of contactInputs) {
+      await db.insert(vendorContacts).values({
+        id: crypto.randomUUID(),
+        vendorId: id,
+        name: contact.name,
+        title: nullableText(contact.title),
+        email: nullableText(contact.email),
+        phone: nullableText(contact.phone),
+        isPrimary: contact.isPrimary,
+        active: true,
+        sourceSystem: "manual",
+        sourceRecordId: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+    }
 
     revalidatePath("/dashboard/vendors")
+    revalidatePath("/dashboard/contacts")
+    revalidatePath("/dashboard/projects", "layout")
     return { success: true, id }
   } catch (err) {
     return {
@@ -335,8 +307,8 @@ export async function createVendor(
 
 export async function updateVendor(
   id: string,
-  data: Partial<NewVendor>
-) {
+  data: VendorCompanyUpdateInput
+): Promise<VendorUpdateResult> {
   try {
     const user = await requireAuth()
     if (isDemoUser(user.id)) {
@@ -356,10 +328,23 @@ export async function updateVendor(
       .get()
     if (!existing) return { success: false, error: "Vendor not found" }
 
+    const name = data.name?.trim() ?? existing.name
+    const category = data.category?.trim() ?? existing.category
+    if (!name) return { success: false, error: "Vendor company name is required" }
+    if (!category) return { success: false, error: "Vendor category is required" }
     const nextIdentity = {
-      email: data.email === undefined ? existing.email : data.email,
-      phone: data.phone === undefined ? existing.phone : data.phone,
-      address: data.address === undefined ? existing.address : data.address,
+      email:
+        data.email === undefined
+          ? existing.email
+          : nullableOptionalText(data.email),
+      phone:
+        data.phone === undefined
+          ? existing.phone
+          : nullableOptionalText(data.phone),
+      address:
+        data.address === undefined
+          ? existing.address
+          : nullableOptionalText(data.address),
     }
     const identityChanged = contactIdentityChanged(existing, nextIdentity)
     if (
@@ -378,22 +363,179 @@ export async function updateVendor(
       }
     }
 
+    const contactInputs = normalizedContactInputs(data.contacts ?? [])
+    const existingContacts =
+      data.contacts === undefined
+        ? []
+        : await db
+            .select()
+            .from(vendorContacts)
+            .where(eq(vendorContacts.vendorId, id))
+    const existingById = new Map(
+      existingContacts.map((contact) => [contact.id, contact])
+    )
+    for (const contact of contactInputs) {
+      const existingContact = contact.id
+        ? existingById.get(contact.id)
+        : undefined
+      if (contact.id && !existingContact) {
+        return { success: false, error: "Vendor contact not found" }
+      }
+      if (
+        existingContact &&
+        contactIdentityChanged(
+          {
+            email: existingContact.email,
+            phone: existingContact.phone,
+            address: null,
+          },
+          {
+            email: nullableText(contact.email),
+            phone: nullableText(contact.phone),
+            address: null,
+          }
+        ) &&
+        (await directoryIdentityManagedByActiveUser({
+          db,
+          organizationId: orgId,
+          entityType: "vendor_contact",
+          entityId: existingContact.id,
+        }))
+      ) {
+        return {
+          success: false,
+          error: `${existingContact.name} manages their own email and phone in Compass.`,
+        }
+      }
+    }
+    const submittedExistingIds = new Set(
+      contactInputs.flatMap((contact) => (contact.id ? [contact.id] : []))
+    )
+    const removedContacts = existingContacts.filter(
+      (contact) => contact.active && !submittedExistingIds.has(contact.id)
+    )
+    for (const removedContact of removedContacts) {
+      if (
+        await directoryIdentityManagedByActiveUser({
+          db,
+          organizationId: orgId,
+          entityType: "vendor_contact",
+          entityId: removedContact.id,
+        })
+      ) {
+        return {
+          success: false,
+          error: `${removedContact.name} is an active Compass user and cannot be removed from this vendor company.`,
+        }
+      }
+    }
+
     const updatedAt = new Date().toISOString()
-    await db.batch([
-      db
-        .update(vendors)
-        .set({ ...data, updatedAt })
-        .where(and(eq(vendors.id, id), eq(vendors.organizationId, orgId))),
-      db
-        .update(projectContacts)
-        .set({ ...nextIdentity, updatedAt })
-        .where(
-          and(
-            eq(projectContacts.sourceEntityType, "vendor"),
-            eq(projectContacts.sourceEntityId, id)
+    await db
+      .update(vendors)
+      .set({ name, category, ...nextIdentity, updatedAt })
+      .where(and(eq(vendors.id, id), eq(vendors.organizationId, orgId)))
+    await db
+      .update(projectContacts)
+      .set({ companyName: name, updatedAt })
+      .where(eq(projectContacts.vendorId, id))
+    await db
+      .update(projectContacts)
+      .set({ ...nextIdentity, updatedAt })
+      .where(
+        and(
+          eq(projectContacts.sourceEntityType, "vendor"),
+          eq(projectContacts.sourceEntityId, id),
+          isNull(projectContacts.vendorContactId)
+        )
+      )
+
+    if (data.contacts === undefined) {
+      revalidatePath("/dashboard/vendors")
+      revalidatePath("/dashboard/contacts")
+      revalidatePath("/dashboard/projects", "layout")
+      return { success: true }
+    }
+
+    const retainedIds = new Set<string>()
+    await db
+      .update(vendorContacts)
+      .set({ isPrimary: false, updatedAt })
+      .where(eq(vendorContacts.vendorId, id))
+
+    for (const contact of contactInputs) {
+      const existingContact = contact.id ? existingById.get(contact.id) : undefined
+      const identity = {
+        email: nullableText(contact.email),
+        phone: nullableText(contact.phone),
+        address: null,
+      }
+
+      const contactId = existingContact?.id ?? crypto.randomUUID()
+      retainedIds.add(contactId)
+      if (existingContact) {
+        await db
+          .update(vendorContacts)
+          .set({
+            name: contact.name,
+            title: nullableText(contact.title),
+            email: identity.email,
+            phone: identity.phone,
+            isPrimary: contact.isPrimary,
+            active: true,
+            updatedAt,
+          })
+          .where(
+            and(
+              eq(vendorContacts.id, contactId),
+              eq(vendorContacts.vendorId, id)
+            )
           )
-        ),
-    ])
+      } else {
+        await db.insert(vendorContacts).values({
+          id: contactId,
+          vendorId: id,
+          name: contact.name,
+          title: nullableText(contact.title),
+          email: identity.email,
+          phone: identity.phone,
+          isPrimary: contact.isPrimary,
+          active: true,
+          sourceSystem: "manual",
+          sourceRecordId: null,
+          createdAt: updatedAt,
+          updatedAt,
+        })
+      }
+      await db
+        .update(projectContacts)
+        .set({
+          displayName: contact.name,
+          companyName: name,
+          email: identity.email,
+          phone: identity.phone,
+          updatedAt,
+        })
+        .where(
+          or(
+            eq(projectContacts.vendorContactId, contactId),
+            and(
+              eq(projectContacts.sourceEntityType, "vendor_contact"),
+              eq(projectContacts.sourceEntityId, contactId)
+            )
+          )
+        )
+    }
+
+    const removedIds = existingContacts
+      .map((contact) => contact.id)
+      .filter((contactId) => !retainedIds.has(contactId))
+    if (removedIds.length > 0) {
+      await db
+        .update(vendorContacts)
+        .set({ active: false, isPrimary: false, updatedAt })
+        .where(inArray(vendorContacts.id, removedIds))
+    }
 
     revalidatePath("/dashboard/vendors")
     revalidatePath("/dashboard/contacts")
@@ -405,6 +547,67 @@ export async function updateVendor(
       error:
         err instanceof Error ? err.message : "Failed to update vendor",
     }
+  }
+}
+
+export async function createVendorContact(
+  vendorId: string,
+  input: VendorContactMutationInput
+): Promise<VendorContactMutationResult> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) return { success: false, error: "DEMO_READ_ONLY" }
+    requirePermission(user, "vendor", "update")
+    const orgId = requireOrg(user)
+    const name = input.name.trim()
+    if (!name) return { success: false, error: "Contact name is required" }
+
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const vendor = await db
+      .select({ id: vendors.id })
+      .from(vendors)
+      .where(
+        and(
+          eq(vendors.id, vendorId),
+          eq(vendors.organizationId, orgId),
+          eq(vendors.directoryStatus, "active")
+        )
+      )
+      .get()
+    if (!vendor) return { success: false, error: "Vendor company not found" }
+
+    const now = new Date().toISOString()
+    const id = crypto.randomUUID()
+    if (input.isPrimary) {
+      await db
+        .update(vendorContacts)
+        .set({ isPrimary: false, updatedAt: now })
+        .where(eq(vendorContacts.vendorId, vendorId))
+    }
+    const contact: VendorContactItem = {
+      id,
+      vendorId,
+      name,
+      title: nullableText(input.title),
+      email: nullableText(input.email),
+      phone: nullableText(input.phone),
+      isPrimary: input.isPrimary,
+      active: true,
+      sourceSystem: "manual",
+    }
+    await db.insert(vendorContacts).values({
+      ...contact,
+      sourceRecordId: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    revalidatePath("/dashboard/contacts")
+    revalidatePath("/dashboard/projects", "layout")
+    return { success: true, contact }
+  } catch (error) {
+    console.error("Failed to create vendor contact", error)
+    return { success: false, error: "Failed to create vendor contact" }
   }
 }
 

--- a/src/app/dashboard/contacts/page.tsx
+++ b/src/app/dashboard/contacts/page.tsx
@@ -20,8 +20,10 @@ import {
   updateVendor,
   deleteVendor,
   type InternalDirectoryContact,
+  type VendorCompanyMutationInput,
+  type VendorDirectoryCompany,
 } from "@/app/actions/vendors"
-import type { Customer, Vendor } from "@/db/schema"
+import type { Customer } from "@/db/schema"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -55,7 +57,7 @@ function toContactsTab(value: string | null): Tab {
   return "customers"
 }
 
-function isInternalVendor(vendor: Vendor): boolean {
+function isInternalVendor(vendor: VendorDirectoryCompany): boolean {
   return vendor.category.trim().toLowerCase() === "internal"
 }
 
@@ -154,7 +156,9 @@ function ContactsContent() {
   const [loading, setLoading] = React.useState(true)
 
   const [customersList, setCustomersList] = React.useState<Customer[]>([])
-  const [vendorsList, setVendorsList] = React.useState<Vendor[]>([])
+  const [vendorsList, setVendorsList] = React.useState<
+    readonly VendorDirectoryCompany[]
+  >([])
   const [internalContactsList, setInternalContactsList] = React.useState<
     readonly InternalDirectoryContact[]
   >([])
@@ -165,7 +169,7 @@ function ContactsContent() {
 
   const [vendorDialogOpen, setVendorDialogOpen] = React.useState(false)
   const [editingVendor, setEditingVendor] =
-    React.useState<Vendor | null>(null)
+    React.useState<VendorDirectoryCompany | null>(null)
 
   const loadAll = async () => {
     try {
@@ -288,13 +292,7 @@ function ContactsContent() {
     }
   }
 
-  const handleVendorSubmit = async (data: {
-    name: string
-    category: string
-    email: string
-    phone: string
-    address: string
-  }) => {
+  const handleVendorSubmit = async (data: VendorCompanyMutationInput) => {
     if (editingVendor) {
       const result = await updateVendor(editingVendor.id, data)
       if (result.success) {

--- a/src/components/financials/vendor-dialog.tsx
+++ b/src/components/financials/vendor-dialog.tsx
@@ -1,6 +1,11 @@
 "use client"
 
 import * as React from "react"
+import { IconPlus, IconTrash } from "@tabler/icons-react"
+import type {
+  VendorCompanyMutationInput,
+  VendorDirectoryCompany,
+} from "@/app/actions/vendors"
 import { Button } from "@/components/ui/button"
 import {
   ResponsiveDialog,
@@ -16,20 +21,23 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import type { Vendor } from "@/db/schema"
+
+type ContactDraft = {
+  readonly key: string
+  readonly id: string | null
+  readonly name: string
+  readonly title: string
+  readonly email: string
+  readonly phone: string
+  readonly isPrimary: boolean
+}
 
 interface VendorDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  initialData?: Vendor | null
+  initialData?: VendorDirectoryCompany | null
   categories: readonly string[]
-  onSubmit: (data: {
-    name: string
-    category: string
-    email: string
-    phone: string
-    address: string
-  }) => void
+  onSubmit: (data: VendorCompanyMutationInput) => void
 }
 
 export function VendorDialog({
@@ -44,6 +52,7 @@ export function VendorDialog({
   const [email, setEmail] = React.useState("")
   const [phone, setPhone] = React.useState("")
   const [address, setAddress] = React.useState("")
+  const [contacts, setContacts] = React.useState<readonly ContactDraft[]>([])
 
   React.useEffect(() => {
     if (initialData) {
@@ -52,12 +61,24 @@ export function VendorDialog({
       setEmail(initialData.email ?? "")
       setPhone(initialData.phone ?? "")
       setAddress(initialData.address ?? "")
+      setContacts(
+        initialData.contacts.map((contact) => ({
+          key: contact.id,
+          id: contact.id,
+          name: contact.name,
+          title: contact.title ?? "",
+          email: contact.email ?? "",
+          phone: contact.phone ?? "",
+          isPrimary: contact.isPrimary,
+        }))
+      )
     } else {
       setName("")
       setCategory("Subcontractor")
       setEmail("")
       setPhone("")
       setAddress("")
+      setContacts([])
     }
   }, [initialData, open])
 
@@ -70,6 +91,62 @@ export function VendorDialog({
       email: email.trim(),
       phone: phone.trim(),
       address: address.trim(),
+      contacts: contacts.map((contact) => ({
+        id: contact.id,
+        name: contact.name,
+        title: contact.title,
+        email: contact.email,
+        phone: contact.phone,
+        isPrimary: contact.isPrimary,
+      })),
+    })
+  }
+
+  function addContact(): void {
+    setContacts((current) => [
+      ...current,
+      {
+        key: crypto.randomUUID(),
+        id: null,
+        name: "",
+        title: "",
+        email: "",
+        phone: "",
+        isPrimary: current.length === 0,
+      },
+    ])
+  }
+
+  function updateContact(
+    key: string,
+    field: "name" | "title" | "email" | "phone",
+    value: string
+  ): void {
+    setContacts((current) =>
+      current.map((contact) =>
+        contact.key === key ? { ...contact, [field]: value } : contact
+      )
+    )
+  }
+
+  function makePrimary(key: string): void {
+    setContacts((current) =>
+      current.map((contact) => ({
+        ...contact,
+        isPrimary: contact.key === key,
+      }))
+    )
+  }
+
+  function removeContact(key: string): void {
+    setContacts((current) => {
+      const removed = current.find((contact) => contact.key === key)
+      const remaining = current.filter((contact) => contact.key !== key)
+      if (!removed?.isPrimary || remaining.length === 0) return remaining
+      return remaining.map((contact, index) => ({
+        ...contact,
+        isPrimary: index === 0,
+      }))
     })
   }
 
@@ -84,12 +161,12 @@ export function VendorDialog({
           <div className="grid grid-cols-5 gap-3">
             <div className="col-span-3 space-y-1.5">
               <Label htmlFor="vendor-name" className="text-xs">
-                Name *
+                Company name *
               </Label>
               <Input
                 id="vendor-name"
                 className="h-9"
-                placeholder="Vendor name"
+                placeholder="Vendor company name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 required
@@ -120,7 +197,7 @@ export function VendorDialog({
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
               <Label htmlFor="vendor-email" className="text-xs">
-                Email
+                Company email
               </Label>
               <Input
                 id="vendor-email"
@@ -133,7 +210,7 @@ export function VendorDialog({
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="vendor-phone" className="text-xs">
-                Phone
+                Company phone
               </Label>
               <Input
                 id="vendor-phone"
@@ -155,6 +232,87 @@ export function VendorDialog({
               value={address}
               onChange={(e) => setAddress(e.target.value)}
             />
+          </div>
+          <div className="space-y-3 border-t pt-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <Label>People at this company</Label>
+                <p className="text-xs text-muted-foreground">
+                  Add multiple contacts, each with their own email and phone.
+                </p>
+              </div>
+              <Button type="button" variant="outline" size="sm" onClick={addContact}>
+                <IconPlus className="size-4" />
+                Add person
+              </Button>
+            </div>
+            {contacts.length === 0 ? (
+              <p className="rounded-md border border-dashed p-4 text-center text-sm text-muted-foreground">
+                No contact people have been added.
+              </p>
+            ) : (
+              <div className="grid gap-3">
+                {contacts.map((contact, index) => (
+                  <div key={contact.key} className="grid gap-3 rounded-md border p-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="text-sm font-medium">Contact {index + 1}</p>
+                      <div className="flex items-center gap-2">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant={contact.isPrimary ? "secondary" : "ghost"}
+                          onClick={() => makePrimary(contact.key)}
+                        >
+                          {contact.isPrimary ? "Primary" : "Make primary"}
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-sm"
+                          onClick={() => removeContact(contact.key)}
+                          aria-label={`Remove contact ${index + 1}`}
+                        >
+                          <IconTrash className="size-4" />
+                        </Button>
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <Input
+                        required
+                        value={contact.name}
+                        onChange={(event) =>
+                          updateContact(contact.key, "name", event.target.value)
+                        }
+                        placeholder="Contact name"
+                      />
+                      <Input
+                        value={contact.title}
+                        onChange={(event) =>
+                          updateContact(contact.key, "title", event.target.value)
+                        }
+                        placeholder="Title"
+                      />
+                      <Input
+                        type="email"
+                        value={contact.email}
+                        onChange={(event) =>
+                          updateContact(contact.key, "email", event.target.value)
+                        }
+                        placeholder="Email"
+                      />
+                      <Input
+                        type="tel"
+                        value={contact.phone}
+                        onChange={(event) =>
+                          updateContact(contact.key, "phone", event.target.value)
+                        }
+                        placeholder="Phone"
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         </ResponsiveDialogBody>
 

--- a/src/components/financials/vendors-table.tsx
+++ b/src/components/financials/vendors-table.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import { IconDotsVertical } from "@tabler/icons-react"
+import type { VendorDirectoryCompany } from "@/app/actions/vendors"
 import {
   flexRender,
   getCoreRowModel,
@@ -14,7 +15,6 @@ import {
   type SortingState,
 } from "@tanstack/react-table"
 
-import type { Vendor } from "@/db/schema"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
@@ -45,19 +45,19 @@ import {
 } from "@/components/ui/table"
 
 interface VendorsTableProps {
-  vendors: Vendor[]
+  vendors: readonly VendorDirectoryCompany[]
   categories: readonly string[]
-  onEdit?: (vendor: Vendor) => void
+  onEdit?: (vendor: VendorDirectoryCompany) => void
   onDelete?: (id: string) => void
 }
 
-function vendorSourceLabel(vendor: Vendor): string {
+function vendorSourceLabel(vendor: VendorDirectoryCompany): string {
   if (vendor.sourceSystem?.includes("sage")) return "Sage"
   if (vendor.sourceSystem === "buildertrend") return "BT only"
   return "Compass"
 }
 
-function vendorSyncLabel(vendor: Vendor): string {
+function vendorSyncLabel(vendor: VendorDirectoryCompany): string {
   if (vendor.syncStatus === "needs_sage_review") return "Needs Sage review"
   if (vendor.syncStatus === "synced") return "Synced"
   return "Manual"
@@ -103,7 +103,7 @@ export function VendorsTable({
     }
   }
 
-  const columns: ColumnDef<Vendor>[] = [
+  const columns: ColumnDef<VendorDirectoryCompany>[] = [
     {
       id: "select",
       header: ({ table }) => (
@@ -168,10 +168,29 @@ export function VendorsTable({
       },
     },
     {
-      accessorKey: "email",
-      header: "Email",
+      id: "contacts",
+      header: "People",
       cell: ({ row }) => {
-        const email = row.getValue("email") as string | null
+        const contacts = row.original.contacts
+        const primary = contacts.find((contact) => contact.isPrimary)
+        if (contacts.length === 0) {
+          return <span className="text-muted-foreground/40">—</span>
+        }
+        return (
+          <div className="flex flex-col">
+            <span>{primary?.name ?? contacts[0]?.name}</span>
+            <span className="text-xs text-muted-foreground">
+              {contacts.length} {contacts.length === 1 ? "person" : "people"}
+            </span>
+          </div>
+        )
+      },
+    },
+    {
+      accessorKey: "email",
+      header: "Company email",
+      cell: ({ row }) => {
+        const email = row.original.email
         if (!email) {
           return (
             <span className="text-muted-foreground/40">—</span>
@@ -190,9 +209,9 @@ export function VendorsTable({
     },
     {
       accessorKey: "phone",
-      header: "Phone",
+      header: "Company phone",
       cell: ({ row }) => {
-        const phone = row.getValue("phone") as string | null
+        const phone = row.original.phone
         if (!phone) {
           return (
             <span className="text-muted-foreground/40">—</span>
@@ -260,7 +279,7 @@ export function VendorsTable({
   ]
 
   const table = useReactTable({
-    data: vendors,
+    data: [...vendors],
     columns,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
@@ -382,8 +401,9 @@ export function VendorsTable({
                       </Badge>
                     </div>
                     <p className="text-xs text-muted-foreground truncate">
-                      {[v.email, v.phone].filter(Boolean).join(" \u00b7 ") ||
-                        "No contact info"}
+                      {v.contacts.length > 0
+                        ? `${v.contacts.length} ${v.contacts.length === 1 ? "person" : "people"}`
+                        : "No contact people"}
                     </p>
                     <p className="mt-1 text-[11px] text-muted-foreground">
                       {vendorSourceLabel(v)} · {vendorSyncLabel(v)}

--- a/src/components/projects/project-contact-management.tsx
+++ b/src/components/projects/project-contact-management.tsx
@@ -20,6 +20,10 @@ import {
   type ProjectContactType,
 } from "@/app/actions/project-contacts"
 import {
+  createVendor,
+  createVendorContact,
+} from "@/app/actions/vendors"
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -111,11 +115,26 @@ function initialInput(
   projectId: string,
   contact: ProjectContactItem | null
 ): ProjectContactMutationInput {
+  const directorySourceType = contact?.vendorId
+    ? "vendor"
+    : contact?.sourceEntityType === "customer"
+      ? "customer"
+      : contact?.sourceEntityType === "user"
+        ? "team"
+        : null
+  const directorySourceId =
+    contact?.vendorId ??
+    (directorySourceType && contact?.sourceEntityId
+      ? contact.sourceEntityId
+      : null)
+
   return {
     projectId,
     contactId: contact?.id ?? null,
-    directorySourceType: null,
-    directorySourceId: null,
+    directorySourceType,
+    directorySourceId,
+    vendorId: contact?.vendorId ?? null,
+    vendorContactId: contact?.vendorContactId ?? null,
     contactType: contact?.contactType ?? "owner",
     displayName: contact?.displayName ?? "",
     companyName: contact?.companyName ?? "",
@@ -133,6 +152,10 @@ function initialInput(
     internalVisible: contact?.internalVisible ?? true,
     primaryContact: contact?.primaryContact ?? false,
   }
+}
+
+function isVendorContactType(type: ProjectContactType): boolean {
+  return type === "supplier" || type === "subcontractor"
 }
 
 function groupedDirectoryOptions(
@@ -264,21 +287,40 @@ export function ProjectContactEditor({
   const router = useRouter()
   const [open, setOpen] = useState(false)
   const [directoryOpenKey, setDirectoryOpenKey] = useState<string | null>(null)
+  const [availableDirectoryOptions, setAvailableDirectoryOptions] = useState(
+    directoryOptions
+  )
   const [input, setInput] = useState(() => initialInput(projectId, contact))
+  const [showNewVendor, setShowNewVendor] = useState(false)
+  const [newVendorName, setNewVendorName] = useState("")
+  const [showNewVendorContact, setShowNewVendorContact] = useState(false)
+  const [newVendorContactName, setNewVendorContactName] = useState("")
+  const [newVendorContactEmail, setNewVendorContactEmail] = useState("")
+  const [newVendorContactPhone, setNewVendorContactPhone] = useState("")
   const [customRoleSelected, setCustomRoleSelected] = useState(
     () => Boolean(contact?.role && !isPresetProjectRole(contact.role))
   )
   const [isPending, startTransition] = useTransition()
   const isEditing = contact !== null
-  const selectedDirectory = directoryOptions.find(
+  const selectedDirectory = availableDirectoryOptions.find(
     (option) =>
       option.id === input.directorySourceId &&
       option.sourceType === input.directorySourceType
   ) ?? null
+  const vendorOptions = availableDirectoryOptions.filter(
+    (option) => option.sourceType === "vendor"
+  )
+  const selectedVendor =
+    selectedDirectory?.sourceType === "vendor" ? selectedDirectory : null
+  const selectedVendorContact = selectedVendor?.vendorContacts.find(
+    (vendorContact) => vendorContact.id === input.vendorContactId
+  ) ?? null
   const identityManagedByActiveUser =
-    contact?.identityManagedByActiveUser ??
-    selectedDirectory?.identityManagedByActiveUser ??
-    false
+    input.directorySourceType === null
+      ? (contact?.identityManagedByActiveUser ?? false)
+      : (selectedVendorContact?.identityManagedByActiveUser ??
+        selectedDirectory?.identityManagedByActiveUser ??
+        false)
 
   function updateInput<Key extends keyof ProjectContactMutationInput>(
     key: Key,
@@ -291,7 +333,14 @@ export function ProjectContactEditor({
     setOpen(nextOpen)
     if (nextOpen) {
       setInput(initialInput(projectId, contact))
+      setAvailableDirectoryOptions(directoryOptions)
       setDirectoryOpenKey(null)
+      setShowNewVendor(false)
+      setNewVendorName("")
+      setShowNewVendorContact(false)
+      setNewVendorContactName("")
+      setNewVendorContactEmail("")
+      setNewVendorContactPhone("")
       setCustomRoleSelected(
         Boolean(contact?.role && !isPresetProjectRole(contact.role))
       )
@@ -299,27 +348,151 @@ export function ProjectContactEditor({
   }
 
   function applyDirectoryOption(option: ProjectContactDirectoryOption): void {
-    const projectRole = defaultProjectRole(option.suggestedContactType)
     setDirectoryOpenKey(`${option.sourceType}:${option.id}`)
     setCustomRoleSelected(false)
+    setInput((current) => {
+      const contactType =
+        option.sourceType === "vendor" &&
+        isVendorContactType(current.contactType)
+          ? current.contactType
+          : option.suggestedContactType
+      return {
+        ...current,
+        directorySourceType: option.sourceType,
+        directorySourceId: option.id,
+        vendorId: option.sourceType === "vendor" ? option.id : null,
+        vendorContactId: null,
+        contactType,
+        displayName: option.displayName,
+        companyName: option.companyName ?? "",
+        email: option.email ?? "",
+        phone: option.phone ?? "",
+        address: option.address ?? "",
+        role: defaultProjectRole(contactType),
+        ownerPortalVisible:
+          contactType === "internal" || current.ownerPortalVisible,
+        subVendorPortalVisible:
+          isVendorContactType(contactType) || current.subVendorPortalVisible,
+      }
+    })
+  }
+
+  function applyVendorContact(contactId: string): void {
+    if (!selectedVendor) return
+    if (contactId === "company-only") {
+      setInput((current) => ({
+        ...current,
+        vendorContactId: null,
+        displayName: selectedVendor.displayName,
+        companyName: selectedVendor.displayName,
+        email: selectedVendor.email ?? "",
+        phone: selectedVendor.phone ?? "",
+        address: selectedVendor.address ?? "",
+      }))
+      return
+    }
+    const vendorContact = selectedVendor.vendorContacts.find(
+      (option) => option.id === contactId
+    )
+    if (!vendorContact) return
     setInput((current) => ({
       ...current,
-      directorySourceType: option.sourceType,
-      directorySourceId: option.id,
-      contactType: option.suggestedContactType,
-      displayName: option.displayName,
-      companyName: option.companyName ?? "",
-      email: option.email ?? "",
-      phone: option.phone ?? "",
-      address: option.address ?? "",
-      role: projectRole,
-      ownerPortalVisible:
-        option.suggestedContactType === "internal" || current.ownerPortalVisible,
-      subVendorPortalVisible:
-        option.suggestedContactType === "subcontractor" ||
-        option.suggestedContactType === "supplier" ||
-        current.subVendorPortalVisible,
+      vendorContactId: vendorContact.id,
+      displayName: vendorContact.name,
+      companyName: selectedVendor.displayName,
+      email: vendorContact.email ?? "",
+      phone: vendorContact.phone ?? "",
+      address: selectedVendor.address ?? "",
     }))
+  }
+
+  function addVendorCompany(): void {
+    const name = newVendorName.trim()
+    if (!name) return
+    startTransition(async () => {
+      const category =
+        input.contactType === "supplier" ? "Supplier" : "Subcontractor"
+      const result = await createVendor({
+        name,
+        category,
+        email: "",
+        phone: "",
+        address: "",
+        contacts: [],
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      const option: ProjectContactDirectoryOption = {
+        id: result.id,
+        sourceType: "vendor",
+        displayName: name,
+        companyName: name,
+        email: null,
+        phone: null,
+        address: null,
+        suggestedContactType: input.contactType,
+        identityManagedByActiveUser: false,
+        vendorContacts: [],
+      }
+      setAvailableDirectoryOptions((current) => [...current, option])
+      applyDirectoryOption(option)
+      setNewVendorName("")
+      setShowNewVendor(false)
+      toast.success("Vendor company added.")
+    })
+  }
+
+  function addVendorPerson(): void {
+    if (!selectedVendor || !newVendorContactName.trim()) return
+    startTransition(async () => {
+      const result = await createVendorContact(selectedVendor.id, {
+        id: null,
+        name: newVendorContactName,
+        title: "",
+        email: newVendorContactEmail,
+        phone: newVendorContactPhone,
+        isPrimary: selectedVendor.vendorContacts.length === 0,
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      setAvailableDirectoryOptions((current) =>
+        current.map((option) =>
+          option.sourceType === "vendor" && option.id === selectedVendor.id
+            ? {
+                ...option,
+                vendorContacts: [
+                  ...option.vendorContacts,
+                  {
+                    id: result.contact.id,
+                    name: result.contact.name,
+                    title: result.contact.title,
+                    email: result.contact.email,
+                    phone: result.contact.phone,
+                    isPrimary: result.contact.isPrimary,
+                    identityManagedByActiveUser: false,
+                  },
+                ],
+              }
+            : option
+        )
+      )
+      setInput((current) => ({
+        ...current,
+        vendorContactId: result.contact.id,
+        displayName: result.contact.name,
+        email: result.contact.email ?? "",
+        phone: result.contact.phone ?? "",
+      }))
+      setNewVendorContactName("")
+      setNewVendorContactEmail("")
+      setNewVendorContactPhone("")
+      setShowNewVendorContact(false)
+      toast.success("Vendor contact added.")
+    })
   }
 
   function submit(event: React.FormEvent<HTMLFormElement>): void {
@@ -372,48 +545,206 @@ export function ProjectContactEditor({
           </SheetHeader>
 
           <div className="grid flex-1 gap-5 px-4 py-5 sm:px-6">
-            {!isEditing && directoryOptions.length > 0 && (
-              <div className="grid gap-2">
-                <Label>Company directory</Label>
-                <DirectoryPicker
-                  key={directoryOpenKey ?? "manual"}
-                  options={directoryOptions}
-                  selected={selectedDirectory}
-                  onSelect={applyDirectoryOption}
-                />
-                <p className="text-xs text-muted-foreground">
-                  Select an existing record to prefill the form, or enter a new contact below.
-                </p>
+            <div className="grid gap-2">
+              <Label htmlFor="project-contact-type">Contact type</Label>
+              <Select
+                value={input.contactType}
+                onValueChange={(value) => {
+                  if (
+                    value !== "owner" &&
+                    value !== "supplier" &&
+                    value !== "subcontractor" &&
+                    value !== "internal"
+                  ) {
+                    return
+                  }
+                  const keepVendor =
+                    isVendorContactType(input.contactType) &&
+                    isVendorContactType(value)
+                  setInput((current) => ({
+                    ...current,
+                    contactType: value,
+                    role: defaultProjectRole(value),
+                    ...(keepVendor
+                      ? {}
+                      : {
+                          directorySourceType: null,
+                          directorySourceId: null,
+                          vendorId: null,
+                          vendorContactId: null,
+                        }),
+                  }))
+                  setCustomRoleSelected(false)
+                }}
+              >
+                <SelectTrigger id="project-contact-type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="owner">Owner / customer</SelectItem>
+                  <SelectItem value="supplier">Supplier</SelectItem>
+                  <SelectItem value="subcontractor">Subcontractor</SelectItem>
+                  <SelectItem value="internal">Internal team</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {isVendorContactType(input.contactType) ? (
+              <div className="grid gap-4 rounded-lg border p-4">
+                <div className="grid gap-2">
+                  <Label>Vendor company</Label>
+                  <DirectoryPicker
+                    key={directoryOpenKey ?? "vendor"}
+                    options={vendorOptions}
+                    selected={selectedVendor}
+                    onSelect={applyDirectoryOption}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Choose from all {vendorOptions.length} Sage and Compass vendor companies.
+                  </p>
+                </div>
+                {showNewVendor ? (
+                  <div className="flex gap-2">
+                    <Input
+                      value={newVendorName}
+                      onChange={(event) => setNewVendorName(event.target.value)}
+                      placeholder="New vendor company name"
+                      aria-label="New vendor company name"
+                    />
+                    <Button
+                      type="button"
+                      onClick={addVendorCompany}
+                      disabled={isPending || !newVendorName.trim()}
+                    >
+                      Add
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      onClick={() => setShowNewVendor(false)}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="w-fit"
+                    onClick={() => setShowNewVendor(true)}
+                  >
+                    <IconPlus className="size-4" />
+                    Add new vendor
+                  </Button>
+                )}
+
+                {selectedVendor && (
+                  <div className="grid gap-3 border-t pt-4">
+                    <div className="grid gap-2">
+                      <Label>Contact person</Label>
+                      <Select
+                        value={input.vendorContactId ?? "company-only"}
+                        onValueChange={applyVendorContact}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Choose a person" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="company-only">
+                            Company only (no specific person)
+                          </SelectItem>
+                          {selectedVendor.vendorContacts.map((vendorContact) => (
+                            <SelectItem key={vendorContact.id} value={vendorContact.id}>
+                              {vendorContact.name}
+                              {vendorContact.title ? ` · ${vendorContact.title}` : ""}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    {showNewVendorContact ? (
+                      <div className="grid gap-2 sm:grid-cols-2">
+                        <Input
+                          required
+                          value={newVendorContactName}
+                          onChange={(event) =>
+                            setNewVendorContactName(event.target.value)
+                          }
+                          placeholder="Contact name"
+                        />
+                        <Input
+                          type="email"
+                          value={newVendorContactEmail}
+                          onChange={(event) =>
+                            setNewVendorContactEmail(event.target.value)
+                          }
+                          placeholder="Email"
+                        />
+                        <Input
+                          type="tel"
+                          value={newVendorContactPhone}
+                          onChange={(event) =>
+                            setNewVendorContactPhone(event.target.value)
+                          }
+                          placeholder="Phone"
+                        />
+                        <div className="flex gap-2">
+                          <Button
+                            type="button"
+                            onClick={addVendorPerson}
+                            disabled={isPending || !newVendorContactName.trim()}
+                          >
+                            Add person
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            onClick={() => setShowNewVendorContact(false)}
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      </div>
+                    ) : (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="w-fit"
+                        onClick={() => setShowNewVendorContact(true)}
+                      >
+                        <IconPlus className="size-4" />
+                        Add contact person
+                      </Button>
+                    )}
+                  </div>
+                )}
               </div>
+            ) : (
+              !isEditing && (
+                <div className="grid gap-2">
+                  <Label>
+                    {input.contactType === "owner"
+                      ? "Customer directory"
+                      : "Settings team"}
+                  </Label>
+                  <DirectoryPicker
+                    key={directoryOpenKey ?? input.contactType}
+                    options={availableDirectoryOptions.filter((option) =>
+                      input.contactType === "owner"
+                        ? option.sourceType === "customer"
+                        : option.sourceType === "team"
+                    )}
+                    selected={selectedDirectory}
+                    onSelect={applyDirectoryOption}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Select an existing record to prefill the form, or enter one manually.
+                  </p>
+                </div>
+              )
             )}
 
             <div className="grid gap-4 sm:grid-cols-2">
-              <div className="grid gap-2">
-                <Label htmlFor="project-contact-type">Contact type</Label>
-                <Select
-                  value={input.contactType}
-                  onValueChange={(value) => {
-                    if (
-                      value === "owner" ||
-                      value === "supplier" ||
-                      value === "subcontractor" ||
-                      value === "internal"
-                    ) {
-                      updateInput("contactType", value)
-                    }
-                  }}
-                >
-                  <SelectTrigger id="project-contact-type">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="owner">Owner / customer</SelectItem>
-                    <SelectItem value="supplier">Supplier</SelectItem>
-                    <SelectItem value="subcontractor">Subcontractor</SelectItem>
-                    <SelectItem value="internal">Internal team</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
               <div className="grid gap-2">
                 <Label htmlFor="project-contact-name">Contact name</Label>
                 <Input
@@ -429,6 +760,7 @@ export function ProjectContactEditor({
                   id="project-contact-company"
                   value={input.companyName}
                   onChange={(event) => updateInput("companyName", event.target.value)}
+                  readOnly={selectedVendor !== null}
                 />
               </div>
               <div className="grid gap-2">
@@ -628,7 +960,14 @@ export function ProjectContactEditor({
             <Button type="button" variant="outline" onClick={() => setOpen(false)}>
               Cancel
             </Button>
-            <Button type="submit" disabled={isPending || !input.displayName.trim()}>
+            <Button
+              type="submit"
+              disabled={
+                isPending ||
+                !input.displayName.trim() ||
+                (isVendorContactType(input.contactType) && !input.vendorId)
+              }
+            >
               {isPending ? "Saving..." : "Save contact"}
             </Button>
           </SheetFooter>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1777,6 +1777,13 @@ export const projectContacts = sqliteTable("project_contacts", {
   sourceRecordId: text("source_record_id"),
   sourceEntityType: text("source_entity_type").notNull().default("manual"),
   sourceEntityId: text("source_entity_id"),
+  vendorId: text("vendor_id").references(() => vendors.id, {
+    onDelete: "set null",
+  }),
+  vendorContactId: text("vendor_contact_id").references(
+    () => vendorContacts.id,
+    { onDelete: "set null" }
+  ),
   displayName: text("display_name").notNull(),
   companyName: text("company_name"),
   role: text("role"),
@@ -2141,6 +2148,32 @@ export const vendors = sqliteTable("vendors", {
   updatedAt: text("updated_at"),
 })
 
+export const vendorContacts = sqliteTable(
+  "vendor_contacts",
+  {
+    id: text("id").primaryKey(),
+    vendorId: text("vendor_id")
+      .notNull()
+      .references(() => vendors.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    title: text("title"),
+    email: text("email"),
+    phone: text("phone"),
+    isPrimary: integer("is_primary", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    active: integer("active", { mode: "boolean" }).notNull().default(true),
+    sourceSystem: text("source_system").notNull().default("manual"),
+    sourceRecordId: text("source_record_id"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    index("vendor_contacts_vendor_idx").on(table.vendorId),
+    index("vendor_contacts_vendor_active_idx").on(table.vendorId, table.active),
+  ]
+)
+
 export const sageCostCodes = sqliteTable("sage_cost_codes", {
   id: text("id").primaryKey(),
   sourceSystem: text("source_system").notNull().default("sage"),
@@ -2267,6 +2300,8 @@ export const feedback = sqliteTable("feedback", {
 
 export type Vendor = typeof vendors.$inferSelect
 export type NewVendor = typeof vendors.$inferInsert
+export type VendorContact = typeof vendorContacts.$inferSelect
+export type NewVendorContact = typeof vendorContacts.$inferInsert
 export type Feedback = typeof feedback.$inferSelect
 export type NewFeedback = typeof feedback.$inferInsert
 

--- a/src/lib/__tests__/contact-identity-ownership.test.ts
+++ b/src/lib/__tests__/contact-identity-ownership.test.ts
@@ -53,6 +53,7 @@ describe("contact identity ownership", () => {
       rows: [
         { entityType: "customer", entityId: "directory-10" },
         { entityType: "vendor", entityId: "directory-539" },
+        { entityType: "vendor_contact", entityId: "directory-42" },
         { entityType: "vendor", entityId: "outside-directory" },
         { entityType: "customer", entityId: null },
       ],
@@ -61,6 +62,7 @@ describe("contact identity ownership", () => {
     expect(Array.from(result)).toEqual([
       "customer:directory-10",
       "vendor:directory-539",
+      "vendor_contact:directory-42",
     ])
   })
 })

--- a/src/lib/__tests__/internal-contact-directory.test.ts
+++ b/src/lib/__tests__/internal-contact-directory.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+
+import { uniqueInternalStaffMembers } from "@/lib/internal-contact-directory"
+
+describe("internal contact directory", () => {
+  it("uses Settings team user IDs to remove repeated staff records", () => {
+    const result = uniqueInternalStaffMembers([
+      { id: "user-1", role: "office", name: "Alex Smith" },
+      { id: "user-1", role: "office", name: "Alex Smith (project copy)" },
+      { id: "user-2", role: "project_manager", name: "Sam Lee" },
+    ])
+
+    expect(result).toEqual([
+      { id: "user-1", role: "office", name: "Alex Smith" },
+      { id: "user-2", role: "project_manager", name: "Sam Lee" },
+    ])
+  })
+
+  it("excludes external project contacts from the internal roster", () => {
+    const result = uniqueInternalStaffMembers([
+      { id: "staff", role: "admin" },
+      { id: "owner", role: "client" },
+      { id: "sub", role: "subcontractor" },
+      { id: "supplier", role: "supplier" },
+    ])
+
+    expect(result.map((member) => member.id)).toEqual(["staff"])
+  })
+})

--- a/src/lib/agent/render/action-registry.ts
+++ b/src/lib/agent/render/action-registry.ts
@@ -243,9 +243,16 @@ export const actionRegistry: Record<
     resource: "vendor",
     permission: "create",
     execute: async (params) => {
-      const result = await createVendor(
-        params as Parameters<typeof createVendor>[0]
-      )
+      const result = await createVendor({
+        name: typeof params.name === "string" ? params.name : "",
+        category:
+          typeof params.category === "string"
+            ? params.category
+            : "Miscellaneous Vendor",
+        email: typeof params.email === "string" ? params.email : "",
+        phone: typeof params.phone === "string" ? params.phone : "",
+        address: typeof params.address === "string" ? params.address : "",
+      })
       return wrapResult(result)
     },
   },
@@ -254,8 +261,18 @@ export const actionRegistry: Record<
     resource: "vendor",
     permission: "update",
     execute: async (params) => {
-      const { id, ...data } = params as { id: string } & Record<string, unknown>
-      const result = await updateVendor(id, data)
+      const id = typeof params.id === "string" ? params.id : ""
+      const result = await updateVendor(id, {
+        ...(typeof params.name === "string" ? { name: params.name } : {}),
+        ...(typeof params.category === "string"
+          ? { category: params.category }
+          : {}),
+        ...(typeof params.email === "string" ? { email: params.email } : {}),
+        ...(typeof params.phone === "string" ? { phone: params.phone } : {}),
+        ...(typeof params.address === "string"
+          ? { address: params.address }
+          : {}),
+      })
       return wrapResult(result)
     },
   },

--- a/src/lib/contact-identity-ownership.ts
+++ b/src/lib/contact-identity-ownership.ts
@@ -1,4 +1,4 @@
-import { and, eq, or } from "drizzle-orm"
+import { and, eq, isNull, or } from "drizzle-orm"
 
 import type { getDb } from "@/db"
 import {
@@ -14,7 +14,7 @@ export type ContactIdentityFields = {
   readonly address: string | null
 }
 
-type DirectoryEntityType = "customer" | "vendor"
+type DirectoryEntityType = "customer" | "vendor" | "vendor_contact"
 
 type DirectoryIdentityRow = {
   readonly entityType: string
@@ -64,6 +64,19 @@ export async function directoryIdentityManagedByActiveUser(input: {
   readonly entityType: DirectoryEntityType
   readonly entityId: string
 }): Promise<boolean> {
+  const directoryMatch =
+    input.entityType === "vendor_contact"
+      ? eq(projectContacts.vendorContactId, input.entityId)
+      : input.entityType === "vendor"
+        ? and(
+            eq(projectContacts.sourceEntityType, "vendor"),
+            eq(projectContacts.sourceEntityId, input.entityId),
+            isNull(projectContacts.vendorContactId)
+          )
+        : and(
+            eq(projectContacts.sourceEntityType, input.entityType),
+            eq(projectContacts.sourceEntityId, input.entityId)
+          )
   const row = await input.db
     .select({ userId: users.id })
     .from(projectContacts)
@@ -80,8 +93,7 @@ export async function directoryIdentityManagedByActiveUser(input: {
     .where(
       and(
         eq(projects.organizationId, input.organizationId),
-        eq(projectContacts.sourceEntityType, input.entityType),
-        eq(projectContacts.sourceEntityId, input.entityId),
+        directoryMatch,
         eq(users.isActive, true)
       )
     )
@@ -107,6 +119,7 @@ export async function activeDirectoryIdentityKeys(input: {
     .select({
       entityType: projectContacts.sourceEntityType,
       entityId: projectContacts.sourceEntityId,
+      vendorContactId: projectContacts.vendorContactId,
     })
     .from(projectContacts)
     .innerJoin(projects, eq(projects.id, projectContacts.projectId))
@@ -125,10 +138,22 @@ export async function activeDirectoryIdentityKeys(input: {
         eq(users.isActive, true),
         or(
           eq(projectContacts.sourceEntityType, "customer"),
-          eq(projectContacts.sourceEntityType, "vendor")
+          eq(projectContacts.sourceEntityType, "vendor"),
+          eq(projectContacts.sourceEntityType, "vendor_contact")
         )
       )
     )
 
-  return requestedDirectoryIdentityKeys({ entityIds, rows })
+  const identityRows: DirectoryIdentityRow[] = rows.flatMap((row) => {
+    const directoryRows: DirectoryIdentityRow[] = [row]
+    if (row.vendorContactId) {
+      directoryRows.push({
+        entityType: "vendor_contact",
+        entityId: row.vendorContactId,
+      })
+    }
+    return directoryRows
+  })
+
+  return requestedDirectoryIdentityKeys({ entityIds, rows: identityRows })
 }

--- a/src/lib/internal-contact-directory.ts
+++ b/src/lib/internal-contact-directory.ts
@@ -1,0 +1,20 @@
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+type TeamMemberIdentity = {
+  readonly id: string
+  readonly role: string
+}
+
+/** Returns one canonical internal contact per Settings team user. */
+export function uniqueInternalStaffMembers<Member extends TeamMemberIdentity>(
+  members: readonly Member[]
+): readonly Member[] {
+  const membersByUserId = new Map<string, Member>()
+  for (const member of members) {
+    if (!isInternalStaffRole(member.role) || membersByUserId.has(member.id)) {
+      continue
+    }
+    membersByUserId.set(member.id, member)
+  }
+  return Array.from(membersByUserId.values())
+}


### PR DESCRIPTION
## Summary
- make Settings Team the canonical deduplicated internal contact roster
- connect project suppliers and subcontractors to the Sage/Compass vendor company directory
- support multiple people per vendor company with person-level project and invitation identity
- preserve invited, accepted, and expired/reinvite behavior
- migrate existing vendor contact details and project links safely

## Validation
- `bun run test` — 169 files, 937 tests passed
- `node_modules/.bin/tsc --noEmit`
- `bun lint` — 0 errors (80 pre-existing warnings)
- `bun run build`
- D1 migration rehearsal with foreign-key check
- live browser validation, including 526 vendor companies
