### PR TITLE
fix(android): require Firebase config for releases

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.hpscolorado.compass"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 15
-        versionName "0.1.0-alpha.15"
+        versionCode 16
+        versionName "0.1.0-alpha.16"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
@@ -61,11 +61,19 @@ dependencies {
 
 apply from: 'capacitor.build.gradle'
 
-try {
-    def servicesJSON = file('google-services.json')
-    if (servicesJSON.text) {
-        apply plugin: 'com.google.gms.google-services'
-    }
-} catch(Exception e) {
-    logger.info("google-services.json not found, google-services plugin not applied. Push Notifications won't work")
+def servicesJSON = file('google-services.json')
+def isReleaseBuild = gradle.startParameter.taskNames.any { taskName ->
+    taskName.toLowerCase().contains('release')
+}
+
+if (servicesJSON.exists() && servicesJSON.text.trim()) {
+    apply plugin: 'com.google.gms.google-services'
+} else if (isReleaseBuild) {
+    // A release without Firebase configuration crashes when Android users
+    // grant notification permission and push registration begins.
+    throw new GradleException(
+        "android/app/google-services.json is required for Android release builds"
+    )
+} else {
+    logger.warn("google-services.json not found; Android push notifications are disabled")
 }

--- a/docs/architecture/native-mobile.md
+++ b/docs/architecture/native-mobile.md
@@ -232,7 +232,7 @@ Android push notifications go through Firebase Cloud Messaging, even if they ori
 
 1. Create a Firebase project at console.firebase.google.com
 2. Add an Android app with package name `com.hpscolorado.compass`
-3. Download `google-services.json` and place it at `android/app/google-services.json`
+3. Download `google-services.json` and place it at `android/app/google-services.json`. The file is intentionally gitignored; Android release builds fail if it is missing so a notification-registration crash cannot be shipped.
 4. The `classpath 'com.google.gms:google-services'` line needs to be added to `android/build.gradle`
 5. Add `apply plugin: 'com.google.gms.google-services'` at the bottom of `android/app/build.gradle`
 


### PR DESCRIPTION
## Summary
- bump the Android internal build to `0.1.0-alpha.16` (`versionCode 16`)
- require `google-services.json` for every Android release build
- keep Firebase optional for local debug builds and document the release guard

## Cause
Alpha.15 was built without the gitignored Firebase Android configuration. Granting notification permission then entered native push registration without a default Firebase app, causing Android to close or loop. Denying permission skipped that path, which matches the reported device behavior.

## Verification
- `bun run cap:sync`
- signed `./gradlew bundleRelease` with the Firebase config: passed (631 tasks)
- `:app:processReleaseGoogleServices`: passed and generated Firebase resources
- `jarsigner -verify app-release.aab`: verified
- release dry run without Firebase config: failed immediately with the intended clear error
- `bun lint`: 0 errors (existing warnings only)
- manual diff and adjacent-code review: no actionable findings

The structured autoreview helper could not initialize its isolated Codex state database under the local filesystem sandbox, so no external reviewer result is claimed.
