### PR TITLE
fix(feedback): automate non-feature lifecycle routing

### DIFF
--- a/scripts/jarvis-feedback-notifier.py
+++ b/scripts/jarvis-feedback-notifier.py
@@ -157,6 +157,17 @@ def acknowledge(
     )
 
 
+def delivery_details(event_id: str) -> dict[str, Any]:
+    escaped_id = urllib.parse.quote(event_id, safe="")
+    response = compass_request(
+        "GET",
+        f"/api/integrations/jarvis/events/{escaped_id}/delivery",
+    )
+    if not isinstance(response, dict):
+        raise RetryableError("Compass returned invalid feedback delivery details")
+    return response
+
+
 def metadata_object(payload: dict[str, Any]) -> dict[str, Any]:
     metadata = payload.get("metadata")
     if isinstance(metadata, dict):
@@ -282,18 +293,32 @@ def deliver_event(event: dict[str, Any]) -> bool:
     ):
         raise RuntimeError("Invalid feedback lifecycle event")
 
-    message = message_text(payload)
+    details = delivery_details(event_id)
+    message_value = details.get("message")
+    if not isinstance(message_value, str) or not message_value.strip():
+        raise RuntimeError("Compass feedback delivery has no requester message")
+    message = message_value.strip()[:2_000]
+    target_details = details.get("deliveryTarget")
+    target = target_details if isinstance(target_details, dict) else {}
     if source == "telegram":
-        target = telegram_delivery_target(payload)
-        if target is None:
+        actor_id = target.get("externalActorId")
+        if not isinstance(actor_id, str) or not actor_id.strip():
             raise RuntimeError("Telegram feedback has no valid reply target")
-        send_via_hermes(target, message)
+        normalized_payload = {"reporter": {"externalActorId": actor_id}}
+        telegram_target = telegram_delivery_target(normalized_payload)
+        if telegram_target is None:
+            raise RuntimeError("Telegram feedback has no valid reply target")
+        send_via_hermes(telegram_target, message)
         return True
     if source == "jarvis-email":
-        target = reporter_email(payload)
-        if target is None:
+        email = target.get("email")
+        if not isinstance(email, str) or not email.strip():
             raise RuntimeError("Email feedback has no valid reply target")
-        send_via_hermes(f"email:{target}", message)
+        normalized_payload = {"reporter": {"email": email}}
+        email_target = reporter_email(normalized_payload)
+        if email_target is None:
+            raise RuntimeError("Email feedback has no valid reply target")
+        send_via_hermes(f"email:{email_target}", message)
         return True
     if source == "compass-conversation":
         reply_to_compass(event_id, message)

--- a/scripts/test_jarvis_feedback_notifier.py
+++ b/scripts/test_jarvis_feedback_notifier.py
@@ -33,13 +33,19 @@ class RoutingTests(unittest.TestCase):
             "id": "event-1",
             "eventType": "feedback.status_changed",
             "source": "telegram",
-            "payload": {
-                "message": "Your request was received.",
-                "reporter": {"externalActorId": "123456"},
-            },
+            "payload": {},
         }
-
-        with patch.object(MODULE, "send_via_hermes") as sender:
+        with (
+            patch.object(
+                MODULE,
+                "delivery_details",
+                return_value={
+                    "message": "Your request was received.",
+                    "deliveryTarget": {"externalActorId": "123456"},
+                },
+            ),
+            patch.object(MODULE, "send_via_hermes") as sender,
+        ):
             requires_ack = MODULE.deliver_event(event)
 
         self.assertTrue(requires_ack)
@@ -53,15 +59,20 @@ class RoutingTests(unittest.TestCase):
             "id": "event-telegram-username",
             "eventType": "feedback.status_changed",
             "source": "telegram",
-            "payload": {
-                "message": "Your request was closed.",
-                "reporter": {
-                    "externalActorId": "telegram:martinevogel"
-                },
-            },
+            "payload": {},
         }
 
-        with patch.object(MODULE, "send_via_hermes") as sender:
+        with (
+            patch.object(
+                MODULE,
+                "delivery_details",
+                return_value={
+                    "message": "Your request was closed.",
+                    "deliveryTarget": {"externalActorId": "telegram:martinevogel"},
+                },
+            ),
+            patch.object(MODULE, "send_via_hermes") as sender,
+        ):
             requires_ack = MODULE.deliver_event(event)
 
         self.assertTrue(requires_ack)
@@ -75,13 +86,20 @@ class RoutingTests(unittest.TestCase):
             "id": "event-2",
             "eventType": "feedback.status_changed",
             "source": "jarvis-email",
-            "payload": {
-                "message": "Your request is ready for testing.",
-                "reporter": {"email": "staff@example.com"},
-            },
+            "payload": {},
         }
 
-        with patch.object(MODULE, "send_via_hermes") as sender:
+        with (
+            patch.object(
+                MODULE,
+                "delivery_details",
+                return_value={
+                    "message": "Your request is ready for testing.",
+                    "deliveryTarget": {"email": "staff@example.com"},
+                },
+            ),
+            patch.object(MODULE, "send_via_hermes") as sender,
+        ):
             requires_ack = MODULE.deliver_event(event)
 
         self.assertTrue(requires_ack)
@@ -95,10 +113,17 @@ class RoutingTests(unittest.TestCase):
             "id": "event-3",
             "eventType": "feedback.status_changed",
             "source": "compass-conversation",
-            "payload": {"message": "Development has started."},
+            "payload": {},
         }
 
-        with patch.object(MODULE, "reply_to_compass") as reply:
+        with (
+            patch.object(
+                MODULE,
+                "delivery_details",
+                return_value={"message": "Development has started."},
+            ),
+            patch.object(MODULE, "reply_to_compass") as reply,
+        ):
             requires_ack = MODULE.deliver_event(event)
 
         self.assertFalse(requires_ack)

--- a/src/app/api/integrations/jarvis/events/[id]/ack/__tests__/route.test.ts
+++ b/src/app/api/integrations/jarvis/events/[id]/ack/__tests__/route.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   getDb: vi.fn(),
   getJarvisBridgeSecrets: vi.fn(),
   getJarvisEnvValue: vi.fn(),
+  applyFeedbackLifecycleUpdate: vi.fn(),
   readBoundedBody: vi.fn(),
   verifyJarvisRequest: vi.fn(),
 }))
@@ -19,6 +20,9 @@ vi.mock("@/lib/jarvis/auth", () => ({
 }))
 vi.mock("@/lib/jarvis/visual-context", () => ({
   jarvisPayloadAfterCompletion: vi.fn((payload: string) => payload),
+}))
+vi.mock("@/lib/jarvis/feedback-status-update", () => ({
+  applyFeedbackLifecycleUpdate: mocks.applyFeedbackLifecycleUpdate,
 }))
 
 import { POST } from "../route"
@@ -76,8 +80,19 @@ async function acknowledge() {
   )
 }
 
+async function acknowledgeFailure() {
+  return POST(
+    new Request("https://compass.example/api/integrations/jarvis/events/event-1/ack", {
+      method: "POST",
+      body: JSON.stringify({ status: "failed", error: "worker unavailable" }),
+    }),
+    { params: Promise.resolve({ id: "event-1" }) },
+  )
+}
+
 describe("POST /api/integrations/jarvis/events/:id/ack", () => {
   beforeEach(() => {
+    mocks.applyFeedbackLifecycleUpdate.mockReset()
     mocks.getCloudflareContext.mockResolvedValue({
       env: { DB: {}, JARVIS_BRIDGE_SECRET: "secret" },
     })
@@ -123,5 +138,22 @@ describe("POST /api/integrations/jarvis/events/:id/ack", () => {
     expect(db.set).toHaveBeenCalledWith(expect.objectContaining({
       status: "completed",
     }))
+  })
+
+  it("routes graph failures through the lifecycle so the requester is notified", async () => {
+    configureDb({ ...completeItem, status: "triaged" })
+
+    const response = await acknowledgeFailure()
+
+    expect(response.status).toBe(200)
+    expect(mocks.applyFeedbackLifecycleUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: "feedback-1" }),
+      expect.objectContaining({
+        status: "triaged",
+        deliveryRoute: "engineering",
+        deliveryGraph: expect.objectContaining({ status: "failed" }),
+      }),
+    )
   })
 })

--- a/src/app/api/integrations/jarvis/events/[id]/ack/route.ts
+++ b/src/app/api/integrations/jarvis/events/[id]/ack/route.ts
@@ -8,7 +8,10 @@ import {
   readBoundedBody,
   verifyJarvisRequest,
 } from "@/lib/jarvis/auth"
+import { knownFeedbackStatus } from "@/lib/jarvis/feedback-lifecycle"
 import { feedbackDeliveryGraphIsComplete } from "@/lib/jarvis/feedback-lifecycle-evidence"
+import { applyFeedbackLifecycleUpdate } from "@/lib/jarvis/feedback-status-update"
+import { feedbackDeliveryGraphUpdate } from "@/lib/jarvis/feedback-delivery"
 import { jarvisPayloadAfterCompletion } from "@/lib/jarvis/visual-context"
 
 const acknowledgementSchema = z.object({
@@ -102,16 +105,17 @@ export async function POST(
     return Response.json({ error: "Event not found" }, { status: 404 })
   }
 
+  const feedbackItem = existing.feedbackDeskItemId
+    ? await db.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, existing.feedbackDeskItemId))
+      .get()
+    : null
+
   if (
     existing.eventType === "feedback.delivery_requested" &&
     parsed.data.status === "completed"
   ) {
-    const item = existing.feedbackDeskItemId
-      ? await db.select().from(feedbackDeskItems)
-        .where(eq(feedbackDeskItems.id, existing.feedbackDeskItemId))
-        .get()
-      : null
-    if (!item || !feedbackDeliveryGraphIsComplete(item)) {
+    if (!feedbackItem || !feedbackDeliveryGraphIsComplete(feedbackItem)) {
       const retrySeconds = parsed.data.retryAfterSeconds ?? 60
       const retryAt = new Date(
         now.getTime() + retrySeconds * 1000,
@@ -160,14 +164,29 @@ export async function POST(
   if (
     existing.eventType === "feedback.delivery_requested" &&
     parsed.data.status === "failed" &&
-    existing.feedbackDeskItemId
+    feedbackItem
   ) {
-    await db.update(feedbackDeskItems).set({
-      deliveryGraphStatus: "failed",
-      deliveryGraphLastError: parsed.data.error ?? "Delivery worker failed",
-      deliveryGraphUpdatedAt: nowIso,
-      updatedAt: nowIso,
-    }).where(eq(feedbackDeskItems.id, existing.feedbackDeskItemId))
+    const failureIdempotencyKey = `feedback-delivery-failed:${id}`
+    const failureAlreadyReported = await db
+      .select({ id: jarvisBridgeEvents.id })
+      .from(jarvisBridgeEvents)
+      .where(eq(jarvisBridgeEvents.idempotencyKey, failureIdempotencyKey))
+      .get()
+    if (!failureAlreadyReported) {
+      const deliveryGraph = feedbackDeliveryGraphUpdate({
+          status: "failed",
+          error: parsed.data.error ?? "Delivery worker failed",
+      })
+      if (deliveryGraph) {
+        await applyFeedbackLifecycleUpdate(db, feedbackItem, {
+          status: knownFeedbackStatus(feedbackItem.status),
+          deliveryGraph,
+          deliveryRoute: "engineering",
+          actorSource: "jarvis",
+          idempotencyKey: failureIdempotencyKey,
+        })
+      }
+    }
   }
 
   return Response.json({ success: true })

--- a/src/app/api/integrations/jarvis/events/[id]/delivery/route.ts
+++ b/src/app/api/integrations/jarvis/events/[id]/delivery/route.ts
@@ -1,0 +1,101 @@
+import { and, eq } from "drizzle-orm"
+
+import { getDb } from "@/db"
+import { feedbackDeskItems, jarvisBridgeEvents } from "@/db/schema-jarvis"
+import { getCloudflareContext } from "@/lib/db"
+import {
+  getJarvisBridgeSecrets,
+  readBoundedBody,
+  verifyJarvisRequest,
+} from "@/lib/jarvis/auth"
+
+function metadataActorId(metadata: string | null): string | null {
+  if (!metadata) return null
+  try {
+    const parsed: unknown = JSON.parse(metadata)
+    if (typeof parsed !== "object" || parsed === null) return null
+    const value = Reflect.get(parsed, "externalActorId")
+    return typeof value === "string" && value.trim().length > 0
+      ? value.trim()
+      : null
+  } catch {
+    return null
+  }
+}
+
+function eventMessage(payload: string): string {
+  try {
+    const parsed: unknown = JSON.parse(payload)
+    if (typeof parsed !== "object" || parsed === null) {
+      return "Your Compass request has a new update."
+    }
+    const value = Reflect.get(parsed, "message")
+    return typeof value === "string" && value.trim().length > 0
+      ? value.trim().slice(0, 2_000)
+      : "Your Compass request has a new update."
+  } catch {
+    return "Your Compass request has a new update."
+  }
+}
+
+export async function GET(
+  request: Request,
+  { params }: { readonly params: Promise<{ readonly id: string }> },
+): Promise<Response> {
+  const bodyResult = await readBoundedBody(request)
+  if (!bodyResult.success) {
+    return Response.json({ error: bodyResult.error }, { status: 413 })
+  }
+  const { env } = await getCloudflareContext()
+  const secrets = getJarvisBridgeSecrets(env)
+  if (!secrets) {
+    return Response.json({ error: "Jarvis bridge is not configured" }, { status: 503 })
+  }
+  const verification = await verifyJarvisRequest(
+    request,
+    secrets,
+    bodyResult.rawBody,
+  )
+  if (!verification.success) {
+    return Response.json({ error: verification.error }, { status: 401 })
+  }
+
+  const { id } = await params
+  const db = getDb(env.DB)
+  const event = await db
+    .select({
+      source: jarvisBridgeEvents.source,
+      eventType: jarvisBridgeEvents.eventType,
+      payload: jarvisBridgeEvents.payload,
+      feedbackDeskItemId: jarvisBridgeEvents.feedbackDeskItemId,
+    })
+    .from(jarvisBridgeEvents)
+    .where(and(
+      eq(jarvisBridgeEvents.id, id),
+      eq(jarvisBridgeEvents.direction, "outbound"),
+      eq(jarvisBridgeEvents.eventType, "feedback.status_changed"),
+    ))
+    .get()
+  if (!event?.feedbackDeskItemId) {
+    return Response.json({ error: "Feedback delivery event not found" }, { status: 404 })
+  }
+
+  const item = await db
+    .select({ reporterEmail: feedbackDeskItems.reporterEmail, metadata: feedbackDeskItems.metadata })
+    .from(feedbackDeskItems)
+    .where(eq(feedbackDeskItems.id, event.feedbackDeskItemId))
+    .get()
+  if (!item) {
+    return Response.json({ error: "Feedback request not found" }, { status: 404 })
+  }
+
+  return Response.json({
+    eventType: event.eventType,
+    source: event.source,
+    message: eventMessage(event.payload),
+    deliveryTarget: {
+      externalActorId: metadataActorId(item.metadata),
+      email: item.reporterEmail?.trim().toLowerCase() ?? null,
+    },
+  })
+}

--- a/src/app/api/integrations/jarvis/feedback/[id]/status/__tests__/route.test.ts
+++ b/src/app/api/integrations/jarvis/feedback/[id]/status/__tests__/route.test.ts
@@ -46,6 +46,14 @@ function configureDb() {
   })
 }
 
+function configureDuplicateDb() {
+  const get = vi.fn().mockResolvedValue({ id: "inbound-duplicate" })
+  const chain = { from: vi.fn(), where: vi.fn(), get }
+  chain.from.mockReturnValue(chain)
+  chain.where.mockReturnValue(chain)
+  mocks.getDb.mockReturnValue({ select: vi.fn().mockReturnValue(chain) })
+}
+
 describe("POST /api/integrations/jarvis/feedback/:id/status", () => {
   beforeEach(() => {
     configureDb()
@@ -82,6 +90,21 @@ describe("POST /api/integrations/jarvis/feedback/:id/status", () => {
     await expect(response.json()).resolves.toEqual({
       error: "A bug must have a complete durable delivery graph before implementation starts",
     })
+    expect(mocks.applyFeedbackLifecycleUpdate).not.toHaveBeenCalled()
+  })
+
+  it("does not publish a second requester update for an idempotent retry", async () => {
+    configureDuplicateDb()
+    const response = await POST(
+      new Request("https://compass.example/api/integrations/jarvis/feedback/feedback-1/status", {
+        method: "POST",
+        body: JSON.stringify({ idempotencyKey: "callback-1", status: "triaged" }),
+      }),
+      { params: Promise.resolve({ id: "feedback-1" }) },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ success: true, duplicate: true })
     expect(mocks.applyFeedbackLifecycleUpdate).not.toHaveBeenCalled()
   })
 

--- a/src/app/api/integrations/jarvis/feedback/[id]/status/route.ts
+++ b/src/app/api/integrations/jarvis/feedback/[id]/status/route.ts
@@ -12,8 +12,13 @@ import {
 } from "@/lib/jarvis/auth"
 import { FEEDBACK_DESK_STATUSES } from "@/lib/jarvis/feedback-lifecycle"
 import { applyFeedbackLifecycleUpdate } from "@/lib/jarvis/feedback-status-update"
-import { feedbackDeliveryGraphUpdate } from "@/lib/jarvis/feedback-delivery"
-import { feedbackBugTransitionIsBlocked } from "@/lib/jarvis/feedback-lifecycle-evidence"
+import {
+  feedbackDeliveryGraphUpdate,
+  feedbackDeliveryRoute,
+} from "@/lib/jarvis/feedback-delivery"
+import {
+  feedbackEngineeringTransitionIsBlocked,
+} from "@/lib/jarvis/feedback-lifecycle-evidence"
 
 const statusUpdateSchema = z.object({
   idempotencyKey: z.string().min(1).max(256),
@@ -42,6 +47,7 @@ const statusUpdateSchema = z.object({
     releaseTaskId: z.string().min(1).max(256).optional(),
     error: z.string().max(2_000).optional(),
   }).optional(),
+  deliveryRoute: z.enum(["engineering", "response"]).optional(),
 })
 
 export async function POST(
@@ -116,15 +122,17 @@ export async function POST(
   if (!item) {
     return Response.json({ error: "Feedback request not found" }, { status: 404 })
   }
-  if (deliveryGraph && (item.kind !== "bug" || item.status !== "triaged")) {
+  const deliveryRoute = parsed.data.deliveryRoute ?? feedbackDeliveryRoute(item)
+  if (deliveryGraph && (deliveryRoute !== "engineering" || item.status !== "triaged")) {
     return Response.json(
-      { error: "Only an already-triaged bug can receive a delivery graph" },
+      { error: "Only an already-triaged engineering request can receive a delivery graph" },
       { status: 409 },
     )
   }
-  const evidenceError = feedbackBugTransitionIsBlocked({
+  const evidenceError = feedbackEngineeringTransitionIsBlocked({
     ...item,
     nextStatus: parsed.data.status,
+    deliveryRoute,
     githubDraftPullRequestUrl:
       parsed.data.draftPullRequestUrl === undefined
         ? item.githubDraftPullRequestUrl
@@ -143,6 +151,7 @@ export async function POST(
       githubIssueUrl: parsed.data.githubIssueUrl,
       draftPullRequestUrl: parsed.data.draftPullRequestUrl,
       deliveryGraph,
+      deliveryRoute,
       actorSource: "signet",
       idempotencyKey: eventKey,
     })

--- a/src/app/api/integrations/jarvis/replies/route.ts
+++ b/src/app/api/integrations/jarvis/replies/route.ts
@@ -8,7 +8,10 @@ import {
   channels,
   messages,
 } from "@/db/schema-conversations"
-import { jarvisBridgeEvents } from "@/db/schema-jarvis"
+import {
+  feedbackDeskItems,
+  jarvisBridgeEvents,
+} from "@/db/schema-jarvis"
 import { getCloudflareContext } from "@/lib/db"
 import {
   getJarvisBridgeSecrets,
@@ -125,6 +128,7 @@ export async function POST(request: Request): Promise<Response> {
       eventType: jarvisBridgeEvents.eventType,
       source: jarvisBridgeEvents.source,
       payload: jarvisBridgeEvents.payload,
+      feedbackDeskItemId: jarvisBridgeEvents.feedbackDeskItemId,
     })
     .from(jarvisBridgeEvents)
     .where(
@@ -156,7 +160,26 @@ export async function POST(request: Request): Promise<Response> {
     )
   }
 
-  const target = replyTarget(sourceEvent.payload)
+  const feedbackItem = sourceEvent.feedbackDeskItemId
+    ? await db
+      .select({
+        organizationId: feedbackDeskItems.organizationId,
+        channelId: feedbackDeskItems.channelId,
+        messageId: feedbackDeskItems.messageId,
+      })
+      .from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, sourceEvent.feedbackDeskItemId))
+      .get()
+    : null
+  const target = sourceEvent.eventType === "feedback.status_changed"
+    ? feedbackItem?.organizationId && feedbackItem.channelId && feedbackItem.messageId
+      ? {
+          organizationId: feedbackItem.organizationId,
+          channelId: feedbackItem.channelId,
+          messageId: feedbackItem.messageId,
+        }
+      : null
+    : replyTarget(sourceEvent.payload)
   if (!target) {
     return Response.json(
       { error: "Request has no Compass reply target" },

--- a/src/lib/jarvis/__tests__/feedback-lifecycle-evidence.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-lifecycle-evidence.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   feedbackBugTransitionIsBlocked,
   feedbackDeliveryGraphIsComplete,
+  feedbackEngineeringTransitionIsBlocked,
 } from "@/lib/jarvis/feedback-lifecycle-evidence"
 
 const completeGraph = {
@@ -89,5 +90,27 @@ describe("Feedback Desk lifecycle evidence", () => {
       deliveryGraphStatus: null,
       githubDraftPullRequestUrl: null,
     })).toBeNull()
+  })
+
+  it("applies the same evidence gates to an explicitly engineering-required question", () => {
+    expect(feedbackEngineeringTransitionIsBlocked({
+      kind: "question",
+      status: "triaged",
+      nextStatus: "in_progress",
+      deliveryRoute: "engineering",
+      ...completeGraph,
+      githubDraftPullRequestUrl: null,
+    })).toBeNull()
+    expect(feedbackEngineeringTransitionIsBlocked({
+      kind: "question",
+      status: "triaged",
+      nextStatus: "in_progress",
+      deliveryRoute: "engineering",
+      ...completeGraph,
+      deliveryGraphImplementationTaskId: null,
+      githubDraftPullRequestUrl: null,
+    })).toBe(
+      "An engineering request must have a complete durable delivery graph before implementation starts",
+    )
   })
 })

--- a/src/lib/jarvis/__tests__/feedback-nonfeature-lifecycle.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-nonfeature-lifecycle.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  feedbackDeliveryGraphEvent,
+  feedbackDeliveryRoute,
+  feedbackResponseClosure,
+  shouldRequestFeedbackDeliveryGraph,
+} from "@/lib/jarvis/feedback-delivery"
+import {
+  feedbackNonEngineeringTransitionIsBlocked,
+  feedbackStatusMessage,
+} from "@/lib/jarvis/feedback-lifecycle"
+import { feedbackRequesterUpdateKind } from "@/lib/jarvis/feedback-lifecycle"
+import { feedbackTimeline } from "@/lib/jarvis/feedback-timeline"
+
+const requestId = "feedback-opaque-1"
+
+ describe("Feedback Desk non-feature lifecycle routing", () => {
+  it("routes bug reports to engineering and other confirmed non-features to response handling", () => {
+    expect(feedbackDeliveryRoute({ kind: "bug" })).toBe("engineering")
+    expect(feedbackDeliveryRoute({ kind: "question" })).toBe("response")
+    expect(feedbackDeliveryRoute({ kind: "assistance" })).toBe("response")
+    expect(feedbackDeliveryRoute({ kind: "general" })).toBe("response")
+    expect(feedbackDeliveryRoute({ kind: "feature" })).toBe("feature_decision")
+  })
+
+  it("allows an explicitly engineering-required question to use the delivery graph", () => {
+    const item = { id: requestId, kind: "question", status: "new" } as const
+    expect(feedbackDeliveryRoute({ ...item, requiresEngineering: true })).toBe("engineering")
+    expect(shouldRequestFeedbackDeliveryGraph(item, "triaged", "engineering")).toBe(true)
+  })
+
+  it("keeps response-only requests out of implementation and deployment statuses", () => {
+    for (const status of ["planned", "in_progress", "testing", "deployed"]) {
+      expect(feedbackNonEngineeringTransitionIsBlocked({
+        kind: "question",
+        status: "triaged",
+        nextStatus: status,
+        deliveryRoute: "response",
+      })).toBe("A response-only request cannot enter an engineering lifecycle")
+    }
+    expect(feedbackNonEngineeringTransitionIsBlocked({
+      kind: "question",
+      status: "triaged",
+      nextStatus: "closed",
+      deliveryRoute: "response",
+    })).toBeNull()
+  })
+
+  it("builds a deterministic accountable closure without claiming deployment", () => {
+    expect(feedbackResponseClosure({
+      id: requestId,
+      kind: "assistance",
+      status: "triaged",
+    })).toEqual({
+      status: "closed",
+      message: "The Feedback Desk reviewed this request and provided an accountable response. No Compass code change was required.",
+    })
+    expect(feedbackStatusMessage("closed", "private request", "question")).toContain(
+      "No Compass code change was required",
+    )
+    expect(feedbackStatusMessage("closed", "private request", "question")).not.toContain(
+      "private request",
+    )
+  })
+
+  it("uses one opaque, idempotent graph request for each engineering-required item", () => {
+    const event = feedbackDeliveryGraphEvent({
+      id: requestId,
+      kind: "question",
+      status: "new",
+      title: "private title",
+      description: "private description",
+      reporterEmail: "private@example.com",
+      channelId: "private-channel",
+    })
+    expect(event.idempotencyKey).toBe(`feedback-delivery-graph:${requestId}`)
+    expect(event.payload).toEqual({
+      schemaVersion: 1,
+      feedbackDeskItemId: requestId,
+      reference: `CFD-${requestId}`,
+      kind: "question",
+    })
+    expect(JSON.stringify(event)).not.toContain("private title")
+    expect(JSON.stringify(event)).not.toContain("private description")
+    expect(JSON.stringify(event)).not.toContain("private@example.com")
+    expect(JSON.stringify(event)).not.toContain("private-channel")
+  })
+
+  it("publishes requester updates for graph creation and failure milestones", () => {
+    expect(feedbackRequesterUpdateKind("triaged", "triaged", null, null, "created")).toBe(
+      "delivery_graph_created",
+    )
+    expect(feedbackRequesterUpdateKind("triaged", "triaged", null, null, "failed")).toBe(
+      "delivery_graph_failed",
+    )
+  })
+
+  it("shows graph milestones in the protected My Requests timeline", () => {
+    const timeline = feedbackTimeline(
+      {
+        title: "Private request",
+        status: "triaged",
+        createdAt: "2026-08-21T12:00:00.000Z",
+      },
+      [{
+        eventType: "feedback.status_updated",
+        payload: "{}",
+        result: JSON.stringify({
+          status: "triaged",
+          notificationKind: "delivery_graph_created",
+          message: "Engineering work has been set up.",
+          updatedAt: "2026-08-21T12:01:00.000Z",
+        }),
+        createdAt: "2026-08-21T12:01:00.000Z",
+        completedAt: "2026-08-21T12:01:00.000Z",
+      }],
+    )
+    expect(timeline).toHaveLength(2)
+    expect(timeline[1]).toMatchObject({
+      label: "Engineering work set up",
+      message: "Engineering work has been set up.",
+    })
+  })
+})

--- a/src/lib/jarvis/feedback-delivery.ts
+++ b/src/lib/jarvis/feedback-delivery.ts
@@ -8,6 +8,40 @@ export type FeedbackDeliveryGraphItem = Readonly<{
   channelId?: string | null
 }>
 
+export type FeedbackDeliveryRoute =
+  | "engineering"
+  | "response"
+  | "feature_decision"
+
+export type FeedbackResponseClosure = Readonly<{
+  status: "closed"
+  message: string
+}>
+
+export function feedbackDeliveryRoute(
+  item: Readonly<{
+    kind: string
+    requiresEngineering?: boolean
+  }>,
+): FeedbackDeliveryRoute {
+  if (item.kind === "feature") return "feature_decision"
+  if (item.kind === "bug" || item.requiresEngineering === true) {
+    return "engineering"
+  }
+  return "response"
+}
+
+export function feedbackResponseClosure(
+  item: Pick<FeedbackDeliveryGraphItem, "id" | "kind" | "status">,
+): FeedbackResponseClosure {
+  void item
+  return {
+    status: "closed",
+    message:
+      "The Feedback Desk reviewed this request and provided an accountable response. No Compass code change was required.",
+  }
+}
+
 export type FeedbackDeliveryGraphEvent = Readonly<{
   eventType: "feedback.delivery_requested"
   idempotencyKey: string
@@ -15,7 +49,7 @@ export type FeedbackDeliveryGraphEvent = Readonly<{
     schemaVersion: 1
     feedbackDeskItemId: string
     reference: string
-    kind: "bug"
+    kind: string
   }>
 }>
 
@@ -31,8 +65,9 @@ export type FeedbackDeliveryGraphUpdate = Readonly<{
 export function shouldRequestFeedbackDeliveryGraph(
   item: Pick<FeedbackDeliveryGraphItem, "kind" | "status">,
   nextStatus: string,
+  route?: FeedbackDeliveryRoute,
 ): boolean {
-  return item.kind === "bug" &&
+  return (route ?? feedbackDeliveryRoute(item)) === "engineering" &&
     item.status !== "triaged" &&
     nextStatus === "triaged"
 }
@@ -47,7 +82,7 @@ export function feedbackDeliveryGraphEvent(
       schemaVersion: 1,
       feedbackDeskItemId: item.id,
       reference: `CFD-${item.id}`,
-      kind: "bug",
+      kind: item.kind,
     },
   }
 }

--- a/src/lib/jarvis/feedback-lifecycle-evidence.ts
+++ b/src/lib/jarvis/feedback-lifecycle-evidence.ts
@@ -13,6 +13,10 @@ type FeedbackBugTransition = FeedbackLifecycleEvidenceItem & Readonly<{
   nextStatus: string
 }>
 
+type FeedbackEngineeringTransition = FeedbackBugTransition & Readonly<{
+  deliveryRoute: "engineering" | "response" | "feature_decision"
+}>
+
 function present(value: string | null): boolean {
   return value !== null && value.trim().length > 0
 }
@@ -36,38 +40,53 @@ export function feedbackDeliveryGraphIsComplete(
   )
 }
 
-export function feedbackBugTransitionIsBlocked(
-  transition: FeedbackBugTransition,
+export function feedbackEngineeringTransitionIsBlocked(
+  transition: FeedbackEngineeringTransition,
 ): string | null {
-  if (transition.kind !== "bug" || transition.status === transition.nextStatus) {
+  if (
+    transition.kind === "feature" ||
+    transition.deliveryRoute !== "engineering" ||
+    transition.status === transition.nextStatus
+  ) {
     return null
   }
+
+  const subject = transition.kind === "bug" ? "A bug" : "An engineering request"
 
   if (transition.nextStatus === "planned") {
     return feedbackDeliveryGraphIsComplete(transition)
       ? null
-      : "A bug must have a complete durable delivery graph before it is planned"
+      : `${subject} must have a complete durable delivery graph before it is planned`
   }
 
   if (transition.nextStatus === "in_progress") {
     return feedbackDeliveryGraphIsComplete(transition)
       ? null
-      : "A bug must have a complete durable delivery graph before implementation starts"
+      : `${subject} must have a complete durable delivery graph before implementation starts`
   }
 
   if (transition.nextStatus === "testing") {
     return feedbackDeliveryGraphIsComplete(transition) &&
       present(transition.githubDraftPullRequestUrl)
       ? null
-      : "A bug must have a pull request and complete durable review evidence before testing"
+      : `${subject} must have a pull request and complete durable review evidence before testing`
   }
 
   if (transition.nextStatus === "deployed") {
     return feedbackDeliveryGraphIsComplete(transition) &&
       present(transition.githubDraftPullRequestUrl)
       ? null
-      : "A bug must have a pull request and complete durable release evidence before deployment"
+      : `${subject} must have a pull request and complete durable release evidence before deployment`
   }
 
   return null
+}
+
+export function feedbackBugTransitionIsBlocked(
+  transition: FeedbackBugTransition,
+): string | null {
+  return feedbackEngineeringTransitionIsBlocked({
+    ...transition,
+    deliveryRoute: "engineering",
+  })
 }

--- a/src/lib/jarvis/feedback-lifecycle.ts
+++ b/src/lib/jarvis/feedback-lifecycle.ts
@@ -33,13 +33,18 @@ export type FeedbackRequesterUpdateKind =
   | "status_changed"
   | "draft_pull_request_opened"
   | "draft_pull_request_updated"
+  | "delivery_graph_created"
+  | "delivery_graph_failed"
 
 export function feedbackRequesterUpdateKind(
   previousStatus: string,
   nextStatus: string,
   previousDraftPullRequestUrl: string | null,
   nextDraftPullRequestUrl: string | null,
+  deliveryGraphStatus: "created" | "failed" | null = null,
 ): FeedbackRequesterUpdateKind | null {
+  if (deliveryGraphStatus === "created") return "delivery_graph_created"
+  if (deliveryGraphStatus === "failed") return "delivery_graph_failed"
   if (
     nextDraftPullRequestUrl !== null &&
     nextDraftPullRequestUrl !== previousDraftPullRequestUrl
@@ -97,8 +102,12 @@ export function feedbackStaffStage(status: string): FeedbackStaffStage {
 
 export function feedbackStatusMessage(
   status: FeedbackDeskStatus,
-  title: string
+  title: string,
+  kind = "bug",
 ): string {
+  if (kind !== "bug" && status === "closed") {
+    return "The Feedback Desk reviewed this request and provided an accountable response. No Compass code change was required."
+  }
   switch (status) {
     case "new":
       return `Your request “${title}” has been received.`
@@ -117,6 +126,23 @@ export function feedbackStatusMessage(
     case "closed":
       return `Your request “${title}” has been completed and closed.`
   }
+}
+
+export function feedbackNonEngineeringTransitionIsBlocked(
+  transition: Readonly<{
+    kind: string
+    status: string
+    nextStatus: string
+    deliveryRoute: "engineering" | "response" | "feature_decision"
+  }>,
+): string | null {
+  if (transition.kind === "feature" || transition.deliveryRoute !== "response") {
+    return null
+  }
+  if (["planned", "in_progress", "testing", "deployed"].includes(transition.nextStatus)) {
+    return "A response-only request cannot enter an engineering lifecycle"
+  }
+  return null
 }
 
 export function feedbackDraftPullRequestMessage(

--- a/src/lib/jarvis/feedback-maintenance.ts
+++ b/src/lib/jarvis/feedback-maintenance.ts
@@ -23,6 +23,7 @@ import { feedbackFeatureGithubIssueCreationIsBlocked } from "@/lib/jarvis/feedba
 import { githubFeedbackIssueContent } from "@/lib/jarvis/feedback-github-content"
 import { syncFeedbackDeskItemsFromGithub } from "@/lib/jarvis/feedback-github-sync"
 import { feedbackDeliveryGraphEvent } from "@/lib/jarvis/feedback-delivery"
+import { applyFeedbackLifecycleUpdate } from "@/lib/jarvis/feedback-status-update"
 import {
   feedbackIsResolved,
   feedbackSlaTarget,
@@ -37,6 +38,7 @@ export type FeedbackMaintenanceResult = Readonly<{
   missingLinkReviewCount: number
   syncedCount: number
   deliveryRequestedCount: number
+  responseClosedCount: number
   scrubbedCount: number
   slaBackfilledCount: number
   failedCount: number
@@ -267,6 +269,36 @@ async function ensureFeedbackDeliveryGraphRequests(
   return requestedCount
 }
 
+async function ensureFeedbackResponseClosures(
+  db: CompassDb,
+  items: readonly FeedbackDeskItem[],
+): Promise<number> {
+  let closedCount = 0
+  for (const item of items) {
+    if (
+      item.kind === "bug" ||
+      item.kind === "feature" ||
+      item.status !== "triaged"
+    ) continue
+    const engineeringRequest = await db.select({ id: jarvisBridgeEvents.id })
+      .from(jarvisBridgeEvents)
+      .where(and(
+        eq(jarvisBridgeEvents.feedbackDeskItemId, item.id),
+        eq(jarvisBridgeEvents.eventType, "feedback.delivery_requested"),
+      ))
+      .get()
+    if (engineeringRequest) continue
+    const result = await applyFeedbackLifecycleUpdate(db, item, {
+      status: "closed",
+      assignedToName: item.assignedToName ?? "Feedback Desk",
+      actorSource: "feedback-maintenance",
+      idempotencyKey: `feedback-response-closure:${item.id}`,
+    })
+    if (result.changed) closedCount += 1
+  }
+  return closedCount
+}
+
 export async function recordFeedbackServiceHealth(
   db: CompassDb,
   input: Readonly<{
@@ -367,6 +399,10 @@ export async function runFeedbackMaintenance(
           ...item,
           slaTargetAt: feedbackSlaTarget(item.priority, new Date(item.createdAt)),
         })
+    const responseClosedCount = await ensureFeedbackResponseClosures(
+      db,
+      itemsWithSla,
+    )
     const deliveryRequestedCount = await ensureFeedbackDeliveryGraphRequests(
       db,
       itemsWithSla,
@@ -385,6 +421,7 @@ export async function runFeedbackMaintenance(
       missingLinkReviewCount,
       syncedCount,
       deliveryRequestedCount,
+      responseClosedCount,
       scrubbedCount: privacy.scrubbed,
       slaBackfilledCount,
       failedCount,
@@ -395,7 +432,7 @@ export async function runFeedbackMaintenance(
       processedCount: result.processedCount,
       updatedCount:
         recoveredCount + linkedCount + syncedCount + privacy.scrubbed +
-        slaBackfilledCount + deliveryRequestedCount,
+        slaBackfilledCount + deliveryRequestedCount + responseClosedCount,
       failedCount,
       summary: JSON.stringify(result),
       completedAt,

--- a/src/lib/jarvis/feedback-status-update.ts
+++ b/src/lib/jarvis/feedback-status-update.ts
@@ -15,15 +15,21 @@ import {
   feedbackStatusLabel,
   feedbackStatusMessage,
   feedbackStatusUsesEmail,
+  feedbackNonEngineeringTransitionIsBlocked,
   type FeedbackDeskStatus,
 } from "@/lib/jarvis/feedback-lifecycle"
 import { feedbackFeatureTransitionIsBlocked } from "@/lib/jarvis/feedback-feature-priority"
 import {
   feedbackDeliveryGraphEvent,
+  feedbackDeliveryRoute,
+  feedbackResponseClosure,
   shouldRequestFeedbackDeliveryGraph,
   type FeedbackDeliveryGraphUpdate,
+  type FeedbackDeliveryRoute,
 } from "@/lib/jarvis/feedback-delivery"
-import { feedbackBugTransitionIsBlocked } from "@/lib/jarvis/feedback-lifecycle-evidence"
+import {
+  feedbackEngineeringTransitionIsBlocked,
+} from "@/lib/jarvis/feedback-lifecycle-evidence"
 import { createSystemNotificationEvent } from "@/lib/notifications/events"
 
 type CompassDb = ReturnType<typeof getDb>
@@ -86,6 +92,7 @@ export type FeedbackLifecycleUpdate = Readonly<{
   githubIssueNodeId?: string | null
   draftPullRequestUrl?: string | null
   deliveryGraph?: FeedbackDeliveryGraphUpdate
+  deliveryRoute?: FeedbackDeliveryRoute
   assignedToUserId?: string | null
   assignedToName?: string | null
   actorSource: string
@@ -101,6 +108,14 @@ export async function applyFeedbackLifecycleUpdate(
   notifiedUserCount: number
   requesterUpdateQueued: boolean
 }>> {
+  const duplicate = await db
+    .select({ id: jarvisBridgeEvents.id })
+    .from(jarvisBridgeEvents)
+    .where(eq(jarvisBridgeEvents.idempotencyKey, update.idempotencyKey))
+    .get()
+  if (duplicate) {
+    return { changed: false, notifiedUserCount: 0, requesterUpdateQueued: false }
+  }
   if (feedbackFeatureTransitionIsBlocked({
     currentStatus: item.status,
     featurePriorityApprovedAt: item.featurePriorityApprovedAt,
@@ -152,7 +167,19 @@ export async function applyFeedbackLifecycleUpdate(
   const deliveryGraphUpdatedAt = update.deliveryGraph
     ? new Date().toISOString()
     : item.deliveryGraphUpdatedAt
-  const evidenceError = feedbackBugTransitionIsBlocked({
+  const deliveryRoute = update.deliveryRoute ?? (
+    item.deliveryGraphId !== null
+      ? "engineering"
+      : feedbackDeliveryRoute(item)
+  )
+  const nonEngineeringError = feedbackNonEngineeringTransitionIsBlocked({
+    kind: item.kind,
+    status: item.status,
+    nextStatus: update.status,
+    deliveryRoute,
+  })
+  if (nonEngineeringError) throw new Error(nonEngineeringError)
+  const evidenceError = feedbackEngineeringTransitionIsBlocked({
     kind: item.kind,
     status: item.status,
     nextStatus: update.status,
@@ -162,6 +189,7 @@ export async function applyFeedbackLifecycleUpdate(
     deliveryGraphReviewTaskId,
     deliveryGraphReleaseTaskId,
     githubDraftPullRequestUrl: draftUrl,
+    deliveryRoute,
   })
   if (evidenceError) throw new Error(evidenceError)
   const lifecycleUpdateKind = feedbackRequesterUpdateKind(
@@ -169,6 +197,7 @@ export async function applyFeedbackLifecycleUpdate(
     update.status,
     item.githubDraftPullRequestUrl,
     draftUrl,
+    update.deliveryGraph?.status ?? null,
   )
   const requesterUpdateKind = lifecycleUpdateKind ?? (
     update.message?.trim() ? "status_changed" : null
@@ -200,10 +229,25 @@ export async function applyFeedbackLifecycleUpdate(
   const priorityChanged = item.priority !== priority
   const hasDraftUpdate = draftUrl !== null && draftUrl !== item.githubDraftPullRequestUrl
   const message = update.message ?? (
-    hasDraftUpdate
-      ? feedbackDraftPullRequestMessage(item.title, draftUrl)
-      : feedbackStatusMessage(update.status, item.title)
+    update.deliveryGraph?.status === "created"
+      ? `Engineering work for “${item.title}” has been set up with implementation, review, and release accountability.`
+      : update.deliveryGraph?.status === "failed"
+        ? `Engineering work for “${item.title}” could not be set up yet and will be retried.`
+        : hasDraftUpdate
+          ? feedbackDraftPullRequestMessage(item.title, draftUrl)
+          : deliveryRoute === "response" && update.status === "closed"
+            ? feedbackResponseClosure({
+                id: item.id,
+                kind: item.kind,
+                status: item.status,
+              }).message
+            : feedbackStatusMessage(update.status, item.title, item.kind)
   )
+  const eventMessage = requesterUpdateKind === "delivery_graph_created"
+    ? "Your Compass request now has accountable engineering work."
+    : requesterUpdateKind === "delivery_graph_failed"
+      ? "Your Compass request could not enter engineering work yet and will be retried."
+      : `Your Compass request was updated: ${feedbackStatusLabel(update.status)}.`
 
   const updateStatement = db.update(feedbackDeskItems).set({
     status: update.status,
@@ -238,26 +282,9 @@ export async function applyFeedbackLifecycleUpdate(
   const payload = JSON.stringify({
     schemaVersion: 1,
     feedbackDeskItemId: item.id,
-    source: item.source,
-    sourceId: item.sourceId,
     status: update.status,
-    title: item.title,
-    message,
-    reporter: {
-      name: item.reporterName,
-      email: item.reporterEmail,
-      externalActorId: metadataActorId(item.metadata),
-    },
-    compass: {
-      organizationId: item.organizationId,
-      channelId: item.channelId,
-      messageId: item.messageId,
-      threadId: item.threadId,
-    },
-    metadata: item.metadata,
-    githubIssueUrl: issueUrl,
-    draftPullRequestUrl: draftUrl,
     notificationKind: requesterUpdateKind,
+    message: eventMessage,
     updatedAt: now,
   })
   const inboundStatement = db.insert(jarvisBridgeEvents).values({
@@ -276,7 +303,11 @@ export async function applyFeedbackLifecycleUpdate(
     createdAt: now,
     updatedAt: now,
   }).onConflictDoNothing()
-  const deliveryEvent = shouldRequestFeedbackDeliveryGraph(item, update.status)
+  const deliveryEvent = shouldRequestFeedbackDeliveryGraph(
+    item,
+    update.status,
+    deliveryRoute,
+  )
     ? feedbackDeliveryGraphEvent(item)
     : null
   const deliveryStatement = deliveryEvent

--- a/src/lib/jarvis/feedback-timeline.ts
+++ b/src/lib/jarvis/feedback-timeline.ts
@@ -44,6 +44,16 @@ function recordString(
     : null
 }
 
+function timelineLabel(status: string, notificationKind: string | null): string {
+  if (notificationKind === "delivery_graph_created") {
+    return "Engineering work set up"
+  }
+  if (notificationKind === "delivery_graph_failed") {
+    return "Engineering work retrying"
+  }
+  return feedbackStatusLabel(status)
+}
+
 export function feedbackTimeline(
   item: FeedbackTimelineItem,
   events: readonly FeedbackTimelineEvent[],
@@ -63,6 +73,7 @@ export function feedbackTimeline(
     const data = recordFromJson(event.result) ?? recordFromJson(event.payload)
     const status = recordString(data, "status")
     if (!status) continue
+    const notificationKind = recordString(data, "notificationKind")
     const message =
       recordString(data, "message") ??
       `Request status changed to ${feedbackStatusLabel(status)}.`
@@ -74,7 +85,7 @@ export function feedbackTimeline(
     entries.push({
       id: `${event.eventType}:${occurredAt}:${status}`,
       status,
-      label: feedbackStatusLabel(status),
+      label: timelineLabel(status, notificationKind),
       message,
       occurredAt,
     })


### PR DESCRIPTION
## Summary
- Route non-feature Feedback Desk requests through accountable response or engineering handling without weakening feature-priority gates.
- Add idempotent non-feature delivery-graph creation, lifecycle evidence gates, requester timeline milestones, and signed graph-failure lifecycle updates.
- Keep persisted bridge payloads opaque; resolve requester delivery targets through a signed protected endpoint.

## Issue
Fixes #464

## Verification
- `bunx tsc --noEmit` ✅
- `bun run lint` ✅ (existing warnings only)
- `bun run build` ✅
- `bun run test -- src/lib/jarvis/__tests__/feedback-nonfeature-lifecycle.test.ts src/lib/jarvis/__tests__/feedback-lifecycle-evidence.test.ts src/app/api/integrations/jarvis/feedback/[id]/status/__tests__/route.test.ts src/app/api/integrations/jarvis/events/[id]/ack/__tests__/route.test.ts` ✅ (23 tests)
- `python3 -m unittest scripts/test_jarvis_feedback_notifier.py` ✅ (6 tests)
- Full `bun run test`: 1057 tests passed; 5 pre-existing suites fail in this environment because Vitest cannot resolve `next/cache`.