### PR TITLE
feat(jarvis): support dual-secret bridge rollover

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,9 @@ GITHUB_REPO=High-Performance-Structures/compass
 # Jarvis / Signet feedback bridge (optional)
 # Generate the shared HMAC secret with: openssl rand -hex 32
 JARVIS_BRIDGE_SECRET=your_random_bridge_secret_here
+# Temporary rollover credential only. Leave unset outside an approved rollover.
+# Generate separately from the primary secret with: openssl rand -hex 32
+# JARVIS_BRIDGE_SECONDARY_SECRET=your_temporary_bridge_secret_here
 JARVIS_BRIDGE_ORGANIZATION_ID=your_organization_id_here
 JARVIS_SERVICE_USER_ID=your_jarvis_service_user_id_here
 

--- a/docs/architecture/jarvis-feedback-bridge.md
+++ b/docs/architecture/jarvis-feedback-bridge.md
@@ -170,6 +170,43 @@ Authentication
 Every adapter request is signed with HMAC-SHA256. Configure the same
 `JARVIS_BRIDGE_SECRET` as a secret in Compass and the private adapter.
 
+Temporary dual-secret rollover
+---
+
+Use `JARVIS_BRIDGE_SECONDARY_SECRET` only for a time-bounded, approved
+operator rollover. It is an additional Cloudflare secret binding, not a
+replacement for `JARVIS_BRIDGE_SECRET`; the existing primary-signed poller
+and notifier continue to work unchanged. The shared verifier checks the
+primary and secondary candidates with constant-time comparisons, and only the
+existing Jarvis integration and signed maintenance endpoints use that verifier.
+
+1. Generate a new random value independently of the primary, for example with
+   `openssl rand -hex 32`. Do not print it, place it in a repository or local
+   environment file, or include it in logs, tickets, screenshots, or command
+   history.
+2. Deploy the verifier change while the secondary binding is absent. This
+   preserves the existing primary-only behavior during the code rollout.
+3. Provision the generated value as the production
+   `JARVIS_BRIDGE_SECONDARY_SECRET` secret and, separately, in the approved
+   operator credential store. The operator process may use the secondary value
+   as its local `JARVIS_BRIDGE_SECRET`; do not replace the primary value used
+   by the existing poller or notifier.
+4. Exercise only the required existing Jarvis endpoint(s), using the normal
+   timestamp, raw-body, path, idempotency, and authorization contracts. Verify
+   the primary path still succeeds and the secondary path succeeds before any
+   operational use. Do not add a new endpoint or broaden the route scope.
+5. When the operator task is complete, stop using the secondary credential,
+   remove `JARVIS_BRIDGE_SECONDARY_SECRET` from the production Worker, and
+   revoke/delete the operator-side copy. Confirm that a request signed only
+   with the retired value receives HTTP 401, while the primary poller and
+   notifier still succeed.
+
+If the temporary credential may have been exposed, treat it as compromised:
+remove it immediately and generate a new primary/secondary pair according to
+the approved incident procedure. Do not rely on application logs to identify
+which secret signed a request; the bridge deliberately does not log secret
+material or secret identifiers.
+
 Set `JARVIS_AGENT_BRIDGE_ENABLED=true` in Compass only after the private
 poller and loopback-only Hermes API are healthy. Setting it to `false`
 immediately restores the direct provider route.

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -143,6 +143,7 @@ decision reactivates NetSuite for a specific workflow.
 | Variable | Description |
 |----------|-------------|
 | `JARVIS_BRIDGE_SECRET` | Shared HMAC-SHA256 secret used to authenticate bridge requests. Generate with `openssl rand -hex 32` and store it as a secret on both sides. |
+| `JARVIS_BRIDGE_SECONDARY_SECRET` | Optional, temporary rollover secret accepted alongside the primary. Provision only for an approved operator rollover and remove it when that work is complete. |
 | `JARVIS_BRIDGE_ORGANIZATION_ID` | Compass organization that receives inbound Telegram and Jarvis mailbox feedback. |
 | `JARVIS_AGENT_BRIDGE_ENABLED` | Set to `true` to route authenticated Ask Jarvis chat through the private Signet/Hermes bridge. |
 | `JARVIS_SERVICE_USER_ID` | Active Compass service user used for Jarvis replies. It must belong to the configured organization and each channel where it may reply. |

--- a/src/app/api/integrations/jarvis/events/[id]/ack/__tests__/route.test.ts
+++ b/src/app/api/integrations/jarvis/events/[id]/ack/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const mocks = vi.hoisted(() => ({
   getCloudflareContext: vi.fn(),
   getDb: vi.fn(),
+  getJarvisBridgeSecrets: vi.fn(),
   getJarvisEnvValue: vi.fn(),
   readBoundedBody: vi.fn(),
   verifyJarvisRequest: vi.fn(),
@@ -11,6 +12,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/lib/db", () => ({ getCloudflareContext: mocks.getCloudflareContext }))
 vi.mock("@/db", () => ({ getDb: mocks.getDb }))
 vi.mock("@/lib/jarvis/auth", () => ({
+  getJarvisBridgeSecrets: mocks.getJarvisBridgeSecrets,
   getJarvisEnvValue: mocks.getJarvisEnvValue,
   readBoundedBody: mocks.readBoundedBody,
   verifyJarvisRequest: mocks.verifyJarvisRequest,
@@ -82,6 +84,7 @@ describe("POST /api/integrations/jarvis/events/:id/ack", () => {
     mocks.getJarvisEnvValue.mockImplementation((_env: unknown, key: string) =>
       key === "JARVIS_BRIDGE_SECRET" ? "secret" : null,
     )
+    mocks.getJarvisBridgeSecrets.mockReturnValue(["secret"])
     mocks.readBoundedBody.mockImplementation(async (request: Request) => ({
       success: true,
       rawBody: await request.text(),

--- a/src/app/api/integrations/jarvis/events/[id]/ack/route.ts
+++ b/src/app/api/integrations/jarvis/events/[id]/ack/route.ts
@@ -4,7 +4,7 @@ import { getDb } from "@/db"
 import { feedbackDeskItems, jarvisBridgeEvents } from "@/db/schema-jarvis"
 import { getCloudflareContext } from "@/lib/db"
 import {
-  getJarvisEnvValue,
+  getJarvisBridgeSecrets,
   readBoundedBody,
   verifyJarvisRequest,
 } from "@/lib/jarvis/auth"
@@ -33,8 +33,8 @@ export async function POST(
   }
 
   const { env } = await getCloudflareContext()
-  const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
-  if (!secret) {
+  const secrets = getJarvisBridgeSecrets(env)
+  if (!secrets) {
     return Response.json(
       { error: "Jarvis bridge is not configured" },
       { status: 503 },
@@ -43,7 +43,7 @@ export async function POST(
 
   const verification = await verifyJarvisRequest(
     request,
-    secret,
+    secrets,
     bodyResult.rawBody,
   )
   if (!verification.success) {

--- a/src/app/api/integrations/jarvis/events/[id]/search/route.ts
+++ b/src/app/api/integrations/jarvis/events/[id]/search/route.ts
@@ -13,7 +13,7 @@ import {
 } from "@/db/schema-jarvis"
 import { getCloudflareContext } from "@/lib/db"
 import {
-  getJarvisEnvValue,
+  getJarvisBridgeSecrets,
   verifyJarvisRequest,
 } from "@/lib/jarvis/auth"
 import {
@@ -133,15 +133,15 @@ export async function GET(
   }
 ): Promise<Response> {
   const { env } = await getCloudflareContext()
-  const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
-  if (!secret) {
+  const secrets = getJarvisBridgeSecrets(env)
+  if (!secrets) {
     return Response.json(
       { error: "Jarvis bridge is not configured" },
       { status: 503 }
     )
   }
 
-  const verification = await verifyJarvisRequest(request, secret, "")
+  const verification = await verifyJarvisRequest(request, secrets, "")
   if (!verification.success) {
     return Response.json({ error: verification.error }, { status: 401 })
   }

--- a/src/app/api/integrations/jarvis/events/[id]/visuals/route.ts
+++ b/src/app/api/integrations/jarvis/events/[id]/visuals/route.ts
@@ -4,7 +4,7 @@ import { getDb } from "@/db"
 import { jarvisBridgeEvents } from "@/db/schema-jarvis"
 import { getCloudflareContext } from "@/lib/db"
 import {
-  getJarvisEnvValue,
+  getJarvisBridgeSecrets,
   verifyJarvisRequest,
 } from "@/lib/jarvis/auth"
 import { canSearchCompassRole } from "@/lib/jarvis/search"
@@ -33,15 +33,15 @@ export async function GET(
   },
 ): Promise<Response> {
   const { env } = await getCloudflareContext()
-  const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
-  if (!secret) {
+  const secrets = getJarvisBridgeSecrets(env)
+  if (!secrets) {
     return Response.json(
       { error: "Jarvis bridge is not configured" },
       { status: 503 },
     )
   }
 
-  const verification = await verifyJarvisRequest(request, secret, "")
+  const verification = await verifyJarvisRequest(request, secrets, "")
   if (!verification.success) {
     return Response.json({ error: verification.error }, { status: 401 })
   }

--- a/src/app/api/integrations/jarvis/events/route.ts
+++ b/src/app/api/integrations/jarvis/events/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/db/schema-jarvis"
 import { getCloudflareContext } from "@/lib/db"
 import {
+  getJarvisBridgeSecrets,
   getJarvisEnvValue,
   readBoundedBody,
   verifyJarvisRequest,
@@ -67,8 +68,8 @@ function unauthorized(error: string): Response {
 
 export async function GET(request: Request): Promise<Response> {
   const { env } = await getCloudflareContext()
-  const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
-  if (!secret) {
+  const secrets = getJarvisBridgeSecrets(env)
+  if (!secrets) {
     return Response.json(
       { error: "Jarvis bridge is not configured" },
       { status: 503 },
@@ -77,7 +78,7 @@ export async function GET(request: Request): Promise<Response> {
 
   const verification = await verifyJarvisRequest(
     request,
-    secret,
+    secrets,
     "",
   )
   if (!verification.success) {
@@ -187,8 +188,8 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   const { env } = await getCloudflareContext()
-  const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
-  if (!secret) {
+  const secrets = getJarvisBridgeSecrets(env)
+  if (!secrets) {
     return Response.json(
       { error: "Jarvis bridge is not configured" },
       { status: 503 },
@@ -197,7 +198,7 @@ export async function POST(request: Request): Promise<Response> {
 
   const verification = await verifyJarvisRequest(
     request,
-    secret,
+    secrets,
     bodyResult.rawBody,
   )
   if (!verification.success) {

--- a/src/app/api/integrations/jarvis/feedback/[id]/status/__tests__/route.test.ts
+++ b/src/app/api/integrations/jarvis/feedback/[id]/status/__tests__/route.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   applyFeedbackLifecycleUpdate: vi.fn(),
   getCloudflareContext: vi.fn(),
   getDb: vi.fn(),
+  getJarvisBridgeSecrets: vi.fn(),
   getJarvisEnvValue: vi.fn(),
   readBoundedBody: vi.fn(),
   verifyJarvisRequest: vi.fn(),
@@ -12,6 +13,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/lib/db", () => ({ getCloudflareContext: mocks.getCloudflareContext }))
 vi.mock("@/db", () => ({ getDb: mocks.getDb }))
 vi.mock("@/lib/jarvis/auth", () => ({
+  getJarvisBridgeSecrets: mocks.getJarvisBridgeSecrets,
   getJarvisEnvValue: mocks.getJarvisEnvValue,
   readBoundedBody: mocks.readBoundedBody,
   verifyJarvisRequest: mocks.verifyJarvisRequest,
@@ -55,6 +57,7 @@ describe("POST /api/integrations/jarvis/feedback/:id/status", () => {
       if (key === "JARVIS_BRIDGE_ORGANIZATION_ID") return "org-1"
       return null
     })
+    mocks.getJarvisBridgeSecrets.mockReturnValue(["secret"])
     mocks.readBoundedBody.mockImplementation(async (request: Request) => ({
       success: true,
       rawBody: await request.text(),

--- a/src/app/api/integrations/jarvis/feedback/[id]/status/route.ts
+++ b/src/app/api/integrations/jarvis/feedback/[id]/status/route.ts
@@ -5,6 +5,7 @@ import { getDb } from "@/db"
 import { feedbackDeskItems, jarvisBridgeEvents } from "@/db/schema-jarvis"
 import { getCloudflareContext } from "@/lib/db"
 import {
+  getJarvisBridgeSecrets,
   getJarvisEnvValue,
   readBoundedBody,
   verifyJarvisRequest,
@@ -52,9 +53,9 @@ export async function POST(
     return Response.json({ error: bodyResult.error }, { status: 413 })
   }
   const { env } = await getCloudflareContext()
-  const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
+  const secrets = getJarvisBridgeSecrets(env)
   const organizationId = getJarvisEnvValue(env, "JARVIS_BRIDGE_ORGANIZATION_ID")
-  if (!secret || !organizationId) {
+  if (!secrets || !organizationId) {
     return Response.json(
       { error: "Jarvis lifecycle bridge is not configured" },
       { status: 503 },
@@ -62,7 +63,7 @@ export async function POST(
   }
   const verification = await verifyJarvisRequest(
     request,
-    secret,
+    secrets,
     bodyResult.rawBody,
   )
   if (!verification.success) {

--- a/src/app/api/integrations/jarvis/health/route.ts
+++ b/src/app/api/integrations/jarvis/health/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod/v4"
 import { getDb } from "@/db"
 import { getCloudflareContext } from "@/lib/db"
 import {
+  getJarvisBridgeSecrets,
   getJarvisEnvValue,
   readBoundedBody,
   verifyJarvisRequest,
@@ -20,12 +21,12 @@ export async function POST(request: Request): Promise<Response> {
   const body = await readBoundedBody(request)
   if (!body.success) return Response.json({ error: body.error }, { status: 413 })
   const { env } = await getCloudflareContext()
-  const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
+  const secrets = getJarvisBridgeSecrets(env)
   const organizationId = getJarvisEnvValue(env, "JARVIS_BRIDGE_ORGANIZATION_ID")
-  if (!secret || !organizationId) {
+  if (!secrets || !organizationId) {
     return Response.json({ error: "Jarvis health bridge is not configured" }, { status: 503 })
   }
-  const verification = await verifyJarvisRequest(request, secret, body.rawBody)
+  const verification = await verifyJarvisRequest(request, secrets, body.rawBody)
   if (!verification.success) {
     return Response.json({ error: verification.error }, { status: 401 })
   }

--- a/src/app/api/integrations/jarvis/replies/route.ts
+++ b/src/app/api/integrations/jarvis/replies/route.ts
@@ -11,6 +11,7 @@ import {
 import { jarvisBridgeEvents } from "@/db/schema-jarvis"
 import { getCloudflareContext } from "@/lib/db"
 import {
+  getJarvisBridgeSecrets,
   getJarvisEnvValue,
   readBoundedBody,
   verifyJarvisRequest,
@@ -79,12 +80,12 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   const { env } = await getCloudflareContext()
-  const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
+  const secrets = getJarvisBridgeSecrets(env)
   const serviceUserId = getJarvisEnvValue(
     env,
     "JARVIS_SERVICE_USER_ID",
   )
-  if (!secret || !serviceUserId) {
+  if (!secrets || !serviceUserId) {
     return Response.json(
       { error: "Jarvis reply bridge is not configured" },
       { status: 503 },
@@ -93,7 +94,7 @@ export async function POST(request: Request): Promise<Response> {
 
   const verification = await verifyJarvisRequest(
     request,
-    secret,
+    secrets,
     bodyResult.rawBody,
   )
   if (!verification.success) {

--- a/src/app/api/operations/feedback/reconcile/route.ts
+++ b/src/app/api/operations/feedback/reconcile/route.ts
@@ -1,6 +1,6 @@
 import { getCloudflareContext } from "@/lib/db"
 import {
-  getJarvisEnvValue,
+  getJarvisBridgeSecrets,
   readBoundedBody,
   verifyJarvisRequest,
 } from "@/lib/jarvis/auth"
@@ -12,13 +12,13 @@ export async function POST(request: Request): Promise<Response> {
     return Response.json({ error: body.error }, { status: 413 })
   }
   const { env } = await getCloudflareContext()
-  const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
-  if (!secret) {
+  const secrets = getJarvisBridgeSecrets(env)
+  if (!secrets) {
     return Response.json({ error: "Maintenance authentication is not configured" }, { status: 503 })
   }
   const verification = await verifyJarvisRequest(
     request,
-    secret,
+    secrets,
     body.rawBody,
   )
   if (!verification.success) {

--- a/src/app/api/operations/goto/recover-message-bodies/route.ts
+++ b/src/app/api/operations/goto/recover-message-bodies/route.ts
@@ -2,7 +2,7 @@ import { getDb } from "@/db"
 import { getCloudflareContext } from "@/lib/db"
 import { recoverLegacyGotoMessageBodies } from "@/lib/goto/message-recovery"
 import {
-  getJarvisEnvValue,
+  getJarvisBridgeSecrets,
   readBoundedBody,
   verifyJarvisRequest,
 } from "@/lib/jarvis/auth"
@@ -13,8 +13,8 @@ export async function POST(request: Request): Promise<Response> {
     return Response.json({ error: body.error }, { status: 413 })
   }
   const { env } = await getCloudflareContext()
-  const secret = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
-  if (!secret) {
+  const secrets = getJarvisBridgeSecrets(env)
+  if (!secrets) {
     return Response.json(
       { error: "Maintenance authentication is not configured" },
       { status: 503 }
@@ -22,7 +22,7 @@ export async function POST(request: Request): Promise<Response> {
   }
   const verification = await verifyJarvisRequest(
     request,
-    secret,
+    secrets,
     body.rawBody
   )
   if (!verification.success) {

--- a/src/lib/cloudflare-context.ts
+++ b/src/lib/cloudflare-context.ts
@@ -279,6 +279,7 @@ function createLocalEnv(DB: D1Database): CloudflareEnv {
 
     for (const key of [
         "JARVIS_BRIDGE_SECRET",
+        "JARVIS_BRIDGE_SECONDARY_SECRET",
         "JARVIS_BRIDGE_ORGANIZATION_ID",
         "JARVIS_SERVICE_USER_ID",
         "JARVIS_AGENT_BRIDGE_ENABLED",

--- a/src/lib/jarvis/__tests__/auth.test.ts
+++ b/src/lib/jarvis/__tests__/auth.test.ts
@@ -6,16 +6,18 @@ import {
 } from "@/lib/jarvis/auth"
 
 const SECRET = "test-bridge-secret"
+const SECONDARY_SECRET = "test-secondary-bridge-secret"
 const NOW = 1_800_000_000_000
 const TIMESTAMP = String(Math.floor(NOW / 1000))
 
 async function signedRequest(
   body: string,
   timestamp = TIMESTAMP,
+  secret = SECRET,
 ): Promise<Request> {
   const target = "/api/integrations/jarvis/events?limit=10"
   const signature = await createJarvisSignature(
-    SECRET,
+    secret,
     timestamp,
     "POST",
     target,
@@ -34,13 +36,39 @@ async function signedRequest(
 }
 
 describe("Jarvis bridge authentication", () => {
-  it("accepts an intact signed request", async () => {
+  it("accepts a request signed with the primary secret", async () => {
     const body = JSON.stringify({ source: "telegram" })
     const request = await signedRequest(body)
 
     await expect(
       verifyJarvisRequest(request, SECRET, body, NOW),
     ).resolves.toEqual({ success: true })
+  })
+
+  it("accepts a request signed with the secondary secret", async () => {
+    const body = JSON.stringify({ source: "telegram" })
+    const request = await signedRequest(body, TIMESTAMP, SECONDARY_SECRET)
+
+    await expect(
+      verifyJarvisRequest(
+        request,
+        [SECRET, SECONDARY_SECRET],
+        body,
+        NOW,
+      ),
+    ).resolves.toEqual({ success: true })
+  })
+
+  it("rejects a request signed with an unconfigured secret", async () => {
+    const body = JSON.stringify({ source: "telegram" })
+    const request = await signedRequest(body, TIMESTAMP, "invalid-secret")
+
+    await expect(
+      verifyJarvisRequest(request, [SECRET, SECONDARY_SECRET], body, NOW),
+    ).resolves.toEqual({
+      success: false,
+      error: "Invalid bridge signature",
+    })
   })
 
   it("rejects a modified request body", async () => {

--- a/src/lib/jarvis/auth.ts
+++ b/src/lib/jarvis/auth.ts
@@ -7,6 +7,8 @@ type VerificationResult =
   | { readonly success: true }
   | { readonly success: false; readonly error: string }
 
+export type JarvisBridgeSecrets = string | readonly string[]
+
 function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes)
     .map((byte) => byte.toString(16).padStart(2, "0"))
@@ -14,11 +16,12 @@ function bytesToHex(bytes: Uint8Array): string {
 }
 
 function constantTimeEqual(left: string, right: string): boolean {
-  if (left.length !== right.length) return false
-
-  let difference = 0
-  for (let index = 0; index < left.length; index += 1) {
-    difference |= left.charCodeAt(index) ^ right.charCodeAt(index)
+  const length = Math.max(left.length, right.length)
+  let difference = left.length ^ right.length
+  for (let index = 0; index < length; index += 1) {
+    const leftCode = index < left.length ? left.charCodeAt(index) : 0
+    const rightCode = index < right.length ? right.charCodeAt(index) : 0
+    difference |= leftCode ^ rightCode
   }
   return difference === 0
 }
@@ -60,7 +63,7 @@ export async function createJarvisSignature(
 
 export async function verifyJarvisRequest(
   request: Request,
-  secret: string,
+  secret: JarvisBridgeSecrets,
   rawBody: string,
   now = Date.now(),
 ): Promise<VerificationResult> {
@@ -86,15 +89,22 @@ export async function verifyJarvisRequest(
 
   const url = new URL(request.url)
   const target = `${url.pathname}${url.search}`
-  const expectedSignature = await createJarvisSignature(
-    secret,
-    timestamp,
-    request.method,
-    target,
-    rawBody,
-  )
+  const secrets = typeof secret === "string" ? [secret] : secret
+  let signatureMatches = false
+  for (const candidate of secrets) {
+    const expectedSignature = await createJarvisSignature(
+      candidate,
+      timestamp,
+      request.method,
+      target,
+      rawBody,
+    )
+    if (constantTimeEqual(expectedSignature, suppliedSignature)) {
+      signatureMatches = true
+    }
+  }
 
-  if (!constantTimeEqual(expectedSignature, suppliedSignature)) {
+  if (!signatureMatches) {
     return { success: false, error: "Invalid bridge signature" }
   }
 
@@ -136,4 +146,18 @@ export function getJarvisEnvValue(
   return typeof value === "string" && value.length > 0
     ? value
     : null
+}
+
+export function getJarvisBridgeSecrets(
+  env: CloudflareEnv,
+): readonly string[] | null {
+  const primary = getJarvisEnvValue(env, "JARVIS_BRIDGE_SECRET")
+  if (!primary) return null
+
+  const secondary = getJarvisEnvValue(
+    env,
+    "JARVIS_BRIDGE_SECONDARY_SECRET",
+  )
+  if (!secondary || secondary === primary) return [primary]
+  return [primary, secondary]
 }


### PR DESCRIPTION
## Summary
- Accept a primary and temporary secondary HMAC secret through one shared Jarvis verifier.
- Route all existing signed Jarvis integration and maintenance endpoints through the dual-secret binding.
- Add primary/secondary/invalid-signature regression coverage and document secure rollout/removal.

## Verification
- Focused Jarvis tests: passed (12 tests).
- `bun run lint`: passed with existing warnings only.
- `bun run build`: passed.
- `bun run test`: 1,047 tests passed; 5 test files fail during import because `next/cache` cannot be resolved in the local Vitest environment. No test assertions failed.

## Security notes
- No secret values are stored in source control, logs, or this PR.
- Secondary binding is documented as temporary and must be removed after rollover.