### PR TITLE
fix(ui): standardize searchable value selectors

### DIFF
--- a/docs/development/conventions.md
+++ b/docs/development/conventions.md
@@ -212,19 +212,23 @@ React Hook Form with Zod resolvers. The validation schemas from `src/lib/validat
 
 ### Dropdowns and comboboxes
 
-Use a searchable combobox for entity lists that can grow or need recognition
-by more than one field: projects, people, companies, templates, cost codes, and
-similar records. Search values should include the identifiers and secondary
-labels users recognize, not only the displayed name. Project selectors use
+`SearchableCombobox` is the default Compass value selector. Users must be able
+to open a selector, type to filter its choices, move through results with the
+keyboard, and select a value consistently. This includes entity lists and
+workflow vocabularies such as status, priority, category, visibility, and sort
+order. Search values should include the identifiers and secondary labels users
+recognize, not only the displayed name. Project selectors use
 `ProjectCombobox`, which searches project number, name, client, and ID.
 
-Keep the ordinary shadcn `Select` for short, fixed vocabularies such as status,
-priority, visibility, recurrence, and sort order. Action menus remain
-`DropdownMenu`; they are commands rather than value selectors. This distinction
-keeps small controls fast while preventing long business-data lists from
-becoming scroll-only pickers.
+Use `SearchableComboboxField` when a selector submits through native
+`FormData`; it keeps the selected value in a named hidden field. Use the
+controlled `SearchableCombobox` with React state or form-controller fields.
+Do not add native HTML `select` controls or new shadcn `Select` value pickers
+without a documented accessibility or platform reason. Existing compact fixed
+selectors may be migrated as their owning workflow is touched. Action menus
+remain `DropdownMenu`; they issue commands rather than select values.
 
-Entity combobox options must come from the current server result or current
+Live combobox options must come from the current server result or current
 component props; do not copy them into a one-time hard-coded list. Refresh the
 source whenever the owning dialog or page reloads, and revalidate affected
 paths after mutations. Dependent comboboxes (for example division → cost code

--- a/docs/development/conventions.md
+++ b/docs/development/conventions.md
@@ -224,6 +224,13 @@ priority, visibility, recurrence, and sort order. Action menus remain
 keeps small controls fast while preventing long business-data lists from
 becoming scroll-only pickers.
 
+Entity combobox options must come from the current server result or current
+component props; do not copy them into a one-time hard-coded list. Refresh the
+source whenever the owning dialog or page reloads, and revalidate affected
+paths after mutations. Dependent comboboxes (for example division → cost code
+or template → template item) must recompute from the current parent value and
+clear a child selection when it is no longer available.
+
 ### Information density and responsive text
 
 Keep Compass clean, crisp, professional, and easy to scan. Rounded cards,

--- a/docs/development/conventions.md
+++ b/docs/development/conventions.md
@@ -210,6 +210,20 @@ Built on `@tanstack/react-table`. The pattern uses a `DataTable` component that 
 
 React Hook Form with Zod resolvers. The validation schemas from `src/lib/validations/` plug directly into form configuration.
 
+### Dropdowns and comboboxes
+
+Use a searchable combobox for entity lists that can grow or need recognition
+by more than one field: projects, people, companies, templates, cost codes, and
+similar records. Search values should include the identifiers and secondary
+labels users recognize, not only the displayed name. Project selectors use
+`ProjectCombobox`, which searches project number, name, client, and ID.
+
+Keep the ordinary shadcn `Select` for short, fixed vocabularies such as status,
+priority, visibility, recurrence, and sort order. Action menus remain
+`DropdownMenu`; they are commands rather than value selectors. This distinction
+keeps small controls fast while preventing long business-data lists from
+becoming scroll-only pickers.
+
 ### Information density and responsive text
 
 Keep Compass clean, crisp, professional, and easy to scan. Rounded cards,

--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -902,6 +902,38 @@ test.describe("usable Compass areas", () => {
     ).toBeVisible()
   })
 
+  test("project selectors use the searchable project standard", async ({
+    page,
+  }) => {
+    const path = "/dashboard/projects/e2e-project-001/schedule?view=list"
+    const response = await page.goto(path)
+    await expectHealthyNavigation(
+      page,
+      response,
+      "/dashboard/projects/e2e-project-001/schedule"
+    )
+
+    const projectCombobox = page
+      .getByRole("main")
+      .getByRole("combobox", { name: "Switch project" })
+    await expect(projectCombobox).toBeVisible()
+    await projectCombobox.click()
+
+    const projectPopover = page.locator('[data-slot="popover-content"]:visible')
+    const projectSearch = projectPopover.getByPlaceholder(
+      "Search number, name, or client..."
+    )
+    await projectSearch.fill("Regression Test")
+    await expect(
+      projectPopover.getByText("H-E2E-001", { exact: true })
+    ).toBeVisible()
+
+    await projectSearch.fill("not-a-real-project")
+    await expect(
+      projectPopover.getByText("No matching projects.")
+    ).toBeVisible()
+  })
+
   test("work calendar arrows move by the active view period", async ({
     page,
   }) => {

--- a/src/app/dashboard/activity/page.tsx
+++ b/src/app/dashboard/activity/page.tsx
@@ -5,6 +5,7 @@ import { IconActivity, IconChevronRight } from "@tabler/icons-react"
 import { getActivityEvents } from "@/app/actions/activity"
 import { getProjects } from "@/app/actions/projects"
 import { Badge } from "@/components/ui/badge"
+import { SearchableComboboxField } from "@/components/searchable-combobox"
 import { getCurrentUser } from "@/lib/auth"
 import {
   ACTIVITY_CATEGORIES,
@@ -90,21 +91,23 @@ export default async function ActivityPage({
               </option>
             ))}
           </select>
-          <select
+          <SearchableComboboxField
             name="project"
             defaultValue={params.project ?? ""}
-            aria-label="Filter activity by project"
-            className="h-9 min-w-56 border bg-background px-3 text-sm"
-          >
-            <option value="">All projects</option>
-            {projects.map((project) => (
-              <option key={project.id} value={project.id}>
-                {project.projectNumber
-                  ? `${project.projectNumber} · ${project.name}`
-                  : project.name}
-              </option>
-            ))}
-          </select>
+            ariaLabel="Filter activity by project"
+            placeholder="All projects"
+            searchPlaceholder="Search projects..."
+            className="h-9 min-w-56"
+            options={[
+              { value: "", label: "All projects" },
+              ...projects.map((project) => ({
+                value: project.id,
+                label: project.name,
+                description: project.projectNumber ?? undefined,
+                keywords: project.projectNumber ?? undefined,
+              })),
+            ]}
+          />
           <button
             type="submit"
             className="h-9 border bg-background px-4 text-sm font-medium hover:bg-muted"

--- a/src/app/dashboard/office-maintenance/message-desk/page.tsx
+++ b/src/app/dashboard/office-maintenance/message-desk/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/app/actions/staff-message-desk"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { SearchableComboboxField } from "@/components/searchable-combobox"
 
 function fieldClassName(): string {
   return "h-10 border bg-background px-3 text-sm"
@@ -70,12 +71,20 @@ export default async function StaffMessageDeskPage(): Promise<React.ReactElement
             </label>
             <label className="flex flex-col gap-1 text-sm font-medium">
               Assign to one staff member
-              <select name="assigneeUserId" required defaultValue="" className={fieldClassName()}>
-                <option value="" disabled>Select a recipient…</option>
-                {assignees.map((assignee) => (
-                  <option key={assignee.id} value={assignee.id}>{assignee.name} · {assignee.email}</option>
-                ))}
-              </select>
+              <SearchableComboboxField
+                name="assigneeUserId"
+                ariaLabel="Assign message to staff member"
+                options={assignees.map((assignee) => ({
+                  value: assignee.id,
+                  label: assignee.name,
+                  description: assignee.email,
+                }))}
+                placeholder="Select a recipient…"
+                searchPlaceholder="Search internal staff..."
+                emptyMessage="No matching staff."
+                groupHeading="Internal staff"
+                required
+              />
             </label>
             <label className="flex flex-col gap-1 text-sm font-medium">
               Caller / contact name
@@ -170,12 +179,20 @@ export default async function StaffMessageDeskPage(): Promise<React.ReactElement
                 <input type="hidden" name="eventId" value={item.id} />
                 <label className="flex flex-1 flex-col gap-1 text-sm font-medium">
                   Route to one staff member
-                  <select name="assigneeUserId" required defaultValue="" className={fieldClassName()}>
-                    <option value="" disabled>Select a recipient…</option>
-                    {assignees.map((assignee) => (
-                      <option key={assignee.id} value={assignee.id}>{assignee.name} · {assignee.email}</option>
-                    ))}
-                  </select>
+                  <SearchableComboboxField
+                    name="assigneeUserId"
+                    ariaLabel="Route text to staff member"
+                    options={assignees.map((assignee) => ({
+                      value: assignee.id,
+                      label: assignee.name,
+                      description: assignee.email,
+                    }))}
+                    placeholder="Select a recipient…"
+                    searchPlaceholder="Search internal staff..."
+                    emptyMessage="No matching staff."
+                    groupHeading="Internal staff"
+                    required
+                  />
                 </label>
                 <Button type="submit">Route to Message Desk</Button>
               </form>

--- a/src/components/conversations/create-channel-dialog.tsx
+++ b/src/components/conversations/create-channel-dialog.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation"
 import { useForm } from "react-hook-form"
 import { z } from "zod/v4"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { Hash, Volume2, Megaphone, Lock, FolderOpen } from "lucide-react"
+import { Hash, Volume2, Megaphone, Lock } from "lucide-react"
 import {
   Dialog,
   DialogContent,
@@ -21,13 +21,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
@@ -262,30 +256,23 @@ export function CreateChannelDialog({
                     Category
                   </FormLabel>
                   <FormControl>
-                    <Select
+                    <SearchableCombobox
                       value={field.value ?? "none"}
                       onValueChange={(value) =>
                         field.onChange(value === "none" ? null : value)
                       }
                       disabled={loadingCategories}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select a category" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="none">
-                          <div className="flex items-center gap-2">
-                            <FolderOpen className="h-4 w-4 text-muted-foreground" />
-                            <span>No Category</span>
-                          </div>
-                        </SelectItem>
-                        {categories.map((category) => (
-                          <SelectItem key={category.id} value={category.id}>
-                            {category.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                      ariaLabel="Channel category"
+                      placeholder="Select a category"
+                      searchPlaceholder="Search categories..."
+                      options={[
+                        { value: "none", label: "No Category" },
+                        ...categories.map((category) => ({
+                          value: category.id,
+                          label: category.name,
+                        })),
+                      ]}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/src/components/conversations/search-dialog.tsx
+++ b/src/components/conversations/search-dialog.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { normalizeConversationMentions } from "@/lib/conversations/message-content"
 import { formatDistanceToNow, format, parseISO } from "date-fns"
-import { IconMessageCircle, IconUser, IconCalendar, IconSearch, IconLoader2 } from "@tabler/icons-react"
+import { IconCalendar, IconSearch, IconLoader2 } from "@tabler/icons-react"
 import {
   CommandDialog,
   CommandList,
@@ -11,13 +11,7 @@ import {
   CommandGroup,
   CommandItem,
 } from "@/components/ui/command"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
@@ -192,35 +186,42 @@ export function SearchDialog({
       </div>
 
       <div className="flex items-center gap-2 border-b px-3 py-2">
-        <Select value={selectedChannel} onValueChange={setSelectedChannel}>
-          <SelectTrigger size="sm" className="h-7 text-xs">
-            <IconMessageCircle className="mr-1 size-3" />
-            <SelectValue placeholder="Channel" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All Channels</SelectItem>
-            {channels.map((channel) => (
-              <SelectItem key={channel.id} value={channel.id}>
-                {channel.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <SearchableCombobox
+          ariaLabel="Filter by channel"
+          options={[
+            { value: "all", label: "All Channels" },
+            ...channels.map((channel) => ({
+              value: channel.id,
+              label: channel.name,
+            })),
+          ]}
+          value={selectedChannel}
+          onValueChange={setSelectedChannel}
+          placeholder="Channel"
+          searchPlaceholder="Search channels..."
+          emptyMessage="No matching channels."
+          groupHeading="Channels"
+          className="h-7 w-auto min-w-36 text-xs"
+        />
 
-        <Select value={selectedUser} onValueChange={setSelectedUser}>
-          <SelectTrigger size="sm" className="h-7 text-xs">
-            <IconUser className="mr-1 size-3" />
-            <SelectValue placeholder="User" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All Users</SelectItem>
-            {users.map((user) => (
-              <SelectItem key={user.id} value={user.id}>
-                {user.displayName ?? user.email.split("@")[0]}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <SearchableCombobox
+          ariaLabel="Filter by user"
+          options={[
+            { value: "all", label: "All Users" },
+            ...users.map((user) => ({
+              value: user.id,
+              label: user.displayName ?? user.email.split("@")[0],
+              description: user.email,
+            })),
+          ]}
+          value={selectedUser}
+          onValueChange={setSelectedUser}
+          placeholder="User"
+          searchPlaceholder="Search users..."
+          emptyMessage="No matching users."
+          groupHeading="Users"
+          className="h-7 w-auto min-w-36 text-xs"
+        />
 
         <Popover>
           <PopoverTrigger asChild>

--- a/src/components/feedback/feedback-desk-admin.tsx
+++ b/src/components/feedback/feedback-desk-admin.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/app/actions/feedback-admin"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 import {
   Card,
   CardContent,
@@ -198,10 +199,23 @@ function RequestEditor({
           </label>
           <label className="space-y-1 text-xs font-medium">
             Owner
-            <select className="h-9 w-full rounded-md border bg-background px-3 text-sm" value={assignee} onChange={(event) => setAssignee(event.target.value)}>
-              <option value="">Unassigned</option>
-              {assignees.map((value) => <option key={value.id} value={value.id}>{value.name}</option>)}
-            </select>
+            <SearchableCombobox
+              ariaLabel="Choose feedback owner"
+              options={[
+                { value: "", label: "Unassigned" },
+                ...assignees.map((value) => ({
+                  value: value.id,
+                  label: value.name,
+                })),
+              ]}
+              value={assignee}
+              onValueChange={setAssignee}
+              placeholder="Unassigned"
+              searchPlaceholder="Search internal staff..."
+              emptyMessage="No matching staff."
+              groupHeading="Owners"
+              className="h-9"
+            />
           </label>
         </div>
         <div className="grid gap-3 md:grid-cols-2">
@@ -341,7 +355,7 @@ export function FeedbackDeskAdmin({ overview }: Readonly<{ overview: FeedbackAdm
           </div>
         </CardHeader>
         <CardContent className="space-y-3">
-          {filteredItems.length === 0 ? <p className="py-4 text-center text-sm text-muted-foreground">No requests match these filters. Try a broader queue or clear the search.</p> : <label className="block space-y-1 text-xs font-medium">Selected request<select className="h-10 w-full rounded-md border bg-background px-3 text-sm" value={selectedItem?.id ?? ""} onChange={(event) => setSelectedId(event.target.value)}>{filteredItems.map((item) => <option key={item.id} value={item.id}>{item.kind} · {feedbackStatusLabel(item.status)} · {item.title}</option>)}</select></label>}
+          {filteredItems.length === 0 ? <p className="py-4 text-center text-sm text-muted-foreground">No requests match these filters. Try a broader queue or clear the search.</p> : <label className="block space-y-1 text-xs font-medium">Selected request<SearchableCombobox ariaLabel="Choose feedback request" options={filteredItems.map((item) => ({ value: item.id, label: item.title, description: `${item.kind} · ${feedbackStatusLabel(item.status)}` }))} value={selectedItem?.id ?? ""} onValueChange={setSelectedId} placeholder="Choose request" searchPlaceholder="Search requests..." emptyMessage="No matching requests." groupHeading="Requests" /></label>}
         </CardContent>
       </Card>
 

--- a/src/components/financials/credit-memo-dialog.tsx
+++ b/src/components/financials/credit-memo-dialog.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 import * as React from "react"
+import { ProjectCombobox } from "@/components/projects/project-combobox"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 import { Button } from "@/components/ui/button"
 import {
   ResponsiveDialog,
@@ -107,34 +109,35 @@ export function CreditMemoDialog({
     <>
       <div className="space-y-1.5">
         <Label className="text-xs">Customer *</Label>
-        <Select value={customerId} onValueChange={setCustomerId}>
-          <SelectTrigger className="h-9">
-            <SelectValue placeholder="Select customer" />
-          </SelectTrigger>
-          <SelectContent>
-            {customers.map((c) => (
-              <SelectItem key={c.id} value={c.id}>
-                {c.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <SearchableCombobox
+          options={customers.map((customer) => ({
+            value: customer.id,
+            label: customer.name,
+            description: customer.company ?? customer.email ?? undefined,
+            keywords: [customer.company, customer.email, customer.phone]
+              .filter(Boolean)
+              .join(" "),
+          }))}
+          value={customerId}
+          onValueChange={setCustomerId}
+          ariaLabel="Choose customer"
+          placeholder="Select customer"
+          searchPlaceholder="Search name, company, or email..."
+          emptyMessage="No matching customers."
+          className="h-9"
+        />
       </div>
       <div className="space-y-1.5">
         <Label className="text-xs">Project</Label>
-        <Select value={projectId || "none"} onValueChange={(v) => setProjectId(v === "none" ? "" : v)}>
-          <SelectTrigger className="h-9">
-            <SelectValue placeholder="Select project" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="none">None</SelectItem>
-            {projects.map((p) => (
-              <SelectItem key={p.id} value={p.id}>
-                {p.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <ProjectCombobox
+          projects={projects}
+          value={projectId}
+          onValueChange={setProjectId}
+          specialOptions={[
+            { value: "", label: "None", keywords: "clear no project" },
+          ]}
+          className="h-9"
+        />
       </div>
       <div className="space-y-1.5">
         <Label className="text-xs">Memo #</Label>

--- a/src/components/financials/invoice-dialog.tsx
+++ b/src/components/financials/invoice-dialog.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 import * as React from "react"
+import { ProjectCombobox } from "@/components/projects/project-combobox"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 import { Button } from "@/components/ui/button"
 import {
   ResponsiveDialog,
@@ -128,34 +130,35 @@ export function InvoiceDialog({
     <>
       <div className="space-y-1.5">
         <Label className="text-xs">Customer *</Label>
-        <Select value={customerId} onValueChange={setCustomerId}>
-          <SelectTrigger className="h-9">
-            <SelectValue placeholder="Select customer" />
-          </SelectTrigger>
-          <SelectContent>
-            {customers.map((c) => (
-              <SelectItem key={c.id} value={c.id}>
-                {c.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <SearchableCombobox
+          options={customers.map((customer) => ({
+            value: customer.id,
+            label: customer.name,
+            description: customer.company ?? customer.email ?? undefined,
+            keywords: [customer.company, customer.email, customer.phone]
+              .filter(Boolean)
+              .join(" "),
+          }))}
+          value={customerId}
+          onValueChange={setCustomerId}
+          ariaLabel="Choose customer"
+          placeholder="Select customer"
+          searchPlaceholder="Search name, company, or email..."
+          emptyMessage="No matching customers."
+          className="h-9"
+        />
       </div>
       <div className="space-y-1.5">
         <Label className="text-xs">Project</Label>
-        <Select value={projectId || "none"} onValueChange={(v) => setProjectId(v === "none" ? "" : v)}>
-          <SelectTrigger className="h-9">
-            <SelectValue placeholder="Select project" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="none">None</SelectItem>
-            {projects.map((p) => (
-              <SelectItem key={p.id} value={p.id}>
-                {p.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <ProjectCombobox
+          projects={projects}
+          value={projectId}
+          onValueChange={setProjectId}
+          specialOptions={[
+            { value: "", label: "None", keywords: "clear no project" },
+          ]}
+          className="h-9"
+        />
       </div>
       <div className="space-y-1.5">
         <Label className="text-xs">Invoice #</Label>

--- a/src/components/financials/payment-dialog.tsx
+++ b/src/components/financials/payment-dialog.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 import * as React from "react"
+import { ProjectCombobox } from "@/components/projects/project-combobox"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 import { Button } from "@/components/ui/button"
 import {
   ResponsiveDialog,
@@ -126,54 +128,64 @@ export function PaymentDialog({
       {paymentType === "received" && (
         <div className="space-y-1.5">
           <Label className="text-xs">Customer</Label>
-          <Select value={customerId || "none"} onValueChange={(v) => setCustomerId(v === "none" ? "" : v)}>
-            <SelectTrigger className="h-9">
-              <SelectValue placeholder="Select customer" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="none">None</SelectItem>
-              {customers.map((c) => (
-                <SelectItem key={c.id} value={c.id}>
-                  {c.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <SearchableCombobox
+            options={[
+              { value: "", label: "None", keywords: "clear no customer" },
+              ...customers.map((customer) => ({
+                value: customer.id,
+                label: customer.name,
+                description: customer.company ?? customer.email ?? undefined,
+                keywords: [customer.company, customer.email, customer.phone]
+                  .filter(Boolean)
+                  .join(" "),
+              })),
+            ]}
+            value={customerId}
+            onValueChange={setCustomerId}
+            ariaLabel="Choose customer"
+            placeholder="Select customer"
+            searchPlaceholder="Search name, company, or email..."
+            emptyMessage="No matching customers."
+            className="h-9"
+          />
         </div>
       )}
       {paymentType === "sent" && (
         <div className="space-y-1.5">
           <Label className="text-xs">Vendor</Label>
-          <Select value={vendorId || "none"} onValueChange={(v) => setVendorId(v === "none" ? "" : v)}>
-            <SelectTrigger className="h-9">
-              <SelectValue placeholder="Select vendor" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="none">None</SelectItem>
-              {vendors.map((v) => (
-                <SelectItem key={v.id} value={v.id}>
-                  {v.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <SearchableCombobox
+            options={[
+              { value: "", label: "None", keywords: "clear no vendor" },
+              ...vendors.map((vendor) => ({
+                value: vendor.id,
+                label: vendor.name,
+                description: vendor.category,
+                keywords: [vendor.category, vendor.email, vendor.phone]
+                  .filter(Boolean)
+                  .join(" "),
+              })),
+            ]}
+            value={vendorId}
+            onValueChange={setVendorId}
+            ariaLabel="Choose vendor"
+            placeholder="Select vendor"
+            searchPlaceholder="Search name, category, or email..."
+            emptyMessage="No matching vendors."
+            className="h-9"
+          />
         </div>
       )}
       <div className="space-y-1.5">
         <Label className="text-xs">Project</Label>
-        <Select value={projectId || "none"} onValueChange={(v) => setProjectId(v === "none" ? "" : v)}>
-          <SelectTrigger className="h-9">
-            <SelectValue placeholder="Select project" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="none">None</SelectItem>
-            {projects.map((p) => (
-              <SelectItem key={p.id} value={p.id}>
-                {p.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <ProjectCombobox
+          projects={projects}
+          value={projectId}
+          onValueChange={setProjectId}
+          specialOptions={[
+            { value: "", label: "None", keywords: "clear no project" },
+          ]}
+          className="h-9"
+        />
       </div>
     </>
   )

--- a/src/components/financials/vendor-bill-dialog.tsx
+++ b/src/components/financials/vendor-bill-dialog.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 import * as React from "react"
+import { ProjectCombobox } from "@/components/projects/project-combobox"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 import { Button } from "@/components/ui/button"
 import {
   ResponsiveDialog,
@@ -125,34 +127,35 @@ export function VendorBillDialog({
     <>
       <div className="space-y-1.5">
         <Label className="text-xs">Vendor *</Label>
-        <Select value={vendorId} onValueChange={setVendorId}>
-          <SelectTrigger className="h-9">
-            <SelectValue placeholder="Select vendor" />
-          </SelectTrigger>
-          <SelectContent>
-            {vendors.map((v) => (
-              <SelectItem key={v.id} value={v.id}>
-                {v.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <SearchableCombobox
+          options={vendors.map((vendor) => ({
+            value: vendor.id,
+            label: vendor.name,
+            description: vendor.category,
+            keywords: [vendor.category, vendor.email, vendor.phone]
+              .filter(Boolean)
+              .join(" "),
+          }))}
+          value={vendorId}
+          onValueChange={setVendorId}
+          ariaLabel="Choose vendor"
+          placeholder="Select vendor"
+          searchPlaceholder="Search name, category, or email..."
+          emptyMessage="No matching vendors."
+          className="h-9"
+        />
       </div>
       <div className="space-y-1.5">
         <Label className="text-xs">Project</Label>
-        <Select value={projectId || "none"} onValueChange={(v) => setProjectId(v === "none" ? "" : v)}>
-          <SelectTrigger className="h-9">
-            <SelectValue placeholder="Select project" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="none">None</SelectItem>
-            {projects.map((p) => (
-              <SelectItem key={p.id} value={p.id}>
-                {p.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <ProjectCombobox
+          projects={projects}
+          value={projectId}
+          onValueChange={setProjectId}
+          specialOptions={[
+            { value: "", label: "None", keywords: "clear no project" },
+          ]}
+          className="h-9"
+        />
       </div>
       <div className="space-y-1.5">
         <Label className="text-xs">Bill #</Label>

--- a/src/components/financials/vendors-table.tsx
+++ b/src/components/financials/vendors-table.tsx
@@ -35,6 +35,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 import {
   Table,
   TableBody,
@@ -307,26 +308,25 @@ export function VendorsTable({
   )
 
   const categoryFilter = (
-    <Select
+    <SearchableCombobox
       value={
         (table.getColumn("category")?.getFilterValue() as string) ?? "all"
       }
       onValueChange={(v) =>
         table.getColumn("category")?.setFilterValue(v === "all" ? "" : v)
       }
-    >
-      <SelectTrigger className="h-8 flex-1 sm:w-[200px] sm:flex-none">
-        <SelectValue placeholder="Filter by category" />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem value="all">All Categories</SelectItem>
-        {categories.map((categoryOption) => (
-          <SelectItem key={categoryOption} value={categoryOption}>
-            {categoryOption}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+      ariaLabel="Filter vendors by category"
+      placeholder="All Categories"
+      searchPlaceholder="Search categories..."
+      className="h-8 flex-1 sm:w-[200px] sm:flex-none"
+      options={[
+        { value: "all", label: "All Categories" },
+        ...categories.map((categoryOption) => ({
+          value: categoryOption,
+          label: categoryOption,
+        })),
+      ]}
+    />
   )
 
   if (isMobile) {
@@ -355,7 +355,7 @@ export function VendorsTable({
               <SelectItem value="oldest">Oldest</SelectItem>
             </SelectContent>
           </Select>
-          <Select
+          <SearchableCombobox
             value={
               (table.getColumn("category")?.getFilterValue() as string) ??
               "all"
@@ -365,19 +365,17 @@ export function VendorsTable({
                 .getColumn("category")
                 ?.setFilterValue(v === "all" ? "" : v)
             }
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="Category" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Categories</SelectItem>
-              {categories.map((categoryOption) => (
-                <SelectItem key={categoryOption} value={categoryOption}>
-                  {categoryOption}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+            ariaLabel="Filter vendors by category"
+            placeholder="All Categories"
+            searchPlaceholder="Search categories..."
+            options={[
+              { value: "all", label: "All Categories" },
+              ...categories.map((categoryOption) => ({
+                value: categoryOption,
+                label: categoryOption,
+              })),
+            ]}
+          />
         </div>
         {rows.length ? (
           <div className="rounded-md border divide-y">

--- a/src/components/mobile-project-switcher.tsx
+++ b/src/components/mobile-project-switcher.tsx
@@ -11,6 +11,14 @@ import { cn } from "@/lib/utils"
 import { useProjectList } from "@/components/project-list-provider"
 import { useIsMobile } from "@/hooks/use-mobile"
 import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import {
   Sheet,
   SheetContent,
   SheetHeader,
@@ -135,57 +143,66 @@ export function MobileProjectSwitcher({
               Projects
             </SheetTitle>
           </SheetHeader>
-          <div className="max-h-[60vh] overflow-y-auto py-1">
-            {projects.map((project) => {
-              const isActive = project.id === projectId
-              return (
-                <button
-                  key={project.id}
-                  className={cn(
-                    "flex w-full items-center gap-3",
-                    "px-4 py-3 text-left",
-                    "active:bg-muted/50",
-                    isActive && "bg-muted/30"
-                  )}
-                  onClick={() => {
-                    setOpen(false)
-                    if (!isActive) {
-                      router.push(
-                        projectSectionHref(pathname, project.id)
-                      )
-                    }
-                  }}
-                >
-                  <IconFolder
-                    className={cn(
-                      "size-5 shrink-0",
-                      isActive
-                        ? "text-primary"
-                        : "text-muted-foreground"
-                    )}
-                  />
-                  <span className="min-w-0 flex-1">
-                    <span
-                      className={cn(
-                        "block truncate text-sm",
-                        isActive && "font-medium"
-                      )}
+          <Command>
+            <CommandInput placeholder="Search number, name, or client..." />
+            <CommandList className="compass-content-scroll max-h-[60vh]">
+              <CommandEmpty>No matching projects.</CommandEmpty>
+              <CommandGroup>
+                {projects.map((project) => {
+                  const isActive = project.id === projectId
+                  return (
+                    <CommandItem
+                      key={project.id}
+                      value={[
+                        project.projectNumber,
+                        project.name,
+                        project.clientName,
+                        project.id,
+                      ]
+                        .filter(Boolean)
+                        .join(" ")}
+                      className="gap-3 px-4 py-3"
+                      onSelect={() => {
+                        setOpen(false)
+                        if (!isActive) {
+                          router.push(
+                            projectSectionHref(pathname, project.id)
+                          )
+                        }
+                      }}
                     >
-                      {project.projectNumber ?? project.name}
-                    </span>
-                    {project.projectNumber && (
-                      <span className="block truncate text-xs text-muted-foreground">
-                        {project.name}
+                      <IconFolder
+                        className={cn(
+                          "size-5 shrink-0",
+                          isActive
+                            ? "text-primary"
+                            : "text-muted-foreground"
+                        )}
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span
+                          className={cn(
+                            "block truncate text-sm",
+                            isActive && "font-medium"
+                          )}
+                        >
+                          {project.projectNumber ?? project.name}
+                        </span>
+                        {project.projectNumber && (
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {project.name}
+                          </span>
+                        )}
                       </span>
-                    )}
-                  </span>
-                  {isActive && (
-                    <IconCheck className="size-4 text-primary shrink-0" />
-                  )}
-                </button>
-              )
-            })}
-          </div>
+                      {isActive && (
+                        <IconCheck className="size-4 shrink-0 text-primary" />
+                      )}
+                    </CommandItem>
+                  )
+                })}
+              </CommandGroup>
+            </CommandList>
+          </Command>
         </SheetContent>
       </Sheet>
     </>

--- a/src/components/people/invite-dialog.tsx
+++ b/src/components/people/invite-dialog.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 import {
   Select,
   SelectContent,
@@ -104,7 +105,7 @@ export function InviteDialog({
       } else {
         toast.error(result.error || "Failed to invite user")
       }
-    } catch (error) {
+    } catch {
       toast.error("Failed to invite user")
     } finally {
       setLoading(false)
@@ -174,23 +175,25 @@ export function InviteDialog({
               </div>
             ) : (
               <>
-                <Select
+                <SearchableCombobox
+                  id="organization"
+                  ariaLabel="Choose organization"
+                  options={[
+                    { value: "none", label: "None" },
+                    ...organizations.map((organization) => ({
+                      value: organization.id,
+                      label: organization.name,
+                      description: organization.type,
+                    })),
+                  ]}
                   value={organizationId}
                   onValueChange={setOrganizationId}
                   disabled={loading}
-                >
-                  <SelectTrigger id="organization">
-                    <SelectValue placeholder="Select organization" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {organizations.map((org) => (
-                      <SelectItem key={org.id} value={org.id}>
-                        {org.name} ({org.type})
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  placeholder="Select organization"
+                  searchPlaceholder="Search organizations..."
+                  emptyMessage="No matching organizations."
+                  groupHeading="Organizations"
+                />
                 <p className="text-xs text-muted-foreground">
                   Assign the user to an organization upon invitation
                 </p>

--- a/src/components/projects/project-audience-photo-gallery.tsx
+++ b/src/components/projects/project-audience-photo-gallery.tsx
@@ -12,6 +12,7 @@ import {
 import type { AudiencePhoto } from "@/app/actions/project-audience-preview"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 import {
   Dialog,
   DialogContent,
@@ -215,24 +216,26 @@ export function ProjectAudiencePhotoGallery({
               <span className="text-xs font-medium uppercase text-muted-foreground">
                 Phase
               </span>
-              <Select
+              <SearchableCombobox
+                ariaLabel="Photo phase"
+                options={[
+                  { value: "all", label: "All phases" },
+                  ...phases.map((phase) => ({
+                    value: phase.value,
+                    label: `${phaseLabel(
+                      phase.value === NO_PHASE_VALUE ? "" : phase.value
+                    )} (${phase.count})`,
+                    keywords: phase.value,
+                  })),
+                ]}
                 value={phaseFilter}
                 onValueChange={setPhaseFilter}
-              >
-                <SelectTrigger aria-label="Photo phase" className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All phases</SelectItem>
-                  {phases.map((phase) => (
-                    <SelectItem key={phase.value} value={phase.value}>
-                      {phaseLabel(
-                        phase.value === NO_PHASE_VALUE ? "" : phase.value
-                      )} ({phase.count})
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                placeholder="All phases"
+                searchPlaceholder="Search phases..."
+                emptyMessage="No matching phases."
+                groupHeading="Phases"
+                className="h-9"
+              />
             </label>
             <label className="w-full space-y-1 text-sm sm:w-56">
               <span className="text-xs font-medium uppercase text-muted-foreground">

--- a/src/components/projects/project-audience-preview-shell.tsx
+++ b/src/components/projects/project-audience-preview-shell.tsx
@@ -3,7 +3,6 @@ import Image from "next/image"
 import Link from "next/link"
 import {
   IconCalendar,
-  IconChevronDown,
   IconClipboardCheck,
   IconEye,
   IconFileDollar,
@@ -25,12 +24,7 @@ import {
   type ProjectAudienceWorkspaceSection,
 } from "@/lib/project-audience-preview-routes"
 import { Button } from "@/components/ui/button"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
+import { ProjectAudienceSwitcher } from "@/components/projects/project-audience-switcher"
 import { ProjectAudiencePreviewWindowControls } from "@/components/projects/project-audience-preview-window-controls"
 import { ProjectAudienceHeaderControls } from "@/components/projects/project-audience-header-controls"
 import { ProjectAudienceSidebarProfile } from "@/components/projects/project-audience-sidebar-profile"
@@ -144,12 +138,6 @@ function audienceRoute(audience: ProjectAudience): "owner" | "sub-vendor" {
   return audience === "owner" ? "owner" : "sub-vendor"
 }
 
-function projectOptionLabel(project: AudienceProjectOption): string {
-  return project.projectNumber
-    ? `${project.projectNumber} · ${project.name}`
-    : project.name
-}
-
 export function ProjectAudiencePreviewShell({
   audience,
   projectId,
@@ -227,39 +215,18 @@ export function ProjectAudiencePreviewShell({
 
         <div className="border-b border-sidebar-border p-3">
           {projectOptions.length > 1 ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  className="h-auto w-full justify-between px-2 py-2 text-left"
-                >
-                  <span className="min-w-0">
-                    <span className="block truncate text-xs text-sidebar-foreground/60">
-                      Current project
-                    </span>
-                    <span className="mt-1 block truncate text-sm font-medium">
-                      {projectNumber ?? projectName}
-                    </span>
-                  </span>
-                  <IconChevronDown className="size-4 shrink-0" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent side="right" align="start" className="w-80">
-                {projectOptions.map((project) => (
-                  <DropdownMenuItem key={project.id} asChild>
-                    <Link
-                      href={projectAudienceSectionHref(
-                        project.id,
-                        routeAudience,
-                        activeSection
-                      )}
-                    >
-                      {projectOptionLabel(project)}
-                    </Link>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <div className="grid gap-1">
+              <p className="px-2 text-xs text-sidebar-foreground/60">
+                Current project
+              </p>
+              <ProjectAudienceSwitcher
+                projects={projectOptions}
+                currentProjectId={projectId}
+                audience={routeAudience}
+                section={activeSection}
+                className="h-9 border-sidebar-border bg-sidebar text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+              />
+            </div>
           ) : (
             <div className="px-2 py-2">
               <p className="text-xs text-sidebar-foreground/60">

--- a/src/components/projects/project-audience-preview.tsx
+++ b/src/components/projects/project-audience-preview.tsx
@@ -3,7 +3,6 @@ import Link from "next/link"
 import {
   IconArrowRight,
   IconCalendarStats,
-  IconChevronDown,
   IconClipboardCheck,
   IconExternalLink,
   IconFolder,
@@ -28,13 +27,8 @@ import type {
 } from "@/app/actions/project-audience-preview"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import { OwnerCoverPhotoControl } from "@/components/projects/owner-cover-photo-control"
+import { ProjectAudienceSwitcher } from "@/components/projects/project-audience-switcher"
 import { ProjectEmailAddressCard } from "@/components/projects/project-email-address-card"
 import { ProjectAudienceMessageLauncher } from "@/components/projects/project-audience-message-launcher"
 import { ProjectAudiencePhotoGallery } from "@/components/projects/project-audience-photo-gallery"
@@ -46,7 +40,6 @@ import { ProjectAudienceSchedule } from "@/components/projects/project-audience-
 import {
   ownerUpdatePreviewHref,
   projectAudienceConversationHref,
-  projectAudiencePreviewHref,
   projectAudienceSectionHref,
   type ProjectAudienceWorkspaceSection,
 } from "@/lib/project-audience-preview-routes"
@@ -89,12 +82,6 @@ function projectOptionLabel(project: AudienceProjectOption): string {
   return project.projectNumber
     ? `${project.projectNumber} · ${project.name}`
     : project.name
-}
-
-function previewPath(projectId: string, audience: ProjectAudience): string {
-  return audience === "owner"
-    ? projectAudiencePreviewHref(projectId, "owner")
-    : projectAudiencePreviewHref(projectId, "sub-vendor")
 }
 
 function recordTypeLabel(value: string): string {
@@ -1023,38 +1010,13 @@ export function ProjectAudiencePreview({
                 </p>
               </div>
               {data.projectOptions.length > 1 ? (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="outline" size="sm" className="h-8">
-                      Switch project
-                      <IconChevronDown className="size-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-72">
-                    {data.projectOptions.map((project) => {
-                      const active = project.id === data.project.id
-
-                      return (
-                        <DropdownMenuItem key={project.id} asChild>
-                          <Link
-                            href={previewPath(project.id, data.audience)}
-                            className="flex items-center justify-between gap-3"
-                          >
-                            <span className="min-w-0">
-                              <span className="block truncate text-sm font-medium">
-                                {projectOptionLabel(project)}
-                              </span>
-                              <span className="block truncate text-xs text-muted-foreground">
-                                {project.status}
-                              </span>
-                            </span>
-                            {active && <Badge variant="secondary">Current</Badge>}
-                          </Link>
-                        </DropdownMenuItem>
-                      )
-                    })}
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                <ProjectAudienceSwitcher
+                  projects={data.projectOptions}
+                  currentProjectId={data.project.id}
+                  audience="sub-vendor"
+                  section="overview"
+                  className="h-8 w-auto max-w-[18rem]"
+                />
               ) : (
                 <Badge variant="outline">Project scoped</Badge>
               )}

--- a/src/components/projects/project-audience-switcher.tsx
+++ b/src/components/projects/project-audience-switcher.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import type * as React from "react"
+import { useRouter } from "next/navigation"
+
+import type { AudienceProjectOption } from "@/app/actions/project-audience-preview"
+import { ProjectCombobox } from "@/components/projects/project-combobox"
+import {
+  projectAudienceSectionHref,
+  type ProjectAudiencePreviewRoute,
+  type ProjectAudienceWorkspaceSection,
+} from "@/lib/project-audience-preview-routes"
+
+export function ProjectAudienceSwitcher({
+  projects,
+  currentProjectId,
+  audience,
+  section,
+  className,
+}: {
+  readonly projects: readonly AudienceProjectOption[]
+  readonly currentProjectId: string
+  readonly audience: ProjectAudiencePreviewRoute
+  readonly section: ProjectAudienceWorkspaceSection
+  readonly className?: string
+}): React.ReactElement {
+  const router = useRouter()
+
+  return (
+    <ProjectCombobox
+      projects={projects}
+      value={currentProjectId}
+      onValueChange={(projectId) => {
+        if (projectId === currentProjectId) return
+        router.push(projectAudienceSectionHref(projectId, audience, section))
+      }}
+      ariaLabel="Switch preview project"
+      className={className}
+      popoverClassName="w-[min(22rem,calc(100vw-3rem))]"
+    />
+  )
+}

--- a/src/components/projects/project-combobox.tsx
+++ b/src/components/projects/project-combobox.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import type * as React from "react"
+
+import {
+  SearchableCombobox,
+  type SearchableComboboxOption,
+} from "@/components/searchable-combobox"
+
+export type ProjectComboboxOption = {
+  readonly id: string
+  readonly name: string
+  readonly projectNumber?: string | null
+  readonly clientName?: string | null
+}
+
+export type ProjectComboboxSpecialOption = {
+  readonly value: string
+  readonly label: string
+  readonly description?: string
+  readonly keywords?: string
+}
+
+type ProjectComboboxProps = {
+  readonly projects: readonly ProjectComboboxOption[]
+  readonly value: string
+  readonly onValueChange: (value: string) => void
+  readonly id?: string
+  readonly ariaLabel?: string
+  readonly placeholder?: string
+  readonly searchPlaceholder?: string
+  readonly emptyMessage?: string
+  readonly specialOptions?: readonly ProjectComboboxSpecialOption[]
+  readonly disabled?: boolean
+  readonly className?: string
+  readonly popoverClassName?: string
+}
+
+function projectDescription(project: ProjectComboboxOption): string | null {
+  if (project.projectNumber && project.clientName) {
+    return `${project.name} - ${project.clientName}`
+  }
+  if (project.projectNumber) return project.name
+  return project.clientName ?? null
+}
+
+export function ProjectCombobox({
+  projects,
+  value,
+  onValueChange,
+  id,
+  ariaLabel = "Choose project",
+  placeholder = "Select a project",
+  searchPlaceholder = "Search number, name, or client...",
+  emptyMessage = "No matching projects.",
+  specialOptions = [],
+  disabled = false,
+  className,
+  popoverClassName,
+}: ProjectComboboxProps): React.ReactElement {
+  const specialChoices: readonly SearchableComboboxOption[] = specialOptions.map(
+    (option) => ({
+      value: option.value,
+      label: option.label,
+      description: option.description,
+      keywords: option.keywords,
+    })
+  )
+  const projectChoices: readonly SearchableComboboxOption[] = projects.map(
+    (project) => ({
+      value: project.id,
+      label: project.projectNumber ?? project.name,
+      selectedLabel: project.projectNumber
+        ? `${project.projectNumber} - ${project.name}`
+        : project.name,
+      description: projectDescription(project) ?? undefined,
+      keywords: project.clientName ?? undefined,
+    })
+  )
+
+  return (
+    <SearchableCombobox
+      id={id}
+      ariaLabel={ariaLabel}
+      options={[...specialChoices, ...projectChoices]}
+      value={value}
+      onValueChange={onValueChange}
+      placeholder={placeholder}
+      searchPlaceholder={searchPlaceholder}
+      emptyMessage={emptyMessage}
+      groupHeading="Projects"
+      disabled={disabled}
+      className={className}
+      popoverClassName={popoverClassName}
+    />
+  )
+}

--- a/src/components/projects/project-contact-match-review.tsx
+++ b/src/components/projects/project-contact-match-review.tsx
@@ -27,6 +27,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { ProjectContactDirectorySelect } from "@/components/projects/project-contact-directory-select"
 import { ProjectContactReviewScrollRestorer } from "@/components/projects/project-contact-review-scroll-restorer"
+import { SearchableComboboxField } from "@/components/searchable-combobox"
 
 async function approveContactSourceLinkForm(formData: FormData): Promise<void> {
   "use server"
@@ -237,20 +238,20 @@ function AssignContactForm({
     >
       <input type="hidden" name="projectId" value={projectId} />
       <LinkIdInputs links={group.links} />
-      <select
+      <SearchableComboboxField
         name="projectContactId"
         defaultValue={primary.projectContactId ?? ""}
-        className="h-9 min-w-0 flex-1 rounded-md border bg-background px-3 text-sm shadow-xs outline-none transition-colors focus:border-ring focus:ring-ring/50 focus:ring-[3px]"
-      >
-        <option value="" disabled>
-          Choose contact
-        </option>
-        {contacts.map((contact) => (
-          <option key={contact.id} value={contact.id}>
-            {contact.displayName} - {contactTypeLabel(contact.contactType)}
-          </option>
-        ))}
-      </select>
+        required
+        ariaLabel="Project contact"
+        placeholder="Choose contact"
+        searchPlaceholder="Search project contacts..."
+        className="h-9 min-w-0 flex-1"
+        options={contacts.map((contact) => ({
+          value: contact.id,
+          label: contact.displayName,
+          description: contactTypeLabel(contact.contactType),
+        }))}
+      />
       <Button type="submit" size="sm" variant="secondary">
         <IconLink />
         Assign

--- a/src/components/projects/project-daily-log-workspace.tsx
+++ b/src/components/projects/project-daily-log-workspace.tsx
@@ -45,13 +45,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 import { Textarea } from "@/components/ui/textarea"
 import { DailyLogPrintDocument } from "@/components/projects/daily-log-print-document"
 import { useDeveloperMode } from "@/components/developer-mode-provider"
@@ -1414,26 +1408,25 @@ export function ProjectDailyLogWorkspace({
               </div>
               <div className="grid min-w-0 gap-1.5">
                 <Label htmlFor="daily-log-print-author">Author</Label>
-                <select
+                <SearchableCombobox
                   id="daily-log-print-author"
                   value={printAuthor}
-                  onChange={(event) =>
-                    setPrintAuthor(event.currentTarget.value)
-                  }
-                  className="h-9 min-w-0 rounded-md border bg-background px-3 text-sm"
-                >
-                  <option value={ALL_DAILY_LOG_AUTHORS}>All authors</option>
-                  {printAuthorOptions.map((author) => (
-                    <option key={author} value={author}>
-                      {author}
-                    </option>
-                  ))}
-                  {hasUnknownPrintAuthor && (
-                    <option value={UNKNOWN_DAILY_LOG_AUTHOR}>
-                      Imported / no author
-                    </option>
-                  )}
-                </select>
+                  onValueChange={setPrintAuthor}
+                  ariaLabel="Filter daily logs by author"
+                  placeholder="All authors"
+                  searchPlaceholder="Search authors..."
+                  className="h-9 min-w-0"
+                  options={[
+                    { value: ALL_DAILY_LOG_AUTHORS, label: "All authors" },
+                    ...printAuthorOptions.map((author) => ({
+                      value: author,
+                      label: author,
+                    })),
+                    ...(hasUnknownPrintAuthor
+                      ? [{ value: UNKNOWN_DAILY_LOG_AUTHOR, label: "Imported / no author" }]
+                      : []),
+                  ]}
+                />
               </div>
               <div className="flex items-end">
                 <Button
@@ -1832,19 +1825,23 @@ export function ProjectDailyLogWorkspace({
                       <Label htmlFor={`daily-log-file-phase-${log.id}`}>
                         Phase for this batch
                       </Label>
-                      <Select value={uploadPhase} onValueChange={setUploadPhase}>
-                        <SelectTrigger id={`daily-log-file-phase-${log.id}`}>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value={NO_PHASE_VALUE}>No phase</SelectItem>
-                          {workspace.schedulePhases.map((phase) => (
-                            <SelectItem key={phase} value={phase}>
-                              {phase}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <SearchableCombobox
+                        id={`daily-log-file-phase-${log.id}`}
+                        ariaLabel="Choose phase for attachment batch"
+                        options={[
+                          { value: NO_PHASE_VALUE, label: "No phase" },
+                          ...workspace.schedulePhases.map((phase) => ({
+                            value: phase,
+                            label: phase,
+                          })),
+                        ]}
+                        value={uploadPhase}
+                        onValueChange={setUploadPhase}
+                        placeholder="No phase"
+                        searchPlaceholder="Search phases..."
+                        emptyMessage="No matching phases."
+                        groupHeading="Phases"
+                      />
                     </div>
                     <fieldset className="min-w-0">
                       <legend className="text-sm font-medium">

--- a/src/components/projects/project-daily-log-workspace.tsx
+++ b/src/components/projects/project-daily-log-workspace.tsx
@@ -56,6 +56,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { DailyLogPrintDocument } from "@/components/projects/daily-log-print-document"
 import { useDeveloperMode } from "@/components/developer-mode-provider"
 import { useProjectList } from "@/components/project-list-provider"
+import { ProjectCombobox } from "@/components/projects/project-combobox"
 import { ProjectContextSwitcher } from "@/components/projects/project-context-switcher"
 import { ProjectTaskCreateButton } from "@/components/projects/project-task-create-button"
 import {
@@ -1672,26 +1673,13 @@ export function ProjectDailyLogWorkspace({
                     <Label htmlFor={`daily-log-edit-project-${log.id}`}>
                       Project
                     </Label>
-                    <Select
+                    <ProjectCombobox
+                      id={`daily-log-edit-project-${log.id}`}
+                      ariaLabel="Choose daily log project"
+                      projects={projects}
                       value={editProjectId}
                       onValueChange={setEditProjectId}
-                    >
-                      <SelectTrigger
-                        id={`daily-log-edit-project-${log.id}`}
-                        aria-label="Project"
-                      >
-                        <SelectValue placeholder="Select a project" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {projects.map((project) => (
-                          <SelectItem key={project.id} value={project.id}>
-                            {project.projectNumber
-                              ? `${project.projectNumber} - ${project.name}`
-                              : project.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    />
                     <p className="text-xs text-muted-foreground">
                       Moving a log also moves its files and linked to-dos.
                       Project-specific schedule links are cleared.

--- a/src/components/projects/project-photo-review.tsx
+++ b/src/components/projects/project-photo-review.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/app/actions/project-photos"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 import {
   Dialog,
   DialogContent,
@@ -721,23 +722,24 @@ export function ProjectPhotoReview({
                 <span className="text-xs font-medium uppercase text-muted-foreground">
                   Phase
                 </span>
-                <Select
+                <SearchableCombobox
+                  ariaLabel="Phase"
+                  options={[
+                    { value: "all", label: "All phases" },
+                    { value: NO_PHASE_VALUE, label: "No phase" },
+                    ...library.phases.map((phase) => ({
+                      value: phase.value,
+                      label: `${phase.label} (${phase.count})`,
+                    })),
+                  ]}
                   value={phaseFilter}
                   onValueChange={setPhaseFilter}
-                >
-                  <SelectTrigger aria-label="Phase" className="w-full">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All phases</SelectItem>
-                    <SelectItem value={NO_PHASE_VALUE}>No phase</SelectItem>
-                    {library.phases.map((phase) => (
-                      <SelectItem key={phase.value} value={phase.value}>
-                        {phase.label} ({phase.count})
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  placeholder="All phases"
+                  searchPlaceholder="Search phases..."
+                  emptyMessage="No matching phases."
+                  groupHeading="Phases"
+                  className="h-9"
+                />
               </label>
               <label className="w-full space-y-1 text-sm sm:w-56">
                 <span className="text-xs font-medium uppercase text-muted-foreground">
@@ -987,27 +989,24 @@ export function ProjectPhotoReview({
                 <div className="border-t px-2 py-1.5">
                   <label className="flex min-w-0 items-center justify-between gap-2 text-xs text-muted-foreground">
                     <span className="shrink-0">Phase</span>
-                    <Select
+                    <SearchableCombobox
+                      ariaLabel={`Phase for ${photo.caption ?? photo.fileName}`}
+                      options={[
+                        { value: NO_PHASE_VALUE, label: "No phase" },
+                        ...library.phases.map((phase) => ({
+                          value: phase.value,
+                          label: phase.label,
+                        })),
+                      ]}
                       value={photo.schedulePhase || NO_PHASE_VALUE}
                       onValueChange={(value) => changePhotoPhase(photo.id, value)}
                       disabled={isPending}
-                    >
-                      <SelectTrigger
-                        aria-label={`Phase for ${photo.caption ?? photo.fileName}`}
-                        size="sm"
-                        className="h-7 min-w-0 flex-1 px-1.5 text-xs"
-                      >
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value={NO_PHASE_VALUE}>No phase</SelectItem>
-                        {library.phases.map((phase) => (
-                          <SelectItem key={phase.value} value={phase.value}>
-                            {phase.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                      placeholder="No phase"
+                      searchPlaceholder="Search phases..."
+                      emptyMessage="No matching phases."
+                      groupHeading="Phases"
+                      className="h-7 min-w-0 flex-1 px-1.5 text-xs"
+                    />
                   </label>
                 </div>
                 <div className="flex items-center justify-between gap-2 border-t px-2 py-1.5">
@@ -1271,22 +1270,22 @@ export function ProjectPhotoReview({
                 <span className="text-xs font-medium uppercase text-muted-foreground">
                   Phase
                 </span>
-                <Select
+                <SearchableCombobox
+                  ariaLabel="Upload phase"
+                  options={[
+                    { value: NO_PHASE_VALUE, label: "No phase" },
+                    ...library.phases.map((phase) => ({
+                      value: phase.value,
+                      label: phase.label,
+                    })),
+                  ]}
                   value={uploadPhase}
                   onValueChange={setUploadPhase}
-                >
-                  <SelectTrigger aria-label="Upload phase" className="w-full">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value={NO_PHASE_VALUE}>No phase</SelectItem>
-                    {library.phases.map((phase) => (
-                      <SelectItem key={phase.value} value={phase.value}>
-                        {phase.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  placeholder="No phase"
+                  searchPlaceholder="Search phases..."
+                  emptyMessage="No matching phases."
+                  groupHeading="Phases"
+                />
               </label>
 
               <div className="rounded-md border bg-muted/20 p-3 text-xs text-muted-foreground">

--- a/src/components/projects/project-quick-switcher.tsx
+++ b/src/components/projects/project-quick-switcher.tsx
@@ -1,27 +1,11 @@
 "use client"
 
-import * as React from "react"
+import type * as React from "react"
 import { useRouter } from "next/navigation"
-import { Check, ChevronsUpDown } from "lucide-react"
 
 import type { ProjectListItem } from "@/app/actions/projects"
 import { useActiveProject } from "@/components/project-list-provider"
-import { Button } from "@/components/ui/button"
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command"
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover"
-import { cn } from "@/lib/utils"
-import { projectClientStatusLabel } from "@/lib/project-profile"
+import { ProjectCombobox } from "@/components/projects/project-combobox"
 
 type ProjectQuickSwitcherProps = {
   readonly projects: readonly ProjectListItem[]
@@ -29,26 +13,6 @@ type ProjectQuickSwitcherProps = {
   readonly targetSection?: string
   readonly placeholder?: string
   readonly className?: string
-}
-
-function projectLabel(project: ProjectListItem): string {
-  return project.projectNumber
-    ? `${project.projectNumber} - ${project.name}`
-    : project.name
-}
-
-function projectSearchValue(project: ProjectListItem): string {
-  return [
-    project.projectNumber,
-    project.name,
-    project.clientName,
-    projectClientStatusLabel(project.clientStatus),
-    project.jobStatusId,
-    project.jobStatusLabel,
-    project.id,
-  ]
-    .filter((value): value is string => Boolean(value))
-    .join(" ")
 }
 
 function projectHref(projectId: string, targetSection?: string): string {
@@ -65,92 +29,18 @@ export function ProjectQuickSwitcher({
 }: ProjectQuickSwitcherProps): React.ReactElement {
   const router = useRouter()
   const { setActiveProjectId } = useActiveProject()
-  const [open, setOpen] = React.useState(false)
-  const selectedProject =
-    projects.find((project) => project.id === currentProjectId) ?? null
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          aria-label="Switch project"
-          onClick={() => setOpen(true)}
-          onKeyDown={(event) => {
-            if (
-              event.key === "Enter" ||
-              event.key === " " ||
-              event.key === "ArrowDown"
-            ) {
-              event.preventDefault()
-              setOpen(true)
-            }
-          }}
-          className={cn(
-            "h-10 min-w-0 justify-between px-3 font-normal",
-            className
-          )}
-          disabled={projects.length === 0}
-        >
-          <span
-            className={cn(
-              "truncate text-left",
-              !selectedProject && "text-muted-foreground"
-            )}
-          >
-            {selectedProject ? projectLabel(selectedProject) : placeholder}
-          </span>
-          <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        className="w-[var(--radix-popover-trigger-width)] p-0"
-      >
-        <Command>
-          <CommandInput placeholder="Search number, name, client, or status..." />
-          <CommandList>
-            <CommandEmpty>No matching projects.</CommandEmpty>
-            <CommandGroup>
-              {projects.map((project) => {
-                const isSelected = project.id === currentProjectId
-                return (
-                  <CommandItem
-                    key={project.id}
-                    value={projectSearchValue(project)}
-                    onSelect={() => {
-                      setOpen(false)
-                      setActiveProjectId(project.id)
-                      router.push(projectHref(project.id, targetSection))
-                    }}
-                  >
-                    <Check
-                      className={cn(
-                        "size-4",
-                        isSelected ? "opacity-100" : "opacity-0"
-                      )}
-                    />
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate font-medium">
-                        {project.projectNumber ?? project.name}
-                      </span>
-                      <span className="block truncate text-xs text-muted-foreground">
-                        {project.projectNumber ? project.name : project.clientName}
-                        {project.projectNumber && project.clientName
-                          ? ` - ${project.clientName}`
-                          : ""}
-                      </span>
-                    </span>
-                  </CommandItem>
-                )
-              })}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+    <ProjectCombobox
+      projects={projects}
+      value={currentProjectId ?? ""}
+      onValueChange={(projectId) => {
+        setActiveProjectId(projectId)
+        router.push(projectHref(projectId, targetSection))
+      }}
+      ariaLabel="Switch project"
+      placeholder={placeholder}
+      className={className}
+    />
   )
 }

--- a/src/components/projects/project-rfi-create-form.tsx
+++ b/src/components/projects/project-rfi-create-form.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/app/actions/project-rfis"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { SearchableComboboxField } from "@/components/searchable-combobox"
 import {
   Sheet,
   SheetContent,
@@ -247,18 +248,17 @@ export function ProjectRfiCreateForm({
             <label className="mb-1 block text-xs font-medium text-muted-foreground">
               Company or trade
             </label>
-            <select
+            <SearchableComboboxField
               name="companyNameSelect"
-              defaultValue=""
+              ariaLabel="Company or trade"
+              placeholder="Choose from project contacts"
+              searchPlaceholder="Search companies and trades..."
               className={DOCUMENT_SELECT_CLASS}
-            >
-              <option value="">Choose from project contacts</option>
-              {companyOrTradeOptions.map((option) => (
-                <option key={option} value={option}>
-                  {option}
-                </option>
-              ))}
-            </select>
+              options={companyOrTradeOptions.map((option) => ({
+                value: option,
+                label: option,
+              }))}
+            />
             <Input
               name="companyNameCustom"
               placeholder="Or type company/trade"
@@ -270,28 +270,18 @@ export function ProjectRfiCreateForm({
               <label className="mb-1 block text-xs font-medium text-muted-foreground">
                 Assigned to
               </label>
-              <select
+              <SearchableComboboxField
                 name="assignedToNameSelect"
-                defaultValue=""
+                ariaLabel="Assigned to"
+                placeholder="Choose project contact"
+                searchPlaceholder="Search project contacts..."
                 className={DOCUMENT_SELECT_CLASS}
-              >
-                <option value="">Choose project contact</option>
-                {RFI_CONTACT_GROUPS.map((group) => {
-                  const options = peopleOptions.filter(
-                    (option) => option.group === group.value
-                  )
-                  if (options.length === 0) return null
-                  return (
-                    <optgroup key={group.value} label={group.label}>
-                      {options.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </optgroup>
-                  )
-                })}
-              </select>
+                options={peopleOptions.map((option) => ({
+                  value: option.value,
+                  label: option.label,
+                  description: RFI_CONTACT_GROUPS.find((group) => group.value === option.group)?.label,
+                }))}
+              />
               <Input
                 name="assignedToNameCustom"
                 placeholder="Or type assignee"
@@ -302,28 +292,18 @@ export function ProjectRfiCreateForm({
               <label className="mb-1 block text-xs font-medium text-muted-foreground">
                 Requested by
               </label>
-              <select
+              <SearchableComboboxField
                 name="requesterNameSelect"
-                defaultValue=""
+                ariaLabel="Requested by"
+                placeholder="Choose project contact"
+                searchPlaceholder="Search project contacts..."
                 className={DOCUMENT_SELECT_CLASS}
-              >
-                <option value="">Choose project contact</option>
-                {RFI_CONTACT_GROUPS.map((group) => {
-                  const options = peopleOptions.filter(
-                    (option) => option.group === group.value
-                  )
-                  if (options.length === 0) return null
-                  return (
-                    <optgroup key={group.value} label={group.label}>
-                      {options.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </optgroup>
-                  )
-                })}
-              </select>
+                options={peopleOptions.map((option) => ({
+                  value: option.value,
+                  label: option.label,
+                  description: RFI_CONTACT_GROUPS.find((group) => group.value === option.group)?.label,
+                }))}
+              />
               <Input
                 name="requesterNameCustom"
                 placeholder="Or type requester"

--- a/src/components/projects/project-selection-create-form.tsx
+++ b/src/components/projects/project-selection-create-form.tsx
@@ -10,6 +10,7 @@ import {
   type ProjectSelectionStatus
 } from "@/app/actions/project-selections"
 import { ProjectSelectionComboboxInput } from "@/components/projects/project-selection-combobox-input"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
@@ -130,7 +131,7 @@ export function ProjectSelectionCreateForm({
   )
 
   React.useEffect(() => {
-    if (!open || templateGroups !== null) return
+    if (!open) return
     let cancelled = false
     setTemplateLoading(true)
     void getFinishSelectionTemplateImportOptions()
@@ -153,7 +154,7 @@ export function ProjectSelectionCreateForm({
     return () => {
       cancelled = true
     }
-  }, [open, templateGroups])
+  }, [open])
 
   function setFormFieldValue(name: string, value: string): void {
     const field = formRef.current?.elements.namedItem(name)
@@ -266,41 +267,33 @@ export function ProjectSelectionCreateForm({
               </p>
             ) : (
               <div className="grid gap-2 sm:grid-cols-2">
-                <Select
+                <SearchableCombobox
                   value={selectedTemplateId}
                   onValueChange={(value) => {
                     setSelectedTemplateId(value)
                     setSelectedTemplateSelectionId("")
                     setTemplateCostCode("")
                   }}
-                >
-                  <SelectTrigger aria-label="Choose finish selection template">
-                    <SelectValue placeholder="Choose template" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {(templateGroups ?? []).map((group) => (
-                      <SelectItem key={group.templateId} value={group.templateId}>
-                        {group.templateName}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <Select
+                  ariaLabel="Choose finish selection template"
+                  placeholder="Choose template"
+                  searchPlaceholder="Search templates..."
+                  options={(templateGroups ?? []).map((group) => ({
+                    value: group.templateId,
+                    label: group.templateName,
+                  }))}
+                />
+                <SearchableCombobox
                   value={selectedTemplateSelectionId}
                   onValueChange={applyTemplateSelection}
                   disabled={!selectedTemplateGroup}
-                >
-                  <SelectTrigger aria-label="Choose template finish selection">
-                    <SelectValue placeholder="Choose selection" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {(selectedTemplateGroup?.selections ?? []).map((selection) => (
-                      <SelectItem key={selection.id} value={selection.id}>
-                        {selection.title}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  ariaLabel="Choose template finish selection"
+                  placeholder="Choose selection"
+                  searchPlaceholder="Search selections..."
+                  options={(selectedTemplateGroup?.selections ?? []).map((selection) => ({
+                    value: selection.id,
+                    label: selection.title,
+                  }))}
+                />
               </div>
             )}
             {selectedTemplateSelection && (
@@ -342,18 +335,15 @@ export function ProjectSelectionCreateForm({
                 />
               </Field>
               <Field label="Room type">
-                <Select value={selectedRoomType} onValueChange={setSelectedRoomType}>
-                  <SelectTrigger className={DOCUMENT_SELECT_CLASS}>
-                    <SelectValue placeholder="Select room type" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {options.roomTypes.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <SearchableCombobox
+                  value={selectedRoomType}
+                  onValueChange={setSelectedRoomType}
+                  ariaLabel="Room type"
+                  placeholder="Select room type"
+                  searchPlaceholder="Search room types..."
+                  className={DOCUMENT_SELECT_CLASS}
+                  options={options.roomTypes}
+                />
                 <input type="hidden" name="roomType" value={selectedRoomType} />
               </Field>
               <Field label="Status">
@@ -426,29 +416,32 @@ export function ProjectSelectionCreateForm({
           <div className="border-y py-3">
             <div className="grid gap-3 sm:grid-cols-[minmax(0,.85fr)_minmax(0,1fr)_minmax(0,.65fr)]">
               <Field label="Division">
-                <Select value={division} onValueChange={setDivision}>
-                  <SelectTrigger className={DOCUMENT_SELECT_CLASS}>
-                    <SelectValue placeholder="All divisions" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All divisions</SelectItem>
-                    {options.divisions.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <SearchableCombobox
+                  value={division}
+                  onValueChange={setDivision}
+                  ariaLabel="Division"
+                  placeholder="All divisions"
+                  searchPlaceholder="Search divisions..."
+                  className={DOCUMENT_SELECT_CLASS}
+                  options={[
+                    { value: "all", label: "All divisions" },
+                    ...options.divisions,
+                  ]}
+                />
               </Field>
               <Field label="Cost code">
                 <ProjectSelectionComboboxInput
-                  key={`selection-cost-code-${templateCostCode}`}
+                  key={`selection-cost-code-${division}-${templateCostCode}`}
                   id="selection-cost-code"
                   name="costCode"
                   options={costCodeOptions}
                   placeholder="Search cost code"
                   emptyMessage="No cost codes in this division."
-                  defaultValue={templateCostCode}
+                  defaultValue={
+                    costCodeOptions.some((option) => option.value === templateCostCode)
+                      ? templateCostCode
+                      : ""
+                  }
                 />
               </Field>
               <Field label="Phase">

--- a/src/components/projects/project-selection-edit-form.tsx
+++ b/src/components/projects/project-selection-edit-form.tsx
@@ -11,6 +11,7 @@ import {
   type ProjectSelectionStatus,
 } from "@/app/actions/project-selections"
 import { ProjectSelectionComboboxInput } from "@/components/projects/project-selection-combobox-input"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
@@ -208,21 +209,15 @@ export function ProjectSelectionEditForm({
                 />
               </Field>
               <Field label="Room type">
-                <Select
+                <SearchableCombobox
                   value={selectedRoomType}
                   onValueChange={setSelectedRoomType}
-                >
-                  <SelectTrigger className={DOCUMENT_SELECT_CLASS}>
-                    <SelectValue placeholder="Select room type" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {options.roomTypes.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  ariaLabel="Room type"
+                  placeholder="Select room type"
+                  searchPlaceholder="Search room types..."
+                  className={DOCUMENT_SELECT_CLASS}
+                  options={options.roomTypes}
+                />
                 <input
                   type="hidden"
                   name="roomType"
@@ -291,18 +286,18 @@ export function ProjectSelectionEditForm({
               <Field label="Color / finish">
                 {selection.choiceOptions.length > 0 ? (
                   <>
-                    <Select value={selectedChoice} onValueChange={setSelectedChoice}>
-                      <SelectTrigger className={DOCUMENT_SELECT_CLASS}>
-                        <SelectValue placeholder="Choose an option" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {selection.choiceOptions.map((option) => (
-                          <SelectItem key={option} value={option}>
-                            {option}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <SearchableCombobox
+                      value={selectedChoice}
+                      onValueChange={setSelectedChoice}
+                      ariaLabel="Color or finish"
+                      placeholder="Choose an option"
+                      searchPlaceholder="Search options..."
+                      className={DOCUMENT_SELECT_CLASS}
+                      options={selection.choiceOptions.map((option) => ({
+                        value: option,
+                        label: option,
+                      }))}
+                    />
                     <input type="hidden" name="colorFinish" value={selectedChoice} />
                   </>
                 ) : (
@@ -337,27 +332,31 @@ export function ProjectSelectionEditForm({
           <div className="border-y py-3">
             <div className="grid gap-3 sm:grid-cols-[minmax(0,.85fr)_minmax(0,1fr)_minmax(0,.65fr)]">
               <Field label="Division">
-                <Select value={division} onValueChange={setDivision}>
-                  <SelectTrigger className={DOCUMENT_SELECT_CLASS}>
-                    <SelectValue placeholder="All divisions" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All divisions</SelectItem>
-                    {options.divisions.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <SearchableCombobox
+                  value={division}
+                  onValueChange={setDivision}
+                  ariaLabel="Division"
+                  placeholder="All divisions"
+                  searchPlaceholder="Search divisions..."
+                  className={DOCUMENT_SELECT_CLASS}
+                  options={[
+                    { value: "all", label: "All divisions" },
+                    ...options.divisions,
+                  ]}
+                />
               </Field>
               <Field label="Cost code">
                 <ProjectSelectionComboboxInput
+                  key={`selection-cost-code-${selection.id}-${division}`}
                   id={`selection-cost-code-${selection.id}`}
                   name="costCode"
                   options={costCodeOptions}
                   placeholder="Search cost code"
-                  defaultValue={textValue(selection.costCode)}
+                  defaultValue={
+                    division === initialDivision(selection, options)
+                      ? textValue(selection.costCode)
+                      : ""
+                  }
                   emptyMessage="No cost codes in this division."
                 />
               </Field>

--- a/src/components/projects/project-warranty-workspace.tsx
+++ b/src/components/projects/project-warranty-workspace.tsx
@@ -22,6 +22,7 @@ import {
   type WarrantyClaimItem,
   type WarrantyWorkspace,
 } from "@/app/actions/project-warranty"
+import { SearchableComboboxField } from "@/components/searchable-combobox"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -67,6 +68,21 @@ function label(value: string): string {
     .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
     .join(" ")
 }
+
+const CATEGORY_OPTIONS = CATEGORIES.map((category) => ({
+  value: category,
+  label: category,
+}))
+
+const PRIORITY_OPTIONS = WARRANTY_CLAIM_PRIORITIES.map((priority) => ({
+  value: priority,
+  label: label(priority),
+}))
+
+const STATUS_OPTIONS = WARRANTY_CLAIM_STATUSES.map((status) => ({
+  value: status,
+  label: label(status),
+}))
 
 function formatDate(value: string | null): string {
   if (!value) return "Not scheduled"
@@ -172,17 +188,18 @@ function ClaimCreateSheet({
           <Input name="title" placeholder="Short issue title" required />
           <div className="grid gap-3 sm:grid-cols-2">
             <Input name="location" placeholder="Location (room or area)" />
-            <select
+            <SearchableComboboxField
               name="category"
+              ariaLabel="Warranty category"
+              options={CATEGORY_OPTIONS}
+              placeholder="Choose category"
+              searchPlaceholder="Type a warranty category..."
+              emptyMessage="No matching warranty categories."
+              groupHeading="Categories"
               defaultValue=""
               required
-              className="flex h-9 w-full rounded-md border bg-background px-3 text-sm"
-            >
-              <option value="" disabled>Choose category</option>
-              {CATEGORIES.map((category) => (
-                <option key={category} value={category}>{category}</option>
-              ))}
-            </select>
+              className="h-9"
+            />
           </div>
           <Textarea
             name="description"
@@ -191,15 +208,17 @@ function ClaimCreateSheet({
             required
           />
           <div className="grid gap-3 sm:grid-cols-2">
-            <select
+            <SearchableComboboxField
               name="priority"
+              ariaLabel="Warranty priority"
+              options={PRIORITY_OPTIONS}
+              placeholder="Choose priority"
+              searchPlaceholder="Type a priority..."
+              emptyMessage="No matching priorities."
+              groupHeading="Priorities"
               defaultValue="normal"
-              className="flex h-9 w-full rounded-md border bg-background px-3 text-sm"
-            >
-              {WARRANTY_CLAIM_PRIORITIES.map((priority) => (
-                <option key={priority} value={priority}>{label(priority)} priority</option>
-              ))}
-            </select>
+              className="h-9"
+            />
             {viewerIsInternal && (
               <Input name="claimantName" placeholder="Owner / claimant name" />
             )}
@@ -300,26 +319,48 @@ function ClaimActions({
         <div className="grid gap-3 md:grid-cols-3">
           <label className="space-y-1 text-xs font-medium text-muted-foreground">
             Status
-            <select name="status" defaultValue={claim.status} className="flex h-9 w-full rounded-md border bg-background px-3 text-sm text-foreground">
-              {WARRANTY_CLAIM_STATUSES.map((status) => (
-                <option key={status} value={status}>{label(status)}</option>
-              ))}
-            </select>
+            <SearchableComboboxField
+              name="status"
+              defaultValue={claim.status}
+              ariaLabel={`Status for ${claim.claimNumber}`}
+              options={STATUS_OPTIONS}
+              placeholder="Choose status"
+              searchPlaceholder="Type a claim status..."
+              emptyMessage="No matching statuses."
+              groupHeading="Statuses"
+              className="h-9 text-foreground"
+            />
           </label>
           <label className="space-y-1 text-xs font-medium text-muted-foreground">
             Priority
-            <select name="priority" defaultValue={claim.priority} className="flex h-9 w-full rounded-md border bg-background px-3 text-sm text-foreground">
-              {WARRANTY_CLAIM_PRIORITIES.map((priority) => (
-                <option key={priority} value={priority}>{label(priority)}</option>
-              ))}
-            </select>
+            <SearchableComboboxField
+              name="priority"
+              defaultValue={claim.priority}
+              ariaLabel={`Priority for ${claim.claimNumber}`}
+              options={PRIORITY_OPTIONS}
+              placeholder="Choose priority"
+              searchPlaceholder="Type a priority..."
+              emptyMessage="No matching priorities."
+              groupHeading="Priorities"
+              className="h-9 text-foreground"
+            />
           </label>
           <label className="space-y-1 text-xs font-medium text-muted-foreground">
             Assigned to
-            <select name="assignedName" defaultValue={claim.assignedName ?? ""} className="flex h-9 w-full rounded-md border bg-background px-3 text-sm text-foreground">
-              <option value="">Unassigned</option>
-              {assigneeNames.map((name) => <option key={name} value={name}>{name}</option>)}
-            </select>
+            <SearchableComboboxField
+              name="assignedName"
+              defaultValue={claim.assignedName ?? ""}
+              ariaLabel={`Assign ${claim.claimNumber}`}
+              options={[
+                { value: "", label: "Unassigned" },
+                ...assigneeNames.map((name) => ({ value: name, label: name })),
+              ]}
+              placeholder="Unassigned"
+              searchPlaceholder="Type an assignee name..."
+              emptyMessage="No matching assignees."
+              groupHeading="Assignees"
+              className="h-9 text-foreground"
+            />
           </label>
         </div>
         <label className="space-y-1 text-xs font-medium text-muted-foreground">

--- a/src/components/schedule/dependency-dialog.tsx
+++ b/src/components/schedule/dependency-dialog.tsx
@@ -17,6 +17,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 import { createDependency } from "@/app/actions/schedule"
 import { wouldCreateCycle } from "@/lib/schedule/dependency-validation"
 import type {
@@ -106,36 +107,42 @@ export function DependencyDialog({
         <div className="space-y-4">
           <div>
             <Label>Predecessor (must finish first)</Label>
-            <Select value={predecessorId} onValueChange={setPredecessorId}>
-              <SelectTrigger className="mt-1">
-                <SelectValue placeholder="Select schedule item" />
-              </SelectTrigger>
-              <SelectContent>
-                {tasks.map((t) => (
-                  <SelectItem key={t.id} value={t.id}>
-                    {t.title}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <SearchableCombobox
+              ariaLabel="Choose predecessor schedule item"
+              options={tasks.map((task) => ({
+                value: task.id,
+                label: task.title,
+                keywords: task.id,
+              }))}
+              value={predecessorId}
+              onValueChange={setPredecessorId}
+              placeholder="Select schedule item"
+              searchPlaceholder="Search schedule items..."
+              emptyMessage="No matching schedule items."
+              groupHeading="Schedule items"
+              className="mt-1"
+            />
           </div>
 
           <div>
             <Label>Successor (depends on predecessor)</Label>
-            <Select value={successorId} onValueChange={setSuccessorId}>
-              <SelectTrigger className="mt-1">
-                <SelectValue placeholder="Select schedule item" />
-              </SelectTrigger>
-              <SelectContent>
-                {tasks
-                  .filter((t) => t.id !== predecessorId)
-                  .map((t) => (
-                    <SelectItem key={t.id} value={t.id}>
-                      {t.title}
-                    </SelectItem>
-                  ))}
-              </SelectContent>
-            </Select>
+            <SearchableCombobox
+              ariaLabel="Choose successor schedule item"
+              options={tasks
+                .filter((task) => task.id !== predecessorId)
+                .map((task) => ({
+                  value: task.id,
+                  label: task.title,
+                  keywords: task.id,
+                }))}
+              value={successorId}
+              onValueChange={setSuccessorId}
+              placeholder="Select schedule item"
+              searchPlaceholder="Search schedule items..."
+              emptyMessage="No matching schedule items."
+              groupHeading="Schedule items"
+              className="mt-1"
+            />
           </div>
 
           <div className="grid grid-cols-2 gap-4">

--- a/src/components/schedule/project-switcher.tsx
+++ b/src/components/schedule/project-switcher.tsx
@@ -1,13 +1,9 @@
 "use client"
 
 import { useRouter } from "next/navigation"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-} from "@/components/ui/select"
-import { IconChevronDown, IconBuilding } from "@tabler/icons-react"
+import { IconBuilding } from "@tabler/icons-react"
+
+import { ProjectCombobox } from "@/components/projects/project-combobox"
 
 interface ProjectSwitcherProps {
   readonly projects: readonly {
@@ -42,19 +38,13 @@ export function ProjectSwitcher({
   }
 
   return (
-    <Select value={currentProjectId} onValueChange={handleProjectChange}>
-      <SelectTrigger className="h-9 w-auto border border-input bg-background hover:bg-accent hover:text-accent-foreground gap-2 px-3 max-w-[280px]">
-        <IconBuilding className="size-4 text-muted-foreground shrink-0" />
-        <span className="truncate font-medium">{currentProjectName}</span>
-        <IconChevronDown className="size-4 text-muted-foreground shrink-0 ml-auto" />
-      </SelectTrigger>
-      <SelectContent>
-        {projects.map((project) => (
-          <SelectItem key={project.id} value={project.id}>
-            {project.projectNumber ?? project.name}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+    <ProjectCombobox
+      projects={projects}
+      value={currentProjectId}
+      onValueChange={handleProjectChange}
+      ariaLabel="Switch project"
+      className="h-9 w-auto max-w-[280px] gap-2 font-medium"
+      popoverClassName="w-[min(24rem,calc(100vw-3rem))]"
+    />
   )
 }

--- a/src/components/schedule/schedule-template-bulk-import-dialog.tsx
+++ b/src/components/schedule/schedule-template-bulk-import-dialog.tsx
@@ -23,13 +23,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from "@/components/ui/select"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 
 type ScheduleTemplateBulkImportDialogProps = {
   readonly open: boolean
@@ -81,7 +75,7 @@ export function ScheduleTemplateBulkImportDialog({
     let cancelled = false
     setLoading(true)
     setLoadError(false)
-    void loadScheduleTemplateImportOptions()
+    void loadScheduleTemplateImportOptions({ refresh: true })
       .then((groups) => {
         if (!cancelled) setTemplateGroups(groups)
       })
@@ -249,18 +243,20 @@ export function ScheduleTemplateBulkImportDialog({
               <div className="grid gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
                   <Label htmlFor="bulk-schedule-template">Template</Label>
-                  <Select value={templateId} onValueChange={chooseTemplate}>
-                    <SelectTrigger id="bulk-schedule-template">
-                      <SelectValue placeholder="Choose a published template" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {templateGroups?.map((group) => (
-                        <SelectItem key={group.templateId} value={group.templateId}>
-                          {group.templateName}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <SearchableCombobox
+                    id="bulk-schedule-template"
+                    ariaLabel="Choose published schedule template"
+                    options={(templateGroups ?? []).map((group) => ({
+                      value: group.templateId,
+                      label: group.templateName,
+                    }))}
+                    value={templateId}
+                    onValueChange={chooseTemplate}
+                    placeholder="Choose a published template"
+                    searchPlaceholder="Search templates..."
+                    emptyMessage="No matching templates."
+                    groupHeading="Templates"
+                  />
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="bulk-template-anchor-date">First-item start date</Label>
@@ -370,21 +366,19 @@ export function ScheduleTemplateBulkImportDialog({
                             </span>
                           </label>
                           {assignedItemId && (
-                            <Select
+                            <SearchableCombobox
+                              ariaLabel={`Schedule item for ${todo.title}`}
+                              options={selectedItems.map((item) => ({
+                                value: item.id,
+                                label: item.title,
+                              }))}
                               value={assignedItemId}
                               onValueChange={(value) => assignTodo(todo.id, value)}
-                            >
-                              <SelectTrigger aria-label={`Schedule item for ${todo.title}`}>
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {selectedItems.map((item) => (
-                                  <SelectItem key={item.id} value={item.id}>
-                                    {item.title}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
+                              placeholder="Choose schedule item"
+                              searchPlaceholder="Search selected items..."
+                              emptyMessage="No matching schedule items."
+                              groupHeading="Schedule items"
+                            />
                           )}
                         </div>
                       )

--- a/src/components/schedule/schedule-template-dialog.tsx
+++ b/src/components/schedule/schedule-template-dialog.tsx
@@ -23,13 +23,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { SearchableCombobox } from "@/components/searchable-combobox"
 
 type ScheduleTemplateDialogProps = {
   readonly open: boolean
@@ -151,18 +145,20 @@ export function ScheduleTemplateDialog({
           <div className="space-y-5 py-2">
             <div className="space-y-2">
               <Label htmlFor="schedule-template">Template</Label>
-              <Select value={templateId} onValueChange={setTemplateId}>
-                <SelectTrigger id="schedule-template">
-                  <SelectValue placeholder="Choose a verified template…" />
-                </SelectTrigger>
-                <SelectContent>
-                  {readyTemplates.map((template) => (
-                    <SelectItem key={template.id} value={template.id}>
-                      {template.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <SearchableCombobox
+                id="schedule-template"
+                ariaLabel="Choose verified schedule template"
+                options={readyTemplates.map((template) => ({
+                  value: template.id,
+                  label: template.name,
+                }))}
+                value={templateId}
+                onValueChange={setTemplateId}
+                placeholder="Choose a verified template…"
+                searchPlaceholder="Search templates..."
+                emptyMessage="No matching templates."
+                groupHeading="Templates"
+              />
             </div>
             <div className="space-y-2">
               <Label htmlFor="template-anchor-date">New start date</Label>

--- a/src/components/schedule/schedule-template-import-options-client.ts
+++ b/src/components/schedule/schedule-template-import-options-client.ts
@@ -13,14 +13,16 @@ let scheduleTemplateOptionsLoadedAt: number | null = null
 const SCHEDULE_TEMPLATE_OPTIONS_CACHE_MS = 30_000
 
 /**
- * Share one options request between the single-item and bulk import dialogs.
+ * Share one in-flight options request between the single-item and bulk import dialogs.
  * The single-item dialog often starts loading immediately before the user opens
  * the bulk importer, so issuing a second Server Action request here is both
- * wasteful and vulnerable to a deployment changing the action manifest.
+ * wasteful and vulnerable to a deployment changing the action manifest. Dialogs
+ * request a refresh when opened so newly published template data is not hidden by
+ * the short reuse window.
  */
-export function loadScheduleTemplateImportOptions(): Promise<
-  readonly ScheduleTemplateImportGroup[]
-> {
+export function loadScheduleTemplateImportOptions(options?: {
+  readonly refresh?: boolean
+}): Promise<readonly ScheduleTemplateImportGroup[]> {
   const cacheIsFresh =
     scheduleTemplateOptionsLoadedAt !== null &&
     Date.now() - scheduleTemplateOptionsLoadedAt <
@@ -28,6 +30,9 @@ export function loadScheduleTemplateImportOptions(): Promise<
   const requestIsInFlight =
     scheduleTemplateOptionsPromise !== null &&
     scheduleTemplateOptionsLoadedAt === null
+  if (options?.refresh === true && !requestIsInFlight) {
+    clearScheduleTemplateImportOptions()
+  }
   if (
     !requestIsInFlight &&
     (scheduleTemplateOptionsPromise === null || !cacheIsFresh)

--- a/src/components/schedule/work-calendar-event-dialog.tsx
+++ b/src/components/schedule/work-calendar-event-dialog.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
+import { ProjectCombobox } from "@/components/projects/project-combobox"
 import {
   Dialog,
   DialogContent,
@@ -107,12 +108,6 @@ type EventFormSeed = {
   readonly recurrenceUntil: string
   readonly attendeeUserIds: readonly string[]
   readonly calendarSelectionId: string
-}
-
-function projectLabel(project: ProjectRow): string {
-  return project.projectNumber
-    ? `${project.projectNumber} — ${project.name}`
-    : project.name
 }
 
 function formSeed(
@@ -460,25 +455,24 @@ export function WorkCalendarEventDialog(
               <Label htmlFor={`work-calendar-event-project-${props.variant}`}>
                 Project
               </Label>
-              <Select value={projectValue} onValueChange={setProjectValue}>
-                <SelectTrigger
-                  id={`work-calendar-event-project-${props.variant}`}
-                >
-                  <SelectValue placeholder="Select a project" />
-                </SelectTrigger>
-                <SelectContent>
-                  {props.defaultProjectId && (
-                    <SelectItem value={DEFAULT_PROJECT_VALUE}>
-                      H-Office (default)
-                    </SelectItem>
-                  )}
-                  {props.projects.map((project) => (
-                    <SelectItem key={project.id} value={project.id}>
-                      {projectLabel(project)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <ProjectCombobox
+                id={`work-calendar-event-project-${props.variant}`}
+                ariaLabel="Choose event project"
+                projects={props.projects}
+                value={projectValue}
+                onValueChange={setProjectValue}
+                specialOptions={
+                  props.defaultProjectId
+                    ? [
+                        {
+                          value: DEFAULT_PROJECT_VALUE,
+                          label: "H-Office (default)",
+                          keywords: "office company default",
+                        },
+                      ]
+                    : []
+                }
+              />
               {!props.defaultProjectId && (
                 <p className="text-xs text-muted-foreground">
                   Compass could not identify one unique H-Office project, so a

--- a/src/components/schedule/work-calendar-todo-dialog.tsx
+++ b/src/components/schedule/work-calendar-todo-dialog.tsx
@@ -12,6 +12,7 @@ import {
 import { createProjectTask } from "@/app/actions/project-operations"
 import type { ProjectRow } from "@/app/actions/work-calendar"
 import { ProjectAssigneePicker } from "@/components/projects/project-assignee-picker"
+import { ProjectCombobox } from "@/components/projects/project-combobox"
 import { ProjectCompanyPicker } from "@/components/projects/project-company-picker"
 import { Button } from "@/components/ui/button"
 import {
@@ -33,12 +34,6 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
-
-function projectLabel(project: ProjectRow): string {
-  return project.projectNumber
-    ? `${project.projectNumber} — ${project.name}`
-    : project.name
-}
 
 export function WorkCalendarTodoDialog({
   projects,
@@ -163,25 +158,17 @@ export function WorkCalendarTodoDialog({
           <div className="grid gap-4 py-5">
             <div className="grid gap-2">
               <Label htmlFor="calendar-todo-project">Project</Label>
-              <Select
+              <ProjectCombobox
+                id="calendar-todo-project"
+                ariaLabel="Choose to-do project"
+                projects={projects}
                 value={projectId}
                 onValueChange={(value) => {
                   setProjectId(value)
                   setAssigneeName("")
                   setCompanyName("")
                 }}
-              >
-                <SelectTrigger id="calendar-todo-project">
-                  <SelectValue placeholder="Select a project" />
-                </SelectTrigger>
-                <SelectContent>
-                  {projects.map((project) => (
-                    <SelectItem key={project.id} value={project.id}>
-                      {projectLabel(project)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              />
             </div>
             <div className="grid gap-2">
               <Label htmlFor="calendar-todo-title">Title</Label>

--- a/src/components/searchable-combobox.tsx
+++ b/src/components/searchable-combobox.tsx
@@ -99,7 +99,7 @@ export function SearchableCombobox({
       <PopoverContent
         align="start"
         className={cn(
-          "w-[var(--radix-popover-trigger-width)] min-w-[18rem] p-0",
+          "w-[var(--radix-popover-trigger-width)] min-w-[18rem] max-w-[calc(100vw-2rem)] p-0",
           popoverClassName
         )}
       >

--- a/src/components/searchable-combobox.tsx
+++ b/src/components/searchable-combobox.tsx
@@ -1,0 +1,174 @@
+"use client"
+
+import * as React from "react"
+import { Check, ChevronsUpDown } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { reconcileSearchableComboboxValue } from "@/lib/searchable-combobox"
+import { cn } from "@/lib/utils"
+
+export type SearchableComboboxOption = {
+  readonly value: string
+  readonly label: string
+  readonly selectedLabel?: string
+  readonly description?: string
+  readonly keywords?: string
+}
+
+export type SearchableComboboxProps = {
+  readonly options: readonly SearchableComboboxOption[]
+  readonly value: string
+  readonly onValueChange: (value: string) => void
+  readonly id?: string
+  readonly ariaLabel: string
+  readonly placeholder: string
+  readonly searchPlaceholder?: string
+  readonly emptyMessage?: string
+  readonly groupHeading?: string
+  readonly disabled?: boolean
+  readonly required?: boolean
+  readonly className?: string
+  readonly popoverClassName?: string
+}
+
+export function SearchableCombobox({
+  options,
+  value,
+  onValueChange,
+  id,
+  ariaLabel,
+  placeholder,
+  searchPlaceholder = "Search...",
+  emptyMessage = "No matching options.",
+  groupHeading,
+  disabled = false,
+  required = false,
+  className,
+  popoverClassName,
+}: SearchableComboboxProps): React.ReactElement {
+  const [open, setOpen] = React.useState(false)
+  const selectedOption =
+    options.find((option) => option.value === value) ?? null
+
+  React.useEffect(() => {
+    const nextValue = reconcileSearchableComboboxValue(options, value)
+    if (nextValue !== value) onValueChange(nextValue)
+  }, [onValueChange, options, value])
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-label={ariaLabel}
+          aria-required={required}
+          disabled={disabled || options.length === 0}
+          className={cn(
+            "h-10 w-full min-w-0 justify-between px-3 text-left font-normal",
+            className
+          )}
+        >
+          <span
+            className={cn(
+              "truncate",
+              selectedOption === null && "text-muted-foreground"
+            )}
+          >
+            {selectedOption?.selectedLabel ??
+              selectedOption?.label ??
+              placeholder}
+          </span>
+          <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className={cn(
+          "w-[var(--radix-popover-trigger-width)] min-w-[18rem] p-0",
+          popoverClassName
+        )}
+      >
+        <Command>
+          <CommandInput placeholder={searchPlaceholder} />
+          <CommandList className="compass-content-scroll max-h-72">
+            <CommandEmpty>{emptyMessage}</CommandEmpty>
+            <CommandGroup heading={groupHeading}>
+              {options.map((option) => (
+                <CommandItem
+                  key={option.value}
+                  value={`${option.label} ${option.description ?? ""} ${option.keywords ?? ""} ${option.value}`}
+                  onSelect={() => {
+                    onValueChange(option.value)
+                    setOpen(false)
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "size-4",
+                      value === option.value ? "opacity-100" : "opacity-0"
+                    )}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate font-medium">
+                      {option.label}
+                    </span>
+                    {option.description && (
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {option.description}
+                      </span>
+                    )}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export function SearchableComboboxField({
+  name,
+  defaultValue = "",
+  required = false,
+  ...props
+}: Omit<SearchableComboboxProps, "value" | "onValueChange"> & {
+  readonly name: string
+  readonly defaultValue?: string
+}): React.ReactElement {
+  const [value, setValue] = React.useState(defaultValue)
+
+  React.useEffect(() => {
+    setValue(defaultValue)
+  }, [defaultValue])
+
+  return (
+    <>
+      <input type="hidden" name={name} value={value} />
+      <SearchableCombobox
+        {...props}
+        value={value}
+        onValueChange={setValue}
+        required={required}
+      />
+    </>
+  )
+}

--- a/src/components/searchable-combobox.tsx
+++ b/src/components/searchable-combobox.tsx
@@ -43,7 +43,6 @@ export type SearchableComboboxProps = {
   readonly className?: string
   readonly popoverClassName?: string
 }
-
 export function SearchableCombobox({
   options,
   value,
@@ -67,7 +66,6 @@ export function SearchableCombobox({
     const nextValue = reconcileSearchableComboboxValue(options, value)
     if (nextValue !== value) onValueChange(nextValue)
   }, [onValueChange, options, value])
-
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>

--- a/src/lib/__tests__/searchable-combobox.test.ts
+++ b/src/lib/__tests__/searchable-combobox.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+
+import { reconcileSearchableComboboxValue } from "@/lib/searchable-combobox"
+
+describe("reconcileSearchableComboboxValue", () => {
+  const options = [
+    { value: "project-1" },
+    { value: "project-2" },
+  ] as const
+
+  it("keeps a selection that is still present in refreshed data", () => {
+    expect(reconcileSearchableComboboxValue(options, "project-2")).toBe(
+      "project-2"
+    )
+  })
+
+  it("clears a selection removed from refreshed data", () => {
+    expect(reconcileSearchableComboboxValue(options, "project-3")).toBe("")
+  })
+
+  it("preserves an intentionally empty selection", () => {
+    expect(reconcileSearchableComboboxValue(options, "")).toBe("")
+  })
+})

--- a/src/lib/searchable-combobox.ts
+++ b/src/lib/searchable-combobox.ts
@@ -1,0 +1,7 @@
+export function reconcileSearchableComboboxValue(
+  options: readonly { readonly value: string }[],
+  value: string
+): string {
+  if (value === "") return value
+  return options.some((option) => option.value === value) ? value : ""
+}


### PR DESCRIPTION
## Summary

- establish `SearchableCombobox` and `SearchableComboboxField` as the default Compass value-selector pattern
- migrate live selectors across project, schedule, financial, conversation, and administrative workflows
- convert warranty category, priority, status, and assignee controls to type-to-filter selection
- preserve action menus as menus and keep dependent selections reconciled when their options change
- constrain selector popovers to narrow viewports and document the system convention

## Validation

- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit`
- `bun lint` (0 errors; existing warnings only)
- `bun test src/lib/__tests__/searchable-combobox.test.ts src/lib/warranty/__tests__/status.test.ts` (7 passed)
- `git diff --check origin/main...HEAD`

## Review notes

- Reuses the previously approved searchable-selector work on current `main` while excluding the stale, unrelated contact-directory refactor.
- The external autoreview helper was not run because repository-diff transmission was not authorized; local source review found and fixed the narrow-viewport popover issue.
