### PR TITLE
feat(calendar): add managed Google Calendar sync

### DIFF
--- a/docs/wip/google-calendar-sync-2026-07-27.md
+++ b/docs/wip/google-calendar-sync-2026-07-27.md
@@ -1,10 +1,10 @@
 # Google Calendar Sync
 
-Status: foundation in progress
+Status: managed calendar sync implementation in progress
 
 Owner: Compass product and engineering
 
-Tracking branch: `martinevogel/google-calendar-sync`
+Tracking branch: `martine/google-calendar-managed-sync`
 
 ## Decision
 
@@ -24,9 +24,10 @@ The Work Calendar presents these sources together without changing their source
 of truth. H-Office remains the default project for office events and receives
 priority in Office mode.
 
-## First Reviewable Slice
+## Implemented Slice
 
-The first slice establishes safe boundaries before external writes:
+The current slice includes the OAuth foundation plus managed import and
+write-through behavior:
 
 - per-user Google connection records with encrypted refresh credentials;
 - selected Google calendars and incremental sync/watch metadata;
@@ -35,12 +36,22 @@ The first slice establishes safe boundaries before external writes:
 - explicit privacy projection and conflict-decision helpers;
 - event type, visibility, and meeting-link fields in the existing scheduler;
 - project-access-aware event projection that hides or reduces private details;
-- an integration status surface that remains safe when Google OAuth is not
-  configured;
+- calendar discovery and per-calendar import/export configuration;
+- personal-calendar caches that remain owner-scoped and project other users'
+  events as `Busy`;
+- a Work Calendar people filter for the current user, one internal user, or all
+  connected internal users;
+- organization calendars (such as ORC Master) that import into the shared Work
+  Calendar and carry explicit detail/create/edit/delete permissions;
+- an event destination selector that can publish Compass events to a writable
+  personal or organization Google calendar;
+- linked create/update/delete calls so Google-backed Work Calendar events stay
+  synchronized when the calendar policy permits the action;
+- an integration status surface that remains safe when Google OAuth is not configured;
 - tests for privacy, idempotency, and two-way conflict behavior.
 
-External calendar writes, staff-wide enablement, and the production migration
-are separate approval points.
+The production D1 migration and OAuth secret configuration remain deployment
+approval points.
 
 ## Google Cloud Configuration
 
@@ -68,7 +79,12 @@ Google Tasks permissions are added only when the Tasks phase is implemented.
 - A project-scoped event is hidden from users without access to that project.
 - Event owners and participants see full details.
 - Participant-only and busy events appear as `Busy` to other authorized staff.
-- Private events are hidden from nonparticipants.
+- Personal Google events always show full details only to their owner. Other
+  internal users receive a `Busy` projection without description, location,
+  meeting URL, or Google link.
+- Organization calendar visibility is configured independently as details or
+  busy-only.
+- Private Compass events are hidden from nonparticipants.
 - Guests cannot connect a Google account or view private staff-calendar data.
 - Tokens, private descriptions, and attendee contact details must never appear
   in sync logs.
@@ -87,12 +103,15 @@ Google Tasks permissions are added only when the Tasks phase is implemented.
 - A failed webhook is only a signal to run incremental sync; webhook requests
   are not trusted as event payloads.
 
+The current implementation uses a bounded manual sync window (90 days in the
+past through two years in the future). Incremental sync tokens and push watches
+remain follow-up work.
+
 ## Follow-up Slices
 
-1. Calendar selection and staff-wide enablement of the completed OAuth flow.
-2. Dedicated Compass Google calendar creation and event publishing.
-3. Imported Google events in the user's Work Calendar with busy projection.
-4. Push notifications, incremental sync, retries, and conflict UI.
-5. Remaining robust event fields: recurrence, exceptions, external attendees,
+1. Scheduled sync, retries, incremental sync tokens, renewable watches, and a
+   conflict-resolution UI.
+2. Google Meet conference creation (existing Meet links already round-trip).
+3. Remaining robust event fields: recurrence exceptions, external attendees,
    reminders, attachments, and related Compass records.
-6. Google Tasks synchronization after calendar behavior is stable.
+4. Google Tasks synchronization after calendar behavior is stable.

--- a/drizzle/0121_google_calendar_managed_sync.sql
+++ b/drizzle/0121_google_calendar_managed_sync.sql
@@ -1,0 +1,57 @@
+ALTER TABLE `google_calendar_selections`
+  ADD COLUMN `calendar_scope` text NOT NULL DEFAULT 'personal'
+  CHECK (`calendar_scope` IN ('personal', 'organization'));
+--> statement-breakpoint
+ALTER TABLE `google_calendar_selections`
+  ADD COLUMN `internal_visibility` text NOT NULL DEFAULT 'busy'
+  CHECK (`internal_visibility` IN ('busy', 'details'));
+--> statement-breakpoint
+ALTER TABLE `google_calendar_selections`
+  ADD COLUMN `internal_can_create` integer NOT NULL DEFAULT 0
+  CHECK (`internal_can_create` IN (0, 1));
+--> statement-breakpoint
+ALTER TABLE `google_calendar_selections`
+  ADD COLUMN `internal_can_edit` integer NOT NULL DEFAULT 0
+  CHECK (`internal_can_edit` IN (0, 1));
+--> statement-breakpoint
+ALTER TABLE `google_calendar_selections`
+  ADD COLUMN `internal_can_delete` integer NOT NULL DEFAULT 0
+  CHECK (`internal_can_delete` IN (0, 1));
+--> statement-breakpoint
+CREATE TABLE `google_calendar_events` (
+  `id` text PRIMARY KEY NOT NULL,
+  `selection_id` text NOT NULL,
+  `google_event_id` text NOT NULL,
+  `google_ical_uid` text,
+  `recurring_event_id` text,
+  `status` text NOT NULL DEFAULT 'confirmed',
+  `title` text NOT NULL,
+  `description` text,
+  `location` text,
+  `html_link` text,
+  `meeting_url` text,
+  `start_date` text,
+  `end_date_exclusive` text,
+  `starts_at` text,
+  `ends_at` text,
+  `all_day` integer NOT NULL DEFAULT 0,
+  `time_zone` text,
+  `visibility` text NOT NULL DEFAULT 'default',
+  `transparency` text NOT NULL DEFAULT 'opaque',
+  `organizer_email` text,
+  `google_etag` text,
+  `google_updated_at` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`selection_id`) REFERENCES `google_calendar_selections`(`id`) ON UPDATE no action ON DELETE cascade,
+  CHECK (`all_day` IN (0, 1))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `google_calendar_event_unique`
+  ON `google_calendar_events` (`selection_id`, `google_event_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_google_calendar_events_start`
+  ON `google_calendar_events` (`selection_id`, `status`, `start_date`, `starts_at`);
+--> statement-breakpoint
+CREATE INDEX `idx_google_calendar_events_ical_uid`
+  ON `google_calendar_events` (`google_ical_uid`);

--- a/src/app/actions/google-calendar.ts
+++ b/src/app/actions/google-calendar.ts
@@ -4,22 +4,51 @@ import { and, eq } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
-import { googleCalendarConnections } from "@/db/schema"
+import { googleCalendarConnections, googleCalendarSelections } from "@/db/schema"
 import { requireAuth } from "@/lib/auth"
 import { decrypt } from "@/lib/crypto"
 import { getCloudflareContext } from "@/lib/db"
-import { isDemoUser } from "@/lib/demo"
+import { listGoogleCalendars } from "@/lib/google/calendar/client"
 import {
   getGoogleCalendarOAuthConfig,
   googleCalendarTokenSalt,
 } from "@/lib/google/calendar/config"
+import { refreshGoogleAccessToken } from "@/lib/google/calendar/oauth"
+import {
+  canConnectGoogleCalendar,
+  canManageOrganizationCalendars,
+  canWriteGoogleCalendar,
+} from "@/lib/google/calendar/policy"
+import { syncGoogleCalendarSelection } from "@/lib/google/calendar/sync"
 import { requireOrg } from "@/lib/org-scope"
 import { requirePermission } from "@/lib/permissions"
-import { isInternalStaffRole } from "@/lib/user-roles"
+
+export type GoogleCalendarSelectionStatus = {
+  readonly id: string
+  readonly googleCalendarId: string
+  readonly summary: string
+  readonly description: string | null
+  readonly timeZone: string | null
+  readonly backgroundColor: string | null
+  readonly accessRole: string
+  readonly isPrimary: boolean
+  readonly selected: boolean
+  readonly importEvents: boolean
+  readonly exportCompassEvents: boolean
+  readonly isCompassDestination: boolean
+  readonly calendarScope: string
+  readonly internalVisibility: string
+  readonly internalCanCreate: boolean
+  readonly internalCanEdit: boolean
+  readonly internalCanDelete: boolean
+  readonly lastSyncedAt: string | null
+  readonly lastError: string | null
+}
 
 export type GoogleCalendarConnectionStatus = {
   readonly configured: boolean
   readonly canConnect: boolean
+  readonly canManageOrganizationCalendars: boolean
   readonly connected: boolean
   readonly accountEmail: string | null
   readonly status: string | null
@@ -27,13 +56,47 @@ export type GoogleCalendarConnectionStatus = {
   readonly tasksSyncEnabled: boolean
   readonly lastSyncedAt: string | null
   readonly lastError: string | null
+  readonly calendars: readonly GoogleCalendarSelectionStatus[]
 }
 
-function canConnectGoogleCalendar(input: {
+type ActionResult =
+  | { readonly success: true }
+  | { readonly success: false; readonly error: string }
+
+async function ownConnection(
+  organizationId: string,
+  userId: string,
+): Promise<{ readonly id: string; readonly refreshTokenEncrypted: string } | null> {
+  const { env } = await getCloudflareContext()
+  return getDb(env.DB)
+    .select({
+      id: googleCalendarConnections.id,
+      refreshTokenEncrypted: googleCalendarConnections.refreshTokenEncrypted,
+    })
+    .from(googleCalendarConnections)
+    .where(
+      and(
+        eq(googleCalendarConnections.organizationId, organizationId),
+        eq(googleCalendarConnections.userId, userId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+}
+
+async function connectionAccessToken(input: {
+  readonly env: object
   readonly userId: string
-  readonly role: string
-}): boolean {
-  return !isDemoUser(input.userId) && isInternalStaffRole(input.role)
+  readonly refreshTokenEncrypted: string
+}): Promise<string> {
+  const configuration = getGoogleCalendarOAuthConfig(input.env)
+  if (!configuration.configured) throw new Error("Google Calendar OAuth is not configured.")
+  const refreshToken = await decrypt(
+    input.refreshTokenEncrypted,
+    configuration.config.tokenEncryptionKey,
+    googleCalendarTokenSalt(input.userId),
+  )
+  return (await refreshGoogleAccessToken(configuration.config, refreshToken)).accessToken
 }
 
 export async function getGoogleCalendarConnectionStatus(): Promise<GoogleCalendarConnectionStatus> {
@@ -41,11 +104,11 @@ export async function getGoogleCalendarConnectionStatus(): Promise<GoogleCalenda
   requirePermission(user, "schedule", "read")
   const organizationId = requireOrg(user)
   const { env } = await getCloudflareContext()
-  const configuration = getGoogleCalendarOAuthConfig(env)
   const db = getDb(env.DB)
   const connection = await db
     .select({
-      googleAccountEmail: googleCalendarConnections.googleAccountEmail,
+      id: googleCalendarConnections.id,
+      accountEmail: googleCalendarConnections.googleAccountEmail,
       status: googleCalendarConnections.status,
       calendarSyncEnabled: googleCalendarConnections.calendarSyncEnabled,
       tasksSyncEnabled: googleCalendarConnections.tasksSyncEnabled,
@@ -61,20 +124,243 @@ export async function getGoogleCalendarConnectionStatus(): Promise<GoogleCalenda
     )
     .limit(1)
     .then((rows) => rows[0] ?? null)
-
+  const calendars = connection
+    ? await db
+        .select({
+          id: googleCalendarSelections.id,
+          googleCalendarId: googleCalendarSelections.googleCalendarId,
+          summary: googleCalendarSelections.summary,
+          description: googleCalendarSelections.description,
+          timeZone: googleCalendarSelections.timeZone,
+          backgroundColor: googleCalendarSelections.backgroundColor,
+          accessRole: googleCalendarSelections.accessRole,
+          isPrimary: googleCalendarSelections.isPrimary,
+          selected: googleCalendarSelections.selected,
+          importEvents: googleCalendarSelections.importEvents,
+          exportCompassEvents: googleCalendarSelections.exportCompassEvents,
+          isCompassDestination: googleCalendarSelections.isCompassDestination,
+          calendarScope: googleCalendarSelections.calendarScope,
+          internalVisibility: googleCalendarSelections.internalVisibility,
+          internalCanCreate: googleCalendarSelections.internalCanCreate,
+          internalCanEdit: googleCalendarSelections.internalCanEdit,
+          internalCanDelete: googleCalendarSelections.internalCanDelete,
+          lastSyncedAt: googleCalendarSelections.lastSyncedAt,
+          lastError: googleCalendarSelections.lastError,
+        })
+        .from(googleCalendarSelections)
+        .where(eq(googleCalendarSelections.connectionId, connection.id))
+        .orderBy(googleCalendarSelections.summary)
+    : []
   return {
-    configured: configuration.configured,
-    canConnect: canConnectGoogleCalendar({
-      userId: user.id,
-      role: user.role,
-    }),
+    configured: getGoogleCalendarOAuthConfig(env).configured,
+    canConnect: canConnectGoogleCalendar({ userId: user.id, role: user.role }),
+    canManageOrganizationCalendars: canManageOrganizationCalendars(user.role),
     connected: connection !== null,
-    accountEmail: connection?.googleAccountEmail ?? null,
+    accountEmail: connection?.accountEmail ?? null,
     status: connection?.status ?? null,
     calendarSyncEnabled: connection?.calendarSyncEnabled ?? false,
     tasksSyncEnabled: connection?.tasksSyncEnabled ?? false,
     lastSyncedAt: connection?.lastSyncedAt ?? null,
     lastError: connection?.lastError ?? null,
+    calendars,
+  }
+}
+
+export async function refreshGoogleCalendarList(): Promise<ActionResult> {
+  try {
+    const user = await requireAuth()
+    requirePermission(user, "schedule", "read")
+    const organizationId = requireOrg(user)
+    if (!canConnectGoogleCalendar({ userId: user.id, role: user.role })) {
+      return { success: false, error: "Google Calendar is staff-only." }
+    }
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const connection = await ownConnection(organizationId, user.id)
+    if (!connection) return { success: false, error: "Connect Google Calendar first." }
+    const token = await connectionAccessToken({
+      env,
+      userId: user.id,
+      refreshTokenEncrypted: connection.refreshTokenEncrypted,
+    })
+    const calendars = await listGoogleCalendars(token)
+    const now = new Date().toISOString()
+    for (const calendar of calendars) {
+      await db
+        .insert(googleCalendarSelections)
+        .values({
+          id: crypto.randomUUID(),
+          connectionId: connection.id,
+          googleCalendarId: calendar.id,
+          summary: calendar.summary,
+          description: calendar.description,
+          timeZone: calendar.timeZone,
+          backgroundColor: calendar.backgroundColor,
+          accessRole: calendar.accessRole,
+          isPrimary: calendar.primary,
+          selected: false,
+          importEvents: false,
+          exportCompassEvents: false,
+          isCompassDestination: false,
+          calendarScope: "personal",
+          internalVisibility: "busy",
+          internalCanCreate: false,
+          internalCanEdit: false,
+          internalCanDelete: false,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: [googleCalendarSelections.connectionId, googleCalendarSelections.googleCalendarId],
+          set: {
+            summary: calendar.summary,
+            description: calendar.description,
+            timeZone: calendar.timeZone,
+            backgroundColor: calendar.backgroundColor,
+            accessRole: calendar.accessRole,
+            isPrimary: calendar.primary,
+            updatedAt: now,
+          },
+        })
+    }
+    revalidatePath("/dashboard/settings")
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : "Calendars could not be loaded." }
+  }
+}
+
+export type GoogleCalendarSelectionConfiguration = {
+  readonly selectionId: string
+  readonly selected: boolean
+  readonly importEvents: boolean
+  readonly exportCompassEvents: boolean
+  readonly isCompassDestination: boolean
+  readonly calendarScope: "personal" | "organization"
+  readonly internalVisibility: "busy" | "details"
+  readonly internalCanCreate: boolean
+  readonly internalCanEdit: boolean
+  readonly internalCanDelete: boolean
+}
+
+export async function configureGoogleCalendarSelection(
+  input: GoogleCalendarSelectionConfiguration,
+): Promise<ActionResult> {
+  try {
+    const user = await requireAuth()
+    requirePermission(user, "schedule", "read")
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const selection = await db
+      .select({
+        id: googleCalendarSelections.id,
+        connectionId: googleCalendarSelections.connectionId,
+        accessRole: googleCalendarSelections.accessRole,
+      })
+      .from(googleCalendarSelections)
+      .innerJoin(googleCalendarConnections, eq(googleCalendarConnections.id, googleCalendarSelections.connectionId))
+      .where(
+        and(
+          eq(googleCalendarSelections.id, input.selectionId),
+          eq(googleCalendarConnections.organizationId, organizationId),
+          eq(googleCalendarConnections.userId, user.id),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!selection) return { success: false, error: "Calendar was not found." }
+    const organizationCalendar = input.calendarScope === "organization"
+    if (organizationCalendar && !canManageOrganizationCalendars(user.role)) {
+      return { success: false, error: "Only an administrator or developer can publish an organization calendar." }
+    }
+    const requestsWrite =
+      input.exportCompassEvents || input.isCompassDestination || input.internalCanCreate ||
+      input.internalCanEdit || input.internalCanDelete
+    if (requestsWrite && !canWriteGoogleCalendar(selection.accessRole)) {
+      return { success: false, error: "The connected Google account has read-only access to this calendar." }
+    }
+    const now = new Date().toISOString()
+    await db
+      .update(googleCalendarSelections)
+      .set({
+        selected: input.selected,
+        importEvents: input.selected && input.importEvents,
+        exportCompassEvents: input.selected && input.exportCompassEvents,
+        isCompassDestination: input.selected && input.isCompassDestination,
+        calendarScope: input.calendarScope,
+        internalVisibility: organizationCalendar ? input.internalVisibility : "busy",
+        internalCanCreate: organizationCalendar && input.internalCanCreate,
+        internalCanEdit: organizationCalendar && input.internalCanEdit,
+        internalCanDelete: organizationCalendar && input.internalCanDelete,
+        updatedAt: now,
+      })
+      .where(eq(googleCalendarSelections.id, selection.id))
+    const enabled = await db
+      .select({ id: googleCalendarSelections.id })
+      .from(googleCalendarSelections)
+      .where(
+        and(
+          eq(googleCalendarSelections.connectionId, selection.connectionId),
+          eq(googleCalendarSelections.selected, true),
+          eq(googleCalendarSelections.importEvents, true),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows.length > 0)
+    await db
+      .update(googleCalendarConnections)
+      .set({ calendarSyncEnabled: enabled, updatedAt: now })
+      .where(eq(googleCalendarConnections.id, selection.connectionId))
+    revalidatePath("/dashboard/settings")
+    revalidatePath("/dashboard/schedule")
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : "Calendar settings could not be saved." }
+  }
+}
+
+export async function syncSelectedGoogleCalendar(selectionId: string): Promise<
+  | { readonly success: true; readonly imported: number; readonly updated: number; readonly conflicts: number }
+  | { readonly success: false; readonly error: string }
+> {
+  try {
+    const user = await requireAuth()
+    requirePermission(user, "schedule", "read")
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const selection = await db
+      .select({
+        ownerUserId: googleCalendarConnections.userId,
+        calendarScope: googleCalendarSelections.calendarScope,
+        importEvents: googleCalendarSelections.importEvents,
+      })
+      .from(googleCalendarSelections)
+      .innerJoin(googleCalendarConnections, eq(googleCalendarConnections.id, googleCalendarSelections.connectionId))
+      .where(
+        and(
+          eq(googleCalendarSelections.id, selectionId),
+          eq(googleCalendarConnections.organizationId, organizationId),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!selection || !selection.importEvents) {
+      return { success: false, error: "Enable event import for this calendar first." }
+    }
+    if (selection.ownerUserId !== user.id && !canManageOrganizationCalendars(user.role)) {
+      return { success: false, error: "You cannot sync another user's calendar." }
+    }
+    if (selection.calendarScope === "organization" && !canManageOrganizationCalendars(user.role)) {
+      return { success: false, error: "You cannot sync an organization calendar." }
+    }
+    const result = await syncGoogleCalendarSelection(db, env, selectionId)
+    revalidatePath("/dashboard/settings")
+    revalidatePath("/dashboard/schedule")
+    return { success: true, ...result }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : "Google Calendar sync failed." }
   }
 }
 
@@ -85,35 +371,14 @@ export async function disconnectGoogleCalendar(): Promise<
   try {
     const user = await requireAuth()
     requirePermission(user, "schedule", "read")
-    if (
-      !canConnectGoogleCalendar({
-        userId: user.id,
-        role: user.role,
-      })
-    ) {
+    if (!canConnectGoogleCalendar({ userId: user.id, role: user.role })) {
       return { success: false, error: "Google Calendar is staff-only." }
     }
     const organizationId = requireOrg(user)
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
-    const connection = await db
-      .select({
-        id: googleCalendarConnections.id,
-        refreshTokenEncrypted:
-          googleCalendarConnections.refreshTokenEncrypted,
-      })
-      .from(googleCalendarConnections)
-      .where(
-        and(
-          eq(googleCalendarConnections.organizationId, organizationId),
-          eq(googleCalendarConnections.userId, user.id),
-        ),
-      )
-      .limit(1)
-      .then((rows) => rows[0] ?? null)
-
+    const connection = await ownConnection(organizationId, user.id)
     if (!connection) return { success: true, revoked: true }
-
     let revoked = false
     const configuration = getGoogleCalendarOAuthConfig(env)
     if (configuration.configured) {
@@ -123,32 +388,22 @@ export async function disconnectGoogleCalendar(): Promise<
           configuration.config.tokenEncryptionKey,
           googleCalendarTokenSalt(user.id),
         )
-        const response = await fetch(
-          "https://oauth2.googleapis.com/revoke",
-          {
+        revoked = (
+          await fetch("https://oauth2.googleapis.com/revoke", {
             method: "POST",
-            headers: {
-              "Content-Type": "application/x-www-form-urlencoded",
-            },
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
             body: new URLSearchParams({ token: refreshToken }),
-          },
-        )
-        revoked = response.ok
+          })
+        ).ok
       } catch {
         revoked = false
       }
     }
-
-    await db
-      .delete(googleCalendarConnections)
-      .where(eq(googleCalendarConnections.id, connection.id))
-      .run()
+    await db.delete(googleCalendarConnections).where(eq(googleCalendarConnections.id, connection.id)).run()
     revalidatePath("/dashboard/settings")
+    revalidatePath("/dashboard/schedule")
     return { success: true, revoked }
   } catch {
-    return {
-      success: false,
-      error: "Google Calendar could not be disconnected.",
-    }
+    return { success: false, error: "Google Calendar could not be disconnected." }
   }
 }

--- a/src/app/actions/work-calendar.ts
+++ b/src/app/actions/work-calendar.ts
@@ -7,6 +7,10 @@ import { getDb } from "@/db"
 import {
   organizationCalendarSettings,
   organizationMembers,
+  googleCalendarConnections,
+  googleCalendarEntityLinks,
+  googleCalendarEvents,
+  googleCalendarSelections,
   projectMembers,
   projectOperations,
   projectRfis,
@@ -20,6 +24,14 @@ import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { isDemoUser } from "@/lib/demo"
 import { calendarDetailLevel } from "@/lib/google/calendar/sync-policy"
+import {
+  canManageOrganizationCalendars,
+  canWriteGoogleCalendar,
+} from "@/lib/google/calendar/policy"
+import {
+  deleteLinkedWorkCalendarEventFromGoogle,
+  publishWorkCalendarEventToGoogle,
+} from "@/lib/google/calendar/sync"
 import { createNotificationEvent } from "@/lib/notifications/events"
 import { eventAttendeeNotificationRecipients } from "@/lib/notifications/audience"
 import { requireOrg } from "@/lib/org-scope"
@@ -125,6 +137,20 @@ export type WorkCalendarData = {
   readonly canCreateEvents: boolean
   readonly canCreateTodos: boolean
   readonly canManageEvents: boolean
+  readonly googlePeople: readonly GoogleCalendarPerson[]
+  readonly activeGooglePeopleFilter: string
+  readonly googleDestinations: readonly GoogleCalendarDestination[]
+}
+
+export type GoogleCalendarPerson = {
+  readonly userId: string
+  readonly name: string
+}
+
+export type GoogleCalendarDestination = {
+  readonly selectionId: string
+  readonly label: string
+  readonly calendarScope: "personal" | "organization"
 }
 
 export type ProjectRow = {
@@ -237,6 +263,7 @@ export async function getWorkCalendar(
   referenceDate?: string,
   options?: {
     readonly eventsOnly?: boolean
+    readonly googlePeople?: string
   },
 ): Promise<WorkCalendarData> {
   const user = await requireAuth()
@@ -244,8 +271,10 @@ export async function getWorkCalendar(
   const orgId = requireOrg(user)
   const canManageEvents =
     !isDemoUser(user.id) && canManageWorkCalendarEvents(user)
-  const canCreateEvents =
+  const canCreateCompassEvents =
     canManageEvents && can(user, "schedule", "create")
+  const canUseManagedGoogleCalendar =
+    isInternalStaffRole(user.role) || user.role === "developer"
   const canCreateTodos =
     !isDemoUser(user.id) && (await canFeature(user, "tasks", "update"))
 
@@ -305,7 +334,7 @@ export async function getWorkCalendar(
       : null
   const defaultProjectId =
     configuredDefaultProjectId ?? resolveHOfficeProjectId(projectRows)
-  const organizationUsers = canManageEvents
+  const organizationUsers = canManageEvents || canUseManagedGoogleCalendar
     ? await db
         .select({
           id: users.id,
@@ -329,6 +358,83 @@ export async function getWorkCalendar(
     name: userDisplayName(member),
     email: member.email,
   }))
+  const connectedPeopleRows = canUseManagedGoogleCalendar
+    ? await db
+        .select({
+          userId: googleCalendarConnections.userId,
+          email: users.email,
+          displayName: users.displayName,
+          firstName: users.firstName,
+          lastName: users.lastName,
+        })
+        .from(googleCalendarConnections)
+        .innerJoin(users, eq(users.id, googleCalendarConnections.userId))
+        .where(
+          and(
+            eq(googleCalendarConnections.organizationId, orgId),
+            eq(googleCalendarConnections.status, "connected"),
+            eq(users.isActive, true),
+          ),
+        )
+        .orderBy(asc(users.displayName), asc(users.email))
+    : []
+  const googlePeople = connectedPeopleRows.map((member) => ({
+    userId: member.userId,
+    name: userDisplayName(member),
+  }))
+  const requestedPeopleFilter = options?.googlePeople ?? "me"
+  const activeGooglePeopleFilter =
+    requestedPeopleFilter === "all" ||
+    requestedPeopleFilter === "me" ||
+    googlePeople.some((person) => person.userId === requestedPeopleFilter)
+      ? requestedPeopleFilter
+      : "me"
+  const destinationRows = canUseManagedGoogleCalendar
+    ? await db
+        .select({
+          selectionId: googleCalendarSelections.id,
+          summary: googleCalendarSelections.summary,
+          calendarScope: googleCalendarSelections.calendarScope,
+          accessRole: googleCalendarSelections.accessRole,
+          ownerUserId: googleCalendarConnections.userId,
+          internalCanCreate: googleCalendarSelections.internalCanCreate,
+        })
+        .from(googleCalendarSelections)
+        .innerJoin(
+          googleCalendarConnections,
+          eq(
+            googleCalendarConnections.id,
+            googleCalendarSelections.connectionId,
+          ),
+        )
+        .where(
+          and(
+            eq(googleCalendarConnections.organizationId, orgId),
+            eq(googleCalendarSelections.selected, true),
+            eq(googleCalendarSelections.exportCompassEvents, true),
+            eq(googleCalendarSelections.isCompassDestination, true),
+          ),
+        )
+    : []
+  const googleDestinations = destinationRows
+    .filter((destination) => {
+      if (!canWriteGoogleCalendar(destination.accessRole)) return false
+      if (destination.calendarScope === "organization") {
+        return destination.internalCanCreate
+      }
+      return destination.ownerUserId === user.id
+    })
+    .map((destination): GoogleCalendarDestination => ({
+      selectionId: destination.selectionId,
+      label: destination.summary,
+      calendarScope:
+        destination.calendarScope === "organization" ? "organization" : "personal",
+    }))
+  const canCreateEvents =
+    canCreateCompassEvents ||
+    (!isDemoUser(user.id) &&
+      canUseManagedGoogleCalendar &&
+      googleDestinations.length > 0)
   const dedicatedEventIds = new Set(
     (
       await db
@@ -571,6 +677,47 @@ export async function getWorkCalendar(
       asc(workCalendarEvents.title)
     )
   const eventIds = eventRows.map((event) => event.id)
+  const linkedEventRows =
+    eventIds.length === 0
+      ? []
+      : await db
+          .select({
+            eventId: googleCalendarEntityLinks.sourceId,
+            ownerUserId: googleCalendarConnections.userId,
+            calendarScope: googleCalendarSelections.calendarScope,
+            internalCanEdit: googleCalendarSelections.internalCanEdit,
+          })
+          .from(googleCalendarEntityLinks)
+          .innerJoin(
+            googleCalendarConnections,
+            eq(
+              googleCalendarConnections.id,
+              googleCalendarEntityLinks.connectionId,
+            ),
+          )
+          .innerJoin(
+            googleCalendarSelections,
+            and(
+              eq(
+                googleCalendarSelections.connectionId,
+                googleCalendarEntityLinks.connectionId,
+              ),
+              eq(
+                googleCalendarSelections.googleCalendarId,
+                googleCalendarEntityLinks.googleCalendarId,
+              ),
+            ),
+          )
+          .where(
+            and(
+              eq(googleCalendarConnections.organizationId, orgId),
+              eq(googleCalendarEntityLinks.sourceType, "work_calendar_event"),
+              inArray(googleCalendarEntityLinks.sourceId, eventIds),
+            ),
+          )
+  const linkedEventById = new Map(
+    linkedEventRows.map((link) => [link.eventId, link]),
+  )
   const attendeeRows =
     eventIds.length === 0
       ? []
@@ -642,6 +789,17 @@ export async function getWorkCalendar(
     })
     if (detailLevel === "hidden") continue
     const showDetails = detailLevel === "full"
+    const linkedEvent = linkedEventById.get(event.id) ?? null
+    const canEditEvent = linkedEvent
+      ? canUseManagedGoogleCalendar &&
+        canChangeLinkedGoogleEvent({
+          role: user.role,
+          userId: user.id,
+          ownerUserId: linkedEvent.ownerUserId,
+          calendarScope: linkedEvent.calendarScope,
+          allowedForInternalUsers: linkedEvent.internalCanEdit,
+        })
+      : canManageEvents
     const eventType = isWorkCalendarEventType(event.eventType)
       ? event.eventType
       : "other"
@@ -752,10 +910,144 @@ export async function getWorkCalendar(
           recurrenceUntil: showDetails ? event.recurrenceUntil : null,
           attendees: showDetails ? attendees : [],
           version: event.version,
-          managed: showDetails,
+          managed: showDetails && canEditEvent,
         },
       })
     }
+  }
+
+  const personalGoogleEvents = canUseManagedGoogleCalendar
+    ? await db
+        .select({
+          id: googleCalendarEvents.id,
+          ownerUserId: googleCalendarConnections.userId,
+          ownerEmail: users.email,
+          ownerDisplayName: users.displayName,
+          ownerFirstName: users.firstName,
+          ownerLastName: users.lastName,
+          calendarName: googleCalendarSelections.summary,
+          title: googleCalendarEvents.title,
+          description: googleCalendarEvents.description,
+          location: googleCalendarEvents.location,
+          htmlLink: googleCalendarEvents.htmlLink,
+          meetingUrl: googleCalendarEvents.meetingUrl,
+          startDate: googleCalendarEvents.startDate,
+          endDateExclusive: googleCalendarEvents.endDateExclusive,
+          startsAt: googleCalendarEvents.startsAt,
+          endsAt: googleCalendarEvents.endsAt,
+          allDay: googleCalendarEvents.allDay,
+          timeZone: googleCalendarEvents.timeZone,
+          visibility: googleCalendarEvents.visibility,
+          transparency: googleCalendarEvents.transparency,
+          status: googleCalendarEvents.status,
+        })
+        .from(googleCalendarEvents)
+        .innerJoin(
+          googleCalendarSelections,
+          eq(googleCalendarSelections.id, googleCalendarEvents.selectionId),
+        )
+        .innerJoin(
+          googleCalendarConnections,
+          eq(
+            googleCalendarConnections.id,
+            googleCalendarSelections.connectionId,
+          ),
+        )
+        .innerJoin(users, eq(users.id, googleCalendarConnections.userId))
+        .where(
+          and(
+            eq(googleCalendarConnections.organizationId, orgId),
+            eq(googleCalendarSelections.selected, true),
+            eq(googleCalendarSelections.importEvents, true),
+            eq(googleCalendarSelections.calendarScope, "personal"),
+          ),
+        )
+    : []
+
+  for (const googleEvent of personalGoogleEvents) {
+    if (googleEvent.status === "cancelled") continue
+    const selectedOwner =
+      activeGooglePeopleFilter === "all" ||
+      (activeGooglePeopleFilter === "me"
+        ? googleEvent.ownerUserId === user.id
+        : googleEvent.ownerUserId === activeGooglePeopleFilter)
+    if (!selectedOwner) continue
+    const startDate = googleEvent.allDay
+      ? googleEvent.startDate
+      : googleEvent.startsAt
+        ? dateKeyInTimeZone(
+            new Date(googleEvent.startsAt),
+            googleEvent.timeZone ?? defaultTimeZone,
+          )
+        : null
+    const endDate = googleEvent.allDay
+      ? googleEvent.endDateExclusive
+        ? inclusiveEndDateFromExclusive(googleEvent.endDateExclusive)
+        : null
+      : googleEvent.endsAt
+        ? dateKeyInTimeZone(
+            new Date(new Date(googleEvent.endsAt).getTime() - 1),
+            googleEvent.timeZone ?? defaultTimeZone,
+          )
+        : null
+    if (
+      !startDate ||
+      !endDate ||
+      !intersectsCalendarWindow(startDate, endDate, rangeStart, rangeEnd, today)
+    ) {
+      continue
+    }
+    const viewerIsOwner = googleEvent.ownerUserId === user.id
+    const ownerName = userDisplayName({
+      displayName: googleEvent.ownerDisplayName,
+      firstName: googleEvent.ownerFirstName,
+      lastName: googleEvent.ownerLastName,
+      email: googleEvent.ownerEmail,
+    })
+    const fullDetails = viewerIsOwner
+    if (!fullDetails && googleEvent.transparency === "transparent") continue
+    const calendarLabel = fullDetails ? googleEvent.calendarName : "Google Calendar"
+    entries.push({
+      id: `google-${googleEvent.id}`,
+      kind: "event",
+      projectId: null,
+      projectLabel: ownerName,
+      projectName: calendarLabel,
+      title: fullDetails ? googleEvent.title : "Busy",
+      status: "open",
+      priority: "normal",
+      startDate,
+      endDate,
+      assignedTo: ownerName,
+      companyName: null,
+      sourceLabel: `${ownerName} · ${calendarLabel}`,
+      href: fullDetails && googleEvent.htmlLink ? googleEvent.htmlLink : "/dashboard/schedule",
+      eventDetails: {
+        masterEventId: `google-${googleEvent.id}`,
+        eventType: fullDetails && googleEvent.meetingUrl ? "meeting" : "other",
+        visibility: fullDetails ? "private" : "busy",
+        description: fullDetails ? googleEvent.description : null,
+        startDate,
+        endDate,
+        startTime: googleEvent.allDay
+          ? ""
+          : localTimeInZone(googleEvent.startsAt, googleEvent.timeZone ?? defaultTimeZone),
+        endTime: googleEvent.allDay
+          ? ""
+          : localTimeInZone(googleEvent.endsAt, googleEvent.timeZone ?? defaultTimeZone),
+        startsAt: googleEvent.startsAt,
+        endsAt: googleEvent.endsAt,
+        allDay: googleEvent.allDay,
+        timeZone: googleEvent.timeZone ?? defaultTimeZone,
+        location: fullDetails ? googleEvent.location : null,
+        meetingUrl: fullDetails ? googleEvent.meetingUrl : null,
+        recurrence: "none",
+        recurrenceUntil: null,
+        attendees: [],
+        version: 0,
+        managed: false,
+      },
+    })
   }
 
   entries.sort((left, right) => {
@@ -778,6 +1070,9 @@ export async function getWorkCalendar(
     canCreateEvents,
     canCreateTodos,
     canManageEvents,
+    googlePeople,
+    activeGooglePeopleFilter,
+    googleDestinations,
   }
 }
 
@@ -800,10 +1095,11 @@ export type WorkCalendarEventMutationInput = {
   readonly recurrence: WorkCalendarRecurrence
   readonly recurrenceUntil: string | null
   readonly attendeeUserIds: readonly string[]
+  readonly calendarSelectionId: string | null
 }
 
 type WorkCalendarEventMutationResult =
-  | { readonly success: true; readonly id: string }
+  | { readonly success: true; readonly id: string; readonly warning?: string }
   | { readonly success: false; readonly error: string }
 
 type ValidatedEventInput = {
@@ -1044,6 +1340,130 @@ async function validateEventInput(
   }
 }
 
+async function validateGoogleCalendarDestination(input: {
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string
+  readonly userId: string
+  readonly selectionId: string | null
+}): Promise<{
+  readonly selectionId: string
+  readonly calendarScope: string
+  readonly internalVisibility: string
+} | null> {
+  const selectionId = input.selectionId?.trim() ?? ""
+  if (!selectionId) return null
+  const destination = await input.db
+    .select({
+      id: googleCalendarSelections.id,
+      ownerUserId: googleCalendarConnections.userId,
+      calendarScope: googleCalendarSelections.calendarScope,
+      accessRole: googleCalendarSelections.accessRole,
+      selected: googleCalendarSelections.selected,
+      exportCompassEvents: googleCalendarSelections.exportCompassEvents,
+      isCompassDestination: googleCalendarSelections.isCompassDestination,
+      internalCanCreate: googleCalendarSelections.internalCanCreate,
+      internalVisibility: googleCalendarSelections.internalVisibility,
+    })
+    .from(googleCalendarSelections)
+    .innerJoin(
+      googleCalendarConnections,
+      eq(googleCalendarConnections.id, googleCalendarSelections.connectionId),
+    )
+    .where(
+      and(
+        eq(googleCalendarSelections.id, selectionId),
+        eq(googleCalendarConnections.organizationId, input.organizationId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  if (
+    !destination ||
+    !destination.selected ||
+    !destination.exportCompassEvents ||
+    !destination.isCompassDestination ||
+    !canWriteGoogleCalendar(destination.accessRole)
+  ) {
+    throw new Error("The selected Google Calendar destination is unavailable.")
+  }
+  const canCreate =
+    destination.calendarScope === "organization"
+      ? destination.internalCanCreate
+      : destination.ownerUserId === input.userId
+  if (!canCreate) {
+    throw new Error("You cannot create events in this Google calendar.")
+  }
+  return {
+    selectionId: destination.id,
+    calendarScope: destination.calendarScope,
+    internalVisibility: destination.internalVisibility,
+  }
+}
+
+async function linkedGoogleCalendarPermissions(input: {
+  readonly db: ReturnType<typeof getDb>
+  readonly organizationId: string
+  readonly eventId: string
+}): Promise<{
+  readonly selectionId: string
+  readonly ownerUserId: string
+  readonly calendarScope: string
+  readonly internalCanEdit: boolean
+  readonly internalCanDelete: boolean
+  readonly internalVisibility: string
+} | null> {
+  return input.db
+    .select({
+      selectionId: googleCalendarSelections.id,
+      ownerUserId: googleCalendarConnections.userId,
+      calendarScope: googleCalendarSelections.calendarScope,
+      internalCanEdit: googleCalendarSelections.internalCanEdit,
+      internalCanDelete: googleCalendarSelections.internalCanDelete,
+      internalVisibility: googleCalendarSelections.internalVisibility,
+    })
+    .from(googleCalendarEntityLinks)
+    .innerJoin(
+      googleCalendarConnections,
+      eq(googleCalendarConnections.id, googleCalendarEntityLinks.connectionId),
+    )
+    .innerJoin(
+      googleCalendarSelections,
+      and(
+        eq(
+          googleCalendarSelections.connectionId,
+          googleCalendarEntityLinks.connectionId,
+        ),
+        eq(
+          googleCalendarSelections.googleCalendarId,
+          googleCalendarEntityLinks.googleCalendarId,
+        ),
+      ),
+    )
+    .where(
+      and(
+        eq(googleCalendarConnections.organizationId, input.organizationId),
+        eq(googleCalendarEntityLinks.sourceType, "work_calendar_event"),
+        eq(googleCalendarEntityLinks.sourceId, input.eventId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+}
+
+function canChangeLinkedGoogleEvent(input: {
+  readonly role: string
+  readonly userId: string
+  readonly ownerUserId: string
+  readonly calendarScope: string
+  readonly allowedForInternalUsers: boolean
+}): boolean {
+  if (input.ownerUserId === input.userId) return true
+  if (input.calendarScope !== "organization") return false
+  return (
+    input.allowedForInternalUsers || canManageOrganizationCalendars(input.role)
+  )
+}
+
 async function syncEventAttendees(
   db: ReturnType<typeof getDb>,
   eventId: string,
@@ -1213,26 +1633,45 @@ export async function createWorkCalendarEvent(
 ): Promise<WorkCalendarEventMutationResult> {
   try {
     const user = await requireAuth()
-    if (!canManageWorkCalendarEvents(user)) {
-      return { success: false, error: "Permission denied" }
-    }
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
-    requirePermission(user, "schedule", "create")
+    requirePermission(user, "schedule", "read")
     const orgId = requireOrg(user)
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
+    const calendarDestination = await validateGoogleCalendarDestination({
+      db,
+      organizationId: orgId,
+      userId: user.id,
+      selectionId: input.calendarSelectionId,
+    })
+    const canCreateCompassEvent =
+      canManageWorkCalendarEvents(user) && can(user, "schedule", "create")
+    const canCreateManagedGoogleEvent =
+      calendarDestination !== null &&
+      (isInternalStaffRole(user.role) || user.role === "developer")
+    if (!canCreateCompassEvent && !canCreateManagedGoogleEvent) {
+      return { success: false, error: "Permission denied" }
+    }
     const validated = await validateEventInput(db, orgId, input)
+    const organizationCalendar =
+      calendarDestination?.calendarScope === "organization"
+    const targetProject = organizationCalendar ? null : validated.project
+    const targetVisibility: WorkCalendarEventVisibility = organizationCalendar
+      ? calendarDestination.internalVisibility === "details"
+        ? "organization"
+        : "busy"
+      : validated.visibility
     const id = crypto.randomUUID()
     const now = new Date().toISOString()
     await db.insert(workCalendarEvents).values({
       id,
       organizationId: orgId,
-      projectId: validated.project.id,
+      projectId: targetProject?.id ?? null,
       title: validated.title,
       eventType: validated.eventType,
-      visibility: validated.visibility,
+      visibility: targetVisibility,
       description: validated.description,
       startDate: validated.startDate,
       endDateExclusive: validated.endDateExclusive,
@@ -1254,10 +1693,26 @@ export async function createWorkCalendarEvent(
       updatedAt: now,
     })
     await syncEventAttendees(db, id, [], validated.attendees, now)
+    let warning: string | undefined
+    if (calendarDestination) {
+      try {
+        await publishWorkCalendarEventToGoogle(
+          db,
+          env,
+          id,
+          calendarDestination.selectionId,
+        )
+      } catch (error) {
+        warning =
+          error instanceof Error
+            ? `Saved in Compass, but Google Calendar did not update: ${error.message}`
+            : "Saved in Compass, but Google Calendar did not update."
+      }
+    }
     await notifyEventParticipants({
       organizationId: orgId,
-      projectId: validated.project.id,
-      project: validated.project,
+      projectId: targetProject?.id ?? null,
+      project: targetProject,
       eventId: id,
       eventTitle: validated.title,
       startLabel: eventStartLabel(validated),
@@ -1267,8 +1722,8 @@ export async function createWorkCalendarEvent(
       attendees: validated.attendees,
     })
 
-    revalidateEventPaths([validated.project.id])
-    return { success: true, id }
+    revalidateEventPaths([targetProject?.id ?? null])
+    return { success: true, id, warning }
   } catch (error) {
     return {
       success: false,
@@ -1285,16 +1740,37 @@ export async function updateWorkCalendarEvent(
 ): Promise<WorkCalendarEventMutationResult> {
   try {
     const user = await requireAuth()
-    if (!canManageWorkCalendarEvents(user)) {
-      return { success: false, error: "Permission denied" }
-    }
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
     requirePermission(user, "schedule", "update")
+    const canManageCompassEvent = canManageWorkCalendarEvents(user)
+    const canUseManagedGoogleCalendar =
+      isInternalStaffRole(user.role) || user.role === "developer"
     const orgId = requireOrg(user)
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
+
+    const googleLink = await linkedGoogleCalendarPermissions({
+      db,
+      organizationId: orgId,
+      eventId,
+    })
+    if (!canManageCompassEvent && (!googleLink || !canUseManagedGoogleCalendar)) {
+      return { success: false, error: "Permission denied" }
+    }
+    if (
+      googleLink &&
+      !canChangeLinkedGoogleEvent({
+        role: user.role,
+        userId: user.id,
+        ownerUserId: googleLink.ownerUserId,
+        calendarScope: googleLink.calendarScope,
+        allowedForInternalUsers: googleLink.internalCanEdit,
+      })
+    ) {
+      return { success: false, error: "You cannot edit events in this Google calendar." }
+    }
 
     const existing = await db
       .select({
@@ -1335,14 +1811,21 @@ export async function updateWorkCalendarEvent(
 
     const previousAttendees = await eventAttendees(db, eventId)
     const validated = await validateEventInput(db, orgId, input)
+    const organizationCalendar = googleLink?.calendarScope === "organization"
+    const targetProject = organizationCalendar ? null : validated.project
+    const targetVisibility: WorkCalendarEventVisibility = organizationCalendar
+      ? googleLink?.internalVisibility === "details"
+        ? "organization"
+        : "busy"
+      : validated.visibility
     const now = new Date().toISOString()
     const updated = await db
       .update(workCalendarEvents)
       .set({
-        projectId: validated.project.id,
+        projectId: targetProject?.id ?? null,
         title: validated.title,
         eventType: validated.eventType,
-        visibility: validated.visibility,
+        visibility: targetVisibility,
         description: validated.description,
         startDate: validated.startDate,
         endDateExclusive: validated.endDateExclusive,
@@ -1382,6 +1865,22 @@ export async function updateWorkCalendarEvent(
       validated.attendees,
       now
     )
+    let warning: string | undefined
+    if (googleLink) {
+      try {
+        await publishWorkCalendarEventToGoogle(
+          db,
+          env,
+          eventId,
+          googleLink.selectionId,
+        )
+      } catch (error) {
+        warning =
+          error instanceof Error
+            ? `Updated in Compass, but Google Calendar did not update: ${error.message}`
+            : "Updated in Compass, but Google Calendar did not update."
+      }
+    }
 
     const notificationAttendees = new Map<
       string,
@@ -1395,8 +1894,8 @@ export async function updateWorkCalendarEvent(
     }
     await notifyEventParticipants({
       organizationId: orgId,
-      projectId: validated.project.id,
-      project: validated.project,
+      projectId: targetProject?.id ?? null,
+      project: targetProject,
       eventId,
       eventTitle: validated.title,
       startLabel: eventStartLabel(validated),
@@ -1406,8 +1905,8 @@ export async function updateWorkCalendarEvent(
       attendees: Array.from(notificationAttendees.values()),
     })
 
-    revalidateEventPaths([existing.projectId, validated.project.id])
-    return { success: true, id: eventId }
+    revalidateEventPaths([existing.projectId, targetProject?.id ?? null])
+    return { success: true, id: eventId, warning }
   } catch (error) {
     return {
       success: false,
@@ -1423,16 +1922,37 @@ export async function cancelWorkCalendarEvent(
 ): Promise<WorkCalendarEventMutationResult> {
   try {
     const user = await requireAuth()
-    if (!canManageWorkCalendarEvents(user)) {
-      return { success: false, error: "Permission denied" }
-    }
     if (isDemoUser(user.id)) {
       return { success: false, error: "DEMO_READ_ONLY" }
     }
     requirePermission(user, "schedule", "update")
+    const canManageCompassEvent = canManageWorkCalendarEvents(user)
+    const canUseManagedGoogleCalendar =
+      isInternalStaffRole(user.role) || user.role === "developer"
     const orgId = requireOrg(user)
     const { env } = await getCloudflareContext()
     const db = getDb(env.DB)
+
+    const googleLink = await linkedGoogleCalendarPermissions({
+      db,
+      organizationId: orgId,
+      eventId,
+    })
+    if (!canManageCompassEvent && (!googleLink || !canUseManagedGoogleCalendar)) {
+      return { success: false, error: "Permission denied" }
+    }
+    if (
+      googleLink &&
+      !canChangeLinkedGoogleEvent({
+        role: user.role,
+        userId: user.id,
+        ownerUserId: googleLink.ownerUserId,
+        calendarScope: googleLink.calendarScope,
+        allowedForInternalUsers: googleLink.internalCanDelete,
+      })
+    ) {
+      return { success: false, error: "You cannot delete events from this Google calendar." }
+    }
 
     const existing = await db
       .select({
@@ -1507,6 +2027,17 @@ export async function cancelWorkCalendarEvent(
           "This event changed after you opened it. Refresh and try again.",
       }
     }
+    let warning: string | undefined
+    if (googleLink) {
+      try {
+        await deleteLinkedWorkCalendarEventFromGoogle(db, env, eventId)
+      } catch (error) {
+        warning =
+          error instanceof Error
+            ? `Cancelled in Compass, but Google Calendar did not update: ${error.message}`
+            : "Cancelled in Compass, but Google Calendar did not update."
+      }
+    }
     await notifyEventParticipants({
       organizationId: orgId,
       projectId: existing.projectId,
@@ -1521,7 +2052,7 @@ export async function cancelWorkCalendarEvent(
     })
 
     revalidateEventPaths([existing.projectId])
-    return { success: true, id: eventId }
+    return { success: true, id: eventId, warning }
   } catch (error) {
     return {
       success: false,

--- a/src/app/api/google/calendar/callback/route.ts
+++ b/src/app/api/google/calendar/callback/route.ts
@@ -6,7 +6,6 @@ import { googleCalendarConnections } from "@/db/schema"
 import { getCurrentUser } from "@/lib/auth"
 import { encrypt } from "@/lib/crypto"
 import { getCloudflareContext } from "@/lib/db"
-import { isDemoUser } from "@/lib/demo"
 import {
   getGoogleCalendarOAuthConfig,
   googleCalendarTokenSalt,
@@ -16,8 +15,8 @@ import {
   getGoogleAccountIdentity,
   hasRequiredGoogleCalendarScopes,
 } from "@/lib/google/calendar/oauth"
+import { canConnectGoogleCalendar } from "@/lib/google/calendar/policy"
 import { can } from "@/lib/permissions"
-import { isInternalStaffRole } from "@/lib/user-roles"
 
 const OAUTH_STATE_COOKIE = "compass_google_calendar_oauth_state"
 
@@ -46,8 +45,7 @@ export async function GET(request: NextRequest): Promise<Response> {
   const user = await getCurrentUser()
   if (
     !user ||
-    isDemoUser(user.id) ||
-    !isInternalStaffRole(user.role) ||
+    !canConnectGoogleCalendar({ userId: user.id, role: user.role }) ||
     !can(user, "schedule", "read") ||
     !user.organizationId
   ) {

--- a/src/app/api/google/calendar/connect/route.ts
+++ b/src/app/api/google/calendar/connect/route.ts
@@ -2,13 +2,12 @@ import { NextResponse } from "next/server"
 
 import { getCurrentUser } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
-import { isDemoUser } from "@/lib/demo"
 import {
   getGoogleCalendarOAuthConfig,
 } from "@/lib/google/calendar/config"
 import { buildGoogleCalendarAuthorizationUrl } from "@/lib/google/calendar/oauth"
+import { canConnectGoogleCalendar } from "@/lib/google/calendar/policy"
 import { can } from "@/lib/permissions"
-import { isInternalStaffRole } from "@/lib/user-roles"
 
 const OAUTH_STATE_COOKIE = "compass_google_calendar_oauth_state"
 
@@ -22,8 +21,7 @@ export async function GET(request: Request): Promise<Response> {
   const user = await getCurrentUser()
   if (
     !user ||
-    isDemoUser(user.id) ||
-    !isInternalStaffRole(user.role) ||
+    !canConnectGoogleCalendar({ userId: user.id, role: user.role }) ||
     !can(user, "schedule", "read") ||
     !user.organizationId
   ) {

--- a/src/app/dashboard/schedule/page.tsx
+++ b/src/app/dashboard/schedule/page.tsx
@@ -92,6 +92,7 @@ export default async function SchedulePage({
     readonly project?: string | readonly string[]
     readonly projects?: string | readonly string[]
     readonly department?: string | readonly string[]
+    readonly people?: string | readonly string[]
   }>
 }): Promise<React.ReactElement> {
   const query = await searchParams
@@ -214,7 +215,9 @@ export default async function SchedulePage({
     typeof query.date === "string" ? query.date : query.date?.[0]
   const initialDate =
     requestedDate && isValidDateKey(requestedDate) ? requestedDate : undefined
-  const data = await getWorkCalendar(initialDate)
+  const data = await getWorkCalendar(initialDate, {
+    googlePeople: firstValue(query.people),
+  })
 
   const initialItemId =
     typeof query.item === "string" ? query.item : query.item?.[0] ?? null

--- a/src/components/google/calendar-connection-status.tsx
+++ b/src/components/google/calendar-connection-status.tsx
@@ -1,17 +1,217 @@
 "use client"
 
 import * as React from "react"
-import { IconBrandGoogle, IconCheck, IconLoader2 } from "@tabler/icons-react"
+import { IconBrandGoogle, IconCheck, IconLoader2, IconRefresh } from "@tabler/icons-react"
 import { toast } from "sonner"
 
 import {
   disconnectGoogleCalendar,
+  configureGoogleCalendarSelection,
   getGoogleCalendarConnectionStatus,
+  refreshGoogleCalendarList,
+  syncSelectedGoogleCalendar,
   type GoogleCalendarConnectionStatus,
+  type GoogleCalendarSelectionConfiguration,
+  type GoogleCalendarSelectionStatus,
 } from "@/app/actions/google-calendar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { DeveloperOnly } from "@/components/developer-mode-provider"
+
+function CalendarSettingRow({
+  calendar,
+  canManageOrganization,
+  onSaved,
+}: {
+  readonly calendar: GoogleCalendarSelectionStatus
+  readonly canManageOrganization: boolean
+  readonly onSaved: () => Promise<void>
+}): React.ReactElement {
+  const [saving, setSaving] = React.useState(false)
+  const [syncing, setSyncing] = React.useState(false)
+  const writable = calendar.accessRole === "owner" || calendar.accessRole === "writer"
+
+  async function save(
+    changes: Partial<GoogleCalendarSelectionConfiguration>,
+  ): Promise<void> {
+    setSaving(true)
+    const result = await configureGoogleCalendarSelection({
+      selectionId: calendar.id,
+      selected: calendar.selected,
+      importEvents: calendar.importEvents,
+      exportCompassEvents: calendar.exportCompassEvents,
+      isCompassDestination: calendar.isCompassDestination,
+      calendarScope:
+        calendar.calendarScope === "organization" ? "organization" : "personal",
+      internalVisibility:
+        calendar.internalVisibility === "details" ? "details" : "busy",
+      internalCanCreate: calendar.internalCanCreate,
+      internalCanEdit: calendar.internalCanEdit,
+      internalCanDelete: calendar.internalCanDelete,
+      ...changes,
+    })
+    setSaving(false)
+    if (!result.success) {
+      toast.error(result.error)
+      return
+    }
+    await onSaved()
+  }
+
+  async function sync(): Promise<void> {
+    setSyncing(true)
+    const result = await syncSelectedGoogleCalendar(calendar.id)
+    setSyncing(false)
+    if (!result.success) {
+      toast.error(result.error)
+      return
+    }
+    toast.success(
+      `Calendar synced: ${result.imported} new, ${result.updated} updated${
+        result.conflicts > 0 ? `, ${result.conflicts} conflicts` : ""
+      }.`,
+    )
+    await onSaved()
+  }
+
+  return (
+    <div className="space-y-3 rounded-md border p-3">
+      <div className="flex items-start gap-3">
+        <Checkbox
+          aria-label={`Show ${calendar.summary}`}
+          checked={calendar.selected}
+          disabled={saving}
+          onCheckedChange={(checked) => void save({ selected: checked === true })}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="truncate text-sm font-medium">{calendar.summary}</p>
+            {calendar.isPrimary ? <Badge variant="secondary">Primary</Badge> : null}
+            <Badge variant="outline">{calendar.accessRole}</Badge>
+          </div>
+          {calendar.description ? (
+            <p className="mt-1 text-xs text-muted-foreground">{calendar.description}</p>
+          ) : null}
+        </div>
+      </div>
+
+      {calendar.selected ? (
+        <div className="ml-7 grid gap-3 text-xs">
+          <label className="flex items-center gap-2">
+            <Checkbox
+              checked={calendar.importEvents}
+              disabled={saving}
+              onCheckedChange={(checked) => void save({ importEvents: checked === true })}
+            />
+            Import events into the Work Calendar
+          </label>
+
+          {canManageOrganization ? (
+            <label className="grid gap-1">
+              <span className="text-muted-foreground">Calendar use</span>
+              <Select
+                value={calendar.calendarScope === "organization" ? "organization" : "personal"}
+                disabled={saving}
+                onValueChange={(value) =>
+                  void save({
+                    calendarScope: value === "organization" ? "organization" : "personal",
+                  })
+                }
+              >
+                <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="personal">Personal — others see Busy</SelectItem>
+                  <SelectItem value="organization">Organization shared calendar</SelectItem>
+                </SelectContent>
+              </Select>
+            </label>
+          ) : null}
+
+          {calendar.calendarScope === "organization" && canManageOrganization ? (
+            <div className="grid gap-2 rounded-md bg-muted/40 p-3">
+              <p className="font-medium">Internal access</p>
+              <label className="grid gap-1">
+                <span className="text-muted-foreground">Event visibility</span>
+                <Select
+                  value={calendar.internalVisibility === "details" ? "details" : "busy"}
+                  disabled={saving}
+                  onValueChange={(value) =>
+                    void save({ internalVisibility: value === "details" ? "details" : "busy" })
+                  }
+                >
+                  <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="details">Show event details</SelectItem>
+                    <SelectItem value="busy">Show Busy only</SelectItem>
+                  </SelectContent>
+                </Select>
+              </label>
+              <label className="flex items-center gap-2">
+                <Checkbox
+                  checked={calendar.internalCanCreate}
+                  disabled={saving || !writable}
+                  onCheckedChange={(checked) => void save({ internalCanCreate: checked === true })}
+                />
+                Internal users can create events
+              </label>
+              <label className="flex items-center gap-2">
+                <Checkbox
+                  checked={calendar.internalCanEdit}
+                  disabled={saving || !writable}
+                  onCheckedChange={(checked) => void save({ internalCanEdit: checked === true })}
+                />
+                Internal users can edit events
+              </label>
+              <label className="flex items-center gap-2">
+                <Checkbox
+                  checked={calendar.internalCanDelete}
+                  disabled={saving || !writable}
+                  onCheckedChange={(checked) => void save({ internalCanDelete: checked === true })}
+                />
+                Internal users can delete events
+              </label>
+              <label className="flex items-center gap-2">
+                <Checkbox
+                  checked={calendar.isCompassDestination}
+                  disabled={saving || !writable}
+                  onCheckedChange={(checked) =>
+                    void save({
+                      isCompassDestination: checked === true,
+                      exportCompassEvents: checked === true || calendar.exportCompassEvents,
+                    })
+                  }
+                />
+                Offer as a Compass event destination
+              </label>
+            </div>
+          ) : null}
+
+          {calendar.importEvents ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <Button type="button" size="sm" variant="outline" disabled={syncing} onClick={() => void sync()}>
+                {syncing ? "Syncing..." : "Sync now"}
+              </Button>
+              {calendar.lastSyncedAt ? (
+                <span className="text-muted-foreground">
+                  Last synced {new Date(calendar.lastSyncedAt).toLocaleString()}
+                </span>
+              ) : null}
+            </div>
+          ) : null}
+          {calendar.lastError ? <p className="text-destructive">{calendar.lastError}</p> : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}
 
 const GOOGLE_CALENDAR_CALLBACK_MESSAGES: Readonly<
   Record<string, { readonly type: "success" | "error"; readonly message: string }>
@@ -62,6 +262,7 @@ export function GoogleCalendarConnectionCard(): React.ReactElement {
   const [status, setStatus] =
     React.useState<GoogleCalendarConnectionStatus | null>(null)
   const [disconnecting, setDisconnecting] = React.useState(false)
+  const [refreshing, setRefreshing] = React.useState(false)
 
   const loadStatus = React.useCallback(async (): Promise<void> => {
     const result = await getGoogleCalendarConnectionStatus()
@@ -101,6 +302,18 @@ export function GoogleCalendarConnectionCard(): React.ReactElement {
         ? "Google Calendar disconnected."
         : "Google Calendar disconnected from Compass. Google access may also need to be removed from your Google Account.",
     )
+    await loadStatus()
+  }
+
+  async function refreshCalendars(): Promise<void> {
+    setRefreshing(true)
+    const result = await refreshGoogleCalendarList()
+    setRefreshing(false)
+    if (!result.success) {
+      toast.error(result.error)
+      return
+    }
+    toast.success("Google calendars refreshed.")
     await loadStatus()
   }
 
@@ -162,15 +375,49 @@ export function GoogleCalendarConnectionCard(): React.ReactElement {
               </p>
             </DeveloperOnly>
           ) : null}
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            disabled={disconnecting}
-            onClick={() => void disconnect()}
-          >
-            {disconnecting ? "Disconnecting..." : "Disconnect"}
-          </Button>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={refreshing}
+              onClick={() => void refreshCalendars()}
+            >
+              <IconRefresh className={refreshing ? "animate-spin" : ""} />
+              {refreshing ? "Refreshing..." : "Refresh calendars"}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={disconnecting}
+              onClick={() => void disconnect()}
+            >
+              {disconnecting ? "Disconnecting..." : "Disconnect"}
+            </Button>
+          </div>
+          {status.calendars.length > 0 ? (
+            <div className="grid gap-3">
+              <div>
+                <p className="text-sm font-medium">Calendars</p>
+                <p className="text-xs text-muted-foreground">
+                  Personal calendars remain owner-scoped. Shared organization calendars can be published to everyone.
+                </p>
+              </div>
+              {status.calendars.map((calendar) => (
+                <CalendarSettingRow
+                  key={calendar.id}
+                  calendar={calendar}
+                  canManageOrganization={status.canManageOrganizationCalendars}
+                  onSaved={loadStatus}
+                />
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Refresh calendars to choose which Google calendars Compass should import.
+            </p>
+          )}
         </>
       ) : (
         <>

--- a/src/components/schedule/work-calendar-event-dialog.tsx
+++ b/src/components/schedule/work-calendar-event-dialog.tsx
@@ -16,6 +16,7 @@ import {
   type ProjectRow,
   type WorkCalendarEntry,
   type WorkCalendarEventAttendee,
+  type GoogleCalendarDestination,
 } from "@/app/actions/work-calendar"
 import {
   AlertDialog,
@@ -62,6 +63,7 @@ import {
 } from "@/lib/work-calendar-recurrence"
 
 const DEFAULT_PROJECT_VALUE = "__h_office_default__"
+const COMPASS_DESTINATION_VALUE = "__compass__"
 
 type CalendarEventEntry = Extract<WorkCalendarEntry, { kind: "event" }>
 
@@ -71,6 +73,7 @@ type CommonProps = {
   readonly defaultProjectId: string | null
   readonly defaultTimeZone: string
   readonly today: string
+  readonly googleDestinations: readonly GoogleCalendarDestination[]
 }
 
 type WorkCalendarEventDialogProps = CommonProps &
@@ -103,6 +106,7 @@ type EventFormSeed = {
   readonly recurrence: WorkCalendarRecurrence
   readonly recurrenceUntil: string
   readonly attendeeUserIds: readonly string[]
+  readonly calendarSelectionId: string
 }
 
 function projectLabel(project: ProjectRow): string {
@@ -137,6 +141,7 @@ function formSeed(
       attendeeUserIds: details.attendees.map(
         (attendee) => attendee.userId
       ),
+      calendarSelectionId: COMPASS_DESTINATION_VALUE,
     }
   }
 
@@ -159,6 +164,7 @@ function formSeed(
     recurrence: "none",
     recurrenceUntil: "",
     attendeeUserIds: [],
+    calendarSelectionId: COMPASS_DESTINATION_VALUE,
   }
 }
 
@@ -189,6 +195,9 @@ export function WorkCalendarEventDialog(
   const [attendeeUserIds, setAttendeeUserIds] = React.useState<
     readonly string[]
   >(seed.attendeeUserIds)
+  const [calendarSelectionId, setCalendarSelectionId] = React.useState(
+    seed.calendarSelectionId,
+  )
 
   const open = props.variant === "create" ? createOpen : props.open
 
@@ -210,6 +219,7 @@ export function WorkCalendarEventDialog(
     setRecurrence(next.recurrence)
     setRecurrenceUntil(next.recurrenceUntil)
     setAttendeeUserIds(next.attendeeUserIds)
+    setCalendarSelectionId(next.calendarSelectionId)
   }
 
   function changeOpen(nextOpen: boolean): void {
@@ -271,6 +281,10 @@ export function WorkCalendarEventDialog(
       recurrence,
       recurrenceUntil: recurrence === "none" ? null : recurrenceUntil,
       attendeeUserIds,
+      calendarSelectionId:
+        calendarSelectionId === COMPASS_DESTINATION_VALUE
+          ? null
+          : calendarSelectionId,
     }
 
     startTransition(async () => {
@@ -288,11 +302,14 @@ export function WorkCalendarEventDialog(
         return
       }
 
-      toast.success(
-        props.variant === "create"
-          ? "Event added to the work calendar."
-          : "Event updated."
-      )
+      if (result.warning) toast.warning(result.warning)
+      else {
+        toast.success(
+          props.variant === "create"
+            ? "Event added to the work calendar."
+            : "Event updated."
+        )
+      }
       changeOpen(false)
       router.refresh()
     })
@@ -309,7 +326,8 @@ export function WorkCalendarEventDialog(
         toast.error(result.error)
         return
       }
-      toast.success("Event cancelled.")
+      if (result.warning) toast.warning(result.warning)
+      else toast.success("Event cancelled.")
       changeOpen(false)
       router.refresh()
     })
@@ -340,6 +358,28 @@ export function WorkCalendarEventDialog(
           </DialogHeader>
 
           <div className="grid gap-4 py-5">
+            {props.variant === "create" && props.googleDestinations.length > 0 ? (
+              <div className="grid gap-2">
+                <Label htmlFor="work-calendar-event-destination">Calendar</Label>
+                <Select value={calendarSelectionId} onValueChange={setCalendarSelectionId}>
+                  <SelectTrigger id="work-calendar-event-destination">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={COMPASS_DESTINATION_VALUE}>Compass Work Calendar only</SelectItem>
+                    {props.googleDestinations.map((destination) => (
+                      <SelectItem key={destination.selectionId} value={destination.selectionId}>
+                        {destination.label}
+                        {destination.calendarScope === "organization" ? " (shared)" : " (personal)"}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Google destinations also keep a linked Compass event for permissions and filtering.
+                </p>
+              </div>
+            ) : null}
             <div className="grid gap-2">
               <Label htmlFor={`work-calendar-event-title-${props.variant}`}>
                 Title

--- a/src/components/schedule/work-calendar.tsx
+++ b/src/components/schedule/work-calendar.tsx
@@ -33,6 +33,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { cn } from "@/lib/utils"
 import { workCalendarEntryMatches } from "@/lib/work-calendar"
 import { WorkCalendarEventDialog } from "./work-calendar-event-dialog"
@@ -242,13 +249,11 @@ function WorkItem({
   compact = false,
   focused = false,
   onEditEvent,
-  canManageEvents,
 }: {
   readonly entry: WorkCalendarEntry
   readonly compact?: boolean
   readonly focused?: boolean
   readonly onEditEvent: (event: CalendarEventEntry) => void
-  readonly canManageEvents: boolean
 }): React.ReactElement {
   const { developerModeEnabled } = useDeveloperMode()
   const className = cn(
@@ -317,8 +322,7 @@ function WorkItem({
 
   if (
     entry.kind === "event" &&
-    entry.eventDetails.managed &&
-    canManageEvents
+    entry.eventDetails.managed
   ) {
     return (
       <button
@@ -443,6 +447,14 @@ export function WorkCalendar({
     })
   }
 
+  function changePeopleFilter(value: string): void {
+    const params = new URLSearchParams(searchParams.toString())
+    if (value === "me") params.delete("people")
+    else params.set("people", value)
+    params.delete("item")
+    router.replace(`/dashboard/schedule?${params.toString()}`, { scroll: false })
+  }
+
   React.useEffect(() => {
     if (!initialItemId) return
     document
@@ -507,6 +519,31 @@ export function WorkCalendar({
               className="pl-9"
             />
           </div>
+          {data.googlePeople.length > 0 ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-xs font-medium text-muted-foreground">Google calendars</span>
+              <Select
+                value={data.activeGooglePeopleFilter}
+                onValueChange={changePeopleFilter}
+              >
+                <SelectTrigger size="sm" className="w-[240px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="me">My Google calendars</SelectItem>
+                  <SelectItem value="all">All staff availability</SelectItem>
+                  {data.googlePeople.map((person) => (
+                    <SelectItem key={person.userId} value={person.userId}>
+                      {person.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <span className="text-xs text-muted-foreground">
+                Other users' personal events are shown as Busy.
+              </span>
+            </div>
+          ) : null}
           <div className="flex flex-wrap gap-2">
             <Button asChild size="sm" variant="outline">
               <Link href="/dashboard/schedule?mode=projects&scope=all&view=gantt">
@@ -521,6 +558,7 @@ export function WorkCalendar({
                 defaultProjectId={data.defaultProjectId}
                 defaultTimeZone={data.defaultTimeZone}
                 today={data.today}
+                googleDestinations={data.googleDestinations}
               />
             )}
             {data.canCreateTodos && (
@@ -676,7 +714,6 @@ export function WorkCalendar({
                         compact={activeView !== "today"}
                         focused={entry.id === initialItemId}
                         onEditEvent={setEditingEvent}
-                        canManageEvents={data.canManageEvents}
                       />
                     ))}
                     {activeView !== "today" && dayEntries.length > 3 && (
@@ -712,7 +749,6 @@ export function WorkCalendar({
                     entry={entry}
                     focused={entry.id === initialItemId}
                     onEditEvent={setEditingEvent}
-                    canManageEvents={data.canManageEvents}
                   />
                 ))
               ) : (
@@ -782,13 +818,12 @@ export function WorkCalendar({
                   setExpandedDay(null)
                   setEditingEvent(event)
                 }}
-                canManageEvents={data.canManageEvents}
               />
             ))}
           </div>
         </DialogContent>
       </Dialog>
-      {editingEvent && data.canManageEvents && (
+      {editingEvent && editingEvent.eventDetails.managed && (
         <WorkCalendarEventDialog
           key={`${editingEvent.id}-${editingEvent.eventDetails.version}`}
           variant="edit"
@@ -802,6 +837,7 @@ export function WorkCalendar({
           defaultProjectId={data.defaultProjectId}
           defaultTimeZone={data.defaultTimeZone}
           today={data.today}
+          googleDestinations={data.googleDestinations}
         />
       )}
     </div>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1348,6 +1348,19 @@ export const googleCalendarSelections = sqliteTable(
     })
       .notNull()
       .default(false),
+    calendarScope: text("calendar_scope").notNull().default("personal"),
+    internalVisibility: text("internal_visibility")
+      .notNull()
+      .default("busy"),
+    internalCanCreate: integer("internal_can_create", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    internalCanEdit: integer("internal_can_edit", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    internalCanDelete: integer("internal_can_delete", { mode: "boolean" })
+      .notNull()
+      .default(false),
     syncToken: text("sync_token"),
     watchChannelId: text("watch_channel_id"),
     watchResourceId: text("watch_resource_id"),
@@ -1366,6 +1379,55 @@ export const googleCalendarSelections = sqliteTable(
       table.connectionId,
       table.selected,
     ),
+  ],
+)
+
+export const googleCalendarEvents = sqliteTable(
+  "google_calendar_events",
+  {
+    id: text("id").primaryKey(),
+    selectionId: text("selection_id")
+      .notNull()
+      .references(() => googleCalendarSelections.id, {
+        onDelete: "cascade",
+      }),
+    googleEventId: text("google_event_id").notNull(),
+    googleICalUid: text("google_ical_uid"),
+    recurringEventId: text("recurring_event_id"),
+    status: text("status").notNull().default("confirmed"),
+    title: text("title").notNull(),
+    description: text("description"),
+    location: text("location"),
+    htmlLink: text("html_link"),
+    meetingUrl: text("meeting_url"),
+    startDate: text("start_date"),
+    endDateExclusive: text("end_date_exclusive"),
+    startsAt: text("starts_at"),
+    endsAt: text("ends_at"),
+    allDay: integer("all_day", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    timeZone: text("time_zone"),
+    visibility: text("visibility").notNull().default("default"),
+    transparency: text("transparency").notNull().default("opaque"),
+    organizerEmail: text("organizer_email"),
+    googleEtag: text("google_etag"),
+    googleUpdatedAt: text("google_updated_at"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("google_calendar_event_unique").on(
+      table.selectionId,
+      table.googleEventId,
+    ),
+    index("idx_google_calendar_events_start").on(
+      table.selectionId,
+      table.status,
+      table.startDate,
+      table.startsAt,
+    ),
+    index("idx_google_calendar_events_ical_uid").on(table.googleICalUid),
   ],
 )
 
@@ -2246,6 +2308,8 @@ export type GoogleCalendarSelection =
   typeof googleCalendarSelections.$inferSelect
 export type NewGoogleCalendarSelection =
   typeof googleCalendarSelections.$inferInsert
+export type GoogleCalendarEvent = typeof googleCalendarEvents.$inferSelect
+export type NewGoogleCalendarEvent = typeof googleCalendarEvents.$inferInsert
 export type GoogleCalendarEntityLink =
   typeof googleCalendarEntityLinks.$inferSelect
 export type NewGoogleCalendarEntityLink =

--- a/src/lib/__tests__/google-calendar-sync.test.ts
+++ b/src/lib/__tests__/google-calendar-sync.test.ts
@@ -13,6 +13,12 @@ import {
   decideGoogleCalendarSyncAction,
   googleEventIdForCompass,
 } from "@/lib/google/calendar/sync-policy"
+import { parseGoogleCalendarEvent } from "@/lib/google/calendar/client"
+import {
+  canConnectGoogleCalendar,
+  canManageOrganizationCalendars,
+  canWriteGoogleCalendar,
+} from "@/lib/google/calendar/policy"
 
 describe("Google Calendar OAuth configuration", () => {
   it("fails closed when required secrets are missing", () => {
@@ -201,5 +207,64 @@ describe("Google Calendar event IDs", () => {
     )
 
     expect(new Set([eventId, taskId, otherAccountId]).size).toBe(3)
+  })
+})
+
+describe("managed Google Calendar policy", () => {
+  it("lets developers manage a shared organization calendar", () => {
+    expect(
+      canConnectGoogleCalendar({ userId: "developer-1", role: "developer" }),
+    ).toBe(true)
+    expect(canManageOrganizationCalendars("developer")).toBe(true)
+    expect(canManageOrganizationCalendars("office")).toBe(false)
+  })
+
+  it("requires Google writer access for Compass destinations", () => {
+    expect(canWriteGoogleCalendar("owner")).toBe(true)
+    expect(canWriteGoogleCalendar("writer")).toBe(true)
+    expect(canWriteGoogleCalendar("reader")).toBe(false)
+  })
+})
+
+describe("Google Calendar event parsing", () => {
+  it("normalizes a timed Google Meet event", () => {
+    expect(
+      parseGoogleCalendarEvent({
+        id: "google-event-1",
+        etag: "etag-1",
+        summary: "Owner meeting",
+        status: "confirmed",
+        hangoutLink: "https://meet.google.com/abc-defg-hij",
+        start: {
+          dateTime: "2026-08-20T09:00:00-06:00",
+          timeZone: "America/Denver",
+        },
+        end: {
+          dateTime: "2026-08-20T10:00:00-06:00",
+          timeZone: "America/Denver",
+        },
+      }),
+    ).toMatchObject({
+      id: "google-event-1",
+      summary: "Owner meeting",
+      allDay: false,
+      meetingUrl: "https://meet.google.com/abc-defg-hij",
+      timeZone: "America/Denver",
+    })
+  })
+
+  it("uses exclusive end dates for all-day events", () => {
+    expect(
+      parseGoogleCalendarEvent({
+        id: "holiday-1",
+        start: { date: "2026-12-24" },
+        end: { date: "2026-12-26" },
+      }),
+    ).toMatchObject({
+      summary: "Busy",
+      startDate: "2026-12-24",
+      endDateExclusive: "2026-12-26",
+      allDay: true,
+    })
   })
 })

--- a/src/lib/google/calendar/client.ts
+++ b/src/lib/google/calendar/client.ts
@@ -1,0 +1,332 @@
+const GOOGLE_CALENDAR_API = "https://www.googleapis.com/calendar/v3"
+
+type JsonRecord = Record<string, unknown>
+
+export type GoogleCalendarListEntry = {
+  readonly id: string
+  readonly summary: string
+  readonly description: string | null
+  readonly timeZone: string | null
+  readonly backgroundColor: string | null
+  readonly accessRole: string
+  readonly primary: boolean
+  readonly deleted: boolean
+}
+
+export type GoogleCalendarEventItem = {
+  readonly id: string
+  readonly etag: string | null
+  readonly iCalUID: string | null
+  readonly recurringEventId: string | null
+  readonly status: string
+  readonly summary: string
+  readonly description: string | null
+  readonly location: string | null
+  readonly htmlLink: string | null
+  readonly meetingUrl: string | null
+  readonly startDate: string | null
+  readonly endDateExclusive: string | null
+  readonly startsAt: string | null
+  readonly endsAt: string | null
+  readonly allDay: boolean
+  readonly timeZone: string | null
+  readonly visibility: string
+  readonly transparency: string
+  readonly organizerEmail: string | null
+  readonly updatedAt: string | null
+}
+
+export type GoogleCalendarEventWrite = {
+  readonly id?: string
+  readonly summary: string
+  readonly description: string | null
+  readonly location: string | null
+  readonly startDate: string | null
+  readonly endDateExclusive: string | null
+  readonly startsAt: string | null
+  readonly endsAt: string | null
+  readonly timeZone: string
+  readonly visibility: "default" | "public" | "private"
+  readonly recurrence: readonly string[]
+  readonly attendeeEmails: readonly string[]
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function stringValue(record: JsonRecord, key: string): string | null {
+  const value = record[key]
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null
+}
+
+function booleanValue(record: JsonRecord, key: string): boolean {
+  return record[key] === true
+}
+
+async function responsePayload(response: Response): Promise<unknown> {
+  try {
+    return await response.json()
+  } catch {
+    return null
+  }
+}
+
+function googleError(payload: unknown, fallback: string): string {
+  if (!isRecord(payload)) return fallback
+  const error = payload.error
+  if (!isRecord(error)) return fallback
+  return stringValue(error, "message") ?? fallback
+}
+
+async function googleRequest(
+  accessToken: string,
+  url: URL,
+  init?: RequestInit,
+): Promise<unknown> {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+  })
+  const payload = await responsePayload(response)
+  if (!response.ok) {
+    throw new Error(
+      googleError(payload, `Google Calendar request failed (${response.status}).`),
+    )
+  }
+  return payload
+}
+
+function parseCalendar(value: unknown): GoogleCalendarListEntry | null {
+  if (!isRecord(value)) return null
+  const id = stringValue(value, "id")
+  const summary = stringValue(value, "summary")
+  if (!id || !summary) return null
+  return {
+    id,
+    summary,
+    description: stringValue(value, "description"),
+    timeZone: stringValue(value, "timeZone"),
+    backgroundColor: stringValue(value, "backgroundColor"),
+    accessRole: stringValue(value, "accessRole") ?? "reader",
+    primary: booleanValue(value, "primary"),
+    deleted: booleanValue(value, "deleted"),
+  }
+}
+
+function endpoint(path: string): URL {
+  return new URL(`${GOOGLE_CALENDAR_API}${path}`)
+}
+
+export async function listGoogleCalendars(
+  accessToken: string,
+): Promise<readonly GoogleCalendarListEntry[]> {
+  const calendars: GoogleCalendarListEntry[] = []
+  let pageToken: string | null = null
+
+  do {
+    const url = endpoint("/users/me/calendarList")
+    url.searchParams.set("maxResults", "250")
+    url.searchParams.set("showDeleted", "false")
+    if (pageToken) url.searchParams.set("pageToken", pageToken)
+    const payload = await googleRequest(accessToken, url)
+    if (!isRecord(payload)) throw new Error("Google returned an invalid calendar list.")
+    const items = payload.items
+    if (Array.isArray(items)) {
+      for (const item of items) {
+        const calendar = parseCalendar(item)
+        if (calendar && !calendar.deleted) calendars.push(calendar)
+      }
+    }
+    pageToken = stringValue(payload, "nextPageToken")
+  } while (pageToken)
+
+  return calendars.sort((left, right) => {
+    if (left.primary !== right.primary) return left.primary ? -1 : 1
+    return left.summary.localeCompare(right.summary)
+  })
+}
+
+function nestedDate(record: JsonRecord, key: string): JsonRecord | null {
+  const value = record[key]
+  return isRecord(value) ? value : null
+}
+
+function conferenceMeetingUrl(record: JsonRecord): string | null {
+  const hangoutLink = stringValue(record, "hangoutLink")
+  if (hangoutLink) return hangoutLink
+  const conferenceData = record.conferenceData
+  if (!isRecord(conferenceData) || !Array.isArray(conferenceData.entryPoints)) {
+    return null
+  }
+  for (const entryPoint of conferenceData.entryPoints) {
+    if (!isRecord(entryPoint)) continue
+    if (stringValue(entryPoint, "entryPointType") !== "video") continue
+    const uri = stringValue(entryPoint, "uri")
+    if (uri) return uri
+  }
+  return null
+}
+
+export function parseGoogleCalendarEvent(
+  value: unknown,
+): GoogleCalendarEventItem | null {
+  if (!isRecord(value)) return null
+  const id = stringValue(value, "id")
+  if (!id) return null
+  const start = nestedDate(value, "start")
+  const end = nestedDate(value, "end")
+  const startDate = start ? stringValue(start, "date") : null
+  const endDateExclusive = end ? stringValue(end, "date") : null
+  const startsAt = start ? stringValue(start, "dateTime") : null
+  const endsAt = end ? stringValue(end, "dateTime") : null
+  const organizer = isRecord(value.organizer) ? value.organizer : null
+
+  return {
+    id,
+    etag: stringValue(value, "etag"),
+    iCalUID: stringValue(value, "iCalUID"),
+    recurringEventId: stringValue(value, "recurringEventId"),
+    status: stringValue(value, "status") ?? "confirmed",
+    summary: stringValue(value, "summary") ?? "Busy",
+    description: stringValue(value, "description"),
+    location: stringValue(value, "location"),
+    htmlLink: stringValue(value, "htmlLink"),
+    meetingUrl: conferenceMeetingUrl(value),
+    startDate,
+    endDateExclusive,
+    startsAt,
+    endsAt,
+    allDay: startDate !== null,
+    timeZone:
+      (start ? stringValue(start, "timeZone") : null) ??
+      (end ? stringValue(end, "timeZone") : null),
+    visibility: stringValue(value, "visibility") ?? "default",
+    transparency: stringValue(value, "transparency") ?? "opaque",
+    organizerEmail: organizer ? stringValue(organizer, "email") : null,
+    updatedAt: stringValue(value, "updated"),
+  }
+}
+
+export async function listGoogleCalendarEvents(
+  accessToken: string,
+  calendarId: string,
+  window: { readonly timeMin: string; readonly timeMax: string },
+): Promise<readonly GoogleCalendarEventItem[]> {
+  const events: GoogleCalendarEventItem[] = []
+  let pageToken: string | null = null
+
+  do {
+    const url = endpoint(`/calendars/${encodeURIComponent(calendarId)}/events`)
+    url.searchParams.set("maxResults", "2500")
+    url.searchParams.set("showDeleted", "true")
+    url.searchParams.set("singleEvents", "true")
+    url.searchParams.set("timeMin", window.timeMin)
+    url.searchParams.set("timeMax", window.timeMax)
+    url.searchParams.set("orderBy", "startTime")
+    if (pageToken) url.searchParams.set("pageToken", pageToken)
+    const payload = await googleRequest(accessToken, url)
+    if (!isRecord(payload)) throw new Error("Google returned an invalid event list.")
+    const items = payload.items
+    if (Array.isArray(items)) {
+      for (const item of items) {
+        const event = parseGoogleCalendarEvent(item)
+        if (event) events.push(event)
+      }
+    }
+    pageToken = stringValue(payload, "nextPageToken")
+  } while (pageToken)
+
+  return events
+}
+
+function eventBody(input: GoogleCalendarEventWrite): JsonRecord {
+  const body: JsonRecord = {
+    summary: input.summary,
+    visibility: input.visibility,
+  }
+  if (input.description) body.description = input.description
+  if (input.location) body.location = input.location
+  if (input.startDate && input.endDateExclusive) {
+    body.start = { date: input.startDate }
+    body.end = { date: input.endDateExclusive }
+  } else if (input.startsAt && input.endsAt) {
+    body.start = { dateTime: input.startsAt, timeZone: input.timeZone }
+    body.end = { dateTime: input.endsAt, timeZone: input.timeZone }
+  }
+  if (input.recurrence.length > 0) body.recurrence = [...input.recurrence]
+  if (input.attendeeEmails.length > 0) {
+    body.attendees = input.attendeeEmails.map((email) => ({ email }))
+  }
+  if (input.id) body.id = input.id
+  return body
+}
+
+export async function createGoogleCalendarEvent(
+  accessToken: string,
+  calendarId: string,
+  input: GoogleCalendarEventWrite,
+): Promise<GoogleCalendarEventItem> {
+  const url = endpoint(`/calendars/${encodeURIComponent(calendarId)}/events`)
+  url.searchParams.set(
+    "sendUpdates",
+    input.attendeeEmails.length > 0 ? "all" : "none",
+  )
+  const payload = await googleRequest(accessToken, url, {
+    method: "POST",
+    body: JSON.stringify(eventBody(input)),
+  })
+  const event = parseGoogleCalendarEvent(payload)
+  if (!event) throw new Error("Google returned an invalid created event.")
+  return event
+}
+
+export async function updateGoogleCalendarEvent(
+  accessToken: string,
+  calendarId: string,
+  googleEventId: string,
+  input: GoogleCalendarEventWrite,
+): Promise<GoogleCalendarEventItem> {
+  const url = endpoint(
+    `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(googleEventId)}`,
+  )
+  url.searchParams.set(
+    "sendUpdates",
+    input.attendeeEmails.length > 0 ? "all" : "none",
+  )
+  const payload = await googleRequest(accessToken, url, {
+    method: "PATCH",
+    body: JSON.stringify(eventBody(input)),
+  })
+  const event = parseGoogleCalendarEvent(payload)
+  if (!event) throw new Error("Google returned an invalid updated event.")
+  return event
+}
+
+export async function deleteGoogleCalendarEvent(
+  accessToken: string,
+  calendarId: string,
+  googleEventId: string,
+): Promise<void> {
+  const url = endpoint(
+    `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(googleEventId)}`,
+  )
+  url.searchParams.set("sendUpdates", "all")
+  const response = await fetch(url, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
+  if (response.status === 404 || response.status === 410) return
+  if (!response.ok) {
+    const payload = await responsePayload(response)
+    throw new Error(
+      googleError(payload, `Google Calendar delete failed (${response.status}).`),
+    )
+  }
+}

--- a/src/lib/google/calendar/oauth.ts
+++ b/src/lib/google/calendar/oauth.ts
@@ -15,6 +15,11 @@ export type GoogleTokenGrant = {
   readonly scopes: readonly string[]
 }
 
+export type GoogleAccessToken = {
+  readonly accessToken: string
+  readonly expiresIn: number
+}
+
 export type GoogleAccountIdentity = {
   readonly subject: string
   readonly email: string
@@ -132,6 +137,40 @@ export async function exchangeGoogleAuthorizationCode(
       ? scope.split(/\s+/).filter(Boolean)
       : [...GOOGLE_CALENDAR_SCOPES],
   }
+}
+
+export async function refreshGoogleAccessToken(
+  config: GoogleCalendarOAuthConfig,
+  refreshToken: string,
+): Promise<GoogleAccessToken> {
+  const response = await fetch(GOOGLE_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      refresh_token: refreshToken,
+      grant_type: "refresh_token",
+    }),
+  })
+  const payload = await responseJson(response)
+  if (!response.ok || !isRecord(payload)) {
+    throw new Error(`Google token refresh failed (${response.status}).`)
+  }
+
+  const accessToken = requiredString(payload, "access_token")
+  const expiresIn = payload.expires_in
+  if (
+    !accessToken ||
+    typeof expiresIn !== "number" ||
+    !Number.isFinite(expiresIn)
+  ) {
+    throw new Error("Google returned an incomplete refreshed token.")
+  }
+
+  return { accessToken, expiresIn }
 }
 
 export async function getGoogleAccountIdentity(

--- a/src/lib/google/calendar/policy.ts
+++ b/src/lib/google/calendar/policy.ts
@@ -1,0 +1,24 @@
+import { isDemoUser } from "@/lib/demo"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+export function canConnectGoogleCalendar(input: {
+  readonly userId: string
+  readonly role: string
+}): boolean {
+  return (
+    !isDemoUser(input.userId) &&
+    (isInternalStaffRole(input.role) || input.role === "developer")
+  )
+}
+
+export function canManageOrganizationCalendars(role: string): boolean {
+  return (
+    role === "admin" ||
+    role === "secondary_admin" ||
+    role === "developer"
+  )
+}
+
+export function canWriteGoogleCalendar(accessRole: string): boolean {
+  return accessRole === "owner" || accessRole === "writer"
+}

--- a/src/lib/google/calendar/sync.ts
+++ b/src/lib/google/calendar/sync.ts
@@ -1,0 +1,619 @@
+import { and, eq } from "drizzle-orm"
+
+import { getDb } from "@/db"
+import {
+  googleCalendarConnections,
+  googleCalendarEntityLinks,
+  googleCalendarEvents,
+  googleCalendarSelections,
+  users,
+  workCalendarEventAttendees,
+  workCalendarEvents,
+} from "@/db/schema"
+import { decrypt } from "@/lib/crypto"
+import {
+  getGoogleCalendarOAuthConfig,
+  googleCalendarTokenSalt,
+} from "@/lib/google/calendar/config"
+import {
+  createGoogleCalendarEvent,
+  deleteGoogleCalendarEvent,
+  listGoogleCalendarEvents,
+  updateGoogleCalendarEvent,
+  type GoogleCalendarEventWrite,
+  type GoogleCalendarEventItem,
+} from "@/lib/google/calendar/client"
+import { refreshGoogleAccessToken } from "@/lib/google/calendar/oauth"
+import { googleEventIdForCompass } from "@/lib/google/calendar/sync-policy"
+
+type Database = ReturnType<typeof getDb>
+
+export type GoogleCalendarSyncResult = {
+  readonly imported: number
+  readonly updated: number
+  readonly conflicts: number
+}
+
+type SelectionWithConnection = {
+  readonly selectionId: string
+  readonly connectionId: string
+  readonly calendarId: string
+  readonly calendarScope: string
+  readonly internalVisibility: string
+  readonly connectionUserId: string
+  readonly refreshTokenEncrypted: string
+}
+
+function syncWindow(): { readonly timeMin: string; readonly timeMax: string } {
+  const now = new Date()
+  const timeMin = new Date(now)
+  timeMin.setUTCDate(timeMin.getUTCDate() - 90)
+  const timeMax = new Date(now)
+  timeMax.setUTCFullYear(timeMax.getUTCFullYear() + 2)
+  return {
+    timeMin: timeMin.toISOString(),
+    timeMax: timeMax.toISOString(),
+  }
+}
+
+async function accessTokenForConnection(
+  env: object,
+  connection: Pick<
+    SelectionWithConnection,
+    "connectionUserId" | "refreshTokenEncrypted"
+  >,
+): Promise<string> {
+  const configuration = getGoogleCalendarOAuthConfig(env)
+  if (!configuration.configured) {
+    throw new Error("Google Calendar OAuth is not configured.")
+  }
+  const refreshToken = await decrypt(
+    connection.refreshTokenEncrypted,
+    configuration.config.tokenEncryptionKey,
+    googleCalendarTokenSalt(connection.connectionUserId),
+  )
+  const token = await refreshGoogleAccessToken(
+    configuration.config,
+    refreshToken,
+  )
+  return token.accessToken
+}
+
+async function selectionWithConnection(
+  db: Database,
+  selectionId: string,
+): Promise<SelectionWithConnection | null> {
+  return db
+    .select({
+      selectionId: googleCalendarSelections.id,
+      connectionId: googleCalendarSelections.connectionId,
+      calendarId: googleCalendarSelections.googleCalendarId,
+      calendarScope: googleCalendarSelections.calendarScope,
+      internalVisibility: googleCalendarSelections.internalVisibility,
+      connectionUserId: googleCalendarConnections.userId,
+      refreshTokenEncrypted:
+        googleCalendarConnections.refreshTokenEncrypted,
+    })
+    .from(googleCalendarSelections)
+    .innerJoin(
+      googleCalendarConnections,
+      eq(
+        googleCalendarConnections.id,
+        googleCalendarSelections.connectionId,
+      ),
+    )
+    .where(eq(googleCalendarSelections.id, selectionId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+}
+
+function localVisibility(
+  selection: SelectionWithConnection,
+  event: GoogleCalendarEventItem,
+): "organization" | "busy" | "private" {
+  if (event.visibility === "private") return "private"
+  return selection.internalVisibility === "details" ? "organization" : "busy"
+}
+
+async function cachePersonalEvent(
+  db: Database,
+  selection: SelectionWithConnection,
+  event: GoogleCalendarEventItem,
+  now: string,
+): Promise<"imported" | "updated"> {
+  const existing = await db
+    .select({ id: googleCalendarEvents.id })
+    .from(googleCalendarEvents)
+    .where(
+      and(
+        eq(googleCalendarEvents.selectionId, selection.selectionId),
+        eq(googleCalendarEvents.googleEventId, event.id),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+
+  const values = {
+    googleICalUid: event.iCalUID,
+    recurringEventId: event.recurringEventId,
+    status: event.status,
+    title: event.summary,
+    description: event.description,
+    location: event.location,
+    htmlLink: event.htmlLink,
+    meetingUrl: event.meetingUrl,
+    startDate: event.startDate,
+    endDateExclusive: event.endDateExclusive,
+    startsAt: event.startsAt,
+    endsAt: event.endsAt,
+    allDay: event.allDay,
+    timeZone: event.timeZone,
+    visibility: event.visibility,
+    transparency: event.transparency,
+    organizerEmail: event.organizerEmail,
+    googleEtag: event.etag,
+    googleUpdatedAt: event.updatedAt,
+    updatedAt: now,
+  }
+
+  if (existing) {
+    await db
+      .update(googleCalendarEvents)
+      .set(values)
+      .where(eq(googleCalendarEvents.id, existing.id))
+    return "updated"
+  }
+
+  await db.insert(googleCalendarEvents).values({
+    id: crypto.randomUUID(),
+    selectionId: selection.selectionId,
+    googleEventId: event.id,
+    ...values,
+    createdAt: now,
+  })
+  return "imported"
+}
+
+async function syncOrganizationEvent(
+  db: Database,
+  selection: SelectionWithConnection,
+  event: GoogleCalendarEventItem,
+  now: string,
+): Promise<"imported" | "updated" | "conflict"> {
+  const link = await db
+    .select({
+      id: googleCalendarEntityLinks.id,
+      sourceId: googleCalendarEntityLinks.sourceId,
+      googleEtag: googleCalendarEntityLinks.googleEtag,
+      compassVersion: googleCalendarEntityLinks.compassVersion,
+    })
+    .from(googleCalendarEntityLinks)
+    .where(
+      and(
+        eq(googleCalendarEntityLinks.connectionId, selection.connectionId),
+        eq(googleCalendarEntityLinks.googleCalendarId, selection.calendarId),
+        eq(googleCalendarEntityLinks.googleEventId, event.id),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+
+  if (link) {
+    const local = await db
+      .select({
+        id: workCalendarEvents.id,
+        version: workCalendarEvents.version,
+      })
+      .from(workCalendarEvents)
+      .where(eq(workCalendarEvents.id, link.sourceId))
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (!local) {
+      await db
+        .delete(googleCalendarEntityLinks)
+        .where(eq(googleCalendarEntityLinks.id, link.id))
+      return syncOrganizationEvent(db, selection, event, now)
+    }
+    if (link.googleEtag === event.etag) return "updated"
+    if (
+      link.compassVersion !== null &&
+      local.version !== link.compassVersion
+    ) {
+      await db
+        .update(googleCalendarEntityLinks)
+        .set({
+          syncStatus: "conflict",
+          lastError: "This event changed in both Compass and Google Calendar.",
+          updatedAt: now,
+        })
+        .where(eq(googleCalendarEntityLinks.id, link.id))
+      return "conflict"
+    }
+
+    const nextVersion = local.version + 1
+    await db
+      .update(workCalendarEvents)
+      .set({
+        title: event.summary,
+        eventType: event.meetingUrl ? "meeting" : "other",
+        visibility: localVisibility(selection, event),
+        description: event.description,
+        startDate: event.startDate,
+        endDateExclusive: event.endDateExclusive,
+        startsAt: event.startsAt,
+        endsAt: event.endsAt,
+        allDay: event.allDay,
+        timeZone: event.timeZone ?? "UTC",
+        location: event.location,
+        meetingUrl: event.meetingUrl,
+        recurrence: "none",
+        recurrenceUntil: null,
+        status: event.status === "cancelled" ? "cancelled" : "open",
+        version: nextVersion,
+        updatedBy: selection.connectionUserId,
+        cancelledBy:
+          event.status === "cancelled" ? selection.connectionUserId : null,
+        cancelledAt: event.status === "cancelled" ? now : null,
+        updatedAt: now,
+      })
+      .where(eq(workCalendarEvents.id, local.id))
+    await db
+      .update(googleCalendarEntityLinks)
+      .set({
+        googleICalUid: event.iCalUID,
+        syncStatus: "synced",
+        googleEtag: event.etag,
+        googleUpdatedAt: event.updatedAt,
+        compassVersion: nextVersion,
+        lastSyncedAt: now,
+        lastError: null,
+        updatedAt: now,
+      })
+      .where(eq(googleCalendarEntityLinks.id, link.id))
+    return "updated"
+  }
+
+  if (event.status === "cancelled") return "updated"
+  const localId = crypto.randomUUID()
+  await db.insert(workCalendarEvents).values({
+    id: localId,
+    organizationId: await organizationIdForConnection(
+      db,
+      selection.connectionId,
+    ),
+    projectId: null,
+    title: event.summary,
+    eventType: event.meetingUrl ? "meeting" : "other",
+    visibility: localVisibility(selection, event),
+    description: event.description,
+    startDate: event.startDate,
+    endDateExclusive: event.endDateExclusive,
+    startsAt: event.startsAt,
+    endsAt: event.endsAt,
+    allDay: event.allDay,
+    timeZone: event.timeZone ?? "UTC",
+    location: event.location,
+    meetingUrl: event.meetingUrl,
+    recurrence: "none",
+    recurrenceUntil: null,
+    status: "open",
+    version: 1,
+    createdBy: selection.connectionUserId,
+    updatedBy: selection.connectionUserId,
+    cancelledBy: null,
+    cancelledAt: null,
+    createdAt: now,
+    updatedAt: now,
+  })
+  await db.insert(googleCalendarEntityLinks).values({
+    id: crypto.randomUUID(),
+    connectionId: selection.connectionId,
+    googleCalendarId: selection.calendarId,
+    googleEventId: event.id,
+    googleICalUid: event.iCalUID,
+    sourceType: "work_calendar_event",
+    sourceId: localId,
+    syncDirection: "two_way",
+    syncStatus: "synced",
+    googleEtag: event.etag,
+    googleUpdatedAt: event.updatedAt,
+    compassVersion: 1,
+    lastSyncedAt: now,
+    lastError: null,
+    createdAt: now,
+    updatedAt: now,
+  })
+  return "imported"
+}
+
+async function organizationIdForConnection(
+  db: Database,
+  connectionId: string,
+): Promise<string> {
+  const row = await db
+    .select({ organizationId: googleCalendarConnections.organizationId })
+    .from(googleCalendarConnections)
+    .where(eq(googleCalendarConnections.id, connectionId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  if (!row) throw new Error("Google Calendar connection was not found.")
+  return row.organizationId
+}
+
+export async function syncGoogleCalendarSelection(
+  db: Database,
+  env: object,
+  selectionId: string,
+): Promise<GoogleCalendarSyncResult> {
+  const selection = await selectionWithConnection(db, selectionId)
+  if (!selection) throw new Error("Google Calendar selection was not found.")
+  const accessToken = await accessTokenForConnection(env, selection)
+  const events = await listGoogleCalendarEvents(
+    accessToken,
+    selection.calendarId,
+    syncWindow(),
+  )
+  const now = new Date().toISOString()
+  let imported = 0
+  let updated = 0
+  let conflicts = 0
+
+  try {
+    for (const event of events) {
+      const outcome =
+        selection.calendarScope === "organization"
+          ? await syncOrganizationEvent(db, selection, event, now)
+          : await cachePersonalEvent(db, selection, event, now)
+      if (outcome === "imported") imported += 1
+      else if (outcome === "conflict") conflicts += 1
+      else updated += 1
+    }
+    if (selection.calendarScope === "organization") {
+      const compassChanges = await db
+        .select({
+          eventId: workCalendarEvents.id,
+          eventStatus: workCalendarEvents.status,
+          eventVersion: workCalendarEvents.version,
+          linkedVersion: googleCalendarEntityLinks.compassVersion,
+          syncStatus: googleCalendarEntityLinks.syncStatus,
+        })
+        .from(googleCalendarEntityLinks)
+        .innerJoin(
+          workCalendarEvents,
+          eq(workCalendarEvents.id, googleCalendarEntityLinks.sourceId),
+        )
+        .where(
+          and(
+            eq(googleCalendarEntityLinks.connectionId, selection.connectionId),
+            eq(googleCalendarEntityLinks.googleCalendarId, selection.calendarId),
+            eq(googleCalendarEntityLinks.sourceType, "work_calendar_event"),
+          ),
+        )
+      for (const change of compassChanges) {
+        if (
+          change.syncStatus === "conflict" ||
+          change.linkedVersion === change.eventVersion
+        ) {
+          continue
+        }
+        if (change.eventStatus === "cancelled") {
+          await deleteLinkedWorkCalendarEventFromGoogle(db, env, change.eventId)
+        } else {
+          await publishWorkCalendarEventToGoogle(
+            db,
+            env,
+            change.eventId,
+            selection.selectionId,
+          )
+        }
+        updated += 1
+      }
+    }
+    await db
+      .update(googleCalendarSelections)
+      .set({ lastSyncedAt: now, lastError: null, updatedAt: now })
+      .where(eq(googleCalendarSelections.id, selection.selectionId))
+    await db
+      .update(googleCalendarConnections)
+      .set({ lastSyncedAt: now, lastError: null, updatedAt: now })
+      .where(eq(googleCalendarConnections.id, selection.connectionId))
+    return { imported, updated, conflicts }
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Google Calendar sync failed."
+    await db
+      .update(googleCalendarSelections)
+      .set({ lastError: message, updatedAt: now })
+      .where(eq(googleCalendarSelections.id, selection.selectionId))
+    await db
+      .update(googleCalendarConnections)
+      .set({ lastError: message, updatedAt: now })
+      .where(eq(googleCalendarConnections.id, selection.connectionId))
+    throw error
+  }
+}
+
+export async function googleCalendarAccessToken(
+  db: Database,
+  env: object,
+  selectionId: string,
+): Promise<{
+  readonly accessToken: string
+  readonly selection: SelectionWithConnection
+}> {
+  const selection = await selectionWithConnection(db, selectionId)
+  if (!selection) throw new Error("Google Calendar selection was not found.")
+  return {
+    accessToken: await accessTokenForConnection(env, selection),
+    selection,
+  }
+}
+
+function googleRecurrence(input: {
+  readonly recurrence: string
+  readonly recurrenceUntil: string | null
+}): readonly string[] {
+  if (input.recurrence === "none") return []
+  const frequency = input.recurrence.toUpperCase()
+  const until = input.recurrenceUntil?.replaceAll("-", "")
+  return [
+    `RRULE:FREQ=${frequency}${until ? `;UNTIL=${until}T235959Z` : ""}`,
+  ]
+}
+
+export async function publishWorkCalendarEventToGoogle(
+  db: Database,
+  env: object,
+  eventId: string,
+  selectionId: string,
+): Promise<void> {
+  const token = await googleCalendarAccessToken(db, env, selectionId)
+  const event = await db
+    .select()
+    .from(workCalendarEvents)
+    .where(eq(workCalendarEvents.id, eventId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  if (!event) throw new Error("Work Calendar event was not found.")
+  const attendeeRows = await db
+    .select({ email: users.email })
+    .from(workCalendarEventAttendees)
+    .innerJoin(users, eq(users.id, workCalendarEventAttendees.userId))
+    .where(eq(workCalendarEventAttendees.eventId, eventId))
+  const input: GoogleCalendarEventWrite = {
+    summary: event.title,
+    description: event.description,
+    location: event.location,
+    startDate: event.startDate,
+    endDateExclusive: event.endDateExclusive,
+    startsAt: event.startsAt,
+    endsAt: event.endsAt,
+    timeZone: event.timeZone,
+    visibility: event.visibility === "private" ? "private" : "default",
+    recurrence: googleRecurrence(event),
+    attendeeEmails: attendeeRows.map((attendee) => attendee.email),
+  }
+  const link = await db
+    .select({
+      id: googleCalendarEntityLinks.id,
+      googleEventId: googleCalendarEntityLinks.googleEventId,
+    })
+    .from(googleCalendarEntityLinks)
+    .where(
+      and(
+        eq(googleCalendarEntityLinks.connectionId, token.selection.connectionId),
+        eq(googleCalendarEntityLinks.googleCalendarId, token.selection.calendarId),
+        eq(googleCalendarEntityLinks.sourceType, "work_calendar_event"),
+        eq(googleCalendarEntityLinks.sourceId, eventId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  const googleEvent = link
+    ? await updateGoogleCalendarEvent(
+        token.accessToken,
+        token.selection.calendarId,
+        link.googleEventId,
+        input,
+      )
+    : await createGoogleCalendarEvent(
+        token.accessToken,
+        token.selection.calendarId,
+        {
+          ...input,
+          id: await googleEventIdForCompass(
+            "work_calendar_event",
+            eventId,
+            token.selection.connectionId,
+          ),
+        },
+      )
+  const now = new Date().toISOString()
+  if (link) {
+    await db
+      .update(googleCalendarEntityLinks)
+      .set({
+        googleICalUid: googleEvent.iCalUID,
+        googleEtag: googleEvent.etag,
+        googleUpdatedAt: googleEvent.updatedAt,
+        compassVersion: event.version,
+        syncStatus: "synced",
+        lastSyncedAt: now,
+        lastError: null,
+        updatedAt: now,
+      })
+      .where(eq(googleCalendarEntityLinks.id, link.id))
+    return
+  }
+  await db.insert(googleCalendarEntityLinks).values({
+    id: crypto.randomUUID(),
+    connectionId: token.selection.connectionId,
+    googleCalendarId: token.selection.calendarId,
+    googleEventId: googleEvent.id,
+    googleICalUid: googleEvent.iCalUID,
+    sourceType: "work_calendar_event",
+    sourceId: eventId,
+    syncDirection: "two_way",
+    syncStatus: "synced",
+    googleEtag: googleEvent.etag,
+    googleUpdatedAt: googleEvent.updatedAt,
+    compassVersion: event.version,
+    lastSyncedAt: now,
+    lastError: null,
+    createdAt: now,
+    updatedAt: now,
+  })
+}
+
+export async function deleteLinkedWorkCalendarEventFromGoogle(
+  db: Database,
+  env: object,
+  eventId: string,
+): Promise<void> {
+  const linked = await db
+    .select({
+      linkId: googleCalendarEntityLinks.id,
+      googleEventId: googleCalendarEntityLinks.googleEventId,
+      selectionId: googleCalendarSelections.id,
+    })
+    .from(googleCalendarEntityLinks)
+    .innerJoin(
+      googleCalendarSelections,
+      and(
+        eq(
+          googleCalendarSelections.connectionId,
+          googleCalendarEntityLinks.connectionId,
+        ),
+        eq(
+          googleCalendarSelections.googleCalendarId,
+          googleCalendarEntityLinks.googleCalendarId,
+        ),
+      ),
+    )
+    .where(
+      and(
+        eq(googleCalendarEntityLinks.sourceType, "work_calendar_event"),
+        eq(googleCalendarEntityLinks.sourceId, eventId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  if (!linked) return
+  const token = await googleCalendarAccessToken(db, env, linked.selectionId)
+  await deleteGoogleCalendarEvent(
+    token.accessToken,
+    token.selection.calendarId,
+    linked.googleEventId,
+  )
+  const now = new Date().toISOString()
+  await db
+    .update(googleCalendarEntityLinks)
+    .set({
+      syncStatus: "synced",
+      googleEtag: null,
+      lastSyncedAt: now,
+      lastError: null,
+      updatedAt: now,
+    })
+    .where(eq(googleCalendarEntityLinks.id, linked.linkId))
+}


### PR DESCRIPTION
## Summary

- add personal and organization Google Calendar discovery and sync
- add ORC Master-style visibility and create/edit/delete permissions
- add Work Calendar people filters with Busy-only projection for colleagues
- add calendar destinations with linked Google create/update/delete behavior
- add the D1 migration, tests, and implementation documentation

## Verification

- `bunx tsc --noEmit`
- `bun test src/lib/__tests__/google-calendar-sync.test.ts src/lib/__tests__/work-calendar.test.ts src/lib/__tests__/work-calendar-recurrence.test.ts`
- targeted ESLint on all touched TypeScript/TSX files
- `bun run build`
