### PR TITLE
feat(estimates): add department client report profiles

### DIFF
--- a/drizzle/0124_estimate_client_report_profiles.sql
+++ b/drizzle/0124_estimate_client_report_profiles.sql
@@ -1,0 +1,69 @@
+ALTER TABLE `estimate_terms_templates` ADD `department_code` text;
+ALTER TABLE `estimate_terms_templates` ADD `template_type` text DEFAULT 'terms' NOT NULL;
+ALTER TABLE `estimate_terms_templates` ADD `source_document_id` text;
+ALTER TABLE `estimate_terms_templates` ADD `source_url` text;
+ALTER TABLE `estimate_terms_templates` ADD `sort_order` integer DEFAULT 0 NOT NULL;
+
+DROP INDEX `estimate_terms_templates_org_name_uq`;
+DROP INDEX `estimate_terms_templates_org_active_idx`;
+CREATE UNIQUE INDEX `estimate_terms_templates_org_department_type_name_uq`
+  ON `estimate_terms_templates` (`organization_id`, `department_code`, `template_type`, `name`);
+CREATE INDEX `estimate_terms_templates_org_active_idx`
+  ON `estimate_terms_templates` (`organization_id`, `department_code`, `template_type`, `active`);
+
+ALTER TABLE `project_estimates` ADD `introduction_template_id` text
+  REFERENCES `estimate_terms_templates`(`id`) ON UPDATE no action ON DELETE set null;
+ALTER TABLE `project_estimates` ADD `introduction_text` text;
+ALTER TABLE `project_estimates` ADD `closing_template_id` text
+  REFERENCES `estimate_terms_templates`(`id`) ON UPDATE no action ON DELETE set null;
+ALTER TABLE `project_estimates` ADD `closing_text` text;
+
+CREATE TABLE `project_estimate_phase_descriptions` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_id` text NOT NULL,
+  `estimate_id` text NOT NULL,
+  `division_code` text NOT NULL,
+  `description` text NOT NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`estimate_id`) REFERENCES `project_estimates`(`id`) ON UPDATE no action ON DELETE cascade
+);
+CREATE UNIQUE INDEX `project_estimate_phase_description_uq`
+  ON `project_estimate_phase_descriptions` (`estimate_id`, `division_code`);
+CREATE INDEX `project_estimate_phase_descriptions_project_idx`
+  ON `project_estimate_phase_descriptions` (`project_id`, `estimate_id`);
+
+CREATE TABLE `project_estimate_acknowledgements` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_id` text NOT NULL,
+  `estimate_id` text NOT NULL,
+  `template_id` text NOT NULL,
+  `title` text NOT NULL,
+  `body` text NOT NULL,
+  `source_document_id` text,
+  `source_url` text,
+  `sort_order` integer DEFAULT 0 NOT NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`estimate_id`) REFERENCES `project_estimates`(`id`) ON UPDATE no action ON DELETE cascade
+);
+CREATE UNIQUE INDEX `project_estimate_acknowledgements_template_uq`
+  ON `project_estimate_acknowledgements` (`estimate_id`, `template_id`);
+CREATE INDEX `project_estimate_acknowledgements_project_idx`
+  ON `project_estimate_acknowledgements` (`project_id`, `estimate_id`, `sort_order`);
+
+UPDATE `project_estimates`
+SET `title` = CASE
+  WHEN UPPER(SUBSTR(TRIM(COALESCE(
+    (SELECT `project_number` FROM `projects` WHERE `projects`.`id` = `project_estimates`.`project_id`),
+    `project_estimates`.`project_id`
+  )), 1, 1)) = 'N' THEN 'Material Estimate'
+  ELSE 'Construction Estimate'
+END
+WHERE `title` = 'CA22 Construction Estimate'
+  AND UPPER(SUBSTR(TRIM(COALESCE(
+    (SELECT `project_number` FROM `projects` WHERE `projects`.`id` = `project_estimates`.`project_id`),
+    `project_estimates`.`project_id`
+  )), 1, 1)) IN ('H', 'N');

--- a/src/app/actions/estimate-templates.ts
+++ b/src/app/actions/estimate-templates.ts
@@ -20,10 +20,12 @@ import { recordActivityEvent } from "@/lib/activity-log"
 import { requireAuth } from "@/lib/auth"
 import { getCloudflareContext } from "@/lib/db"
 import { isDemoUser } from "@/lib/demo"
+import { estimateTitleForDepartment } from "@/lib/estimates/client-report"
 import { CONTRACT_ADJUSTMENT_COST_CODES } from "@/lib/financials/project-totals-import"
 import { requireOrg } from "@/lib/org-scope"
 import { can, requirePermission } from "@/lib/permissions"
 import { assertProjectAccess } from "@/lib/project-access"
+import { projectDepartment } from "@/lib/project-branding"
 import {
   buildEstimateTemplateApplication,
   type EstimateTemplateSourceLine,
@@ -985,6 +987,13 @@ export async function createProjectEstimateFromTemplate(input: {
     const now = new Date().toISOString()
     const estimateDate = now.slice(0, 10)
     const estimateVersion = (priorEstimate?.versionNumber ?? 0) + 1
+    const documentTitle = estimateTitleForDepartment({
+      department: projectDepartment({
+        projectId: project.id,
+        projectNumber: project.projectNumber,
+      }),
+      requestedTitle: defaults.documentTitle,
+    })
     const statements: D1PreparedStatement[] = [
       access.env.DB.prepare(
         `INSERT INTO project_template_applications (
@@ -1019,7 +1028,7 @@ export async function createProjectEstimateFromTemplate(input: {
         input.projectId,
         `${project.projectNumber ?? "PROJECT"}-00`,
         estimateVersion,
-        defaults.documentTitle,
+        documentTitle,
         estimateDate,
         `${template.name} v${version.versionNumber}`,
         version.id,

--- a/src/app/actions/project-estimates.ts
+++ b/src/app/actions/project-estimates.ts
@@ -559,8 +559,17 @@ async function loadEstimateTextTemplate(input: {
   readonly department: ProjectDepartment
   readonly templateId: string | null
   readonly templateType: EstimateTextTemplateType
-}): Promise<typeof estimateTermsTemplates.$inferSelect | null> {
+}): Promise<{ readonly id: string | null; readonly body: string } | null> {
   if (!input.templateId) return null
+  const builtInTemplate = builtInEstimateTextTemplates({
+    department: input.department,
+    templateType: input.templateType,
+  }).find((template) => template.id === input.templateId)
+  if (builtInTemplate) {
+    // Built-ins are code-backed rather than database rows, so only snapshot
+    // their body onto the estimate and leave the foreign key unset.
+    return { id: null, body: builtInTemplate.body }
+  }
   if (!input.organizationId) {
     throw new Error("The project organization is required for text templates.")
   }

--- a/src/app/actions/project-estimates.ts
+++ b/src/app/actions/project-estimates.ts
@@ -7,8 +7,10 @@ import { getDb } from "@/db"
 import { projectBudgetLines, projects, sageCostCodes } from "@/db/schema"
 import {
   estimateTermsTemplates,
+  projectEstimateAcknowledgements,
   projectEstimateBasisDocuments,
   projectEstimateLines,
+  projectEstimatePhaseDescriptions,
   projectEstimates,
   sageTaxEntities,
 } from "@/db/schema-estimates"
@@ -31,6 +33,16 @@ import {
   spreadsheetIdFromUrl,
 } from "@/lib/financials/project-totals-import"
 import {
+  builtInEstimateTextTemplates,
+  defaultEstimateTitle,
+  estimateClientReportMode,
+  estimateTitleForDepartment,
+  isEstimateTextTemplateType,
+  type EstimateClientReportMode,
+  type EstimateTextTemplateOption,
+  type EstimateTextTemplateType,
+} from "@/lib/estimates/client-report"
+import {
   projectEstimateCostCodeCatalog,
   type ProjectEstimateCostCodeCatalogItem,
 } from "@/lib/estimates/project-cost-code-catalog"
@@ -42,6 +54,10 @@ import {
 } from "@/lib/google/config"
 import { requirePermission } from "@/lib/permissions"
 import { assertProjectAccess } from "@/lib/project-access"
+import {
+  projectDepartment,
+  type ProjectDepartment,
+} from "@/lib/project-branding"
 import { isInternalStaffRole } from "@/lib/user-roles"
 
 export type ProjectEstimateSummary = {
@@ -59,6 +75,10 @@ export type ProjectEstimateSummary = {
   readonly defaultTaxRateBasisPoints: number
   readonly termsTemplateId: string | null
   readonly contractTerms: string | null
+  readonly introductionTemplateId: string | null
+  readonly introductionText: string | null
+  readonly closingTemplateId: string | null
+  readonly closingText: string | null
   readonly directCostCents: number
   readonly markupCents: number
   readonly taxCents: number
@@ -126,13 +146,34 @@ export type ProjectEstimateTaxOption = {
 export type ProjectEstimateTermsOption = {
   readonly value: string
   readonly label: string
+  readonly departmentCode: ProjectDepartment | null
+  readonly templateType: EstimateTextTemplateType
   readonly body: string
+  readonly sourceDocumentId: string | null
+  readonly sourceUrl: string | null
+}
+
+export type ProjectEstimatePhaseDescriptionItem = {
+  readonly divisionCode: string
+  readonly description: string
+}
+
+export type ProjectEstimateAcknowledgementItem = {
+  readonly id: string
+  readonly templateId: string
+  readonly title: string
+  readonly body: string
+  readonly sourceDocumentId: string | null
+  readonly sourceUrl: string | null
+  readonly sortOrder: number
 }
 
 export type ProjectEstimateWorkspace = {
   readonly canEdit: boolean
   readonly projectNumber: string | null
   readonly projectName: string
+  readonly department: ProjectDepartment
+  readonly reportMode: EstimateClientReportMode
   readonly estimates: readonly ProjectEstimateSummary[]
   readonly activeEstimate: ProjectEstimateSummary | null
   readonly lines: readonly ProjectEstimateLineItem[]
@@ -140,6 +181,11 @@ export type ProjectEstimateWorkspace = {
   readonly costCodes: readonly ProjectEstimateCostCodeOption[]
   readonly taxEntities: readonly ProjectEstimateTaxOption[]
   readonly termsTemplates: readonly ProjectEstimateTermsOption[]
+  readonly introductionTemplates: readonly ProjectEstimateTermsOption[]
+  readonly closingTemplates: readonly ProjectEstimateTermsOption[]
+  readonly acknowledgementTemplates: readonly ProjectEstimateTermsOption[]
+  readonly phaseDescriptions: readonly ProjectEstimatePhaseDescriptionItem[]
+  readonly selectedAcknowledgements: readonly ProjectEstimateAcknowledgementItem[]
 }
 
 export type ProjectEstimateHeaderInput = {
@@ -151,6 +197,10 @@ export type ProjectEstimateHeaderInput = {
   readonly defaultTaxEntityId: string | null
   readonly termsTemplateId: string | null
   readonly contractTerms: string | null
+  readonly introductionTemplateId: string | null
+  readonly introductionText: string | null
+  readonly closingTemplateId: string | null
+  readonly closingText: string | null
 }
 
 export type ProjectEstimateLineInput = {
@@ -223,6 +273,7 @@ type EstimateAccess = {
   readonly projectNumber: string | null
   readonly projectName: string
   readonly organizationId: string | null
+  readonly department: ProjectDepartment
   readonly canEdit: boolean
 }
 
@@ -255,6 +306,10 @@ async function estimateAccess(
     projectNumber: access.projectNumber,
     projectName: project.name,
     organizationId: project.organizationId,
+    department: projectDepartment({
+      projectId,
+      projectNumber: access.projectNumber,
+    }),
     canEdit,
   }
 }
@@ -282,14 +337,39 @@ function safeUrl(value: string | null): string | null {
   }
 }
 
+function templateDepartment(value: string | null): ProjectDepartment | null {
+  if (value === "O" || value === "H" || value === "N" || value === "D") {
+    return value
+  }
+  return null
+}
+
+function templateOption(
+  template: EstimateTextTemplateOption
+): ProjectEstimateTermsOption {
+  return {
+    value: template.id,
+    label: template.name,
+    departmentCode: template.departmentCode,
+    templateType: template.templateType,
+    body: template.body,
+    sourceDocumentId: template.sourceDocumentId,
+    sourceUrl: template.sourceUrl,
+  }
+}
+
 function estimateSummary(
-  row: typeof projectEstimates.$inferSelect
+  row: typeof projectEstimates.$inferSelect,
+  department: ProjectDepartment
 ): ProjectEstimateSummary {
   return {
     id: row.id,
     estimateNumber: row.estimateNumber,
     versionNumber: row.versionNumber,
-    title: row.title,
+    title: estimateTitleForDepartment({
+      department,
+      requestedTitle: row.title,
+    }),
     status: row.status,
     estimateDate: row.estimateDate,
     clientName: row.clientName,
@@ -300,6 +380,10 @@ function estimateSummary(
     defaultTaxRateBasisPoints: row.defaultTaxRateBasisPoints,
     termsTemplateId: row.termsTemplateId,
     contractTerms: row.contractTerms,
+    introductionTemplateId: row.introductionTemplateId,
+    introductionText: row.introductionText,
+    closingTemplateId: row.closingTemplateId,
+    closingText: row.closingText,
     directCostCents: row.directCostCents,
     markupCents: row.markupCents,
     taxCents: row.taxCents,
@@ -381,6 +465,7 @@ function activeEstimate(
 
 function revalidateEstimate(projectId: string): void {
   revalidatePath(`/dashboard/projects/${projectId}/estimate`)
+  revalidatePath(`/print/projects/${projectId}/estimate`)
   revalidatePath(`/dashboard/projects/${projectId}/budget`)
   revalidatePath(`/dashboard/projects/${projectId}/financials`)
   revalidatePath(`/dashboard/projects/${projectId}/preview/owner`)
@@ -468,6 +553,40 @@ async function loadProjectEstimateCostCodes(
   return projectEstimateCostCodeCatalog(sageRows, namedSageRows)
 }
 
+async function loadEstimateTextTemplate(input: {
+  readonly db: CompassDb
+  readonly organizationId: string | null
+  readonly department: ProjectDepartment
+  readonly templateId: string | null
+  readonly templateType: EstimateTextTemplateType
+}): Promise<typeof estimateTermsTemplates.$inferSelect | null> {
+  if (!input.templateId) return null
+  if (!input.organizationId) {
+    throw new Error("The project organization is required for text templates.")
+  }
+  const rows = await input.db
+    .select()
+    .from(estimateTermsTemplates)
+    .where(
+      and(
+        eq(estimateTermsTemplates.id, input.templateId),
+        eq(estimateTermsTemplates.organizationId, input.organizationId),
+        eq(estimateTermsTemplates.active, true)
+      )
+    )
+    .limit(1)
+  const template = rows[0]
+  if (
+    !template ||
+    template.templateType !== input.templateType ||
+    (template.departmentCode !== null &&
+      template.departmentCode !== input.department)
+  ) {
+    throw new Error(`Choose an available ${input.templateType} template.`)
+  }
+  return template
+}
+
 export async function getProjectEstimateWorkspace(
   projectId: string,
   estimateId?: string
@@ -482,9 +601,19 @@ export async function getProjectEstimateWorkspace(
       desc(projectEstimates.versionNumber),
       desc(projectEstimates.updatedAt)
     )
-  const estimates = estimateRows.map(estimateSummary)
+  const estimates = estimateRows.map((row) =>
+    estimateSummary(row, access.department)
+  )
   const selected = activeEstimate(estimates, estimateId)
-  const [lineRows, basisRows, estimateCostCodes, taxRows, templateRows] =
+  const [
+    lineRows,
+    basisRows,
+    estimateCostCodes,
+    taxRows,
+    templateRows,
+    phaseRows,
+    acknowledgementRows,
+  ] =
     await Promise.all([
       selected
         ? access.db
@@ -522,14 +651,66 @@ export async function getProjectEstimateWorkspace(
                 eq(estimateTermsTemplates.active, true)
               )
             )
-            .orderBy(asc(estimateTermsTemplates.name))
+            .orderBy(
+              asc(estimateTermsTemplates.sortOrder),
+              asc(estimateTermsTemplates.name)
+            )
+        : Promise.resolve([]),
+      selected
+        ? access.db
+            .select()
+            .from(projectEstimatePhaseDescriptions)
+            .where(
+              eq(projectEstimatePhaseDescriptions.estimateId, selected.id)
+            )
+            .orderBy(asc(projectEstimatePhaseDescriptions.divisionCode))
+        : Promise.resolve([]),
+      selected
+        ? access.db
+            .select()
+            .from(projectEstimateAcknowledgements)
+            .where(eq(projectEstimateAcknowledgements.estimateId, selected.id))
+            .orderBy(asc(projectEstimateAcknowledgements.sortOrder))
         : Promise.resolve([]),
     ])
+
+  const databaseTemplates = templateRows.flatMap(
+    (row): readonly EstimateTextTemplateOption[] => {
+      if (!isEstimateTextTemplateType(row.templateType)) return []
+      const departmentCode = templateDepartment(row.departmentCode)
+      if (departmentCode !== null && departmentCode !== access.department) {
+        return []
+      }
+      return [
+        {
+          id: row.id,
+          name: row.name,
+          departmentCode,
+          templateType: row.templateType,
+          body: row.body,
+          sourceDocumentId: row.sourceDocumentId,
+          sourceUrl: row.sourceUrl,
+        },
+      ]
+    }
+  )
+  const availableTemplates = [
+    ...databaseTemplates,
+    ...builtInEstimateTextTemplates({ department: access.department }),
+  ]
+  const templatesByType = (
+    templateType: EstimateTextTemplateType
+  ): readonly ProjectEstimateTermsOption[] =>
+    availableTemplates
+      .filter((template) => template.templateType === templateType)
+      .map(templateOption)
 
   return {
     canEdit,
     projectNumber: access.projectNumber,
     projectName: access.projectName,
+    department: access.department,
+    reportMode: estimateClientReportMode(access.department),
     estimates,
     activeEstimate: selected,
     lines: lineRows.map(estimateLineItem),
@@ -567,10 +748,22 @@ export async function getProjectEstimateWorkspace(
       code: row.code,
       rateBasisPoints: row.rateBasisPoints,
     })),
-    termsTemplates: templateRows.map((row) => ({
-      value: row.id,
-      label: row.name,
+    termsTemplates: templatesByType("terms"),
+    introductionTemplates: templatesByType("introduction"),
+    closingTemplates: templatesByType("closing"),
+    acknowledgementTemplates: templatesByType("acknowledgement"),
+    phaseDescriptions: phaseRows.map((row) => ({
+      divisionCode: row.divisionCode,
+      description: row.description,
+    })),
+    selectedAcknowledgements: acknowledgementRows.map((row) => ({
+      id: row.id,
+      templateId: row.templateId,
+      title: row.title,
       body: row.body,
+      sourceDocumentId: row.sourceDocumentId,
+      sourceUrl: row.sourceUrl,
+      sortOrder: row.sortOrder,
     })),
   }
 }
@@ -595,7 +788,7 @@ export async function createProjectEstimateDraft(
       projectId,
       estimateNumber,
       versionNumber,
-      title: "CA22 Construction Estimate",
+      title: defaultEstimateTitle(access.department),
       status: "draft",
       estimateDate: now.slice(0, 10),
       sourceSystem: "compass",
@@ -630,16 +823,36 @@ export async function updateProjectEstimateHeader(
           .limit(1)
       : []
     const taxEntity = taxEntityRows[0]
-    const termsTemplateRows = input.termsTemplateId
-      ? await access.db
-          .select()
-          .from(estimateTermsTemplates)
-          .where(eq(estimateTermsTemplates.id, input.termsTemplateId))
-          .limit(1)
-      : []
-    const termsTemplate = termsTemplateRows[0]
+    const [termsTemplate, introductionTemplate, closingTemplate] =
+      await Promise.all([
+        loadEstimateTextTemplate({
+          db: access.db,
+          organizationId: access.organizationId,
+          department: access.department,
+          templateId: input.termsTemplateId,
+          templateType: "terms",
+        }),
+        loadEstimateTextTemplate({
+          db: access.db,
+          organizationId: access.organizationId,
+          department: access.department,
+          templateId: input.introductionTemplateId,
+          templateType: "introduction",
+        }),
+        loadEstimateTextTemplate({
+          db: access.db,
+          organizationId: access.organizationId,
+          department: access.department,
+          templateId: input.closingTemplateId,
+          templateType: "closing",
+        }),
+      ])
     const contractTerms =
       cleanText(input.contractTerms) ?? termsTemplate?.body ?? null
+    const introductionText =
+      cleanText(input.introductionText) ?? introductionTemplate?.body ?? null
+    const closingText =
+      cleanText(input.closingText) ?? closingTemplate?.body ?? null
     await access.db
       .update(projectEstimates)
       .set({
@@ -654,6 +867,10 @@ export async function updateProjectEstimateHeader(
         defaultTaxRateBasisPoints: taxEntity?.rateBasisPoints ?? 0,
         termsTemplateId: termsTemplate?.id ?? null,
         contractTerms,
+        introductionTemplateId: introductionTemplate?.id ?? null,
+        introductionText,
+        closingTemplateId: closingTemplate?.id ?? null,
+        closingText,
         updatedAt: new Date().toISOString(),
       })
       .where(eq(projectEstimates.id, estimateId))
@@ -665,6 +882,237 @@ export async function updateProjectEstimateHeader(
       success: false,
       error:
         error instanceof Error ? error.message : "Unable to save estimate.",
+    }
+  }
+}
+
+export async function saveProjectEstimatePhaseDescription(
+  projectId: string,
+  estimateId: string,
+  input: {
+    readonly divisionCode: string | null
+    readonly description: string | null
+  }
+): Promise<ProjectEstimateActionResult> {
+  try {
+    const access = await estimateAccess(projectId, true)
+    await requireEditableEstimate(access.db, projectId, estimateId)
+    const divisionCode = requiredText(input.divisionCode, "Phase")
+    const matchingLine = await access.db
+      .select({ id: projectEstimateLines.id })
+      .from(projectEstimateLines)
+      .where(
+        and(
+          eq(projectEstimateLines.estimateId, estimateId),
+          eq(projectEstimateLines.divisionCode, divisionCode)
+        )
+      )
+      .limit(1)
+    if (!matchingLine[0]) {
+      throw new Error("Choose a phase used by this estimate.")
+    }
+    const description = cleanText(input.description)
+    if (!description) {
+      await access.db
+        .delete(projectEstimatePhaseDescriptions)
+        .where(
+          and(
+            eq(projectEstimatePhaseDescriptions.estimateId, estimateId),
+            eq(projectEstimatePhaseDescriptions.divisionCode, divisionCode)
+          )
+        )
+        .run()
+      revalidateEstimate(projectId)
+      return { success: true, id: estimateId }
+    }
+    const now = new Date().toISOString()
+    await access.db
+      .insert(projectEstimatePhaseDescriptions)
+      .values({
+        id: crypto.randomUUID(),
+        projectId,
+        estimateId,
+        divisionCode,
+        description,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [
+          projectEstimatePhaseDescriptions.estimateId,
+          projectEstimatePhaseDescriptions.divisionCode,
+        ],
+        set: { description, updatedAt: now },
+      })
+      .run()
+    revalidateEstimate(projectId)
+    return { success: true, id: estimateId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to save the phase description.",
+    }
+  }
+}
+
+export async function setProjectEstimateAcknowledgements(
+  projectId: string,
+  estimateId: string,
+  templateIds: readonly string[]
+): Promise<ProjectEstimateActionResult> {
+  try {
+    const access = await estimateAccess(projectId, true)
+    await requireEditableEstimate(access.db, projectId, estimateId)
+    if (access.department !== "N") {
+      throw new Error("Acknowledgements are available for Nu-Tech estimates.")
+    }
+    const uniqueTemplateIds = [...new Set(templateIds)].slice(0, 10)
+    const databaseRows = access.organizationId
+      ? await access.db
+          .select()
+          .from(estimateTermsTemplates)
+          .where(
+            and(
+              eq(
+                estimateTermsTemplates.organizationId,
+                access.organizationId
+              ),
+              eq(estimateTermsTemplates.active, true),
+              eq(estimateTermsTemplates.templateType, "acknowledgement")
+            )
+          )
+      : []
+    const databaseTemplates = databaseRows.flatMap(
+      (row): readonly EstimateTextTemplateOption[] => {
+        const departmentCode = templateDepartment(row.departmentCode)
+        if (departmentCode !== null && departmentCode !== access.department) {
+          return []
+        }
+        return [
+          {
+            id: row.id,
+            name: row.name,
+            departmentCode,
+            templateType: "acknowledgement",
+            body: row.body,
+            sourceDocumentId: row.sourceDocumentId,
+            sourceUrl: row.sourceUrl,
+          },
+        ]
+      }
+    )
+    const availableTemplates = [
+      ...databaseTemplates,
+      ...builtInEstimateTextTemplates({
+        department: access.department,
+        templateType: "acknowledgement",
+      }),
+    ]
+    const selectedTemplates = uniqueTemplateIds.map((templateId) => {
+      const template = availableTemplates.find(
+        (candidate) => candidate.id === templateId
+      )
+      if (!template) throw new Error("Choose an available acknowledgement.")
+      return template
+    })
+    const now = new Date().toISOString()
+    await access.db
+      .delete(projectEstimateAcknowledgements)
+      .where(eq(projectEstimateAcknowledgements.estimateId, estimateId))
+      .run()
+    if (selectedTemplates.length > 0) {
+      await access.db
+        .insert(projectEstimateAcknowledgements)
+        .values(
+          selectedTemplates.map((template, sortOrder) => ({
+            id: crypto.randomUUID(),
+            projectId,
+            estimateId,
+            templateId: template.id,
+            title: template.name,
+            body: template.body,
+            sourceDocumentId: template.sourceDocumentId,
+            sourceUrl: template.sourceUrl,
+            sortOrder,
+            createdAt: now,
+            updatedAt: now,
+          }))
+        )
+        .run()
+    }
+    revalidateEstimate(projectId)
+    return { success: true, id: estimateId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to save acknowledgements.",
+    }
+  }
+}
+
+export async function saveEstimateTextTemplate(
+  projectId: string,
+  input: {
+    readonly name: string | null
+    readonly templateType: string | null
+    readonly body: string | null
+    readonly sourceUrl: string | null
+  }
+): Promise<ProjectEstimateActionResult> {
+  try {
+    const access = await estimateAccess(projectId, true)
+    if (!access.organizationId) {
+      throw new Error("The project organization is required for templates.")
+    }
+    const name = requiredText(input.name, "Template name")
+    const templateType = requiredText(input.templateType, "Template type")
+    if (!isEstimateTextTemplateType(templateType)) {
+      throw new Error("Choose a supported estimate text template type.")
+    }
+    const body = requiredText(input.body, "Template text")
+    const sourceUrl = safeUrl(input.sourceUrl)
+    const now = new Date().toISOString()
+    const id = crypto.randomUUID()
+    await access.db
+      .insert(estimateTermsTemplates)
+      .values({
+        id,
+        organizationId: access.organizationId,
+        name,
+        departmentCode: access.department,
+        templateType,
+        body,
+        sourceUrl,
+        active: true,
+        createdBy: access.user.id,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [
+          estimateTermsTemplates.organizationId,
+          estimateTermsTemplates.departmentCode,
+          estimateTermsTemplates.templateType,
+          estimateTermsTemplates.name,
+        ],
+        set: { body, sourceUrl, active: true, updatedAt: now },
+      })
+      .run()
+    revalidateEstimate(projectId)
+    return { success: true, id }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to save the estimate text template.",
     }
   }
 }
@@ -1166,16 +1614,29 @@ export async function prepareProjectEstimateForFoxit(
       projectId,
       estimateId
     )
-    const lines = await access.db
-      .select()
-      .from(projectEstimateLines)
-      .where(eq(projectEstimateLines.estimateId, estimateId))
-      .orderBy(asc(projectEstimateLines.sortOrder))
-    const basisDocuments = await access.db
-      .select()
-      .from(projectEstimateBasisDocuments)
-      .where(eq(projectEstimateBasisDocuments.estimateId, estimateId))
-      .orderBy(asc(projectEstimateBasisDocuments.sortOrder))
+    const [lines, basisDocuments, phaseDescriptions, acknowledgements] =
+      await Promise.all([
+        access.db
+          .select()
+          .from(projectEstimateLines)
+          .where(eq(projectEstimateLines.estimateId, estimateId))
+          .orderBy(asc(projectEstimateLines.sortOrder)),
+        access.db
+          .select()
+          .from(projectEstimateBasisDocuments)
+          .where(eq(projectEstimateBasisDocuments.estimateId, estimateId))
+          .orderBy(asc(projectEstimateBasisDocuments.sortOrder)),
+        access.db
+          .select()
+          .from(projectEstimatePhaseDescriptions)
+          .where(eq(projectEstimatePhaseDescriptions.estimateId, estimateId))
+          .orderBy(asc(projectEstimatePhaseDescriptions.divisionCode)),
+        access.db
+          .select()
+          .from(projectEstimateAcknowledgements)
+          .where(eq(projectEstimateAcknowledgements.estimateId, estimateId))
+          .orderBy(asc(projectEstimateAcknowledgements.sortOrder)),
+      ])
     if (lines.length === 0) throw new Error("Add estimate lines before signature.")
     const sourceCostCodes = [
       ...new Set(
@@ -1197,11 +1658,18 @@ export async function prepareProjectEstimateForFoxit(
     if (!cleanText(estimate.contractTerms)) {
       throw new Error("Add the contract terms before signature.")
     }
+    const reportTitle = estimateTitleForDepartment({
+      department: access.department,
+      requestedTitle: estimate.title,
+    })
     const sourceHash = await estimateSourceHash({
       estimateId,
       versionNumber: estimate.versionNumber,
-      title: estimate.title,
+      title: reportTitle,
+      reportMode: estimateClientReportMode(access.department),
+      introductionText: estimate.introductionText,
       contractTerms: estimate.contractTerms,
+      closingText: estimate.closingText,
       lines: lines.map((line) => ({
         id: line.id,
         divisionCode: line.divisionCode,
@@ -1230,11 +1698,22 @@ export async function prepareProjectEstimateForFoxit(
         notes: document.notes,
         sortOrder: document.sortOrder,
       })),
+      phaseDescriptions: phaseDescriptions.map((phase) => ({
+        divisionCode: phase.divisionCode,
+        description: phase.description,
+      })),
+      acknowledgements: acknowledgements.map((acknowledgement) => ({
+        templateId: acknowledgement.templateId,
+        title: acknowledgement.title,
+        body: acknowledgement.body,
+        sortOrder: acknowledgement.sortOrder,
+      })),
     })
     const now = new Date().toISOString()
     await access.db
       .update(projectEstimates)
       .set({
+        title: reportTitle,
         status: "signature_pending",
         foxitStatus: "handoff_ready",
         signatureRequestedAt: now,

--- a/src/app/dashboard/projects/[id]/estimate/page.tsx
+++ b/src/app/dashboard/projects/[id]/estimate/page.tsx
@@ -33,7 +33,7 @@ export default async function ProjectEstimatePage({
             <h1 className="text-2xl font-semibold tracking-tight">Estimate</h1>
           </div>
           <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
-            Division-first CA22 estimate, contract basis, approval, and budget handoff.
+            Department-specific client estimate, contract basis, approval, and budget handoff.
           </p>
         </div>
         <ProjectContextSwitcher currentProjectId={id} targetSection="estimate" placeholder="Switch estimate project..." className="w-full sm:w-[280px]" />

--- a/src/app/print/projects/[id]/estimate/page.tsx
+++ b/src/app/print/projects/[id]/estimate/page.tsx
@@ -4,6 +4,8 @@ import { getProjectEstimateWorkspace } from "@/app/actions/project-estimates"
 import { getProjects } from "@/app/actions/projects"
 import { ProjectBrandContactDetails } from "@/components/projects/project-brand-contact-details"
 import { ProjectBrandLogo } from "@/components/projects/project-brand-logo"
+import { ProjectEstimateReportActions } from "@/components/projects/project-estimate-report-actions"
+import { clientEstimatePhases } from "@/lib/estimates/client-report"
 import { projectBrandFor } from "@/lib/project-branding"
 
 function money(cents: number): string {
@@ -32,116 +34,252 @@ export default async function ProjectEstimatePrintPage({
     projectId: id,
     projectNumber: workspace.projectNumber,
   })
-  const divisions = new Map<string, typeof workspace.lines>()
-  for (const line of workspace.lines) {
-    const current = divisions.get(line.divisionCode) ?? []
-    divisions.set(line.divisionCode, [...current, line])
-  }
 
   if (!estimate) {
     return <main className="p-8">Estimate not found.</main>
   }
 
+  const phaseDescriptions = Object.fromEntries(
+    workspace.phaseDescriptions.map((item) => [
+      item.divisionCode,
+      item.description,
+    ])
+  )
+  const phases = clientEstimatePhases({
+    lines: workspace.lines,
+    phaseDescriptions,
+  })
+  const visibleLines = phases.flatMap((phase) => phase.lines)
+
   return (
-    <main className="mx-auto max-w-[8.5in] bg-white p-8 text-black print:max-w-none print:p-0">
-      <header className="flex items-start justify-between gap-6 border-b-2 border-black pb-5">
-        <div className="flex items-center gap-4">
-          <ProjectBrandLogo
-            brand={brand}
-            size={80}
-            className="size-20 object-contain"
-          />
-          <div>
-            <p className="text-lg font-bold">{brand.companyName}</p>
-            <ProjectBrandContactDetails
+    <>
+      <style>{`
+        @page { size: letter; margin: 0.55in; }
+        @media print {
+          body { background: white !important; }
+          .estimate-report-actions { display: none !important; }
+          .estimate-report { margin: 0 !important; max-width: none !important; padding: 0 !important; }
+          .estimate-acknowledgement { break-before: page; }
+        }
+      `}</style>
+      <ProjectEstimateReportActions
+        title={estimate.title}
+        estimateNumber={estimate.estimateNumber}
+      />
+      <main className="estimate-report mx-auto max-w-[8.5in] bg-white p-8 text-black print:max-w-none print:p-0">
+        <header className="flex items-start justify-between gap-6 border-b-2 border-black pb-5">
+          <div className="flex items-center gap-4">
+            <ProjectBrandLogo
               brand={brand}
-              lineClassName="text-sm"
+              size={80}
+              className="size-20 object-contain"
             />
-          </div>
-        </div>
-        <div className="text-right">
-          <h1 className="text-xl font-bold">CA22 Construction Estimate</h1>
-          <p className="mt-1 text-sm">{estimate.estimateNumber}</p>
-          <p className="text-sm">Version {estimate.versionNumber}</p>
-        </div>
-      </header>
-
-      <section className="mt-5 grid grid-cols-2 gap-6 text-sm">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-wide">Project</p>
-          <p className="mt-1 font-semibold">{project?.name ?? workspace.projectName}</p>
-          <p>{workspace.projectNumber}</p>
-        </div>
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-wide">Prepared for</p>
-          <p className="mt-1 font-semibold">{estimate.clientName ?? "Project owner"}</p>
-          <p>{estimate.estimateDate ?? ""}</p>
-        </div>
-      </section>
-
-      <section className="mt-6">
-        <div className="grid grid-cols-[1fr_1.2in] border-b border-black pb-1 text-xs font-semibold uppercase tracking-wide">
-          <span>CSI division and cost code</span>
-          <span className="text-right">Amount</span>
-        </div>
-        {[...divisions.entries()].map(([divisionCode, lines]) => {
-          const subtotal = lines.reduce((sum, line) => sum + line.lineTotalCents, 0)
-          return (
-            <div key={divisionCode} className="break-inside-avoid border-b py-3">
-              <div className="flex items-center justify-between gap-3 font-semibold">
-                <span>{divisionCode} · {lines[0]?.divisionName}</span>
-                <span>{money(subtotal)}</span>
-              </div>
-              <div className="mt-1 space-y-1">
-                {lines.map((line) => (
-                  <div key={line.id} className="grid grid-cols-[1fr_1.2in] gap-3 text-sm">
-                    <div>
-                      <span className="font-medium">{line.costCode}</span>
-                      <span> · {line.description}</span>
-                      {line.specifications && <p className="text-xs text-neutral-600">{line.specifications}</p>}
-                    </div>
-                    <span className="text-right">{money(line.lineTotalCents)}</span>
-                  </div>
-                ))}
-              </div>
+            <div>
+              <p className="text-lg font-bold">{brand.companyName}</p>
+              <ProjectBrandContactDetails
+                brand={brand}
+                lineClassName="text-sm"
+              />
             </div>
-          )
-        })}
-      </section>
+          </div>
+          <div className="text-right">
+            <h1 className="text-xl font-bold">{estimate.title}</h1>
+            <p className="mt-1 text-sm">{estimate.estimateNumber}</p>
+            <p className="text-sm">Version {estimate.versionNumber}</p>
+          </div>
+        </header>
 
-      <section className="ml-auto mt-5 w-full max-w-sm space-y-1 text-sm">
-        <div className="flex justify-between"><span>Direct cost</span><span>{money(estimate.directCostCents)}</span></div>
-        <div className="flex justify-between"><span>Line markup</span><span>{money(estimate.markupCents)}</span></div>
-        <div className="flex justify-between"><span>Sales tax</span><span>{money(estimate.taxCents)}</span></div>
-        <div className="flex justify-between border-t border-black pt-2 text-base font-bold"><span>Construction estimate</span><span>{money(estimate.estimateTotalCents)}</span></div>
-      </section>
+        <section className="mt-5 grid grid-cols-2 gap-6 text-sm">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide">
+              Project
+            </p>
+            <p className="mt-1 font-semibold">
+              {project?.name ?? workspace.projectName}
+            </p>
+            <p>{workspace.projectNumber}</p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide">
+              Prepared for
+            </p>
+            <p className="mt-1 font-semibold">
+              {estimate.clientName ?? "Project client"}
+            </p>
+            <p>{estimate.estimateDate ?? ""}</p>
+          </div>
+        </section>
 
-      {workspace.basisDocuments.length > 0 && (
-        <section className="mt-8 break-inside-avoid">
-          <h2 className="border-b pb-1 text-sm font-bold uppercase tracking-wide">Estimate basis</h2>
-          <ul className="mt-2 space-y-1 text-sm">
-            {workspace.basisDocuments.map((document) => (
-              <li key={document.id}>
-                <span className="font-medium">{document.title}</span>
-                {document.documentDate ? ` · ${document.documentDate}` : ""}
-                {document.revision ? ` · revision ${document.revision}` : ""}
-              </li>
+        {estimate.introductionText && (
+          <section className="mt-6 whitespace-pre-wrap text-sm leading-6">
+            {estimate.introductionText}
+          </section>
+        )}
+
+        {workspace.reportMode === "phase_summary" && (
+          <section className="mt-6">
+            <div className="grid grid-cols-[1fr_1.2in] border-b border-black pb-1 text-xs font-semibold uppercase tracking-wide">
+              <span>Phase description</span>
+              <span className="text-right">Subtotal</span>
+            </div>
+            {phases.map((phase) => (
+              <div
+                key={phase.divisionCode}
+                className="grid break-inside-avoid grid-cols-[1fr_1.2in] gap-3 border-b py-3 text-sm"
+              >
+                <div>
+                  <p className="font-semibold">{phase.description}</p>
+                  <p className="text-xs text-neutral-600">
+                    Phase {phase.divisionCode}
+                  </p>
+                </div>
+                <span className="text-right font-semibold">
+                  {money(phase.subtotalCents)}
+                </span>
+              </div>
             ))}
-          </ul>
-        </section>
-      )}
+          </section>
+        )}
 
-      {estimate.contractTerms && (
-        <section className="mt-8 break-inside-avoid">
-          <h2 className="border-b pb-1 text-sm font-bold uppercase tracking-wide">Pertinent contract terms</h2>
-          <p className="mt-2 whitespace-pre-wrap text-sm leading-6">{estimate.contractTerms}</p>
-        </section>
-      )}
+        {workspace.reportMode === "ca22" && (
+          <section className="mt-6">
+            <div className="grid grid-cols-[1fr_1.2in] border-b border-black pb-1 text-xs font-semibold uppercase tracking-wide">
+              <span>Phase and cost code</span>
+              <span className="text-right">Amount</span>
+            </div>
+            {phases.map((phase) => (
+              <div
+                key={phase.divisionCode}
+                className="break-inside-avoid border-b py-3"
+              >
+                <div className="flex items-start justify-between gap-3 font-semibold">
+                  <div>
+                    <p>{phase.description}</p>
+                    <p className="text-xs font-normal text-neutral-600">
+                      Phase {phase.divisionCode}
+                    </p>
+                  </div>
+                  <span>{money(phase.subtotalCents)}</span>
+                </div>
+                <div className="mt-2 space-y-1.5">
+                  {phase.lines.map((line) => (
+                    <div
+                      key={line.id}
+                      className="grid grid-cols-[1fr_1.2in] gap-3 pl-3 text-sm"
+                    >
+                      <div>
+                        <span className="font-medium">{line.costCode}</span>
+                        <span> - {line.description}</span>
+                        {line.specifications && (
+                          <p className="text-xs text-neutral-600">
+                            {line.specifications}
+                          </p>
+                        )}
+                      </div>
+                      <span className="text-right">
+                        {money(line.lineTotalCents)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </section>
+        )}
 
-      <footer className="mt-10 border-t pt-3 text-xs text-neutral-600">
-        Accepted estimate versions are locked in Compass. Revisions to the contract
-        sum are recorded through executed change orders and the G703.
-      </footer>
-    </main>
+        {workspace.reportMode === "cost_code" && (
+          <section className="mt-6">
+            <div className="grid grid-cols-[1fr_1.2in] border-b border-black pb-1 text-xs font-semibold uppercase tracking-wide">
+              <span>Cost code and description</span>
+              <span className="text-right">Amount</span>
+            </div>
+            {visibleLines.map((line) => (
+              <div
+                key={line.id}
+                className="grid break-inside-avoid grid-cols-[1fr_1.2in] gap-3 border-b py-3 text-sm"
+              >
+                <div>
+                  <span className="font-medium">{line.costCode}</span>
+                  <span> - {line.description}</span>
+                  {line.specifications && (
+                    <p className="text-xs text-neutral-600">
+                      {line.specifications}
+                    </p>
+                  )}
+                </div>
+                <span className="text-right font-medium">
+                  {money(line.lineTotalCents)}
+                </span>
+              </div>
+            ))}
+          </section>
+        )}
+
+        <section className="ml-auto mt-5 w-full max-w-sm text-sm">
+          <div className="flex justify-between border-t border-black pt-2 text-base font-bold">
+            <span>Estimate total</span>
+            <span>{money(estimate.estimateTotalCents)}</span>
+          </div>
+        </section>
+
+        {workspace.basisDocuments.length > 0 && (
+          <section className="mt-8 break-inside-avoid">
+            <h2 className="border-b pb-1 text-sm font-bold uppercase tracking-wide">
+              Estimate basis
+            </h2>
+            <ul className="mt-2 space-y-1 text-sm">
+              {workspace.basisDocuments.map((document) => (
+                <li key={document.id}>
+                  <span className="font-medium">{document.title}</span>
+                  {document.documentDate ? ` - ${document.documentDate}` : ""}
+                  {document.revision ? ` - revision ${document.revision}` : ""}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {estimate.contractTerms && (
+          <section className="mt-8 break-inside-avoid">
+            <h2 className="border-b pb-1 text-sm font-bold uppercase tracking-wide">
+              Pertinent contract terms
+            </h2>
+            <p className="mt-2 whitespace-pre-wrap text-sm leading-6">
+              {estimate.contractTerms}
+            </p>
+          </section>
+        )}
+
+        {estimate.closingText && (
+          <section className="mt-8 whitespace-pre-wrap text-sm leading-6">
+            {estimate.closingText}
+          </section>
+        )}
+
+        <footer className="mt-10 border-t pt-3 text-xs text-neutral-600">
+          Estimate {estimate.estimateNumber}, version {estimate.versionNumber}.
+        </footer>
+
+        {workspace.selectedAcknowledgements.map((acknowledgement) => (
+          <section
+            key={acknowledgement.id}
+            className="estimate-acknowledgement pt-2"
+          >
+            <div className="border-b-2 border-black pb-3">
+              <p className="text-sm font-semibold">{brand.companyName}</p>
+              <h2 className="mt-1 text-xl font-bold">
+                {acknowledgement.title}
+              </h2>
+              <p className="mt-1 text-xs text-neutral-600">
+                Appended to {estimate.estimateNumber}
+              </p>
+            </div>
+            <div className="mt-5 whitespace-pre-wrap text-sm leading-6">
+              {acknowledgement.body}
+            </div>
+          </section>
+        ))}
+      </main>
+    </>
   )
 }

--- a/src/components/projects/project-estimate-client-report-settings.tsx
+++ b/src/components/projects/project-estimate-client-report-settings.tsx
@@ -1,0 +1,322 @@
+"use client"
+
+import { useMemo, useState, useTransition, type FormEvent } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { IconExternalLink, IconFileDescription } from "@tabler/icons-react"
+
+import {
+  saveEstimateTextTemplate,
+  saveProjectEstimatePhaseDescription,
+  setProjectEstimateAcknowledgements,
+  type ProjectEstimateSummary,
+  type ProjectEstimateWorkspace,
+} from "@/app/actions/project-estimates"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+
+function reportModeLabel(workspace: ProjectEstimateWorkspace): string {
+  if (workspace.reportMode === "phase_summary") {
+    return "Phase subtotals only"
+  }
+  if (workspace.reportMode === "cost_code") {
+    return "Individual cost codes"
+  }
+  return "CA22 phase and cost-code detail"
+}
+
+export function ProjectEstimateClientReportSettings({
+  projectId,
+  workspace,
+  estimate,
+  editable,
+}: {
+  readonly projectId: string
+  readonly workspace: ProjectEstimateWorkspace
+  readonly estimate: ProjectEstimateSummary
+  readonly editable: boolean
+}): React.ReactElement {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [message, setMessage] = useState<string | null>(null)
+  const [acknowledgementIds, setAcknowledgementIds] = useState<readonly string[]>(
+    workspace.selectedAcknowledgements.map((item) => item.templateId)
+  )
+  const phases = useMemo(() => {
+    const groups = new Map<string, string>()
+    for (const line of workspace.lines) {
+      if (!groups.has(line.divisionCode)) {
+        groups.set(line.divisionCode, line.divisionName)
+      }
+    }
+    return [...groups.entries()].sort((left, right) =>
+      left[0].localeCompare(right[0])
+    )
+  }, [workspace.lines])
+  const phaseDescriptions = useMemo(
+    () =>
+      new Map(
+        workspace.phaseDescriptions.map((item) => [
+          item.divisionCode,
+          item.description,
+        ])
+      ),
+    [workspace.phaseDescriptions]
+  )
+
+  function savePhase(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    const divisionCode = String(formData.get("divisionCode") ?? "").trim()
+    const description = String(formData.get("description") ?? "").trim()
+    setMessage(null)
+    startTransition(async () => {
+      const result = await saveProjectEstimatePhaseDescription(
+        projectId,
+        estimate.id,
+        { divisionCode, description }
+      )
+      setMessage(
+        result.success ? "Phase description saved." : result.error
+      )
+      if (result.success) router.refresh()
+    })
+  }
+
+  function toggleAcknowledgement(templateId: string, selected: boolean): void {
+    setAcknowledgementIds((current) =>
+      selected
+        ? [...current.filter((id) => id !== templateId), templateId]
+        : current.filter((id) => id !== templateId)
+    )
+  }
+
+  function saveAcknowledgements(): void {
+    setMessage(null)
+    startTransition(async () => {
+      const result = await setProjectEstimateAcknowledgements(
+        projectId,
+        estimate.id,
+        acknowledgementIds
+      )
+      setMessage(
+        result.success ? "Acknowledgement selections saved." : result.error
+      )
+      if (result.success) router.refresh()
+    })
+  }
+
+  function saveTextTemplate(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    const form = event.currentTarget
+    const formData = new FormData(form)
+    const value = (name: string): string =>
+      String(formData.get(name) ?? "").trim()
+    setMessage(null)
+    startTransition(async () => {
+      const result = await saveEstimateTextTemplate(projectId, {
+        name: value("templateName"),
+        templateType: value("templateType"),
+        body: value("templateBody"),
+        sourceUrl: value("templateSourceUrl"),
+      })
+      setMessage(
+        result.success
+          ? `${workspace.department}-department text template saved.`
+          : result.error
+      )
+      if (result.success) {
+        form.reset()
+        router.refresh()
+      }
+    })
+  }
+
+  return (
+    <section className="clarity-panel-strong p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <IconFileDescription className="mt-0.5 size-5 text-primary" />
+          <div>
+            <h2 className="font-semibold">Client report presentation</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              The client view follows the {workspace.department}-department
+              estimate format. Internal quantities, markup, and tax details stay
+              in the working estimate.
+            </p>
+          </div>
+        </div>
+        <Badge variant="outline">{reportModeLabel(workspace)}</Badge>
+      </div>
+
+      {message && (
+        <p className="mt-3 rounded-md border bg-muted/35 px-3 py-2 text-sm">
+          {message}
+        </p>
+      )}
+
+      {workspace.reportMode !== "cost_code" && phases.length > 0 && (
+        <div className="mt-5 space-y-3 border-t pt-4">
+          <div>
+            <h3 className="text-sm font-semibold">Phase descriptions</h3>
+            <p className="text-xs text-muted-foreground">
+              These client-facing descriptions replace the default CSI division
+              names. Phase subtotals continue to come from the estimate lines.
+            </p>
+          </div>
+          {phases.map(([divisionCode, divisionName]) => (
+            <form
+              key={divisionCode}
+              className="grid gap-2 md:grid-cols-[9rem_minmax(0,1fr)_auto] md:items-end"
+              onSubmit={savePhase}
+            >
+              <input type="hidden" name="divisionCode" value={divisionCode} />
+              <div className="space-y-1.5">
+                <Label>Phase</Label>
+                <div className="flex h-9 items-center text-sm font-medium">
+                  {divisionCode} - {divisionName}
+                </div>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor={`phase-description-${divisionCode}`}>
+                  Client description
+                </Label>
+                <Input
+                  id={`phase-description-${divisionCode}`}
+                  name="description"
+                  defaultValue={phaseDescriptions.get(divisionCode) ?? ""}
+                  placeholder={divisionName}
+                  disabled={!editable}
+                />
+              </div>
+              {editable && (
+                <Button type="submit" variant="outline" disabled={isPending}>
+                  Save phase
+                </Button>
+              )}
+            </form>
+          ))}
+        </div>
+      )}
+
+      {workspace.department === "N" && (
+        <div className="mt-5 border-t pt-4">
+          <h3 className="text-sm font-semibold">Append acknowledgements</h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Selected forms are snapshotted with this estimate and appended to
+            the printable report.
+          </p>
+          <div className="mt-3 space-y-3">
+            {workspace.acknowledgementTemplates.map((template) => (
+              <div
+                key={template.value}
+                className="flex items-start justify-between gap-4 rounded-md border p-3"
+              >
+                <label className="flex items-start gap-3 text-sm">
+                  <Checkbox
+                    className="mt-0.5"
+                    checked={acknowledgementIds.includes(template.value)}
+                    onCheckedChange={(checked) =>
+                      toggleAcknowledgement(template.value, checked === true)
+                    }
+                    disabled={!editable}
+                  />
+                  <span>
+                    <span className="font-medium">{template.label}</span>
+                    <span className="mt-1 block text-xs text-muted-foreground">
+                      Appended as a separate signature-ready report section.
+                    </span>
+                  </span>
+                </label>
+                {template.sourceUrl && (
+                  <Button variant="ghost" size="sm" asChild>
+                    <Link href={template.sourceUrl} target="_blank">
+                      Source <IconExternalLink className="size-3.5" />
+                    </Link>
+                  </Button>
+                )}
+              </div>
+            ))}
+          </div>
+          {editable && (
+            <Button
+              type="button"
+              className="mt-3"
+              variant="outline"
+              disabled={isPending}
+              onClick={saveAcknowledgements}
+            >
+              Save acknowledgements
+            </Button>
+          )}
+        </div>
+      )}
+
+      {editable && (
+        <form className="mt-5 border-t pt-4" onSubmit={saveTextTemplate}>
+          <h3 className="text-sm font-semibold">
+            Add an {workspace.department}-department text template
+          </h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Department templates become available in future estimates without
+            changing any estimate that has already been issued.
+          </p>
+          <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="estimate-template-type">Template type</Label>
+              <Select name="templateType" defaultValue="terms">
+                <SelectTrigger id="estimate-template-type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="terms">Terms and conditions</SelectItem>
+                  <SelectItem value="introduction">Introduction</SelectItem>
+                  <SelectItem value="closing">Closing text</SelectItem>
+                  <SelectItem value="acknowledgement">Acknowledgement</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5 md:col-span-1 xl:col-span-3">
+              <Label htmlFor="estimate-template-name">Template name</Label>
+              <Input id="estimate-template-name" name="templateName" required />
+            </div>
+            <div className="space-y-1.5 md:col-span-2 xl:col-span-4">
+              <Label htmlFor="estimate-template-body">Template text</Label>
+              <Textarea
+                id="estimate-template-body"
+                name="templateBody"
+                rows={6}
+                required
+              />
+            </div>
+            <div className="space-y-1.5 md:col-span-2 xl:col-span-3">
+              <Label htmlFor="estimate-template-source">Source link</Label>
+              <Input
+                id="estimate-template-source"
+                name="templateSourceUrl"
+                type="url"
+                placeholder="Optional Google Drive source"
+              />
+            </div>
+            <div className="flex items-end">
+              <Button type="submit" disabled={isPending}>
+                Save department template
+              </Button>
+            </div>
+          </div>
+        </form>
+      )}
+    </section>
+  )
+}

--- a/src/components/projects/project-estimate-report-actions.tsx
+++ b/src/components/projects/project-estimate-report-actions.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { IconMail, IconPrinter } from "@tabler/icons-react"
+
+import { Button } from "@/components/ui/button"
+import { trackedMailtoHref } from "@/lib/email/mailto"
+
+export function ProjectEstimateReportActions({
+  title,
+  estimateNumber,
+}: {
+  readonly title: string
+  readonly estimateNumber: string
+}): React.ReactElement {
+  function emailReport(): void {
+    const href = trackedMailtoHref({
+      to: [],
+      cc: [],
+      subject: `${title} - ${estimateNumber}`,
+      body: `Please review ${title} ${estimateNumber}:\n\n${window.location.href}\n\nUse Print / Save PDF to attach a PDF copy when needed.`,
+    })
+    window.location.href = href
+  }
+
+  return (
+    <div className="estimate-report-actions sticky top-0 z-10 flex justify-center gap-2 border-b bg-background/95 p-3 backdrop-blur">
+      <Button type="button" onClick={() => window.print()}>
+        <IconPrinter className="size-4" />
+        Print / Save PDF
+      </Button>
+      <Button type="button" variant="outline" onClick={emailReport}>
+        <IconMail className="size-4" />
+        Email report link
+      </Button>
+    </div>
+  )
+}

--- a/src/components/projects/project-estimate-workspace.tsx
+++ b/src/components/projects/project-estimate-workspace.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/app/actions/project-estimates"
 import { Badge } from "@/components/ui/badge"
 import { useDeveloperMode } from "@/components/developer-mode-provider"
+import { ProjectEstimateClientReportSettings } from "@/components/projects/project-estimate-client-report-settings"
 import { ProjectEstimatePlanSwiftImport } from "@/components/projects/project-estimate-planswift-import"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -217,6 +218,13 @@ export function ProjectEstimateWorkspacePanel({
         defaultTaxEntityId: formText(formData, "defaultTaxEntityId"),
         termsTemplateId: formText(formData, "termsTemplateId"),
         contractTerms: formText(formData, "contractTerms"),
+        introductionTemplateId: formText(
+          formData,
+          "introductionTemplateId"
+        ),
+        introductionText: formText(formData, "introductionText"),
+        closingTemplateId: formText(formData, "closingTemplateId"),
+        closingText: formText(formData, "closingText"),
       })
       finish(result.success ? "Estimate details saved." : result.error)
     })
@@ -327,7 +335,7 @@ export function ProjectEstimateWorkspacePanel({
       const result = await prepareProjectEstimateForFoxit(projectId, estimate.id)
       finish(
         result.success
-          ? "CA22 estimate locked and ready for Foxit signature handoff."
+          ? "Client estimate locked and ready for Foxit signature handoff."
           : result.error
       )
     })
@@ -481,7 +489,7 @@ export function ProjectEstimateWorkspacePanel({
               target="_blank"
             >
               <IconFileExport className="size-4" />
-              CA22 preview
+              Client report preview
             </Link>
           </Button>
         </div>
@@ -590,6 +598,65 @@ export function ProjectEstimateWorkspacePanel({
                 ))}
               </SelectContent>
             </Select>
+            {workspace.termsTemplates.length === 0 && (
+              <p className="text-xs text-muted-foreground">
+                No {workspace.department}-department terms templates are
+                available yet. Enter estimate-specific terms below.
+              </p>
+            )}
+          </div>
+          <div className="space-y-1.5 md:col-span-2">
+            <Label htmlFor="introductionTemplateId">
+              Introductory text template
+            </Label>
+            <Select
+              name="introductionTemplateId"
+              defaultValue={estimate.introductionTemplateId ?? undefined}
+              disabled={!editable || workspace.introductionTemplates.length === 0}
+            >
+              <SelectTrigger id="introductionTemplateId">
+                <SelectValue placeholder="Choose introductory copy" />
+              </SelectTrigger>
+              <SelectContent>
+                {workspace.introductionTemplates.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5 md:col-span-2">
+            <Label htmlFor="closingTemplateId">Closing text template</Label>
+            <Select
+              name="closingTemplateId"
+              defaultValue={estimate.closingTemplateId ?? undefined}
+              disabled={!editable || workspace.closingTemplates.length === 0}
+            >
+              <SelectTrigger id="closingTemplateId">
+                <SelectValue placeholder="Choose closing copy" />
+              </SelectTrigger>
+              <SelectContent>
+                {workspace.closingTemplates.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5 md:col-span-2 xl:col-span-4">
+            <Label htmlFor="introductionText">
+              Client report introduction
+            </Label>
+            <Textarea
+              id="introductionText"
+              name="introductionText"
+              rows={4}
+              defaultValue={estimate.introductionText ?? ""}
+              disabled={!editable}
+              placeholder="Optional editable text shown before the estimate detail."
+            />
           </div>
           <div className="space-y-1.5 md:col-span-2 xl:col-span-4">
             <Label htmlFor="contractTerms">Pertinent contract terms</Label>
@@ -602,6 +669,17 @@ export function ProjectEstimateWorkspacePanel({
               placeholder="Use a template or draft the estimate-specific terms here."
             />
           </div>
+          <div className="space-y-1.5 md:col-span-2 xl:col-span-4">
+            <Label htmlFor="closingText">Client report closing text</Label>
+            <Textarea
+              id="closingText"
+              name="closingText"
+              rows={4}
+              defaultValue={estimate.closingText ?? ""}
+              disabled={!editable}
+              placeholder="Optional editable text shown after the estimate detail."
+            />
+          </div>
         </div>
         {editable && (
           <div className="mt-4 flex justify-end">
@@ -609,6 +687,13 @@ export function ProjectEstimateWorkspacePanel({
           </div>
         )}
       </form>
+
+      <ProjectEstimateClientReportSettings
+        projectId={projectId}
+        workspace={workspace}
+        estimate={estimate}
+        editable={editable}
+      />
 
       <section className="clarity-panel-strong p-4">
         <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
@@ -868,7 +953,7 @@ export function ProjectEstimateWorkspacePanel({
             </p>
             {editable && (
               <Button className="mt-3" onClick={prepareFoxit} disabled={isPending || workspace.lines.length === 0}>
-                <IconSend className="size-4" />Prepare CA22 for Foxit
+                <IconSend className="size-4" />Prepare client estimate for Foxit
               </Button>
             )}
             {estimate.status === "signature_pending" && workspace.canEdit && (

--- a/src/db/__tests__/estimate-client-report-schema.test.ts
+++ b/src/db/__tests__/estimate-client-report-schema.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  estimateTermsTemplates,
+  projectEstimateAcknowledgements,
+  projectEstimatePhaseDescriptions,
+  projectEstimates,
+} from "@/db/schema-estimates"
+
+describe("estimate client report persistence contract", () => {
+  it("scopes reusable estimate copy by department and content type", () => {
+    expect(estimateTermsTemplates.departmentCode.name).toBe("department_code")
+    expect(estimateTermsTemplates.templateType.name).toBe("template_type")
+    expect(estimateTermsTemplates.sourceDocumentId.name).toBe(
+      "source_document_id"
+    )
+  })
+
+  it("stores editable opening and closing estimate copy", () => {
+    expect(projectEstimates.introductionText.name).toBe("introduction_text")
+    expect(projectEstimates.closingText.name).toBe("closing_text")
+  })
+
+  it("snapshots phase descriptions and selected acknowledgements", () => {
+    expect(projectEstimatePhaseDescriptions.divisionCode.name).toBe(
+      "division_code"
+    )
+    expect(projectEstimateAcknowledgements.templateId.name).toBe("template_id")
+    expect(projectEstimateAcknowledgements.body.name).toBe("body")
+  })
+})

--- a/src/db/schema-estimates.ts
+++ b/src/db/schema-estimates.ts
@@ -42,7 +42,12 @@ export const estimateTermsTemplates = sqliteTable(
       .notNull()
       .references(() => organizations.id, { onDelete: "cascade" }),
     name: text("name").notNull(),
+    departmentCode: text("department_code"),
+    templateType: text("template_type").notNull().default("terms"),
     body: text("body").notNull(),
+    sourceDocumentId: text("source_document_id"),
+    sourceUrl: text("source_url"),
+    sortOrder: integer("sort_order").notNull().default(0),
     active: integer("active", { mode: "boolean" }).notNull().default(true),
     createdBy: text("created_by").references(() => users.id, {
       onDelete: "set null",
@@ -51,12 +56,16 @@ export const estimateTermsTemplates = sqliteTable(
     updatedAt: text("updated_at").notNull(),
   },
   (table) => [
-    uniqueIndex("estimate_terms_templates_org_name_uq").on(
+    uniqueIndex("estimate_terms_templates_org_department_type_name_uq").on(
       table.organizationId,
+      table.departmentCode,
+      table.templateType,
       table.name
     ),
     index("estimate_terms_templates_org_active_idx").on(
       table.organizationId,
+      table.departmentCode,
+      table.templateType,
       table.active
     ),
   ]
@@ -101,6 +110,16 @@ export const projectEstimates = sqliteTable(
       { onDelete: "set null" }
     ),
     contractTerms: text("contract_terms"),
+    introductionTemplateId: text("introduction_template_id").references(
+      () => estimateTermsTemplates.id,
+      { onDelete: "set null" }
+    ),
+    introductionText: text("introduction_text"),
+    closingTemplateId: text("closing_template_id").references(
+      () => estimateTermsTemplates.id,
+      { onDelete: "set null" }
+    ),
+    closingText: text("closing_text"),
     directCostCents: integer("direct_cost_cents").notNull().default(0),
     markupCents: integer("markup_cents").notNull().default(0),
     taxCents: integer("tax_cents").notNull().default(0),
@@ -134,6 +153,65 @@ export const projectEstimates = sqliteTable(
       table.projectId,
       table.status,
       table.versionNumber
+    ),
+  ]
+)
+
+export const projectEstimatePhaseDescriptions = sqliteTable(
+  "project_estimate_phase_descriptions",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    estimateId: text("estimate_id")
+      .notNull()
+      .references(() => projectEstimates.id, { onDelete: "cascade" }),
+    divisionCode: text("division_code").notNull(),
+    description: text("description").notNull(),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("project_estimate_phase_description_uq").on(
+      table.estimateId,
+      table.divisionCode
+    ),
+    index("project_estimate_phase_descriptions_project_idx").on(
+      table.projectId,
+      table.estimateId
+    ),
+  ]
+)
+
+export const projectEstimateAcknowledgements = sqliteTable(
+  "project_estimate_acknowledgements",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    estimateId: text("estimate_id")
+      .notNull()
+      .references(() => projectEstimates.id, { onDelete: "cascade" }),
+    templateId: text("template_id").notNull(),
+    title: text("title").notNull(),
+    body: text("body").notNull(),
+    sourceDocumentId: text("source_document_id"),
+    sourceUrl: text("source_url"),
+    sortOrder: integer("sort_order").notNull().default(0),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("project_estimate_acknowledgements_template_uq").on(
+      table.estimateId,
+      table.templateId
+    ),
+    index("project_estimate_acknowledgements_project_idx").on(
+      table.projectId,
+      table.estimateId,
+      table.sortOrder
     ),
   ]
 )
@@ -352,6 +430,10 @@ export type ProjectEstimate = typeof projectEstimates.$inferSelect
 export type ProjectEstimateLine = typeof projectEstimateLines.$inferSelect
 export type ProjectEstimateBasisDocument =
   typeof projectEstimateBasisDocuments.$inferSelect
+export type ProjectEstimatePhaseDescription =
+  typeof projectEstimatePhaseDescriptions.$inferSelect
+export type ProjectEstimateAcknowledgement =
+  typeof projectEstimateAcknowledgements.$inferSelect
 export type ProjectContractBudgetRevision =
   typeof projectContractBudgetRevisions.$inferSelect
 export type ProjectContractBudgetLine =

--- a/src/lib/estimates/__tests__/client-report.test.ts
+++ b/src/lib/estimates/__tests__/client-report.test.ts
@@ -103,4 +103,36 @@ describe("estimate client report profiles", () => {
       })
     ).toEqual([])
   })
+
+  it("offers the default introduction to every department", () => {
+    for (const department of ["H", "O", "N", "D"] as const) {
+      const templates = builtInEstimateTextTemplates({
+        department,
+        templateType: "introduction",
+      })
+      expect(templates).toHaveLength(1)
+      expect(templates[0]?.name).toBe("Default Introductory Text")
+      expect(templates[0]?.body).toContain(
+        "Thank you for the opportunity to provide you with an estimate"
+      )
+    }
+  })
+
+  it("limits the HPS closing text to H and O estimates", () => {
+    for (const department of ["H", "O"] as const) {
+      const templates = builtInEstimateTextTemplates({
+        department,
+        templateType: "closing",
+      })
+      expect(templates).toHaveLength(1)
+      expect(templates[0]?.body).toContain("General Exclusions:")
+      expect(templates[0]?.body).toContain("Payment Terms:")
+    }
+    expect(
+      builtInEstimateTextTemplates({
+        department: "N",
+        templateType: "closing",
+      })
+    ).toEqual([])
+  })
 })

--- a/src/lib/estimates/__tests__/client-report.test.ts
+++ b/src/lib/estimates/__tests__/client-report.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  builtInEstimateTextTemplates,
+  clientEstimatePhases,
+  defaultEstimateTitle,
+  estimateClientReportMode,
+  estimateTitleForDepartment,
+  type ClientEstimateLine,
+} from "@/lib/estimates/client-report"
+
+function line(
+  overrides: Partial<ClientEstimateLine> = {}
+): ClientEstimateLine {
+  return {
+    id: "line-1",
+    divisionCode: "03",
+    divisionName: "Concrete",
+    costCode: "03 30 00",
+    description: "Cast-in-place concrete",
+    specifications: null,
+    lineTotalCents: 10_000,
+    ownerVisible: true,
+    sortOrder: 0,
+    ...overrides,
+  }
+}
+
+describe("estimate client report profiles", () => {
+  it("selects the department-specific client detail level", () => {
+    expect(estimateClientReportMode("H")).toBe("phase_summary")
+    expect(estimateClientReportMode("O")).toBe("ca22")
+    expect(estimateClientReportMode("N")).toBe("cost_code")
+    expect(estimateClientReportMode("D")).toBe("ca22")
+  })
+
+  it("does not label H or N estimates as CA22 by default", () => {
+    expect(defaultEstimateTitle("H")).toBe("Construction Estimate")
+    expect(defaultEstimateTitle("N")).toBe("Material Estimate")
+    expect(defaultEstimateTitle("O")).toBe("CA22 Construction Estimate")
+    expect(
+      estimateTitleForDepartment({
+        department: "H",
+        requestedTitle: "CA22 Construction Estimate",
+      })
+    ).toBe("Construction Estimate")
+    expect(
+      estimateTitleForDepartment({
+        department: "H",
+        requestedTitle: "Foundation and Shell Proposal",
+      })
+    ).toBe("Foundation and Shell Proposal")
+  })
+
+  it("uses editable phase descriptions and excludes internal-only lines", () => {
+    const phases = clientEstimatePhases({
+      lines: [
+        line(),
+        line({
+          id: "line-2",
+          costCode: "03 40 00",
+          description: "Precast concrete",
+          lineTotalCents: 5_000,
+          sortOrder: 1,
+        }),
+        line({
+          id: "line-private",
+          ownerVisible: false,
+          lineTotalCents: 99_000,
+        }),
+      ],
+      phaseDescriptions: {
+        "03": "Concrete foundations and structural slabs",
+      },
+    })
+
+    expect(phases).toHaveLength(1)
+    expect(phases[0]).toMatchObject({
+      divisionCode: "03",
+      description: "Concrete foundations and structural slabs",
+      subtotalCents: 15_000,
+    })
+    expect(phases[0]?.lines.map((item) => item.id)).toEqual([
+      "line-1",
+      "line-2",
+    ])
+  })
+
+  it("offers the Drive-sourced acknowledgement forms only to Nu-Tech", () => {
+    const nutech = builtInEstimateTextTemplates({
+      department: "N",
+      templateType: "acknowledgement",
+    })
+    expect(nutech.map((template) => template.name)).toEqual([
+      "Takeoff Acknowledgement",
+      "Consultation and Indemnification Agreement",
+    ])
+    expect(nutech.every((template) => template.sourceUrl !== null)).toBe(true)
+    expect(
+      builtInEstimateTextTemplates({
+        department: "H",
+        templateType: "acknowledgement",
+      })
+    ).toEqual([])
+  })
+})

--- a/src/lib/estimates/client-report.ts
+++ b/src/lib/estimates/client-report.ts
@@ -45,6 +45,39 @@ export type ClientEstimatePhase = {
   readonly lines: readonly ClientEstimateLine[]
 }
 
+const DEFAULT_INTRODUCTION = `Thank you for the opportunity to provide you with an estimate for your project. Please direct any questions to ___________________ at _______________________.`
+
+const HPS_DEFAULT_CLOSING = `General Exclusions: Estimate excludes a construction dumpster and offsite hauling of debris. Should a construction dumpster not be provided by the Owner/Builder, debris shall be consolidated into an area on-site as designated by Owner/Builder but will not be taken offsite.
+
+Material: All material is guaranteed to be as specified. All materials brought to or delivered to the project property by High Performance Structures, inc. is assumed to be property of High Performance Structures, inc. until after completion of final demobilization of High Performance Structures, inc. Owner/builder agrees to pay to High Performance Structures, inc. current market price for any materials tampered with or misappropriated by owner/builder or other subcontractors on the project per the discretion of High Performance Structures, inc.
+
+Concrete Washout: Owner/builder agrees to provide on-site resources and location for concrete washout. If concrete washout is not to be on site owner/builder agrees to pay any and all necessary fees due to offsite concrete washout within scope of work to be completed by High Performance Structures, inc.
+
+Scope of Work: Scope of work for this estimate is based upon Architectural Drawings Drafted by _________ with a drawing date of __________ and Structural Drawings drafted and engineered by _____________ with a drawing date of ____________. Any deviation in work from the scope of work determined in this estimate (including due to but not limited to, changes after construction commencement, site conditions, etc.) will require a new estimate or incur a change order if it takes place during the High Performance Structures, Inc. construction process.
+
+On Site Facilities: Owner/Builder to provide on site restroom facilities prior to the arrival of High Performance Structures, Inc. Crew. If restroom facilities are not onsite prior to the arrival High Performance Structures, inc. crew, owner/builder recognizes this will incur delays and agrees to pay for any man hours incurred due to offsite restroom facilities at a man hour rate of $65/man/hour per the discretion of High Performance Structures, inc.
+
+Site Conditions: Estimate is prepared based upon plan conditions and site conditions discussed with the Owner/Builder. If site conditions differ from plan conditions or those previously discussed with Owner/Builder previously, pricing is subject to change to meet need via change order before or after construction commencement.
+
+On Site Resources: Estimate is prepared under the assumption of on-site electricity and water. Owner/Builder agrees to pay any additional charges incurred as a result of lacking these resources on site including, but not limited to, generator use (fuel, wear, rental, etc.), bringing water on-site, etc.
+
+Safety Conditions: High Performance Structures, Inc. is dedicated to the safety of its team members. Safe job sites also contribute to efficient and precise work, benefiting the Owner/Builder. Owner/Builder agrees that the site will adhere to OSHA safety standards. If OSHA safety standards are not met, Owner/Builder is aware that this may be brought to their attention and will be required by the Owner/Builder to make adjustments in order for High Performance Structures, Inc. to continue working. High Performance Structures, Inc. is not responsible for any delays or additional charges incurred as a result of on-site safety violations.
+
+Pricing: The prices stated in the categories above will remain firm for 30 days after the Print Date above. If performance of this agreement extends beyond this 30-day period, you agree to pay Contractor's then current pricing ("Price") for any Work performed after that 30-day period. The Prices are based only on the terms and conditions expressly stated in this agreement. The Prices exclude any and all terms and conditions not expressly stated herein, including, without limitation, any obligation by Contractor to name you or any third-party as an additional insured on its insurance policy; to provide per project aggregate insurance coverage for the work; to participate in any owner controlled, wrap, or similar insurance program; to indemnify or defend you or any third-party from any claims actions and /or lawsuits of any kind or nature whatsoever. Any terms or conditions required by you by contract or otherwise in addition to or inconsistent with those expressly stated in this agreement will result in additional charge and/or higher Prices. Any additional work performed is subject to Contractor's then current pricing (unless Contractor otherwise agrees in writing) and to this agreement. Contractor will notify owner of any changes in Pricing prior to commencement of work.
+
+All material is guaranteed to be as specified. All work to be completed in a workmanlike manner according to standard practices. Any alteration or deviation from above specifications involving extra costs will become an extra charge over and above the estimate and billed for separate from this original contract. All agreements contingent upon strikes, accidents or delays beyond our control. Client to carry fire, tornado and other necessary insurance. Our workers are fully covered by Workmen's Compensation Insurance.
+
+Payment Terms: 20% Due at contract signing, additional will be billed monthly and due within 10 days after bill is sent. Note: A Finance Charge is charged on any unpaid balance after 30 days from the date of invoice, and is computed by a "Periodic Rate" of 2% per month, which is an ANNUAL PERCENTAGE RATE of 24% applied to the unpaid balance. Client agrees to pay any and all associated attorney fees and legal fees to collect this debt for work completed.
+
+Contractor:
+High Performance Structures, Inc. by
+
+________________________________ _______________________
+Martine Y. Vogel, President                     Date`
+
+const PLAN_SWIFT_COMPASS_SOURCE_URL =
+  "https://drive.google.com/open?id=1Fp_eJ3vevW7wKYmQ4R1G7SUVxHJDbUDC&usp=drive_fs"
+
 const TAKEOFF_ACKNOWLEDGEMENT = `Thank you for choosing Nu-Tech Systems as your distributor and for granting us the opportunity to provide an estimate and takeoff services. We are happy to provide those takeoff services as preliminary quantities. The final takeoffs, however, must be determined by the installation contractor, especially considering external factors such as site conditions, final heights based on site conditions, installation, waste factors, etc. Please review and initial the following terms of takeoff services:
 
 I acknowledge that I have reviewed the height verifications sent from Nu-Tech Systems and verified that the heights in their respective locations with corresponding block sizes are correct. Initial: _______
@@ -78,6 +111,33 @@ Client Signature: __________________________________________ Date: _____________
 Contractor Signature: ______________________________________ Date: ________________`
 
 export const BUILT_IN_ESTIMATE_TEXT_TEMPLATES: readonly EstimateTextTemplateOption[] = [
+  {
+    id: "builtin:all:default-introduction",
+    name: "Default Introductory Text",
+    departmentCode: null,
+    templateType: "introduction",
+    body: DEFAULT_INTRODUCTION,
+    sourceDocumentId: null,
+    sourceUrl: PLAN_SWIFT_COMPASS_SOURCE_URL,
+  },
+  {
+    id: "builtin:h:default-closing",
+    name: "Default HPS Closing Text",
+    departmentCode: "H",
+    templateType: "closing",
+    body: HPS_DEFAULT_CLOSING,
+    sourceDocumentId: null,
+    sourceUrl: PLAN_SWIFT_COMPASS_SOURCE_URL,
+  },
+  {
+    id: "builtin:o:default-closing",
+    name: "Default HPS Closing Text",
+    departmentCode: "O",
+    templateType: "closing",
+    body: HPS_DEFAULT_CLOSING,
+    sourceDocumentId: null,
+    sourceUrl: PLAN_SWIFT_COMPASS_SOURCE_URL,
+  },
   {
     id: "builtin:n:takeoff-acknowledgement",
     name: "Takeoff Acknowledgement",

--- a/src/lib/estimates/client-report.ts
+++ b/src/lib/estimates/client-report.ts
@@ -1,0 +1,188 @@
+import type { ProjectDepartment } from "@/lib/project-branding"
+
+export const ESTIMATE_TEXT_TEMPLATE_TYPES = [
+  "terms",
+  "introduction",
+  "closing",
+  "acknowledgement",
+] as const
+
+export type EstimateTextTemplateType =
+  (typeof ESTIMATE_TEXT_TEMPLATE_TYPES)[number]
+
+export type EstimateClientReportMode =
+  | "phase_summary"
+  | "ca22"
+  | "cost_code"
+
+export type EstimateTextTemplateOption = {
+  readonly id: string
+  readonly name: string
+  readonly departmentCode: ProjectDepartment | null
+  readonly templateType: EstimateTextTemplateType
+  readonly body: string
+  readonly sourceDocumentId: string | null
+  readonly sourceUrl: string | null
+}
+
+export type ClientEstimateLine = {
+  readonly id: string
+  readonly divisionCode: string
+  readonly divisionName: string
+  readonly costCode: string
+  readonly description: string
+  readonly specifications: string | null
+  readonly lineTotalCents: number
+  readonly ownerVisible: boolean
+  readonly sortOrder: number
+}
+
+export type ClientEstimatePhase = {
+  readonly divisionCode: string
+  readonly divisionName: string
+  readonly description: string
+  readonly subtotalCents: number
+  readonly lines: readonly ClientEstimateLine[]
+}
+
+const TAKEOFF_ACKNOWLEDGEMENT = `Thank you for choosing Nu-Tech Systems as your distributor and for granting us the opportunity to provide an estimate and takeoff services. We are happy to provide those takeoff services as preliminary quantities. The final takeoffs, however, must be determined by the installation contractor, especially considering external factors such as site conditions, final heights based on site conditions, installation, waste factors, etc. Please review and initial the following terms of takeoff services:
+
+I acknowledge that I have reviewed the height verifications sent from Nu-Tech Systems and verified that the heights in their respective locations with corresponding block sizes are correct. Initial: _______
+
+I acknowledge that I received notice for adding any waste margin, and either requested or denied procuring extra bundles for potential waste. Initial: _______
+
+I acknowledge that I have reviewed the final quantities in the takeoffs and approve those quantities. Initial: _______
+
+I understand that I am solely responsible as the installing contractor for the final quantities of the takeoffs. Initial: _______
+
+I acknowledge that I am responsible for counting the inventory of block picked up or delivered by Fox Blocks. Initial: _______
+
+I acknowledge that if I need any additional quantities after the initial order, Nu-Tech Systems will need a minimum of 2 days' notice, pending availability. I also acknowledge that additional block may not be readily available. Initial: _______
+
+Takeoff Disclaimer: Nu-Tech Systems is not responsible for final quantities. Responsibility for final quantities is solely that of the installing contractor. All sales final.
+
+With this knowledge, I ____________________________ (Printed Name) accept and acknowledge the takeoff terms outlined herein.
+
+Client Signature: __________________________________________ Date: ________________
+
+Nu-Tech Signature: ________________________________________ Date: ________________`
+
+const CONSULTATION_INDEMNIFICATION = `The consultation advice given by High Performance Structures, Inc. consists of suggestions from installation experience, but does not take the place of advice or inspections from engineers or building departments. All consultation advice is information about best practices and standards and should not be construed as approval from an engineer. Thus, in seeking consultation advice, there is recognition and acknowledgement of this Indemnification Agreement:
+
+The Indemnifying Party agrees to indemnify and hold the Indemnified Party harmless from and against any and all claims, liability, loss, expenses, suits, damages, judgments, demands, and costs (including reasonable legal fees and expenses) arising out of (i) the acts or omissions of the Indemnifying Party; or (ii) any accident, injury or death to persons, or loss of or damage to property, or fines and penalties which may result, in whole or in part, by reason of description except to the extent that such damage is due solely and directly to the negligence of the Indemnified Party.
+
+With this knowledge, I _______________________________ (Printed Name) accept the policies outlined herein as a condition of consultation.
+
+Client Signature: __________________________________________ Date: ________________
+
+Contractor Signature: ______________________________________ Date: ________________`
+
+export const BUILT_IN_ESTIMATE_TEXT_TEMPLATES: readonly EstimateTextTemplateOption[] = [
+  {
+    id: "builtin:n:takeoff-acknowledgement",
+    name: "Takeoff Acknowledgement",
+    departmentCode: "N",
+    templateType: "acknowledgement",
+    body: TAKEOFF_ACKNOWLEDGEMENT,
+    sourceDocumentId: "16WWC1527X__He1_bo0CDT8FC0hWpajj3",
+    sourceUrl:
+      "https://docs.google.com/document/d/16WWC1527X__He1_bo0CDT8FC0hWpajj3/edit",
+  },
+  {
+    id: "builtin:n:consultation-indemnification",
+    name: "Consultation and Indemnification Agreement",
+    departmentCode: "N",
+    templateType: "acknowledgement",
+    body: CONSULTATION_INDEMNIFICATION,
+    sourceDocumentId: "1E3J6YWvOxWP0EoMpV9H7IxLN03icacE7",
+    sourceUrl:
+      "https://docs.google.com/document/d/1E3J6YWvOxWP0EoMpV9H7IxLN03icacE7/edit",
+  },
+]
+
+export function isEstimateTextTemplateType(
+  value: string
+): value is EstimateTextTemplateType {
+  return ESTIMATE_TEXT_TEMPLATE_TYPES.some((type) => type === value)
+}
+
+export function estimateClientReportMode(
+  department: ProjectDepartment
+): EstimateClientReportMode {
+  if (department === "H") return "phase_summary"
+  if (department === "N") return "cost_code"
+  return "ca22"
+}
+
+export function defaultEstimateTitle(
+  department: ProjectDepartment
+): string {
+  if (department === "H") return "Construction Estimate"
+  if (department === "N") return "Material Estimate"
+  return "CA22 Construction Estimate"
+}
+
+export function estimateTitleForDepartment(input: {
+  readonly department: ProjectDepartment
+  readonly requestedTitle: string | null
+}): string {
+  const requestedTitle = input.requestedTitle?.trim() ?? ""
+  if (
+    requestedTitle.length === 0 ||
+    (input.department !== "O" &&
+      requestedTitle === "CA22 Construction Estimate")
+  ) {
+    return defaultEstimateTitle(input.department)
+  }
+  return requestedTitle
+}
+
+export function builtInEstimateTextTemplates(input: {
+  readonly department: ProjectDepartment
+  readonly templateType?: EstimateTextTemplateType
+}): readonly EstimateTextTemplateOption[] {
+  return BUILT_IN_ESTIMATE_TEXT_TEMPLATES.filter(
+    (template) =>
+      (template.departmentCode === null ||
+        template.departmentCode === input.department) &&
+      (!input.templateType || template.templateType === input.templateType)
+  )
+}
+
+export function clientEstimatePhases(input: {
+  readonly lines: readonly ClientEstimateLine[]
+  readonly phaseDescriptions: Readonly<Record<string, string>>
+}): readonly ClientEstimatePhase[] {
+  const groups = new Map<string, ClientEstimateLine[]>()
+  for (const line of input.lines) {
+    if (!line.ownerVisible) continue
+    const current = groups.get(line.divisionCode) ?? []
+    current.push(line)
+    groups.set(line.divisionCode, current)
+  }
+
+  return [...groups.entries()]
+    .sort((left, right) => left[0].localeCompare(right[0]))
+    .map(([divisionCode, sourceLines]) => {
+      const lines = [...sourceLines].sort((left, right) => {
+        const sortOrder = left.sortOrder - right.sortOrder
+        if (sortOrder !== 0) return sortOrder
+        return left.costCode.localeCompare(right.costCode)
+      })
+      const divisionName = lines[0]?.divisionName ?? `Phase ${divisionCode}`
+      const customDescription = input.phaseDescriptions[divisionCode]?.trim()
+      return {
+        divisionCode,
+        divisionName,
+        description:
+          customDescription && customDescription.length > 0
+            ? customDescription
+            : divisionName,
+        subtotalCents: lines.reduce(
+          (total, line) => total + line.lineTotalCents,
+          0
+        ),
+        lines,
+      }
+    })
+}

--- a/src/lib/financials/__tests__/estimate-ledger.test.ts
+++ b/src/lib/financials/__tests__/estimate-ledger.test.ts
@@ -141,7 +141,10 @@ describe("estimate ledger", () => {
       estimateId: "estimate-1",
       versionNumber: 1,
       title: "CA22 Construction Estimate",
+      reportMode: "ca22",
+      introductionText: "Thank you for the opportunity to estimate the work.",
       contractTerms: "Base terms",
+      closingText: "Please contact us with any questions.",
       lines: [
         {
           id: "line-1",
@@ -174,6 +177,10 @@ describe("estimate ledger", () => {
           sortOrder: 1,
         },
       ],
+      phaseDescriptions: [
+        { divisionCode: "03", description: "Concrete structure" },
+      ],
+      acknowledgements: [],
     }
     const original = await estimateSourceHash(input)
     const revised = await estimateSourceHash({
@@ -186,8 +193,15 @@ describe("estimate ledger", () => {
         { ...input.basisDocuments[0], documentDate: "2026-07-31" },
       ],
     })
+    const differentPresentation = await estimateSourceHash({
+      ...input,
+      phaseDescriptions: [
+        { divisionCode: "03", description: "Concrete foundations" },
+      ],
+    })
 
     expect(revised).not.toBe(original)
     expect(differentBasis).not.toBe(original)
+    expect(differentPresentation).not.toBe(original)
   })
 })

--- a/src/lib/financials/estimate-ledger.ts
+++ b/src/lib/financials/estimate-ledger.ts
@@ -271,7 +271,10 @@ export async function estimateSourceHash(input: {
   readonly estimateId: string
   readonly versionNumber: number
   readonly title: string
+  readonly reportMode: string
+  readonly introductionText: string | null
   readonly contractTerms: string | null
+  readonly closingText: string | null
   readonly lines: readonly {
     readonly id: string
     readonly divisionCode: string
@@ -300,6 +303,16 @@ export async function estimateSourceHash(input: {
     readonly notes: string | null
     readonly sortOrder: number
   }[]
+  readonly phaseDescriptions: readonly {
+    readonly divisionCode: string
+    readonly description: string
+  }[]
+  readonly acknowledgements: readonly {
+    readonly templateId: string
+    readonly title: string
+    readonly body: string
+    readonly sortOrder: number
+  }[]
 }): Promise<string> {
   const lines = [...input.lines]
     .sort((left, right) => {
@@ -310,14 +323,25 @@ export async function estimateSourceHash(input: {
   const basisDocuments = [...input.basisDocuments].sort(
     (left, right) => left.sortOrder - right.sortOrder
   )
+  const phaseDescriptions = [...input.phaseDescriptions].sort((left, right) =>
+    left.divisionCode.localeCompare(right.divisionCode)
+  )
+  const acknowledgements = [...input.acknowledgements].sort(
+    (left, right) => left.sortOrder - right.sortOrder
+  )
   const bytes = new TextEncoder().encode(
     JSON.stringify({
       estimateId: input.estimateId,
       versionNumber: input.versionNumber,
       title: input.title,
+      reportMode: input.reportMode,
+      introductionText: input.introductionText,
       contractTerms: input.contractTerms,
+      closingText: input.closingText,
       lines,
       basisDocuments,
+      phaseDescriptions,
+      acknowledgements,
     })
   )
   const digest = await crypto.subtle.digest("SHA-256", bytes)


### PR DESCRIPTION
## what

- add department-specific H, O, and N client estimate report formats
- add editable phase, introduction, closing, terms, and acknowledgement presentation controls
- seed the Drive-sourced Nu-Tech acknowledgements and default introductory/HPS closing copy
- add migration 0124 for report profiles, phase descriptions, and acknowledgement snapshots

## why

Client estimate reports need different detail levels and contractual copy by department while preserving internal cost details.

## how to test

- `bunx tsc --noEmit`
- `bunx vitest run --maxWorkers=4` (199 files, 1,081 tests)
- production build through the pre-push gate
- visually verify H, O, and N print layouts and PDF page breaks

## notes

- H shows phase descriptions and subtotals only.
- O keeps the CA22 phase and cost-code format.
- N shows individual cost codes and selected acknowledgement pages.
- External Codex autoreview was intentionally skipped at the requester's direction.