### PR TITLE
feat(calendar): add Google Meet conference creation

### DIFF
--- a/docs/wip/google-calendar-sync-2026-07-27.md
+++ b/docs/wip/google-calendar-sync-2026-07-27.md
@@ -53,6 +53,10 @@ write-through behavior:
   and per-user “Add to my Google Calendar” subscriptions;
 - project-level event sync that preserves the Compass project scope for events
   created or edited from the shared Google calendar;
+- optional Google Meet conference creation for Compass events published to a
+  writable Google calendar, with the returned Meet URL stored in Compass;
+- external Meet launch actions that open Google Meet in a separate tab or
+  native app rather than embedding the call in Compass;
 - Google ACL roles derived from Compass access: office staff can edit events
   without managing sharing, while field and external project members are readers;
 - an integration status surface that remains safe when Google OAuth is not configured;
@@ -128,7 +132,6 @@ remain follow-up work.
 1. Scheduled event/access reconciliation, retries, incremental sync tokens,
    renewable watches, and a
    conflict-resolution UI.
-2. Google Meet conference creation (existing Meet links already round-trip).
-3. Remaining robust event fields: recurrence exceptions, external attendees,
+2. Remaining robust event fields: recurrence exceptions, external attendees,
    reminders, attachments, and related Compass records.
-4. Google Tasks synchronization after calendar behavior is stable.
+3. Google Tasks synchronization after calendar behavior is stable.

--- a/src/app/actions/work-calendar.ts
+++ b/src/app/actions/work-calendar.ts
@@ -1133,6 +1133,7 @@ export type WorkCalendarEventMutationInput = {
   readonly timeZone: string
   readonly location: string | null
   readonly meetingUrl: string | null
+  readonly createGoogleMeet: boolean
   readonly recurrence: WorkCalendarRecurrence
   readonly recurrenceUntil: string | null
   readonly attendeeUserIds: readonly string[]
@@ -1157,6 +1158,7 @@ type ValidatedEventInput = {
   readonly timeZone: string
   readonly location: string | null
   readonly meetingUrl: string | null
+  readonly createGoogleMeet: boolean
   readonly recurrence: WorkCalendarRecurrence
   readonly recurrenceUntil: string | null
   readonly attendees: readonly WorkCalendarEventAttendee[]
@@ -1356,6 +1358,16 @@ async function validateEventInput(
       throw new Error("A recurring series can span up to 10 years")
     }
   }
+  if (typeof input.createGoogleMeet !== "boolean") {
+    throw new Error("Select whether Google Meet should be added")
+  }
+  const meetingUrl = cleanOptionalUrl(input.meetingUrl, "Meeting link")
+  if (input.createGoogleMeet && input.eventType !== "meeting") {
+    throw new Error("Google Meet can only be added to meeting events")
+  }
+  if (input.createGoogleMeet && meetingUrl) {
+    throw new Error("Clear the meeting link before asking Google to create one")
+  }
 
   return {
     project,
@@ -1370,7 +1382,8 @@ async function validateEventInput(
     allDay: input.allDay,
     timeZone: timing.timeZone,
     location: cleanOptionalText(input.location, "Location", 500),
-    meetingUrl: cleanOptionalUrl(input.meetingUrl, "Meeting link"),
+    meetingUrl,
+    createGoogleMeet: input.createGoogleMeet === true,
     recurrence: input.recurrence,
     recurrenceUntil: recurrenceUntil || null,
     attendees: await validateAttendees(
@@ -1711,6 +1724,15 @@ export async function createWorkCalendarEvent(
         ? "organization"
         : "busy"
       : validated.visibility
+    const publishSelectionId =
+      calendarDestination?.selectionId ?? projectCalendarSelectionId
+    if (validated.createGoogleMeet && !publishSelectionId) {
+      return {
+        success: false,
+        error:
+          "Select a writable Google Calendar or enable the project's Google Calendar before adding Google Meet.",
+      }
+    }
     const id = crypto.randomUUID()
     const now = new Date().toISOString()
     await db.insert(workCalendarEvents).values({
@@ -1742,16 +1764,20 @@ export async function createWorkCalendarEvent(
     })
     await syncEventAttendees(db, id, [], validated.attendees, now)
     let warning: string | undefined
-    const publishSelectionId =
-      calendarDestination?.selectionId ?? projectCalendarSelectionId
     if (publishSelectionId) {
       try {
-        await publishWorkCalendarEventToGoogle(
+        const published = await publishWorkCalendarEventToGoogle(
           db,
           env,
           id,
           publishSelectionId,
+          { createGoogleMeet: validated.createGoogleMeet },
         )
+        if (validated.createGoogleMeet && !published.meetingUrl) {
+          warning = published.conferenceStatus === "failure"
+            ? "Event saved, but Google Calendar could not create the Meet link. Edit the event and try Add Google Meet again."
+            : "Event saved and Google Meet creation is still processing. Sync the Google Calendar shortly to retrieve the link."
+        }
       } catch (error) {
         warning =
           error instanceof Error
@@ -1868,6 +1894,21 @@ export async function updateWorkCalendarEvent(
         ? "organization"
         : "busy"
       : validated.visibility
+    const projectCalendarSelectionId = googleLink
+      ? null
+      : await activeGoogleProjectCalendarSelectionId(
+          db,
+          orgId,
+          targetProject?.id ?? null,
+        )
+    const publishSelectionId = googleLink?.selectionId ?? projectCalendarSelectionId
+    if (validated.createGoogleMeet && !publishSelectionId) {
+      return {
+        success: false,
+        error:
+          "This event must be linked to a writable Google Calendar before adding Google Meet.",
+      }
+    }
     const now = new Date().toISOString()
     const updated = await db
       .update(workCalendarEvents)
@@ -1916,22 +1957,20 @@ export async function updateWorkCalendarEvent(
       now
     )
     let warning: string | undefined
-    const projectCalendarSelectionId = googleLink
-      ? null
-      : await activeGoogleProjectCalendarSelectionId(
-          db,
-          orgId,
-          targetProject?.id ?? null,
-        )
-    const publishSelectionId = googleLink?.selectionId ?? projectCalendarSelectionId
     if (publishSelectionId) {
       try {
-        await publishWorkCalendarEventToGoogle(
+        const published = await publishWorkCalendarEventToGoogle(
           db,
           env,
           eventId,
           publishSelectionId,
+          { createGoogleMeet: validated.createGoogleMeet },
         )
+        if (validated.createGoogleMeet && !published.meetingUrl) {
+          warning = published.conferenceStatus === "failure"
+            ? "Event updated, but Google Calendar could not create the Meet link. Edit the event and try Add Google Meet again."
+            : "Event updated and Google Meet creation is still processing. Sync the Google Calendar shortly to retrieve the link."
+        }
       } catch (error) {
         warning =
           error instanceof Error

--- a/src/components/schedule/work-calendar-event-dialog.tsx
+++ b/src/components/schedule/work-calendar-event-dialog.tsx
@@ -4,8 +4,10 @@ import * as React from "react"
 import { useRouter } from "next/navigation"
 import {
   IconCalendarPlus,
+  IconExternalLink,
   IconPencil,
   IconTrash,
+  IconVideoPlus,
 } from "@tabler/icons-react"
 import { toast } from "sonner"
 
@@ -103,6 +105,7 @@ type EventFormSeed = {
   readonly timeZone: string
   readonly location: string
   readonly meetingUrl: string
+  readonly createGoogleMeet: boolean
   readonly recurrence: WorkCalendarRecurrence
   readonly recurrenceUntil: string
   readonly attendeeUserIds: readonly string[]
@@ -136,6 +139,7 @@ function formSeed(
       timeZone: details.timeZone,
       location: details.location ?? "",
       meetingUrl: details.meetingUrl ?? "",
+      createGoogleMeet: false,
       recurrence: details.recurrence,
       recurrenceUntil: details.recurrenceUntil ?? "",
       attendeeUserIds: details.attendees.map(
@@ -161,6 +165,7 @@ function formSeed(
     timeZone: props.defaultTimeZone,
     location: "",
     meetingUrl: "",
+    createGoogleMeet: false,
     recurrence: "none",
     recurrenceUntil: "",
     attendeeUserIds: [],
@@ -188,6 +193,9 @@ export function WorkCalendarEventDialog(
   const [timeZone, setTimeZone] = React.useState(seed.timeZone)
   const [location, setLocation] = React.useState(seed.location)
   const [meetingUrl, setMeetingUrl] = React.useState(seed.meetingUrl)
+  const [createGoogleMeet, setCreateGoogleMeet] = React.useState(
+    seed.createGoogleMeet,
+  )
   const [recurrence, setRecurrence] = React.useState(seed.recurrence)
   const [recurrenceUntil, setRecurrenceUntil] = React.useState(
     seed.recurrenceUntil
@@ -216,6 +224,7 @@ export function WorkCalendarEventDialog(
     setTimeZone(next.timeZone)
     setLocation(next.location)
     setMeetingUrl(next.meetingUrl)
+    setCreateGoogleMeet(next.createGoogleMeet)
     setRecurrence(next.recurrence)
     setRecurrenceUntil(next.recurrenceUntil)
     setAttendeeUserIds(next.attendeeUserIds)
@@ -278,6 +287,7 @@ export function WorkCalendarEventDialog(
       timeZone,
       location: location || null,
       meetingUrl: meetingUrl || null,
+      createGoogleMeet,
       recurrence,
       recurrenceUntil: recurrence === "none" ? null : recurrenceUntil,
       attendeeUserIds,
@@ -402,7 +412,9 @@ export function WorkCalendarEventDialog(
                 <Select
                   value={eventType}
                   onValueChange={(value) => {
-                    if (isWorkCalendarEventType(value)) setEventType(value)
+                    if (!isWorkCalendarEventType(value)) return
+                    setEventType(value)
+                    if (value !== "meeting") setCreateGoogleMeet(false)
                   }}
                 >
                   <SelectTrigger
@@ -625,14 +637,60 @@ export function WorkCalendarEventDialog(
               >
                 Meeting link
               </Label>
-              <Input
-                id={`work-calendar-event-meeting-link-${props.variant}`}
-                type="url"
-                value={meetingUrl}
-                onChange={(event) => setMeetingUrl(event.target.value)}
-                placeholder="https://meet.google.com/..."
-                maxLength={2_000}
-              />
+              <div className="flex gap-2">
+                <Input
+                  id={`work-calendar-event-meeting-link-${props.variant}`}
+                  type="url"
+                  value={meetingUrl}
+                  onChange={(event) => setMeetingUrl(event.target.value)}
+                  placeholder={
+                    createGoogleMeet
+                      ? "Google will create the Meet link"
+                      : "https://meet.google.com/..."
+                  }
+                  maxLength={2_000}
+                  disabled={createGoogleMeet}
+                />
+                {meetingUrl && (
+                  <Button asChild type="button" variant="outline">
+                    <a
+                      href={meetingUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <IconExternalLink className="size-4" />
+                      Join
+                    </a>
+                  </Button>
+                )}
+              </div>
+              {eventType === "meeting" && !meetingUrl && (
+                <label className="flex items-start gap-3 rounded-md border bg-muted/20 p-3">
+                  <Checkbox
+                    checked={createGoogleMeet}
+                    onCheckedChange={(checked) =>
+                      setCreateGoogleMeet(checked === true)
+                    }
+                  />
+                  <span className="min-w-0 text-sm">
+                    <span className="flex items-center gap-2 font-medium">
+                      <IconVideoPlus className="size-4" />
+                      Add Google Meet
+                    </span>
+                    <span className="mt-1 block text-xs text-muted-foreground">
+                      Google Calendar creates the link. Participants open Meet
+                      in a separate tab or the Google Meet app; Compass does not
+                      embed the call.
+                    </span>
+                  </span>
+                </label>
+              )}
+              {createGoogleMeet && (
+                <p className="text-xs text-muted-foreground">
+                  Requires a writable Google Calendar destination or an enabled
+                  Google project calendar.
+                </p>
+              )}
             </div>
 
             <fieldset className="grid gap-2">

--- a/src/lib/__tests__/google-calendar-sync.test.ts
+++ b/src/lib/__tests__/google-calendar-sync.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   addGoogleCalendarToList,
   createGoogleCalendar,
+  createGoogleCalendarEvent,
   parseGoogleCalendarEvent,
 } from "@/lib/google/calendar/client"
 import {
@@ -151,6 +152,105 @@ describe("managed Google Calendar API requests", () => {
     await expect(
       addGoogleCalendarToList("access-token", "project-calendar@example.com"),
     ).resolves.toBeUndefined()
+  })
+
+  it("requests a Google Meet conference when publishing an event", async () => {
+    let requestUrl = ""
+    let requestBody = ""
+    globalThis.fetch = async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      requestUrl = input.toString()
+      requestBody = typeof init?.body === "string" ? init.body : ""
+      return Response.json({
+        id: "google-event-1",
+        summary: "Owner meeting",
+        hangoutLink: "https://meet.google.com/abc-defg-hij",
+        start: { dateTime: "2026-08-20T15:00:00.000Z" },
+        end: { dateTime: "2026-08-20T16:00:00.000Z" },
+      })
+    }
+
+    const event = await createGoogleCalendarEvent(
+      "access-token",
+      "project-calendar@example.com",
+      {
+        summary: "Owner meeting",
+        description: null,
+        location: null,
+        startDate: null,
+        endDateExclusive: null,
+        startsAt: "2026-08-20T15:00:00.000Z",
+        endsAt: "2026-08-20T16:00:00.000Z",
+        timeZone: "America/Denver",
+        visibility: "default",
+        recurrence: [],
+        attendeeEmails: ["owner@example.com"],
+        conferenceRequestId: "cmpmeetrequest1",
+      },
+    )
+
+    const url = new URL(requestUrl)
+    expect(url.searchParams.get("conferenceDataVersion")).toBe("1")
+    expect(url.searchParams.get("sendUpdates")).toBe("all")
+    expect(JSON.parse(requestBody)).toMatchObject({
+      conferenceData: {
+        createRequest: {
+          requestId: "cmpmeetrequest1",
+          conferenceSolutionKey: { type: "hangoutsMeet" },
+        },
+      },
+      attendees: [{ email: "owner@example.com" }],
+    })
+    expect(event.meetingUrl).toBe("https://meet.google.com/abc-defg-hij")
+  })
+
+  it("converges a retried deterministic event create on the existing event", async () => {
+    const methods: string[] = []
+    globalThis.fetch = async (
+      _input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      methods.push(init?.method ?? "GET")
+      if (methods.length === 1) {
+        return Response.json(
+          { error: { message: "The requested identifier already exists." } },
+          { status: 409 },
+        )
+      }
+      return Response.json({
+        id: "cmpexistingevent",
+        summary: "Owner meeting",
+        hangoutLink: "https://meet.google.com/retry-link",
+        start: { dateTime: "2026-08-20T15:00:00.000Z" },
+        end: { dateTime: "2026-08-20T16:00:00.000Z" },
+      })
+    }
+
+    const event = await createGoogleCalendarEvent(
+      "access-token",
+      "project-calendar@example.com",
+      {
+        id: "cmpexistingevent",
+        summary: "Owner meeting",
+        description: null,
+        location: null,
+        startDate: null,
+        endDateExclusive: null,
+        startsAt: "2026-08-20T15:00:00.000Z",
+        endsAt: "2026-08-20T16:00:00.000Z",
+        timeZone: "America/Denver",
+        visibility: "default",
+        recurrence: [],
+        attendeeEmails: [],
+        conferenceRequestId: "cmpretryrequest",
+      },
+    )
+
+    expect(methods).toEqual(["POST", "PATCH"])
+    expect(event.id).toBe("cmpexistingevent")
+    expect(event.meetingUrl).toBe("https://meet.google.com/retry-link")
   })
 })
 
@@ -352,6 +452,25 @@ describe("Google Calendar event parsing", () => {
       startDate: "2026-12-24",
       endDateExclusive: "2026-12-26",
       allDay: true,
+    })
+  })
+
+  it("exposes a failed Google Meet creation status without losing the event", () => {
+    expect(
+      parseGoogleCalendarEvent({
+        id: "google-event-with-failed-meet",
+        conferenceData: {
+          createRequest: {
+            status: { statusCode: "failure" },
+          },
+        },
+        start: { dateTime: "2026-08-20T15:00:00.000Z" },
+        end: { dateTime: "2026-08-20T16:00:00.000Z" },
+      }),
+    ).toMatchObject({
+      id: "google-event-with-failed-meet",
+      meetingUrl: null,
+      conferenceStatus: "failure",
     })
   })
 })

--- a/src/lib/google/calendar/client.ts
+++ b/src/lib/google/calendar/client.ts
@@ -24,6 +24,7 @@ export type GoogleCalendarEventItem = {
   readonly location: string | null
   readonly htmlLink: string | null
   readonly meetingUrl: string | null
+  readonly conferenceStatus: string | null
   readonly startDate: string | null
   readonly endDateExclusive: string | null
   readonly startsAt: string | null
@@ -49,6 +50,7 @@ export type GoogleCalendarEventWrite = {
   readonly visibility: "default" | "public" | "private"
   readonly recurrence: readonly string[]
   readonly attendeeEmails: readonly string[]
+  readonly conferenceRequestId: string | null
 }
 
 export type GoogleCalendarAclRole =
@@ -361,6 +363,7 @@ export function parseGoogleCalendarEvent(
     location: stringValue(value, "location"),
     htmlLink: stringValue(value, "htmlLink"),
     meetingUrl: conferenceMeetingUrl(value),
+    conferenceStatus: conferenceRequestStatus(value),
     startDate,
     endDateExclusive,
     startsAt,
@@ -426,8 +429,49 @@ function eventBody(input: GoogleCalendarEventWrite): JsonRecord {
   if (input.attendeeEmails.length > 0) {
     body.attendees = input.attendeeEmails.map((email) => ({ email }))
   }
+  if (input.conferenceRequestId) {
+    body.conferenceData = {
+      createRequest: {
+        requestId: input.conferenceRequestId,
+        conferenceSolutionKey: { type: "hangoutsMeet" },
+      },
+    }
+  }
   if (input.id) body.id = input.id
   return body
+}
+
+function conferenceRequestStatus(value: unknown): string | null {
+  if (!isRecord(value) || !isRecord(value.conferenceData)) return null
+  const createRequest = value.conferenceData.createRequest
+  if (!isRecord(createRequest) || !isRecord(createRequest.status)) return null
+  return stringValue(createRequest.status, "statusCode")
+}
+
+async function waitForGoogleMeet(
+  accessToken: string,
+  calendarId: string,
+  event: GoogleCalendarEventItem,
+  conferenceRequestId: string | null,
+): Promise<GoogleCalendarEventItem> {
+  if (!conferenceRequestId || event.meetingUrl) return event
+
+  let latest = event
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    // Google can acknowledge conference creation before the Meet URL is ready.
+    await new Promise((resolve) => setTimeout(resolve, 200 * (attempt + 1)))
+    const url = endpoint(
+      `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(event.id)}`,
+    )
+    url.searchParams.set("conferenceDataVersion", "1")
+    const payload = await googleRequest(accessToken, url)
+    const parsed = parseGoogleCalendarEvent(payload)
+    if (!parsed) throw new Error("Google returned an invalid calendar event.")
+    latest = parsed
+    if (latest.meetingUrl) return latest
+    if (latest.conferenceStatus === "failure") return latest
+  }
+  return latest
 }
 
 export async function createGoogleCalendarEvent(
@@ -436,17 +480,42 @@ export async function createGoogleCalendarEvent(
   input: GoogleCalendarEventWrite,
 ): Promise<GoogleCalendarEventItem> {
   const url = endpoint(`/calendars/${encodeURIComponent(calendarId)}/events`)
+  url.searchParams.set("conferenceDataVersion", "1")
   url.searchParams.set(
     "sendUpdates",
     input.attendeeEmails.length > 0 ? "all" : "none",
   )
-  const payload = await googleRequest(accessToken, url, {
+  const response = await fetch(url, {
     method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
     body: JSON.stringify(eventBody(input)),
   })
+  const payload = await responsePayload(response)
+  if (response.status === 409 && input.id) {
+    // Deterministic Compass IDs make retries converge on the existing event.
+    return updateGoogleCalendarEvent(
+      accessToken,
+      calendarId,
+      input.id,
+      { ...input, id: undefined },
+    )
+  }
+  if (!response.ok) {
+    throw new Error(
+      googleError(payload, `Google Calendar request failed (${response.status}).`),
+    )
+  }
   const event = parseGoogleCalendarEvent(payload)
   if (!event) throw new Error("Google returned an invalid created event.")
-  return event
+  return waitForGoogleMeet(
+    accessToken,
+    calendarId,
+    event,
+    input.conferenceRequestId,
+  )
 }
 
 export async function updateGoogleCalendarEvent(
@@ -458,6 +527,7 @@ export async function updateGoogleCalendarEvent(
   const url = endpoint(
     `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(googleEventId)}`,
   )
+  url.searchParams.set("conferenceDataVersion", "1")
   url.searchParams.set(
     "sendUpdates",
     input.attendeeEmails.length > 0 ? "all" : "none",
@@ -468,7 +538,12 @@ export async function updateGoogleCalendarEvent(
   })
   const event = parseGoogleCalendarEvent(payload)
   if (!event) throw new Error("Google returned an invalid updated event.")
-  return event
+  return waitForGoogleMeet(
+    accessToken,
+    calendarId,
+    event,
+    input.conferenceRequestId,
+  )
 }
 
 export async function deleteGoogleCalendarEvent(

--- a/src/lib/google/calendar/sync.ts
+++ b/src/lib/google/calendar/sync.ts
@@ -473,7 +473,11 @@ export async function publishWorkCalendarEventToGoogle(
   env: object,
   eventId: string,
   selectionId: string,
-): Promise<void> {
+  options?: { readonly createGoogleMeet: boolean },
+): Promise<{
+  readonly meetingUrl: string | null
+  readonly conferenceStatus: string | null
+}> {
   const managedProjectCalendar = await db
     .select({ status: googleProjectCalendars.status })
     .from(googleProjectCalendars)
@@ -491,6 +495,14 @@ export async function publishWorkCalendarEventToGoogle(
     .limit(1)
     .then((rows) => rows[0] ?? null)
   if (!event) throw new Error("Work Calendar event was not found.")
+  const conferenceRequestId =
+    options?.createGoogleMeet && !event.meetingUrl
+      ? await googleEventIdForCompass(
+          "work_calendar_event",
+          `${eventId}:meet:${event.version}`,
+          token.selection.connectionId,
+        )
+      : null
   const attendeeRows = await db
     .select({ email: users.email })
     .from(workCalendarEventAttendees)
@@ -508,6 +520,7 @@ export async function publishWorkCalendarEventToGoogle(
     visibility: event.visibility === "private" ? "private" : "default",
     recurrence: googleRecurrence(event),
     attendeeEmails: attendeeRows.map((attendee) => attendee.email),
+    conferenceRequestId,
   }
   const link = await db
     .select({
@@ -559,26 +572,36 @@ export async function publishWorkCalendarEventToGoogle(
         updatedAt: now,
       })
       .where(eq(googleCalendarEntityLinks.id, link.id))
-    return
+  } else {
+    await db.insert(googleCalendarEntityLinks).values({
+      id: crypto.randomUUID(),
+      connectionId: token.selection.connectionId,
+      googleCalendarId: token.selection.calendarId,
+      googleEventId: googleEvent.id,
+      googleICalUid: googleEvent.iCalUID,
+      sourceType: "work_calendar_event",
+      sourceId: eventId,
+      syncDirection: "two_way",
+      syncStatus: "synced",
+      googleEtag: googleEvent.etag,
+      googleUpdatedAt: googleEvent.updatedAt,
+      compassVersion: event.version,
+      lastSyncedAt: now,
+      lastError: null,
+      createdAt: now,
+      updatedAt: now,
+    })
   }
-  await db.insert(googleCalendarEntityLinks).values({
-    id: crypto.randomUUID(),
-    connectionId: token.selection.connectionId,
-    googleCalendarId: token.selection.calendarId,
-    googleEventId: googleEvent.id,
-    googleICalUid: googleEvent.iCalUID,
-    sourceType: "work_calendar_event",
-    sourceId: eventId,
-    syncDirection: "two_way",
-    syncStatus: "synced",
-    googleEtag: googleEvent.etag,
-    googleUpdatedAt: googleEvent.updatedAt,
-    compassVersion: event.version,
-    lastSyncedAt: now,
-    lastError: null,
-    createdAt: now,
-    updatedAt: now,
-  })
+  if (googleEvent.meetingUrl && googleEvent.meetingUrl !== event.meetingUrl) {
+    await db
+      .update(workCalendarEvents)
+      .set({ meetingUrl: googleEvent.meetingUrl })
+      .where(eq(workCalendarEvents.id, eventId))
+  }
+  return {
+    meetingUrl: googleEvent.meetingUrl,
+    conferenceStatus: googleEvent.conferenceStatus,
+  }
 }
 
 export async function deleteLinkedWorkCalendarEventFromGoogle(


### PR DESCRIPTION
## Summary

- create Google Meet conferences through linked Google Calendar events
- persist returned Meet URLs in Compass and open meetings externally
- enforce writable-calendar permissions and recover deterministic retry conflicts safely

## Validation

- `bun test src/lib/__tests__/google-calendar-sync.test.ts` — 25 passed
- affected-file ESLint — clean
- full repository lint — 0 errors
- production Next.js build and TypeScript — passed
- no database migration required
