### PR TITLE
feat(purchase-orders): add ship-to choices

### DIFF
--- a/src/app/actions/project-operations.ts
+++ b/src/app/actions/project-operations.ts
@@ -114,6 +114,7 @@ export type ProjectPurchaseOrderCostCodeOption = {
 }
 
 export type ProjectPurchaseOrderFormOptions = {
+  readonly jobsiteAddress: string | null
   readonly phases: readonly ProjectPurchaseOrderPhaseOption[]
   readonly costCodes: readonly ProjectPurchaseOrderCostCodeOption[]
 }
@@ -1579,7 +1580,12 @@ export async function getProjectPurchaseOrderFormOptions(
   projectId: string
 ): Promise<ProjectPurchaseOrderFormOptions> {
   const db = await verifyProjectAccess(projectId, "purchase-orders")
-  const [sageRows, budgetRows] = await Promise.all([
+  const [projectRows, sageRows, budgetRows] = await Promise.all([
+    db
+      .select({ address: projects.address })
+      .from(projects)
+      .where(eq(projects.id, projectId))
+      .limit(1),
     db
       .select({
         code: sageCostCodes.code,
@@ -1640,6 +1646,7 @@ export async function getProjectPurchaseOrderFormOptions(
   }
 
   return {
+    jobsiteAddress: cleanText(projectRows[0]?.address ?? null),
     phases: Array.from(phaseMap.values()).sort((left, right) =>
       left.label.localeCompare(right.label)
     ),

--- a/src/app/dashboard/projects/[id]/purchase-orders/page.tsx
+++ b/src/app/dashboard/projects/[id]/purchase-orders/page.tsx
@@ -115,6 +115,7 @@ function PurchaseOrderCard({
   isCreated,
   isFocused,
   taskAssigneeOptions,
+  jobsiteAddress,
   phaseOptions,
   costCodeOptions,
 }: {
@@ -125,6 +126,7 @@ function PurchaseOrderCard({
   readonly isCreated: boolean
   readonly isFocused: boolean
   readonly taskAssigneeOptions: readonly ProjectTaskAssigneeOption[]
+  readonly jobsiteAddress: string | null
   readonly phaseOptions: React.ComponentProps<
     typeof ProjectPurchaseOrderEditForm
   >["phaseOptions"]
@@ -169,6 +171,7 @@ function PurchaseOrderCard({
                 projectId={projectId}
                 purchaseOrder={order}
                 contactOptions={taskAssigneeOptions}
+                jobsiteAddress={jobsiteAddress}
                 phaseOptions={phaseOptions}
                 costCodeOptions={costCodeOptions}
               />
@@ -494,6 +497,7 @@ export default async function ProjectPurchaseOrdersPage({
             </Button>
             <ProjectPurchaseOrderCreateForm
               projectId={id}
+              jobsiteAddress={purchaseOrderCodingOptions.jobsiteAddress}
               contactOptions={taskAssignees}
               phaseOptions={purchaseOrderCodingOptions.phases}
               costCodeOptions={purchaseOrderCodingOptions.costCodes}
@@ -541,6 +545,7 @@ export default async function ProjectPurchaseOrdersPage({
               isCreated={order.id === createdPurchaseOrderId}
               isFocused={order.id === focusedPurchaseOrderId}
               taskAssigneeOptions={taskAssignees}
+              jobsiteAddress={purchaseOrderCodingOptions.jobsiteAddress}
               phaseOptions={purchaseOrderCodingOptions.phases}
               costCodeOptions={purchaseOrderCodingOptions.costCodes}
             />

--- a/src/components/projects/project-purchase-order-create-form.tsx
+++ b/src/components/projects/project-purchase-order-create-form.tsx
@@ -50,6 +50,11 @@ import {
   purchaseOrderInternalOwnerOptions,
   purchaseOrderVendorOptions,
 } from "@/lib/purchase-orders/form-options"
+import {
+  initialPurchaseOrderShipToState,
+  purchaseOrderShipToValue,
+  type PurchaseOrderShipToState,
+} from "@/lib/purchase-orders/ship-to"
 
 type DraftPurchaseOrderLine = {
   readonly id: string
@@ -302,6 +307,7 @@ function Field({
 
 type SharedPurchaseOrderFormProps = {
   readonly projectId: string
+  readonly jobsiteAddress: string | null
   readonly contactOptions: readonly ProjectTaskAssigneeOption[]
   readonly phaseOptions: readonly ProjectPurchaseOrderPhaseOption[]
   readonly costCodeOptions: readonly ProjectPurchaseOrderCostCodeOption[]
@@ -319,7 +325,13 @@ type PurchaseOrderFormProps = SharedPurchaseOrderFormProps &
 function ProjectPurchaseOrderForm(
   props: PurchaseOrderFormProps
 ): React.ReactElement {
-  const { projectId, contactOptions, phaseOptions, costCodeOptions } = props
+  const {
+    projectId,
+    jobsiteAddress,
+    contactOptions,
+    phaseOptions,
+    costCodeOptions,
+  } = props
   const purchaseOrder = props.kind === "edit" ? props.purchaseOrder : null
   const router = useRouter()
   const formRef = React.useRef<HTMLFormElement>(null)
@@ -334,6 +346,12 @@ function ProjectPurchaseOrderForm(
   )
   const [assigneeName, setAssigneeName] = React.useState(
     purchaseOrder?.assigneeName ?? ""
+  )
+  const [shipTo, setShipTo] = React.useState<PurchaseOrderShipToState>(() =>
+    initialPurchaseOrderShipToState({
+      storedShipTo: purchaseOrder?.sageShipTo ?? null,
+      jobsiteAddress,
+    })
   )
   const [submitting, setSubmitting] = React.useState(false)
   const [message, setMessage] = React.useState<string | null>(null)
@@ -388,6 +406,12 @@ function ProjectPurchaseOrderForm(
         setSageVendorId(purchaseOrder.sageVendorId ?? "")
         setCompanyName(purchaseOrder.companyName ?? "")
         setAssigneeName(purchaseOrder.assigneeName ?? "")
+        setShipTo(
+          initialPurchaseOrderShipToState({
+            storedShipTo: purchaseOrder.sageShipTo,
+            jobsiteAddress,
+          })
+        )
       }
     }
     setOpen(nextOpen)
@@ -411,7 +435,7 @@ function ProjectPurchaseOrderForm(
         companyName: cleanText(companyName),
         sageVendorId: cleanText(String(formData.get("sageVendorId") ?? "")),
         assigneeName: cleanText(assigneeName),
-        shipTo: cleanText(String(formData.get("shipTo") ?? "")),
+        shipTo: purchaseOrderShipToValue({ state: shipTo, jobsiteAddress }),
         orderDate: cleanText(String(formData.get("orderDate") ?? "")),
         dueDate: cleanText(String(formData.get("dueDate") ?? "")),
         priority: String(formData.get("priority") ?? "normal"),
@@ -435,6 +459,12 @@ function ProjectPurchaseOrderForm(
         setSageVendorId("")
         setCompanyName("")
         setAssigneeName("")
+        setShipTo(
+          initialPurchaseOrderShipToState({
+            storedShipTo: null,
+            jobsiteAddress,
+          })
+        )
       }
       setMessage(
         purchaseOrder === null
@@ -551,14 +581,63 @@ function ProjectPurchaseOrderForm(
                 className="rounded-none border-x-0 border-t-0 px-0 shadow-none focus-visible:ring-0"
               />
             </Field>
-            <Field label="Ship to / delivery location">
-              <Input
-                name="shipTo"
-                defaultValue={purchaseOrder?.sageShipTo ?? ""}
-                placeholder="Jobsite, office, or pickup"
-                className={DOCUMENT_INPUT_CLASS}
-              />
-            </Field>
+            <div className="space-y-2">
+              <Field label="Ship to / delivery location">
+                <select
+                  value={shipTo.choice}
+                  onChange={(event) => {
+                    const choice = event.target.value
+                    if (choice === "jobsite") {
+                      setShipTo((current) => ({ ...current, choice: "jobsite" }))
+                    } else if (choice === "pickup") {
+                      setShipTo((current) => ({ ...current, choice: "pickup" }))
+                    } else if (choice === "other") {
+                      setShipTo((current) => ({ ...current, choice: "other" }))
+                    }
+                  }}
+                  className={DOCUMENT_SELECT_CLASS}
+                >
+                  <option value="jobsite" disabled={jobsiteAddress === null}>
+                    Jobsite
+                  </option>
+                  <option value="pickup">Pick-Up</option>
+                  <option value="other">Other</option>
+                </select>
+              </Field>
+              {shipTo.choice === "jobsite" && jobsiteAddress !== null && (
+                <Input
+                  aria-label="Jobsite shipping address"
+                  value={jobsiteAddress}
+                  readOnly
+                  className={DOCUMENT_INPUT_CLASS}
+                />
+              )}
+              {shipTo.choice === "pickup" && (
+                <p className="text-xs text-muted-foreground">
+                  Supplier pickup; no delivery address required.
+                </p>
+              )}
+              {shipTo.choice === "other" && (
+                <Input
+                  aria-label="Other shipping address"
+                  value={shipTo.otherAddress}
+                  onChange={(event) =>
+                    setShipTo((current) => ({
+                      ...current,
+                      otherAddress: event.target.value,
+                    }))
+                  }
+                  placeholder="Enter another delivery address"
+                  className={DOCUMENT_INPUT_CLASS}
+                  required
+                />
+              )}
+              {jobsiteAddress === null && (
+                <p className="text-xs text-muted-foreground">
+                  Add a project address to enable Jobsite delivery.
+                </p>
+              )}
+            </div>
             <Field label="P.O. date">
               <Input
                 name="orderDate"

--- a/src/lib/purchase-orders/__tests__/ship-to.test.ts
+++ b/src/lib/purchase-orders/__tests__/ship-to.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  initialPurchaseOrderShipToState,
+  purchaseOrderShipToValue,
+} from "@/lib/purchase-orders/ship-to"
+
+describe("initialPurchaseOrderShipToState", () => {
+  it("defaults a new purchase order to an available jobsite", () => {
+    expect(
+      initialPurchaseOrderShipToState({
+        storedShipTo: null,
+        jobsiteAddress: "123 Main St, Denver, CO",
+      })
+    ).toEqual({ choice: "jobsite", otherAddress: "" })
+  })
+
+  it("defaults to pickup when no jobsite address is available", () => {
+    expect(
+      initialPurchaseOrderShipToState({
+        storedShipTo: null,
+        jobsiteAddress: null,
+      })
+    ).toEqual({ choice: "pickup", otherAddress: "" })
+  })
+
+  it("recognizes a saved jobsite address without case or punctuation sensitivity", () => {
+    expect(
+      initialPurchaseOrderShipToState({
+        storedShipTo: "123 MAIN ST., DENVER CO",
+        jobsiteAddress: "123 Main St, Denver CO",
+      })
+    ).toEqual({ choice: "jobsite", otherAddress: "" })
+  })
+
+  it("upgrades a legacy Jobsite label when the project has an address", () => {
+    expect(
+      initialPurchaseOrderShipToState({
+        storedShipTo: "Job Site",
+        jobsiteAddress: "123 Main St, Denver, CO",
+      })
+    ).toEqual({ choice: "jobsite", otherAddress: "" })
+  })
+
+  it("recognizes existing pickup spellings", () => {
+    expect(
+      initialPurchaseOrderShipToState({
+        storedShipTo: "pick up",
+        jobsiteAddress: "123 Main St",
+      })
+    ).toEqual({ choice: "pickup", otherAddress: "" })
+  })
+
+  it("preserves a custom saved address as Other", () => {
+    expect(
+      initialPurchaseOrderShipToState({
+        storedShipTo: " 456 Supplier Ave, Colorado Springs, CO ",
+        jobsiteAddress: "123 Main St, Denver, CO",
+      })
+    ).toEqual({
+      choice: "other",
+      otherAddress: "456 Supplier Ave, Colorado Springs, CO",
+    })
+  })
+})
+
+describe("purchaseOrderShipToValue", () => {
+  it("resolves Jobsite to the current saved project address", () => {
+    expect(
+      purchaseOrderShipToValue({
+        state: { choice: "jobsite", otherAddress: "" },
+        jobsiteAddress: " 123 Main St, Denver, CO ",
+      })
+    ).toBe("123 Main St, Denver, CO")
+  })
+
+  it("stores a consistent Pick-Up value", () => {
+    expect(
+      purchaseOrderShipToValue({
+        state: { choice: "pickup", otherAddress: "" },
+        jobsiteAddress: "123 Main St",
+      })
+    ).toBe("Pick-Up")
+  })
+
+  it("trims an Other address and returns null for a blank value", () => {
+    expect(
+      purchaseOrderShipToValue({
+        state: { choice: "other", otherAddress: " 456 Supplier Ave " },
+        jobsiteAddress: null,
+      })
+    ).toBe("456 Supplier Ave")
+    expect(
+      purchaseOrderShipToValue({
+        state: { choice: "other", otherAddress: "   " },
+        jobsiteAddress: null,
+      })
+    ).toBeNull()
+  })
+})

--- a/src/lib/purchase-orders/ship-to.ts
+++ b/src/lib/purchase-orders/ship-to.ts
@@ -1,0 +1,65 @@
+export type PurchaseOrderShipToState = {
+  readonly choice: "jobsite" | "pickup" | "other"
+  readonly otherAddress: string
+}
+
+function cleanText(value: string | null): string | null {
+  const trimmed = value?.trim() ?? ""
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function normalizedComparisonValue(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "")
+}
+
+function isPickupValue(value: string): boolean {
+  return normalizedComparisonValue(value) === "pickup"
+}
+
+function isJobsiteValue(value: string): boolean {
+  return normalizedComparisonValue(value) === "jobsite"
+}
+
+export function initialPurchaseOrderShipToState({
+  storedShipTo,
+  jobsiteAddress,
+}: {
+  readonly storedShipTo: string | null
+  readonly jobsiteAddress: string | null
+}): PurchaseOrderShipToState {
+  const savedValue = cleanText(storedShipTo)
+  const jobsiteValue = cleanText(jobsiteAddress)
+
+  if (savedValue === null) {
+    return jobsiteValue === null
+      ? { choice: "pickup", otherAddress: "" }
+      : { choice: "jobsite", otherAddress: "" }
+  }
+  if (isPickupValue(savedValue)) return { choice: "pickup", otherAddress: "" }
+  if (jobsiteValue !== null && isJobsiteValue(savedValue)) {
+    return { choice: "jobsite", otherAddress: "" }
+  }
+  if (
+    jobsiteValue !== null &&
+    normalizedComparisonValue(savedValue) ===
+      normalizedComparisonValue(jobsiteValue)
+  ) {
+    return { choice: "jobsite", otherAddress: "" }
+  }
+  return { choice: "other", otherAddress: savedValue }
+}
+
+export function purchaseOrderShipToValue({
+  state,
+  jobsiteAddress,
+}: {
+  readonly state: PurchaseOrderShipToState
+  readonly jobsiteAddress: string | null
+}): string | null {
+  if (state.choice === "jobsite") return cleanText(jobsiteAddress)
+  if (state.choice === "pickup") return "Pick-Up"
+  return cleanText(state.otherAddress)
+}


### PR DESCRIPTION
## Summary
- add Jobsite, Pick-Up, and Other choices to purchase-order drafts
- auto-fill Jobsite with the saved project address when available
- show a required free-text address field for Other
- preserve and correctly classify existing draft ship-to values

## Validation
- `bun run test` (170 files, 945 tests)
- focused ship-to tests (9 tests)
- `bun lint` (0 errors; existing repository warnings only)
- `bun run build`
- local manual diff review; external autoreview was not run because source-code disclosure was not authorized
