### PR TITLE
fix(settings): repair internal user invitations

### DIFF
--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -16,7 +16,8 @@ import {
 import { getCurrentUser } from "@/lib/auth"
 import { canManageUserAccess, requirePermission } from "@/lib/permissions"
 import { isDemoOrg, isDemoUser } from "@/lib/demo"
-import { eq, and, getTableColumns } from "drizzle-orm"
+import { sendOrResendWorkOSInvitation } from "@/lib/workos-invitations"
+import { eq, and, getTableColumns, or, sql } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import {
   updateUserRoleSchema,
@@ -32,9 +33,20 @@ export type UserWithRelations = User & {
   groups: { id: string; name: string; color: string | null }[]
   projectCount: number
   organizationCount: number
+  accessStatus: "active" | "invited"
 }
 
-export async function getUsers(): Promise<UserWithRelations[]> {
+function isPendingInvitationPlaceholder(user: User): boolean {
+  return (
+    !user.isActive &&
+    user.lastLoginAt === null &&
+    !user.id.startsWith("user_")
+  )
+}
+
+async function getOrganizationUsers(
+  includeInvited: boolean
+): Promise<UserWithRelations[]> {
   try {
     const currentUser = await getCurrentUser()
     requirePermission(currentUser, "user", "read")
@@ -51,6 +63,16 @@ export async function getUsers(): Promise<UserWithRelations[]> {
 
     const db = getDb(env.DB)
     const organizationId = currentUser.organizationId
+    const availabilityCondition = includeInvited
+      ? or(
+          eq(users.isActive, true),
+          and(
+            eq(users.isActive, false),
+            sql`${users.lastLoginAt} IS NULL`,
+            sql`${users.id} NOT LIKE 'user\_%' ESCAPE '\'`
+          )
+        )
+      : eq(users.isActive, true)
 
     // Never expose users from another organization in the people directory.
     const allUsers = await db
@@ -59,7 +81,7 @@ export async function getUsers(): Promise<UserWithRelations[]> {
       .innerJoin(organizationMembers, eq(organizationMembers.userId, users.id))
       .where(
         and(
-          eq(users.isActive, true),
+          availabilityCondition,
           eq(organizationMembers.organizationId, organizationId)
         )
       )
@@ -67,6 +89,9 @@ export async function getUsers(): Promise<UserWithRelations[]> {
     // for each user, fetch their teams, groups, and counts
     const usersWithRelations = await Promise.all(
       allUsers.map(async (user) => {
+        const accessStatus: UserWithRelations["accessStatus"] = user.isActive
+          ? "active"
+          : "invited"
         // get teams
         const userTeams = await db
           .select({ id: teams.id, name: teams.name })
@@ -116,6 +141,7 @@ export async function getUsers(): Promise<UserWithRelations[]> {
           groups: userGroups,
           projectCount,
           organizationCount,
+          accessStatus,
         }
       })
     )
@@ -125,6 +151,16 @@ export async function getUsers(): Promise<UserWithRelations[]> {
     console.error("Error fetching users:", error)
     return []
   }
+}
+
+/** Active users available to collaboration and assignment surfaces. */
+export async function getUsers(): Promise<UserWithRelations[]> {
+  return getOrganizationUsers(false)
+}
+
+/** Settings roster, including pending invitation placeholders. */
+export async function getSettingsUsers(): Promise<UserWithRelations[]> {
+  return getOrganizationUsers(true)
 }
 
 export async function updateUserRole(
@@ -459,6 +495,7 @@ export async function inviteUser(
   }
 
   const validated = parseResult.data
+  const normalizedEmail = validated.email.trim().toLowerCase()
 
   try {
     const currentUser = await getCurrentUser()
@@ -488,11 +525,11 @@ export async function inviteUser(
     const now = new Date().toISOString()
 
     // check if user already exists
-    const existing = await db.select().from(users).where(eq(users.email, validated.email)).get()
-
-    if (existing) {
-      return { success: false, error: "User already exists" }
-    }
+    const existing = await db
+      .select()
+      .from(users)
+      .where(sql`lower(trim(${users.email})) = ${normalizedEmail}`)
+      .get()
 
     // check if workos is configured
     const envRecord = env as unknown as Record<string, string>
@@ -504,27 +541,66 @@ export async function inviteUser(
     if (isWorkOSConfigured) {
       // send invitation through workos
       try {
-        const { WorkOS } = await import("@workos-inc/node")
-        const workos = new WorkOS(envRecord.WORKOS_API_KEY)
+        if (existing) {
+          if (!isPendingInvitationPlaceholder(existing)) {
+            return { success: false, error: "User already exists" }
+          }
+          const existingMembership = await db
+            .select({ id: organizationMembers.id })
+            .from(organizationMembers)
+            .where(
+              and(
+                eq(organizationMembers.userId, existing.id),
+                eq(organizationMembers.organizationId, targetOrganizationId)
+              )
+            )
+            .get()
+          if (!existingMembership) {
+            return {
+              success: false,
+              error: "This pending user belongs to another organization",
+            }
+          }
 
-        // send invitation via workos
-        // note: when user accepts, they'll be created in workos
-        // and on first login, ensureUserExists() will sync them to our db
-        await workos.userManagement.sendInvitation({
-          email: validated.email,
+          const resendResult = await sendOrResendWorkOSInvitation({
+            apiKey: envRecord.WORKOS_API_KEY,
+            email: normalizedEmail,
+          })
+          if (!resendResult.success) return resendResult
+
+          await db
+            .update(users)
+            .set({ role: validated.role, updatedAt: now })
+            .where(eq(users.id, existing.id))
+            .run()
+          await db
+            .update(organizationMembers)
+            .set({ role: validated.role })
+            .where(eq(organizationMembers.id, existingMembership.id))
+            .run()
+          revalidatePath("/dashboard/settings")
+          revalidatePath("/dashboard/people")
+          return { success: true }
+        }
+
+        // On first login, ensureUserExists() activates the pending local row.
+        const invitationResult = await sendOrResendWorkOSInvitation({
+          apiKey: envRecord.WORKOS_API_KEY,
+          email: normalizedEmail,
         })
+        if (!invitationResult.success) return invitationResult
 
         // create pending user record in our db
         const newUser: NewUser = {
           id: crypto.randomUUID(), // temporary until workos creates real user
-          email: validated.email,
+          email: normalizedEmail,
           role: validated.role,
           isActive: false, // inactive until they accept invite
           createdAt: now,
           updatedAt: now,
           firstName: null,
           lastName: null,
-          displayName: validated.email.split("@")[0],
+          displayName: normalizedEmail.split("@")[0],
           avatarUrl: null,
           lastLoginAt: null,
         }
@@ -543,6 +619,7 @@ export async function inviteUser(
           })
           .run()
 
+        revalidatePath("/dashboard/settings")
         revalidatePath("/dashboard/people")
         return { success: true }
       } catch (workosError) {
@@ -553,17 +630,20 @@ export async function inviteUser(
         }
       }
     } else {
+      if (existing) {
+        return { success: false, error: "User already exists" }
+      }
       // development mode: just create user in db without sending email
       const newUser: NewUser = {
         id: crypto.randomUUID(),
-        email: validated.email,
+        email: normalizedEmail,
         role: validated.role,
         isActive: true, // active immediately in dev mode
         createdAt: now,
         updatedAt: now,
         firstName: null,
         lastName: null,
-        displayName: validated.email.split("@")[0],
+        displayName: normalizedEmail.split("@")[0],
         avatarUrl: null,
         lastLoginAt: null,
       }
@@ -581,6 +661,7 @@ export async function inviteUser(
         })
         .run()
 
+      revalidatePath("/dashboard/settings")
       revalidatePath("/dashboard/people")
       return { success: true }
     }

--- a/src/components/people-table.tsx
+++ b/src/components/people-table.tsx
@@ -54,6 +54,7 @@ interface PeopleTableProps {
   users: UserWithRelations[]
   onEditUser?: (user: UserWithRelations) => void
   onDeactivateUser?: (userId: string) => void
+  onReinviteUser?: (user: UserWithRelations) => void
   /** Hides select, teams, groups, and projects columns */
   compact?: boolean
 }
@@ -62,6 +63,7 @@ export function PeopleTable({
   users,
   onEditUser,
   onDeactivateUser,
+  onReinviteUser,
   compact = false,
 }: PeopleTableProps) {
   const isMobile = useIsMobile()
@@ -108,9 +110,14 @@ export function PeopleTable({
               <IconUserCircle className="size-8 text-muted-foreground" />
             )}
             <div className="flex flex-col">
-              <span className="font-medium">
-                {user.displayName || user.email.split("@")[0]}
-              </span>
+              <div className="flex items-center gap-2">
+                <span className="font-medium">
+                  {user.displayName || user.email.split("@")[0]}
+                </span>
+                {user.accessStatus === "invited" && (
+                  <Badge variant="secondary">Invited</Badge>
+                )}
+              </div>
               <span className="text-sm text-muted-foreground flex items-center gap-1">
                 <IconMail className="size-3" />
                 {user.email}
@@ -198,18 +205,26 @@ export function PeopleTable({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={() => onEditUser?.(user)}>
-                Edit User
-              </DropdownMenuItem>
-              <DropdownMenuItem>Assign to Project</DropdownMenuItem>
-              <DropdownMenuItem>Assign to Team</DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                className="text-destructive"
-                onClick={() => onDeactivateUser?.(user.id)}
-              >
-                Deactivate
-              </DropdownMenuItem>
+              {user.accessStatus === "invited" ? (
+                <DropdownMenuItem onClick={() => onReinviteUser?.(user)}>
+                  Send invitation again
+                </DropdownMenuItem>
+              ) : (
+                <>
+                  <DropdownMenuItem onClick={() => onEditUser?.(user)}>
+                    Edit User
+                  </DropdownMenuItem>
+                  <DropdownMenuItem>Assign to Project</DropdownMenuItem>
+                  <DropdownMenuItem>Assign to Team</DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    className="text-destructive"
+                    onClick={() => onDeactivateUser?.(user.id)}
+                  >
+                    Deactivate
+                  </DropdownMenuItem>
+                </>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         )

--- a/src/components/settings/team-tab.tsx
+++ b/src/components/settings/team-tab.tsx
@@ -4,7 +4,12 @@ import * as React from "react"
 import { IconUserPlus } from "@tabler/icons-react"
 import { toast } from "sonner"
 
-import { getUsers, deactivateUser, type UserWithRelations } from "@/app/actions/users"
+import {
+  getSettingsUsers,
+  deactivateUser,
+  inviteUser,
+  type UserWithRelations,
+} from "@/app/actions/users"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { PeopleTable } from "@/components/people-table"
@@ -25,7 +30,7 @@ export function TeamTab() {
 
   const loadUsers = async () => {
     try {
-      const data = await getUsers()
+      const data = await getSettingsUsers()
       setUsers(data)
     } catch (error) {
       console.error("Failed to load users:", error)
@@ -52,6 +57,21 @@ export function TeamTab() {
     } catch (error) {
       console.error("Failed to deactivate user:", error)
       toast.error("Failed to deactivate user")
+    }
+  }
+
+  const handleReinviteUser = async (user: UserWithRelations) => {
+    try {
+      const result = await inviteUser(user.email, user.role)
+      if (result.success) {
+        toast.success("Invitation sent again")
+        await loadUsers()
+      } else {
+        toast.error(result.error || "Failed to resend invitation")
+      }
+    } catch (error) {
+      console.error("Failed to resend invitation:", error)
+      toast.error("Failed to resend invitation")
     }
   }
 
@@ -99,6 +119,7 @@ export function TeamTab() {
             users={users}
             onEditUser={handleEditUser}
             onDeactivateUser={handleDeactivateUser}
+            onReinviteUser={handleReinviteUser}
           />
         )}
       </div>

--- a/src/lib/__tests__/workos-invitations.test.ts
+++ b/src/lib/__tests__/workos-invitations.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const workosMocks = vi.hoisted(() => ({
+  listInvitations: vi.fn(),
+  resendInvitation: vi.fn(),
+  sendInvitation: vi.fn(),
+}))
+
+vi.mock("@workos-inc/node", () => ({
+  WorkOS: class MockWorkOS {
+    readonly userManagement = workosMocks
+  },
+}))
+
+import { sendOrResendWorkOSInvitation } from "../workos-invitations"
+
+describe("sendOrResendWorkOSInvitation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("resends a pending invitation", async () => {
+    workosMocks.listInvitations.mockResolvedValue({
+      data: [{ id: "invitation_pending", state: "pending" }],
+    })
+
+    const result = await sendOrResendWorkOSInvitation({
+      apiKey: "test-key",
+      email: "staff@example.com",
+    })
+
+    expect(result).toEqual({ success: true })
+    expect(workosMocks.resendInvitation).toHaveBeenCalledWith(
+      "invitation_pending"
+    )
+    expect(workosMocks.sendInvitation).not.toHaveBeenCalled()
+  })
+
+  it("creates a replacement invitation after expiration", async () => {
+    workosMocks.listInvitations.mockResolvedValue({
+      data: [{ id: "invitation_expired", state: "expired" }],
+    })
+
+    const result = await sendOrResendWorkOSInvitation({
+      apiKey: "test-key",
+      email: "staff@example.com",
+    })
+
+    expect(result).toEqual({ success: true })
+    expect(workosMocks.sendInvitation).toHaveBeenCalledWith({
+      email: "staff@example.com",
+    })
+    expect(workosMocks.resendInvitation).not.toHaveBeenCalled()
+  })
+
+  it("does not duplicate an accepted invitation", async () => {
+    workosMocks.listInvitations.mockResolvedValue({
+      data: [{ id: "invitation_accepted", state: "accepted" }],
+    })
+
+    const result = await sendOrResendWorkOSInvitation({
+      apiKey: "test-key",
+      email: "staff@example.com",
+    })
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        "Invitation was already accepted. Ask the user to sign in to activate their Compass account.",
+    })
+    expect(workosMocks.sendInvitation).not.toHaveBeenCalled()
+    expect(workosMocks.resendInvitation).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/validations/__tests__/users.test.ts
+++ b/src/lib/validations/__tests__/users.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  assignUserToProjectSchema,
+  deactivateUserSchema,
+  inviteUserSchema,
+  updateUserRoleSchema,
+} from "../users"
+
+describe("inviteUserSchema", () => {
+  const validInvite = {
+    email: "new.staff@example.com",
+    role: "office",
+  } as const
+
+  it("accepts the legacy organization IDs used by Compass production", () => {
+    const result = inviteUserSchema.safeParse({
+      ...validInvite,
+      organizationId: "org-1",
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it("continues to accept UUID organization IDs", () => {
+    const result = inviteUserSchema.safeParse({
+      ...validInvite,
+      organizationId: "bc817751-f289-4c57-bac7-b5bc08d3a61e",
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects malformed organization identifiers", () => {
+    const result = inviteUserSchema.safeParse({
+      ...validInvite,
+      organizationId: "org 1",
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("Invalid identifier format")
+    }
+  })
+})
+
+describe("settings user identifier validation", () => {
+  it("accepts WorkOS user IDs for role and deactivation actions", () => {
+    const workosUserId = "user_01KGSRW8957M25E2YJ1XTMS74Q"
+
+    expect(
+      updateUserRoleSchema.safeParse({ userId: workosUserId, role: "office" })
+        .success
+    ).toBe(true)
+    expect(deactivateUserSchema.safeParse({ userId: workosUserId }).success).toBe(
+      true
+    )
+  })
+
+  it("accepts legacy project IDs when assigning a user", () => {
+    const result = assignUserToProjectSchema.safeParse({
+      userId: "user_01KGSRW8957M25E2YJ1XTMS74Q",
+      projectId: "proj-o-202-loeffler",
+      role: "field_superintendent",
+    })
+
+    expect(result.success).toBe(true)
+  })
+})

--- a/src/lib/validations/common.ts
+++ b/src/lib/validations/common.ts
@@ -13,6 +13,16 @@ export const uuidSchema = z
   .string()
   .uuid("Invalid identifier format")
 
+// Compass contains both UUIDs and stable legacy/source identifiers such as
+// `org-1` and WorkOS-style `user_...` values. Use this schema when validating
+// an existing database record ID rather than a value that must be a UUID.
+export const databaseIdSchema = z
+  .string()
+  .trim()
+  .min(1, "Identifier is required")
+  .max(255, "Identifier is too long")
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/, "Invalid identifier format")
+
 export const nonEmptyString = z
   .string()
   .min(1, "This field is required")

--- a/src/lib/validations/users.ts
+++ b/src/lib/validations/users.ts
@@ -1,10 +1,15 @@
 import { z } from "zod"
-import { emailSchema, uuidSchema, userRoleSchema, nonEmptyString } from "./common"
+import {
+  databaseIdSchema,
+  emailSchema,
+  userRoleSchema,
+  nonEmptyString,
+} from "./common"
 
 // --- Update user role ---
 
 export const updateUserRoleSchema = z.object({
-  userId: uuidSchema,
+  userId: databaseIdSchema,
   role: userRoleSchema,
 })
 
@@ -13,7 +18,7 @@ export type UpdateUserRoleInput = z.infer<typeof updateUserRoleSchema>
 // --- Deactivate user ---
 
 export const deactivateUserSchema = z.object({
-  userId: uuidSchema,
+  userId: databaseIdSchema,
 })
 
 export type DeactivateUserInput = z.infer<typeof deactivateUserSchema>
@@ -23,7 +28,7 @@ export type DeactivateUserInput = z.infer<typeof deactivateUserSchema>
 export const inviteUserSchema = z.object({
   email: emailSchema,
   role: userRoleSchema,
-  organizationId: uuidSchema.optional(),
+  organizationId: databaseIdSchema.optional(),
 })
 
 export type InviteUserInput = z.infer<typeof inviteUserSchema>
@@ -31,8 +36,8 @@ export type InviteUserInput = z.infer<typeof inviteUserSchema>
 // --- Assign user to project ---
 
 export const assignUserToProjectSchema = z.object({
-  userId: uuidSchema,
-  projectId: uuidSchema,
+  userId: databaseIdSchema,
+  projectId: databaseIdSchema,
   role: nonEmptyString,
 })
 
@@ -41,8 +46,8 @@ export type AssignUserToProjectInput = z.infer<typeof assignUserToProjectSchema>
 // --- Assign user to team ---
 
 export const assignUserToTeamSchema = z.object({
-  userId: uuidSchema,
-  teamId: uuidSchema,
+  userId: databaseIdSchema,
+  teamId: databaseIdSchema,
 })
 
 export type AssignUserToTeamInput = z.infer<typeof assignUserToTeamSchema>
@@ -50,8 +55,8 @@ export type AssignUserToTeamInput = z.infer<typeof assignUserToTeamSchema>
 // --- Assign user to group ---
 
 export const assignUserToGroupSchema = z.object({
-  userId: uuidSchema,
-  groupId: uuidSchema,
+  userId: databaseIdSchema,
+  groupId: databaseIdSchema,
 })
 
 export type AssignUserToGroupInput = z.infer<typeof assignUserToGroupSchema>
@@ -59,8 +64,8 @@ export type AssignUserToGroupInput = z.infer<typeof assignUserToGroupSchema>
 // --- Remove user from team ---
 
 export const removeUserFromTeamSchema = z.object({
-  userId: uuidSchema,
-  teamId: uuidSchema,
+  userId: databaseIdSchema,
+  teamId: databaseIdSchema,
 })
 
 export type RemoveUserFromTeamInput = z.infer<typeof removeUserFromTeamSchema>
@@ -68,8 +73,8 @@ export type RemoveUserFromTeamInput = z.infer<typeof removeUserFromTeamSchema>
 // --- Remove user from group ---
 
 export const removeUserFromGroupSchema = z.object({
-  userId: uuidSchema,
-  groupId: uuidSchema,
+  userId: databaseIdSchema,
+  groupId: databaseIdSchema,
 })
 
 export type RemoveUserFromGroupInput = z.infer<typeof removeUserFromGroupSchema>

--- a/src/lib/workos-invitations.ts
+++ b/src/lib/workos-invitations.ts
@@ -1,0 +1,38 @@
+export type WorkOSInvitationDeliveryResult =
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string }
+
+/** Resends a pending invitation or creates a replacement for an expired one. */
+export async function sendOrResendWorkOSInvitation(input: {
+  readonly apiKey: string
+  readonly email: string
+}): Promise<WorkOSInvitationDeliveryResult> {
+  const { WorkOS } = await import("@workos-inc/node")
+  const workos = new WorkOS(input.apiKey)
+  const invitations = await workos.userManagement.listInvitations({
+    email: input.email,
+    limit: 100,
+  })
+  const existingInvitations = invitations.data
+  const pendingInvitation = existingInvitations.find(
+    (invitation) => invitation.state === "pending"
+  )
+
+  if (pendingInvitation) {
+    await workos.userManagement.resendInvitation(pendingInvitation.id)
+    return { success: true }
+  }
+
+  if (
+    existingInvitations.some((invitation) => invitation.state === "accepted")
+  ) {
+    return {
+      success: false,
+      error:
+        "Invitation was already accepted. Ask the user to sign in to activate their Compass account.",
+    }
+  }
+
+  await workos.userManagement.sendInvitation({ email: input.email })
+  return { success: true }
+}


### PR DESCRIPTION
Summary
- accept Compass legacy identifiers in Settings user actions while retaining UUID validation
- show pending internal invitations in Settings with clear invited and reinvite states
- resend pending WorkOS invitations and replace expired or revoked invitations
- keep pending invite placeholders out of active collaboration user lists

Validation
- bun run test: 978 passed
- bunx tsc --noEmit
- bun lint: 0 errors
- bun run build