### PR TITLE
fix(schedule): restore external colors and complete printing

### DIFF
--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -824,11 +824,12 @@ test.describe("usable Compass areas", () => {
     try {
       const ownerResponse = await ownerPage.goto(ownerPath)
       await expectHealthyNavigation(ownerPage, ownerResponse, ownerPath)
+      const ownerSchedule = ownerPage.locator("#schedule")
       await expect(
-        ownerPage.getByText("Published schedule commitment", { exact: true })
+        ownerSchedule.getByText("Published schedule commitment", { exact: true })
       ).toBeVisible()
       await expect(
-        ownerPage.getByText("Owner-visible published milestone", {
+        ownerSchedule.getByText("Owner-visible published milestone", {
           exact: true,
         })
       ).toBeVisible()
@@ -857,11 +858,14 @@ test.describe("usable Compass areas", () => {
     try {
       const partnerResponse = await partnerPage.goto(partnerPath)
       await expectHealthyNavigation(partnerPage, partnerResponse, partnerPath)
+      const partnerSchedule = partnerPage.locator("#schedule")
       await expect(
-        partnerPage.getByText("Published schedule commitment", { exact: true })
+        partnerSchedule.getByText("Published schedule commitment", {
+          exact: true,
+        })
       ).toBeVisible()
       await expect(
-        partnerPage.getByText("Partner-visible published delivery", {
+        partnerSchedule.getByText("Partner-visible published delivery", {
           exact: true,
         })
       ).toBeVisible()

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -436,6 +436,10 @@ em-emoji-picker {
   display: none;
 }
 
+.schedule-print-document {
+  display: none;
+}
+
 @media print {
   @page {
     margin: 0.5in;
@@ -444,6 +448,160 @@ em-emoji-picker {
   @page owner-budget {
     size: landscape;
     margin: 0.35in;
+  }
+
+  @page schedule-report {
+    size: landscape;
+    margin: 0.35in;
+  }
+
+  body.schedule-printing > :not([data-project-schedule-print-document="true"]) {
+    display: none !important;
+  }
+
+  body.schedule-printing,
+  body.schedule-printing [data-project-schedule-print-document="true"] {
+    background: #ffffff !important;
+    color: #111111 !important;
+    height: auto !important;
+    max-height: none !important;
+    min-height: 0 !important;
+    overflow: visible !important;
+  }
+
+  body.schedule-printing [data-project-schedule-print-document="true"] {
+    display: block !important;
+    font-family: Arial, sans-serif;
+    page: schedule-report;
+    position: static !important;
+    width: 100%;
+  }
+
+  .schedule-print-header {
+    align-items: flex-start;
+    border-bottom: 2px solid #111111;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 0.14in;
+    padding-bottom: 0.1in;
+  }
+
+  .schedule-print-brand {
+    align-items: flex-start;
+    display: flex;
+    gap: 0.1in;
+  }
+
+  .schedule-print-logo {
+    height: 0.48in !important;
+    object-fit: contain;
+    width: 0.48in !important;
+  }
+
+  .schedule-print-company,
+  .schedule-print-contact-line,
+  .schedule-print-title p,
+  .schedule-print-title h1,
+  .schedule-print-title span {
+    margin: 0;
+  }
+
+  .schedule-print-company {
+    font-size: 10pt;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+
+  .schedule-print-contact-line {
+    font-size: 6.5pt;
+    line-height: 1.3;
+  }
+
+  .schedule-print-title {
+    max-width: 55%;
+    text-align: right;
+  }
+
+  .schedule-print-title p {
+    font-size: 7pt;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .schedule-print-title h1 {
+    font-size: 14pt;
+    line-height: 1.15;
+    margin-top: 0.03in;
+  }
+
+  .schedule-print-title span {
+    display: block;
+    font-size: 7pt;
+    margin-top: 0.03in;
+  }
+
+  .schedule-print-table {
+    border-collapse: collapse;
+    font-size: 7.5pt;
+    table-layout: fixed;
+    width: 100%;
+  }
+
+  .schedule-print-table thead {
+    display: table-header-group;
+  }
+
+  .schedule-print-table tr {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .schedule-print-table th,
+  .schedule-print-table td {
+    border: 1px solid #a3a3a3;
+    padding: 0.055in 0.06in;
+    text-align: left;
+    vertical-align: top;
+  }
+
+  .schedule-print-table th {
+    background: #e5e7eb !important;
+    font-size: 6.5pt;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .schedule-print-table th:first-child {
+    width: 24%;
+  }
+
+  .schedule-print-table td:first-child {
+    font-weight: 700;
+  }
+
+  .schedule-print-color {
+    border: 1px solid rgb(0 0 0 / 0.25);
+    border-radius: 999px;
+    display: inline-block;
+    height: 0.08in;
+    margin-right: 0.05in;
+    vertical-align: 0.01in;
+    width: 0.08in;
+  }
+
+  .schedule-print-document,
+  .schedule-print-document * {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+
+  .schedule-print-footer {
+    display: flex;
+    font-size: 6.5pt;
+    justify-content: space-between;
+    margin-top: 0.08in;
   }
 
   body.po-printing-selected > * {

--- a/src/components/projects/project-audience-preview.tsx
+++ b/src/components/projects/project-audience-preview.tsx
@@ -837,8 +837,11 @@ function OwnerProjectPreview({
 
         {section === "schedule" && (
         <ProjectAudienceSchedule
+          audienceLabel="Client schedule"
           items={data.scheduleItems}
           projectId={data.project.id}
+          projectName={data.project.name}
+          projectNumber={data.project.projectNumber}
           presentation={data.project.ownerScheduleView}
         />
         )}
@@ -1057,8 +1060,11 @@ export function ProjectAudiencePreview({
 
         {section === "schedule" && (
           <ProjectAudienceSchedule
+            audienceLabel="Sub/vendor schedule"
             items={data.scheduleItems}
             projectId={data.project.id}
+            projectName={data.project.name}
+            projectNumber={data.project.projectNumber}
           />
         )}
 

--- a/src/components/projects/project-audience-schedule.tsx
+++ b/src/components/projects/project-audience-schedule.tsx
@@ -9,6 +9,7 @@ import {
   IconChevronRight,
   IconList,
   IconPencil,
+  IconPrinter,
   IconTimeline,
   IconX,
 } from "@tabler/icons-react"
@@ -32,7 +33,12 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import {
+  printScheduleDocument,
+  SchedulePrintDocument,
+} from "@/components/schedule/schedule-print-document"
 import { useScheduleDisplayPalette } from "@/hooks/use-schedule-display-palette"
+import { projectBrandFor } from "@/lib/project-branding"
 import { getScheduleItemDisplayColor } from "@/lib/schedule/appearance"
 import {
   centeredTimelineScrollLeft,
@@ -790,15 +796,22 @@ function ProjectAudienceGantt({
 }
 
 export function ProjectAudienceSchedule({
+  audienceLabel,
   items,
   projectId,
+  projectName,
+  projectNumber,
   presentation = "items",
 }: {
+  readonly audienceLabel: string
   readonly items: readonly AudienceScheduleItem[]
   readonly projectId: string
+  readonly projectName: string
+  readonly projectNumber: string | null
   readonly presentation?: OwnerScheduleView
 }): React.ReactElement {
   const displayColorPalette = useScheduleDisplayPalette(projectId)
+  const printBrand = projectBrandFor({ projectId, projectNumber })
   const [view, setView] = React.useState<ScheduleView>("list")
   const [visibleMonth, setVisibleMonth] = React.useState(() =>
     monthStart(new Date())
@@ -816,7 +829,8 @@ export function ProjectAudienceSchedule({
   const today = dateKey(new Date())
 
   return (
-    <section id="schedule" className="scroll-mt-24 border bg-background">
+    <>
+      <section id="schedule" className="scroll-mt-24 border bg-background">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b px-4 py-3 sm:px-5">
         <div>
           <h2 className="text-sm font-semibold">Project Schedule</h2>
@@ -825,34 +839,45 @@ export function ProjectAudienceSchedule({
             {items.length === 1 ? "" : "s"} · Read only
           </p>
         </div>
-        <div className="flex items-center border">
+        <div className="flex flex-wrap items-center gap-2">
           <Button
-            variant={view === "list" ? "secondary" : "ghost"}
+            type="button"
+            variant="outline"
             size="sm"
-            className="rounded-none"
-            onClick={() => setView("list")}
+            onClick={() => void printScheduleDocument()}
           >
-            <IconList className="size-4" />
-            List
+            <IconPrinter className="size-4" />
+            Print
           </Button>
-          <Button
-            variant={view === "calendar" ? "secondary" : "ghost"}
-            size="sm"
-            className="rounded-none border-l"
-            onClick={() => setView("calendar")}
-          >
-            <IconCalendar className="size-4" />
-            Calendar
-          </Button>
-          <Button
-            variant={view === "gantt" ? "secondary" : "ghost"}
-            size="sm"
-            className="rounded-none border-l"
-            onClick={() => setView("gantt")}
-          >
-            <IconTimeline className="size-4" />
-            Gantt
-          </Button>
+          <div className="flex items-center border">
+            <Button
+              variant={view === "list" ? "secondary" : "ghost"}
+              size="sm"
+              className="rounded-none"
+              onClick={() => setView("list")}
+            >
+              <IconList className="size-4" />
+              List
+            </Button>
+            <Button
+              variant={view === "calendar" ? "secondary" : "ghost"}
+              size="sm"
+              className="rounded-none border-l"
+              onClick={() => setView("calendar")}
+            >
+              <IconCalendar className="size-4" />
+              Calendar
+            </Button>
+            <Button
+              variant={view === "gantt" ? "secondary" : "ghost"}
+              size="sm"
+              className="rounded-none border-l"
+              onClick={() => setView("gantt")}
+            >
+              <IconTimeline className="size-4" />
+              Gantt
+            </Button>
+          </div>
         </div>
       </div>
 
@@ -1014,6 +1039,15 @@ export function ProjectAudienceSchedule({
       ) : (
         <ProjectAudienceGantt items={sortedItems} projectId={projectId} />
       )}
-    </section>
+      </section>
+      <SchedulePrintDocument
+        audienceLabel={audienceLabel}
+        brand={printBrand}
+        items={sortedItems}
+        paletteScopeId={projectId}
+        projectName={projectName}
+        projectNumber={projectNumber}
+      />
+    </>
   )
 }

--- a/src/components/projects/project-audience-schedule.tsx
+++ b/src/components/projects/project-audience-schedule.tsx
@@ -740,8 +740,8 @@ function ProjectAudienceGantt({
                     style={{
                       left,
                       width,
-                      borderColor: displayColor,
-                      backgroundColor: `${displayColor}33`,
+                      borderColor: `color-mix(in srgb, ${displayColor} 78%, black)`,
+                      backgroundColor: displayColor,
                     }}
                     title={`${item.title}: ${percentComplete}% complete`}
                   >
@@ -749,7 +749,7 @@ function ProjectAudienceGantt({
                       className="h-full"
                       style={{
                         width: `${percentComplete}%`,
-                        backgroundColor: `${displayColor}80`,
+                        backgroundColor: `color-mix(in srgb, ${displayColor} 68%, black)`,
                       }}
                     />
                     <span className="absolute inset-0 flex items-center px-2 text-[10px] font-medium">

--- a/src/components/schedule/__tests__/schedule-print-document.test.ts
+++ b/src/components/schedule/__tests__/schedule-print-document.test.ts
@@ -1,0 +1,106 @@
+/** @vitest-environment jsdom */
+
+import * as React from "react"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  printScheduleDocument,
+  SchedulePrintDocument,
+  type SchedulePrintItem,
+} from "@/components/schedule/schedule-print-document"
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock("@/lib/print/ios-print", () => ({
+  requiresSynchronousPrint: () => false,
+}))
+
+vi.mock("@/lib/print/readiness", () => ({
+  IOS_PRINT_STATE_TIMEOUT_MS: 120_000,
+  PRINT_STATE_TIMEOUT_MS: 5_000,
+  waitForPrintLayout: vi.fn(async () => undefined),
+}))
+
+function scheduleItems(count: number): readonly SchedulePrintItem[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `task-${index}`,
+    projectId: "project-202",
+    title: `Schedule item ${index + 1}`,
+    startDate: "2026-08-21",
+    endDate: "2026-08-22",
+    workdays: 2,
+    status: "PENDING",
+    phase: "finish",
+    displayColor: index % 2 === 0 ? "blue" : "green",
+    assignedTo: "Trade partner",
+    percentComplete: index,
+    isMilestone: false,
+  }))
+}
+
+describe("SchedulePrintDocument", () => {
+  let host: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    host = document.createElement("div")
+    document.body.appendChild(host)
+    root = createRoot(host)
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    document.body.className = ""
+    document.body.replaceChildren()
+    vi.restoreAllMocks()
+  })
+
+  it("renders every accessible schedule row outside the scrolling workspace", async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(SchedulePrintDocument, {
+          audienceLabel: "Client schedule",
+          brand: null,
+          items: scheduleItems(75),
+          paletteScopeId: "project-202",
+          projectName: "Bishop and Loeffler",
+          projectNumber: "O-202-595",
+        })
+      )
+    })
+
+    const printRoot = document.querySelector(
+      '[data-project-schedule-print-document="true"]'
+    )
+    expect(printRoot?.parentElement).toBe(document.body)
+    expect(
+      printRoot?.querySelectorAll(".schedule-print-table tbody tr")
+    ).toHaveLength(75)
+  })
+
+  it("isolates the print document until the browser finishes printing", async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(SchedulePrintDocument, {
+          audienceLabel: "Sub/vendor schedule",
+          brand: null,
+          items: scheduleItems(2),
+          paletteScopeId: "project-202",
+          projectName: "Bishop and Loeffler",
+          projectNumber: "O-202-595",
+        })
+      )
+    })
+    const printSpy = vi.spyOn(window, "print").mockImplementation(() => undefined)
+
+    await printScheduleDocument()
+
+    expect(document.body.classList.contains("schedule-printing")).toBe(true)
+    expect(printSpy).toHaveBeenCalledOnce()
+
+    window.dispatchEvent(new Event("afterprint"))
+    expect(document.body.classList.contains("schedule-printing")).toBe(false)
+  })
+})

--- a/src/components/schedule/schedule-print-document.tsx
+++ b/src/components/schedule/schedule-print-document.tsx
@@ -1,0 +1,213 @@
+"use client"
+
+import * as React from "react"
+import { createPortal } from "react-dom"
+
+import { ProjectBrandContactDetails } from "@/components/projects/project-brand-contact-details"
+import { ProjectBrandLogo } from "@/components/projects/project-brand-logo"
+import { useScheduleDisplayPalette } from "@/hooks/use-schedule-display-palette"
+import type { ProjectBrand } from "@/lib/project-branding"
+import { requiresSynchronousPrint } from "@/lib/print/ios-print"
+import {
+  IOS_PRINT_STATE_TIMEOUT_MS,
+  PRINT_STATE_TIMEOUT_MS,
+  waitForPrintLayout,
+} from "@/lib/print/readiness"
+import { getScheduleItemDisplayColor } from "@/lib/schedule/appearance"
+
+export type SchedulePrintItem = {
+  readonly id: string
+  readonly projectId?: string
+  readonly title: string
+  readonly startDate: string
+  readonly endDate: string
+  readonly workdays: number
+  readonly status: string
+  readonly phase: string
+  readonly displayColor: string | null
+  readonly assignedTo: string | null
+  readonly percentComplete: number
+  readonly isMilestone: boolean
+}
+
+type SchedulePrintProject = {
+  readonly id: string
+  readonly name: string
+  readonly projectNumber: string | null
+}
+
+function formatDate(value: string): string {
+  const parsed = new Date(`${value}T00:00:00`)
+  if (Number.isNaN(parsed.getTime())) return value
+  return parsed.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+function formatLabel(value: string): string {
+  return value
+    .toLowerCase()
+    .split(/[_-]+/)
+    .filter(Boolean)
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ")
+}
+
+function projectLabel(project: SchedulePrintProject): string {
+  return project.projectNumber
+    ? `${project.projectNumber} · ${project.name}`
+    : project.name
+}
+
+export async function printScheduleDocument(): Promise<void> {
+  const printRoot = document.querySelector(
+    '[data-project-schedule-print-document="true"]'
+  )
+  if (!(printRoot instanceof HTMLElement)) {
+    window.print()
+    return
+  }
+
+  document.body.classList.add("schedule-printing")
+  const resetPrintState = (): void => {
+    document.body.classList.remove("schedule-printing")
+    window.removeEventListener("afterprint", resetPrintState)
+  }
+
+  if (requiresSynchronousPrint(window.navigator)) {
+    window.print()
+    window.setTimeout(resetPrintState, IOS_PRINT_STATE_TIMEOUT_MS)
+    return
+  }
+
+  window.addEventListener("afterprint", resetPrintState)
+  await waitForPrintLayout(printRoot)
+  window.print()
+  window.setTimeout(resetPrintState, PRINT_STATE_TIMEOUT_MS)
+}
+
+export function SchedulePrintDocument({
+  audienceLabel,
+  brand,
+  items,
+  paletteScopeId,
+  projectName,
+  projectNumber,
+  projects = [],
+}: {
+  readonly audienceLabel: string
+  readonly brand: ProjectBrand | null
+  readonly items: readonly SchedulePrintItem[]
+  readonly paletteScopeId: string
+  readonly projectName: string
+  readonly projectNumber?: string | null
+  readonly projects?: readonly SchedulePrintProject[]
+}): React.ReactElement | null {
+  const [mounted, setMounted] = React.useState(false)
+  const displayColorPalette = useScheduleDisplayPalette(paletteScopeId)
+  const projectById = React.useMemo(
+    () => new Map(projects.map((project) => [project.id, project])),
+    [projects]
+  )
+
+  React.useEffect(() => setMounted(true), [])
+  if (!mounted) return null
+
+  const title = projectNumber
+    ? `${projectNumber} · ${projectName}`
+    : projectName
+
+  return createPortal(
+    <section
+      className="schedule-print-document"
+      data-project-schedule-print-document="true"
+    >
+      <header className="schedule-print-header">
+        <div className="schedule-print-brand">
+          {brand && (
+            <ProjectBrandLogo
+              brand={brand}
+              size={52}
+              className="schedule-print-logo"
+            />
+          )}
+          <div>
+            <p className="schedule-print-company">
+              {brand?.companyName ?? "Compass"}
+            </p>
+            {brand && (
+              <ProjectBrandContactDetails
+                brand={brand}
+                lineClassName="schedule-print-contact-line"
+              />
+            )}
+          </div>
+        </div>
+        <div className="schedule-print-title">
+          <p>{audienceLabel}</p>
+          <h1>{title}</h1>
+          <span>
+            {items.length} schedule item{items.length === 1 ? "" : "s"}
+          </span>
+        </div>
+      </header>
+
+      <table className="schedule-print-table">
+        <thead>
+          <tr>
+            <th>Schedule item</th>
+            {projects.length > 1 && <th>Project</th>}
+            <th>Phase</th>
+            <th>Start</th>
+            <th>Finish</th>
+            <th>Duration</th>
+            <th>Status</th>
+            <th>Assigned to</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => {
+            const itemProject = item.projectId
+              ? projectById.get(item.projectId)
+              : undefined
+            return (
+              <tr key={item.id}>
+                <td>
+                  <span
+                    className="schedule-print-color"
+                    style={{
+                      backgroundColor: getScheduleItemDisplayColor(
+                        item,
+                        displayColorPalette
+                      ),
+                    }}
+                  />
+                  <span>{item.title}</span>
+                </td>
+                {projects.length > 1 && (
+                  <td>{itemProject ? projectLabel(itemProject) : "—"}</td>
+                )}
+                <td>{formatLabel(item.phase)}</td>
+                <td>{formatDate(item.startDate)}</td>
+                <td>{formatDate(item.endDate)}</td>
+                <td>{item.isMilestone ? "Milestone" : `${item.workdays} wd`}</td>
+                <td>
+                  {formatLabel(item.status)} · {item.percentComplete}%
+                </td>
+                <td>{item.assignedTo ?? "—"}</td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+
+      <footer className="schedule-print-footer">
+        <span>Printed {new Date().toLocaleDateString()}</span>
+        <span>Read-only schedule report</span>
+      </footer>
+    </section>,
+    document.body
+  )
+}

--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -83,9 +83,11 @@ import { ScheduleBaselineView } from "./schedule-baseline-view"
 import { ScheduleItemFormDialog } from "./schedule-item-form-dialog"
 import { ScheduleTemplateDialog } from "./schedule-template-dialog"
 import { ScheduleTemplateBulkImportDialog } from "./schedule-template-bulk-import-dialog"
-import { ProjectBrandContactDetails } from "@/components/projects/project-brand-contact-details"
-import { ProjectBrandLogo } from "@/components/projects/project-brand-logo"
 import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
+import {
+  printScheduleDocument,
+  SchedulePrintDocument,
+} from "./schedule-print-document"
 import { ScheduleScopeSwitcher } from "./schedule-scope-switcher"
 import { OwnerScheduleVisibilityControl } from "./owner-schedule-visibility-control"
 import type { ProjectListItem } from "@/app/actions/projects"
@@ -113,8 +115,6 @@ import {
 import type { OwnerScheduleView } from "@/lib/schedule/owner-visibility"
 import type { GanttScrollMode } from "@/lib/schedule/gantt-interaction-mode"
 import { projectBrandFor } from "@/lib/project-branding"
-import { requiresSynchronousPrint } from "@/lib/print/ios-print"
-import { waitForPrintLayout } from "@/lib/print/readiness"
 import {
   deleteScheduleView,
   saveScheduleView,
@@ -434,6 +434,24 @@ export function ScheduleView({
     preset,
     scheduleProjects,
   ])
+  const printItems = useMemo(
+    () =>
+      filteredTasks.map((task) => ({
+        id: task.id,
+        projectId: task.projectId,
+        title: task.title,
+        startDate: task.startDate,
+        endDate: task.endDateCalculated,
+        workdays: task.workdays,
+        status: task.status,
+        phase: task.phase,
+        displayColor: task.displayColor,
+        assignedTo: task.assignedTo,
+        percentComplete: task.percentComplete,
+        isMilestone: task.isMilestone,
+      })),
+    [filteredTasks]
+  )
 
   const activeFilterCount =
     filters.status.length +
@@ -666,46 +684,23 @@ export function ScheduleView({
   }
 
   async function printSchedule(): Promise<void> {
-    const printRoot = document.querySelector(
-      '[data-project-schedule-print-root="true"]'
-    )
-    if (
-      printRoot instanceof HTMLElement &&
-      !requiresSynchronousPrint(window.navigator)
-    ) {
-      await waitForPrintLayout(printRoot)
-    }
-    window.print()
+    await printScheduleDocument()
   }
 
   return (
     <div
       className="flex min-h-full min-w-[960px] flex-col"
       data-schedule-workspace
-      data-project-schedule-print-root="true"
     >
-      {printBrand && (
-        <header className="hidden border-b-2 border-black pb-3 text-black print:flex print:items-start print:justify-between print:gap-4">
-          <div className="flex items-center gap-3">
-            <ProjectBrandLogo
-              brand={printBrand}
-              size={56}
-              className="size-14 object-contain"
-            />
-            <div>
-              <p className="text-sm font-bold uppercase">
-                {printBrand.companyName}
-              </p>
-              <ProjectBrandContactDetails
-                brand={printBrand}
-                lineClassName="text-xs"
-              />
-              <p className="text-xs">Project Schedule</p>
-            </div>
-          </div>
-          <p className="text-right text-xs font-semibold">{projectName}</p>
-        </header>
-      )}
+      <SchedulePrintDocument
+        audienceLabel={projectId ? "Project schedule" : "Company schedule"}
+        brand={printBrand}
+        items={printItems}
+        paletteScopeId={preferenceScopeKey}
+        projectName={projectName}
+        projectNumber={activeProject?.projectNumber}
+        projects={scheduleProjects}
+      />
       <div
         className="mb-1 flex h-8 w-max min-w-full shrink-0 flex-nowrap items-center gap-1"
         data-schedule-controls

--- a/src/lib/print/__tests__/document-branding-coverage.test.ts
+++ b/src/lib/print/__tests__/document-branding-coverage.test.ts
@@ -9,7 +9,7 @@ const REACT_PRINT_DOCUMENTS = [
   "src/app/print/projects/[id]/estimate/page.tsx",
   "src/components/projects/daily-log-print-document.tsx",
   "src/components/projects/owner-update-document.tsx",
-  "src/components/schedule/schedule-view.tsx",
+  "src/components/schedule/schedule-print-document.tsx",
 ] as const
 
 const GENERATED_PRINT_DOCUMENTS = [


### PR DESCRIPTION
## Summary
- restore solid schedule item colors in client and sub/vendor Gantt views
- add read-only print access to client and sub/vendor schedules
- replace viewport printing with a complete multi-page landscape schedule report for internal and external users
- preserve audience visibility rules and current internal schedule filters

## Verification
- production build passed
- focused schedule tests: 18 passed
- repository lint completed with existing warnings only
