### PR TITLE
feat(contacts): link client and vendor directories

### DIFF
--- a/drizzle/0119_buildertrend_client_directory.sql
+++ b/drizzle/0119_buildertrend_client_directory.sql
@@ -1,0 +1,213 @@
+ALTER TABLE `customers` ADD `buildertrend_contact_id` text;
+--> statement-breakpoint
+ALTER TABLE `customers` ADD `relationship_type` text DEFAULT 'client' NOT NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `customers_org_sage_client_id_unique`
+  ON `customers` (`organization_id`, `sage_client_id`)
+  WHERE `sage_client_id` IS NOT NULL AND trim(`sage_client_id`) <> '';
+--> statement-breakpoint
+CREATE UNIQUE INDEX `customers_org_sage_client_number_unique`
+  ON `customers` (`organization_id`, `sage_client_number`)
+  WHERE `sage_client_number` IS NOT NULL AND trim(`sage_client_number`) <> '';
+--> statement-breakpoint
+CREATE UNIQUE INDEX `customers_org_buildertrend_contact_unique`
+  ON `customers` (`organization_id`, `buildertrend_contact_id`)
+  WHERE `buildertrend_contact_id` IS NOT NULL AND trim(`buildertrend_contact_id`) <> '';
+--> statement-breakpoint
+
+-- Preserve a one-to-one Buildertrend identity on an existing Compass/Sage
+-- client instead of inserting a duplicate directory row.
+WITH `stable_buildertrend_clients` AS (
+  SELECT
+    bac.`organization_id`,
+    bac.`buildertrend_contact_id`,
+    MIN(trim(bac.`contact_name`)) AS `contact_name`,
+    MAX(NULLIF(trim(bac.`email`), '')) AS `email`,
+    MAX(NULLIF(trim(bac.`phone`), '')) AS `phone`,
+    CASE
+      WHEN MAX(CASE WHEN bac.`buildertrend_access_role` = 'lead_contact' THEN 1 ELSE 0 END) = 1
+        AND MAX(CASE WHEN bac.`buildertrend_access_role` = 'client' THEN 1 ELSE 0 END) = 0
+        THEN 'lead'
+      ELSE 'client'
+    END AS `relationship_type`
+  FROM `buildertrend_staging_access_candidates` bac
+  WHERE bac.`organization_id` IS NOT NULL
+    AND bac.`buildertrend_contact_id` IS NOT NULL
+    AND trim(bac.`buildertrend_contact_id`) <> ''
+    AND bac.`contact_name` IS NOT NULL
+    AND trim(bac.`contact_name`) <> ''
+    AND (
+      bac.`proposed_contact_type` = 'owner'
+      OR bac.`buildertrend_access_role` IN ('client', 'client_contact', 'lead_contact')
+    )
+  GROUP BY bac.`organization_id`, bac.`buildertrend_contact_id`
+  HAVING COUNT(DISTINCT lower(trim(bac.`contact_name`))) = 1
+),
+`possible_matches` AS (
+  SELECT
+    sbc.`organization_id`,
+    sbc.`buildertrend_contact_id`,
+    c.`id` AS `customer_id`
+  FROM `stable_buildertrend_clients` sbc
+  INNER JOIN `customers` c
+    ON c.`organization_id` = sbc.`organization_id`
+   AND (
+     (sbc.`email` IS NOT NULL
+       AND c.`email` IS NOT NULL
+       AND lower(trim(c.`email`)) = lower(sbc.`email`))
+     OR (
+       lower(trim(c.`name`)) = lower(sbc.`contact_name`)
+       AND (
+         sbc.`phone` IS NULL
+         OR c.`phone` IS NULL
+         OR trim(c.`phone`) = sbc.`phone`
+       )
+     )
+   )
+  WHERE c.`buildertrend_contact_id` IS NULL
+),
+`source_unique_matches` AS (
+  SELECT
+    pm.`organization_id`,
+    pm.`buildertrend_contact_id`,
+    MIN(pm.`customer_id`) AS `customer_id`
+  FROM `possible_matches` pm
+  GROUP BY pm.`organization_id`, pm.`buildertrend_contact_id`
+  HAVING COUNT(DISTINCT pm.`customer_id`) = 1
+),
+`one_to_one_matches` AS (
+  SELECT
+    source_match.`customer_id`,
+    MIN(source_match.`buildertrend_contact_id`) AS `buildertrend_contact_id`
+  FROM `source_unique_matches` source_match
+  GROUP BY source_match.`customer_id`
+  HAVING COUNT(DISTINCT source_match.`buildertrend_contact_id`) = 1
+)
+UPDATE `customers`
+SET
+  `buildertrend_contact_id` = (
+    SELECT otm.`buildertrend_contact_id`
+    FROM `one_to_one_matches` otm
+    WHERE otm.`customer_id` = `customers`.`id`
+  ),
+  `email` = COALESCE(
+    NULLIF(trim(`email`), ''),
+    (
+      SELECT sbc.`email`
+      FROM `stable_buildertrend_clients` sbc
+      INNER JOIN `one_to_one_matches` otm
+        ON otm.`buildertrend_contact_id` = sbc.`buildertrend_contact_id`
+      WHERE otm.`customer_id` = `customers`.`id`
+    )
+  ),
+  `phone` = COALESCE(
+    NULLIF(trim(`phone`), ''),
+    (
+      SELECT sbc.`phone`
+      FROM `stable_buildertrend_clients` sbc
+      INNER JOIN `one_to_one_matches` otm
+        ON otm.`buildertrend_contact_id` = sbc.`buildertrend_contact_id`
+      WHERE otm.`customer_id` = `customers`.`id`
+    )
+  )
+WHERE `id` IN (SELECT `customer_id` FROM `one_to_one_matches`);
+--> statement-breakpoint
+
+-- Promote only stable Buildertrend client identities. Four source IDs currently
+-- carry conflicting names and intentionally remain in staging for review.
+WITH `buildertrend_clients` AS (
+  SELECT
+    bac.`organization_id`,
+    bac.`buildertrend_contact_id`,
+    MIN(trim(bac.`contact_name`)) AS `contact_name`,
+    MAX(NULLIF(trim(bac.`email`), '')) AS `email`,
+    MAX(NULLIF(trim(bac.`phone`), '')) AS `phone`,
+    CASE
+      WHEN MAX(CASE WHEN bac.`buildertrend_access_role` = 'lead_contact' THEN 1 ELSE 0 END) = 1
+        AND MAX(CASE WHEN bac.`buildertrend_access_role` = 'client' THEN 1 ELSE 0 END) = 0
+        THEN 'lead'
+      ELSE 'client'
+    END AS `relationship_type`,
+    MIN(bac.`created_at`) AS `created_at`,
+    MAX(bac.`updated_at`) AS `updated_at`
+  FROM `buildertrend_staging_access_candidates` bac
+  WHERE bac.`organization_id` IS NOT NULL
+    AND bac.`buildertrend_contact_id` IS NOT NULL
+    AND trim(bac.`buildertrend_contact_id`) <> ''
+    AND bac.`contact_name` IS NOT NULL
+    AND trim(bac.`contact_name`) <> ''
+    AND (
+      bac.`proposed_contact_type` = 'owner'
+      OR bac.`buildertrend_access_role` IN ('client', 'client_contact', 'lead_contact')
+    )
+  GROUP BY bac.`organization_id`, bac.`buildertrend_contact_id`
+  HAVING COUNT(DISTINCT lower(trim(bac.`contact_name`))) = 1
+)
+INSERT OR IGNORE INTO `customers` (
+  `id`, `name`, `company`, `email`, `phone`, `address`, `notes`,
+  `netsuite_id`, `sage_client_id`, `sage_client_number`,
+  `sage_client_status_id`, `buildertrend_contact_id`, `relationship_type`,
+  `organization_id`, `created_at`, `updated_at`
+)
+SELECT
+  'buildertrend-customer-' || bc.`organization_id` || '-' || bc.`buildertrend_contact_id`,
+  bc.`contact_name`,
+  NULL,
+  bc.`email`,
+  bc.`phone`,
+  NULL,
+  'Imported from the Buildertrend client contact directory. Review before granting portal access.',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  bc.`buildertrend_contact_id`,
+  bc.`relationship_type`,
+  bc.`organization_id`,
+  COALESCE(bc.`created_at`, strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  COALESCE(bc.`updated_at`, bc.`created_at`, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+FROM `buildertrend_clients` bc
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM `customers` c
+  WHERE c.`organization_id` = bc.`organization_id`
+    AND c.`buildertrend_contact_id` = bc.`buildertrend_contact_id`
+);
+--> statement-breakpoint
+
+-- Link imported project owner rows only when one organization-scoped client
+-- directory record matches exactly. Ambiguous names remain manual.
+WITH `customer_matches` AS (
+  SELECT pc.`id` AS `project_contact_id`, MIN(c.`id`) AS `customer_id`
+  FROM `project_contacts` pc
+  INNER JOIN `projects` p ON p.`id` = pc.`project_id`
+  INNER JOIN `customers` c
+    ON c.`organization_id` = p.`organization_id`
+   AND (
+     (pc.`email` IS NOT NULL AND trim(pc.`email`) <> ''
+       AND c.`email` IS NOT NULL AND trim(c.`email`) <> ''
+       AND lower(trim(pc.`email`)) = lower(trim(c.`email`)))
+     OR (
+       lower(trim(pc.`display_name`)) = lower(trim(c.`name`))
+       AND (
+         pc.`phone` IS NULL OR trim(pc.`phone`) = ''
+         OR (c.`phone` IS NOT NULL AND trim(c.`phone`) = trim(pc.`phone`))
+       )
+     )
+   )
+  WHERE pc.`active` = 1
+    AND pc.`contact_type` = 'owner'
+    AND (pc.`source_entity_type` <> 'customer' OR pc.`source_entity_id` IS NULL)
+  GROUP BY pc.`id`
+  HAVING COUNT(DISTINCT c.`id`) = 1
+)
+UPDATE `project_contacts`
+SET
+  `source_entity_type` = 'customer',
+  `source_entity_id` = (
+    SELECT cm.`customer_id`
+    FROM `customer_matches` cm
+    WHERE cm.`project_contact_id` = `project_contacts`.`id`
+  ),
+  `updated_at` = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE `id` IN (SELECT `project_contact_id` FROM `customer_matches`);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"db:generate": "drizzle-kit generate",
 		"db:migrate:local": "wrangler d1 migrations apply compass-db --local",
 		"db:migrate:prod": "wrangler d1 migrations apply compass-db --remote",
+		"db:prepare-sage-clients": "bun scripts/import-sage-client-directory.mjs",
 		"db:migrate-orgs": "bun run scripts/migrate-to-orgs.ts",
 		"db:seed-demo": "bun run scripts/seed-demo.ts",
 		"prepare": "husky",

--- a/scripts/import-sage-client-directory.mjs
+++ b/scripts/import-sage-client-directory.mjs
@@ -1,0 +1,110 @@
+import { execFileSync } from "node:child_process"
+import fs from "node:fs"
+import { XMLParser } from "fast-xml-parser"
+
+import {
+  buildSageClientDirectoryImportSql,
+  stableSageClientDirectory,
+} from "../src/lib/sage/client-directory-import.ts"
+
+function text(value) {
+  return value == null ? "" : String(value).trim()
+}
+
+function asArray(value) {
+  if (!value) return []
+  return Array.isArray(value) ? value : [value]
+}
+
+function sharedStringText(item) {
+  if (!item) return ""
+  if (item.t != null) return text(item.t)
+  if (Array.isArray(item.r)) {
+    return item.r.map((run) => text(run.t)).join("")
+  }
+  if (item.r) return text(item.r.t)
+  return ""
+}
+
+function columnIndex(cellReference) {
+  const letters = text(cellReference).replace(/[0-9]/g, "")
+  let index = 0
+  for (const letter of letters) {
+    index = index * 26 + letter.charCodeAt(0) - 64
+  }
+  return index - 1
+}
+
+function unzipXml(filePath, entry) {
+  return execFileSync("unzip", ["-p", filePath, entry], {
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  })
+}
+
+function workbookRows(filePath) {
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: "@_",
+    textNodeName: "#text",
+  })
+  const shared = parser.parse(unzipXml(filePath, "xl/sharedStrings.xml"))
+  const strings = asArray(shared.sst.si).map(sharedStringText)
+  const sheet = parser.parse(
+    unzipXml(filePath, "xl/worksheets/sheet1.xml")
+  )
+  return asArray(sheet.worksheet.sheetData.row).map((row) => {
+    const cells = []
+    for (const cell of asArray(row.c)) {
+      const index = columnIndex(cell["@_r"])
+      const rawValue = text(cell.v)
+      cells[index] = cell["@_t"] === "s" ? strings[Number(rawValue)] ?? "" : rawValue
+    }
+    return cells
+  })
+}
+
+export function parseSageClientList(filePath) {
+  const rows = workbookRows(filePath)
+  const records = []
+  for (let index = 0; index < rows.length - 1; index += 1) {
+    if (text(rows[index][0]) !== "Client#") continue
+    const clientNumber = text(rows[index][2])
+    const nextRow = rows[index + 1]
+    if (text(nextRow[0]) !== "Client Name") continue
+    const name = text(nextRow[2])
+    if (clientNumber && name) records.push({ clientNumber, name })
+  }
+  return records
+}
+
+function argumentValue(name) {
+  const index = process.argv.indexOf(name)
+  return index >= 0 ? text(process.argv[index + 1]) : ""
+}
+
+function main() {
+  const inputPath = argumentValue("--input")
+  const organizationId = argumentValue("--organization-id")
+  const outputPath = argumentValue("--output")
+  if (!inputPath || !organizationId || !outputPath) {
+    throw new Error(
+      "Usage: bun scripts/import-sage-client-directory.mjs --input <SAGE-CLIENTLIST.xlsx> --organization-id <id> --output <import.sql>"
+    )
+  }
+
+  const records = parseSageClientList(inputPath)
+  const stable = stableSageClientDirectory(records)
+  const sql = buildSageClientDirectoryImportSql({ organizationId, records })
+  fs.writeFileSync(outputPath, sql, { encoding: "utf8", flag: "wx" })
+  process.stdout.write(
+    `${JSON.stringify({
+      parsedRecords: records.length,
+      stableRecords: stable.clients.length,
+      conflictingClientNumbers: stable.conflictingClientNumbers,
+      outputPath,
+    })}\n`
+  )
+}
+
+main()

--- a/src/app/actions/customers.ts
+++ b/src/app/actions/customers.ts
@@ -1,7 +1,7 @@
 "use server"
 
 import { getCloudflareContext } from "@/lib/db"
-import { eq, and } from "drizzle-orm"
+import { eq, and, or, sql } from "drizzle-orm"
 import { getDb } from "@/db"
 import { customers, projectContacts, type NewCustomer } from "@/db/schema"
 import { sageClientProjectWriteOperations } from "@/db/schema-sage"
@@ -30,6 +30,18 @@ export type CreateCustomerInput = {
   readonly address: string | null
   readonly notes: string | null
   readonly sageClientStatusId: SageClientStatusId
+}
+
+export type CustomerRelationshipType = "client" | "lead"
+
+export type CreateCustomerDirectoryContactInput = {
+  readonly name: string
+  readonly company: string | null
+  readonly email: string | null
+  readonly phone: string | null
+  readonly address: string | null
+  readonly notes: string | null
+  readonly relationshipType: CustomerRelationshipType
 }
 
 export async function getCustomers() {
@@ -149,6 +161,101 @@ export async function createCustomer(
   }
 }
 
+export async function createCustomerDirectoryContact(
+  data: CreateCustomerDirectoryContactInput
+) {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    requirePermission(user, "customer", "create")
+    const orgId = requireOrg(user)
+    const name = data.name.trim()
+    if (!name) {
+      return { success: false, error: "Client or lead name is required." }
+    }
+    if (data.relationshipType !== "client" && data.relationshipType !== "lead") {
+      return { success: false, error: "Choose Client or Lead." }
+    }
+
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const company = data.company?.trim() || null
+    const email = data.email?.trim() || null
+    const phone = data.phone?.trim() || null
+    const address = data.address?.trim() || null
+    const notes = data.notes?.trim() || null
+    const nameAndCompanyMatch = and(
+      sql`lower(trim(${customers.name})) = ${name.toLowerCase()}`,
+      sql`lower(trim(COALESCE(${customers.company}, ''))) = ${(company ?? "").toLowerCase()}`
+    )
+    const identityMatch = email
+      ? or(
+          sql`lower(trim(COALESCE(${customers.email}, ''))) = ${email.toLowerCase()}`,
+          nameAndCompanyMatch
+        )
+      : nameAndCompanyMatch
+    const existingMatches = await db
+      .select()
+      .from(customers)
+      .where(and(eq(customers.organizationId, orgId), identityMatch))
+      .limit(2)
+    if (existingMatches.length > 1) {
+      return {
+        success: false,
+        error:
+          "More than one directory contact matches. Select the correct existing contact instead.",
+      }
+    }
+    const existing = existingMatches[0]
+    if (existing) {
+      return { success: true, id: existing.id, existing: true, customer: existing }
+    }
+
+    const now = new Date().toISOString()
+    const customer = {
+      id: crypto.randomUUID(),
+      organizationId: orgId,
+      name,
+      company,
+      email,
+      phone,
+      address,
+      notes,
+      relationshipType: data.relationshipType,
+      createdAt: now,
+      updatedAt: now,
+    }
+    await db.insert(customers).values(customer)
+
+    revalidatePath("/dashboard/customers")
+    revalidatePath("/dashboard/contacts")
+    revalidatePath("/dashboard/projects", "layout")
+    return {
+      success: true,
+      id: customer.id,
+      existing: false,
+      customer: {
+        ...customer,
+        netsuiteId: null,
+        sageClientId: null,
+        sageClientNumber: null,
+        sageClientStatusId: null,
+        buildertrendContactId: null,
+      },
+    }
+  } catch (err) {
+    return {
+      success: false,
+      error:
+        err instanceof Error
+          ? err.message
+          : "Failed to create client or lead contact",
+    }
+  }
+}
+
 export async function updateCustomer(
   id: string,
   data: Partial<NewCustomer>
@@ -171,6 +278,13 @@ export async function updateCustomer(
       .limit(1)
       .get()
     if (!existing) return { success: false, error: "Customer not found" }
+    if (
+      data.relationshipType !== undefined &&
+      data.relationshipType !== "client" &&
+      data.relationshipType !== "lead"
+    ) {
+      return { success: false, error: "Choose Client or Lead." }
+    }
 
     const nextIdentity = {
       email: data.email === undefined ? existing.email : data.email,
@@ -195,10 +309,15 @@ export async function updateCustomer(
     }
 
     const updatedAt = new Date().toISOString()
+    const safeData =
+      (existing.sageClientId || existing.sageClientNumber) &&
+      data.relationshipType === "lead"
+        ? { ...data, relationshipType: "client" }
+        : data
     await db.batch([
       db
         .update(customers)
-        .set({ ...data, updatedAt })
+        .set({ ...safeData, updatedAt })
         .where(and(eq(customers.id, id), eq(customers.organizationId, orgId))),
       db
         .update(projectContacts)

--- a/src/app/actions/project-access-invitations.ts
+++ b/src/app/actions/project-access-invitations.ts
@@ -267,6 +267,17 @@ export async function sendProjectAccessInvitation(
     if (!row || !row.organizationId) {
       return { success: false, error: "Project contact not found." }
     }
+    if (
+      (row.contact.contactType === "supplier" ||
+        row.contact.contactType === "subcontractor") &&
+      !row.contact.vendorContactId
+    ) {
+      return {
+        success: false,
+        error:
+          "Select or add a contact person for this vendor before inviting them.",
+      }
+    }
 
     const directoryIdentity =
       row.contact.vendorContactId

--- a/src/app/actions/project-contacts.ts
+++ b/src/app/actions/project-contacts.ts
@@ -13,6 +13,7 @@ import {
   projectProfileSyncOperations,
   projectMembers,
   projects,
+  sageCostCodes,
   users,
   vendorContacts,
   vendors,
@@ -200,6 +201,25 @@ export type ProjectVendorContactOption = {
   readonly phone: string | null
   readonly isPrimary: boolean
   readonly identityManagedByActiveUser: boolean
+}
+
+export type ProjectContactDivisionOption = {
+  readonly value: string
+  readonly label: string
+  readonly name: string
+}
+
+export type ProjectContactCostCodeOption = {
+  readonly value: string
+  readonly label: string
+  readonly description: string
+  readonly divisionCode: string
+  readonly divisionName: string
+}
+
+export type ProjectContactSageOptions = {
+  readonly divisions: readonly ProjectContactDivisionOption[]
+  readonly costCodes: readonly ProjectContactCostCodeOption[]
 }
 
 export type ProjectContactMutationInput = {
@@ -987,7 +1007,6 @@ export async function getProjectContactDirectoryOptions(
   }
 
   const customerOptions: ProjectContactDirectoryOption[] = customerRows
-    .filter((row) => !existingSources.has(`customer:${row.id}`))
     .map((row) => ({
       id: row.id,
       sourceType: "customer",
@@ -1050,6 +1069,50 @@ export async function getProjectContactDirectoryOptions(
   )
 }
 
+export async function getProjectContactSageOptions(
+  projectId: string
+): Promise<ProjectContactSageOptions> {
+  const user = await requireAuth()
+  await requireFeaturePermission(user, "project-contacts", "update")
+  const db = await verifyProjectAccess(projectId, "update")
+  const rows = await db
+    .select({
+      code: sageCostCodes.code,
+      description: sageCostCodes.description,
+      divisionCode: sageCostCodes.divisionCode,
+      divisionDescription: sageCostCodes.divisionDescription,
+    })
+    .from(sageCostCodes)
+    .where(eq(sageCostCodes.active, true))
+    .orderBy(asc(sageCostCodes.divisionCode), asc(sageCostCodes.code))
+
+  const divisions = new Map<string, ProjectContactDivisionOption>()
+  const costCodes = new Map<string, ProjectContactCostCodeOption>()
+  for (const row of rows) {
+    const description =
+      row.code === `${row.divisionCode} 00 00`
+        ? row.divisionDescription
+        : row.description
+    divisions.set(row.divisionCode, {
+      value: row.divisionCode,
+      label: `${row.divisionCode} 00 00 - ${row.divisionDescription}`,
+      name: row.divisionDescription,
+    })
+    costCodes.set(row.code, {
+      value: row.code,
+      label: `${row.code} - ${description}`,
+      description,
+      divisionCode: row.divisionCode,
+      divisionName: row.divisionDescription,
+    })
+  }
+
+  return {
+    divisions: Array.from(divisions.values()),
+    costCodes: Array.from(costCodes.values()),
+  }
+}
+
 export async function saveProjectContact(
   input: ProjectContactMutationInput
 ): Promise<ProjectContactMutationResult> {
@@ -1081,11 +1144,12 @@ export async function saveProjectContact(
     let warning: string | undefined
     let directoryIdentity: ContactIdentityFields | null = null
     let directoryIdentityManaged = false
+    let canonicalDisplayName: string | null = null
+    let canonicalCompanyName: string | null = null
 
     const requiresVendorCompany =
       input.contactType === "subcontractor" || input.contactType === "supplier"
     if (
-      !contactId &&
       requiresVendorCompany &&
       (input.directorySourceType !== "vendor" || !input.directorySourceId)
     ) {
@@ -1093,6 +1157,20 @@ export async function saveProjectContact(
         success: false,
         error: "Choose a vendor company for this project contact.",
       }
+    }
+    if (
+      input.contactType === "owner" &&
+      input.directorySourceType !== null &&
+      input.directorySourceType !== "customer"
+    ) {
+      return { success: false, error: "Choose a client or lead contact." }
+    }
+    if (
+      input.contactType === "internal" &&
+      input.directorySourceType !== null &&
+      input.directorySourceType !== "team"
+    ) {
+      return { success: false, error: "Choose a Settings team member." }
     }
 
     if (input.directorySourceType && input.directorySourceId) {
@@ -1103,6 +1181,8 @@ export async function saveProjectContact(
         const [directoryRecord] = await db
           .select({
             id: customers.id,
+            name: customers.name,
+            company: customers.company,
             email: customers.email,
             phone: customers.phone,
             address: customers.address,
@@ -1120,6 +1200,8 @@ export async function saveProjectContact(
         }
         sourceSystem = "customer_directory"
         sourceEntityType = "customer"
+        canonicalDisplayName = directoryRecord.name
+        canonicalCompanyName = directoryRecord.company
         directoryIdentity = directoryRecord
         directoryIdentityManaged =
           await directoryIdentityManagedByActiveUser({
@@ -1158,6 +1240,7 @@ export async function saveProjectContact(
           const contactRecord = await db
             .select({
               id: vendorContacts.id,
+              name: vendorContacts.name,
               email: vendorContacts.email,
               phone: vendorContacts.phone,
             })
@@ -1173,6 +1256,8 @@ export async function saveProjectContact(
           if (!contactRecord) {
             return { success: false, error: "Vendor contact not found" }
           }
+          canonicalDisplayName = contactRecord.name
+          canonicalCompanyName = directoryRecord.name
           sourceRecordId = contactRecord.id
           sourceEntityType = "vendor_contact"
           sourceEntityId = contactRecord.id
@@ -1185,6 +1270,8 @@ export async function saveProjectContact(
               entityId: contactRecord.id,
             })
         } else {
+          canonicalDisplayName = directoryRecord.name
+          canonicalCompanyName = directoryRecord.name
           sourceRecordId = directoryRecord.id
           sourceEntityType = "vendor"
           sourceEntityId = directoryRecord.id
@@ -1247,8 +1334,8 @@ export async function saveProjectContact(
 
     const contactValues = {
       contactType: input.contactType,
-      displayName: input.displayName.trim(),
-      companyName: nullableInput(input.companyName),
+      displayName: canonicalDisplayName ?? input.displayName.trim(),
+      companyName: canonicalCompanyName ?? nullableInput(input.companyName),
       role: nullableInput(input.role),
       trade: nullableInput(input.trade),
       csiDivision: nullableInput(input.csiDivision),

--- a/src/app/dashboard/contacts/page.tsx
+++ b/src/app/dashboard/contacts/page.tsx
@@ -9,9 +9,10 @@ import { useRegisterPageActions } from "@/hooks/use-register-page-actions"
 
 import {
   getCustomers,
-  createCustomer,
+  createCustomerDirectoryContact,
   updateCustomer,
   deleteCustomer,
+  type CustomerRelationshipType,
 } from "@/app/actions/customers"
 import {
   getVendors,
@@ -35,7 +36,6 @@ import {
 import { Skeleton } from "@/components/ui/skeleton"
 import { CustomersTable } from "@/components/financials/customers-table"
 import { CustomerDialog } from "@/components/financials/customer-dialog"
-import type { SageClientStatusId } from "@/lib/sage/client-project-write"
 import { VendorsTable } from "@/components/financials/vendors-table"
 import { VendorDialog } from "@/components/financials/vendor-dialog"
 
@@ -209,7 +209,7 @@ function ContactsContent() {
     () => ({
       customers: {
         id: "add-customer",
-        label: "Add Customer",
+        label: "Add Client / Lead",
         onSelect: openCustomer,
       },
       vendors: {
@@ -248,7 +248,7 @@ function ContactsContent() {
     phone: string
     address: string
     notes: string
-    sageClientStatusId: SageClientStatusId
+    relationshipType: CustomerRelationshipType
   }) => {
     if (editingCustomer) {
       const result = await updateCustomer(editingCustomer.id, data)
@@ -259,7 +259,7 @@ function ContactsContent() {
         return
       }
     } else {
-      const result = await createCustomer({
+      const result = await createCustomerDirectoryContact({
         ...data,
         company: data.company || null,
         email: data.email || null,
@@ -269,9 +269,9 @@ function ContactsContent() {
       })
       if (result.success) {
         toast.success(
-          result.sageStatus === "queued"
-            ? "Customer created; Sage write queued"
-            : "Customer created in Compass; Sage write requires an approved user"
+          result.existing
+            ? "Existing client/lead contact selected"
+            : "Client/lead contact added to Contacts"
         )
       } else {
         toast.error(result.error || "Failed")
@@ -329,7 +329,7 @@ function ContactsContent() {
   }
 
   const vendorContacts = vendorsList.filter((vendor) => !isInternalVendor(vendor))
-  const addLabel = tab === "customers" ? "Add Customer" : "Add Vendor"
+  const addLabel = tab === "customers" ? "Add Client / Lead" : "Add Vendor"
   const addHandler = tab === "customers" ? openCustomer : openVendor
   const vendorCategories = Array.from(
     new Set([
@@ -354,7 +354,7 @@ function ContactsContent() {
           <div className="flex items-center justify-between gap-3 shrink-0">
             <TabsList>
               <TabsTrigger value="customers" className="text-xs sm:text-sm">
-                Customers
+                Clients & Leads
                 <span className="ml-1.5 text-muted-foreground tabular-nums">
                   {customersList.length}
                 </span>

--- a/src/app/dashboard/projects/[id]/contacts/page.tsx
+++ b/src/app/dashboard/projects/[id]/contacts/page.tsx
@@ -10,8 +10,10 @@ import Link from "next/link"
 
 import {
   getProjectContactDirectoryOptions,
+  getProjectContactSageOptions,
   getProjectContactsSummary,
   type ProjectContactDirectoryOption,
+  type ProjectContactSageOptions,
   type ProjectContactsSummary,
 } from "@/app/actions/project-contacts"
 import { getProjects } from "@/app/actions/projects"
@@ -31,6 +33,7 @@ export default async function ProjectContactsPage({
 
   let contacts: ProjectContactsSummary | null = null
   let directoryOptions: readonly ProjectContactDirectoryOption[] = []
+  let sageOptions: ProjectContactSageOptions = { divisions: [], costCodes: [] }
   let canManageContacts = false
   let projectLabel = "This project"
 
@@ -51,7 +54,12 @@ export default async function ProjectContactsPage({
   }
 
   try {
-    directoryOptions = await getProjectContactDirectoryOptions(id)
+    const [loadedDirectoryOptions, loadedSageOptions] = await Promise.all([
+      getProjectContactDirectoryOptions(id),
+      getProjectContactSageOptions(id),
+    ])
+    directoryOptions = loadedDirectoryOptions
+    sageOptions = loadedSageOptions
     canManageContacts = true
   } catch {
     // Read-only project users may view allowed contacts without receiving the
@@ -106,6 +114,7 @@ export default async function ProjectContactsPage({
           summary={contacts}
           showOpenLink={false}
           directoryOptions={canManageContacts ? directoryOptions : undefined}
+          sageOptions={canManageContacts ? sageOptions : undefined}
         />
       </div>
 
@@ -115,6 +124,7 @@ export default async function ProjectContactsPage({
           projectLabel={projectLabel}
           summary={contacts}
           directoryOptions={canManageContacts ? directoryOptions : undefined}
+          sageOptions={canManageContacts ? sageOptions : undefined}
         />
       )}
     </div>

--- a/src/components/financials/customer-dialog.tsx
+++ b/src/components/financials/customer-dialog.tsx
@@ -18,10 +18,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import type { Customer } from "@/db/schema"
-import {
-  SAGE_CLIENT_STATUS_OPTIONS,
-  type SageClientStatusId,
-} from "@/lib/sage/client-project-write"
+import type { CustomerRelationshipType } from "@/app/actions/customers"
 
 interface CustomerDialogProps {
   open: boolean
@@ -34,7 +31,7 @@ interface CustomerDialogProps {
     phone: string
     address: string
     notes: string
-    sageClientStatusId: SageClientStatusId
+    relationshipType: CustomerRelationshipType
   }) => void
 }
 
@@ -50,7 +47,8 @@ export function CustomerDialog({
   const [phone, setPhone] = React.useState("")
   const [address, setAddress] = React.useState("")
   const [notes, setNotes] = React.useState("")
-  const [sageClientStatusId, setSageClientStatusId] = React.useState("")
+  const [relationshipType, setRelationshipType] =
+    React.useState<CustomerRelationshipType>("client")
 
   React.useEffect(() => {
     if (initialData) {
@@ -60,7 +58,13 @@ export function CustomerDialog({
       setPhone(initialData.phone ?? "")
       setAddress(initialData.address ?? "")
       setNotes(initialData.notes ?? "")
-      setSageClientStatusId(String(initialData.sageClientStatusId ?? 1))
+      setRelationshipType(
+        initialData.sageClientId || initialData.sageClientNumber
+          ? "client"
+          : initialData.relationshipType === "lead"
+            ? "lead"
+            : "client"
+      )
     } else {
       setName("")
       setCompany("")
@@ -68,17 +72,13 @@ export function CustomerDialog({
       setPhone("")
       setAddress("")
       setNotes("")
-      setSageClientStatusId("")
+      setRelationshipType("client")
     }
   }, [initialData, open])
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (!name.trim()) return
-    const selectedStatus = SAGE_CLIENT_STATUS_OPTIONS.find(
-      (option) => String(option.id) === sageClientStatusId
-    )
-    if (!selectedStatus) return
     onSubmit({
       name: name.trim(),
       company: company.trim(),
@@ -86,7 +86,7 @@ export function CustomerDialog({
       phone: phone.trim(),
       address: address.trim(),
       notes: notes.trim(),
-      sageClientStatusId: selectedStatus.id,
+      relationshipType,
     })
   }
 
@@ -94,7 +94,8 @@ export function CustomerDialog({
     <ResponsiveDialog
       open={open}
       onOpenChange={onOpenChange}
-      title={initialData ? "Edit Customer" : "Add Customer"}
+      title={initialData ? "Edit Client / Lead" : "Add Client / Lead Contact"}
+      description="Maintain the directory contact without granting project access or creating a Sage client."
     >
       <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0">
         <ResponsiveDialogBody>
@@ -113,25 +114,33 @@ export function CustomerDialog({
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="cust-sage-status" className="text-xs">
-              Sage client status *
+            <Label htmlFor="cust-relationship" className="text-xs">
+              Contact status
             </Label>
             <Select
-              value={sageClientStatusId}
-              onValueChange={setSageClientStatusId}
-              required
+              value={relationshipType}
+              onValueChange={(value) => {
+                if (value === "client" || value === "lead") {
+                  setRelationshipType(value)
+                }
+              }}
+              disabled={Boolean(
+                initialData?.sageClientId || initialData?.sageClientNumber
+              )}
             >
-              <SelectTrigger id="cust-sage-status" className="h-9">
-                <SelectValue placeholder="Choose a status" />
+              <SelectTrigger id="cust-relationship" className="h-9">
+                <SelectValue placeholder="Client or lead" />
               </SelectTrigger>
               <SelectContent>
-                {SAGE_CLIENT_STATUS_OPTIONS.map((option) => (
-                  <SelectItem key={option.id} value={String(option.id)}>
-                    {option.id} — {option.name}
-                  </SelectItem>
-                ))}
+                <SelectItem value="client">Client</SelectItem>
+                <SelectItem value="lead">Lead</SelectItem>
               </SelectContent>
             </Select>
+            {initialData?.sageClientId || initialData?.sageClientNumber ? (
+              <p className="text-xs text-muted-foreground">
+                Sage-linked directory records remain clients.
+              </p>
+            ) : null}
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="cust-company" className="text-xs">
@@ -211,9 +220,8 @@ export function CustomerDialog({
           <Button
             type="submit"
             className="h-9"
-            disabled={!initialData && !sageClientStatusId}
           >
-            {initialData ? "Save Changes" : "Create Customer"}
+            {initialData ? "Save Changes" : "Add to Contacts"}
           </Button>
         </ResponsiveDialogFooter>
       </form>

--- a/src/components/financials/customers-table.tsx
+++ b/src/components/financials/customers-table.tsx
@@ -18,6 +18,7 @@ import type { Customer } from "@/db/schema"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
   DropdownMenu,
@@ -182,6 +183,48 @@ export function CustomersTable({
       },
     },
     {
+      accessorKey: "relationshipType",
+      header: "Status",
+      cell: ({ row }) => (
+        <Badge
+          variant={
+            row.original.relationshipType === "lead" ? "secondary" : "outline"
+          }
+        >
+          {row.original.relationshipType === "lead" ? "Lead" : "Client"}
+        </Badge>
+      ),
+    },
+    {
+      id: "source",
+      header: "Source",
+      cell: ({ row }) => {
+        const customer = row.original
+        const isSageLinked = Boolean(
+          customer.sageClientId || customer.sageClientNumber
+        )
+        const isBuildertrendLinked = Boolean(customer.buildertrendContactId)
+        return (
+          <div className="flex flex-wrap gap-1">
+            {isSageLinked ? (
+              <Badge variant="outline">
+                Sage
+                {customer.sageClientNumber
+                  ? ` #${customer.sageClientNumber}`
+                  : ""}
+              </Badge>
+            ) : null}
+            {isBuildertrendLinked ? (
+              <Badge variant="outline">Buildertrend</Badge>
+            ) : null}
+            {!isSageLinked && !isBuildertrendLinked ? (
+              <Badge variant="outline">Compass</Badge>
+            ) : null}
+          </div>
+        )
+      },
+    },
+    {
       accessorKey: "createdAt",
       header: "Added",
       cell: ({ row }) => {
@@ -242,9 +285,9 @@ export function CustomersTable({
 
   const emptyState = (
     <div className="rounded-md border border-dashed p-8 text-center">
-      <p className="text-muted-foreground">No customers yet</p>
+      <p className="text-muted-foreground">No client or lead contacts yet</p>
       <p className="text-sm text-muted-foreground/70 mt-1">
-        Add your first customer to start tracking contacts and invoices.
+        Add a contact to associate them with projects when ready.
       </p>
     </div>
   )
@@ -254,7 +297,7 @@ export function CustomersTable({
     return (
       <div className="space-y-3">
         <Input
-          placeholder="Search customers..."
+          placeholder="Search clients and leads..."
           value={
             (table.getColumn("name")?.getFilterValue() as string) ?? ""
           }

--- a/src/components/projects/project-contact-invite-launcher.tsx
+++ b/src/components/projects/project-contact-invite-launcher.tsx
@@ -44,7 +44,12 @@ type InvitableContact = ProjectContactItem & {
 function isInvitableContact(
   contact: ProjectContactItem
 ): contact is InvitableContact {
+  const isCompanyOnlyVendor =
+    (contact.contactType === "supplier" ||
+      contact.contactType === "subcontractor") &&
+    contact.vendorContactId === null
   return (
+    !isCompanyOnlyVendor &&
     Boolean(contact.email?.trim()) &&
     projectContactCanInvite(contact.accessStatus)
   )

--- a/src/components/projects/project-contact-management.tsx
+++ b/src/components/projects/project-contact-management.tsx
@@ -12,11 +12,17 @@ import { useState, useTransition } from "react"
 import { toast } from "sonner"
 
 import {
+  createCustomerDirectoryContact,
+  type CustomerRelationshipType,
+} from "@/app/actions/customers"
+import {
   removeProjectContact,
   saveProjectContact,
+  type ProjectContactCostCodeOption,
   type ProjectContactDirectoryOption,
   type ProjectContactItem,
   type ProjectContactMutationInput,
+  type ProjectContactSageOptions,
   type ProjectContactType,
 } from "@/app/actions/project-contacts"
 import {
@@ -176,10 +182,14 @@ function DirectoryPicker({
   options,
   selected,
   onSelect,
+  placeholder = "Choose a contact or enter one manually...",
+  searchPlaceholder = "Search customers, vendors, or staff...",
 }: {
   readonly options: readonly ProjectContactDirectoryOption[]
   readonly selected: ProjectContactDirectoryOption | null
   readonly onSelect: (option: ProjectContactDirectoryOption) => void
+  readonly placeholder?: string
+  readonly searchPlaceholder?: string
 }): React.ReactElement {
   const [open, setOpen] = useState(false)
   const groups = groupedDirectoryOptions(options)
@@ -195,14 +205,14 @@ function DirectoryPicker({
           className="w-full justify-between font-normal"
         >
           <span className="truncate">
-            {selected ? selected.displayName : "Choose a contact or enter one manually..."}
+            {selected ? selected.displayName : placeholder}
           </span>
           <IconChevronDown className="ml-2 size-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
         <Command>
-          <CommandInput placeholder="Search customers, vendors, or staff..." />
+          <CommandInput placeholder={searchPlaceholder} />
           <CommandList>
             <CommandEmpty>No matching directory contact.</CommandEmpty>
             {groups.map((group) => (
@@ -247,6 +257,84 @@ function DirectoryPicker({
   )
 }
 
+function CostCodePicker({
+  options,
+  value,
+  onSelect,
+}: {
+  readonly options: readonly ProjectContactCostCodeOption[]
+  readonly value: string
+  readonly onSelect: (option: ProjectContactCostCodeOption | null) => void
+}): React.ReactElement {
+  const [open, setOpen] = useState(false)
+  const selected = options.find((option) => option.value === value) ?? null
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id="project-contact-cost-code"
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full justify-between font-normal"
+          disabled={options.length === 0 && !value}
+        >
+          <span className="truncate">
+            {selected?.label ?? (value || "Choose a Sage cost code...")}
+          </span>
+          <IconChevronDown className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+      >
+        <Command>
+          <CommandInput placeholder="Search Sage cost codes..." />
+          <CommandList className="max-h-72">
+            <CommandEmpty>No matching Sage cost code.</CommandEmpty>
+            <CommandGroup>
+              {value && (
+                <CommandItem
+                  value="Clear cost code"
+                  onSelect={() => {
+                    onSelect(null)
+                    setOpen(false)
+                  }}
+                >
+                  Clear cost code
+                </CommandItem>
+              )}
+              {options.map((option) => (
+                <CommandItem
+                  key={option.value}
+                  value={`${option.label} ${option.description}`}
+                  onSelect={() => {
+                    onSelect(option)
+                    setOpen(false)
+                  }}
+                >
+                  <IconCheck
+                    className={cn(
+                      "mr-2 size-4",
+                      selected?.value === option.value
+                        ? "opacity-100"
+                        : "opacity-0"
+                    )}
+                  />
+                  <span className="truncate">{option.label}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
 function VisibilityCheckbox({
   id,
   checked,
@@ -279,10 +367,12 @@ export function ProjectContactEditor({
   projectId,
   contact = null,
   directoryOptions,
+  sageOptions,
 }: {
   readonly projectId: string
   readonly contact?: ProjectContactItem | null
   readonly directoryOptions: readonly ProjectContactDirectoryOption[]
+  readonly sageOptions: ProjectContactSageOptions
 }): React.ReactElement {
   const router = useRouter()
   const [open, setOpen] = useState(false)
@@ -291,10 +381,18 @@ export function ProjectContactEditor({
     directoryOptions
   )
   const [input, setInput] = useState(() => initialInput(projectId, contact))
+  const [showNewCustomer, setShowNewCustomer] = useState(false)
+  const [newCustomerName, setNewCustomerName] = useState("")
+  const [newCustomerCompany, setNewCustomerCompany] = useState("")
+  const [newCustomerEmail, setNewCustomerEmail] = useState("")
+  const [newCustomerPhone, setNewCustomerPhone] = useState("")
+  const [newCustomerRelationship, setNewCustomerRelationship] =
+    useState<CustomerRelationshipType>("client")
   const [showNewVendor, setShowNewVendor] = useState(false)
   const [newVendorName, setNewVendorName] = useState("")
   const [showNewVendorContact, setShowNewVendorContact] = useState(false)
   const [newVendorContactName, setNewVendorContactName] = useState("")
+  const [newVendorContactTitle, setNewVendorContactTitle] = useState("")
   const [newVendorContactEmail, setNewVendorContactEmail] = useState("")
   const [newVendorContactPhone, setNewVendorContactPhone] = useState("")
   const [customRoleSelected, setCustomRoleSelected] = useState(
@@ -310,17 +408,33 @@ export function ProjectContactEditor({
   const vendorOptions = availableDirectoryOptions.filter(
     (option) => option.sourceType === "vendor"
   )
+  const customerOptions = availableDirectoryOptions.filter(
+    (option) => option.sourceType === "customer"
+  )
   const selectedVendor =
     selectedDirectory?.sourceType === "vendor" ? selectedDirectory : null
   const selectedVendorContact = selectedVendor?.vendorContacts.find(
     (vendorContact) => vendorContact.id === input.vendorContactId
   ) ?? null
+  const legacyVendorPerson =
+    selectedVendor &&
+    !input.vendorContactId &&
+    input.displayName.trim() &&
+    input.displayName.trim() !== selectedVendor.displayName
+      ? input.displayName.trim()
+      : null
+  const filteredCostCodes = input.csiDivision
+    ? sageOptions.costCodes.filter(
+        (option) => option.divisionCode === input.csiDivision
+      )
+    : sageOptions.costCodes
   const identityManagedByActiveUser =
     input.directorySourceType === null
       ? (contact?.identityManagedByActiveUser ?? false)
       : (selectedVendorContact?.identityManagedByActiveUser ??
         selectedDirectory?.identityManagedByActiveUser ??
         false)
+  const identityReadOnly = selectedDirectory !== null || identityManagedByActiveUser
 
   function updateInput<Key extends keyof ProjectContactMutationInput>(
     key: Key,
@@ -335,10 +449,17 @@ export function ProjectContactEditor({
       setInput(initialInput(projectId, contact))
       setAvailableDirectoryOptions(directoryOptions)
       setDirectoryOpenKey(null)
+      setShowNewCustomer(false)
+      setNewCustomerName("")
+      setNewCustomerCompany("")
+      setNewCustomerEmail("")
+      setNewCustomerPhone("")
+      setNewCustomerRelationship("client")
       setShowNewVendor(false)
       setNewVendorName("")
       setShowNewVendorContact(false)
       setNewVendorContactName("")
+      setNewVendorContactTitle("")
       setNewVendorContactEmail("")
       setNewVendorContactPhone("")
       setCustomRoleSelected(
@@ -406,6 +527,129 @@ export function ProjectContactEditor({
     }))
   }
 
+  function applyDivision(divisionCode: string): void {
+    if (divisionCode === "unassigned") {
+      setInput((current) => ({
+        ...current,
+        csiDivision: "",
+        csiDivisionName: "",
+        primaryCostCode: "",
+      }))
+      return
+    }
+    const division = sageOptions.divisions.find(
+      (option) => option.value === divisionCode
+    )
+    if (!division) return
+    setInput((current) => {
+      const selectedCostCode = sageOptions.costCodes.find(
+        (option) => option.value === current.primaryCostCode
+      )
+      return {
+        ...current,
+        csiDivision: division.value,
+        csiDivisionName: division.name,
+        primaryCostCode:
+          selectedCostCode?.divisionCode === division.value
+            ? current.primaryCostCode
+            : "",
+      }
+    })
+  }
+
+  function applyCostCode(
+    option: ProjectContactCostCodeOption | null
+  ): void {
+    setInput((current) =>
+      option
+        ? {
+            ...current,
+            primaryCostCode: option.value,
+            csiDivision: option.divisionCode,
+            csiDivisionName: option.divisionName,
+          }
+        : { ...current, primaryCostCode: "" }
+    )
+  }
+
+  function addCustomerContact(): void {
+    const name = newCustomerName.trim()
+    if (!name) return
+    const email = newCustomerEmail.trim().toLowerCase()
+    const company = newCustomerCompany.trim().toLowerCase()
+    const existingMatches = customerOptions.filter((option) => {
+      const sameEmail =
+        email.length > 0 && option.email?.trim().toLowerCase() === email
+      const sameNameAndCompany =
+        option.displayName.trim().toLowerCase() === name.toLowerCase() &&
+        (option.companyName?.trim().toLowerCase() ?? "") === company
+      return sameEmail || sameNameAndCompany
+    })
+    if (existingMatches.length > 1) {
+      toast.error(
+        "More than one contact matches. Choose the correct existing contact from the list."
+      )
+      return
+    }
+    const existing = existingMatches[0]
+    if (existing) {
+      applyDirectoryOption(existing)
+      setShowNewCustomer(false)
+      toast.info("That client contact already exists and was selected.")
+      return
+    }
+
+    startTransition(async () => {
+      const result = await createCustomerDirectoryContact({
+        name,
+        company: newCustomerCompany || null,
+        email: newCustomerEmail || null,
+        phone: newCustomerPhone || null,
+        address: null,
+        notes: null,
+        relationshipType: newCustomerRelationship,
+      })
+      if (!result.success || !result.id || !result.customer) {
+        toast.error(result.error)
+        return
+      }
+      const customer = result.customer
+      const option: ProjectContactDirectoryOption = {
+        id: result.id,
+        sourceType: "customer",
+        displayName: customer.name,
+        companyName: customer.company,
+        email: customer.email,
+        phone: customer.phone,
+        address: customer.address,
+        suggestedContactType: "owner",
+        identityManagedByActiveUser: false,
+        vendorContacts: [],
+      }
+      setAvailableDirectoryOptions((current) =>
+        current.some(
+          (existingOption) =>
+            existingOption.sourceType === "customer" &&
+            existingOption.id === option.id
+        )
+          ? current
+          : [...current, option]
+      )
+      applyDirectoryOption(option)
+      setShowNewCustomer(false)
+      setNewCustomerName("")
+      setNewCustomerCompany("")
+      setNewCustomerEmail("")
+      setNewCustomerPhone("")
+      setNewCustomerRelationship("client")
+      toast.success(
+        result.existing
+          ? "Existing client/lead contact selected."
+          : "Client/lead contact added to Contacts and selected."
+      )
+    })
+  }
+
   function addVendorCompany(): void {
     const name = newVendorName.trim()
     if (!name) return
@@ -450,7 +694,7 @@ export function ProjectContactEditor({
       const result = await createVendorContact(selectedVendor.id, {
         id: null,
         name: newVendorContactName,
-        title: "",
+        title: newVendorContactTitle,
         email: newVendorContactEmail,
         phone: newVendorContactPhone,
         isPrimary: selectedVendor.vendorContacts.length === 0,
@@ -488,6 +732,7 @@ export function ProjectContactEditor({
         phone: result.contact.phone ?? "",
       }))
       setNewVendorContactName("")
+      setNewVendorContactTitle("")
       setNewVendorContactEmail("")
       setNewVendorContactPhone("")
       setShowNewVendorContact(false)
@@ -540,7 +785,9 @@ export function ProjectContactEditor({
             <SheetDescription>
               {identityManagedByActiveUser
                 ? "This active Compass user manages their own phone, email, and address. Project role and visibility remain editable here."
-                : "Phone, email, and address stay synchronized with the linked company directory record."}
+                : selectedDirectory
+                  ? "Phone, email, and address stay synchronized with the linked directory record."
+                  : "Add a project contact or link an existing directory record."}
             </SheetDescription>
           </SheetHeader>
 
@@ -598,6 +845,8 @@ export function ProjectContactEditor({
                     options={vendorOptions}
                     selected={selectedVendor}
                     onSelect={applyDirectoryOption}
+                    placeholder="Choose a vendor company..."
+                    searchPlaceholder="Search vendor companies..."
                   />
                   <p className="text-xs text-muted-foreground">
                     Choose from all {vendorOptions.length} Sage and Compass vendor companies.
@@ -643,7 +892,10 @@ export function ProjectContactEditor({
                     <div className="grid gap-2">
                       <Label>Contact person</Label>
                       <Select
-                        value={input.vendorContactId ?? "company-only"}
+                        value={
+                          input.vendorContactId ??
+                          (legacyVendorPerson ? "legacy-person" : "company-only")
+                        }
                         onValueChange={applyVendorContact}
                       >
                         <SelectTrigger>
@@ -651,16 +903,27 @@ export function ProjectContactEditor({
                         </SelectTrigger>
                         <SelectContent>
                           <SelectItem value="company-only">
-                            Company only (no specific person)
+                            No specific person (company assignment only)
                           </SelectItem>
+                          {legacyVendorPerson && (
+                            <SelectItem value="legacy-person">
+                              {legacyVendorPerson} · imported contact
+                            </SelectItem>
+                          )}
                           {selectedVendor.vendorContacts.map((vendorContact) => (
                             <SelectItem key={vendorContact.id} value={vendorContact.id}>
                               {vendorContact.name}
                               {vendorContact.title ? ` · ${vendorContact.title}` : ""}
+                              {vendorContact.email ? ` · ${vendorContact.email}` : ""}
+                              {vendorContact.isPrimary ? " · Primary" : ""}
                             </SelectItem>
                           ))}
                         </SelectContent>
                       </Select>
+                      <p className="text-xs text-muted-foreground">
+                        Select a person when project access or email invitations are needed.
+                        Company-only assignments cannot be invited.
+                      </p>
                     </div>
                     {showNewVendorContact ? (
                       <div className="grid gap-2 sm:grid-cols-2">
@@ -671,6 +934,13 @@ export function ProjectContactEditor({
                             setNewVendorContactName(event.target.value)
                           }
                           placeholder="Contact name"
+                        />
+                        <Input
+                          value={newVendorContactTitle}
+                          onChange={(event) =>
+                            setNewVendorContactTitle(event.target.value)
+                          }
+                          placeholder="Title / position"
                         />
                         <Input
                           type="email"
@@ -719,50 +989,143 @@ export function ProjectContactEditor({
                   </div>
                 )}
               </div>
+            ) : input.contactType === "owner" ? (
+              <div className="grid gap-4 rounded-lg border p-4">
+                <div className="grid gap-2">
+                  <Label>Client contact</Label>
+                  <DirectoryPicker
+                    key={directoryOpenKey ?? "customer"}
+                    options={customerOptions}
+                    selected={selectedDirectory}
+                    onSelect={applyDirectoryOption}
+                    placeholder="Choose a client or lead contact..."
+                    searchPlaceholder="Search client and lead contacts..."
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Choose from {customerOptions.length} Compass and Buildertrend
+                    client/lead contacts. Selection does not grant project access.
+                  </p>
+                </div>
+                {showNewCustomer ? (
+                  <div className="grid gap-2 border-t pt-4 sm:grid-cols-2">
+                    <Input
+                      required
+                      value={newCustomerName}
+                      onChange={(event) => setNewCustomerName(event.target.value)}
+                      placeholder="Contact name"
+                    />
+                    <Input
+                      value={newCustomerCompany}
+                      onChange={(event) => setNewCustomerCompany(event.target.value)}
+                      placeholder="Company / organization"
+                    />
+                    <Input
+                      type="email"
+                      value={newCustomerEmail}
+                      onChange={(event) => setNewCustomerEmail(event.target.value)}
+                      placeholder="Email"
+                    />
+                    <Input
+                      type="tel"
+                      value={newCustomerPhone}
+                      onChange={(event) => setNewCustomerPhone(event.target.value)}
+                      placeholder="Phone"
+                    />
+                    <Select
+                      value={newCustomerRelationship}
+                      onValueChange={(value) => {
+                        if (value === "client" || value === "lead") {
+                          setNewCustomerRelationship(value)
+                        }
+                      }}
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Client or lead" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="client">Client</SelectItem>
+                        <SelectItem value="lead">Lead</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <div className="flex gap-2">
+                      <Button
+                        type="button"
+                        onClick={addCustomerContact}
+                        disabled={isPending || !newCustomerName.trim()}
+                      >
+                        Add client
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() => setShowNewCustomer(false)}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="w-fit"
+                    onClick={() => setShowNewCustomer(true)}
+                  >
+                    <IconPlus className="size-4" />
+                    Add new client contact
+                  </Button>
+                )}
+              </div>
             ) : (
               !isEditing && (
                 <div className="grid gap-2">
-                  <Label>
-                    {input.contactType === "owner"
-                      ? "Customer directory"
-                      : "Settings team"}
-                  </Label>
+                  <Label>Settings team</Label>
                   <DirectoryPicker
-                    key={directoryOpenKey ?? input.contactType}
-                    options={availableDirectoryOptions.filter((option) =>
-                      input.contactType === "owner"
-                        ? option.sourceType === "customer"
-                        : option.sourceType === "team"
+                    key={directoryOpenKey ?? "internal"}
+                    options={availableDirectoryOptions.filter(
+                      (option) => option.sourceType === "team"
                     )}
                     selected={selectedDirectory}
                     onSelect={applyDirectoryOption}
+                    placeholder="Choose a Settings team member..."
+                    searchPlaceholder="Search Settings team..."
                   />
                   <p className="text-xs text-muted-foreground">
-                    Select an existing record to prefill the form, or enter one manually.
+                    Internal contacts come from active Settings team members.
                   </p>
                 </div>
               )
             )}
 
             <div className="grid gap-4 sm:grid-cols-2">
-              <div className="grid gap-2">
-                <Label htmlFor="project-contact-name">Contact name</Label>
-                <Input
-                  id="project-contact-name"
-                  required
-                  value={input.displayName}
-                  onChange={(event) => updateInput("displayName", event.target.value)}
-                />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="project-contact-company">Company</Label>
-                <Input
-                  id="project-contact-company"
-                  value={input.companyName}
-                  onChange={(event) => updateInput("companyName", event.target.value)}
-                  readOnly={selectedVendor !== null}
-                />
-              </div>
+              {!isVendorContactType(input.contactType) && (
+                <div
+                  className={cn(
+                    "grid gap-2",
+                    input.contactType === "internal" && "sm:col-span-2"
+                  )}
+                >
+                  <Label htmlFor="project-contact-name">Contact name</Label>
+                  <Input
+                    id="project-contact-name"
+                    required
+                    value={input.displayName}
+                    onChange={(event) => updateInput("displayName", event.target.value)}
+                    readOnly={selectedDirectory !== null}
+                  />
+                </div>
+              )}
+              {input.contactType === "owner" && (
+                <div className="grid gap-2">
+                  <Label htmlFor="project-contact-company">Company</Label>
+                  <Input
+                    id="project-contact-company"
+                    value={input.companyName}
+                    onChange={(event) => updateInput("companyName", event.target.value)}
+                    readOnly={selectedDirectory !== null}
+                  />
+                </div>
+              )}
               <div className="grid gap-2">
                 <Label htmlFor="project-contact-role">Project role</Label>
                 <Select
@@ -833,7 +1196,7 @@ export function ProjectContactEditor({
                   type="email"
                   value={input.email}
                   onChange={(event) => updateInput("email", event.target.value)}
-                  disabled={identityManagedByActiveUser}
+                  disabled={identityReadOnly}
                 />
               </div>
               <div className="grid gap-2">
@@ -843,7 +1206,7 @@ export function ProjectContactEditor({
                   type="tel"
                   value={input.phone}
                   onChange={(event) => updateInput("phone", event.target.value)}
-                  disabled={identityManagedByActiveUser}
+                  disabled={identityReadOnly}
                 />
               </div>
               <div className="grid gap-2 sm:col-span-2">
@@ -852,35 +1215,40 @@ export function ProjectContactEditor({
                   id="project-contact-address"
                   value={input.address}
                   onChange={(event) => updateInput("address", event.target.value)}
-                  disabled={identityManagedByActiveUser}
+                  disabled={identityReadOnly}
                 />
               </div>
               <div className="grid gap-2">
-                <Label htmlFor="project-contact-cost-code">Primary cost code</Label>
-                <Input
-                  id="project-contact-cost-code"
+                <Label htmlFor="project-contact-csi">Sage division</Label>
+                <Select
+                  value={input.csiDivision || "unassigned"}
+                  onValueChange={applyDivision}
+                >
+                  <SelectTrigger id="project-contact-csi" className="w-full">
+                    <SelectValue placeholder="Choose a Sage division..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="unassigned">No division</SelectItem>
+                    {sageOptions.divisions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="project-contact-cost-code">Sage cost code</Label>
+                <CostCodePicker
+                  options={filteredCostCodes}
                   value={input.primaryCostCode}
-                  onChange={(event) => updateInput("primaryCostCode", event.target.value)}
+                  onSelect={applyCostCode}
                 />
               </div>
-              <div className="grid gap-2">
-                <Label htmlFor="project-contact-csi">CSI division</Label>
-                <Input
-                  id="project-contact-csi"
-                  value={input.csiDivision}
-                  onChange={(event) => updateInput("csiDivision", event.target.value)}
-                  placeholder="09"
-                />
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="project-contact-csi-name">CSI division name</Label>
-                <Input
-                  id="project-contact-csi-name"
-                  value={input.csiDivisionName}
-                  onChange={(event) => updateInput("csiDivisionName", event.target.value)}
-                  placeholder="Finishes"
-                />
-              </div>
+              <p className="text-xs text-muted-foreground sm:col-span-2">
+                Choosing a cost code automatically sets its Sage division. Choose a
+                division first to narrow the cost-code list.
+              </p>
             </div>
 
             <div className="grid gap-2">

--- a/src/components/projects/project-contacts-panel.tsx
+++ b/src/components/projects/project-contacts-panel.tsx
@@ -15,6 +15,7 @@ import Link from "next/link"
 import type {
   ProjectContactDirectoryOption,
   ProjectContactItem,
+  ProjectContactSageOptions,
   ProjectContactsSummary,
 } from "@/app/actions/project-contacts"
 import { ProjectContactEditor } from "@/components/projects/project-contact-management"
@@ -78,7 +79,7 @@ function visibilityLabel(contact: ProjectContactItem): string {
 
 function contactSubtitle(contact: ProjectContactItem): string {
   return [
-    contact.companyName,
+    contact.companyName !== contact.displayName ? contact.companyName : null,
     contact.role,
     contact.trade,
   ].filter(Boolean).join(" · ")
@@ -87,7 +88,15 @@ function contactSubtitle(contact: ProjectContactItem): string {
 function csiLabel(contact: ProjectContactItem): string | null {
   if (!contact.csiDivision || !contact.csiDivisionName) return null
 
-  return `${contact.csiDivision} ${contact.csiDivisionName}`
+  return `${contact.csiDivision} 00 00 - ${contact.csiDivisionName}`
+}
+
+function isCompanyOnlyVendor(contact: ProjectContactItem): boolean {
+  return (
+    (contact.contactType === "supplier" ||
+      contact.contactType === "subcontractor") &&
+    contact.vendorContactId === null
+  )
 }
 
 function accessStatusLabel(contact: ProjectContactItem): string {
@@ -127,12 +136,14 @@ function ContactCard({
   projectLabel,
   compact = false,
   directoryOptions,
+  sageOptions,
 }: {
   readonly contact: ProjectContactItem
   readonly projectId: string
   readonly projectLabel: string
   readonly compact?: boolean
   readonly directoryOptions?: readonly ProjectContactDirectoryOption[]
+  readonly sageOptions?: ProjectContactSageOptions
 }): React.ReactElement {
   return (
     <article className="rounded-md border bg-background p-3">
@@ -163,6 +174,7 @@ function ContactCard({
               projectId={projectId}
               contact={contact}
               directoryOptions={directoryOptions}
+              sageOptions={sageOptions ?? { divisions: [], costCodes: [] }}
             />
           )}
         </div>
@@ -197,8 +209,16 @@ function ContactCard({
         </p>
       )}
 
+      {!compact && isCompanyOnlyVendor(contact) && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Company assignment only. Select or add a contact person before sending
+          a Compass invitation.
+        </p>
+      )}
+
       {!compact &&
         contact.email &&
+        !isCompanyOnlyVendor(contact) &&
         projectContactCanInvite(contact.accessStatus) && (
           <div className="mt-3 flex justify-end">
             <ProjectContactInviteButton
@@ -221,12 +241,14 @@ export function ProjectContactsPanel({
   summary,
   showOpenLink = true,
   directoryOptions,
+  sageOptions,
 }: {
   readonly projectId: string
   readonly projectLabel?: string
   readonly summary: ProjectContactsSummary | null
   readonly showOpenLink?: boolean
   readonly directoryOptions?: readonly ProjectContactDirectoryOption[]
+  readonly sageOptions?: ProjectContactSageOptions
 }): React.ReactElement {
   if (!summary) {
     return (
@@ -263,6 +285,7 @@ export function ProjectContactsPanel({
             <ProjectContactEditor
               projectId={projectId}
               directoryOptions={directoryOptions}
+              sageOptions={sageOptions ?? { divisions: [], costCodes: [] }}
             />
           )}
           {!showOpenLink && (
@@ -350,6 +373,7 @@ export function ProjectContactsPanel({
               projectLabel={projectLabel}
               compact
               directoryOptions={directoryOptions}
+              sageOptions={sageOptions}
             />
           ))}
         </div>
@@ -375,11 +399,13 @@ export function ProjectContactsDirectory({
   projectLabel,
   summary,
   directoryOptions,
+  sageOptions,
 }: {
   readonly projectId: string
   readonly projectLabel: string
   readonly summary: ProjectContactsSummary
   readonly directoryOptions?: readonly ProjectContactDirectoryOption[]
+  readonly sageOptions?: ProjectContactSageOptions
 }): React.ReactElement {
   const displayGroups = buildDisplayGroups(summary.allContacts)
 
@@ -403,6 +429,7 @@ export function ProjectContactsDirectory({
                   projectId={projectId}
                   projectLabel={projectLabel}
                   directoryOptions={directoryOptions}
+                  sageOptions={sageOptions}
                 />
               ))}
             </div>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2111,22 +2111,44 @@ export const schedulePublications = sqliteTable(
   ]
 )
 
-export const customers = sqliteTable("customers", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  company: text("company"),
-  email: text("email"),
-  phone: text("phone"),
-  address: text("address"),
-  notes: text("notes"),
-  netsuiteId: text("netsuite_id"),
-  sageClientId: text("sage_client_id"),
-  sageClientNumber: text("sage_client_number"),
-  sageClientStatusId: integer("sage_client_status_id"),
-  organizationId: text("organization_id").references(() => organizations.id),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at"),
-})
+export const customers = sqliteTable(
+  "customers",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    company: text("company"),
+    email: text("email"),
+    phone: text("phone"),
+    address: text("address"),
+    notes: text("notes"),
+    netsuiteId: text("netsuite_id"),
+    sageClientId: text("sage_client_id"),
+    sageClientNumber: text("sage_client_number"),
+    sageClientStatusId: integer("sage_client_status_id"),
+    buildertrendContactId: text("buildertrend_contact_id"),
+    relationshipType: text("relationship_type").notNull().default("client"),
+    organizationId: text("organization_id").references(() => organizations.id),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at"),
+  },
+  (table) => [
+    uniqueIndex("customers_org_sage_client_id_unique")
+      .on(table.organizationId, table.sageClientId)
+      .where(
+        sql`${table.sageClientId} IS NOT NULL AND trim(${table.sageClientId}) <> ''`
+      ),
+    uniqueIndex("customers_org_sage_client_number_unique")
+      .on(table.organizationId, table.sageClientNumber)
+      .where(
+        sql`${table.sageClientNumber} IS NOT NULL AND trim(${table.sageClientNumber}) <> ''`
+      ),
+    uniqueIndex("customers_org_buildertrend_contact_unique")
+      .on(table.organizationId, table.buildertrendContactId)
+      .where(
+        sql`${table.buildertrendContactId} IS NOT NULL AND trim(${table.buildertrendContactId}) <> ''`
+      ),
+  ]
+)
 
 export const vendors = sqliteTable("vendors", {
   id: text("id").primaryKey(),

--- a/src/lib/buildertrend/__tests__/client-directory-migration.test.ts
+++ b/src/lib/buildertrend/__tests__/client-directory-migration.test.ts
@@ -1,0 +1,141 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const migration = readFileSync(
+  resolve(process.cwd(), "drizzle/0119_buildertrend_client_directory.sql"),
+  "utf8"
+).replaceAll("--> statement-breakpoint", "")
+
+type TestStatement = {
+  readonly all: () => readonly unknown[]
+  readonly get: () => unknown
+}
+
+type TestDatabase = {
+  readonly exec: (sql: string) => unknown
+  readonly prepare: (sql: string) => TestStatement
+  readonly close: () => void
+}
+
+type TestDatabaseModule = {
+  readonly Database: new (filename: string) => TestDatabase
+}
+
+function isTestDatabaseModule(value: unknown): value is TestDatabaseModule {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "Database" in value &&
+    typeof value.Database === "function"
+  )
+}
+
+async function createDatabase(): Promise<TestDatabase> {
+  if ("Bun" in globalThis) {
+    const bunSqliteSpecifier = "bun:sqlite"
+    const sqliteModule: unknown = await import(bunSqliteSpecifier)
+    if (!isTestDatabaseModule(sqliteModule)) {
+      throw new Error("bun:sqlite did not provide a Database constructor")
+    }
+    return new sqliteModule.Database(":memory:")
+  }
+
+  const { default: Database } = await import("better-sqlite3")
+  return new Database(":memory:")
+}
+
+describe("Buildertrend client contact directory migration", () => {
+  it("promotes stable identities without granting access or guessing conflicts", async () => {
+    const database = await createDatabase()
+    database.exec(`
+      CREATE TABLE customers (
+        id TEXT PRIMARY KEY, name TEXT NOT NULL, company TEXT, email TEXT,
+        phone TEXT, address TEXT, notes TEXT, netsuite_id TEXT,
+        sage_client_id TEXT, sage_client_number TEXT,
+        sage_client_status_id INTEGER, organization_id TEXT,
+        created_at TEXT NOT NULL, updated_at TEXT
+      );
+      CREATE TABLE projects (
+        id TEXT PRIMARY KEY, organization_id TEXT NOT NULL
+      );
+      CREATE TABLE project_contacts (
+        id TEXT PRIMARY KEY, project_id TEXT NOT NULL, contact_type TEXT NOT NULL,
+        source_entity_type TEXT NOT NULL, source_entity_id TEXT,
+        display_name TEXT NOT NULL, email TEXT, phone TEXT, active INTEGER NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE TABLE buildertrend_staging_access_candidates (
+        id TEXT PRIMARY KEY, organization_id TEXT, project_id TEXT,
+        buildertrend_contact_id TEXT, buildertrend_access_role TEXT,
+        contact_name TEXT, email TEXT, phone TEXT,
+        proposed_contact_type TEXT, created_at TEXT, updated_at TEXT
+      );
+
+      INSERT INTO projects VALUES ('project-a', 'org-a'), ('project-b', 'org-a');
+      INSERT INTO customers (
+        id, name, phone, sage_client_id, sage_client_number,
+        organization_id, created_at
+      ) VALUES (
+        'existing', 'Existing Client', NULL, 'sage-existing', '2899',
+        'org-a', '2026-01-01'
+      );
+      INSERT INTO project_contacts VALUES (
+        'project-owner', 'project-a', 'owner', 'manual', NULL,
+        'Stable Lead', NULL, '555-0101', 1, '2026-01-01'
+      );
+      INSERT INTO buildertrend_staging_access_candidates VALUES
+        ('stable-a', 'org-a', 'project-a', 'bt-stable', 'lead_contact',
+         'Stable Lead', NULL, '555-0101', 'owner', '2026-01-01', '2026-02-01'),
+        ('stable-b', 'org-a', 'project-b', 'bt-stable', 'lead_contact',
+         'Stable Lead', NULL, '555-0101', 'owner', '2026-01-02', '2026-02-02'),
+        ('conflict-a', 'org-a', 'project-a', 'bt-conflict', 'client_contact',
+         'First Name', NULL, '555-0102', 'owner', '2026-01-01', '2026-02-01'),
+        ('conflict-b', 'org-a', 'project-b', 'bt-conflict', 'client_contact',
+         'Different Name', NULL, '555-0102', 'owner', '2026-01-01', '2026-02-01'),
+        ('existing-a', 'org-a', 'project-a', 'bt-existing', 'client_contact',
+         'Existing Client', NULL, '555-0100', 'owner', '2026-01-01', '2026-02-01');
+    `)
+
+    database.exec(migration)
+
+    const imported = database
+      .prepare(
+        "SELECT name, phone, sage_client_number AS sageNumber, buildertrend_contact_id AS buildertrendContactId, relationship_type AS relationshipType FROM customers ORDER BY name"
+      )
+      .all()
+    expect(imported).toEqual([
+      {
+        name: "Existing Client",
+        phone: "555-0100",
+        sageNumber: "2899",
+        buildertrendContactId: "bt-existing",
+        relationshipType: "client",
+      },
+      {
+        name: "Stable Lead",
+        phone: "555-0101",
+        sageNumber: null,
+        buildertrendContactId: "bt-stable",
+        relationshipType: "lead",
+      },
+    ])
+    expect(
+      database
+        .prepare("SELECT COUNT(*) AS count FROM customers")
+        .get()
+    ).toEqual({ count: 2 })
+    expect(
+      database
+        .prepare(
+          "SELECT source_entity_type AS sourceType, source_entity_id AS sourceId FROM project_contacts WHERE id = 'project-owner'"
+        )
+        .get()
+    ).toMatchObject({
+      sourceType: "customer",
+      sourceId: expect.stringContaining("bt-stable"),
+    })
+
+    database.close()
+  })
+})

--- a/src/lib/sage/__tests__/client-directory-import.test.ts
+++ b/src/lib/sage/__tests__/client-directory-import.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildSageClientDirectoryImportSql,
+  stableSageClientDirectory,
+} from "@/lib/sage/client-directory-import"
+
+type TestStatement = {
+  readonly all: () => readonly unknown[]
+}
+
+type TestDatabase = {
+  readonly exec: (sql: string) => unknown
+  readonly prepare: (sql: string) => TestStatement
+  readonly close: () => void
+}
+
+type TestDatabaseModule = {
+  readonly Database: new (filename: string) => TestDatabase
+}
+
+function isTestDatabaseModule(value: unknown): value is TestDatabaseModule {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "Database" in value &&
+    typeof value.Database === "function"
+  )
+}
+
+async function createDatabase(): Promise<TestDatabase> {
+  if ("Bun" in globalThis) {
+    const bunSqliteSpecifier = "bun:sqlite"
+    const sqliteModule: unknown = await import(bunSqliteSpecifier)
+    if (!isTestDatabaseModule(sqliteModule)) {
+      throw new Error("bun:sqlite did not provide a Database constructor")
+    }
+    return new sqliteModule.Database(":memory:")
+  }
+
+  const { default: Database } = await import("better-sqlite3")
+  return new Database(":memory:")
+}
+
+describe("Sage client directory import", () => {
+  it("excludes conflicting Sage numbers", () => {
+    expect(
+      stableSageClientDirectory([
+        { clientNumber: "100", name: "Stable Client" },
+        { clientNumber: "100", name: "Stable Client" },
+        { clientNumber: "101", name: "First Name" },
+        { clientNumber: "101", name: "Different Name" },
+      ])
+    ).toEqual({
+      clients: [{ clientNumber: "100", name: "Stable Client" }],
+      conflictingClientNumbers: ["101"],
+    })
+  })
+
+  it("links exact Buildertrend contacts to Sage and retains both identities", async () => {
+    const database = await createDatabase()
+    database.exec(`
+      CREATE TABLE customers (
+        id TEXT PRIMARY KEY, name TEXT NOT NULL, company TEXT, email TEXT,
+        phone TEXT, address TEXT, notes TEXT, netsuite_id TEXT,
+        sage_client_id TEXT, sage_client_number TEXT,
+        sage_client_status_id INTEGER, buildertrend_contact_id TEXT,
+        relationship_type TEXT NOT NULL DEFAULT 'client',
+        organization_id TEXT, created_at TEXT NOT NULL, updated_at TEXT
+      );
+      CREATE UNIQUE INDEX customers_org_sage_client_number_unique
+        ON customers (organization_id, sage_client_number);
+      INSERT INTO customers (
+        id, name, phone,
+        buildertrend_contact_id, organization_id, created_at
+      ) VALUES (
+        'buildertrend-existing', 'Shared Client', '555-0100',
+        'bt-shared', 'org-a', '2026-01-01'
+      );
+    `)
+
+    database.exec(
+      buildSageClientDirectoryImportSql({
+        organizationId: "org-a",
+        records: [
+          { clientNumber: "100", name: "Shared Client" },
+          { clientNumber: "101", name: "Sage Only" },
+        ],
+      })
+    )
+
+    expect(
+      database
+        .prepare(
+          `SELECT name, sage_client_number AS sageNumber,
+                  buildertrend_contact_id AS buildertrendContactId
+           FROM customers ORDER BY name`
+        )
+        .all()
+    ).toEqual([
+      {
+        name: "Sage Only",
+        sageNumber: "101",
+        buildertrendContactId: null,
+      },
+      {
+        name: "Shared Client",
+        sageNumber: "100",
+        buildertrendContactId: "bt-shared",
+      },
+    ])
+    database.close()
+  })
+})

--- a/src/lib/sage/client-directory-import.ts
+++ b/src/lib/sage/client-directory-import.ts
@@ -1,0 +1,154 @@
+export type SageClientDirectoryRecord = {
+  readonly clientNumber: string
+  readonly name: string
+}
+
+export type StableSageClientDirectory = {
+  readonly clients: readonly SageClientDirectoryRecord[]
+  readonly conflictingClientNumbers: readonly string[]
+}
+
+function cleanText(value: string): string {
+  return value.trim()
+}
+
+function sqlLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`
+}
+
+export function stableSageClientDirectory(
+  records: readonly SageClientDirectoryRecord[]
+): StableSageClientDirectory {
+  const namesByNumber = new Map<string, Map<string, string>>()
+  for (const record of records) {
+    const clientNumber = cleanText(record.clientNumber)
+    const name = cleanText(record.name)
+    if (!clientNumber || !name) continue
+    const normalizedName = name.toLocaleLowerCase("en-US")
+    const names = namesByNumber.get(clientNumber) ?? new Map<string, string>()
+    names.set(normalizedName, name)
+    namesByNumber.set(clientNumber, names)
+  }
+
+  const clients: SageClientDirectoryRecord[] = []
+  const conflictingClientNumbers: string[] = []
+  for (const [clientNumber, names] of namesByNumber) {
+    if (names.size !== 1) {
+      conflictingClientNumbers.push(clientNumber)
+      continue
+    }
+    const name = names.values().next().value
+    if (!name) continue
+    clients.push({ clientNumber, name })
+  }
+
+  return {
+    clients: clients.sort((left, right) =>
+      left.name.localeCompare(right.name, "en-US")
+    ),
+    conflictingClientNumbers: conflictingClientNumbers.sort(),
+  }
+}
+
+function sageClientValues(
+  clients: readonly SageClientDirectoryRecord[]
+): string {
+  return clients
+    .map(
+      (client) =>
+        `(${sqlLiteral(client.clientNumber)}, ${sqlLiteral(client.name)})`
+    )
+    .join(",\n    ")
+}
+
+export function buildSageClientDirectoryImportSql(input: {
+  readonly organizationId: string
+  readonly records: readonly SageClientDirectoryRecord[]
+}): string {
+  const organizationId = cleanText(input.organizationId)
+  if (!organizationId) throw new Error("Organization ID is required.")
+
+  const stable = stableSageClientDirectory(input.records)
+  if (stable.clients.length === 0) {
+    throw new Error("The Sage export did not contain any stable client records.")
+  }
+  const values = sageClientValues(stable.clients)
+  const organization = sqlLiteral(organizationId)
+
+  return `-- Generated Sage client directory import (${stable.clients.length} stable records).
+-- Exact one-to-one names are linked. Ambiguous names are inserted separately for review.
+WITH sage_clients(client_number, name) AS (
+  VALUES
+    ${values}
+),
+possible_matches AS (
+  SELECT sc.client_number, c.id AS customer_id
+  FROM sage_clients sc
+  INNER JOIN customers c
+    ON c.organization_id = ${organization}
+   AND lower(trim(c.name)) = lower(trim(sc.name))
+   AND (
+     c.sage_client_number IS NULL
+     OR trim(c.sage_client_number) = ''
+     OR trim(c.sage_client_number) = sc.client_number
+   )
+),
+source_unique_matches AS (
+  SELECT client_number, MIN(customer_id) AS customer_id
+  FROM possible_matches
+  GROUP BY client_number
+  HAVING COUNT(DISTINCT customer_id) = 1
+),
+one_to_one_matches AS (
+  SELECT MIN(client_number) AS client_number, customer_id
+  FROM source_unique_matches
+  GROUP BY customer_id
+  HAVING COUNT(DISTINCT client_number) = 1
+)
+UPDATE customers
+SET
+  sage_client_number = (
+    SELECT match.client_number
+    FROM one_to_one_matches match
+    WHERE match.customer_id = customers.id
+  ),
+  relationship_type = 'client',
+  updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE id IN (SELECT customer_id FROM one_to_one_matches);
+
+WITH sage_clients(client_number, name) AS (
+  VALUES
+    ${values}
+)
+INSERT OR IGNORE INTO customers (
+  id, name, company, email, phone, address, notes, netsuite_id,
+  sage_client_id, sage_client_number, sage_client_status_id,
+  buildertrend_contact_id, relationship_type,
+  organization_id, created_at, updated_at
+)
+SELECT
+  'sage-customer-' || ${organization} || '-' || sc.client_number,
+  sc.name,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  'Imported from the Sage client directory. Portal access is not granted by this import.',
+  NULL,
+  NULL,
+  sc.client_number,
+  NULL,
+  NULL,
+  'client',
+  ${organization},
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+  strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+FROM sage_clients sc
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM customers c
+  WHERE c.organization_id = ${organization}
+    AND c.sage_client_number = sc.client_number
+);
+`
+}


### PR DESCRIPTION
## Summary
- replace duplicate vendor company entry with a shared vendor-company and contact-person directory flow
- add Sage division and cost-code selectors to project contacts
- import Buildertrend clients/leads without granting access and reconcile exact matches to existing Sage clients
- require an individual vendor contact before project invitations

## Data safety
- directory creation in Compass does not create a Sage client
- directory presence does not grant project access
- ambiguous identity matches remain separate for manual review
- production rehearsal preserves existing invitations and project memberships

## Verification
- 940 Vitest tests passed
- TypeScript passed
- ESLint passed with existing repository warnings only
- production Next.js build passed
- full migration chain passed on a fresh database
- migration and Sage import rehearsed against a production export
- project contact and Contacts directory flows browser-verified
