### PR TITLE
fix(settings): restore team roster

### DIFF
--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -17,7 +17,8 @@ import { getCurrentUser } from "@/lib/auth"
 import { canManageUserAccess, requirePermission } from "@/lib/permissions"
 import { isDemoOrg, isDemoUser } from "@/lib/demo"
 import { sendOrResendWorkOSInvitation } from "@/lib/workos-invitations"
-import { eq, and, getTableColumns, or, sql } from "drizzle-orm"
+import { getUserAvailabilityCondition } from "@/lib/user-availability"
+import { eq, and, getTableColumns, sql } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import {
   updateUserRoleSchema,
@@ -63,16 +64,7 @@ async function getOrganizationUsers(
 
     const db = getDb(env.DB)
     const organizationId = currentUser.organizationId
-    const availabilityCondition = includeInvited
-      ? or(
-          eq(users.isActive, true),
-          and(
-            eq(users.isActive, false),
-            sql`${users.lastLoginAt} IS NULL`,
-            sql`${users.id} NOT LIKE 'user\_%' ESCAPE '\'`
-          )
-        )
-      : eq(users.isActive, true)
+    const availabilityCondition = getUserAvailabilityCondition(includeInvited)
 
     // Never expose users from another organization in the people directory.
     const allUsers = await db

--- a/src/lib/__tests__/user-availability.test.ts
+++ b/src/lib/__tests__/user-availability.test.ts
@@ -1,0 +1,60 @@
+import Database from "better-sqlite3"
+import { drizzle } from "drizzle-orm/better-sqlite3"
+import { describe, expect, it } from "vitest"
+
+import { users } from "@/db/schema"
+import { getUserAvailabilityCondition } from "@/lib/user-availability"
+
+function createUsersDatabase(): InstanceType<typeof Database> {
+  const sqlite = new Database(":memory:")
+  sqlite.exec(`
+    CREATE TABLE users (
+      id TEXT PRIMARY KEY,
+      is_active INTEGER NOT NULL,
+      last_login_at TEXT
+    );
+    INSERT INTO users (id, is_active, last_login_at) VALUES
+      ('user_active', 1, '2026-08-20T00:00:00.000Z'),
+      ('user_deactivated', 0, NULL),
+      ('pending-invitation-id', 0, NULL),
+      ('legacy-deactivated-id', 0, '2026-08-19T00:00:00.000Z');
+  `)
+  return sqlite
+}
+
+describe("getUserAvailabilityCondition", () => {
+  it("returns active users and pending invitation placeholders for Settings", () => {
+    const sqlite = createUsersDatabase()
+    try {
+      const db = drizzle(sqlite)
+      const result = db
+        .select({ id: users.id })
+        .from(users)
+        .where(getUserAvailabilityCondition(true))
+        .all()
+
+      expect(result.map((row) => row.id).sort()).toEqual([
+        "pending-invitation-id",
+        "user_active",
+      ])
+    } finally {
+      sqlite.close()
+    }
+  })
+
+  it("returns only active users for collaboration surfaces", () => {
+    const sqlite = createUsersDatabase()
+    try {
+      const db = drizzle(sqlite)
+      const result = db
+        .select({ id: users.id })
+        .from(users)
+        .where(getUserAvailabilityCondition(false))
+        .all()
+
+      expect(result).toEqual([{ id: "user_active" }])
+    } finally {
+      sqlite.close()
+    }
+  })
+})

--- a/src/lib/user-availability.ts
+++ b/src/lib/user-availability.ts
@@ -1,0 +1,27 @@
+import { and, eq, isNull, or, sql, type SQL } from "drizzle-orm"
+
+import { users } from "@/db/schema"
+
+const WORKOS_USER_ID_PREFIX = "user_"
+
+/**
+ * Active-user surfaces exclude invitation placeholders. Settings also includes
+ * pending local invitations, while keeping deactivated WorkOS users hidden.
+ */
+export function getUserAvailabilityCondition(includeInvited: boolean): SQL {
+  if (!includeInvited) return eq(users.isActive, true)
+
+  const condition = or(
+    eq(users.isActive, true),
+    and(
+      eq(users.isActive, false),
+      isNull(users.lastLoginAt),
+      sql`substr(${users.id}, 1, ${WORKOS_USER_ID_PREFIX.length}) <> ${WORKOS_USER_ID_PREFIX}`
+    )
+  )
+
+  if (condition === undefined) {
+    throw new Error("Failed to build the settings user availability condition")
+  }
+  return condition
+}


### PR DESCRIPTION
## Summary

- replace the invalid SQLite LIKE escape expression that caused Settings → Team to return an empty roster
- preserve active users and pending invitation placeholders while keeping deactivated WorkOS users hidden
- add an in-memory SQLite regression test for both Settings and collaboration user filters

## Validation

- bun test (1,002 tests passed)
- bunx vitest run src/lib/__tests__/user-availability.test.ts
- bunx tsc --noEmit
- bun lint (0 errors; existing warnings only)
- bun run build
- pre-push production build