### PR TITLE
feat(jarvis): add constrained feedback lifecycle helper

### DIFF
--- a/docs/architecture/jarvis-feedback-bridge.md
+++ b/docs/architecture/jarvis-feedback-bridge.md
@@ -430,6 +430,42 @@ My requests / All requests filter for organization-wide investigation. Only
 administrators can mutate the organization-wide desk at
 `/dashboard/requests/manage`.
 
+Private scheduled lifecycle operation
+---
+
+The approved private runtime helper at
+`skills/compass-feedback-desk/scripts/compass_feedback_bridge.py` exposes a
+single `status` operation for scheduled or explicitly authorized lifecycle
+work. Install the helper under the private runtime's
+`~/.local/lib/compass/` path, keep `COMPASS_BASE_URL` and
+`JARVIS_BRIDGE_SECRET` in its protected environment, and invoke it with
+structured arguments or a bounded JSON payload file:
+
+```bash
+python ~/.local/lib/compass/compass_feedback_bridge.py status \
+  --item-id <uuid> \
+  --status in_progress \
+  --idempotency-key feedback-<uuid>-status-v1
+```
+
+The helper accepts only the visible lifecycle statuses, bounded requester
+message and priority values, fixed HTTPS GitHub issue/PR URL schemas, and an
+idempotency key. It constructs and signs only
+`POST /api/integrations/jarvis/feedback/<uuid>/status`; it has no target,
+path, header, command, shell, D1, or cross-channel delivery input. A retry
+reuses the same idempotency key, and the compact JSON result reports only
+acceptance, duplicate status, lifecycle status, notification count, and
+requester-update queuing. Compass still performs all organization,
+authorization, evidence, persistence, source-routing, and delivery checks.
+
+To remove the operation, stop the scheduled caller, remove its invocation and
+temporary payload files, and restore the prior approved private helper. Do not
+delete Feedback Desk records or bypass the lifecycle endpoint. To rotate the
+credential, use the temporary dual-secret rollover above, verify both the
+existing poller/notifier and the scheduled caller, then remove the retired
+Worker binding and operator-side copy. Never place a secret in a payload,
+ticket, command output, or log.
+
 Scheduled reconciliation and administration
 ---
 

--- a/skills/compass-feedback-desk/SKILL.md
+++ b/skills/compass-feedback-desk/SKILL.md
@@ -124,6 +124,48 @@ python scripts/compass_feedback_bridge.py pull --limit 20
 
 Do not invoke a model when the response contains no events.
 
+## Update a Feedback Desk lifecycle status
+
+Scheduled or otherwise approved private-runtime operations may update one
+existing Feedback Desk item only through the fixed Compass lifecycle endpoint.
+Use the helper's structured arguments:
+
+```bash
+python scripts/compass_feedback_bridge.py status \
+  --item-id UUID \
+  --status in_progress \
+  --message "The fix is in progress." \
+  --priority normal \
+  --github-issue-url https://github.com/OWNER/REPO/issues/123 \
+  --draft-pull-request-url https://github.com/OWNER/REPO/pull/456 \
+  --idempotency-key feedback-UUID-status-v1
+```
+
+For a scheduled job, write the same fields as a JSON object with a safe file
+writer and use `--payload-file /absolute/path/to/payload.json` instead. The
+payload file is bounded and validated before it is sent. Do not interpolate
+requester text into shell commands, pass a target/path/header/command option,
+or call the generic request function directly. The helper constructs only
+`POST /api/integrations/jarvis/feedback/<UUID>/status`, signs it with the
+injected `JARVIS_BRIDGE_SECRET`, and retries at most once with the same
+idempotency key. Compass remains responsible for organization authorization,
+evidence gates, D1 persistence, and source-specific requester delivery.
+
+The command prints only a compact JSON result containing endpoint acceptance,
+duplicate status, lifecycle status, notification count, and whether a
+requester update was queued. It never prints response bodies, request data,
+or secret material. A `duplicate: true` result is a successful idempotent
+replay, not permission to generate a new key.
+
+To remove the operation, stop the scheduled caller, delete its `status`
+invocation and any temporary payload files, and replace the private installed
+helper with the prior approved version. Do not delete or edit Compass D1
+records as part of removal. To rotate credentials, follow the temporary
+dual-secret procedure in the bridge architecture document: provision the new
+secondary secret, verify both callers, switch the private runtime, then remove
+the retired binding and operator copy. Never print, commit, or place either
+secret in a payload, ticket, or log.
+
 ## Configure the private runtime
 
 For first-time setup, use the helper's `configure` command with an ephemeral

--- a/skills/compass-feedback-desk/scripts/compass_feedback_bridge.py
+++ b/skills/compass-feedback-desk/scripts/compass_feedback_bridge.py
@@ -9,6 +9,7 @@ import hashlib
 import hmac
 import json
 import os
+import re
 import secrets
 import subprocess
 import sys
@@ -22,6 +23,44 @@ from typing import Any
 
 MAX_BODY_BYTES = 64 * 1024
 MAX_VISUAL_RESPONSE_BYTES = 3 * 1024 * 1024
+MAX_FEEDBACK_MESSAGE_CHARS = 2_000
+COMPASS_PRODUCTION_BASE_URL = "https://compass.openrangeconstruction.ltd"
+FEEDBACK_STATUS_PATH = "/api/integrations/jarvis/feedback/{item_id}/status"
+FEEDBACK_STATUSES = frozenset(
+    {
+        "new",
+        "triaged",
+        "needs_info",
+        "planned",
+        "in_progress",
+        "testing",
+        "deployed",
+        "closed",
+    }
+)
+FEEDBACK_PRIORITIES = frozenset({"low", "normal", "high", "urgent"})
+FEEDBACK_STATUS_KEYS = frozenset(
+    {
+        "itemId",
+        "status",
+        "message",
+        "priority",
+        "githubIssueUrl",
+        "draftPullRequestUrl",
+        "idempotencyKey",
+    }
+)
+UUID_PATTERN = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+IDEMPOTENCY_KEY_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$")
+GITHUB_ISSUE_PATTERN = re.compile(
+    r"^https://github\.com/[^/\s]+/[^/\s]+/issues/[1-9][0-9]*(?:/)?$"
+)
+GITHUB_PULL_REQUEST_PATTERN = re.compile(
+    r"^https://github\.com/[^/\s]+/[^/\s]+/pull/[1-9][0-9]*(?:/)?$"
+)
 
 
 def update_env_file(path: Path, values: dict[str, str]) -> None:
@@ -58,10 +97,28 @@ def encrypt_for_transfer(secret: str, public_key_der: str) -> str:
     with tempfile.TemporaryDirectory(prefix="compass-bridge-") as directory:
         temporary = Path(directory)
         public_key_path = temporary / "public.der"
+        public_pem_path = temporary / "public.pem"
         secret_path = temporary / "secret"
         encrypted_path = temporary / "secret.enc"
         public_key_path.write_bytes(public_key)
         secret_path.write_bytes(secret.encode("utf-8"))
+        convert_result = subprocess.run(
+            [
+                "openssl",
+                "pkey",
+                "-pubin",
+                "-inform",
+                "DER",
+                "-in",
+                str(public_key_path),
+                "-out",
+                str(public_pem_path),
+            ],
+            capture_output=True,
+            check=False,
+        )
+        if convert_result.returncode != 0:
+            raise RuntimeError("OpenSSL could not read the bridge public key")
         result = subprocess.run(
             [
                 "openssl",
@@ -69,9 +126,7 @@ def encrypt_for_transfer(secret: str, public_key_der: str) -> str:
                 "-encrypt",
                 "-pubin",
                 "-inkey",
-                str(public_key_path),
-                "-keyform",
-                "DER",
+                str(public_pem_path),
                 "-pkeyopt",
                 "rsa_padding_mode:oaep",
                 "-pkeyopt",
@@ -115,6 +170,173 @@ def load_payload(path: str) -> bytes:
         separators=(",", ":"),
         ensure_ascii=False,
     ).encode("utf-8")
+
+
+def validate_feedback_status_payload(payload: object) -> dict[str, object]:
+    """Validate the only structured payload accepted by the lifecycle command."""
+    if not isinstance(payload, dict):
+        raise ValueError("Feedback status payload must be a JSON object")
+    unknown_keys = set(payload) - FEEDBACK_STATUS_KEYS
+    if unknown_keys:
+        raise ValueError("Feedback status payload contains unsupported fields")
+
+    item_id = payload.get("itemId")
+    if not isinstance(item_id, str) or UUID_PATTERN.fullmatch(item_id) is None:
+        raise ValueError("itemId must be a UUID")
+
+    status = payload.get("status")
+    if not isinstance(status, str) or status not in FEEDBACK_STATUSES:
+        raise ValueError("status is not an allowed Feedback Desk lifecycle status")
+
+    idempotency_key = payload.get("idempotencyKey")
+    if (
+        not isinstance(idempotency_key, str)
+        or IDEMPOTENCY_KEY_PATTERN.fullmatch(idempotency_key) is None
+    ):
+        raise ValueError("idempotencyKey is invalid")
+
+    message = payload.get("message")
+    if message is not None and (
+        not isinstance(message, str)
+        or not message.strip()
+        or len(message) > MAX_FEEDBACK_MESSAGE_CHARS
+    ):
+        raise ValueError("message is invalid or too long")
+
+    priority = payload.get("priority")
+    if priority is not None and (
+        not isinstance(priority, str) or priority not in FEEDBACK_PRIORITIES
+    ):
+        raise ValueError("priority is invalid")
+
+    for key, pattern in (
+        ("githubIssueUrl", GITHUB_ISSUE_PATTERN),
+        ("draftPullRequestUrl", GITHUB_PULL_REQUEST_PATTERN),
+    ):
+        value = payload.get(key)
+        if value is not None and (
+            not isinstance(value, str) or pattern.fullmatch(value) is None
+        ):
+            raise ValueError(f"{key} is invalid")
+
+    normalized = dict(payload)
+    body = json.dumps(
+        normalized,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    if len(body) > MAX_BODY_BYTES:
+        raise ValueError("Feedback status payload exceeds the 64 KiB bridge limit")
+    return normalized
+
+
+def load_feedback_status_payload(path: str) -> dict[str, object]:
+    """Load and validate a bounded JSON file without invoking a shell."""
+    data = Path(path).read_bytes()
+    if len(data) > MAX_BODY_BYTES:
+        raise ValueError("Feedback status payload exceeds the 64 KiB bridge limit")
+    try:
+        parsed = json.loads(data)
+    except json.JSONDecodeError as error:
+        raise ValueError("Feedback status payload is not valid JSON") from error
+    return validate_feedback_status_payload(parsed)
+
+
+def feedback_status_target(item_id: str) -> str:
+    """Build the fixed lifecycle path only after UUID validation."""
+    if UUID_PATTERN.fullmatch(item_id) is None:
+        raise ValueError("itemId must be a UUID")
+    return FEEDBACK_STATUS_PATH.format(item_id=urllib.parse.quote(item_id, safe=""))
+
+
+def redact_feedback_status_response(response: object) -> dict[str, object]:
+    """Return only the documented, non-sensitive lifecycle result fields."""
+    if not isinstance(response, dict) or response.get("success") is not True:
+        return {"success": False, "error": "compass_rejected_feedback_status"}
+    result: dict[str, object] = {"success": True}
+    for key in (
+        "duplicate",
+        "feedbackDeskItemId",
+        "status",
+        "notifiedUserCount",
+        "requesterUpdateQueued",
+    ):
+        if key in response:
+            result[key] = response[key]
+    return result
+
+
+def require_feedback_status_production_origin() -> None:
+    """Prevent the lifecycle command from being redirected to another host."""
+    configured = os.environ.get("COMPASS_BASE_URL", "").rstrip("/")
+    expected = COMPASS_PRODUCTION_BASE_URL
+    parsed = urllib.parse.urlsplit(configured)
+    expected_parsed = urllib.parse.urlsplit(expected)
+    if (
+        configured != expected
+        or parsed.scheme != expected_parsed.scheme
+        or parsed.hostname != expected_parsed.hostname
+        or parsed.port != expected_parsed.port
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise RuntimeError("Feedback status requires the production Compass endpoint")
+
+
+def request_feedback_status(
+    payload: object,
+    max_attempts: int = 2,
+) -> dict[str, object]:
+    """Submit one fixed lifecycle request; retries reuse its idempotency key."""
+    normalized = validate_feedback_status_payload(payload)
+    body = json.dumps(
+        normalized,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    target = feedback_status_target(str(normalized["itemId"]))
+    require_feedback_status_production_origin()
+    attempts = max(1, min(2, max_attempts))
+    for attempt in range(attempts):
+        try:
+            response = request_json("POST", target, body)
+            return redact_feedback_status_response(response)
+        except (TimeoutError, urllib.error.URLError) as error:
+            if attempt + 1 == attempts:
+                raise RuntimeError("Feedback status request failed") from error
+    raise RuntimeError("Feedback status request failed")
+
+
+def feedback_status_payload_from_args(args: argparse.Namespace) -> dict[str, object]:
+    """Convert explicit CLI fields or one safe JSON file into one payload."""
+    direct_fields = (
+        args.item_id,
+        args.status,
+        args.message,
+        args.priority,
+        args.github_issue_url,
+        args.draft_pull_request_url,
+        args.idempotency_key,
+    )
+    if args.payload_file:
+        if any(value is not None for value in direct_fields):
+            raise ValueError("Use --payload-file or structured fields, not both")
+        return load_feedback_status_payload(args.payload_file)
+    payload = {
+        key: value
+        for key, value in {
+            "itemId": args.item_id,
+            "status": args.status,
+            "message": args.message,
+            "priority": args.priority,
+            "githubIssueUrl": args.github_issue_url,
+            "draftPullRequestUrl": args.draft_pull_request_url,
+            "idempotencyKey": args.idempotency_key,
+        }.items()
+        if value is not None
+    }
+    return validate_feedback_status_payload(payload)
 
 
 def request_json(
@@ -206,6 +428,19 @@ def build_parser() -> argparse.ArgumentParser:
     visuals.add_argument("--event-id", required=True)
     visuals.add_argument("--output-dir", required=True)
 
+    status = commands.add_parser(
+        "status",
+        help="update one Feedback Desk item through the fixed lifecycle endpoint",
+    )
+    status.add_argument("--payload-file")
+    status.add_argument("--item-id")
+    status.add_argument("--status")
+    status.add_argument("--message")
+    status.add_argument("--priority")
+    status.add_argument("--github-issue-url")
+    status.add_argument("--draft-pull-request-url")
+    status.add_argument("--idempotency-key")
+
     configure = commands.add_parser("configure")
     configure.add_argument("--base-url", required=True)
     configure.add_argument("--env-file", required=True)
@@ -216,6 +451,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     args = build_parser().parse_args()
+    return_code = 0
 
     if args.command == "configure":
         parsed_base_url = urllib.parse.urlsplit(args.base_url)
@@ -306,6 +542,23 @@ def main() -> int:
             "count": len(written),
             "explicitUserAttachments": True,
         }
+    elif args.command == "status":
+        try:
+            result = request_feedback_status(
+                feedback_status_payload_from_args(args),
+            )
+        except (OSError, ValueError):
+            result = {
+                "success": False,
+                "error": "invalid_feedback_status_input",
+            }
+            return_code = 2
+        except RuntimeError:
+            result = {
+                "success": False,
+                "error": "feedback_status_request_failed",
+            }
+            return_code = 1
     else:
         result = request_json(
             "POST",
@@ -314,7 +567,7 @@ def main() -> int:
         )
 
     print(json.dumps(result, separators=(",", ":"), ensure_ascii=False))
-    return 0
+    return return_code
 
 
 if __name__ == "__main__":

--- a/skills/compass-feedback-desk/scripts/compass_feedback_bridge.py
+++ b/skills/compass-feedback-desk/scripts/compass_feedback_bridge.py
@@ -24,6 +24,7 @@ from typing import Any
 MAX_BODY_BYTES = 64 * 1024
 MAX_VISUAL_RESPONSE_BYTES = 3 * 1024 * 1024
 MAX_FEEDBACK_MESSAGE_CHARS = 2_000
+MAX_FEEDBACK_URL_CHARS = 2_048
 COMPASS_PRODUCTION_BASE_URL = "https://compass.openrangeconstruction.ltd"
 FEEDBACK_STATUS_PATH = "/api/integrations/jarvis/feedback/{item_id}/status"
 FEEDBACK_STATUSES = frozenset(
@@ -215,7 +216,9 @@ def validate_feedback_status_payload(payload: object) -> dict[str, object]:
     ):
         value = payload.get(key)
         if value is not None and (
-            not isinstance(value, str) or pattern.fullmatch(value) is None
+            not isinstance(value, str)
+            or len(value) > MAX_FEEDBACK_URL_CHARS
+            or pattern.fullmatch(value) is None
         ):
             raise ValueError(f"{key} is invalid")
 
@@ -300,7 +303,12 @@ def request_feedback_status(
     attempts = max(1, min(2, max_attempts))
     for attempt in range(attempts):
         try:
-            response = request_json("POST", target, body)
+            response = request_json(
+                "POST",
+                target,
+                body,
+                follow_redirects=False,
+            )
             return redact_feedback_status_response(response)
         except (TimeoutError, urllib.error.URLError) as error:
             if attempt + 1 == attempts:
@@ -339,11 +347,27 @@ def feedback_status_payload_from_args(args: argparse.Namespace) -> dict[str, obj
     return validate_feedback_status_payload(payload)
 
 
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Reject redirects so signed lifecycle headers cannot cross origins."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: object,
+        code: int,
+        msg: str,
+        headers: object,
+        newurl: str,
+    ) -> None:
+        return None
+
+
 def request_json(
     method: str,
     target: str,
     body: bytes = b"",
     max_response_bytes: int = MAX_BODY_BYTES,
+    follow_redirects: bool = True,
 ) -> Any:
     base_url = os.environ.get("COMPASS_BASE_URL", "").rstrip("/")
     secret = os.environ.get("JARVIS_BRIDGE_SECRET", "")
@@ -380,8 +404,13 @@ def request_json(
         headers=headers,
         method=method,
     )
+    opener = (
+        urllib.request.build_opener()
+        if follow_redirects
+        else urllib.request.build_opener(_NoRedirectHandler())
+    )
     try:
-        with urllib.request.urlopen(request, timeout=30) as response:
+        with opener.open(request, timeout=30) as response:
             response_status = response.status
             response_type = response.headers.get("Content-Type", "unknown")
             response_body = response.read(max_response_bytes + 1)

--- a/skills/compass-feedback-desk/scripts/test_compass_feedback_bridge.py
+++ b/skills/compass-feedback-desk/scripts/test_compass_feedback_bridge.py
@@ -1,8 +1,13 @@
 import importlib.util
+import json
+import os
 import subprocess
 import tempfile
+import threading
 import unittest
 from pathlib import Path
+from unittest.mock import patch
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 
 SCRIPT_PATH = (
@@ -71,7 +76,6 @@ class SignatureTests(unittest.TestCase):
                 [
                     "openssl",
                     "genpkey",
-                    "-quiet",
                     "-algorithm",
                     "RSA",
                     "-pkeyopt",
@@ -140,6 +144,184 @@ class SignatureTests(unittest.TestCase):
             MODULE.MAX_VISUAL_RESPONSE_BYTES,
             MODULE.MAX_BODY_BYTES,
         )
+
+
+class FeedbackStatusTests(unittest.TestCase):
+    def valid_payload(self) -> dict[str, object]:
+        return {
+            "itemId": "123e4567-e89b-12d3-a456-426614174000",
+            "status": "in_progress",
+            "message": "The fix is in progress.",
+            "priority": "high",
+            "githubIssueUrl": "https://github.com/High-Performance-Structures/compass/issues/468",
+            "draftPullRequestUrl": "https://github.com/High-Performance-Structures/compass/pull/469",
+            "idempotencyKey": "feedback-468-status-v1",
+        }
+
+    def test_valid_status_payload_signs_only_the_fixed_lifecycle_target(self) -> None:
+        payload = self.valid_payload()
+        with patch.dict(
+            os.environ,
+            {
+                "COMPASS_BASE_URL": MODULE.COMPASS_PRODUCTION_BASE_URL,
+                "JARVIS_BRIDGE_SECRET": "test-secret",
+            },
+        ):
+            with patch.object(
+                MODULE,
+                "request_json",
+                return_value={
+                    "success": True,
+                    "feedbackDeskItemId": payload["itemId"],
+                    "status": payload["status"],
+                    "notifiedUserCount": 1,
+                    "requesterUpdateQueued": True,
+                    "secret": "must-not-leak",
+                },
+            ) as request:
+                result = MODULE.request_feedback_status(payload)
+
+        target = request.call_args.args[1]
+        body = request.call_args.args[2]
+        self.assertEqual(
+            target,
+            "/api/integrations/jarvis/feedback/123e4567-e89b-12d3-a456-426614174000/status",
+        )
+        self.assertEqual(json.loads(body), payload)
+        self.assertEqual(
+            result,
+            {
+                "success": True,
+                "feedbackDeskItemId": payload["itemId"],
+                "status": payload["status"],
+                "notifiedUserCount": 1,
+                "requesterUpdateQueued": True,
+            },
+        )
+        self.assertNotIn("secret", result)
+
+    def test_status_payload_rejects_invalid_uuid_and_arbitrary_target_fields(self) -> None:
+        payload = self.valid_payload()
+        payload["itemId"] = "../../api/bridge/tools"
+        payload["target"] = "https://attacker.example/steal"
+
+        with self.assertRaises(ValueError):
+            MODULE.validate_feedback_status_payload(payload)
+
+    def test_status_payload_rejects_oversize_message_and_invalid_urls(self) -> None:
+        payload = self.valid_payload()
+        payload["message"] = "x" * 2_001
+        with self.assertRaises(ValueError):
+            MODULE.validate_feedback_status_payload(payload)
+
+        payload = self.valid_payload()
+        payload["githubIssueUrl"] = "http://attacker.example/468"
+        with self.assertRaises(ValueError):
+            MODULE.validate_feedback_status_payload(payload)
+
+    def test_retries_use_the_same_idempotency_key_and_body(self) -> None:
+        payload = self.valid_payload()
+        with patch.dict(
+            os.environ,
+            {
+                "COMPASS_BASE_URL": MODULE.COMPASS_PRODUCTION_BASE_URL,
+                "JARVIS_BRIDGE_SECRET": "test-secret",
+            },
+        ):
+            with patch.object(
+                MODULE,
+                "request_json",
+                side_effect=[
+                    MODULE.urllib.error.URLError("temporary"),
+                    {"success": True, "duplicate": True},
+                ],
+            ) as request:
+                result = MODULE.request_feedback_status(payload)
+
+        self.assertEqual(result, {"success": True, "duplicate": True})
+        self.assertEqual(request.call_count, 2)
+        self.assertEqual(request.call_args_list[0].args[1:], request.call_args_list[1].args[1:])
+
+    def test_payload_file_is_bounded_before_json_parsing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            payload_path = Path(directory) / "payload.json"
+            payload_path.write_bytes(b"{" + b'"x":"' + b"x" * MODULE.MAX_BODY_BYTES + b'"}')
+
+            with self.assertRaises(ValueError):
+                MODULE.load_feedback_status_payload(str(payload_path))
+
+    def test_local_integration_signs_the_fixed_path_and_redacts_response(self) -> None:
+        payload = self.valid_payload()
+        observed: dict[str, object] = {}
+        secret = "integration-only-secret"
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                body = self.rfile.read(int(self.headers["Content-Length"]))
+                observed["path"] = self.path
+                observed["body"] = body
+                observed["timestamp"] = self.headers["X-Compass-Timestamp"]
+                observed["signature"] = self.headers["X-Compass-Signature"]
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(
+                    json.dumps(
+                        {
+                            "success": True,
+                            "feedbackDeskItemId": payload["itemId"],
+                            "status": payload["status"],
+                            "notifiedUserCount": 1,
+                            "requesterUpdateQueued": True,
+                            "bridgeSecret": secret,
+                        }
+                    ).encode("utf-8")
+                )
+
+            def log_message(self, format: str, *args: object) -> None:
+                return
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            with patch.dict(
+                os.environ,
+                {
+                    "COMPASS_BASE_URL": f"http://127.0.0.1:{server.server_port}",
+                    "JARVIS_BRIDGE_SECRET": secret,
+                },
+            ):
+                with patch.object(
+                    MODULE,
+                    "COMPASS_PRODUCTION_BASE_URL",
+                    f"http://127.0.0.1:{server.server_port}",
+                ):
+                    result = MODULE.request_feedback_status(payload, max_attempts=1)
+        finally:
+            server.shutdown()
+            thread.join(timeout=2)
+            server.server_close()
+
+        body = observed.get("body")
+        timestamp = observed.get("timestamp")
+        path = observed.get("path")
+        signature = observed.get("signature")
+        if not isinstance(body, bytes) or not isinstance(timestamp, str):
+            raise AssertionError("local server did not capture the signed request")
+        if not isinstance(path, str) or not isinstance(signature, str):
+            raise AssertionError("local server did not capture bridge headers")
+        self.assertEqual(
+            path,
+            "/api/integrations/jarvis/feedback/123e4567-e89b-12d3-a456-426614174000/status",
+        )
+        self.assertEqual(json.loads(body), payload)
+        self.assertEqual(
+            signature,
+            MODULE.signature(secret, timestamp, "POST", path, body),
+        )
+        self.assertEqual(result["requesterUpdateQueued"], True)
+        self.assertNotIn(secret, json.dumps(result))
 
 
 if __name__ == "__main__":

--- a/skills/compass-feedback-desk/scripts/test_compass_feedback_bridge.py
+++ b/skills/compass-feedback-desk/scripts/test_compass_feedback_bridge.py
@@ -219,6 +219,14 @@ class FeedbackStatusTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             MODULE.validate_feedback_status_payload(payload)
 
+        payload = self.valid_payload()
+        payload["githubIssueUrl"] = (
+            "https://github.com/High-Performance-Structures/compass/issues/"
+            + "1" * MODULE.MAX_FEEDBACK_URL_CHARS
+        )
+        with self.assertRaises(ValueError):
+            MODULE.validate_feedback_status_payload(payload)
+
     def test_retries_use_the_same_idempotency_key_and_body(self) -> None:
         payload = self.valid_payload()
         with patch.dict(
@@ -322,6 +330,83 @@ class FeedbackStatusTests(unittest.TestCase):
         )
         self.assertEqual(result["requesterUpdateQueued"], True)
         self.assertNotIn(secret, json.dumps(result))
+
+    def test_status_does_not_follow_redirects_with_bridge_signature(self) -> None:
+        payload = self.valid_payload()
+        primary_observed: dict[str, object] = {}
+        redirected_observed: dict[str, object] = {}
+
+        class RedirectedHandler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                redirected_observed["headers"] = dict(self.headers)
+                self.send_response(200)
+                self.end_headers()
+
+            def do_POST(self) -> None:
+                redirected_observed["headers"] = dict(self.headers)
+                self.send_response(200)
+                self.end_headers()
+
+            def log_message(self, format: str, *args: object) -> None:
+                return
+
+        redirected_server = HTTPServer(("127.0.0.1", 0), RedirectedHandler)
+        redirected_thread = threading.Thread(
+            target=redirected_server.serve_forever,
+            daemon=True,
+        )
+        redirected_thread.start()
+
+        redirect_target = (
+            f"http://127.0.0.1:{redirected_server.server_port}/off-origin"
+        )
+
+        class PrimaryHandler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                primary_observed["path"] = self.path
+                primary_observed["signature"] = self.headers.get(
+                    "X-Compass-Signature"
+                )
+                self.send_response(302)
+                self.send_header("Location", redirect_target)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+            def log_message(self, format: str, *args: object) -> None:
+                return
+
+        primary_server = HTTPServer(("127.0.0.1", 0), PrimaryHandler)
+        primary_thread = threading.Thread(
+            target=primary_server.serve_forever,
+            daemon=True,
+        )
+        primary_thread.start()
+        try:
+            base_url = f"http://127.0.0.1:{primary_server.server_port}"
+            with patch.dict(
+                os.environ,
+                {
+                    "COMPASS_BASE_URL": base_url,
+                    "JARVIS_BRIDGE_SECRET": "redirect-test-secret",
+                },
+            ):
+                with patch.object(MODULE, "COMPASS_PRODUCTION_BASE_URL", base_url):
+                    with self.assertRaises(RuntimeError):
+                        MODULE.request_feedback_status(payload, max_attempts=1)
+        finally:
+            primary_server.shutdown()
+            primary_thread.join(timeout=2)
+            primary_server.server_close()
+            redirected_server.shutdown()
+            redirected_thread.join(timeout=2)
+            redirected_server.server_close()
+
+        self.assertEqual(
+            primary_observed["path"],
+            "/api/integrations/jarvis/feedback/123e4567-e89b-12d3-a456-426614174000/status",
+        )
+        self.assertIsInstance(primary_observed["signature"], str)
+        self.assertEqual(redirected_observed, {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a fixed-target `status` operation to the private Compass feedback bridge helper
- validate UUID, lifecycle status, bounded message, priority, GitHub URLs, and idempotency key before signing
- keep signing, retries, response redaction, server-side authorization/evidence guards, and source-specific delivery in Compass
- document scheduled invocation, removal, and dual-secret rotation

## Security boundaries
- no arbitrary target, path, header, command, shell, D1, or cross-channel inputs
- secrets are read only from the protected environment and never returned in status results
- payload files are bounded JSON and never shell-interpolated

## Verification
- `python3 -m unittest discover -s skills/compass-feedback-desk/scripts -p 'test_*.py' -v`\n- `bun run lint` (passes with existing warnings)\n- `bun run test` (1,071/1,072 assertions passed; one unrelated provider test timed out once, then passed in isolation)\n- `bun run build`\n\nCloses #468\n\nDo not merge or deploy from this draft.