### PR TITLE
fix(calendar): batch D1 event queries

### DIFF
--- a/src/app/actions/work-calendar.ts
+++ b/src/app/actions/work-calendar.ts
@@ -22,6 +22,7 @@ import {
 } from "@/db/schema"
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
+import { chunkD1Values } from "@/lib/d1-query"
 import { isDemoUser } from "@/lib/demo"
 import { calendarDetailLevel } from "@/lib/google/calendar/sync-policy"
 import {
@@ -698,63 +699,81 @@ export async function getWorkCalendar(
       asc(workCalendarEvents.title)
     )
   const eventIds = eventRows.map((event) => event.id)
+  // D1 accepts at most 100 bound parameters per statement. Leave room for
+  // the organization and source-type predicates in the linked-event query.
+  const eventIdChunks = chunkD1Values(eventIds)
   const linkedEventRows =
     eventIds.length === 0
       ? []
-      : await db
-          .select({
-            eventId: googleCalendarEntityLinks.sourceId,
-            ownerUserId: googleCalendarConnections.userId,
-            calendarScope: googleCalendarSelections.calendarScope,
-            internalCanEdit: googleCalendarSelections.internalCanEdit,
-          })
-          .from(googleCalendarEntityLinks)
-          .innerJoin(
-            googleCalendarConnections,
-            eq(
-              googleCalendarConnections.id,
-              googleCalendarEntityLinks.connectionId,
+      : (
+          await Promise.all(
+            eventIdChunks.map((eventIdChunk) =>
+              db
+                .select({
+                  eventId: googleCalendarEntityLinks.sourceId,
+                  ownerUserId: googleCalendarConnections.userId,
+                  calendarScope: googleCalendarSelections.calendarScope,
+                  internalCanEdit: googleCalendarSelections.internalCanEdit,
+                })
+                .from(googleCalendarEntityLinks)
+                .innerJoin(
+                  googleCalendarConnections,
+                  eq(
+                    googleCalendarConnections.id,
+                    googleCalendarEntityLinks.connectionId,
+                  ),
+                )
+                .innerJoin(
+                  googleCalendarSelections,
+                  and(
+                    eq(
+                      googleCalendarSelections.connectionId,
+                      googleCalendarEntityLinks.connectionId,
+                    ),
+                    eq(
+                      googleCalendarSelections.googleCalendarId,
+                      googleCalendarEntityLinks.googleCalendarId,
+                    ),
+                  ),
+                )
+                .where(
+                  and(
+                    eq(googleCalendarConnections.organizationId, orgId),
+                    eq(
+                      googleCalendarEntityLinks.sourceType,
+                      "work_calendar_event",
+                    ),
+                    inArray(googleCalendarEntityLinks.sourceId, eventIdChunk),
+                  ),
+                ),
             ),
           )
-          .innerJoin(
-            googleCalendarSelections,
-            and(
-              eq(
-                googleCalendarSelections.connectionId,
-                googleCalendarEntityLinks.connectionId,
-              ),
-              eq(
-                googleCalendarSelections.googleCalendarId,
-                googleCalendarEntityLinks.googleCalendarId,
-              ),
-            ),
-          )
-          .where(
-            and(
-              eq(googleCalendarConnections.organizationId, orgId),
-              eq(googleCalendarEntityLinks.sourceType, "work_calendar_event"),
-              inArray(googleCalendarEntityLinks.sourceId, eventIds),
-            ),
-          )
+        ).flat()
   const linkedEventById = new Map(
     linkedEventRows.map((link) => [link.eventId, link]),
   )
   const attendeeRows =
     eventIds.length === 0
       ? []
-      : await db
-          .select({
-            eventId: workCalendarEventAttendees.eventId,
-            userId: users.id,
-            email: users.email,
-            displayName: users.displayName,
-            firstName: users.firstName,
-            lastName: users.lastName,
-          })
-          .from(workCalendarEventAttendees)
-          .innerJoin(users, eq(users.id, workCalendarEventAttendees.userId))
-          .where(inArray(workCalendarEventAttendees.eventId, eventIds))
-          .orderBy(asc(users.displayName), asc(users.email))
+      : (
+          await Promise.all(
+            eventIdChunks.map((eventIdChunk) =>
+              db
+                .select({
+                  eventId: workCalendarEventAttendees.eventId,
+                  userId: users.id,
+                  email: users.email,
+                  displayName: users.displayName,
+                  firstName: users.firstName,
+                  lastName: users.lastName,
+                })
+                .from(workCalendarEventAttendees)
+                .innerJoin(users, eq(users.id, workCalendarEventAttendees.userId))
+                .where(inArray(workCalendarEventAttendees.eventId, eventIdChunk))
+                .orderBy(asc(users.displayName), asc(users.email)),
+            ),
+          )
+        ).flat()
   const attendeesByEventId = new Map<
     string,
     WorkCalendarEventAttendee[]

--- a/src/lib/__tests__/d1-query.test.ts
+++ b/src/lib/__tests__/d1-query.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+
+import { chunkD1Values } from "@/lib/d1-query"
+
+describe("chunkD1Values", () => {
+  it("keeps a 110-value query below D1's parameter limit", () => {
+    const chunks = chunkD1Values(
+      Array.from({ length: 110 }, (_value, index) => `event-${index}`),
+    )
+
+    expect(chunks.map((chunk) => chunk.length)).toEqual([50, 50, 10])
+    expect(chunks.flat()).toHaveLength(110)
+  })
+
+  it("does not create a query chunk for an empty collection", () => {
+    expect(chunkD1Values([])).toEqual([])
+  })
+})

--- a/src/lib/d1-query.ts
+++ b/src/lib/d1-query.ts
@@ -1,0 +1,10 @@
+const D1_VALUE_CHUNK_SIZE = 50
+
+/** Keeps dynamic IN predicates below D1's 100-bound-parameter limit. */
+export function chunkD1Values<T>(values: readonly T[]): T[][] {
+  const chunks: T[][] = []
+  for (let index = 0; index < values.length; index += D1_VALUE_CHUNK_SIZE) {
+    chunks.push(values.slice(index, index + D1_VALUE_CHUNK_SIZE))
+  }
+  return chunks
+}


### PR DESCRIPTION
Summary

- batch Work Calendar event ID lookups below D1's 100-parameter limit
- cover the production-sized 110-event case with a regression test
- preserve linked Google event and attendee aggregation across chunks

Verification

- 33 focused calendar tests passed
- targeted ESLint passed
- TypeScript passed
- production build passed twice