### PR TITLE
fix(schedule): match standard gantt scrolling

### DIFF
--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -430,7 +430,7 @@ test.describe("usable Compass areas", () => {
     await page.keyboard.press("Escape")
   })
 
-  test("Gantt lets each user choose synchronized or independent vertical panes", async ({
+  test("Gantt keeps rows synchronized and reserves horizontal scrolling for Shift", async ({
     page,
   }) => {
     await page.setViewportSize({ width: 1366, height: 768 })
@@ -443,17 +443,8 @@ test.describe("usable Compass areas", () => {
       "/dashboard/projects/e2e-project-001/schedule"
     )
 
-    await page.getByRole("button", { name: "Gantt settings" }).click()
-    const powerUserSwitch = page.getByRole("switch", {
-      name: "Use power-user Gantt scrolling",
-    })
-    await expect(powerUserSwitch).toBeVisible()
-    const taskList = page.locator(".schedule-gantt-task-list")
-    const chart = page.locator(".gantt-container")
-    if (await powerUserSwitch.isChecked()) {
-      await powerUserSwitch.click()
-    }
-    await expect(powerUserSwitch).not.toBeChecked()
+    const taskList = page.locator(".schedule-gantt-task-list:visible").first()
+    const chart = page.locator(".gantt-container:visible").first()
     await expect(taskList).toBeVisible()
     await expect(chart).toBeVisible()
     await taskList.evaluate((element) => {
@@ -465,7 +456,6 @@ test.describe("usable Compass areas", () => {
       element.scrollTop = 0
     })
 
-    await page.keyboard.press("Escape")
     await page.getByRole("button", { name: "Gantt controls" }).click()
     await page.getByRole("menuitem", { name: "Today" }).click()
     await expect
@@ -474,41 +464,56 @@ test.describe("usable Compass areas", () => {
     await expect
       .poll(() => chart.evaluate((element) => element.scrollTop))
       .toBeGreaterThan(0)
+    // Today centers the timeline smoothly; wait for that horizontal animation
+    // to settle before asserting that a regular wheel leaves it anchored.
+    await page.waitForTimeout(750)
 
-    await taskList.evaluate((element) => {
-      element.scrollTop = Math.min(96, element.scrollHeight - element.clientHeight)
-      element.dispatchEvent(new Event("scroll"))
-    })
-    const synchronizedChartTop = await chart.evaluate((element) => element.scrollTop)
-    expect(synchronizedChartTop).toBeGreaterThan(0)
-
-    await page.getByRole("button", { name: "Gantt settings" }).click()
-    await expect(powerUserSwitch).toBeVisible()
-    await powerUserSwitch.click()
-    await expect(powerUserSwitch).toBeChecked()
-    await taskList.evaluate((element) => {
-      element.scrollTop = 0
-    })
+    const ordinaryWheelStart = await chart.evaluate((element) => ({
+      left: element.scrollLeft,
+      top: element.scrollTop,
+    }))
     await chart.evaluate((element) => {
-      element.scrollTop = 0
+      const deltaY = element.scrollTop > 0 ? -48 : 48
+      element.dispatchEvent(
+        new WheelEvent("wheel", {
+          bubbles: true,
+          cancelable: true,
+          deltaX: 120,
+          deltaY,
+        })
+      )
     })
-
-    await page.keyboard.press("Escape")
-    await page.getByRole("button", { name: "Gantt controls" }).click()
-    await page.getByRole("menuitem", { name: "Today" }).click()
     await expect
       .poll(() => chart.evaluate((element) => element.scrollTop))
+      .not.toBe(ordinaryWheelStart.top)
+    expect(await chart.evaluate((element) => element.scrollLeft)).toBe(
+      ordinaryWheelStart.left
+    )
+    await expect
+      .poll(() => taskList.evaluate((element) => element.scrollTop))
       .toBeGreaterThan(0)
-    expect(await taskList.evaluate((element) => element.scrollTop)).toBe(0)
 
-    await taskList.evaluate((element) => {
-      element.scrollTop = Math.min(96, element.scrollHeight - element.clientHeight)
-      element.dispatchEvent(new Event("scroll"))
+    const shiftWheelStart = await chart.evaluate((element) => ({
+      left: element.scrollLeft,
+      top: element.scrollTop,
+    }))
+    await chart.evaluate((element) => {
+      const deltaY = element.scrollLeft > 0 ? -96 : 96
+      element.dispatchEvent(
+        new WheelEvent("wheel", {
+          bubbles: true,
+          cancelable: true,
+          deltaY,
+          shiftKey: true,
+        })
+      )
     })
-    const listTop = await taskList.evaluate((element) => element.scrollTop)
-    const chartTop = await chart.evaluate((element) => element.scrollTop)
-    expect(listTop).toBeGreaterThan(0)
-    expect(chartTop).toBeGreaterThan(0)
+    await expect
+      .poll(() => chart.evaluate((element) => element.scrollLeft))
+      .not.toBe(shiftWheelStart.left)
+    expect(await chart.evaluate((element) => element.scrollTop)).toBe(
+      shiftWheelStart.top
+    )
   })
 
   test("Gantt releases edge wheel input to the surrounding Schedule workspace", async ({

--- a/src/components/schedule/gantt-chart.tsx
+++ b/src/components/schedule/gantt-chart.tsx
@@ -8,7 +8,7 @@ import {
   dominantScrollAxis,
   clampGanttScrollOffset,
   canScrollGanttAxis,
-  lockWheelToDominantAxis,
+  ganttWheelIntent,
   normalizeWheelDelta,
   paddingToIncludeDate,
   type GanttScrollAxis,
@@ -300,53 +300,50 @@ export function GanttChart({
 
       const container = ganttContainerRef.current
       if (!container) return
-      const pageSize = Math.max(
-        container.clientWidth,
-        container.clientHeight
-      )
-      const rawDeltaX =
-        e.shiftKey && e.deltaX === 0 ? e.deltaY : e.deltaX
-      const rawDeltaY =
-        e.shiftKey && e.deltaX === 0 ? 0 : e.deltaY
-      const locked = lockWheelToDominantAxis(
-        normalizeWheelDelta(rawDeltaX, e.deltaMode, pageSize),
-        normalizeWheelDelta(rawDeltaY, e.deltaMode, pageSize)
-      )
-      if (locked.deltaX === 0 && locked.deltaY === 0) return
-      const canScrollHorizontally = canScrollGanttAxis(
-        container.scrollLeft,
-        container.scrollWidth,
-        container.clientWidth,
-        locked.deltaX
-      )
-      const canScrollVertically = canScrollGanttAxis(
-        container.scrollTop,
-        container.scrollHeight,
-        container.clientHeight,
-        locked.deltaY
-      )
-      if (!canScrollHorizontally && !canScrollVertically) {
+      const intent = ganttWheelIntent(e.deltaX, e.deltaY, e.shiftKey)
+      if (!intent) return
+      const pageSize =
+        intent.axis === "vertical"
+          ? container.clientHeight
+          : container.clientWidth
+      const delta = normalizeWheelDelta(intent.delta, e.deltaMode, pageSize)
+      const canScroll =
+        intent.axis === "vertical"
+          ? canScrollGanttAxis(
+              container.scrollTop,
+              container.scrollHeight,
+              container.clientHeight,
+              delta
+            )
+          : canScrollGanttAxis(
+              container.scrollLeft,
+              container.scrollWidth,
+              container.clientWidth,
+              delta
+            )
+      if (!canScroll) {
         const workspace = wrapper.closest<HTMLElement>(
           '[data-dashboard-scroll-region="schedule"]'
         )
         if (
+          intent.axis === "vertical" &&
           workspace &&
           canScrollGanttAxis(
             workspace.scrollTop,
             workspace.scrollHeight,
             workspace.clientHeight,
-            locked.deltaY
+            delta
           )
         ) {
           e.preventDefault()
-          workspace.scrollTop += locked.deltaY
+          workspace.scrollTop += delta
         }
         return
       }
 
       e.preventDefault()
-      container.scrollLeft += locked.deltaX
-      container.scrollTop += locked.deltaY
+      if (intent.axis === "vertical") container.scrollTop += delta
+      else container.scrollLeft += delta
     }
 
     wrapper.addEventListener("wheel", handleWheel, { passive: false })

--- a/src/components/schedule/schedule-gantt-view.tsx
+++ b/src/components/schedule/schedule-gantt-view.tsx
@@ -6,7 +6,6 @@ import {
   useEffect,
   useMemo,
   useRef,
-  useTransition,
   type UIEvent,
 } from "react"
 import {
@@ -68,12 +67,7 @@ import {
 } from "@/lib/schedule/gantt-transform"
 import type { DisplayItem, FrappeTask } from "@/lib/schedule/gantt-transform"
 import { updateTask } from "@/app/actions/schedule"
-import { updateGanttScrollMode } from "@/app/actions/user-schedule-preferences"
-import {
-  DEFAULT_GANTT_SCROLL_MODE,
-  type GanttScrollMode,
-  shouldSynchronizeGanttPanes,
-} from "@/lib/schedule/gantt-interaction-mode"
+import type { GanttScrollMode } from "@/lib/schedule/gantt-interaction-mode"
 import { countBusinessDays } from "@/lib/schedule/business-days"
 import { effectivePercentComplete } from "@/lib/schedule/progress"
 import {
@@ -101,8 +95,7 @@ import { projectScheduleLabel } from "@/lib/schedule/project-scope"
 import {
   centeredGanttRowScrollTop,
   canScrollGanttAxis,
-  ganttRowIndexForScrollTop,
-  lockWheelToDominantAxis,
+  ganttWheelIntent,
   nearestScheduleRowIndexForDate,
   normalizeWheelDelta,
   synchronizedScrollTop,
@@ -134,7 +127,6 @@ export function ScheduleGanttView({
   exceptions,
   assigneeOptions,
   projects = [],
-  ganttScrollMode = DEFAULT_GANTT_SCROLL_MODE,
   groupByPhase = false,
   onGroupByPhaseChange,
 }: ScheduleGanttViewProps) {
@@ -160,8 +152,6 @@ export function ScheduleGanttView({
   )
   const [focusedTaskId, setFocusedTaskId] = useState<string | null>(null)
   const [mobileView, setMobileView] = useState<"tasks" | "chart">("chart")
-  const [scrollMode, setScrollMode] = useState<GanttScrollMode>(ganttScrollMode)
-  const [isSavingScrollMode, startScrollModeTransition] = useTransition()
   const [panMode] = useState(false)
   const taskListRef = useRef<HTMLDivElement>(null)
   const ganttContainerRef = useRef<HTMLElement | null>(null)
@@ -169,9 +159,6 @@ export function ScheduleGanttView({
   const scrollStorageTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const scrollToTodayRef = useRef<(() => void) | null>(null)
   const scrollToDateRef = useRef<((date: string) => void) | null>(null)
-  const scrollTaskIntoViewRef = useRef<((taskId: string) => void) | null>(null)
-  const displayItemsRef = useRef<readonly DisplayItem[]>([])
-  const followedListItemRef = useRef<string | null>(null)
   const scrollRestoredProjectRef = useRef<string | null>(null)
   const preferenceScopeKey = projectId ?? "unified"
   const scrollStorageKey = `compass:schedule-scroll:${preferenceScopeKey}`
@@ -184,10 +171,6 @@ export function ScheduleGanttView({
   useEffect(() => {
     setPhaseGrouping(groupByPhase)
   }, [groupByPhase])
-
-  useEffect(() => {
-    setScrollMode(ganttScrollMode)
-  }, [ganttScrollMode])
 
   const [hasLoadedPalette, setHasLoadedPalette] = useState(false)
 
@@ -263,20 +246,6 @@ export function ScheduleGanttView({
     setColumnWidth(defaultWidths[mode])
   }
 
-  const handleScrollModeChange = (powerUser: boolean): void => {
-    const nextMode: GanttScrollMode = powerUser ? "power" : "default"
-    if (nextMode === scrollMode) return
-    const previousMode = scrollMode
-    setScrollMode(nextMode)
-    startScrollModeTransition(async () => {
-      const result = await updateGanttScrollMode(nextMode)
-      if (!result.success) {
-        setScrollMode(previousMode)
-        toast.error(result.error)
-      }
-    })
-  }
-
   const rememberScrollPosition = useCallback(
     (position: GanttScrollPosition) => {
       scrollPositionRef.current = position
@@ -325,51 +294,59 @@ export function ScheduleGanttView({
     // the task pane just as the timeline does so either side remains usable.
     const handleTaskListWheel = (event: WheelEvent) => {
       if (event.ctrlKey) return
-
-      const pageSize = Math.max(taskList.clientWidth, taskList.clientHeight)
-      const rawDeltaX =
-        event.shiftKey && event.deltaX === 0 ? event.deltaY : event.deltaX
-      const rawDeltaY =
-        event.shiftKey && event.deltaX === 0 ? 0 : event.deltaY
-      const locked = lockWheelToDominantAxis(
-        normalizeWheelDelta(rawDeltaX, event.deltaMode, pageSize),
-        normalizeWheelDelta(rawDeltaY, event.deltaMode, pageSize)
+      const intent = ganttWheelIntent(
+        event.deltaX,
+        event.deltaY,
+        event.shiftKey
       )
-      if (locked.deltaX === 0 && locked.deltaY === 0) return
-      const canScrollHorizontally = canScrollGanttAxis(
-        taskList.scrollLeft,
-        taskList.scrollWidth,
-        taskList.clientWidth,
-        locked.deltaX
+      if (!intent) return
+      const target =
+        intent.axis === "horizontal" ? ganttContainerRef.current : taskList
+      if (!target) return
+      const pageSize =
+        intent.axis === "vertical" ? target.clientHeight : target.clientWidth
+      const delta = normalizeWheelDelta(
+        intent.delta,
+        event.deltaMode,
+        pageSize
       )
-      const canScrollVertically = canScrollGanttAxis(
-        taskList.scrollTop,
-        taskList.scrollHeight,
-        taskList.clientHeight,
-        locked.deltaY
-      )
-      if (!canScrollHorizontally && !canScrollVertically) {
+      const canScroll =
+        intent.axis === "vertical"
+          ? canScrollGanttAxis(
+              target.scrollTop,
+              target.scrollHeight,
+              target.clientHeight,
+              delta
+            )
+          : canScrollGanttAxis(
+              target.scrollLeft,
+              target.scrollWidth,
+              target.clientWidth,
+              delta
+            )
+      if (!canScroll) {
         const workspace = taskList.closest<HTMLElement>(
           '[data-dashboard-scroll-region="schedule"]'
         )
         if (
+          intent.axis === "vertical" &&
           workspace &&
           canScrollGanttAxis(
             workspace.scrollTop,
             workspace.scrollHeight,
             workspace.clientHeight,
-            locked.deltaY
+            delta
           )
         ) {
           event.preventDefault()
-          workspace.scrollTop += locked.deltaY
+          workspace.scrollTop += delta
         }
         return
       }
 
       event.preventDefault()
-      taskList.scrollLeft += locked.deltaX
-      taskList.scrollTop += locked.deltaY
+      if (intent.axis === "vertical") target.scrollTop += delta
+      else target.scrollLeft += delta
     }
 
     taskList.addEventListener("wheel", handleTaskListWheel, {
@@ -426,7 +403,7 @@ export function ScheduleGanttView({
             container.scrollLeft = position.left
           }
           container.scrollTop = position.top
-          if (taskListRef.current && shouldSynchronizeGanttPanes(scrollMode)) {
+          if (taskListRef.current) {
             taskListRef.current.scrollTop = synchronizedScrollTop(
               position.top,
               container.scrollHeight,
@@ -438,14 +415,14 @@ export function ScheduleGanttView({
         })
       })
     },
-    [projectId, scrollMode, scrollStorageKey]
+    [projectId, scrollStorageKey]
   )
 
   const handleGanttScroll = useCallback(
     (position: GanttScrollPosition) => {
       const taskList = taskListRef.current
       const ganttContainer = ganttContainerRef.current
-      if (taskList && ganttContainer && shouldSynchronizeGanttPanes(scrollMode)) {
+      if (taskList && ganttContainer) {
         const synchronizedTop = synchronizedScrollTop(
           position.top,
           ganttContainer.scrollHeight,
@@ -459,14 +436,14 @@ export function ScheduleGanttView({
       }
       rememberScrollPosition(position)
     },
-    [rememberScrollPosition, scrollMode]
+    [rememberScrollPosition]
   )
 
   const handleTaskListScroll = useCallback(
     (event: UIEvent<HTMLDivElement>) => {
       const top = event.currentTarget.scrollTop
       const ganttContainer = ganttContainerRef.current
-      if (ganttContainer && shouldSynchronizeGanttPanes(scrollMode)) {
+      if (ganttContainer) {
         const synchronizedTop = synchronizedScrollTop(
           top,
           event.currentTarget.scrollHeight,
@@ -478,22 +455,6 @@ export function ScheduleGanttView({
           ganttContainer.scrollTop = synchronizedTop
         }
 
-        const itemIndex = ganttRowIndexForScrollTop(
-          top,
-          displayItemsRef.current.length
-        )
-        const item =
-          itemIndex === null ? undefined : displayItemsRef.current[itemIndex]
-        const itemKey =
-          item?.type === "task" ? item.task.id : item?.phase ?? null
-        if (item && itemKey && followedListItemRef.current !== itemKey) {
-          followedListItemRef.current = itemKey
-          if (item.type === "task") {
-            scrollTaskIntoViewRef.current?.(item.task.id)
-          } else {
-            scrollToDateRef.current?.(item.group.startDate)
-          }
-        }
       }
       rememberScrollPosition({
         left: ganttContainer?.scrollLeft ?? scrollPositionRef.current.left,
@@ -503,7 +464,7 @@ export function ScheduleGanttView({
           : {}),
       })
     },
-    [rememberScrollPosition, scrollMode]
+    [rememberScrollPosition]
   )
 
   const openTaskEditor = useCallback(
@@ -597,8 +558,6 @@ export function ScheduleGanttView({
     phaseGrouping,
     projectById,
   ])
-  displayItemsRef.current = displayItems
-
   const togglePhase = (phase: string) => {
     setCollapsedPhases((prev) => {
       const next = new Set(prev)
@@ -655,13 +614,6 @@ export function ScheduleGanttView({
     []
   )
 
-  const handleTaskVisibilityReady = useCallback(
-    (handler: ((taskId: string) => void) | null) => {
-      scrollTaskIntoViewRef.current = handler
-    },
-    []
-  )
-
   const scrollToToday = useCallback(() => {
     const ganttContainer = ganttContainerRef.current
     if (!ganttContainer) {
@@ -696,7 +648,7 @@ export function ScheduleGanttView({
     ganttContainer.scrollTop = ganttTop
 
     const taskList = taskListRef.current
-    if (taskList && shouldSynchronizeGanttPanes(scrollMode)) {
+    if (taskList) {
       taskList.scrollTop = synchronizedScrollTop(
         ganttTop,
         ganttContainer.scrollHeight,
@@ -709,15 +661,12 @@ export function ScheduleGanttView({
     const targetItem = displayItems[rowIndex]
     if (targetItem?.type === "task") {
       setFocusedTaskId(targetItem.task.id)
-      followedListItemRef.current = targetItem.task.id
-    } else if (targetItem) {
-      followedListItemRef.current = targetItem.phase
     }
 
     // Start the smooth horizontal movement last. Assigning scrollTop after
     // scrollTo({ behavior: "smooth" }) cancels that animation in browsers.
     scrollToTodayRef.current?.()
-  }, [displayItems, scrollMode])
+  }, [displayItems])
 
   const taskTable = (
     <Table className="table-fixed">
@@ -1083,26 +1032,6 @@ export function ScheduleGanttView({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-48">
               <div className="space-y-2 px-2 py-1.5">
-                <div className="border-b pb-2">
-                  <div className="flex items-center justify-between gap-2">
-                    <div>
-                      <span className="text-xs">Power-user scrolling</span>
-                      <p className="text-[10px] leading-snug text-muted-foreground">
-                        Scroll task list and chart independently.
-                      </p>
-                    </div>
-                    <Switch
-                      aria-label="Use power-user Gantt scrolling"
-                      checked={scrollMode === "power"}
-                      disabled={isSavingScrollMode}
-                      onCheckedChange={handleScrollModeChange}
-                      className="scale-75"
-                    />
-                  </div>
-                  <p className="mt-1 text-[10px] leading-snug text-muted-foreground">
-                    Default keeps rows aligned. Shift + wheel pans the timeline horizontally in either mode.
-                  </p>
-                </div>
                 <div className="flex items-center justify-between">
                   <span className="text-xs">Group by Phase</span>
                   <Switch
@@ -1151,7 +1080,6 @@ export function ScheduleGanttView({
                 onScrollPositionChange={handleGanttScroll}
                 onTodayScrollReady={handleTodayScrollReady}
                 onDateScrollReady={handleDateScrollReady}
-                onTaskVisibilityReady={handleTaskVisibilityReady}
               />
               {scheduleKey}
             </div>
@@ -1190,7 +1118,6 @@ export function ScheduleGanttView({
                 onScrollPositionChange={handleGanttScroll}
                 onTodayScrollReady={handleTodayScrollReady}
                 onDateScrollReady={handleDateScrollReady}
-                onTaskVisibilityReady={handleTaskVisibilityReady}
               />
               {scheduleKey}
             </div>

--- a/src/lib/schedule/__tests__/gantt-scroll.test.ts
+++ b/src/lib/schedule/__tests__/gantt-scroll.test.ts
@@ -5,6 +5,7 @@ import {
   centeredGanttRowScrollTop,
   centeredTimelineScrollLeft,
   dominantScrollAxis,
+  ganttWheelIntent,
   ganttRowIndexForScrollTop,
   lockWheelToDominantAxis,
   nearestScheduleRowIndexForDate,
@@ -31,6 +32,28 @@ describe("Gantt dominant-axis scrolling", () => {
   it("chooses one axis for diagonal drag gestures", () => {
     expect(dominantScrollAxis(18, 31)).toBe("vertical")
     expect(dominantScrollAxis(42, 12)).toBe("horizontal")
+  })
+
+  it("keeps ordinary wheel scrolling vertical despite horizontal noise", () => {
+    expect(ganttWheelIntent(72, 6, false)).toEqual({
+      axis: "vertical",
+      delta: 6,
+    })
+  })
+
+  it("uses Shift+wheel for horizontal timeline navigation", () => {
+    expect(ganttWheelIntent(0, 64, true)).toEqual({
+      axis: "horizontal",
+      delta: 64,
+    })
+    expect(ganttWheelIntent(-72, 6, true)).toEqual({
+      axis: "horizontal",
+      delta: -72,
+    })
+  })
+
+  it("ignores horizontal trackpad movement without Shift", () => {
+    expect(ganttWheelIntent(72, 0, false)).toBeNull()
   })
 
   it("normalizes line and page wheel deltas", () => {

--- a/src/lib/schedule/gantt-scroll.ts
+++ b/src/lib/schedule/gantt-scroll.ts
@@ -5,6 +5,11 @@ interface WheelDelta {
   readonly deltaY: number
 }
 
+export interface GanttWheelIntent {
+  readonly axis: GanttScrollAxis
+  readonly delta: number
+}
+
 interface ScheduleRowDateRange {
   readonly startDate: string
   readonly endDate: string
@@ -33,6 +38,22 @@ export function lockWheelToDominantAxis(
     return { deltaX: 0, deltaY }
   }
   return { deltaX: 0, deltaY: 0 }
+}
+
+export function ganttWheelIntent(
+  deltaX: number,
+  deltaY: number,
+  shiftKey: boolean
+): GanttWheelIntent | null {
+  if (shiftKey) {
+    if (deltaX === 0 && deltaY === 0) return null
+    return {
+      axis: "horizontal",
+      delta: Math.abs(deltaX) >= Math.abs(deltaY) ? deltaX : deltaY,
+    }
+  }
+  if (deltaY === 0) return null
+  return { axis: "vertical", delta: deltaY }
 }
 
 export function normalizeWheelDelta(


### PR DESCRIPTION
## Summary

- keep the task list and Gantt vertically synchronized for every user
- require Shift+wheel for horizontal timeline movement
- preserve Today and clicked-item horizontal focus during later vertical scrolling
- remove the power-user scrolling control while retaining existing edit interactions

## Schedule to-do isolation

This PR changes only the Gantt view, wheel utility, and its regression test. It does not change schedule actions, to-do actions, database schema, or schedule-item forms. The open schedule PR #425 touches different files and has no overlap.

## Validation

- 20 focused Gantt tests passed
- focused ESLint passed
- full repository pre-commit ESLint passed with existing warnings only
- production build passed
- git diff check passed
