### PR TITLE
feat(calendar): add managed project Google calendars

### DIFF
--- a/docs/wip/google-calendar-sync-2026-07-27.md
+++ b/docs/wip/google-calendar-sync-2026-07-27.md
@@ -1,6 +1,6 @@
 # Google Calendar Sync
 
-Status: managed calendar sync implementation in progress
+Status: managed calendar sync and project calendar publishing implemented
 
 Owner: Compass product and engineering
 
@@ -47,6 +47,14 @@ write-through behavior:
   personal or organization Google calendar;
 - linked create/update/delete calls so Google-backed Work Calendar events stay
   synchronized when the calendar policy permits the action;
+- organization-owned, on-demand project Google calendars that automatically
+  receive project-scoped Compass events;
+- office-staff enable/pause/access-sync controls, administrator delete controls,
+  and per-user “Add to my Google Calendar” subscriptions;
+- project-level event sync that preserves the Compass project scope for events
+  created or edited from the shared Google calendar;
+- Google ACL roles derived from Compass access: office staff can edit events
+  without managing sharing, while field and external project members are readers;
 - an integration status surface that remains safe when Google OAuth is not configured;
 - tests for privacy, idempotency, and two-way conflict behavior.
 
@@ -66,11 +74,16 @@ the approved local development callback. Configure:
 The encryption key must be independent from the OAuth client secret. Store all
 production values as Cloudflare secrets. Do not commit them to source control.
 
-The initial consent request is intentionally limited to:
+The consent request is intentionally limited to:
 
 - OpenID email identity;
-- read access to the user's calendar list; and
-- event read/write access.
+- read/write access to the user's subscribed calendar list;
+- event read/write access;
+- creation and management of calendars created by Compass; and
+- ACL management for calendars owned by the connected organization account.
+
+Existing connections created before project calendar publishing must reconnect
+once to grant the added Calendar List, app-created calendar, and ACL scopes.
 
 Google Tasks permissions are added only when the Tasks phase is implemented.
 
@@ -84,6 +97,9 @@ Google Tasks permissions are added only when the Tasks phase is implemented.
   meeting URL, or Google link.
 - Organization calendar visibility is configured independently as details or
   busy-only.
+- Managed project calendars preserve project access when their events are
+  synchronized into the Work Calendar; they are not treated as general
+  organization events.
 - Private Compass events are hidden from nonparticipants.
 - Guests cannot connect a Google account or view private staff-calendar data.
 - Tokens, private descriptions, and attendee contact details must never appear
@@ -109,7 +125,8 @@ remain follow-up work.
 
 ## Follow-up Slices
 
-1. Scheduled sync, retries, incremental sync tokens, renewable watches, and a
+1. Scheduled event/access reconciliation, retries, incremental sync tokens,
+   renewable watches, and a
    conflict-resolution UI.
 2. Google Meet conference creation (existing Meet links already round-trip).
 3. Remaining robust event fields: recurrence exceptions, external attendees,

--- a/drizzle/0122_google_project_calendars.sql
+++ b/drizzle/0122_google_project_calendars.sql
@@ -1,0 +1,71 @@
+ALTER TABLE `google_calendar_connections`
+  ADD `is_organization_calendar_owner` integer DEFAULT false NOT NULL;
+
+CREATE UNIQUE INDEX `google_calendar_connection_org_owner_unique`
+  ON `google_calendar_connections` (`organization_id`)
+  WHERE `is_organization_calendar_owner` = 1;
+
+CREATE TABLE `google_project_calendars` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `project_id` text NOT NULL,
+  `owner_connection_id` text NOT NULL,
+  `selection_id` text NOT NULL,
+  `google_calendar_id` text NOT NULL,
+  `summary` text NOT NULL,
+  `time_zone` text NOT NULL,
+  `status` text DEFAULT 'active' NOT NULL,
+  `last_acl_synced_at` text,
+  `last_synced_at` text,
+  `last_error` text,
+  `created_by` text,
+  `updated_by` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`owner_connection_id`) REFERENCES `google_calendar_connections`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`selection_id`) REFERENCES `google_calendar_selections`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`updated_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+
+CREATE UNIQUE INDEX `google_project_calendar_project_unique`
+  ON `google_project_calendars` (`project_id`);
+CREATE UNIQUE INDEX `google_project_calendar_google_unique`
+  ON `google_project_calendars` (`owner_connection_id`, `google_calendar_id`);
+CREATE INDEX `idx_google_project_calendars_org_status`
+  ON `google_project_calendars` (`organization_id`, `status`);
+
+CREATE TABLE `google_project_calendar_acl_members` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_calendar_id` text NOT NULL,
+  `user_id` text,
+  `email` text NOT NULL,
+  `google_acl_rule_id` text NOT NULL,
+  `role` text NOT NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`project_calendar_id`) REFERENCES `google_project_calendars`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+
+CREATE UNIQUE INDEX `google_project_calendar_acl_email_unique`
+  ON `google_project_calendar_acl_members` (`project_calendar_id`, `email`);
+CREATE INDEX `idx_google_project_calendar_acl_user`
+  ON `google_project_calendar_acl_members` (`user_id`);
+
+CREATE TABLE `google_project_calendar_subscriptions` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_calendar_id` text NOT NULL,
+  `user_id` text NOT NULL,
+  `connection_id` text NOT NULL,
+  `subscribed_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`project_calendar_id`) REFERENCES `google_project_calendars`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`connection_id`) REFERENCES `google_calendar_connections`(`id`) ON UPDATE no action ON DELETE cascade
+);
+
+CREATE UNIQUE INDEX `google_project_calendar_subscription_unique`
+  ON `google_project_calendar_subscriptions` (`project_calendar_id`, `user_id`);

--- a/src/app/actions/google-calendar.ts
+++ b/src/app/actions/google-calendar.ts
@@ -4,7 +4,11 @@ import { and, eq } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
-import { googleCalendarConnections, googleCalendarSelections } from "@/db/schema"
+import {
+  googleCalendarConnections,
+  googleCalendarSelections,
+  googleProjectCalendars,
+} from "@/db/schema"
 import { requireAuth } from "@/lib/auth"
 import { decrypt } from "@/lib/crypto"
 import { getCloudflareContext } from "@/lib/db"
@@ -14,6 +18,7 @@ import {
   googleCalendarTokenSalt,
 } from "@/lib/google/calendar/config"
 import { refreshGoogleAccessToken } from "@/lib/google/calendar/oauth"
+import { hasRequiredGoogleCalendarScopes } from "@/lib/google/calendar/oauth"
 import {
   canConnectGoogleCalendar,
   canManageOrganizationCalendars,
@@ -50,6 +55,9 @@ export type GoogleCalendarConnectionStatus = {
   readonly canConnect: boolean
   readonly canManageOrganizationCalendars: boolean
   readonly connected: boolean
+  readonly requiresReconnect: boolean
+  readonly isOrganizationCalendarOwner: boolean
+  readonly organizationOwnerAccountEmail: string | null
   readonly accountEmail: string | null
   readonly status: string | null
   readonly calendarSyncEnabled: boolean
@@ -114,12 +122,26 @@ export async function getGoogleCalendarConnectionStatus(): Promise<GoogleCalenda
       tasksSyncEnabled: googleCalendarConnections.tasksSyncEnabled,
       lastSyncedAt: googleCalendarConnections.lastSyncedAt,
       lastError: googleCalendarConnections.lastError,
+      grantedScopes: googleCalendarConnections.grantedScopes,
+      isOrganizationCalendarOwner:
+        googleCalendarConnections.isOrganizationCalendarOwner,
     })
     .from(googleCalendarConnections)
     .where(
       and(
         eq(googleCalendarConnections.organizationId, organizationId),
         eq(googleCalendarConnections.userId, user.id),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  const organizationOwner = await db
+    .select({ accountEmail: googleCalendarConnections.googleAccountEmail })
+    .from(googleCalendarConnections)
+    .where(
+      and(
+        eq(googleCalendarConnections.organizationId, organizationId),
+        eq(googleCalendarConnections.isOrganizationCalendarOwner, true),
       ),
     )
     .limit(1)
@@ -156,6 +178,14 @@ export async function getGoogleCalendarConnectionStatus(): Promise<GoogleCalenda
     canConnect: canConnectGoogleCalendar({ userId: user.id, role: user.role }),
     canManageOrganizationCalendars: canManageOrganizationCalendars(user.role),
     connected: connection !== null,
+    requiresReconnect:
+      connection !== null &&
+      !hasRequiredGoogleCalendarScopes(
+        connection.grantedScopes.split(/\s+/).filter(Boolean),
+      ),
+    isOrganizationCalendarOwner:
+      connection?.isOrganizationCalendarOwner ?? false,
+    organizationOwnerAccountEmail: organizationOwner?.accountEmail ?? null,
     accountEmail: connection?.accountEmail ?? null,
     status: connection?.status ?? null,
     calendarSyncEnabled: connection?.calendarSyncEnabled ?? false,
@@ -379,6 +409,18 @@ export async function disconnectGoogleCalendar(): Promise<
     const db = getDb(env.DB)
     const connection = await ownConnection(organizationId, user.id)
     if (!connection) return { success: true, revoked: true }
+    const managedProjectCalendar = await db
+      .select({ id: googleProjectCalendars.id })
+      .from(googleProjectCalendars)
+      .where(eq(googleProjectCalendars.ownerConnectionId, connection.id))
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (managedProjectCalendar) {
+      return {
+        success: false,
+        error: "This account owns managed project calendars. Delete those calendars before disconnecting this Google account.",
+      }
+    }
     let revoked = false
     const configuration = getGoogleCalendarOAuthConfig(env)
     if (configuration.configured) {

--- a/src/app/actions/google-project-calendars.ts
+++ b/src/app/actions/google-project-calendars.ts
@@ -1,0 +1,760 @@
+"use server"
+
+import { and, eq } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import {
+  googleCalendarConnections,
+  googleCalendarSelections,
+  googleProjectCalendarAclMembers,
+  googleProjectCalendars,
+  googleProjectCalendarSubscriptions,
+  organizationCalendarSettings,
+  projectMembers,
+  projects,
+  users,
+  workCalendarEvents,
+} from "@/db/schema"
+import { requireAuth } from "@/lib/auth"
+import { decrypt } from "@/lib/crypto"
+import { getCloudflareContext } from "@/lib/db"
+import {
+  addGoogleCalendarToList,
+  createGoogleCalendar,
+  deleteGoogleCalendar,
+  deleteGoogleCalendarAclRule,
+  listGoogleCalendarAclRules,
+  upsertGoogleCalendarAclRule,
+  type GoogleCalendarAclRule,
+} from "@/lib/google/calendar/client"
+import {
+  getGoogleCalendarOAuthConfig,
+  googleCalendarTokenSalt,
+} from "@/lib/google/calendar/config"
+import { hasRequiredGoogleCalendarScopes, refreshGoogleAccessToken } from "@/lib/google/calendar/oauth"
+import {
+  canDeleteGoogleProjectCalendar,
+  canEnableGoogleProjectCalendar,
+  googleProjectCalendarAclRole,
+} from "@/lib/google/calendar/project-policy"
+import {
+  publishWorkCalendarEventToGoogle,
+  syncGoogleCalendarSelection,
+} from "@/lib/google/calendar/sync"
+import { requireOrg } from "@/lib/org-scope"
+import { getProjectAccessRecord } from "@/lib/project-access"
+import { requirePermission } from "@/lib/permissions"
+
+type Database = ReturnType<typeof getDb>
+
+type ActionResult =
+  | { readonly success: true; readonly warning?: string }
+  | { readonly success: false; readonly error: string }
+
+export type GoogleProjectCalendarStatus = {
+  readonly canEnable: boolean
+  readonly canDelete: boolean
+  readonly ownerConfigured: boolean
+  readonly ownerAccountEmail: string | null
+  readonly connected: boolean
+  readonly requiresReconnect: boolean
+  readonly subscribed: boolean
+  readonly calendar: null | {
+    readonly summary: string
+    readonly status: string
+    readonly lastAclSyncedAt: string | null
+    readonly lastSyncedAt: string | null
+    readonly lastError: string | null
+  }
+}
+
+type ConnectionRecord = {
+  readonly id: string
+  readonly userId: string
+  readonly accountEmail: string
+  readonly refreshTokenEncrypted: string
+  readonly grantedScopes: string
+}
+
+function parsedScopes(value: string): readonly string[] {
+  return value.split(/\s+/).filter(Boolean)
+}
+
+async function accessToken(
+  env: object,
+  connection: ConnectionRecord,
+): Promise<string> {
+  if (!hasRequiredGoogleCalendarScopes(parsedScopes(connection.grantedScopes))) {
+    throw new Error("Reconnect Google Calendar in Settings to grant project calendar access.")
+  }
+  const configuration = getGoogleCalendarOAuthConfig(env)
+  if (!configuration.configured) throw new Error("Google Calendar OAuth is not configured.")
+  const refreshToken = await decrypt(
+    connection.refreshTokenEncrypted,
+    configuration.config.tokenEncryptionKey,
+    googleCalendarTokenSalt(connection.userId),
+  )
+  return (await refreshGoogleAccessToken(configuration.config, refreshToken)).accessToken
+}
+
+async function ownerConnection(
+  db: Database,
+  organizationId: string,
+): Promise<ConnectionRecord | null> {
+  return db
+    .select({
+      id: googleCalendarConnections.id,
+      userId: googleCalendarConnections.userId,
+      accountEmail: googleCalendarConnections.googleAccountEmail,
+      refreshTokenEncrypted: googleCalendarConnections.refreshTokenEncrypted,
+      grantedScopes: googleCalendarConnections.grantedScopes,
+    })
+    .from(googleCalendarConnections)
+    .where(
+      and(
+        eq(googleCalendarConnections.organizationId, organizationId),
+        eq(googleCalendarConnections.status, "connected"),
+        eq(googleCalendarConnections.isOrganizationCalendarOwner, true),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+}
+
+async function ownConnection(
+  db: Database,
+  organizationId: string,
+  userId: string,
+): Promise<ConnectionRecord | null> {
+  return db
+    .select({
+      id: googleCalendarConnections.id,
+      userId: googleCalendarConnections.userId,
+      accountEmail: googleCalendarConnections.googleAccountEmail,
+      refreshTokenEncrypted: googleCalendarConnections.refreshTokenEncrypted,
+      grantedScopes: googleCalendarConnections.grantedScopes,
+    })
+    .from(googleCalendarConnections)
+    .where(
+      and(
+        eq(googleCalendarConnections.organizationId, organizationId),
+        eq(googleCalendarConnections.userId, userId),
+        eq(googleCalendarConnections.status, "connected"),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+}
+
+async function requireProject(
+  db: Database,
+  organizationId: string,
+  user: Awaited<ReturnType<typeof requireAuth>>,
+  projectId: string,
+): Promise<{ readonly id: string; readonly name: string; readonly projectNumber: string | null }> {
+  const access = await getProjectAccessRecord(db, user, projectId)
+  if (!access || access.organizationId !== organizationId) {
+    throw new Error("Project not found.")
+  }
+  const project = await db
+    .select({ id: projects.id, name: projects.name, projectNumber: projects.projectNumber })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  if (!project) throw new Error("Project not found.")
+  return project
+}
+
+function projectCalendarSummary(project: {
+  readonly name: string
+  readonly projectNumber: string | null
+}): string {
+  const label = project.projectNumber
+    ? `${project.projectNumber} ${project.name}`
+    : project.name
+  return `Compass – ${label}`.slice(0, 240)
+}
+
+async function shareWithUser(input: {
+  readonly db: Database
+  readonly token: string
+  readonly projectCalendarId: string
+  readonly googleCalendarId: string
+  readonly ownerEmail: string
+  readonly knownRules?: readonly GoogleCalendarAclRule[]
+  readonly user: { readonly id: string; readonly email: string; readonly role: string }
+}): Promise<void> {
+  if (input.user.email.toLowerCase() === input.ownerEmail.toLowerCase()) return
+  const rule = await upsertGoogleCalendarAclRule(
+    input.token,
+    input.googleCalendarId,
+    input.user.email,
+    googleProjectCalendarAclRole(input.user.role),
+    input.knownRules,
+  )
+  const now = new Date().toISOString()
+  await input.db
+    .insert(googleProjectCalendarAclMembers)
+    .values({
+      id: crypto.randomUUID(),
+      projectCalendarId: input.projectCalendarId,
+      userId: input.user.id,
+      email: input.user.email.toLowerCase(),
+      googleAclRuleId: rule.id,
+      role: rule.role,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [googleProjectCalendarAclMembers.projectCalendarId, googleProjectCalendarAclMembers.email],
+      set: {
+        userId: input.user.id,
+        googleAclRuleId: rule.id,
+        role: rule.role,
+        updatedAt: now,
+      },
+    })
+}
+
+async function reconcileAccess(
+  db: Database,
+  token: string,
+  calendar: {
+    readonly id: string
+    readonly organizationId: string
+    readonly projectId: string
+    readonly googleCalendarId: string
+    readonly ownerEmail: string
+  },
+): Promise<void> {
+  const members = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      googleAccountEmail: googleCalendarConnections.googleAccountEmail,
+      role: users.role,
+    })
+    .from(projectMembers)
+    .innerJoin(users, eq(users.id, projectMembers.userId))
+    .leftJoin(
+      googleCalendarConnections,
+      and(
+        eq(googleCalendarConnections.userId, users.id),
+        eq(
+          googleCalendarConnections.organizationId,
+          calendar.organizationId,
+        ),
+        eq(googleCalendarConnections.status, "connected"),
+      ),
+    )
+    .where(
+      and(
+        eq(projectMembers.projectId, calendar.projectId),
+        eq(users.isActive, true),
+      ),
+    )
+  const desired = new Map<string, { readonly id: string; readonly email: string; readonly role: string }>()
+  for (const member of members) {
+    const normalized = {
+      id: member.id,
+      email: member.googleAccountEmail ?? member.email,
+      role: member.role,
+    }
+    desired.set(normalized.email.toLowerCase(), normalized)
+  }
+  const subscribers = await db
+    .select({
+      id: users.id,
+      email: googleCalendarConnections.googleAccountEmail,
+      role: users.role,
+    })
+    .from(googleProjectCalendarSubscriptions)
+    .innerJoin(users, eq(users.id, googleProjectCalendarSubscriptions.userId))
+    .innerJoin(
+      googleCalendarConnections,
+      and(
+        eq(
+          googleCalendarConnections.id,
+          googleProjectCalendarSubscriptions.connectionId,
+        ),
+        eq(
+          googleCalendarConnections.organizationId,
+          calendar.organizationId,
+        ),
+      ),
+    )
+    .where(
+      eq(
+        googleProjectCalendarSubscriptions.projectCalendarId,
+        calendar.id,
+      ),
+    )
+  for (const subscriber of subscribers) {
+    desired.set(subscriber.email.toLowerCase(), subscriber)
+  }
+  desired.delete(calendar.ownerEmail.toLowerCase())
+  const knownRules = await listGoogleCalendarAclRules(
+    token,
+    calendar.googleCalendarId,
+  )
+
+  for (const member of desired.values()) {
+    await shareWithUser({
+      db,
+      token,
+      projectCalendarId: calendar.id,
+      googleCalendarId: calendar.googleCalendarId,
+      ownerEmail: calendar.ownerEmail,
+      user: member,
+      knownRules,
+    })
+  }
+
+  const tracked = await db
+    .select({
+      id: googleProjectCalendarAclMembers.id,
+      email: googleProjectCalendarAclMembers.email,
+      googleAclRuleId: googleProjectCalendarAclMembers.googleAclRuleId,
+    })
+    .from(googleProjectCalendarAclMembers)
+    .where(eq(googleProjectCalendarAclMembers.projectCalendarId, calendar.id))
+  for (const row of tracked) {
+    if (desired.has(row.email.toLowerCase())) continue
+    await deleteGoogleCalendarAclRule(token, calendar.googleCalendarId, row.googleAclRuleId)
+    await db.delete(googleProjectCalendarAclMembers)
+      .where(eq(googleProjectCalendarAclMembers.id, row.id))
+  }
+  const now = new Date().toISOString()
+  await db.update(googleProjectCalendars).set({
+    lastAclSyncedAt: now,
+    lastError: null,
+    updatedAt: now,
+  }).where(eq(googleProjectCalendars.id, calendar.id))
+}
+
+export async function getGoogleProjectCalendarStatus(
+  projectId: string,
+): Promise<GoogleProjectCalendarStatus> {
+  const user = await requireAuth()
+  requirePermission(user, "schedule", "read")
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  await requireProject(db, organizationId, user, projectId)
+  const [owner, own, calendar] = await Promise.all([
+    ownerConnection(db, organizationId),
+    ownConnection(db, organizationId, user.id),
+    db.select({
+      id: googleProjectCalendars.id,
+      summary: googleProjectCalendars.summary,
+      status: googleProjectCalendars.status,
+      lastAclSyncedAt: googleProjectCalendars.lastAclSyncedAt,
+      lastSyncedAt: googleProjectCalendars.lastSyncedAt,
+      lastError: googleProjectCalendars.lastError,
+    }).from(googleProjectCalendars)
+      .where(and(
+        eq(googleProjectCalendars.organizationId, organizationId),
+        eq(googleProjectCalendars.projectId, projectId),
+      )).limit(1).then((rows) => rows[0] ?? null),
+  ])
+  const subscription = calendar
+    ? await db.select({ id: googleProjectCalendarSubscriptions.id })
+      .from(googleProjectCalendarSubscriptions)
+      .where(and(
+        eq(googleProjectCalendarSubscriptions.projectCalendarId, calendar.id),
+        eq(googleProjectCalendarSubscriptions.userId, user.id),
+      )).limit(1).then((rows) => rows[0] ?? null)
+    : null
+  return {
+    canEnable: canEnableGoogleProjectCalendar(user.role),
+    canDelete: canDeleteGoogleProjectCalendar(user.role),
+    ownerConfigured: owner !== null,
+    ownerAccountEmail: owner?.accountEmail ?? null,
+    connected: own !== null,
+    requiresReconnect: own !== null && !hasRequiredGoogleCalendarScopes(parsedScopes(own.grantedScopes)),
+    subscribed: subscription !== null,
+    calendar: calendar ? {
+      summary: calendar.summary,
+      status: calendar.status,
+      lastAclSyncedAt: calendar.lastAclSyncedAt,
+      lastSyncedAt: calendar.lastSyncedAt,
+      lastError: calendar.lastError,
+    } : null,
+  }
+}
+
+export async function setOwnGoogleCalendarAsOrganizationOwner(): Promise<ActionResult> {
+  try {
+    const user = await requireAuth()
+    if (!canDeleteGoogleProjectCalendar(user.role)) {
+      return { success: false, error: "Only an administrator or developer can designate the organization calendar account." }
+    }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const connection = await ownConnection(db, organizationId, user.id)
+    if (!connection) return { success: false, error: "Connect Google Calendar first." }
+    if (!hasRequiredGoogleCalendarScopes(parsedScopes(connection.grantedScopes))) {
+      return { success: false, error: "Reconnect Google Calendar first to grant project calendar access." }
+    }
+    const existingManagedCalendar = await db
+      .select({ ownerConnectionId: googleProjectCalendars.ownerConnectionId })
+      .from(googleProjectCalendars)
+      .where(eq(googleProjectCalendars.organizationId, organizationId))
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    if (
+      existingManagedCalendar &&
+      existingManagedCalendar.ownerConnectionId !== connection.id
+    ) {
+      return {
+        success: false,
+        error: "Delete existing managed project calendars before changing the organization owner account.",
+      }
+    }
+    await db.update(googleCalendarConnections)
+      .set({ isOrganizationCalendarOwner: false, updatedAt: new Date().toISOString() })
+      .where(eq(googleCalendarConnections.organizationId, organizationId))
+    await db.update(googleCalendarConnections)
+      .set({ isOrganizationCalendarOwner: true, updatedAt: new Date().toISOString() })
+      .where(eq(googleCalendarConnections.id, connection.id))
+    revalidatePath("/dashboard/settings")
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : "The organization calendar account could not be set." }
+  }
+}
+
+export async function enableGoogleProjectCalendar(projectId: string): Promise<ActionResult> {
+  try {
+    const user = await requireAuth()
+    requirePermission(user, "schedule", "create")
+    if (!canEnableGoogleProjectCalendar(user.role)) {
+      return { success: false, error: "Project Google calendars can be enabled by office staff." }
+    }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const project = await requireProject(db, organizationId, user, projectId)
+    const existing = await db.select({ id: googleProjectCalendars.id })
+      .from(googleProjectCalendars).where(eq(googleProjectCalendars.projectId, projectId))
+      .limit(1).then((rows) => rows[0] ?? null)
+    if (existing) return { success: false, error: "This project already has a Google calendar." }
+    const owner = await ownerConnection(db, organizationId)
+    if (!owner) return { success: false, error: "An administrator must designate an organization Google Calendar account in Settings first." }
+    const token = await accessToken(env, owner)
+    const setting = await db.select({ timeZone: organizationCalendarSettings.timeZone })
+      .from(organizationCalendarSettings)
+      .where(eq(organizationCalendarSettings.organizationId, organizationId))
+      .limit(1).then((rows) => rows[0] ?? null)
+    const timeZone = setting?.timeZone ?? "America/Denver"
+    const summary = projectCalendarSummary(project)
+    const created = await createGoogleCalendar(token, {
+      summary,
+      description: "Compass-managed project calendar. Access follows Compass project permissions.",
+      timeZone,
+    })
+    const now = new Date().toISOString()
+    const selectionId = crypto.randomUUID()
+    const projectCalendarId = crypto.randomUUID()
+    try {
+      await db.insert(googleCalendarSelections).values({
+        id: selectionId,
+        connectionId: owner.id,
+        googleCalendarId: created.id,
+        summary: created.summary,
+        description: created.description,
+        timeZone: created.timeZone ?? timeZone,
+        backgroundColor: null,
+        accessRole: "owner",
+        isPrimary: false,
+        selected: false,
+        importEvents: false,
+        exportCompassEvents: true,
+        isCompassDestination: false,
+        calendarScope: "organization",
+        internalVisibility: "details",
+        internalCanCreate: true,
+        internalCanEdit: true,
+        internalCanDelete: false,
+        createdAt: now,
+        updatedAt: now,
+      })
+      await db.insert(googleProjectCalendars).values({
+        id: projectCalendarId,
+        organizationId,
+        projectId,
+        ownerConnectionId: owner.id,
+        selectionId,
+        googleCalendarId: created.id,
+        summary: created.summary,
+        timeZone: created.timeZone ?? timeZone,
+        status: "active",
+        createdBy: user.id,
+        updatedBy: user.id,
+        createdAt: now,
+        updatedAt: now,
+      })
+    } catch (error) {
+      try {
+        await db.delete(googleCalendarSelections)
+          .where(eq(googleCalendarSelections.id, selectionId))
+      } catch {
+        // The external calendar cleanup below is the higher-value rollback.
+      }
+      await deleteGoogleCalendar(token, created.id).catch(() => undefined)
+      throw error
+    }
+    let accessWarning: string | null = null
+    try {
+      await reconcileAccess(db, token, {
+        id: projectCalendarId,
+        organizationId,
+        projectId,
+        googleCalendarId: created.id,
+        ownerEmail: owner.accountEmail,
+      })
+    } catch (error) {
+      accessWarning = error instanceof Error
+        ? `Member access could not be synchronized: ${error.message}`
+        : "Member access could not be synchronized."
+    }
+    const events = await db.select({ id: workCalendarEvents.id })
+      .from(workCalendarEvents)
+      .where(and(
+        eq(workCalendarEvents.organizationId, organizationId),
+        eq(workCalendarEvents.projectId, projectId),
+        eq(workCalendarEvents.status, "open"),
+      ))
+    let failed = 0
+    for (const event of events) {
+      try {
+        await publishWorkCalendarEventToGoogle(db, env, event.id, selectionId)
+      } catch {
+        failed += 1
+      }
+    }
+    const eventWarning = failed > 0
+      ? `${failed} existing event${failed === 1 ? "" : "s"} could not be published.`
+      : null
+    const warning = [accessWarning, eventWarning].filter(
+      (message): message is string => message !== null,
+    ).join(" ")
+    await db.update(googleProjectCalendars).set({
+      lastSyncedAt: new Date().toISOString(),
+      lastError: warning || null,
+      updatedAt: new Date().toISOString(),
+    }).where(eq(googleProjectCalendars.id, projectCalendarId))
+    revalidatePath(`/dashboard/projects/${projectId}/information`)
+    revalidatePath("/dashboard/schedule")
+    return warning
+      ? { success: true, warning }
+      : { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : "The project Google calendar could not be enabled." }
+  }
+}
+
+export async function setGoogleProjectCalendarPaused(
+  projectId: string,
+  paused: boolean,
+): Promise<ActionResult> {
+  try {
+    const user = await requireAuth()
+    if (!canEnableGoogleProjectCalendar(user.role)) return { success: false, error: "Permission denied." }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    await requireProject(db, organizationId, user, projectId)
+    const updated = await db.update(googleProjectCalendars).set({
+      status: paused ? "paused" : "active",
+      updatedBy: user.id,
+      updatedAt: new Date().toISOString(),
+    }).where(and(
+      eq(googleProjectCalendars.organizationId, organizationId),
+      eq(googleProjectCalendars.projectId, projectId),
+    )).returning({ id: googleProjectCalendars.id }).then((rows) => rows[0] ?? null)
+    if (!updated) return { success: false, error: "Project Google calendar not found." }
+    revalidatePath(`/dashboard/projects/${projectId}/information`)
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : "The project Google calendar could not be updated." }
+  }
+}
+
+export async function setGoogleProjectCalendarDisabled(
+  projectId: string,
+  disabled: boolean,
+): Promise<ActionResult> {
+  try {
+    const user = await requireAuth()
+    if (!canDeleteGoogleProjectCalendar(user.role)) {
+      return { success: false, error: "Only an administrator or developer can disable a project Google calendar." }
+    }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    await requireProject(db, organizationId, user, projectId)
+    const updated = await db.update(googleProjectCalendars).set({
+      status: disabled ? "disabled" : "active",
+      updatedBy: user.id,
+      updatedAt: new Date().toISOString(),
+    }).where(and(
+      eq(googleProjectCalendars.organizationId, organizationId),
+      eq(googleProjectCalendars.projectId, projectId),
+    )).returning({ id: googleProjectCalendars.id }).then((rows) => rows[0] ?? null)
+    if (!updated) return { success: false, error: "Project Google calendar not found." }
+    revalidatePath(`/dashboard/projects/${projectId}/information`)
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : "The project Google calendar could not be updated." }
+  }
+}
+
+export async function syncGoogleProjectCalendarAccess(projectId: string): Promise<ActionResult> {
+  try {
+    const user = await requireAuth()
+    if (!canEnableGoogleProjectCalendar(user.role)) return { success: false, error: "Permission denied." }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    await requireProject(db, organizationId, user, projectId)
+    const owner = await ownerConnection(db, organizationId)
+    if (!owner) return { success: false, error: "The organization Google Calendar account is not configured." }
+    const calendar = await db.select({
+      id: googleProjectCalendars.id,
+      organizationId: googleProjectCalendars.organizationId,
+      projectId: googleProjectCalendars.projectId,
+      googleCalendarId: googleProjectCalendars.googleCalendarId,
+    }).from(googleProjectCalendars).where(and(
+      eq(googleProjectCalendars.organizationId, organizationId),
+      eq(googleProjectCalendars.projectId, projectId),
+    )).limit(1).then((rows) => rows[0] ?? null)
+    if (!calendar) return { success: false, error: "Project Google calendar not found." }
+    await reconcileAccess(db, await accessToken(env, owner), {
+      ...calendar,
+      ownerEmail: owner.accountEmail,
+    })
+    revalidatePath(`/dashboard/projects/${projectId}/information`)
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : "Calendar access could not be synchronized." }
+  }
+}
+
+export async function syncGoogleProjectCalendarEvents(projectId: string): Promise<ActionResult> {
+  try {
+    const user = await requireAuth()
+    if (!canEnableGoogleProjectCalendar(user.role)) return { success: false, error: "Permission denied." }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    await requireProject(db, organizationId, user, projectId)
+    const calendar = await db.select({
+      id: googleProjectCalendars.id,
+      selectionId: googleProjectCalendars.selectionId,
+      status: googleProjectCalendars.status,
+    }).from(googleProjectCalendars).where(and(
+      eq(googleProjectCalendars.organizationId, organizationId),
+      eq(googleProjectCalendars.projectId, projectId),
+    )).limit(1).then((rows) => rows[0] ?? null)
+    if (!calendar) return { success: false, error: "Project Google calendar not found." }
+    if (calendar.status !== "active") return { success: false, error: "Enable the project Google calendar before syncing events." }
+    await syncGoogleCalendarSelection(db, env, calendar.selectionId)
+    const now = new Date().toISOString()
+    await db.update(googleProjectCalendars).set({
+      lastSyncedAt: now,
+      lastError: null,
+      updatedAt: now,
+    }).where(eq(googleProjectCalendars.id, calendar.id))
+    revalidatePath(`/dashboard/projects/${projectId}/information`)
+    revalidatePath("/dashboard/schedule")
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : "Project calendar events could not be synchronized." }
+  }
+}
+
+export async function addGoogleProjectCalendarToMine(projectId: string): Promise<ActionResult> {
+  try {
+    const user = await requireAuth()
+    requirePermission(user, "schedule", "read")
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    await requireProject(db, organizationId, user, projectId)
+    const [owner, own, calendar] = await Promise.all([
+      ownerConnection(db, organizationId),
+      ownConnection(db, organizationId, user.id),
+      db.select({
+        id: googleProjectCalendars.id,
+        googleCalendarId: googleProjectCalendars.googleCalendarId,
+        status: googleProjectCalendars.status,
+      }).from(googleProjectCalendars).where(and(
+        eq(googleProjectCalendars.organizationId, organizationId),
+        eq(googleProjectCalendars.projectId, projectId),
+      )).limit(1).then((rows) => rows[0] ?? null),
+    ])
+    if (!calendar || calendar.status !== "active") return { success: false, error: "This project Google calendar is not active." }
+    if (!owner) return { success: false, error: "The organization Google Calendar account is not configured." }
+    if (!own) return { success: false, error: "Connect Google Calendar in Settings first." }
+    const ownerToken = await accessToken(env, owner)
+    await shareWithUser({
+      db,
+      token: ownerToken,
+      projectCalendarId: calendar.id,
+      googleCalendarId: calendar.googleCalendarId,
+      ownerEmail: owner.accountEmail,
+      user: { id: user.id, email: own.accountEmail, role: user.role },
+    })
+    await addGoogleCalendarToList(await accessToken(env, own), calendar.googleCalendarId)
+    const now = new Date().toISOString()
+    await db.insert(googleProjectCalendarSubscriptions).values({
+      id: crypto.randomUUID(),
+      projectCalendarId: calendar.id,
+      userId: user.id,
+      connectionId: own.id,
+      subscribedAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [googleProjectCalendarSubscriptions.projectCalendarId, googleProjectCalendarSubscriptions.userId],
+      set: { connectionId: own.id, subscribedAt: now, updatedAt: now },
+    })
+    revalidatePath(`/dashboard/projects/${projectId}/information`)
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : "The project calendar could not be added to Google Calendar." }
+  }
+}
+
+export async function deleteGoogleProjectCalendarForProject(projectId: string): Promise<ActionResult> {
+  try {
+    const user = await requireAuth()
+    if (!canDeleteGoogleProjectCalendar(user.role)) return { success: false, error: "Only an administrator or developer can delete a project Google calendar." }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    await requireProject(db, organizationId, user, projectId)
+    const owner = await ownerConnection(db, organizationId)
+    const calendar = await db.select({
+      id: googleProjectCalendars.id,
+      selectionId: googleProjectCalendars.selectionId,
+      googleCalendarId: googleProjectCalendars.googleCalendarId,
+    }).from(googleProjectCalendars).where(and(
+      eq(googleProjectCalendars.organizationId, organizationId),
+      eq(googleProjectCalendars.projectId, projectId),
+    )).limit(1).then((rows) => rows[0] ?? null)
+    if (!calendar) return { success: false, error: "Project Google calendar not found." }
+    if (!owner) return { success: false, error: "The organization Google Calendar account is not configured." }
+    await deleteGoogleCalendar(await accessToken(env, owner), calendar.googleCalendarId)
+    await db.delete(googleProjectCalendars).where(eq(googleProjectCalendars.id, calendar.id))
+    await db.delete(googleCalendarSelections).where(eq(googleCalendarSelections.id, calendar.selectionId))
+    revalidatePath(`/dashboard/projects/${projectId}/information`)
+    revalidatePath("/dashboard/schedule")
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : "The project Google calendar could not be deleted." }
+  }
+}

--- a/src/app/actions/work-calendar.ts
+++ b/src/app/actions/work-calendar.ts
@@ -33,6 +33,7 @@ import {
   deleteLinkedWorkCalendarEventFromGoogle,
   publishWorkCalendarEventToGoogle,
 } from "@/lib/google/calendar/sync"
+import { activeGoogleProjectCalendarSelectionId } from "@/lib/google/calendar/project-routing"
 import { createNotificationEvent } from "@/lib/notifications/events"
 import { eventAttendeeNotificationRecipients } from "@/lib/notifications/audience"
 import { requireOrg } from "@/lib/org-scope"
@@ -1695,6 +1696,13 @@ export async function createWorkCalendarEvent(
       return { success: false, error: "Permission denied" }
     }
     const validated = await validateEventInput(db, orgId, input)
+    const projectCalendarSelectionId = calendarDestination
+      ? null
+      : await activeGoogleProjectCalendarSelectionId(
+          db,
+          orgId,
+          validated.project.id,
+        )
     const organizationCalendar =
       calendarDestination?.calendarScope === "organization"
     const targetProject = organizationCalendar ? null : validated.project
@@ -1734,13 +1742,15 @@ export async function createWorkCalendarEvent(
     })
     await syncEventAttendees(db, id, [], validated.attendees, now)
     let warning: string | undefined
-    if (calendarDestination) {
+    const publishSelectionId =
+      calendarDestination?.selectionId ?? projectCalendarSelectionId
+    if (publishSelectionId) {
       try {
         await publishWorkCalendarEventToGoogle(
           db,
           env,
           id,
-          calendarDestination.selectionId,
+          publishSelectionId,
         )
       } catch (error) {
         warning =
@@ -1906,13 +1916,21 @@ export async function updateWorkCalendarEvent(
       now
     )
     let warning: string | undefined
-    if (googleLink) {
+    const projectCalendarSelectionId = googleLink
+      ? null
+      : await activeGoogleProjectCalendarSelectionId(
+          db,
+          orgId,
+          targetProject?.id ?? null,
+        )
+    const publishSelectionId = googleLink?.selectionId ?? projectCalendarSelectionId
+    if (publishSelectionId) {
       try {
         await publishWorkCalendarEventToGoogle(
           db,
           env,
           eventId,
-          googleLink.selectionId,
+          publishSelectionId,
         )
       } catch (error) {
         warning =

--- a/src/app/api/google/calendar/callback/route.ts
+++ b/src/app/api/google/calendar/callback/route.ts
@@ -2,7 +2,7 @@ import { and, eq } from "drizzle-orm"
 import { type NextRequest, NextResponse } from "next/server"
 
 import { getDb } from "@/db"
-import { googleCalendarConnections } from "@/db/schema"
+import { googleCalendarConnections, googleProjectCalendars } from "@/db/schema"
 import { getCurrentUser } from "@/lib/auth"
 import { encrypt } from "@/lib/crypto"
 import { getCloudflareContext } from "@/lib/db"
@@ -85,6 +85,7 @@ export async function GET(request: NextRequest): Promise<Response> {
         refreshTokenEncrypted:
           googleCalendarConnections.refreshTokenEncrypted,
         createdAt: googleCalendarConnections.createdAt,
+        googleAccountId: googleCalendarConnections.googleAccountId,
       })
       .from(googleCalendarConnections)
       .where(
@@ -109,6 +110,25 @@ export async function GET(request: NextRequest): Promise<Response> {
     const identity = await getGoogleAccountIdentity(grant.accessToken)
     if (!identity.emailVerified) {
       return redirectAndClearState(request, "email-not-verified")
+    }
+    if (
+      existingConnection &&
+      existingConnection.googleAccountId !== identity.subject
+    ) {
+      const managedCalendar = await db
+        .select({ id: googleProjectCalendars.id })
+        .from(googleProjectCalendars)
+        .where(
+          eq(
+            googleProjectCalendars.ownerConnectionId,
+            existingConnection.id,
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null)
+      if (managedCalendar) {
+        return redirectAndClearState(request, "owner-account-mismatch")
+      }
     }
 
     const encryptedRefreshToken = grant.refreshToken

--- a/src/components/google/calendar-connection-status.tsx
+++ b/src/components/google/calendar-connection-status.tsx
@@ -14,6 +14,7 @@ import {
   type GoogleCalendarSelectionConfiguration,
   type GoogleCalendarSelectionStatus,
 } from "@/app/actions/google-calendar"
+import { setOwnGoogleCalendarAsOrganizationOwner } from "@/app/actions/google-project-calendars"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -240,6 +241,10 @@ const GOOGLE_CALENDAR_CALLBACK_MESSAGES: Readonly<
     type: "error",
     message: "Google did not grant offline access. Remove Compass from your Google Account and try again.",
   },
+  "owner-account-mismatch": {
+    type: "error",
+    message: "This connection owns managed project calendars. Reconnect using the same Google account.",
+  },
   "not-configured": {
     type: "error",
     message: "Google Calendar has not been configured by a Compass administrator.",
@@ -263,6 +268,7 @@ export function GoogleCalendarConnectionCard(): React.ReactElement {
     React.useState<GoogleCalendarConnectionStatus | null>(null)
   const [disconnecting, setDisconnecting] = React.useState(false)
   const [refreshing, setRefreshing] = React.useState(false)
+  const [settingOwner, setSettingOwner] = React.useState(false)
 
   const loadStatus = React.useCallback(async (): Promise<void> => {
     const result = await getGoogleCalendarConnectionStatus()
@@ -317,6 +323,18 @@ export function GoogleCalendarConnectionCard(): React.ReactElement {
     await loadStatus()
   }
 
+  async function setOrganizationOwner(): Promise<void> {
+    setSettingOwner(true)
+    const result = await setOwnGoogleCalendarAsOrganizationOwner()
+    setSettingOwner(false)
+    if (!result.success) {
+      toast.error(result.error)
+      return
+    }
+    toast.success("This account now owns Compass-managed organization and project calendars.")
+    await loadStatus()
+  }
+
   if (!status) {
     return (
       <div className="flex items-center gap-3 border p-4">
@@ -357,6 +375,12 @@ export function GoogleCalendarConnectionCard(): React.ReactElement {
               <dt>Account:</dt>
               <dd className="text-foreground">{status.accountEmail}</dd>
             </div>
+            <div className="flex gap-2">
+              <dt>Organization calendar owner:</dt>
+              <dd className="text-foreground">
+                {status.organizationOwnerAccountEmail ?? "Not designated"}
+              </dd>
+            </div>
             <DeveloperOnly>
               <div className="flex gap-2">
                 <dt>Calendar sync:</dt>
@@ -368,6 +392,14 @@ export function GoogleCalendarConnectionCard(): React.ReactElement {
               </div>
             </DeveloperOnly>
           </dl>
+          {status.requiresReconnect ? (
+            <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+              Reconnect Google Calendar to authorize managed project calendars and subscriptions.
+              <div className="mt-2">
+                <Button size="sm" asChild><a href="/api/google/calendar/connect">Reconnect</a></Button>
+              </div>
+            </div>
+          ) : null}
           {status.lastError ? (
             <DeveloperOnly>
               <p className="text-xs text-destructive">
@@ -386,6 +418,17 @@ export function GoogleCalendarConnectionCard(): React.ReactElement {
               <IconRefresh className={refreshing ? "animate-spin" : ""} />
               {refreshing ? "Refreshing..." : "Refresh calendars"}
             </Button>
+            {status.canManageOrganizationCalendars && !status.isOrganizationCalendarOwner ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={settingOwner || status.requiresReconnect}
+                onClick={() => void setOrganizationOwner()}
+              >
+                {settingOwner ? "Designating..." : "Use for Compass-managed calendars"}
+              </Button>
+            ) : null}
             <Button
               type="button"
               size="sm"

--- a/src/components/projects/project-google-calendar-card.tsx
+++ b/src/components/projects/project-google-calendar-card.tsx
@@ -1,0 +1,197 @@
+"use client"
+
+import * as React from "react"
+import { IconBrandGoogle, IconCalendarPlus, IconRefresh } from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import {
+  addGoogleProjectCalendarToMine,
+  deleteGoogleProjectCalendarForProject,
+  enableGoogleProjectCalendar,
+  getGoogleProjectCalendarStatus,
+  setGoogleProjectCalendarDisabled,
+  setGoogleProjectCalendarPaused,
+  syncGoogleProjectCalendarAccess,
+  syncGoogleProjectCalendarEvents,
+  type GoogleProjectCalendarStatus,
+} from "@/app/actions/google-project-calendars"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+
+export function ProjectGoogleCalendarCard({
+  projectId,
+}: {
+  readonly projectId: string
+}): React.ReactElement {
+  const [status, setStatus] = React.useState<GoogleProjectCalendarStatus | null>(null)
+  const [pendingAction, setPendingAction] = React.useState<string | null>(null)
+
+  const load = React.useCallback(async (): Promise<void> => {
+    setStatus(await getGoogleProjectCalendarStatus(projectId))
+  }, [projectId])
+
+  React.useEffect(() => { void load() }, [load])
+
+  async function run(
+    name: string,
+    action: () => Promise<
+      | { readonly success: true; readonly warning?: string }
+      | { readonly success: false; readonly error: string }
+    >,
+    successMessage: string,
+  ): Promise<void> {
+    setPendingAction(name)
+    const result = await action()
+    setPendingAction(null)
+    if (!result.success) {
+      toast.error(result.error)
+      return
+    }
+    if (result.warning) toast.warning(result.warning)
+    else toast.success(successMessage)
+    await load()
+  }
+
+  if (!status) {
+    return (
+      <section className="rounded-lg border bg-card p-4 text-sm text-muted-foreground">
+        Loading project calendar settings…
+      </section>
+    )
+  }
+
+  const calendar = status.calendar
+  const busy = pendingAction !== null
+  return (
+    <section className="rounded-lg border bg-card p-4 sm:p-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <IconBrandGoogle className="mt-0.5 size-5" />
+          <div>
+            <h2 className="font-semibold">Project Google Calendar</h2>
+            <p className="text-sm text-muted-foreground">
+              Publishes this project’s Compass events to a dedicated Google calendar without mixing personal calendars into the shared Work Calendar.
+            </p>
+          </div>
+        </div>
+        <Badge variant={calendar?.status === "active" ? "default" : "outline"}>
+          {calendar ? calendar.status : "Not enabled"}
+        </Badge>
+      </div>
+
+      {!status.ownerConfigured ? (
+        <p className="mt-4 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+          An administrator must connect and designate the organization Google Calendar account in Settings before a project calendar can be enabled.
+        </p>
+      ) : null}
+
+      {calendar ? (
+        <div className="mt-4 space-y-3">
+          <div>
+            <p className="text-sm font-medium">{calendar.summary}</p>
+            <p className="text-xs text-muted-foreground">
+              Owned by {status.ownerAccountEmail}. Project members receive Google access according to their Compass role.
+            </p>
+          </div>
+          {calendar.lastError ? <p className="text-xs text-destructive">{calendar.lastError}</p> : null}
+          {status.requiresReconnect ? (
+            <p className="rounded-md border p-3 text-sm">
+              Reconnect Google Calendar in Settings before adding this calendar to your account.
+            </p>
+          ) : null}
+          <div className="flex flex-wrap gap-2">
+            {status.connected ? (
+              <Button
+                type="button"
+                size="sm"
+                disabled={busy || status.subscribed || calendar.status !== "active" || status.requiresReconnect}
+                onClick={() => void run("subscribe", () => addGoogleProjectCalendarToMine(projectId), "Project calendar added to Google Calendar.")}
+              >
+                <IconCalendarPlus />
+                {status.subscribed ? "Added to my Google Calendar" : "Add to my Google Calendar"}
+              </Button>
+            ) : (
+              <Button size="sm" variant="outline" asChild>
+                <a href="/dashboard/settings">Connect Google Calendar</a>
+              </Button>
+            )}
+            {status.canEnable && calendar.status !== "disabled" ? (
+              <>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={busy || calendar.status !== "active"}
+                  onClick={() => void run("events", () => syncGoogleProjectCalendarEvents(projectId), "Project calendar events synchronized.")}
+                >
+                  <IconRefresh className={pendingAction === "events" ? "animate-spin" : ""} />
+                  Sync events
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={busy}
+                  onClick={() => void run("access", () => syncGoogleProjectCalendarAccess(projectId), "Project calendar access synchronized.")}
+                >
+                  <IconRefresh className={pendingAction === "access" ? "animate-spin" : ""} />
+                  Sync access
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={busy}
+                  onClick={() => void run("pause", () => setGoogleProjectCalendarPaused(projectId, calendar.status === "active"), calendar.status === "active" ? "Project calendar paused." : "Project calendar resumed.")}
+                >
+                  {calendar.status === "active" ? "Pause publishing" : "Resume publishing"}
+                </Button>
+              </>
+            ) : null}
+            {status.canDelete ? (
+              <>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={busy}
+                  onClick={() => void run("disable", () => setGoogleProjectCalendarDisabled(projectId, calendar.status !== "disabled"), calendar.status === "disabled" ? "Project calendar enabled." : "Project calendar disabled.")}
+                >
+                  {calendar.status === "disabled" ? "Enable calendar" : "Disable calendar"}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="destructive"
+                  disabled={busy}
+                  onClick={() => {
+                    if (!window.confirm("Delete this project calendar from Google Calendar? This cannot be undone.")) return
+                    void run("delete", () => deleteGoogleProjectCalendarForProject(projectId), "Project Google calendar deleted.")
+                  }}
+                >
+                  Delete calendar
+                </Button>
+              </>
+            ) : null}
+          </div>
+        </div>
+      ) : status.canEnable ? (
+        <div className="mt-4">
+          <Button
+            type="button"
+            size="sm"
+            disabled={busy || !status.ownerConfigured}
+            onClick={() => void run("enable", () => enableGoogleProjectCalendar(projectId), "Project Google calendar enabled.")}
+          >
+            <IconCalendarPlus />
+            {pendingAction === "enable" ? "Creating calendar…" : "Enable project Google Calendar"}
+          </Button>
+        </div>
+      ) : (
+        <p className="mt-4 text-sm text-muted-foreground">
+          Office staff can enable a Google calendar for this project.
+        </p>
+      )}
+    </section>
+  )
+}

--- a/src/components/projects/project-information-workspace.tsx
+++ b/src/components/projects/project-information-workspace.tsx
@@ -24,6 +24,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { customProjectInteractionType } from "@/lib/project-profile"
+import { ProjectGoogleCalendarCard } from "@/components/projects/project-google-calendar-card"
 
 const CUSTOM_INTERACTION_TYPE_OPTION = "__custom__"
 
@@ -245,6 +246,8 @@ export function ProjectInformationWorkspace({
           {message}
         </p>
       )}
+
+      <ProjectGoogleCalendarCard projectId={information.project.id} />
 
       <form className="rounded-lg border bg-card p-4 sm:p-5" onSubmit={saveProfile}>
         <div className="mb-4 flex flex-wrap items-center justify-between gap-2">

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1292,6 +1292,11 @@ export const googleCalendarConnections = sqliteTable(
     tasksSyncEnabled: integer("tasks_sync_enabled", { mode: "boolean" })
       .notNull()
       .default(false),
+    isOrganizationCalendarOwner: integer("is_organization_calendar_owner", {
+      mode: "boolean",
+    })
+      .notNull()
+      .default(false),
     connectedAt: text("connected_at").notNull(),
     lastSyncedAt: text("last_synced_at"),
     lastError: text("last_error"),
@@ -1378,6 +1383,100 @@ export const googleCalendarSelections = sqliteTable(
     index("idx_google_calendar_selections_selected").on(
       table.connectionId,
       table.selected,
+    ),
+  ],
+)
+
+export const googleProjectCalendars = sqliteTable(
+  "google_project_calendars",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    ownerConnectionId: text("owner_connection_id")
+      .notNull()
+      .references(() => googleCalendarConnections.id, { onDelete: "cascade" }),
+    selectionId: text("selection_id")
+      .notNull()
+      .references(() => googleCalendarSelections.id, { onDelete: "cascade" }),
+    googleCalendarId: text("google_calendar_id").notNull(),
+    summary: text("summary").notNull(),
+    timeZone: text("time_zone").notNull(),
+    status: text("status").notNull().default("active"),
+    lastAclSyncedAt: text("last_acl_synced_at"),
+    lastSyncedAt: text("last_synced_at"),
+    lastError: text("last_error"),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    updatedBy: text("updated_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("google_project_calendar_project_unique").on(table.projectId),
+    uniqueIndex("google_project_calendar_google_unique").on(
+      table.ownerConnectionId,
+      table.googleCalendarId,
+    ),
+    index("idx_google_project_calendars_org_status").on(
+      table.organizationId,
+      table.status,
+    ),
+  ],
+)
+
+export const googleProjectCalendarAclMembers = sqliteTable(
+  "google_project_calendar_acl_members",
+  {
+    id: text("id").primaryKey(),
+    projectCalendarId: text("project_calendar_id")
+      .notNull()
+      .references(() => googleProjectCalendars.id, { onDelete: "cascade" }),
+    userId: text("user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    email: text("email").notNull(),
+    googleAclRuleId: text("google_acl_rule_id").notNull(),
+    role: text("role").notNull(),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("google_project_calendar_acl_email_unique").on(
+      table.projectCalendarId,
+      table.email,
+    ),
+    index("idx_google_project_calendar_acl_user").on(table.userId),
+  ],
+)
+
+export const googleProjectCalendarSubscriptions = sqliteTable(
+  "google_project_calendar_subscriptions",
+  {
+    id: text("id").primaryKey(),
+    projectCalendarId: text("project_calendar_id")
+      .notNull()
+      .references(() => googleProjectCalendars.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    connectionId: text("connection_id")
+      .notNull()
+      .references(() => googleCalendarConnections.id, { onDelete: "cascade" }),
+    subscribedAt: text("subscribed_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("google_project_calendar_subscription_unique").on(
+      table.projectCalendarId,
+      table.userId,
     ),
   ],
 )

--- a/src/lib/__tests__/google-calendar-sync.test.ts
+++ b/src/lib/__tests__/google-calendar-sync.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it } from "vitest"
 
 import {
   GOOGLE_CALENDAR_SCOPES,
@@ -13,12 +13,21 @@ import {
   decideGoogleCalendarSyncAction,
   googleEventIdForCompass,
 } from "@/lib/google/calendar/sync-policy"
-import { parseGoogleCalendarEvent } from "@/lib/google/calendar/client"
+import {
+  addGoogleCalendarToList,
+  createGoogleCalendar,
+  parseGoogleCalendarEvent,
+} from "@/lib/google/calendar/client"
 import {
   canConnectGoogleCalendar,
   canManageOrganizationCalendars,
   canWriteGoogleCalendar,
 } from "@/lib/google/calendar/policy"
+import {
+  canDeleteGoogleProjectCalendar,
+  canEnableGoogleProjectCalendar,
+  googleProjectCalendarAclRole,
+} from "@/lib/google/calendar/project-policy"
 
 describe("Google Calendar OAuth configuration", () => {
   it("fails closed when required secrets are missing", () => {
@@ -81,10 +90,88 @@ describe("Google Calendar OAuth configuration", () => {
       hasRequiredGoogleCalendarScopes([
         "openid",
         "https://www.googleapis.com/auth/userinfo.email",
-        "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+        "https://www.googleapis.com/auth/calendar.calendarlist",
         "https://www.googleapis.com/auth/calendar.events",
+        "https://www.googleapis.com/auth/calendar.app.created",
+        "https://www.googleapis.com/auth/calendar.acls",
       ]),
     ).toBe(true)
+  })
+})
+
+describe("managed Google Calendar API requests", () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it("creates an app-owned secondary calendar", async () => {
+    let requestUrl = ""
+    let requestMethod = ""
+    let requestBody = ""
+    globalThis.fetch = async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      requestUrl = input.toString()
+      requestMethod = init?.method ?? "GET"
+      requestBody = typeof init?.body === "string" ? init.body : ""
+      return Response.json({
+        id: "project-calendar@example.com",
+        summary: "Compass – 24-100 Smith",
+        description: "Managed by Compass",
+        timeZone: "America/Denver",
+      })
+    }
+
+    const calendar = await createGoogleCalendar("access-token", {
+      summary: "Compass – 24-100 Smith",
+      description: "Managed by Compass",
+      timeZone: "America/Denver",
+    })
+
+    expect(requestUrl).toBe("https://www.googleapis.com/calendar/v3/calendars")
+    expect(requestMethod).toBe("POST")
+    expect(JSON.parse(requestBody)).toEqual({
+      summary: "Compass – 24-100 Smith",
+      description: "Managed by Compass",
+      timeZone: "America/Denver",
+    })
+    expect(calendar.id).toBe("project-calendar@example.com")
+  })
+
+  it("treats an existing user subscription as success", async () => {
+    globalThis.fetch = async (): Promise<Response> =>
+      Response.json(
+        { error: { message: "Calendar already exists in calendar list." } },
+        { status: 409 },
+      )
+
+    await expect(
+      addGoogleCalendarToList("access-token", "project-calendar@example.com"),
+    ).resolves.toBeUndefined()
+  })
+})
+
+describe("managed project calendar policy", () => {
+  it("allows office staff, but not field-only or external roles, to enable calendars", () => {
+    expect(canEnableGoogleProjectCalendar("office")).toBe(true)
+    expect(canEnableGoogleProjectCalendar("project_manager")).toBe(true)
+    expect(canEnableGoogleProjectCalendar("field_superintendent")).toBe(false)
+    expect(canEnableGoogleProjectCalendar("owner")).toBe(false)
+  })
+
+  it("reserves destructive calendar controls for administrators", () => {
+    expect(canDeleteGoogleProjectCalendar("admin")).toBe(true)
+    expect(canDeleteGoogleProjectCalendar("office")).toBe(false)
+  })
+
+  it("maps office members to event writers and other project members to readers", () => {
+    expect(googleProjectCalendarAclRole("project_manager")).toBe(
+      "writerWithoutPrivateAccess",
+    )
+    expect(googleProjectCalendarAclRole("subcontractor")).toBe("reader")
   })
 })
 

--- a/src/lib/google/calendar/client.ts
+++ b/src/lib/google/calendar/client.ts
@@ -51,6 +51,24 @@ export type GoogleCalendarEventWrite = {
   readonly attendeeEmails: readonly string[]
 }
 
+export type GoogleCalendarAclRole =
+  | "reader"
+  | "writerWithoutPrivateAccess"
+  | "writer"
+
+export type GoogleCalendarAclRule = {
+  readonly id: string
+  readonly email: string
+  readonly role: string
+}
+
+export type GoogleCreatedCalendar = {
+  readonly id: string
+  readonly summary: string
+  readonly description: string | null
+  readonly timeZone: string | null
+}
+
 function isRecord(value: unknown): value is JsonRecord {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
@@ -122,6 +140,150 @@ function parseCalendar(value: unknown): GoogleCalendarListEntry | null {
 
 function endpoint(path: string): URL {
   return new URL(`${GOOGLE_CALENDAR_API}${path}`)
+}
+
+export async function createGoogleCalendar(
+  accessToken: string,
+  input: {
+    readonly summary: string
+    readonly description: string
+    readonly timeZone: string
+  },
+): Promise<GoogleCreatedCalendar> {
+  const payload = await googleRequest(accessToken, endpoint("/calendars"), {
+    method: "POST",
+    body: JSON.stringify(input),
+  })
+  if (!isRecord(payload)) throw new Error("Google returned an invalid calendar.")
+  const id = stringValue(payload, "id")
+  const summary = stringValue(payload, "summary")
+  if (!id || !summary) throw new Error("Google returned an incomplete calendar.")
+  return {
+    id,
+    summary,
+    description: stringValue(payload, "description"),
+    timeZone: stringValue(payload, "timeZone"),
+  }
+}
+
+export async function deleteGoogleCalendar(
+  accessToken: string,
+  calendarId: string,
+): Promise<void> {
+  const response = await fetch(
+    endpoint(`/calendars/${encodeURIComponent(calendarId)}`),
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${accessToken}` },
+    },
+  )
+  const payload = await responsePayload(response)
+  if (!response.ok && response.status !== 404) {
+    throw new Error(
+      googleError(payload, `Google Calendar request failed (${response.status}).`),
+    )
+  }
+}
+
+export async function listGoogleCalendarAclRules(
+  accessToken: string,
+  calendarId: string,
+): Promise<readonly GoogleCalendarAclRule[]> {
+  const rules: GoogleCalendarAclRule[] = []
+  let pageToken: string | null = null
+  do {
+    const url = endpoint(`/calendars/${encodeURIComponent(calendarId)}/acl`)
+    url.searchParams.set("maxResults", "250")
+    if (pageToken) url.searchParams.set("pageToken", pageToken)
+    const payload = await googleRequest(accessToken, url)
+    if (!isRecord(payload)) throw new Error("Google returned an invalid calendar access list.")
+    if (Array.isArray(payload.items)) {
+      for (const item of payload.items) {
+        if (!isRecord(item) || !isRecord(item.scope)) continue
+        if (stringValue(item.scope, "type") !== "user") continue
+        const id = stringValue(item, "id")
+        const email = stringValue(item.scope, "value")
+        const role = stringValue(item, "role")
+        if (id && email && role) rules.push({ id, email, role })
+      }
+    }
+    pageToken = stringValue(payload, "nextPageToken")
+  } while (pageToken)
+  return rules
+}
+
+export async function upsertGoogleCalendarAclRule(
+  accessToken: string,
+  calendarId: string,
+  email: string,
+  role: GoogleCalendarAclRole,
+  knownRules?: readonly GoogleCalendarAclRule[],
+): Promise<GoogleCalendarAclRule> {
+  const existing = (knownRules ?? await listGoogleCalendarAclRules(accessToken, calendarId))
+    .find((rule) => rule.email.toLowerCase() === email.toLowerCase())
+  if (existing?.role === role) return existing
+  const url = existing
+    ? endpoint(`/calendars/${encodeURIComponent(calendarId)}/acl/${encodeURIComponent(existing.id)}`)
+    : endpoint(`/calendars/${encodeURIComponent(calendarId)}/acl`)
+  const payload = await googleRequest(accessToken, url, {
+    method: existing ? "PUT" : "POST",
+    body: JSON.stringify(
+      existing
+        ? { role, scope: { type: "user", value: existing.email } }
+        : { role, scope: { type: "user", value: email } },
+    ),
+  })
+  if (!isRecord(payload)) throw new Error("Google returned an invalid calendar access rule.")
+  const id = stringValue(payload, "id")
+  const resultRole = stringValue(payload, "role")
+  const scope = isRecord(payload.scope) ? payload.scope : null
+  const resultEmail = scope ? stringValue(scope, "value") : email
+  if (!id || !resultEmail || !resultRole) {
+    throw new Error("Google returned an incomplete calendar access rule.")
+  }
+  return { id, email: resultEmail, role: resultRole }
+}
+
+export async function deleteGoogleCalendarAclRule(
+  accessToken: string,
+  calendarId: string,
+  ruleId: string,
+): Promise<void> {
+  const response = await fetch(
+    endpoint(`/calendars/${encodeURIComponent(calendarId)}/acl/${encodeURIComponent(ruleId)}`),
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${accessToken}` },
+    },
+  )
+  const payload = await responsePayload(response)
+  if (!response.ok && response.status !== 404) {
+    throw new Error(
+      googleError(payload, `Google Calendar request failed (${response.status}).`),
+    )
+  }
+}
+
+export async function addGoogleCalendarToList(
+  accessToken: string,
+  calendarId: string,
+): Promise<void> {
+  const url = endpoint("/users/me/calendarList")
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ id: calendarId, selected: true }),
+  })
+  const payload = await responsePayload(response)
+  // CalendarList.insert is idempotent from Compass' perspective.
+  if (!response.ok && response.status !== 409) {
+    throw new Error(
+      googleError(payload, `Google Calendar request failed (${response.status}).`),
+    )
+  }
 }
 
 export async function listGoogleCalendars(

--- a/src/lib/google/calendar/config.ts
+++ b/src/lib/google/calendar/config.ts
@@ -1,8 +1,10 @@
 export const GOOGLE_CALENDAR_SCOPES = [
   "openid",
   "email",
-  "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+  "https://www.googleapis.com/auth/calendar.calendarlist",
   "https://www.googleapis.com/auth/calendar.events",
+  "https://www.googleapis.com/auth/calendar.app.created",
+  "https://www.googleapis.com/auth/calendar.acls",
 ] as const
 
 export const GOOGLE_OAUTH_AUTHORIZATION_URL =

--- a/src/lib/google/calendar/project-policy.ts
+++ b/src/lib/google/calendar/project-policy.ts
@@ -1,0 +1,20 @@
+import type { GoogleCalendarAclRole } from "@/lib/google/calendar/client"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+const FIELD_ONLY_ROLES = new Set(["field", "field_superintendent", "field_crew"])
+
+export function canEnableGoogleProjectCalendar(role: string): boolean {
+  return role === "developer" || (
+    isInternalStaffRole(role) && !FIELD_ONLY_ROLES.has(role)
+  )
+}
+
+export function canDeleteGoogleProjectCalendar(role: string): boolean {
+  return role === "admin" || role === "secondary_admin" || role === "developer"
+}
+
+export function googleProjectCalendarAclRole(role: string): GoogleCalendarAclRole {
+  return canEnableGoogleProjectCalendar(role)
+    ? "writerWithoutPrivateAccess"
+    : "reader"
+}

--- a/src/lib/google/calendar/project-routing.ts
+++ b/src/lib/google/calendar/project-routing.ts
@@ -1,0 +1,27 @@
+import { and, eq } from "drizzle-orm"
+
+import type { getDb } from "@/db"
+import { googleProjectCalendars } from "@/db/schema"
+
+type Database = ReturnType<typeof getDb>
+
+export async function activeGoogleProjectCalendarSelectionId(
+  db: Database,
+  organizationId: string,
+  projectId: string | null,
+): Promise<string | null> {
+  if (!projectId) return null
+  const row = await db
+    .select({ selectionId: googleProjectCalendars.selectionId })
+    .from(googleProjectCalendars)
+    .where(
+      and(
+        eq(googleProjectCalendars.organizationId, organizationId),
+        eq(googleProjectCalendars.projectId, projectId),
+        eq(googleProjectCalendars.status, "active"),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  return row?.selectionId ?? null
+}

--- a/src/lib/google/calendar/sync.ts
+++ b/src/lib/google/calendar/sync.ts
@@ -6,6 +6,7 @@ import {
   googleCalendarEntityLinks,
   googleCalendarEvents,
   googleCalendarSelections,
+  googleProjectCalendars,
   users,
   workCalendarEventAttendees,
   workCalendarEvents,
@@ -274,6 +275,12 @@ async function syncOrganizationEvent(
   }
 
   if (event.status === "cancelled") return "updated"
+  const managedProject = await db
+    .select({ projectId: googleProjectCalendars.projectId })
+    .from(googleProjectCalendars)
+    .where(eq(googleProjectCalendars.selectionId, selection.selectionId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
   const localId = crypto.randomUUID()
   await db.insert(workCalendarEvents).values({
     id: localId,
@@ -281,7 +288,7 @@ async function syncOrganizationEvent(
       db,
       selection.connectionId,
     ),
-    projectId: null,
+    projectId: managedProject?.projectId ?? null,
     title: event.summary,
     eventType: event.meetingUrl ? "meeting" : "other",
     visibility: localVisibility(selection, event),
@@ -467,6 +474,15 @@ export async function publishWorkCalendarEventToGoogle(
   eventId: string,
   selectionId: string,
 ): Promise<void> {
+  const managedProjectCalendar = await db
+    .select({ status: googleProjectCalendars.status })
+    .from(googleProjectCalendars)
+    .where(eq(googleProjectCalendars.selectionId, selectionId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+  if (managedProjectCalendar && managedProjectCalendar.status !== "active") {
+    throw new Error("Project Google Calendar publishing is paused.")
+  }
   const token = await googleCalendarAccessToken(db, env, selectionId)
   const event = await db
     .select()


### PR DESCRIPTION
## Summary

- add organization-owned Google calendars for individual Compass projects
- allow office staff to enable calendars and synchronize project events, with admin-only destructive controls
- grant Google Calendar access from Compass project roles and provide an Add to Google Calendar link
- route project-scoped Work Calendar events to their managed Google calendars
- add the production database migration and expand Google Calendar OAuth scopes

## Validation

- focused Google Calendar tests: 22 passed
- lint: 0 errors (existing warnings remain)
- production Next.js build and TypeScript check passed in the pre-push gate
- migration executed successfully against a local SQLite fixture