### PR TITLE
fix(messages): keep direct replies visible

### DIFF
--- a/src/app/actions/conversations-realtime.ts
+++ b/src/app/actions/conversations-realtime.ts
@@ -92,7 +92,12 @@ export async function getChannelUpdates(
       .select(messageSelectFields)
       .from(messages)
       .leftJoin(users, eq(users.id, messages.userId))
-      .where(eq(messages.channelId, channelId))
+      .where(
+        and(
+          eq(messages.channelId, channelId),
+          sql`${messages.threadId} IS NULL`
+        )
+      )
       .orderBy(desc(messages.createdAt))
 
     if (lastMessageId) {
@@ -112,6 +117,7 @@ export async function getChannelUpdates(
           .where(
             and(
               eq(messages.channelId, channelId),
+              sql`${messages.threadId} IS NULL`,
               gt(messages.createdAt, lastMessage.createdAt)
             )
           )

--- a/src/app/actions/field-mode.ts
+++ b/src/app/actions/field-mode.ts
@@ -204,15 +204,23 @@ export async function getFieldProjectPacket(
         )
       )
     : []
-  const [messageResult, directConversationResults] = await Promise.all([
-    channel ? getMessages(channel.id, { limit: 30 }) : null,
-    Promise.all(
-      directChannels.map(async (directChannel) => ({
-        channel: directChannel,
-        result: await getMessages(directChannel.id, { limit: 12 }),
-      }))
-    ),
-  ])
+  const messageResult = channel
+    ? await getMessages(channel.id, { limit: 30 })
+    : null
+  const directConversationResults: Array<{
+    readonly channel: (typeof directChannels)[number]
+    readonly result: Awaited<ReturnType<typeof getMessages>>
+  }> = []
+
+  // Each message read performs several D1 queries. Loading every direct
+  // conversation in one Promise.all can exceed the Worker's concurrent D1
+  // connection allowance and silently turn otherwise valid threads empty.
+  for (const directChannel of directChannels) {
+    directConversationResults.push({
+      channel: directChannel,
+      result: await getMessages(directChannel.id, { limit: 12 }),
+    })
+  }
   const scheduleItems: FieldProjectPacket["tasks"] = schedule.tasks.map(
     (task) => ({
       id: task.id,

--- a/src/app/api/conversations/[channelId]/updates/__tests__/route.test.ts
+++ b/src/app/api/conversations/[channelId]/updates/__tests__/route.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  getChannelUpdates: vi.fn(),
+}))
+
+vi.mock("@/app/actions/conversations-realtime", () => ({
+  getChannelUpdates: mocks.getChannelUpdates,
+}))
+
+import { GET } from "../route"
+
+describe("GET /api/conversations/:channelId/updates", () => {
+  beforeEach(() => {
+    mocks.getChannelUpdates.mockReset()
+  })
+
+  it("uses a stable no-store endpoint for live conversation updates", async () => {
+    mocks.getChannelUpdates.mockResolvedValue({
+      success: true,
+      data: { messages: [], typingUsers: [] },
+    })
+
+    const response = await GET(
+      new Request(
+        "https://compass.example/api/conversations/channel-1/updates?lastMessageId=message-1"
+      ),
+      { params: Promise.resolve({ channelId: "channel-1" }) }
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("cache-control")).toContain("no-store")
+    expect(mocks.getChannelUpdates).toHaveBeenCalledWith(
+      "channel-1",
+      "message-1"
+    )
+  })
+
+  it("loads the first message when a conversation has no cursor", async () => {
+    mocks.getChannelUpdates.mockResolvedValue({
+      success: true,
+      data: { messages: [], typingUsers: [] },
+    })
+
+    await GET(
+      new Request("https://compass.example/api/conversations/channel-1/updates"),
+      { params: Promise.resolve({ channelId: "channel-1" }) }
+    )
+
+    expect(mocks.getChannelUpdates).toHaveBeenCalledWith(
+      "channel-1",
+      undefined
+    )
+  })
+})

--- a/src/app/api/conversations/[channelId]/updates/route.ts
+++ b/src/app/api/conversations/[channelId]/updates/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server"
+
+import { getChannelUpdates } from "@/app/actions/conversations-realtime"
+
+const RESPONSE_HEADERS: Readonly<Record<string, string>> = {
+  "Cache-Control": "private, no-store, max-age=0, must-revalidate",
+  Pragma: "no-cache",
+  Expires: "0",
+}
+
+export async function GET(
+  request: Request,
+  { params }: { readonly params: Promise<{ readonly channelId: string }> }
+): Promise<Response> {
+  try {
+    const { channelId } = await params
+    if (!channelId) {
+      return NextResponse.json(
+        { success: false, error: "Choose a conversation first." },
+        { status: 400, headers: RESPONSE_HEADERS }
+      )
+    }
+
+    const lastMessageId = new URL(request.url).searchParams.get("lastMessageId")
+    const result = await getChannelUpdates(
+      channelId,
+      lastMessageId && lastMessageId.length > 0 ? lastMessageId : undefined
+    )
+    return NextResponse.json(result, {
+      status: result.success ? 200 : 403,
+      headers: RESPONSE_HEADERS,
+    })
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unable to refresh conversation messages.",
+      },
+      { status: 500, headers: RESPONSE_HEADERS }
+    )
+  }
+}

--- a/src/hooks/use-realtime-channel.ts
+++ b/src/hooks/use-realtime-channel.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useEffect, useRef, useCallback } from "react"
-import { getChannelUpdates } from "@/app/actions/conversations-realtime"
+import { z } from "zod/v4"
 
 type TypingUser = {
   id: string
@@ -42,6 +42,35 @@ type PollingOptions = {
 const DEFAULT_VISIBLE_POLL_INTERVAL = 2500 // 2.5 seconds when tab is visible
 const DEFAULT_HIDDEN_POLL_INTERVAL = 10000 // 10 seconds when tab is hidden
 
+const realtimeUpdateSchema = z.object({
+  success: z.literal(true),
+  data: z.object({
+    messages: z.array(z.object({
+      id: z.string(),
+      channelId: z.string(),
+      threadId: z.string().nullable(),
+      content: z.string(),
+      contentHtml: z.string().nullable(),
+      editedAt: z.string().nullable(),
+      deletedAt: z.string().nullable(),
+      isPinned: z.boolean(),
+      replyCount: z.number(),
+      lastReplyAt: z.string().nullable(),
+      createdAt: z.string(),
+      user: z.object({
+        id: z.string(),
+        displayName: z.string().nullable(),
+        email: z.string(),
+        avatarUrl: z.string().nullable(),
+      }).nullable(),
+    })),
+    typingUsers: z.array(z.object({
+      id: z.string(),
+      displayName: z.string().nullable(),
+    })),
+  }),
+})
+
 function isTransientFetchError(error: unknown): boolean {
   return error instanceof TypeError && error.message === "Failed to fetch"
 }
@@ -68,33 +97,36 @@ export function useRealtimeChannel(
   }, [lastMessageId])
 
   const poll = useCallback(async () => {
-    // don't poll without a baseline message to compare against
-    if (!lastMessageIdRef.current) {
-      return
-    }
-
     setIsPolling(true)
 
     try {
-      const result = await getChannelUpdates(
-        channelId,
-        lastMessageIdRef.current ?? undefined,
-      )
-
-      if (result.success) {
-        // accumulate new messages (avoid duplicates)
-        if (result.data.messages.length > 0) {
-          setNewMessages((prev) => {
-            const existingIds = new Set(prev.map((m) => m.id))
-            const uniqueNew = result.data.messages.filter(
-              (m) => !existingIds.has(m.id),
-            )
-            return [...prev, ...uniqueNew]
-          })
-        }
-
-        setTypingUsers(result.data.typingUsers)
+      const search = new URLSearchParams()
+      if (lastMessageIdRef.current) {
+        search.set("lastMessageId", lastMessageIdRef.current)
       }
+      const response = await fetch(
+        `/api/conversations/${encodeURIComponent(channelId)}/updates?${search.toString()}`,
+        { cache: "no-store" },
+      )
+      const result = realtimeUpdateSchema.safeParse(await response.json())
+      if (!response.ok || !result.success) {
+        throw new Error("Unable to refresh conversation messages.")
+      }
+
+      // Accumulate new messages while avoiding duplicates. With no baseline,
+      // the endpoint returns the latest messages so an initially empty thread
+      // can receive its first reply without a full page reload.
+      if (result.data.data.messages.length > 0) {
+        setNewMessages((prev) => {
+          const existingIds = new Set(prev.map((message) => message.id))
+          const uniqueNew = result.data.data.messages.filter(
+            (message) => !existingIds.has(message.id),
+          )
+          return [...prev, ...uniqueNew]
+        })
+      }
+
+      setTypingUsers(result.data.data.typingUsers)
     } catch (error) {
       if (isTransientFetchError(error)) {
         return
@@ -117,17 +149,14 @@ export function useRealtimeChannel(
         pollingRef.current = null
       }
 
-      // only start polling if we have a lastMessageId
-      if (lastMessageIdRef.current) {
-        const interval = isVisibleRef.current
-          ? visibleInterval
-          : hiddenInterval
+      const interval = isVisibleRef.current
+        ? visibleInterval
+        : hiddenInterval
 
-        pollingRef.current = setInterval(poll, interval)
-        // also poll immediately when becoming visible
-        if (isVisibleRef.current) {
-          poll()
-        }
+      pollingRef.current = setInterval(poll, interval)
+      // also poll immediately when becoming visible
+      if (isVisibleRef.current) {
+        poll()
       }
     }
 
@@ -144,11 +173,6 @@ export function useRealtimeChannel(
     if (pollingRef.current) {
       clearInterval(pollingRef.current)
       pollingRef.current = null
-    }
-
-    // only start polling when we have messages to compare against
-    if (!lastMessageId) {
-      return
     }
 
     const interval = isVisibleRef.current


### PR DESCRIPTION
## Summary
- move browser conversation polling to a stable, no-store API route so open Compass sessions survive deployments
- poll empty conversations so their first incoming reply appears without a reload
- load Field direct-message histories sequentially to avoid concurrent D1 reads emptying valid threads
- keep thread replies out of the top-level live message list

## Production evidence
- Sylvi's reported replies are persisted, undeleted, and top-level in the correct deterministic direct channel
- both Martine and Sylvi have active membership rows for that channel
- the browser test began immediately after a production deployment, matching stale server-action polling
- Martine's Field packet currently loads nine direct channels, exercising the concurrent D1 read path

## Verification
- `bun run test` (192 files, 1,046 tests)
- `bun run build`
- repository pre-commit lint (0 errors; existing warnings only)
- repository pre-push production build
