### PR TITLE
feat(schedule): connect related project todos

### DIFF
--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -739,6 +739,53 @@ test.describe("usable Compass areas", () => {
     ).toHaveCount(2)
   })
 
+  test("schedule items expose related records in the existing to-do workspace", async ({
+    page,
+  }) => {
+    const schedulePath =
+      "/dashboard/projects/e2e-project-001/schedule?view=list"
+    const response = await page.goto(schedulePath)
+    await expectHealthyNavigation(
+      page,
+      response,
+      "/dashboard/projects/e2e-project-001/schedule"
+    )
+
+    const scheduleRow = page
+      .locator("#schedule-item-e2e-schedule-001")
+      .last()
+    await scheduleRow.locator('button[title="Edit schedule item"]').click()
+
+    const editDialog = page.getByRole("dialog", {
+      name: "Edit Schedule Item",
+    })
+    await expect(
+      editDialog.getByRole("heading", { name: "Related to-dos" })
+    ).toBeVisible()
+    const linkedTodo = editDialog.getByRole("link", {
+      name: "Regression follow-up",
+    })
+    await expect(linkedTodo).toHaveAttribute(
+      "href",
+      /\/dashboard\/projects\/e2e-project-001\/todos\?item=e2e-todo-001/
+    )
+    await linkedTodo.click()
+
+    await expect(page).toHaveURL(
+      /\/dashboard\/projects\/e2e-project-001\/todos\?item=e2e-todo-001/
+    )
+    const focusedTodo = page.locator(
+      'article[data-focused="true"]#todo-e2e-todo-001'
+    )
+    await expect(focusedTodo).toContainText("Regression follow-up")
+    await expect(
+      focusedTodo.getByRole("link", { name: "View linked schedule item" })
+    ).toHaveAttribute(
+      "href",
+      /\/dashboard\/projects\/e2e-project-001\/schedule\?view=list&item=e2e-schedule-001/
+    )
+  })
+
   test("published audience schedules stay isolated from drafts and internal links", async ({
     page,
   }) => {

--- a/scripts/seed-e2e-local.mjs
+++ b/scripts/seed-e2e-local.mjs
@@ -287,17 +287,18 @@ const upsert = db.transaction(() => {
 
   db.prepare(`
     INSERT INTO project_operations (
-      id, project_id, source_system, source_record_type, source_record_number,
-      title, description, status, priority, assignee_type, assignee_name,
-      company_name, due_date, sage_write_status, sync_direction, sync_status,
-      created_at, updated_at
+      id, project_id, source_system, source_record_type, source_record_id,
+      source_record_number, title, description, status, priority,
+      assignee_type, assignee_name, company_name, due_date,
+      sage_write_status, sync_direction, sync_status, created_at, updated_at
     ) VALUES (
-      'e2e-todo-001', 'e2e-project-001', 'compass', 'todo', 'E2E-TODO-001',
-      'Regression follow-up', 'Seeded task for read-only workflow checks.',
-      'open', 'normal', 'user', 'Demo User', 'Compass Demo Client', ?,
-      'not_ready', 'read', 'synced', ?, ?
+      'e2e-todo-001', 'e2e-project-001', 'compass', 'todo',
+      'e2e-schedule-001', 'E2E-TODO-001', 'Regression follow-up',
+      'Seeded task for read-only workflow checks.', 'open', 'normal', 'user',
+      'Demo User', 'Compass Demo Client', ?, 'not_ready', 'read', 'synced', ?, ?
     )
     ON CONFLICT(id) DO UPDATE SET
+      source_record_id = excluded.source_record_id,
       title = excluded.title,
       status = excluded.status,
       due_date = excluded.due_date,

--- a/src/app/actions/project-operations.ts
+++ b/src/app/actions/project-operations.ts
@@ -36,6 +36,7 @@ import {
   purchaseOrderStatusAfterEmail,
 } from "@/lib/project-operations/status"
 import { canEditPurchaseOrderDraft } from "@/lib/purchase-orders/draft-edit"
+import { linkedScheduleTaskId } from "@/lib/schedule/linked-todos"
 import {
   purchaseOrderEmailHtml,
   purchaseOrderEmailText,
@@ -59,6 +60,8 @@ export type ProjectOperationItem = {
   readonly id: string
   readonly sourceSystem: string
   readonly sourceRecordType: string
+  readonly sourceRecordId: string | null
+  readonly linkedScheduleTaskId: string | null
   readonly sourceRecordNumber: string | null
   readonly title: string
   readonly description: string | null
@@ -72,6 +75,7 @@ export type ProjectOperationItem = {
   readonly startDate: string | null
   readonly dueDate: string | null
   readonly amount: number | null
+  readonly externalUrl: string | null
   readonly syncStatus: string
   readonly sageJobId: string | null
   readonly sageJobNumber: string | null
@@ -861,11 +865,16 @@ function parseRfqTemplateReview(
     : null
 }
 
-function toOperationItem(row: typeof projectOperations.$inferSelect): ProjectOperationItem {
+function toOperationItem(
+  row: typeof projectOperations.$inferSelect,
+  scheduleTaskIds: ReadonlySet<string> = new Set()
+): ProjectOperationItem {
   return {
     id: row.id,
     sourceSystem: row.sourceSystem,
     sourceRecordType: row.sourceRecordType,
+    sourceRecordId: row.sourceRecordId,
+    linkedScheduleTaskId: linkedScheduleTaskId(row, scheduleTaskIds),
     sourceRecordNumber: row.sourceRecordNumber,
     title: row.title,
     description: row.description,
@@ -879,6 +888,7 @@ function toOperationItem(row: typeof projectOperations.$inferSelect): ProjectOpe
     startDate: row.startDate,
     dueDate: row.dueDate,
     amount: row.amount,
+    externalUrl: row.externalUrl,
     syncStatus: row.syncStatus,
     sageJobId: row.sageJobId,
     sageJobNumber: row.sageJobNumber,
@@ -1079,8 +1089,12 @@ export async function getProjectOperationsSummary(
     ),
     activeCommitmentCount: activeCommitments.length,
     nextScheduleItem,
-    purchaseOrders: purchaseOrders.slice(0, 5).map(toOperationItem),
-    commitments: commitments.slice(0, 6).map(toOperationItem),
+    purchaseOrders: purchaseOrders
+      .slice(0, 5)
+      .map((operation) => toOperationItem(operation)),
+    commitments: commitments
+      .slice(0, 6)
+      .map((operation) => toOperationItem(operation)),
   }
 }
 
@@ -1119,7 +1133,74 @@ export async function getProjectTodos(
       asc(projectOperations.title)
     )
 
-  return operations.map(toOperationItem)
+  const candidateScheduleTaskIds = [
+    ...new Set(
+      operations.flatMap((operation) =>
+        operation.sourceRecordId ? [operation.sourceRecordId] : []
+      )
+    ),
+  ]
+  const scheduleTaskIds = new Set(
+    candidateScheduleTaskIds.length === 0
+      ? []
+      : (
+          await db
+            .select({ id: scheduleTasks.id })
+            .from(scheduleTasks)
+            .where(
+              and(
+                eq(scheduleTasks.projectId, projectId),
+                inArray(scheduleTasks.id, candidateScheduleTaskIds)
+              )
+            )
+        ).map((task) => task.id)
+  )
+
+  return operations.map((operation) =>
+    toOperationItem(operation, scheduleTaskIds)
+  )
+}
+
+export async function getScheduleTaskTodos(
+  projectId: string,
+  scheduleTaskId: string
+): Promise<readonly ProjectOperationItem[]> {
+  const db = await verifyProjectAccess(projectId, "tasks")
+  const [scheduleTask] = await db
+    .select({ id: scheduleTasks.id })
+    .from(scheduleTasks)
+    .where(
+      and(
+        eq(scheduleTasks.id, scheduleTaskId),
+        eq(scheduleTasks.projectId, projectId)
+      )
+    )
+    .limit(1)
+
+  if (!scheduleTask) return []
+
+  const operations = await db
+    .select()
+    .from(projectOperations)
+    .where(
+      and(
+        eq(projectOperations.projectId, projectId),
+        eq(projectOperations.sourceRecordId, scheduleTask.id),
+        inArray(projectOperations.sourceRecordType, [
+          ...PROJECT_TODO_RECORD_TYPES,
+        ])
+      )
+    )
+    .orderBy(
+      asc(projectOperations.dueDate),
+      asc(projectOperations.createdAt),
+      asc(projectOperations.title)
+    )
+
+  const scheduleTaskIds = new Set([scheduleTask.id])
+  return operations.map((operation) =>
+    toOperationItem(operation, scheduleTaskIds)
+  )
 }
 
 export async function getProjectSageSyncQueue(

--- a/src/app/actions/schedule.ts
+++ b/src/app/actions/schedule.ts
@@ -53,6 +53,7 @@ import {
   type BulkScheduleTemplateSelection
 } from "@/lib/templates/schedule-template-bulk-selection"
 import { isOwnerScheduleView, type OwnerScheduleView } from "@/lib/schedule/owner-visibility"
+import { linkedTodoDateUpdateStatement } from "@/lib/schedule/linked-todo-sync"
 import type {
   TaskStatus,
   DependencyType,
@@ -66,7 +67,53 @@ import type {
 
 function revalidateSchedulePaths(projectId: string): void {
   revalidatePath(`/dashboard/projects/${projectId}/schedule`)
+  revalidatePath(`/dashboard/projects/${projectId}/todos`)
+  revalidatePath("/dashboard")
   revalidatePath("/dashboard/schedule")
+}
+
+async function persistScheduleDateUpdates(
+  database: D1Database,
+  projectId: string,
+  updates: ReadonlyMap<
+    string,
+    {
+      readonly startDate: string
+      readonly endDateCalculated: string
+    }
+  >,
+  updatedAt: string
+): Promise<void> {
+  const entries = [...updates]
+  // Two statements are required per item. Keep batches below D1's statement
+  // ceiling while preserving the linked-to-do update before its schedule row.
+  for (const entryChunk of chunkValues(entries, 40)) {
+    const statements = entryChunk.flatMap(([taskId, dates]) => [
+      linkedTodoDateUpdateStatement(database, {
+        scheduleTaskId: taskId,
+        nextStartDate: dates.startDate,
+        nextEndDate: dates.endDateCalculated,
+        updatedAt,
+      }),
+      database
+        .prepare(
+          `UPDATE schedule_tasks
+           SET start_date = ?, end_date_calculated = ?, updated_at = ?
+           WHERE id = ? AND project_id = ?`
+        )
+        .bind(
+          dates.startDate,
+          dates.endDateCalculated,
+          updatedAt,
+          taskId,
+          projectId
+        ),
+    ])
+    const results = await database.batch(statements)
+    if (results.some((result) => !result.success)) {
+      throw new Error("Schedule date update batch failed")
+    }
+  }
 }
 
 function revalidateOwnerSchedulePaths(projectId: string): void {
@@ -1115,7 +1162,8 @@ export async function updateTask(
       return { success: false, error: "Access denied" }
     }
 
-    const exceptions = await fetchExceptions(db, task.projectId)
+    const schedule = await getSchedule(task.projectId)
+    const exceptions = schedule.exceptions
     const startDate = data.startDate ?? task.startDate
     const workdays = data.workdays ?? task.workdays
     const endDate = calculateEndDate(startDate, workdays, exceptions)
@@ -1144,13 +1192,30 @@ export async function updateTask(
       now
     })
 
+    // propagate date changes to downstream tasks
+    const updatedTask = {
+      ...task,
+      status: progress.status,
+      percentComplete: progress.percentComplete,
+      startDate,
+      workdays,
+      endDateCalculated: endDate
+    }
+    const allTasks = schedule.tasks.map((t) => (t.id === taskId ? updatedTask : t))
+    const { updatedTasks } = propagateDates(taskId, allTasks, schedule.dependencies, exceptions)
+    const dateUpdates = new Map(updatedTasks)
+    dateUpdates.set(taskId, {
+      startDate,
+      endDateCalculated: endDate,
+    })
+
+    // Leave dates untouched until the paired D1 batch below. Linked to-dos
+    // must calculate their offsets from the previous schedule dates.
     await db
       .update(scheduleTasks)
       .set({
         ...(data.title && { title: data.title }),
-        startDate,
         workdays,
-        endDateCalculated: endDate,
         ...(data.phase && { phase: data.phase }),
         ...(data.displayColor && { displayColor: data.displayColor }),
         status: progress.status,
@@ -1184,6 +1249,12 @@ export async function updateTask(
         updatedAt: now
       })
       .where(eq(scheduleTasks.id, taskId))
+    await persistScheduleDateUpdates(
+      env.DB,
+      task.projectId,
+      dateUpdates,
+      now
+    )
 
     await recordActivityEvent({
       db,
@@ -1196,30 +1267,6 @@ export async function updateTask(
       entityId: taskId,
       summary: `Updated schedule item “${data.title ?? task.title}”.`
     })
-
-    // propagate date changes to downstream tasks
-    const schedule = await getSchedule(task.projectId)
-    const updatedTask = {
-      ...task,
-      status: progress.status,
-      percentComplete: progress.percentComplete,
-      startDate,
-      workdays,
-      endDateCalculated: endDate
-    }
-    const allTasks = schedule.tasks.map((t) => (t.id === taskId ? updatedTask : t))
-    const { updatedTasks } = propagateDates(taskId, allTasks, schedule.dependencies, exceptions)
-
-    for (const [id, dates] of updatedTasks) {
-      await db
-        .update(scheduleTasks)
-        .set({
-          startDate: dates.startDate,
-          endDateCalculated: dates.endDateCalculated,
-          updatedAt: new Date().toISOString()
-        })
-        .where(eq(scheduleTasks.id, id))
-    }
 
     await recalcCriticalPath(db, task.projectId)
     revalidateSchedulePaths(task.projectId)
@@ -1703,17 +1750,12 @@ export async function createDependency(data: {
       updatedSchedule.dependencies,
       updatedSchedule.exceptions
     )
-
-    for (const [id, dates] of updatedTasks) {
-      await db
-        .update(scheduleTasks)
-        .set({
-          startDate: dates.startDate,
-          endDateCalculated: dates.endDateCalculated,
-          updatedAt: new Date().toISOString()
-        })
-        .where(eq(scheduleTasks.id, id))
-    }
+    await persistScheduleDateUpdates(
+      env.DB,
+      data.projectId,
+      updatedTasks,
+      new Date().toISOString()
+    )
 
     await recordActivityEvent({
       db,
@@ -1836,6 +1878,12 @@ export async function updateDependency(data: {
 
     for (const [taskId, dates] of recalculated.updatedTasks) {
       statements.push(
+        linkedTodoDateUpdateStatement(env.DB, {
+          scheduleTaskId: taskId,
+          nextStartDate: dates.startDate,
+          nextEndDate: dates.endDateCalculated,
+          updatedAt,
+        }),
         env.DB.prepare(
           `UPDATE schedule_tasks
            SET start_date = ?, end_date_calculated = ?, updated_at = ?

--- a/src/app/actions/work-calendar.ts
+++ b/src/app/actions/work-calendar.ts
@@ -45,6 +45,10 @@ import {
   type WorkCalendarEventVisibility,
 } from "@/lib/work-calendar"
 import { isProjectTodoRecordType } from "@/lib/project-todos"
+import {
+  linkedScheduleTaskId,
+  linkedTodoSourceLabel,
+} from "@/lib/schedule/linked-todos"
 import { isInternalStaffRole } from "@/lib/user-roles"
 import {
   expandWorkCalendarRecurrence,
@@ -356,6 +360,10 @@ export async function getWorkCalendar(
       .from(scheduleTasks)
       .where(eq(scheduleTasks.projectId, project.id))
       .orderBy(asc(scheduleTasks.startDate), asc(scheduleTasks.sortOrder))
+    const scheduleTaskById = new Map(
+      taskRows.map((scheduleTask) => [scheduleTask.id, scheduleTask])
+    )
+    const scheduleTaskIds = new Set(scheduleTaskById.keys())
 
     for (const task of taskRows) {
       if (isClosedStatus(task.status)) continue
@@ -443,6 +451,7 @@ export async function getWorkCalendar(
       .select({
         id: projectOperations.id,
         sourceRecordType: projectOperations.sourceRecordType,
+        sourceRecordId: projectOperations.sourceRecordId,
         sourceRecordNumber: projectOperations.sourceRecordNumber,
         title: projectOperations.title,
         status: projectOperations.status,
@@ -518,6 +527,13 @@ export async function getWorkCalendar(
         continue
       }
       if (isClosedStatus(operation.status)) continue
+      const relatedScheduleTaskId = linkedScheduleTaskId(
+        operation,
+        scheduleTaskIds
+      )
+      const relatedScheduleTask = relatedScheduleTaskId
+        ? scheduleTaskById.get(relatedScheduleTaskId) ?? null
+        : null
       const startDate = operation.startDate ?? operation.dueDate
       const endDate = operation.dueDate ?? operation.startDate
       if (!startDate || !endDate) continue
@@ -546,10 +562,15 @@ export async function getWorkCalendar(
         endDate,
         assignedTo: operation.assigneeName,
         companyName: operation.companyName,
-        sourceLabel: operationSourceLabel(
-          operation.sourceRecordType,
-          operation.sourceRecordNumber
-        ),
+        sourceLabel: relatedScheduleTask
+          ? linkedTodoSourceLabel(
+              relatedScheduleTask.title,
+              operation.sourceRecordNumber
+            )
+          : operationSourceLabel(
+              operation.sourceRecordType,
+              operation.sourceRecordNumber
+            ),
         href:
           operation.sourceRecordType === "purchase_order"
             ? projectPurchaseOrderHref(project.id, operation.id)

--- a/src/app/actions/workday-exceptions.ts
+++ b/src/app/actions/workday-exceptions.ts
@@ -16,6 +16,7 @@ import { isDemoUser } from "@/lib/demo"
 import { requirePermission } from "@/lib/permissions"
 import { recordActivityEvent } from "@/lib/activity-log"
 import { recalculateScheduleDates } from "@/lib/schedule/propagate-dates"
+import { linkedTodoDateUpdateStatement } from "@/lib/schedule/linked-todo-sync"
 import type {
   DependencyType,
   TaskStatus,
@@ -104,6 +105,12 @@ async function runExceptionScheduleBatch(
   const statements: D1PreparedStatement[] = [mutation]
   for (const [taskId, dates] of updatedTasks) {
     statements.push(
+      linkedTodoDateUpdateStatement(database, {
+        scheduleTaskId: taskId,
+        nextStartDate: dates.startDate,
+        nextEndDate: dates.endDateCalculated,
+        updatedAt,
+      }),
       database
         .prepare(
           `UPDATE schedule_tasks
@@ -252,6 +259,8 @@ export async function createWorkdayException(
       metadata: { affectedItemCount: updatedTasks.size },
     })
     revalidatePath(`/dashboard/projects/${projectId}/schedule`)
+    revalidatePath(`/dashboard/projects/${projectId}/todos`)
+    revalidatePath("/dashboard")
     revalidatePath("/dashboard/schedule")
     return { success: true }
   } catch (error) {
@@ -367,6 +376,8 @@ export async function updateWorkdayException(
     revalidatePath(
       `/dashboard/projects/${existing.projectId}/schedule`
     )
+    revalidatePath(`/dashboard/projects/${existing.projectId}/todos`)
+    revalidatePath("/dashboard")
     revalidatePath("/dashboard/schedule")
     return { success: true }
   } catch (error) {
@@ -449,6 +460,8 @@ export async function deleteWorkdayException(
     revalidatePath(
       `/dashboard/projects/${existing.projectId}/schedule`
     )
+    revalidatePath(`/dashboard/projects/${existing.projectId}/todos`)
+    revalidatePath("/dashboard")
     revalidatePath("/dashboard/schedule")
     return { success: true }
   } catch (error) {

--- a/src/components/projects/project-task-create-button.tsx
+++ b/src/components/projects/project-task-create-button.tsx
@@ -53,6 +53,7 @@ type ProjectTaskCreateButtonProps = {
   readonly defaultTaskType?: ProjectTaskRecordType
   readonly assigneeOptions?: readonly ProjectTaskAssigneeOption[]
   readonly compact?: boolean
+  readonly onCreated?: (todoId: string) => void
 }
 
 function cleanValue(value: string): string | null {
@@ -100,6 +101,7 @@ export function ProjectTaskCreateButton({
   defaultTaskType = "staff_task",
   assigneeOptions = [],
   compact = false,
+  onCreated,
 }: ProjectTaskCreateButtonProps): React.ReactElement {
   const router = useRouter()
   const [open, setOpen] = React.useState(false)
@@ -183,6 +185,7 @@ export function ProjectTaskCreateButton({
       kind: "saved",
       message: "To-do created and added to the project work queue.",
     })
+    onCreated?.(result.id)
     router.refresh()
   }
 

--- a/src/components/projects/project-todos-view.tsx
+++ b/src/components/projects/project-todos-view.tsx
@@ -1,11 +1,13 @@
 "use client"
 
 import * as React from "react"
+import Link from "next/link"
 import { useRouter } from "next/navigation"
 import {
   IconArchive,
   IconEdit,
   IconSearch,
+  IconTimeline,
 } from "@tabler/icons-react"
 
 import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
@@ -30,7 +32,10 @@ import {
   projectTodoTypeLabel,
   type ProjectTodoStatus,
 } from "@/lib/project-todos"
-import { normalizeWorkCalendarSearch } from "@/lib/work-calendar"
+import {
+  normalizeWorkCalendarSearch,
+  scheduleItemHref,
+} from "@/lib/work-calendar"
 
 type TodoFilter = "active" | "completed" | "archived" | "all"
 
@@ -323,6 +328,18 @@ export function ProjectTodosView({
                     <p className="mt-2 line-clamp-3 whitespace-pre-wrap text-sm text-muted-foreground">
                       {item.description}
                     </p>
+                  )}
+                  {item.linkedScheduleTaskId && (
+                    <Link
+                      href={scheduleItemHref(
+                        projectId,
+                        item.linkedScheduleTaskId
+                      )}
+                      className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+                    >
+                      <IconTimeline className="size-3.5" />
+                      View linked schedule item
+                    </Link>
                   )}
                   <p className="mt-2 text-xs text-muted-foreground">
                     {developerModeEnabled

--- a/src/components/schedule/schedule-gantt-view.tsx
+++ b/src/components/schedule/schedule-gantt-view.tsx
@@ -90,6 +90,7 @@ import { ProjectTaskCreateButton } from "@/components/projects/project-task-crea
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { format } from "date-fns"
+import { scheduleItemHref } from "@/lib/work-calendar"
 import type { ScheduleProjectData } from "@/lib/schedule/project-scope"
 import { projectScheduleLabel } from "@/lib/schedule/project-scope"
 import {
@@ -779,7 +780,7 @@ export function ScheduleGanttView({
                     sourceLabel="Schedule item"
                     sourceRecordId={task.id}
                     sourceRecordNumber={null}
-                    sourceHref={`/dashboard/projects/${task.projectId}/schedule`}
+                    sourceHref={scheduleItemHref(task.projectId, task.id)}
                     defaultTitle={`Follow up: ${task.title}`}
                     defaultDescription={`${task.phase} schedule item.`}
                     defaultAssigneeName={task.assignedTo}

--- a/src/components/schedule/schedule-item-form-dialog.tsx
+++ b/src/components/schedule/schedule-item-form-dialog.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import { useEffect, useMemo, useState } from "react"
+import Link from "next/link"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
 import { zodResolver } from "@hookform/resolvers/zod"
@@ -68,13 +69,19 @@ import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { cn } from "@/lib/utils"
 import type { ProjectTaskAssigneeOption } from "@/app/actions/project-contacts"
+import {
+  getScheduleTaskTodos,
+  type ProjectOperationItem,
+} from "@/app/actions/project-operations"
 import { ProjectAssigneePicker } from "@/components/projects/project-assignee-picker"
+import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
 import { ScheduleItemLinks } from "@/components/schedule/schedule-item-links"
 import type { ScheduleTemplateImportGroup } from "@/app/actions/template-import-options"
 import {
   clearScheduleTemplateImportOptions,
   loadScheduleTemplateImportOptions
 } from "@/components/schedule/schedule-template-import-options-client"
+import { projectTodoHref, scheduleItemHref } from "@/lib/work-calendar"
 
 const defaultPhaseOptions: readonly ReusableSchedulePhaseOption[] = PHASE_ORDER.map((value) => ({
   id: null,
@@ -165,6 +172,12 @@ export function ScheduleItemFormDialog({
   const [customPhaseMode, setCustomPhaseMode] = useState(false)
   const [customPhaseName, setCustomPhaseName] = useState("")
   const [saveCustomPhase, setSaveCustomPhase] = useState(true)
+  const [linkedTodos, setLinkedTodos] = useState<
+    readonly ProjectOperationItem[]
+  >([])
+  const [linkedTodosLoading, setLinkedTodosLoading] = useState(false)
+  const [linkedTodosError, setLinkedTodosError] = useState<string | null>(null)
+  const [linkedTodosRefreshKey, setLinkedTodosRefreshKey] = useState(0)
 
   const existingPredecessors = useMemo(() => {
     if (!editingTask) return []
@@ -318,6 +331,38 @@ export function ScheduleItemFormDialog({
       )
     )
   }, [dependencies, editingTask])
+
+  useEffect(() => {
+    let cancelled = false
+    if (!open || !editingTask) {
+      setLinkedTodos([])
+      setLinkedTodosLoading(false)
+      setLinkedTodosError(null)
+      return () => {
+        cancelled = true
+      }
+    }
+
+    setLinkedTodosLoading(true)
+    setLinkedTodosError(null)
+    void getScheduleTaskTodos(projectId, editingTask.id)
+      .then((todos) => {
+        if (!cancelled) setLinkedTodos(todos)
+      })
+      .catch((error: unknown) => {
+        console.error("Unable to load linked schedule to-dos", error)
+        if (!cancelled) {
+          setLinkedTodosError("Related to-dos could not be loaded.")
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLinkedTodosLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [editingTask, linkedTodosRefreshKey, open, projectId])
 
   const watchedStart = form.watch("startDate")
   const watchedWorkdays = form.watch("workdays")
@@ -1422,6 +1467,95 @@ export function ScheduleItemFormDialog({
                   />
                 </CollapsibleContent>
               </Collapsible>
+
+              {editingTask && (
+                <section className="space-y-3 border-t pt-4" aria-label="Related to-dos">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <h3 className="text-sm font-medium">Related to-dos</h3>
+                        {!linkedTodosLoading && (
+                          <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] tabular-nums text-muted-foreground">
+                            {linkedTodos.length}
+                          </span>
+                        )}
+                      </div>
+                      <p className="mt-1 text-[11px] text-muted-foreground">
+                        These stay in the existing Compass project to-do list and link back here.
+                      </p>
+                    </div>
+                    <ProjectTaskCreateButton
+                      projectId={projectId}
+                      sourceLabel="Schedule item"
+                      sourceRecordId={editingTask.id}
+                      sourceRecordNumber={null}
+                      sourceHref={scheduleItemHref(projectId, editingTask.id)}
+                      defaultTitle={`Follow up: ${editingTask.title}`}
+                      defaultDescription={`${editingTask.phase} schedule item.`}
+                      defaultAssigneeName={editingTask.assignedTo}
+                      defaultCompanyName={null}
+                      defaultDueDate={editingTask.endDateCalculated}
+                      defaultPriority={editingTask.isCriticalPath ? "high" : "normal"}
+                      defaultTaskType="schedule_task"
+                      assigneeOptions={assigneeOptions}
+                      onCreated={() =>
+                        setLinkedTodosRefreshKey((current) => current + 1)
+                      }
+                    />
+                  </div>
+
+                  {linkedTodosLoading ? (
+                    <p className="border bg-muted/20 px-3 py-3 text-xs text-muted-foreground">
+                      Loading related to-dos…
+                    </p>
+                  ) : linkedTodosError ? (
+                    <p className="border border-destructive/40 bg-destructive/5 px-3 py-3 text-xs text-destructive">
+                      {linkedTodosError}
+                    </p>
+                  ) : linkedTodos.length === 0 ? (
+                    <p className="border border-dashed px-3 py-3 text-xs text-muted-foreground">
+                      No to-dos are linked to this schedule item yet.
+                    </p>
+                  ) : (
+                    <div className="divide-y border">
+                      {linkedTodos.map((todo) => (
+                        <div
+                          key={todo.id}
+                          className="flex flex-wrap items-start justify-between gap-3 px-3 py-2.5"
+                        >
+                          <div className="min-w-0">
+                            <Link
+                              href={projectTodoHref(projectId, todo.id)}
+                              className="block truncate text-sm font-medium hover:underline"
+                            >
+                              {todo.title}
+                            </Link>
+                            <p className="mt-1 text-[11px] text-muted-foreground">
+                              {todo.sourceRecordNumber ?? "Compass to-do"}
+                              {todo.assigneeName || todo.companyName
+                                ? ` · ${todo.assigneeName ?? todo.companyName}`
+                                : ""}
+                              {todo.dueDate
+                                ? ` · Due ${format(parseISO(todo.dueDate), "MMM d, yyyy")}`
+                                : " · No due date"}
+                            </p>
+                          </div>
+                          <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                            {todo.status.replaceAll("_", " ")}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  <Link
+                    href={`/dashboard/projects/${encodeURIComponent(projectId)}/todos`}
+                    className="inline-flex text-xs font-medium text-primary hover:underline"
+                  >
+                    Open all project to-dos
+                  </Link>
+                </section>
+              )}
             </div>
 
             {/* Footer */}

--- a/src/components/schedule/schedule-list-view.tsx
+++ b/src/components/schedule/schedule-list-view.tsx
@@ -55,6 +55,7 @@ import { toast } from "sonner"
 import { format, parseISO } from "date-fns"
 import { useScheduleDisplayPalette } from "@/hooks/use-schedule-display-palette"
 import { cn } from "@/lib/utils"
+import { scheduleItemHref } from "@/lib/work-calendar"
 import {
   getScheduleItemDisplayColor,
   type DisplayColorPalette,
@@ -329,7 +330,10 @@ export function ScheduleListView({
               sourceLabel="Schedule item"
               sourceRecordId={row.original.id}
               sourceRecordNumber={null}
-              sourceHref={`/dashboard/projects/${row.original.projectId}/schedule`}
+              sourceHref={scheduleItemHref(
+                row.original.projectId,
+                row.original.id
+              )}
               defaultTitle={`Follow up: ${row.original.title}`}
               defaultDescription={`${row.original.phase} schedule item.`}
               defaultAssigneeName={row.original.assignedTo}

--- a/src/lib/schedule/__tests__/linked-todos.test.ts
+++ b/src/lib/schedule/__tests__/linked-todos.test.ts
@@ -1,0 +1,153 @@
+import Database from "better-sqlite3"
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  linkedScheduleTaskId,
+  linkedTodoSourceLabel,
+} from "@/lib/schedule/linked-todos"
+import { LINKED_TODO_DATE_UPDATE_SQL } from "@/lib/schedule/linked-todo-sync"
+
+describe("linked schedule to-dos", () => {
+  it("only treats a to-do source ID as a schedule link when the item exists", () => {
+    const scheduleTaskIds = new Set(["schedule-1"])
+
+    expect(
+      linkedScheduleTaskId(
+        {
+          sourceRecordType: "schedule_task",
+          sourceRecordId: "schedule-1",
+        },
+        scheduleTaskIds
+      )
+    ).toBe("schedule-1")
+    expect(
+      linkedScheduleTaskId(
+        {
+          sourceRecordType: "staff_task",
+          sourceRecordId: "selection-1",
+        },
+        scheduleTaskIds
+      )
+    ).toBeNull()
+    expect(
+      linkedScheduleTaskId(
+        {
+          sourceRecordType: "purchase_order",
+          sourceRecordId: "schedule-1",
+        },
+        scheduleTaskIds
+      )
+    ).toBeNull()
+  })
+
+  it("labels linked work-queue entries with the schedule item and to-do number", () => {
+    expect(linkedTodoSourceLabel("Footer Pour", "TASK-014")).toBe(
+      "Schedule: Footer Pour · TASK-014"
+    )
+    expect(linkedTodoSourceLabel("Footer Pour", null)).toBe(
+      "Schedule: Footer Pour"
+    )
+  })
+})
+
+describe("linked to-do date synchronization", () => {
+  const databases: ReturnType<typeof Database>[] = []
+
+  afterEach(() => {
+    for (const database of databases.splice(0)) database.close()
+  })
+
+  it("preserves schedule-relative offsets without touching unrelated rows", () => {
+    const database = new Database(":memory:")
+    databases.push(database)
+    database.exec(`
+      CREATE TABLE schedule_tasks (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        start_date TEXT NOT NULL,
+        end_date_calculated TEXT NOT NULL
+      );
+      CREATE TABLE project_operations (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        source_record_type TEXT NOT NULL,
+        source_record_id TEXT,
+        start_date TEXT,
+        due_date TEXT,
+        updated_at TEXT NOT NULL
+      );
+      INSERT INTO schedule_tasks VALUES
+        ('schedule-1', 'project-1', '2026-08-10', '2026-08-14'),
+        ('schedule-2', 'project-1', '2026-08-10', '2026-08-14');
+      INSERT INTO project_operations VALUES
+        ('same-offset', 'project-1', 'schedule_task', 'schedule-1', '2026-08-10', '2026-08-14', 'old'),
+        ('offset-two', 'project-1', 'staff_task', 'schedule-1', '2026-08-12', '2026-08-16', 'old'),
+        ('null-dates', 'project-1', 'task', 'schedule-1', NULL, NULL, 'old'),
+        ('invalid-dates', 'project-1', 'todo', 'schedule-1', 'unknown', 'unknown', 'old'),
+        ('other-project', 'project-2', 'schedule_task', 'schedule-1', '2026-08-10', '2026-08-14', 'old'),
+        ('other-schedule', 'project-1', 'schedule_task', 'schedule-2', '2026-08-10', '2026-08-14', 'old'),
+        ('non-task', 'project-1', 'purchase_order', 'schedule-1', '2026-08-10', '2026-08-14', 'old');
+    `)
+
+    database.prepare(LINKED_TODO_DATE_UPDATE_SQL).run(
+      "2026-08-20",
+      "schedule-1",
+      "2026-08-24",
+      "schedule-1",
+      "new",
+      "schedule-1",
+      "schedule-1"
+    )
+
+    const rows = database
+      .prepare(
+        "SELECT id, start_date, due_date, updated_at FROM project_operations ORDER BY id"
+      )
+      .all()
+
+    expect(rows).toEqual([
+      {
+        id: "invalid-dates",
+        start_date: "unknown",
+        due_date: "unknown",
+        updated_at: "new",
+      },
+      {
+        id: "non-task",
+        start_date: "2026-08-10",
+        due_date: "2026-08-14",
+        updated_at: "old",
+      },
+      {
+        id: "null-dates",
+        start_date: null,
+        due_date: null,
+        updated_at: "new",
+      },
+      {
+        id: "offset-two",
+        start_date: "2026-08-22",
+        due_date: "2026-08-26",
+        updated_at: "new",
+      },
+      {
+        id: "other-project",
+        start_date: "2026-08-10",
+        due_date: "2026-08-14",
+        updated_at: "old",
+      },
+      {
+        id: "other-schedule",
+        start_date: "2026-08-10",
+        due_date: "2026-08-14",
+        updated_at: "old",
+      },
+      {
+        id: "same-offset",
+        start_date: "2026-08-20",
+        due_date: "2026-08-24",
+        updated_at: "new",
+      },
+    ])
+  })
+})

--- a/src/lib/schedule/linked-todo-sync.ts
+++ b/src/lib/schedule/linked-todo-sync.ts
@@ -1,0 +1,70 @@
+export const LINKED_TODO_DATE_UPDATE_SQL = `UPDATE project_operations
+SET start_date = CASE
+  WHEN start_date IS NULL OR julianday(start_date) IS NULL THEN start_date
+  ELSE date(
+    ?,
+    printf(
+      '%+d days',
+      CAST(
+        julianday(start_date) - julianday((
+          SELECT start_date
+          FROM schedule_tasks
+          WHERE id = ?
+        )) AS INTEGER
+      )
+    )
+  )
+END,
+due_date = CASE
+  WHEN due_date IS NULL OR julianday(due_date) IS NULL THEN due_date
+  ELSE date(
+    ?,
+    printf(
+      '%+d days',
+      CAST(
+        julianday(due_date) - julianday((
+          SELECT end_date_calculated
+          FROM schedule_tasks
+          WHERE id = ?
+        )) AS INTEGER
+      )
+    )
+  )
+END,
+updated_at = ?
+WHERE source_record_id = ?
+  AND project_id = (
+    SELECT project_id FROM schedule_tasks WHERE id = ?
+  )
+  AND source_record_type IN (
+    'staff_task',
+    'subcontractor_task',
+    'supplier_task',
+    'schedule_task',
+    'todo',
+    'task'
+  )`
+
+export function linkedTodoDateUpdateStatement(
+  database: D1Database,
+  input: {
+    readonly scheduleTaskId: string
+    readonly nextStartDate: string
+    readonly nextEndDate: string
+    readonly updatedAt: string
+  }
+): D1PreparedStatement {
+  // Run this before updating schedule_tasks so offsets are calculated from the
+  // schedule item's previous dates.
+  return database
+    .prepare(LINKED_TODO_DATE_UPDATE_SQL)
+    .bind(
+      input.nextStartDate,
+      input.scheduleTaskId,
+      input.nextEndDate,
+      input.scheduleTaskId,
+      input.updatedAt,
+      input.scheduleTaskId,
+      input.scheduleTaskId
+    )
+}

--- a/src/lib/schedule/linked-todos.ts
+++ b/src/lib/schedule/linked-todos.ts
@@ -1,0 +1,24 @@
+import { isProjectTodoRecordType } from "@/lib/project-todos"
+
+export function linkedScheduleTaskId(
+  operation: {
+    readonly sourceRecordType: string
+    readonly sourceRecordId: string | null
+  },
+  scheduleTaskIds: ReadonlySet<string>
+): string | null {
+  if (!isProjectTodoRecordType(operation.sourceRecordType)) return null
+  if (!operation.sourceRecordId) return null
+  return scheduleTaskIds.has(operation.sourceRecordId)
+    ? operation.sourceRecordId
+    : null
+}
+
+export function linkedTodoSourceLabel(
+  taskTitle: string,
+  taskNumber: string | null
+): string {
+  return taskNumber
+    ? `Schedule: ${taskTitle} · ${taskNumber}`
+    : `Schedule: ${taskTitle}`
+}


### PR DESCRIPTION
## Summary

- show schedule-linked to-dos inside the schedule item editor
- keep linked records in the existing project To-dos workflow with two-way navigation
- preserve to-do date offsets when schedule dates propagate or move
- keep Gantt editing and external read-only schedule views unchanged

## Validation

- bun run test (1,032 passed)
- bunx tsc --noEmit
- production Next.js build
- focused Playwright schedule-to-do workflow