### PR TITLE
fix(purchase-orders): recover from stale deployments

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,9 @@ const deploymentId =
 const nextConfig: NextConfig = {
     allowedDevOrigins: ["127.0.0.1"],
     deploymentId,
+    env: {
+        NEXT_PUBLIC_COMPASS_DEPLOYMENT_ID: deploymentId ?? "development",
+    },
     transpilePackages: ["agent-core"],
     experimental: {
         proxyClientMaxBodySize: "100mb",

--- a/src/app/api/deployment-version/route.ts
+++ b/src/app/api/deployment-version/route.ts
@@ -1,0 +1,14 @@
+import { COMPASS_DEPLOYMENT_ID } from "@/lib/deployment/version"
+
+export const dynamic = "force-dynamic"
+
+export function GET(): Response {
+  return Response.json(
+    { deploymentId: COMPASS_DEPLOYMENT_ID },
+    {
+      headers: {
+        "Cache-Control": "no-store, max-age=0",
+      },
+    }
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Sora, IBM_Plex_Mono, Playfair_Display } from "next/font/google";
 import { AuthKitProvider } from "@workos-inc/authkit-nextjs/components";
+import { DeploymentRefreshPrompt } from "@/components/deployment-refresh-prompt";
 import { ThemeProvider } from "@/components/theme-provider";
 import { isWorkOSConfigured } from "@/lib/auth-config";
 import "./globals.css";
@@ -43,7 +44,12 @@ export default function RootLayout({
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
-	const content = <ThemeProvider>{children}</ThemeProvider>;
+	const content = (
+		<ThemeProvider>
+			<DeploymentRefreshPrompt />
+			{children}
+		</ThemeProvider>
+	);
 
 	return (
 		<html lang="en" suppressHydrationWarning>

--- a/src/components/deployment-refresh-prompt.tsx
+++ b/src/components/deployment-refresh-prompt.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import * as React from "react"
+import { IconRefresh } from "@tabler/icons-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  COMPASS_DEPLOYMENT_ID,
+  hasDeploymentChanged,
+  STALE_DEPLOYMENT_EVENT,
+} from "@/lib/deployment/version"
+import { isStaleServerActionError } from "@/lib/purchase-orders/action-errors"
+
+const VERSION_CHECK_INTERVAL_MS = 60_000
+
+type DeploymentVersionResponse = {
+  readonly deploymentId?: unknown
+}
+
+function deploymentIdFromResponse(value: unknown): string | null {
+  if (typeof value !== "object" || value === null) return null
+  const response: DeploymentVersionResponse = value
+  return typeof response.deploymentId === "string"
+    ? response.deploymentId
+    : null
+}
+
+export function DeploymentRefreshPrompt(): React.ReactElement | null {
+  const [updateAvailable, setUpdateAvailable] = React.useState(false)
+  const checkingRef = React.useRef(false)
+
+  const checkForUpdate = React.useCallback(async (): Promise<void> => {
+    if (checkingRef.current || document.visibilityState === "hidden") return
+
+    checkingRef.current = true
+    try {
+      const response = await fetch("/api/deployment-version", {
+        cache: "no-store",
+        credentials: "same-origin",
+      })
+      if (!response.ok) return
+
+      const serverDeploymentId = deploymentIdFromResponse(
+        await response.json()
+      )
+      if (
+        serverDeploymentId !== null &&
+        hasDeploymentChanged(COMPASS_DEPLOYMENT_ID, serverDeploymentId)
+      ) {
+        setUpdateAvailable(true)
+      }
+    } catch {
+      // A version check should never interrupt normal Compass work.
+    } finally {
+      checkingRef.current = false
+    }
+  }, [])
+
+  React.useEffect(() => {
+    function handleVisibilityChange(): void {
+      if (document.visibilityState === "visible") void checkForUpdate()
+    }
+
+    function handleWindowFocus(): void {
+      void checkForUpdate()
+    }
+
+    function handleStaleDeployment(): void {
+      setUpdateAvailable(true)
+    }
+
+    function handleUnhandledRejection(event: PromiseRejectionEvent): void {
+      if (isStaleServerActionError(event.reason)) setUpdateAvailable(true)
+    }
+
+    function handleWindowError(event: ErrorEvent): void {
+      if (isStaleServerActionError(event.error ?? event.message)) {
+        setUpdateAvailable(true)
+      }
+    }
+
+    void checkForUpdate()
+    const intervalId = window.setInterval(
+      () => void checkForUpdate(),
+      VERSION_CHECK_INTERVAL_MS
+    )
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+    window.addEventListener("focus", handleWindowFocus)
+    window.addEventListener(STALE_DEPLOYMENT_EVENT, handleStaleDeployment)
+    window.addEventListener("unhandledrejection", handleUnhandledRejection)
+    window.addEventListener("error", handleWindowError)
+
+    return () => {
+      window.clearInterval(intervalId)
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+      window.removeEventListener("focus", handleWindowFocus)
+      window.removeEventListener(STALE_DEPLOYMENT_EVENT, handleStaleDeployment)
+      window.removeEventListener("unhandledrejection", handleUnhandledRejection)
+      window.removeEventListener("error", handleWindowError)
+    }
+  }, [checkForUpdate])
+
+  if (!updateAvailable) return null
+
+  return (
+    <aside
+      role="alert"
+      aria-live="assertive"
+      className="fixed inset-x-3 bottom-3 z-[100] mx-auto flex max-w-3xl flex-wrap items-center justify-between gap-3 border border-primary/30 bg-background px-4 py-3 shadow-xl"
+    >
+      <div>
+        <p className="text-sm font-semibold">Compass update ready</p>
+        <p className="text-xs text-muted-foreground">
+          Finish or copy any unsaved work, then refresh before submitting a form.
+        </p>
+      </div>
+      <Button type="button" size="sm" onClick={() => window.location.reload()}>
+        <IconRefresh className="size-4" />
+        Refresh Compass
+      </Button>
+    </aside>
+  )
+}

--- a/src/components/projects/project-purchase-order-create-form.tsx
+++ b/src/components/projects/project-purchase-order-create-form.tsx
@@ -46,6 +46,11 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet"
 import { Textarea } from "@/components/ui/textarea"
+import { reportStaleDeployment } from "@/lib/deployment/version"
+import {
+  isStaleServerActionError,
+  purchaseOrderSubmissionErrorMessage,
+} from "@/lib/purchase-orders/action-errors"
 import {
   purchaseOrderCostCodesForPhase,
   purchaseOrderSiteContactOptions,
@@ -492,12 +497,13 @@ function ProjectPurchaseOrderForm(
       }
       router.refresh()
     } catch (error) {
+      const isStaleAction = isStaleServerActionError(error)
+      if (isStaleAction) reportStaleDeployment()
       setMessage(
-        error instanceof Error
-          ? error.message
-          : purchaseOrder === null
-            ? "Could not stage the P.O. request."
-            : "Could not update the purchase order draft."
+        purchaseOrderSubmissionErrorMessage(
+          error,
+          purchaseOrder === null ? "create" : "update"
+        )
       )
     } finally {
       setSubmitting(false)
@@ -854,7 +860,10 @@ function ProjectPurchaseOrderForm(
         </div>
 
         {message && (
-          <p className="border-l-2 border-l-primary px-3 py-2 text-sm text-muted-foreground">
+          <p
+            role="alert"
+            className="border-l-2 border-l-primary px-3 py-2 text-sm text-muted-foreground"
+          >
             {message}
           </p>
         )}

--- a/src/lib/deployment/__tests__/version.test.ts
+++ b/src/lib/deployment/__tests__/version.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest"
+
+import { hasDeploymentChanged } from "@/lib/deployment/version"
+
+describe("deployment version", () => {
+  it("detects a newer deployment without treating empty values as versions", () => {
+    expect(hasDeploymentChanged("build-a", "build-b")).toBe(true)
+    expect(hasDeploymentChanged("build-a", "build-a")).toBe(false)
+    expect(hasDeploymentChanged("", "build-b")).toBe(false)
+    expect(hasDeploymentChanged("build-a", "")).toBe(false)
+  })
+})

--- a/src/lib/deployment/version.ts
+++ b/src/lib/deployment/version.ts
@@ -1,0 +1,20 @@
+export const COMPASS_DEPLOYMENT_ID =
+  process.env.NEXT_PUBLIC_COMPASS_DEPLOYMENT_ID ?? "development"
+
+export const STALE_DEPLOYMENT_EVENT = "compass:stale-deployment"
+
+export function hasDeploymentChanged(
+  clientDeploymentId: string,
+  serverDeploymentId: string
+): boolean {
+  return (
+    clientDeploymentId.length > 0 &&
+    serverDeploymentId.length > 0 &&
+    clientDeploymentId !== serverDeploymentId
+  )
+}
+
+export function reportStaleDeployment(): void {
+  if (typeof window === "undefined") return
+  window.dispatchEvent(new Event(STALE_DEPLOYMENT_EVENT))
+}

--- a/src/lib/purchase-orders/__tests__/action-errors.test.ts
+++ b/src/lib/purchase-orders/__tests__/action-errors.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isStaleServerActionError,
+  purchaseOrderSubmissionErrorMessage,
+} from "@/lib/purchase-orders/action-errors"
+
+describe("purchase order action errors", () => {
+  it("recognizes a stale action identifier from an older deployment", () => {
+    const error = new Error(
+      'Server Action "609fce54d4b06dad-ed5a7d32c672ec167e5b46502b" was not found on the server.'
+    )
+
+    expect(isStaleServerActionError(error)).toBe(true)
+    expect(purchaseOrderSubmissionErrorMessage(error, "create")).toContain(
+      "Compass was updated"
+    )
+  })
+
+  it("keeps actionable server errors and supplies a fallback for unknown failures", () => {
+    expect(
+      purchaseOrderSubmissionErrorMessage(
+        new Error("A title is required."),
+        "create"
+      )
+    ).toBe("A title is required.")
+    expect(purchaseOrderSubmissionErrorMessage({}, "update")).toBe(
+      "Could not update the purchase order draft."
+    )
+  })
+})

--- a/src/lib/purchase-orders/__tests__/form-options.test.ts
+++ b/src/lib/purchase-orders/__tests__/form-options.test.ts
@@ -41,4 +41,34 @@ describe("purchase order form options", () => {
       )
     ).toEqual(["06-100", "06-200"])
   })
+
+  it("normalizes single-digit and labeled phase values", () => {
+    const costCodes = [
+      { value: "03-100", divisionCode: "03" },
+      { value: "06-100", divisionCode: "6" },
+    ]
+
+    expect(
+      purchaseOrderCostCodesForPhase(costCodes, "6").map(
+        (option) => option.value
+      )
+    ).toEqual(["06-100"])
+    expect(
+      purchaseOrderCostCodesForPhase(costCodes, "06 00 00 Wood and Plastics").map(
+        (option) => option.value
+      )
+    ).toEqual(["06-100"])
+  })
+
+  it("keeps cost codes available for imported or typed phases without a match", () => {
+    const costCodes = [
+      { value: "03-100", divisionCode: "03" },
+      { value: "06-100", divisionCode: "06" },
+    ]
+
+    expect(purchaseOrderCostCodesForPhase(costCodes, "Concrete")).toEqual(
+      costCodes
+    )
+    expect(purchaseOrderCostCodesForPhase(costCodes, "99")).toEqual(costCodes)
+  })
 })

--- a/src/lib/purchase-orders/action-errors.ts
+++ b/src/lib/purchase-orders/action-errors.ts
@@ -1,0 +1,33 @@
+const MISSING_SERVER_ACTION_PATTERNS = [
+  /server action .+ was not found on the server/i,
+  /failed to find server action/i,
+] as const
+
+function errorMessage(error: unknown): string | null {
+  if (error instanceof Error) return error.message
+  if (typeof error === "string") return error
+  return null
+}
+
+export function isStaleServerActionError(error: unknown): boolean {
+  const message = errorMessage(error)
+  if (message === null) return false
+
+  return MISSING_SERVER_ACTION_PATTERNS.some((pattern) => pattern.test(message))
+}
+
+export function purchaseOrderSubmissionErrorMessage(
+  error: unknown,
+  action: "create" | "update"
+): string {
+  if (isStaleServerActionError(error)) {
+    return "Compass was updated while this form was open. Your entries are still visible; copy anything you need, then refresh Compass and submit again."
+  }
+
+  const message = errorMessage(error)
+  if (message !== null) return message
+
+  return action === "create"
+    ? "Could not stage the P.O. request."
+    : "Could not update the purchase order draft."
+}

--- a/src/lib/purchase-orders/form-options.ts
+++ b/src/lib/purchase-orders/form-options.ts
@@ -6,6 +6,13 @@ type PurchaseOrderCostCodeOption = {
   readonly divisionCode: string
 }
 
+function normalizedDivisionCode(value: string): string | null {
+  const match = /^\s*(\d{1,2})(?:\D|$)/.exec(value)
+  if (match === null) return null
+
+  return match[1].padStart(2, "0")
+}
+
 export function purchaseOrderVendorOptions<
   T extends PurchaseOrderContactOption,
 >(options: readonly T[]): readonly T[] {
@@ -25,10 +32,14 @@ export function purchaseOrderSiteContactOptions<
 export function purchaseOrderCostCodesForPhase<
   T extends PurchaseOrderCostCodeOption,
 >(options: readonly T[], phaseCode: string): readonly T[] {
-  const normalizedPhase = phaseCode.trim()
-  if (normalizedPhase.length === 0) return options
+  const normalizedPhase = normalizedDivisionCode(phaseCode)
+  if (normalizedPhase === null) return options
 
-  return options.filter(
-    (option) => option.divisionCode.trim() === normalizedPhase
+  const matchingOptions = options.filter(
+    (option) => normalizedDivisionCode(option.divisionCode) === normalizedPhase
   )
+
+  // Imported and manually typed phase values are not always canonical CSI
+  // divisions. Keeping all codes visible is safer than presenting an empty menu.
+  return matchingOptions.length > 0 ? matchingOptions : options
 }


### PR DESCRIPTION
## Summary
- detect newer Compass deployments and prompt users to refresh before stale forms fail
- show a clear recovery path for obsolete Server Action errors
- keep PO cost-code options available for imported, typed, or legacy phase values

## Verification
- `bun test src/lib/purchase-orders/__tests__/form-options.test.ts src/lib/purchase-orders/__tests__/action-errors.test.ts src/lib/deployment/__tests__/version.test.ts`
- targeted ESLint
- `tsc --noEmit`
- production Next build (including pre-push build)
