### PR TITLE
fix(estimates): restore Division 01 Sage cost codes

### DIFF
--- a/src/app/actions/project-estimates.ts
+++ b/src/app/actions/project-estimates.ts
@@ -1,10 +1,10 @@
 "use server"
 
-import { and, asc, desc, eq, inArray, ne } from "drizzle-orm"
+import { and, asc, desc, eq, like, ne } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
-import { projects, sageCostCodes } from "@/db/schema"
+import { projectBudgetLines, projects, sageCostCodes } from "@/db/schema"
 import {
   estimateTermsTemplates,
   projectEstimateBasisDocuments,
@@ -30,6 +30,10 @@ import {
   parseProjectTotalsRows,
   spreadsheetIdFromUrl,
 } from "@/lib/financials/project-totals-import"
+import {
+  projectEstimateCostCodeCatalog,
+  type ProjectEstimateCostCodeCatalogItem,
+} from "@/lib/estimates/project-cost-code-catalog"
 import { SheetsClient } from "@/lib/google/client/sheets-client"
 import {
   getGoogleConfig,
@@ -426,6 +430,44 @@ async function refreshEstimateTotals(
     .run()
 }
 
+async function loadProjectEstimateCostCodes(
+  db: CompassDb
+): Promise<readonly ProjectEstimateCostCodeCatalogItem[]> {
+  const [sageRows, namedSageRows] = await Promise.all([
+    db
+      .select()
+      .from(sageCostCodes)
+      .where(eq(sageCostCodes.active, true))
+      .orderBy(
+        asc(sageCostCodes.divisionCode),
+        asc(sageCostCodes.displayLabel)
+      ),
+    db
+      .select({
+        sourceSystem: projectBudgetLines.sourceSystem,
+        costCode: projectBudgetLines.costCode,
+        description: projectBudgetLines.description,
+        divisionName: projectBudgetLines.csiDivisionName,
+      })
+      .from(projectBudgetLines)
+      .where(
+        and(
+          eq(projectBudgetLines.sourceSystem, "sage_read_snapshot"),
+          like(projectBudgetLines.description, "01 %")
+        )
+      )
+      .groupBy(
+        projectBudgetLines.sourceSystem,
+        projectBudgetLines.costCode,
+        projectBudgetLines.description,
+        projectBudgetLines.csiDivisionName
+      )
+      .orderBy(asc(projectBudgetLines.description)),
+  ])
+
+  return projectEstimateCostCodeCatalog(sageRows, namedSageRows)
+}
+
 export async function getProjectEstimateWorkspace(
   projectId: string,
   estimateId?: string
@@ -442,7 +484,7 @@ export async function getProjectEstimateWorkspace(
     )
   const estimates = estimateRows.map(estimateSummary)
   const selected = activeEstimate(estimates, estimateId)
-  const [lineRows, basisRows, costCodeRows, taxRows, templateRows] =
+  const [lineRows, basisRows, estimateCostCodes, taxRows, templateRows] =
     await Promise.all([
       selected
         ? access.db
@@ -461,14 +503,7 @@ export async function getProjectEstimateWorkspace(
             .where(eq(projectEstimateBasisDocuments.estimateId, selected.id))
             .orderBy(asc(projectEstimateBasisDocuments.sortOrder))
         : Promise.resolve([]),
-      access.db
-        .select()
-        .from(sageCostCodes)
-        .where(eq(sageCostCodes.active, true))
-        .orderBy(
-          asc(sageCostCodes.divisionCode),
-          asc(sageCostCodes.displayLabel)
-        ),
+      loadProjectEstimateCostCodes(access.db),
       access.db
         .select()
         .from(sageTaxEntities)
@@ -509,7 +544,7 @@ export async function getProjectEstimateWorkspace(
       sortOrder: row.sortOrder,
     })),
     costCodes: [
-      ...costCodeRows.map((row) => ({
+      ...estimateCostCodes.map((row) => ({
         value: row.code,
         label: row.displayLabel,
         description: row.description,
@@ -684,18 +719,8 @@ export async function importProjectEstimateFromGoogleSheet(
     const sourceCostCodes = parsed.lines
       .filter((line) => line.divisionCode !== "99")
       .map((line) => line.costCode)
-    const activeCostCodeRows = sourceCostCodes.length > 0
-      ? await access.db
-          .select({ code: sageCostCodes.code })
-          .from(sageCostCodes)
-          .where(
-            and(
-              eq(sageCostCodes.active, true),
-              inArray(sageCostCodes.code, sourceCostCodes)
-            )
-          )
-      : []
-    const activeCostCodes = new Set(activeCostCodeRows.map((row) => row.code))
+    const costCodeCatalog = await loadProjectEstimateCostCodes(access.db)
+    const activeCostCodes = new Set(costCodeCatalog.map((row) => row.code))
     const missingCostCodes = sourceCostCodes.filter(
       (code) => !activeCostCodes.has(code)
     )
@@ -841,11 +866,10 @@ export async function importPlanSwiftEstimateLines(
       contractAdjustments.set(item.value, item)
     }
     const sourceCostCodes = [...new Set(normalizedLines.map((line) => line.costCode))]
-    const costRows = await access.db
-      .select()
-      .from(sageCostCodes)
-      .where(eq(sageCostCodes.active, true))
-    const costCodeMap = new Map(costRows.map((row) => [row.code, row]))
+    const costRows = await loadProjectEstimateCostCodes(access.db)
+    const costCodeMap = new Map(
+      costRows.map((row) => [row.code, row])
+    )
     const unknownCostCodes = sourceCostCodes.filter(
       (costCode) =>
         !costCodeMap.has(costCode) && !contractAdjustments.has(costCode)
@@ -853,7 +877,7 @@ export async function importPlanSwiftEstimateLines(
     if (unknownCostCodes.length > 0) {
       const examples = unknownCostCodes.slice(0, 5).join(", ")
       throw new Error(
-        `Map every row to an active cost code before importing. Not found: ${examples}.`
+        `Map every row to an active Sage cost code before importing. Not found: ${examples}.`
       )
     }
 
@@ -963,17 +987,8 @@ export async function saveProjectEstimateLine(
     )
     const costRows = contractAdjustment
       ? []
-      : await access.db
-          .select()
-          .from(sageCostCodes)
-          .where(
-            and(
-              eq(sageCostCodes.code, costCode),
-              eq(sageCostCodes.active, true)
-            )
-          )
-          .limit(1)
-    const cost = costRows[0]
+      : await loadProjectEstimateCostCodes(access.db)
+    const cost = costRows.find((row) => row.code === costCode)
     if (!cost && !contractAdjustment) {
       throw new Error("Choose an active Sage cost code.")
     }
@@ -1169,18 +1184,8 @@ export async function prepareProjectEstimateForFoxit(
           .map((line) => line.costCode)
       ),
     ]
-    const activeCostCodeRows = sourceCostCodes.length > 0
-      ? await access.db
-          .select({ code: sageCostCodes.code })
-          .from(sageCostCodes)
-          .where(
-            and(
-              eq(sageCostCodes.active, true),
-              inArray(sageCostCodes.code, sourceCostCodes)
-            )
-          )
-      : []
-    const activeCostCodes = new Set(activeCostCodeRows.map((row) => row.code))
+    const costCodeCatalog = await loadProjectEstimateCostCodes(access.db)
+    const activeCostCodes = new Set(costCodeCatalog.map((row) => row.code))
     const missingCostCodes = sourceCostCodes.filter(
       (code) => !activeCostCodes.has(code)
     )

--- a/src/lib/estimates/__tests__/project-cost-code-catalog.test.ts
+++ b/src/lib/estimates/__tests__/project-cost-code-catalog.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest"
+
+import { projectEstimateCostCodeCatalog } from "@/lib/estimates/project-cost-code-catalog"
+
+describe("project estimate cost-code catalog", () => {
+  it("derives Division 01 codes from Sage item names", () => {
+    const catalog = projectEstimateCostCodeCatalog([], [
+      {
+        sourceSystem: "sage_read_snapshot",
+        costCode: "1711300.000",
+        description: "01 71 13 - Mobilization",
+        divisionName: "General Requirements",
+      },
+      {
+        sourceSystem: "sage_read_snapshot",
+        costCode: "1732300.000",
+        description: "01 73 23 - Bracing & Anchoring",
+        divisionName: "General Requirements",
+      },
+    ])
+
+    expect(catalog).toEqual([
+      expect.objectContaining({
+        code: "01 71 13",
+        sourceCostCode: "1711300.000",
+        description: "Mobilization",
+        divisionCode: "01",
+        divisionDescription: "General Requirements",
+      }),
+      expect.objectContaining({
+        code: "01 73 23",
+        sourceCostCode: "1732300.000",
+        description: "Bracing & Anchoring",
+      }),
+    ])
+  })
+
+  it("keeps the primary Sage catalog authoritative for duplicate codes", () => {
+    const catalog = projectEstimateCostCodeCatalog(
+      [
+        {
+          code: "03 31 00",
+          description: "Sage concrete",
+          displayLabel: "03 31 00 Sage concrete",
+          divisionCode: "03",
+          divisionDescription: "Concrete",
+          divisionDisplayLabel: "03 · Concrete",
+        },
+      ],
+      [
+        {
+          sourceSystem: "sage_read_snapshot",
+          costCode: "3310000.000",
+          description: "03 31 00 - Project concrete",
+          divisionName: "Concrete",
+        },
+      ]
+    )
+
+    expect(catalog).toHaveLength(1)
+    expect(catalog[0]).toMatchObject({
+      description: "Sage concrete",
+      sourceCostCode: "03 31 00",
+    })
+  })
+
+  it("ignores non-Sage rows and names without a CSI code", () => {
+    const catalog = projectEstimateCostCodeCatalog([], [
+      {
+        sourceSystem: "google_drive_g703",
+        costCode: "01 71 13",
+        description: "01 71 13 - Mobilization",
+        divisionName: "General Requirements",
+      },
+      {
+        sourceSystem: "sage_read_snapshot",
+        costCode: "1711300.000",
+        description: "Mobilization",
+        divisionName: "General Requirements",
+      },
+    ])
+
+    expect(catalog).toEqual([])
+  })
+
+  it("deduplicates the same named Sage item across project snapshots", () => {
+    const row = {
+      sourceSystem: "sage_read_snapshot",
+      costCode: "1711300.000",
+      description: "01 71 13 - Mobilization",
+      divisionName: "General Requirements",
+    }
+
+    expect(projectEstimateCostCodeCatalog([], [row, row])).toHaveLength(1)
+  })
+})

--- a/src/lib/estimates/project-cost-code-catalog.ts
+++ b/src/lib/estimates/project-cost-code-catalog.ts
@@ -1,0 +1,85 @@
+export type EstimateSageCostCode = {
+  readonly code: string
+  readonly description: string
+  readonly displayLabel: string
+  readonly divisionCode: string
+  readonly divisionDescription: string
+  readonly divisionDisplayLabel: string
+}
+
+export type EstimateSageNamedCostCode = {
+  readonly sourceSystem: string
+  readonly costCode: string
+  readonly description: string
+  readonly divisionName: string
+}
+
+export type ProjectEstimateCostCodeCatalogItem = {
+  readonly code: string
+  readonly sourceCostCode: string
+  readonly description: string
+  readonly displayLabel: string
+  readonly divisionCode: string
+  readonly divisionDescription: string
+  readonly divisionDisplayLabel: string
+}
+
+const CSI_CODE_FROM_NAME =
+  /^\s*(\d{2})\s+(\d{2})\s+(\d{2})(\.\d{2})?(?:\s*[-–—]\s*|\s+)?(.*)$/
+
+function sageCodeFromName(
+  row: EstimateSageNamedCostCode
+): ProjectEstimateCostCodeCatalogItem | null {
+  if (!row.sourceSystem.toLowerCase().startsWith("sage")) return null
+
+  const match = CSI_CODE_FROM_NAME.exec(row.description)
+  if (!match) return null
+
+  const divisionCode = match[1]
+  const middleCode = match[2]
+  const finalCode = match[3]
+  if (!divisionCode || !middleCode || !finalCode) return null
+
+  const code = `${divisionCode} ${middleCode} ${finalCode}${match[4] ?? ""}`
+  const description = match[5]?.trim() || code
+  const divisionDescription = row.divisionName.trim() || "General Requirements"
+  return {
+    code,
+    sourceCostCode: row.costCode.trim(),
+    description,
+    displayLabel: `${code} ${description}`,
+    divisionCode,
+    divisionDescription,
+    divisionDisplayLabel: `${divisionCode} · ${divisionDescription}`,
+  }
+}
+
+export function projectEstimateCostCodeCatalog(
+  sageRows: readonly EstimateSageCostCode[],
+  namedSageRows: readonly EstimateSageNamedCostCode[]
+): readonly ProjectEstimateCostCodeCatalogItem[] {
+  const catalog = new Map<string, ProjectEstimateCostCodeCatalogItem>()
+
+  for (const row of sageRows) {
+    catalog.set(row.code, {
+      code: row.code,
+      sourceCostCode: row.code,
+      description: row.description,
+      displayLabel: row.displayLabel,
+      divisionCode: row.divisionCode,
+      divisionDescription: row.divisionDescription,
+      divisionDisplayLabel: row.divisionDisplayLabel,
+    })
+  }
+
+  for (const row of namedSageRows) {
+    const namedCode = sageCodeFromName(row)
+    if (!namedCode || catalog.has(namedCode.code)) continue
+    catalog.set(namedCode.code, namedCode)
+  }
+
+  return [...catalog.values()].sort((left, right) => {
+    const divisionOrder = left.divisionCode.localeCompare(right.divisionCode)
+    return divisionOrder || left.displayLabel.localeCompare(right.displayLabel)
+  })
+}


### PR DESCRIPTION
## Summary
- derive Division 01 CSI codes from Sage-origin item names because Sage numeric item IDs cannot retain a leading zero
- include those aliases in estimate combo boxes and PlanSwift/Google/manual validation
- recognize the same Sage aliases during Foxit signature validation

## Verification
- `bun run test`: 1,069 passed
- focused estimate/PlanSwift tests: 8 passed
- `bunx tsc --noEmit`
- `bun lint`: 0 errors (existing warnings only)
- `bun run build`

External autoreview was intentionally skipped at the user's request.
