### PR TITLE
fix(settings): surface pending team invitations

### DIFF
--- a/src/app/actions/users.ts
+++ b/src/app/actions/users.ts
@@ -17,7 +17,10 @@ import { getCurrentUser } from "@/lib/auth"
 import { canManageUserAccess, requirePermission } from "@/lib/permissions"
 import { isDemoOrg, isDemoUser } from "@/lib/demo"
 import { sendOrResendWorkOSInvitation } from "@/lib/workos-invitations"
-import { getUserAvailabilityCondition } from "@/lib/user-availability"
+import {
+  getUserAvailabilityCondition,
+  sortSettingsRosterUsers,
+} from "@/lib/user-availability"
 import { eq, and, getTableColumns, sql } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import {
@@ -138,7 +141,9 @@ async function getOrganizationUsers(
       })
     )
 
-    return usersWithRelations
+    return includeInvited
+      ? sortSettingsRosterUsers(usersWithRelations)
+      : usersWithRelations
   } catch (error) {
     console.error("Error fetching users:", error)
     return []
@@ -474,13 +479,17 @@ export async function assignUserToGroup(
   }
 }
 
-export async function inviteUser(
-  email: string,
-  role: string,
-  organizationId?: string
-): Promise<{ success: boolean; error?: string }> {
+export async function inviteUser(input: {
+  readonly displayName?: string
+  readonly email: string
+  readonly role: string
+  readonly organizationId?: string
+}): Promise<
+  | { readonly success: true; readonly accessStatus: "active" | "invited" }
+  | { readonly success: false; readonly error: string }
+> {
   // validate input
-  const parseResult = inviteUserSchema.safeParse({ email, role, organizationId })
+  const parseResult = inviteUserSchema.safeParse(input)
   if (!parseResult.success) {
     const firstIssue = parseResult.error.issues[0]
     return { success: false, error: firstIssue?.message || "Invalid input" }
@@ -560,9 +569,31 @@ export async function inviteUser(
           })
           if (!resendResult.success) return resendResult
 
+          const workosUser =
+            resendResult.outcome === "existing_user"
+              ? resendResult.user
+              : null
+          const workosDisplayName = workosUser
+            ? [workosUser.firstName, workosUser.lastName]
+                .filter((part): part is string => Boolean(part?.trim()))
+                .join(" ")
+            : ""
+
           await db
             .update(users)
-            .set({ role: validated.role, updatedAt: now })
+            .set({
+              role: validated.role,
+              displayName:
+                validated.displayName ||
+                workosDisplayName ||
+                existing.displayName,
+              firstName: workosUser?.firstName ?? existing.firstName,
+              lastName: workosUser?.lastName ?? existing.lastName,
+              avatarUrl: workosUser?.profilePictureUrl ?? existing.avatarUrl,
+              isActive: workosUser ? true : existing.isActive,
+              lastLoginAt: workosUser?.lastSignInAt ?? existing.lastLoginAt,
+              updatedAt: now,
+            })
             .where(eq(users.id, existing.id))
             .run()
           await db
@@ -572,7 +603,10 @@ export async function inviteUser(
             .run()
           revalidatePath("/dashboard/settings")
           revalidatePath("/dashboard/people")
-          return { success: true }
+          return {
+            success: true,
+            accessStatus: workosUser ? "active" : "invited",
+          }
         }
 
         // On first login, ensureUserExists() activates the pending local row.
@@ -581,6 +615,45 @@ export async function inviteUser(
           email: normalizedEmail,
         })
         if (!invitationResult.success) return invitationResult
+
+        if (invitationResult.outcome === "existing_user") {
+          const workosUser = invitationResult.user
+          const workosDisplayName = [workosUser.firstName, workosUser.lastName]
+            .filter((part): part is string => Boolean(part?.trim()))
+            .join(" ")
+          const newUser: NewUser = {
+            id: workosUser.id,
+            email: normalizedEmail,
+            role: validated.role,
+            isActive: true,
+            createdAt: now,
+            updatedAt: now,
+            firstName: workosUser.firstName,
+            lastName: workosUser.lastName,
+            displayName:
+              validated.displayName ||
+              workosDisplayName ||
+              normalizedEmail.split("@")[0],
+            avatarUrl: workosUser.profilePictureUrl,
+            lastLoginAt: workosUser.lastSignInAt,
+          }
+
+          await db.insert(users).values(newUser).run()
+          await db
+            .insert(organizationMembers)
+            .values({
+              id: crypto.randomUUID(),
+              organizationId: targetOrganizationId,
+              userId: newUser.id,
+              role: validated.role,
+              joinedAt: now,
+            })
+            .run()
+
+          revalidatePath("/dashboard/settings")
+          revalidatePath("/dashboard/people")
+          return { success: true, accessStatus: "active" }
+        }
 
         // create pending user record in our db
         const newUser: NewUser = {
@@ -592,7 +665,8 @@ export async function inviteUser(
           updatedAt: now,
           firstName: null,
           lastName: null,
-          displayName: normalizedEmail.split("@")[0],
+          displayName:
+            validated.displayName ?? normalizedEmail.split("@")[0],
           avatarUrl: null,
           lastLoginAt: null,
         }
@@ -613,7 +687,7 @@ export async function inviteUser(
 
         revalidatePath("/dashboard/settings")
         revalidatePath("/dashboard/people")
-        return { success: true }
+        return { success: true, accessStatus: "invited" }
       } catch (workosError) {
         console.error("WorkOS invitation error:", workosError)
         return {
@@ -635,7 +709,7 @@ export async function inviteUser(
         updatedAt: now,
         firstName: null,
         lastName: null,
-        displayName: normalizedEmail.split("@")[0],
+        displayName: validated.displayName ?? normalizedEmail.split("@")[0],
         avatarUrl: null,
         lastLoginAt: null,
       }
@@ -655,7 +729,7 @@ export async function inviteUser(
 
       revalidatePath("/dashboard/settings")
       revalidatePath("/dashboard/people")
-      return { success: true }
+      return { success: true, accessStatus: "active" }
     }
   } catch (error) {
     console.error("Error inviting user:", error)

--- a/src/components/people-table.tsx
+++ b/src/components/people-table.tsx
@@ -96,6 +96,16 @@ export function PeopleTable({
     {
       accessorKey: "displayName",
       header: "Name",
+      filterFn: (row, _columnId, value) => {
+        const query = String(value).trim().toLowerCase()
+        if (!query) return true
+
+        const user = row.original
+        return (
+          (user.displayName ?? "").toLowerCase().includes(query) ||
+          user.email.toLowerCase().includes(query)
+        )
+      },
       cell: ({ row }) => {
         const user = row.original
         return (
@@ -115,7 +125,7 @@ export function PeopleTable({
                   {user.displayName || user.email.split("@")[0]}
                 </span>
                 {user.accessStatus === "invited" && (
-                  <Badge variant="secondary">Invited</Badge>
+                  <Badge variant="secondary">Invitation pending</Badge>
                 )}
               </div>
               <span className="text-sm text-muted-foreground flex items-center gap-1">
@@ -318,20 +328,35 @@ export function PeopleTable({
                   title={user.displayName || user.email.split("@")[0]}
                   subtitle={user.email}
                   metadata={[
+                    ...(user.accessStatus === "invited"
+                      ? ["Invitation pending"]
+                      : []),
                     roleLabel,
                     ...(teamNames ? [teamNames] : []),
                     ...(user.projectCount > 0 ? [`${user.projectCount} projects`] : []),
                   ]}
-                  actions={[
-                    { label: "Edit User", onClick: () => onEditUser?.(user) },
-                    { label: "Assign to Project", onClick: () => {} },
-                    { label: "Assign to Team", onClick: () => {} },
-                    {
-                      label: "Deactivate",
-                      onClick: () => onDeactivateUser?.(user.id),
-                      destructive: true,
-                    },
-                  ]}
+                  actions={
+                    user.accessStatus === "invited"
+                      ? [
+                          {
+                            label: "Send invitation again",
+                            onClick: () => onReinviteUser?.(user),
+                          },
+                        ]
+                      : [
+                          {
+                            label: "Edit User",
+                            onClick: () => onEditUser?.(user),
+                          },
+                          { label: "Assign to Project", onClick: () => {} },
+                          { label: "Assign to Team", onClick: () => {} },
+                          {
+                            label: "Deactivate",
+                            onClick: () => onDeactivateUser?.(user.id),
+                            destructive: true,
+                          },
+                        ]
+                  }
                 />
               )
             })

--- a/src/components/people/invite-dialog.tsx
+++ b/src/components/people/invite-dialog.tsx
@@ -30,7 +30,7 @@ import {
 interface InviteDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  onUserInvited?: () => void
+  onUserInvited?: () => void | Promise<void>
 }
 
 export function InviteDialog({
@@ -38,6 +38,7 @@ export function InviteDialog({
   onOpenChange,
   onUserInvited,
 }: InviteDialogProps) {
+  const [displayName, setDisplayName] = React.useState("")
   const [email, setEmail] = React.useState("")
   const [role, setRole] = React.useState("office")
   const [organizationId, setOrganizationId] = React.useState<string>("none")
@@ -63,6 +64,11 @@ export function InviteDialog({
   }
 
   const handleInvite = async () => {
+    if (!displayName.trim()) {
+      toast.error("Please enter the user's name")
+      return
+    }
+
     if (!email) {
       toast.error("Please enter an email address")
       return
@@ -75,16 +81,23 @@ export function InviteDialog({
 
     setLoading(true)
     try {
-      const result = await inviteUser(
+      const result = await inviteUser({
+        displayName,
         email,
         role,
-        organizationId === "none" ? undefined : organizationId
-      )
+        organizationId:
+          organizationId === "none" ? undefined : organizationId,
+      })
       if (result.success) {
-        toast.success("User invited successfully")
-        onUserInvited?.()
+        toast.success(
+          result.accessStatus === "invited"
+            ? "Invitation sent — pending acceptance"
+            : "Existing user added to the team"
+        )
+        await onUserInvited?.()
         onOpenChange(false)
         // reset form
+        setDisplayName("")
         setEmail("")
         setRole("office")
         setOrganizationId("none")
@@ -110,6 +123,17 @@ export function InviteDialog({
         </DialogHeader>
 
         <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="display-name">Name *</Label>
+            <Input
+              id="display-name"
+              placeholder="Stanley Platt"
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+              disabled={loading}
+            />
+          </div>
+
           <div className="space-y-2">
             <Label htmlFor="email">Email Address *</Label>
             <Input

--- a/src/components/settings/team-tab.tsx
+++ b/src/components/settings/team-tab.tsx
@@ -62,7 +62,11 @@ export function TeamTab() {
 
   const handleReinviteUser = async (user: UserWithRelations) => {
     try {
-      const result = await inviteUser(user.email, user.role)
+      const result = await inviteUser({
+        displayName: user.displayName ?? undefined,
+        email: user.email,
+        role: user.role,
+      })
       if (result.success) {
         toast.success("Invitation sent again")
         await loadUsers()

--- a/src/lib/__tests__/user-availability.test.ts
+++ b/src/lib/__tests__/user-availability.test.ts
@@ -3,7 +3,10 @@ import { drizzle } from "drizzle-orm/better-sqlite3"
 import { describe, expect, it } from "vitest"
 
 import { users } from "@/db/schema"
-import { getUserAvailabilityCondition } from "@/lib/user-availability"
+import {
+  getUserAvailabilityCondition,
+  sortSettingsRosterUsers,
+} from "@/lib/user-availability"
 
 function createUsersDatabase(): InstanceType<typeof Database> {
   const sqlite = new Database(":memory:")
@@ -56,5 +59,38 @@ describe("getUserAvailabilityCondition", () => {
     } finally {
       sqlite.close()
     }
+  })
+})
+
+describe("sortSettingsRosterUsers", () => {
+  it("puts pending invitations before the paginated active roster", () => {
+    const rosterUsers: Array<{
+      accessStatus: "active" | "invited"
+      displayName: string
+      email: string
+    }> = [
+      {
+        accessStatus: "active",
+        displayName: "Zoe Active",
+        email: "zoe@example.com",
+      },
+      {
+        accessStatus: "invited",
+        displayName: "Stanley Platt",
+        email: "stanley@example.com",
+      },
+      {
+        accessStatus: "active",
+        displayName: "Alice Active",
+        email: "alice@example.com",
+      },
+    ]
+    const result = sortSettingsRosterUsers(rosterUsers)
+
+    expect(result.map((user) => user.displayName)).toEqual([
+      "Stanley Platt",
+      "Alice Active",
+      "Zoe Active",
+    ])
   })
 })

--- a/src/lib/__tests__/workos-invitations.test.ts
+++ b/src/lib/__tests__/workos-invitations.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const workosMocks = vi.hoisted(() => ({
+  listUsers: vi.fn(),
   listInvitations: vi.fn(),
   resendInvitation: vi.fn(),
   sendInvitation: vi.fn(),
@@ -17,6 +18,7 @@ import { sendOrResendWorkOSInvitation } from "../workos-invitations"
 describe("sendOrResendWorkOSInvitation", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    workosMocks.listUsers.mockResolvedValue({ data: [] })
   })
 
   it("resends a pending invitation", async () => {
@@ -29,7 +31,7 @@ describe("sendOrResendWorkOSInvitation", () => {
       email: "staff@example.com",
     })
 
-    expect(result).toEqual({ success: true })
+    expect(result).toEqual({ success: true, outcome: "invitation_sent" })
     expect(workosMocks.resendInvitation).toHaveBeenCalledWith(
       "invitation_pending"
     )
@@ -46,7 +48,7 @@ describe("sendOrResendWorkOSInvitation", () => {
       email: "staff@example.com",
     })
 
-    expect(result).toEqual({ success: true })
+    expect(result).toEqual({ success: true, outcome: "invitation_sent" })
     expect(workosMocks.sendInvitation).toHaveBeenCalledWith({
       email: "staff@example.com",
     })
@@ -70,5 +72,40 @@ describe("sendOrResendWorkOSInvitation", () => {
     })
     expect(workosMocks.sendInvitation).not.toHaveBeenCalled()
     expect(workosMocks.resendInvitation).not.toHaveBeenCalled()
+  })
+
+  it("returns an existing WorkOS user instead of sending another invitation", async () => {
+    workosMocks.listUsers.mockResolvedValue({
+      data: [
+        {
+          id: "user_isabel",
+          email: "isabel@example.com",
+          firstName: "Isabel",
+          lastName: "Araguz",
+          profilePictureUrl: null,
+          lastSignInAt: "2026-08-01T00:00:00.000Z",
+        },
+      ],
+    })
+
+    const result = await sendOrResendWorkOSInvitation({
+      apiKey: "test-key",
+      email: "ISABEL@example.com",
+    })
+
+    expect(result).toEqual({
+      success: true,
+      outcome: "existing_user",
+      user: {
+        id: "user_isabel",
+        email: "isabel@example.com",
+        firstName: "Isabel",
+        lastName: "Araguz",
+        profilePictureUrl: null,
+        lastSignInAt: "2026-08-01T00:00:00.000Z",
+      },
+    })
+    expect(workosMocks.listInvitations).not.toHaveBeenCalled()
+    expect(workosMocks.sendInvitation).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/user-availability.ts
+++ b/src/lib/user-availability.ts
@@ -4,6 +4,12 @@ import { users } from "@/db/schema"
 
 const WORKOS_USER_ID_PREFIX = "user_"
 
+type SettingsRosterUser = {
+  readonly accessStatus: "active" | "invited"
+  readonly displayName: string | null
+  readonly email: string
+}
+
 /**
  * Active-user surfaces exclude invitation placeholders. Settings also includes
  * pending local invitations, while keeping deactivated WorkOS users hidden.
@@ -24,4 +30,19 @@ export function getUserAvailabilityCondition(includeInvited: boolean): SQL {
     throw new Error("Failed to build the settings user availability condition")
   }
   return condition
+}
+
+/** Keeps pending invitations visible before the paginated active roster. */
+export function sortSettingsRosterUsers<User extends SettingsRosterUser>(
+  rosterUsers: readonly User[]
+): User[] {
+  return [...rosterUsers].sort((left, right) => {
+    if (left.accessStatus !== right.accessStatus) {
+      return left.accessStatus === "invited" ? -1 : 1
+    }
+
+    const leftLabel = left.displayName?.trim() || left.email
+    const rightLabel = right.displayName?.trim() || right.email
+    return leftLabel.localeCompare(rightLabel, undefined, { sensitivity: "base" })
+  })
 }

--- a/src/lib/validations/users.ts
+++ b/src/lib/validations/users.ts
@@ -26,6 +26,12 @@ export type DeactivateUserInput = z.infer<typeof deactivateUserSchema>
 // --- Invite user ---
 
 export const inviteUserSchema = z.object({
+  displayName: z
+    .string()
+    .trim()
+    .min(1, "Name is required")
+    .max(120, "Name is too long")
+    .optional(),
   email: emailSchema,
   role: userRoleSchema,
   organizationId: databaseIdSchema.optional(),

--- a/src/lib/workos-invitations.ts
+++ b/src/lib/workos-invitations.ts
@@ -1,5 +1,17 @@
 export type WorkOSInvitationDeliveryResult =
-  | { readonly success: true }
+  | { readonly success: true; readonly outcome: "invitation_sent" }
+  | {
+      readonly success: true
+      readonly outcome: "existing_user"
+      readonly user: {
+        readonly id: string
+        readonly email: string
+        readonly firstName: string | null
+        readonly lastName: string | null
+        readonly profilePictureUrl: string | null
+        readonly lastSignInAt: string | null
+      }
+    }
   | { readonly success: false; readonly error: string }
 
 /** Resends a pending invitation or creates a replacement for an expired one. */
@@ -9,6 +21,29 @@ export async function sendOrResendWorkOSInvitation(input: {
 }): Promise<WorkOSInvitationDeliveryResult> {
   const { WorkOS } = await import("@workos-inc/node")
   const workos = new WorkOS(input.apiKey)
+  const workosUsers = await workos.userManagement.listUsers({
+    email: input.email,
+    limit: 100,
+  })
+  const existingUser = workosUsers.data.find(
+    (user) => user.email.trim().toLowerCase() === input.email.trim().toLowerCase()
+  )
+
+  if (existingUser) {
+    return {
+      success: true,
+      outcome: "existing_user",
+      user: {
+        id: existingUser.id,
+        email: existingUser.email,
+        firstName: existingUser.firstName,
+        lastName: existingUser.lastName,
+        profilePictureUrl: existingUser.profilePictureUrl,
+        lastSignInAt: existingUser.lastSignInAt,
+      },
+    }
+  }
+
   const invitations = await workos.userManagement.listInvitations({
     email: input.email,
     limit: 100,
@@ -20,7 +55,7 @@ export async function sendOrResendWorkOSInvitation(input: {
 
   if (pendingInvitation) {
     await workos.userManagement.resendInvitation(pendingInvitation.id)
-    return { success: true }
+    return { success: true, outcome: "invitation_sent" }
   }
 
   if (
@@ -34,5 +69,5 @@ export async function sendOrResendWorkOSInvitation(input: {
   }
 
   await workos.userManagement.sendInvitation({ email: input.email })
-  return { success: true }
+  return { success: true, outcome: "invitation_sent" }
 }


### PR DESCRIPTION
## Summary
- surface pending internal invitations at the top of Settings → Team on desktop and mobile
- preserve invitee names and make pending invitations eligible for resend
- link existing WorkOS users into the Compass organization instead of failing the invite
- show clear success messaging for invitation sent versus existing account linked

## Validation
- `bun run test` — 181 files, 1008 tests passed
- focused invitation tests — 3 files, 12 tests passed after rebasing on current main
- `bunx tsc --noEmit`
- `bun lint` — 0 errors (existing warnings only)
- `bun run build`
- pre-push production build
