### PR TITLE
feat(estimates): add Compass-native division estimating

### DIFF
--- a/docs/modules/google-drive.md
+++ b/docs/modules/google-drive.md
@@ -199,6 +199,21 @@ Field Mode intentionally exposes only the canonical
 descendants. Full Compass retains the complete project-folder view.
 
 
+estimate report text library
+---
+
+Organization-wide estimate introductions, closing text, terms, and
+acknowledgements are managed from the Estimate report text tab at
+`/dashboard/templates`. Saving creates or updates a plain-text source file in
+`________Developer/Compass/Template Library` through the organization Drive
+connection. Compass stores the same wording in `estimate_terms_templates` for
+fast selectors and records the Drive file ID and link on that row.
+
+Applying report text to a project estimate snapshots the selected wording.
+Later library edits therefore affect future selections without silently
+changing an estimate that was already prepared or issued.
+
+
 schema
 ---
 

--- a/drizzle/0125_estimate_client_report_mode.sql
+++ b/drizzle/0125_estimate_client_report_mode.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `project_estimates` ADD `client_report_mode` text;
+
+UPDATE `project_estimate_lines`
+SET `owner_visible` = 1,
+    `updated_at` = CURRENT_TIMESTAMP
+WHERE `owner_visible` = 0
+  AND `specifications` LIKE '%PlanSwift source:%';

--- a/src/app/actions/estimate-text-templates.ts
+++ b/src/app/actions/estimate-text-templates.ts
@@ -1,0 +1,260 @@
+"use server"
+
+import { and, asc, eq, isNull } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import { estimateTermsTemplates } from "@/db/schema-estimates"
+import { requireAuth } from "@/lib/auth"
+import { isDemoUser } from "@/lib/demo"
+import { getCloudflareContext } from "@/lib/db"
+import {
+  BUILT_IN_ESTIMATE_TEXT_TEMPLATES,
+  isEstimateTextTemplateType,
+  mergeEstimateTextTemplates,
+  type EstimateTextTemplateOption,
+  type EstimateTextTemplateType,
+} from "@/lib/estimates/client-report"
+import { syncEstimateTextTemplateToDrive } from "@/lib/estimates/text-template-drive-store"
+import { getOrganizationDriveContext } from "@/lib/google/organization-drive"
+import { requireOrg } from "@/lib/org-scope"
+import { requirePermission } from "@/lib/permissions"
+import type { ProjectDepartment } from "@/lib/project-branding"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+export type EstimateTextTemplateLibraryItem = EstimateTextTemplateOption & {
+  readonly builtIn: boolean
+}
+
+export type SaveEstimateTextTemplateLibraryInput = {
+  readonly templateId: string | null
+  readonly name: string | null
+  readonly departmentCode: string | null
+  readonly templateType: string | null
+  readonly body: string | null
+}
+
+type SaveEstimateTextTemplateLibraryResult =
+  | {
+      readonly success: true
+      readonly id: string
+      readonly sourceUrl: string
+    }
+  | { readonly success: false; readonly error: string }
+
+function requiredText(value: string | null, label: string): string {
+  const cleaned = value?.trim() ?? ""
+  if (!cleaned) throw new Error(`${label} is required.`)
+  return cleaned
+}
+
+function templateDepartment(value: string | null): ProjectDepartment | null {
+  if (!value || value === "all") return null
+  if (value === "O" || value === "H" || value === "N" || value === "D") {
+    return value
+  }
+  throw new Error("Choose a supported department.")
+}
+
+function databaseTemplateOption(
+  row: typeof estimateTermsTemplates.$inferSelect
+): EstimateTextTemplateOption | null {
+  if (!isEstimateTextTemplateType(row.templateType)) return null
+  const departmentCode = templateDepartment(row.departmentCode)
+  return {
+    id: row.id,
+    name: row.name,
+    departmentCode,
+    templateType: row.templateType,
+    body: row.body,
+    sourceDocumentId: row.sourceDocumentId,
+    sourceUrl: row.sourceUrl,
+  }
+}
+
+export async function getEstimateTextTemplateLibrary(): Promise<
+  readonly EstimateTextTemplateLibraryItem[]
+> {
+  const user = await requireAuth()
+  requirePermission(user, "budget", "read")
+  if (!isInternalStaffRole(user.role)) return []
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const rows = await db
+    .select()
+    .from(estimateTermsTemplates)
+    .where(
+      and(
+        eq(estimateTermsTemplates.organizationId, organizationId),
+        eq(estimateTermsTemplates.active, true)
+      )
+    )
+    .orderBy(
+      asc(estimateTermsTemplates.departmentCode),
+      asc(estimateTermsTemplates.templateType),
+      asc(estimateTermsTemplates.sortOrder),
+      asc(estimateTermsTemplates.name)
+    )
+  const organizationTemplates = rows.flatMap(
+    (row): readonly EstimateTextTemplateOption[] => {
+      const template = databaseTemplateOption(row)
+      return template ? [template] : []
+    }
+  )
+  const merged = mergeEstimateTextTemplates({
+    organizationTemplates,
+    builtInTemplates: BUILT_IN_ESTIMATE_TEXT_TEMPLATES,
+  })
+  const databaseIds = new Set(organizationTemplates.map((item) => item.id))
+  return merged.map((item) => ({
+    ...item,
+    builtIn: !databaseIds.has(item.id),
+  }))
+}
+
+export async function saveEstimateTextTemplateLibraryItem(
+  input: SaveEstimateTextTemplateLibraryInput
+): Promise<SaveEstimateTextTemplateLibraryResult> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) {
+      return { success: false, error: "DEMO_READ_ONLY" }
+    }
+    requirePermission(user, "budget", "update")
+    if (!isInternalStaffRole(user.role)) {
+      throw new Error("Template management is limited to internal staff.")
+    }
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+
+    const builtIn = input.templateId?.startsWith("builtin:")
+      ? BUILT_IN_ESTIMATE_TEXT_TEMPLATES.find(
+          (candidate) => candidate.id === input.templateId
+        ) ?? null
+      : null
+    if (input.templateId?.startsWith("builtin:") && !builtIn) {
+      throw new Error("The built-in template was not found.")
+    }
+
+    const current =
+      input.templateId && !builtIn
+        ? await db
+            .select()
+            .from(estimateTermsTemplates)
+            .where(
+              and(
+                eq(estimateTermsTemplates.id, input.templateId),
+                eq(estimateTermsTemplates.organizationId, organizationId)
+              )
+            )
+            .get()
+        : null
+    if (input.templateId && !builtIn && !current) {
+      throw new Error("The estimate text template was not found.")
+    }
+
+    const name = builtIn?.name ?? requiredText(input.name, "Template name")
+    const departmentCode =
+      builtIn?.departmentCode ?? templateDepartment(input.departmentCode)
+    const requestedType =
+      builtIn?.templateType ?? requiredText(input.templateType, "Template type")
+    if (!isEstimateTextTemplateType(requestedType)) {
+      throw new Error("Choose a supported estimate text template type.")
+    }
+    const templateType: EstimateTextTemplateType = requestedType
+    const body = requiredText(input.body, "Template text")
+
+    const identityMatch = await db
+      .select()
+      .from(estimateTermsTemplates)
+      .where(
+        and(
+          eq(estimateTermsTemplates.organizationId, organizationId),
+          departmentCode === null
+            ? isNull(estimateTermsTemplates.departmentCode)
+            : eq(estimateTermsTemplates.departmentCode, departmentCode),
+          eq(estimateTermsTemplates.templateType, templateType),
+          eq(estimateTermsTemplates.name, name)
+        )
+      )
+      .get()
+    if (current && identityMatch && identityMatch.id !== current.id) {
+      throw new Error(
+        "A template with this department, type, and name already exists."
+      )
+    }
+    const savedId = current?.id ?? identityMatch?.id ?? crypto.randomUUID()
+    const currentFileId =
+      current?.sourceDocumentId ?? identityMatch?.sourceDocumentId ??
+      builtIn?.sourceDocumentId ?? null
+    const drive = await getOrganizationDriveContext({
+      db,
+      environment: env,
+      organizationId,
+      user,
+    })
+    const driveFile = await syncEstimateTextTemplateToDrive({
+      client: drive.client,
+      userEmail: drive.userEmail,
+      currentFileId,
+      name,
+      departmentCode,
+      templateType,
+      body,
+    })
+    const now = new Date().toISOString()
+    const existing = current ?? identityMatch
+    if (existing) {
+      await db
+        .update(estimateTermsTemplates)
+        .set({
+          name,
+          departmentCode,
+          templateType,
+          body,
+          sourceDocumentId: driveFile.fileId,
+          sourceUrl: driveFile.fileUrl,
+          active: true,
+          updatedAt: now,
+        })
+        .where(eq(estimateTermsTemplates.id, existing.id))
+        .run()
+    } else {
+      await db
+        .insert(estimateTermsTemplates)
+        .values({
+          id: savedId,
+          organizationId,
+          name,
+          departmentCode,
+          templateType,
+          body,
+          sourceDocumentId: driveFile.fileId,
+          sourceUrl: driveFile.fileUrl,
+          active: true,
+          createdBy: user.id,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run()
+    }
+
+    revalidatePath("/dashboard/templates")
+    revalidatePath("/dashboard/projects")
+    return {
+      success: true,
+      id: existing?.id ?? savedId,
+      sourceUrl: driveFile.fileUrl,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to save the estimate text template.",
+    }
+  }
+}

--- a/src/app/actions/project-estimates.ts
+++ b/src/app/actions/project-estimates.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { and, asc, desc, eq, like, ne } from "drizzle-orm"
+import { and, asc, desc, eq, gt, like, ne, sql } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { saveEstimateTextTemplateLibraryItem } from "@/app/actions/estimate-text-templates"
@@ -38,6 +38,7 @@ import {
   defaultEstimateTitle,
   estimateClientReportMode,
   estimateTitleForDepartment,
+  isEstimateClientReportMode,
   isEstimateTextTemplateType,
   mergeEstimateTextTemplates,
   type EstimateClientReportMode,
@@ -81,6 +82,7 @@ export type ProjectEstimateSummary = {
   readonly introductionText: string | null
   readonly closingTemplateId: string | null
   readonly closingText: string | null
+  readonly clientReportMode: EstimateClientReportMode
   readonly directCostCents: number
   readonly markupCents: number
   readonly taxCents: number
@@ -216,6 +218,7 @@ export type ProjectEstimateLineInput = {
   readonly taxable: boolean
   readonly taxEntityId: string | null
   readonly ownerVisible: boolean
+  readonly insertAfterLineId: string | null
 }
 
 export type ProjectEstimateBasisInput = {
@@ -247,12 +250,17 @@ export type ProjectEstimatePlanSwiftImportLine = {
   readonly costCode: string
   readonly description: string
   readonly notes: string | null
+  readonly quantity: number | null
+  readonly unit: string | null
+  readonly unitCost: number | null
+  readonly markupPercentage: number
   readonly amount: number
 }
 
 export type ProjectEstimatePlanSwiftImportInput = {
   readonly sourceFileName: string
   readonly sourceSheetName: string
+  readonly replaceExistingPlanSwiftLines: boolean
   readonly lines: readonly ProjectEstimatePlanSwiftImportLine[]
 }
 
@@ -386,6 +394,9 @@ function estimateSummary(
     introductionText: row.introductionText,
     closingTemplateId: row.closingTemplateId,
     closingText: row.closingText,
+    clientReportMode: isEstimateClientReportMode(row.clientReportMode)
+      ? row.clientReportMode
+      : estimateClientReportMode(department),
     directCostCents: row.directCostCents,
     markupCents: row.markupCents,
     taxCents: row.taxCents,
@@ -723,7 +734,8 @@ export async function getProjectEstimateWorkspace(
     projectNumber: access.projectNumber,
     projectName: access.projectName,
     department: access.department,
-    reportMode: estimateClientReportMode(access.department),
+    reportMode:
+      selected?.clientReportMode ?? estimateClientReportMode(access.department),
     estimates,
     activeEstimate: selected,
     lines: lineRows.map(estimateLineItem),
@@ -895,6 +907,35 @@ export async function updateProjectEstimateHeader(
       success: false,
       error:
         error instanceof Error ? error.message : "Unable to save estimate.",
+    }
+  }
+}
+
+export async function setProjectEstimateClientReportMode(
+  projectId: string,
+  estimateId: string,
+  mode: string
+): Promise<ProjectEstimateActionResult> {
+  try {
+    const access = await estimateAccess(projectId, true)
+    await requireEditableEstimate(access.db, projectId, estimateId)
+    if (!isEstimateClientReportMode(mode)) {
+      throw new Error("Choose an available client report view.")
+    }
+    await access.db
+      .update(projectEstimates)
+      .set({ clientReportMode: mode, updatedAt: new Date().toISOString() })
+      .where(eq(projectEstimates.id, estimateId))
+      .run()
+    revalidateEstimate(projectId)
+    return { success: true, id: estimateId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to save the client report view.",
     }
   }
 }
@@ -1274,6 +1315,25 @@ export async function importPlanSwiftEstimateLines(
       if (amountCents > 10_000_000_000) {
         throw new Error(`PlanSwift row ${rowNumber} exceeds the import amount limit.`)
       }
+      const quantity = line.quantity ?? 1
+      if (!Number.isFinite(quantity) || quantity <= 0) {
+        throw new Error(`PlanSwift row ${rowNumber} must have a positive quantity.`)
+      }
+      const markupRateBasisPoints = Math.round(line.markupPercentage * 100)
+      if (
+        !Number.isFinite(line.markupPercentage) ||
+        markupRateBasisPoints < 0 ||
+        markupRateBasisPoints > 1_000_000
+      ) {
+        throw new Error(`PlanSwift row ${rowNumber} has an invalid markup.`)
+      }
+      const unitCostCents =
+        line.unitCost !== null && line.unitCost > 0
+          ? Math.round(line.unitCost * 100)
+          : Math.round(amountCents / quantity / (1 + line.markupPercentage / 100))
+      if (!Number.isFinite(unitCostCents) || unitCostCents <= 0) {
+        throw new Error(`PlanSwift row ${rowNumber} must have a positive unit cost.`)
+      }
       return {
         rowNumber,
         costCode: requiredText(
@@ -1285,6 +1345,10 @@ export async function importPlanSwiftEstimateLines(
           `Description on row ${rowNumber}`
         ),
         notes: cleanText(line.notes?.slice(0, 5_000) ?? null),
+        quantity,
+        unit: cleanText(line.unit?.slice(0, 40) ?? null) ?? "LS",
+        unitCostCents,
+        markupRateBasisPoints,
         amountCents,
       }
     })
@@ -1316,7 +1380,12 @@ export async function importPlanSwiftEstimateLines(
       .select()
       .from(projectEstimateLines)
       .where(eq(projectEstimateLines.estimateId, estimateId))
-    const priorSortOrder = existingRows.reduce(
+    const retainedRows = input.replaceExistingPlanSwiftLines
+      ? existingRows.filter(
+          (row) => !row.specifications?.includes("PlanSwift source:")
+        )
+      : existingRows
+    const priorSortOrder = retainedRows.reduce(
       (highest, row) => Math.max(highest, row.sortOrder),
       0
     )
@@ -1325,6 +1394,13 @@ export async function importPlanSwiftEstimateLines(
       const cost = costCodeMap.get(line.costCode)
       const adjustment = contractAdjustments.get(line.costCode)
       const sourceNote = `PlanSwift source: ${sourceFileName} · ${sourceSheetName} · row ${line.rowNumber}`
+      const calculation = calculateEstimateLine({
+        quantity: line.quantity,
+        unitCostCents: line.unitCostCents,
+        markupRateBasisPoints: line.markupRateBasisPoints,
+        taxable: false,
+        taxRateBasisPoints: 0,
+      })
       return {
         id: crypto.randomUUID(),
         projectId,
@@ -1337,27 +1413,27 @@ export async function importPlanSwiftEstimateLines(
           cost?.description ?? adjustment?.description ?? line.costCode,
         description: line.description,
         specifications: [line.notes, sourceNote].filter(Boolean).join("\n"),
-        quantity: 1,
-        unit: "LS",
-        unitCostCents: line.amountCents,
-        directCostCents: line.amountCents,
-        markupRateBasisPoints: 0,
-        markupCents: 0,
+        quantity: line.quantity,
+        unit: line.unit,
+        unitCostCents: line.unitCostCents,
+        directCostCents: calculation.directCostCents,
+        markupRateBasisPoints: line.markupRateBasisPoints,
+        markupCents: calculation.markupCents,
         taxable: false,
         taxEntityId: null,
         taxCode: null,
         taxName: null,
         taxRateBasisPoints: 0,
-        taxCents: 0,
-        lineTotalCents: line.amountCents,
-        ownerVisible: false,
+        taxCents: calculation.taxCents,
+        lineTotalCents: calculation.lineTotalCents,
+        ownerVisible: true,
         sortOrder: priorSortOrder + index + 1,
         createdAt: now,
         updatedAt: now,
       }
     })
     const totals = calculateEstimateTotals([
-      ...existingRows.map(ledgerLine),
+      ...retainedRows.map(ledgerLine),
       ...lineValues.map(ledgerLine),
     ])
     // D1 permits at most 100 bound parameters per statement. Each estimate
@@ -1367,16 +1443,34 @@ export async function importPlanSwiftEstimateLines(
     for (let index = 3; index < lineValues.length; index += 3) {
       remainingChunks.push(lineValues.slice(index, index + 3))
     }
-    await access.db.batch([
-      access.db.insert(projectEstimateLines).values(firstChunk),
-      ...remainingChunks.map((chunk) =>
-        access.db.insert(projectEstimateLines).values(chunk)
-      ),
-      access.db
-        .update(projectEstimates)
-        .set({ ...totals, updatedAt: now })
-        .where(eq(projectEstimates.id, estimateId)),
-    ])
+    const firstInsert = access.db
+      .insert(projectEstimateLines)
+      .values(firstChunk)
+    const remainingInserts = remainingChunks.map((chunk) =>
+      access.db.insert(projectEstimateLines).values(chunk)
+    )
+    const totalsUpdate = access.db
+      .update(projectEstimates)
+      .set({ ...totals, updatedAt: now })
+      .where(eq(projectEstimates.id, estimateId))
+    if (input.replaceExistingPlanSwiftLines) {
+      const deletePriorImports = access.db
+        .delete(projectEstimateLines)
+        .where(
+          and(
+            eq(projectEstimateLines.estimateId, estimateId),
+            like(projectEstimateLines.specifications, "%PlanSwift source:%")
+          )
+        )
+      await access.db.batch([
+        deletePriorImports,
+        firstInsert,
+        ...remainingInserts,
+        totalsUpdate,
+      ])
+    } else {
+      await access.db.batch([firstInsert, ...remainingInserts, totalsUpdate])
+    }
 
     revalidateEstimate(projectId)
     return {
@@ -1450,12 +1544,16 @@ export async function saveProjectEstimateLine(
     }
     const now = new Date().toISOString()
     const id = lineId ?? crypto.randomUUID()
-    const prior = await access.db
-      .select({ sortOrder: projectEstimateLines.sortOrder })
-      .from(projectEstimateLines)
-      .where(eq(projectEstimateLines.estimateId, estimateId))
-      .orderBy(desc(projectEstimateLines.sortOrder))
-      .limit(1)
+    const prior = lineId
+      ? []
+      : await access.db
+          .select({
+            id: projectEstimateLines.id,
+            sortOrder: projectEstimateLines.sortOrder,
+          })
+          .from(projectEstimateLines)
+          .where(eq(projectEstimateLines.estimateId, estimateId))
+          .orderBy(desc(projectEstimateLines.sortOrder))
     const values = {
       divisionCode: cost?.divisionCode ?? "99",
       divisionName: cost?.divisionDescription ?? "Contract Adjustments",
@@ -1495,12 +1593,36 @@ export async function saveProjectEstimateLine(
         .where(eq(projectEstimateLines.id, lineId))
         .run()
     } else {
+      const insertionTarget = input.insertAfterLineId
+        ? prior.find((item) => item.id === input.insertAfterLineId)
+        : null
+      if (input.insertAfterLineId && !insertionTarget) {
+        throw new Error("The selected insertion point is no longer available.")
+      }
+      const sortOrder = insertionTarget
+        ? insertionTarget.sortOrder + 1
+        : (prior[0]?.sortOrder ?? 0) + 1
+      if (insertionTarget) {
+        await access.db
+          .update(projectEstimateLines)
+          .set({
+            sortOrder: sql`${projectEstimateLines.sortOrder} + 1`,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(projectEstimateLines.estimateId, estimateId),
+              gt(projectEstimateLines.sortOrder, insertionTarget.sortOrder)
+            )
+          )
+          .run()
+      }
       await access.db.insert(projectEstimateLines).values({
         id,
         projectId,
         estimateId,
         ...values,
-        sortOrder: (prior[0]?.sortOrder ?? 0) + 1,
+        sortOrder,
         createdAt: now,
       })
     }
@@ -1649,7 +1771,9 @@ export async function prepareProjectEstimateForFoxit(
       estimateId,
       versionNumber: estimate.versionNumber,
       title: reportTitle,
-      reportMode: estimateClientReportMode(access.department),
+      reportMode: isEstimateClientReportMode(estimate.clientReportMode)
+        ? estimate.clientReportMode
+        : estimateClientReportMode(access.department),
       introductionText: estimate.introductionText,
       contractTerms: estimate.contractTerms,
       closingText: estimate.closingText,

--- a/src/app/actions/project-estimates.ts
+++ b/src/app/actions/project-estimates.ts
@@ -3,6 +3,7 @@
 import { and, asc, desc, eq, like, ne } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
+import { saveEstimateTextTemplateLibraryItem } from "@/app/actions/estimate-text-templates"
 import { getDb } from "@/db"
 import { projectBudgetLines, projects, sageCostCodes } from "@/db/schema"
 import {
@@ -38,6 +39,7 @@ import {
   estimateClientReportMode,
   estimateTitleForDepartment,
   isEstimateTextTemplateType,
+  mergeEstimateTextTemplates,
   type EstimateClientReportMode,
   type EstimateTextTemplateOption,
   type EstimateTextTemplateType,
@@ -703,10 +705,12 @@ export async function getProjectEstimateWorkspace(
       ]
     }
   )
-  const availableTemplates = [
-    ...databaseTemplates,
-    ...builtInEstimateTextTemplates({ department: access.department }),
-  ]
+  const availableTemplates = mergeEstimateTextTemplates({
+    organizationTemplates: databaseTemplates,
+    builtInTemplates: builtInEstimateTextTemplates({
+      department: access.department,
+    }),
+  })
   const templatesByType = (
     templateType: EstimateTextTemplateType
   ): readonly ProjectEstimateTermsOption[] =>
@@ -1071,50 +1075,20 @@ export async function saveEstimateTextTemplate(
     readonly name: string | null
     readonly templateType: string | null
     readonly body: string | null
-    readonly sourceUrl: string | null
   }
 ): Promise<ProjectEstimateActionResult> {
   try {
     const access = await estimateAccess(projectId, true)
-    if (!access.organizationId) {
-      throw new Error("The project organization is required for templates.")
-    }
-    const name = requiredText(input.name, "Template name")
-    const templateType = requiredText(input.templateType, "Template type")
-    if (!isEstimateTextTemplateType(templateType)) {
-      throw new Error("Choose a supported estimate text template type.")
-    }
-    const body = requiredText(input.body, "Template text")
-    const sourceUrl = safeUrl(input.sourceUrl)
-    const now = new Date().toISOString()
-    const id = crypto.randomUUID()
-    await access.db
-      .insert(estimateTermsTemplates)
-      .values({
-        id,
-        organizationId: access.organizationId,
-        name,
-        departmentCode: access.department,
-        templateType,
-        body,
-        sourceUrl,
-        active: true,
-        createdBy: access.user.id,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .onConflictDoUpdate({
-        target: [
-          estimateTermsTemplates.organizationId,
-          estimateTermsTemplates.departmentCode,
-          estimateTermsTemplates.templateType,
-          estimateTermsTemplates.name,
-        ],
-        set: { body, sourceUrl, active: true, updatedAt: now },
-      })
-      .run()
+    const result = await saveEstimateTextTemplateLibraryItem({
+      templateId: null,
+      name: input.name,
+      departmentCode: access.department,
+      templateType: input.templateType,
+      body: input.body,
+    })
+    if (!result.success) return result
     revalidateEstimate(projectId)
-    return { success: true, id }
+    return { success: true, id: result.id }
   } catch (error) {
     return {
       success: false,

--- a/src/app/dashboard/templates/page.tsx
+++ b/src/app/dashboard/templates/page.tsx
@@ -1,3 +1,4 @@
+import { getEstimateTextTemplateLibrary } from "@/app/actions/estimate-text-templates"
 import { getProjectTemplateLibrary } from "@/app/actions/project-templates"
 import { TemplateLibraryView } from "@/components/templates/template-library-view"
 import { getCurrentUser } from "@/lib/auth"
@@ -7,9 +8,13 @@ import { isInternalStaffRole } from "@/lib/user-roles"
 export const dynamic = "force-dynamic"
 
 export default async function TemplateLibraryPage() {
-  const [templates, user] = await Promise.all([
+  const user = await getCurrentUser()
+  const canViewEstimateText =
+    Boolean(user && isInternalStaffRole(user.role)) &&
+    can(user, "budget", "read")
+  const [templates, estimateTextTemplates] = await Promise.all([
     getProjectTemplateLibrary(),
-    getCurrentUser(),
+    canViewEstimateText ? getEstimateTextTemplateLibrary() : Promise.resolve([]),
   ])
   const canManage =
     Boolean(user && isInternalStaffRole(user.role)) &&
@@ -20,8 +25,10 @@ export default async function TemplateLibraryPage() {
   return (
     <TemplateLibraryView
       templates={templates}
+      estimateTextTemplates={estimateTextTemplates}
       canManage={canManage}
       canCreateEstimate={canCreateEstimate}
+      canManageEstimateText={canCreateEstimate}
     />
   )
 }

--- a/src/app/print/projects/[id]/estimate/page.tsx
+++ b/src/app/print/projects/[id]/estimate/page.tsx
@@ -1,5 +1,7 @@
 export const dynamic = "force-dynamic"
 
+import { Fragment } from "react"
+
 import { getProjectEstimateWorkspace } from "@/app/actions/project-estimates"
 import { getProjects } from "@/app/actions/projects"
 import { ProjectBrandContactDetails } from "@/components/projects/project-brand-contact-details"
@@ -14,6 +16,12 @@ function money(cents: number): string {
     currency: "USD",
     maximumFractionDigits: 2,
   }).format(cents / 100)
+}
+
+function quantity(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 4,
+  }).format(value)
 }
 
 export default async function ProjectEstimatePrintPage({
@@ -49,8 +57,10 @@ export default async function ProjectEstimatePrintPage({
     lines: workspace.lines,
     phaseDescriptions,
   })
-  const visibleLines = phases.flatMap((phase) => phase.lines)
-
+  const clientTotalCents = phases.reduce(
+    (total, phase) => total + phase.subtotalCents,
+    0
+  )
   return (
     <>
       <style>{`
@@ -116,10 +126,15 @@ export default async function ProjectEstimatePrintPage({
           </section>
         )}
 
-        {workspace.reportMode === "phase_summary" && (
+        {(workspace.reportMode === "division_summary" ||
+          workspace.reportMode === "phase_summary") && (
           <section className="mt-6">
             <div className="grid grid-cols-[1fr_1.2in] border-b border-black pb-1 text-xs font-semibold uppercase tracking-wide">
-              <span>Phase description</span>
+              <span>
+                {workspace.reportMode === "phase_summary"
+                  ? "Phase description"
+                  : "Division"}
+              </span>
               <span className="text-right">Subtotal</span>
             </div>
             {phases.map((phase) => (
@@ -128,9 +143,16 @@ export default async function ProjectEstimatePrintPage({
                 className="grid break-inside-avoid grid-cols-[1fr_1.2in] gap-3 border-b py-3 text-sm"
               >
                 <div>
-                  <p className="font-semibold">{phase.description}</p>
+                  <p className="font-semibold">
+                    {workspace.reportMode === "phase_summary"
+                      ? phase.description
+                      : phase.divisionName}
+                  </p>
                   <p className="text-xs text-neutral-600">
-                    Phase {phase.divisionCode}
+                    {workspace.reportMode === "phase_summary"
+                      ? "Phase"
+                      : "Division"}{" "}
+                    {phase.divisionCode}
                   </p>
                 </div>
                 <span className="text-right font-semibold">
@@ -141,84 +163,69 @@ export default async function ProjectEstimatePrintPage({
           </section>
         )}
 
-        {workspace.reportMode === "ca22" && (
+        {workspace.reportMode === "line_items" && (
           <section className="mt-6">
-            <div className="grid grid-cols-[1fr_1.2in] border-b border-black pb-1 text-xs font-semibold uppercase tracking-wide">
-              <span>Phase and cost code</span>
-              <span className="text-right">Amount</span>
-            </div>
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="border-b border-black text-left text-xs font-semibold uppercase tracking-wide">
+                  <th className="pb-1 pr-2">Cost code</th>
+                  <th className="pb-1 pr-2">Description</th>
+                  <th className="pb-1 pr-2 text-right">Quantity</th>
+                  <th className="pb-1 pr-2">Unit</th>
+                  <th className="pb-1 pr-2 text-right">Unit cost</th>
+                  <th className="pb-1 text-right">Total cost</th>
+                </tr>
+              </thead>
+              <tbody>
             {phases.map((phase) => (
-              <div
-                key={phase.divisionCode}
-                className="break-inside-avoid border-b py-3"
-              >
-                <div className="flex items-start justify-between gap-3 font-semibold">
-                  <div>
-                    <p>{phase.description}</p>
-                    <p className="text-xs font-normal text-neutral-600">
-                      Phase {phase.divisionCode}
-                    </p>
-                  </div>
-                  <span>{money(phase.subtotalCents)}</span>
-                </div>
-                <div className="mt-2 space-y-1.5">
+              <Fragment key={phase.divisionCode}>
+                <tr className="break-inside-avoid border-b bg-neutral-100 font-semibold">
+                  <td className="py-2 pr-2" colSpan={6}>
+                    {phase.divisionCode} · {phase.description}
+                  </td>
+                </tr>
                   {phase.lines.map((line) => (
-                    <div
+                    <tr
                       key={line.id}
-                      className="grid grid-cols-[1fr_1.2in] gap-3 pl-3 text-sm"
+                      className="break-inside-avoid border-b"
                     >
-                      <div>
-                        <span className="font-medium">{line.costCode}</span>
-                        <span> - {line.description}</span>
-                        {line.specifications && (
-                          <p className="text-xs text-neutral-600">
-                            {line.specifications}
-                          </p>
-                        )}
-                      </div>
-                      <span className="text-right">
+                      <td className="py-2 pr-2 align-top font-medium">
+                        {line.costCode}
+                      </td>
+                      <td className="py-2 pr-2 align-top">
+                        {line.description}
+                      </td>
+                      <td className="py-2 pr-2 text-right align-top">
+                        {quantity(line.quantity)}
+                      </td>
+                      <td className="py-2 pr-2 align-top">{line.unit}</td>
+                      <td className="py-2 pr-2 text-right align-top">
+                        {money(line.unitCostCents)}
+                      </td>
+                      <td className="py-2 text-right align-top">
                         {money(line.lineTotalCents)}
-                      </span>
-                    </div>
+                      </td>
+                    </tr>
                   ))}
-                </div>
-              </div>
+                <tr className="break-inside-avoid border-b-2 border-black font-semibold">
+                  <td className="py-2" colSpan={5}>
+                    Total: {phase.divisionCode} · {phase.description}
+                  </td>
+                  <td className="py-2 text-right">
+                    {money(phase.subtotalCents)}
+                  </td>
+                </tr>
+              </Fragment>
             ))}
-          </section>
-        )}
-
-        {workspace.reportMode === "cost_code" && (
-          <section className="mt-6">
-            <div className="grid grid-cols-[1fr_1.2in] border-b border-black pb-1 text-xs font-semibold uppercase tracking-wide">
-              <span>Cost code and description</span>
-              <span className="text-right">Amount</span>
-            </div>
-            {visibleLines.map((line) => (
-              <div
-                key={line.id}
-                className="grid break-inside-avoid grid-cols-[1fr_1.2in] gap-3 border-b py-3 text-sm"
-              >
-                <div>
-                  <span className="font-medium">{line.costCode}</span>
-                  <span> - {line.description}</span>
-                  {line.specifications && (
-                    <p className="text-xs text-neutral-600">
-                      {line.specifications}
-                    </p>
-                  )}
-                </div>
-                <span className="text-right font-medium">
-                  {money(line.lineTotalCents)}
-                </span>
-              </div>
-            ))}
+              </tbody>
+            </table>
           </section>
         )}
 
         <section className="ml-auto mt-5 w-full max-w-sm text-sm">
           <div className="flex justify-between border-t border-black pt-2 text-base font-bold">
             <span>Estimate total</span>
-            <span>{money(estimate.estimateTotalCents)}</span>
+            <span>{money(clientTotalCents)}</span>
           </div>
         </section>
 

--- a/src/components/projects/project-estimate-client-report-settings.tsx
+++ b/src/components/projects/project-estimate-client-report-settings.tsx
@@ -129,7 +129,6 @@ export function ProjectEstimateClientReportSettings({
         name: value("templateName"),
         templateType: value("templateType"),
         body: value("templateBody"),
-        sourceUrl: value("templateSourceUrl"),
       })
       setMessage(
         result.success
@@ -270,7 +269,8 @@ export function ProjectEstimateClientReportSettings({
           </h3>
           <p className="mt-1 text-xs text-muted-foreground">
             Department templates become available in future estimates without
-            changing any estimate that has already been issued.
+            changing any estimate that has already been issued. Compass also
+            saves the template in Google Drive under Compass / Template Library.
           </p>
           <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
             <div className="space-y-1.5">
@@ -300,16 +300,7 @@ export function ProjectEstimateClientReportSettings({
                 required
               />
             </div>
-            <div className="space-y-1.5 md:col-span-2 xl:col-span-3">
-              <Label htmlFor="estimate-template-source">Source link</Label>
-              <Input
-                id="estimate-template-source"
-                name="templateSourceUrl"
-                type="url"
-                placeholder="Optional Google Drive source"
-              />
-            </div>
-            <div className="flex items-end">
+            <div className="flex items-end md:col-span-2 xl:col-span-4">
               <Button type="submit" disabled={isPending}>
                 Save department template
               </Button>

--- a/src/components/projects/project-estimate-client-report-settings.tsx
+++ b/src/components/projects/project-estimate-client-report-settings.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState, useTransition, type FormEvent } from "react"
+import { useEffect, useMemo, useState, useTransition, type FormEvent } from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { IconExternalLink, IconFileDescription } from "@tabler/icons-react"
@@ -8,10 +8,15 @@ import { IconExternalLink, IconFileDescription } from "@tabler/icons-react"
 import {
   saveEstimateTextTemplate,
   saveProjectEstimatePhaseDescription,
+  setProjectEstimateClientReportMode,
   setProjectEstimateAcknowledgements,
   type ProjectEstimateSummary,
   type ProjectEstimateWorkspace,
 } from "@/app/actions/project-estimates"
+import {
+  isEstimateClientReportMode,
+  type EstimateClientReportMode,
+} from "@/lib/estimates/client-report"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -26,14 +31,10 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 
-function reportModeLabel(workspace: ProjectEstimateWorkspace): string {
-  if (workspace.reportMode === "phase_summary") {
-    return "Phase subtotals only"
-  }
-  if (workspace.reportMode === "cost_code") {
-    return "Individual cost codes"
-  }
-  return "CA22 phase and cost-code detail"
+function reportModeLabel(mode: EstimateClientReportMode): string {
+  if (mode === "division_summary") return "Division subtotals + grand total"
+  if (mode === "phase_summary") return "Phase subtotals + grand total"
+  return "Line items + division totals"
 }
 
 export function ProjectEstimateClientReportSettings({
@@ -50,9 +51,13 @@ export function ProjectEstimateClientReportSettings({
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [message, setMessage] = useState<string | null>(null)
+  const [reportMode, setReportMode] = useState(workspace.reportMode)
   const [acknowledgementIds, setAcknowledgementIds] = useState<readonly string[]>(
     workspace.selectedAcknowledgements.map((item) => item.templateId)
   )
+  useEffect(() => {
+    setReportMode(workspace.reportMode)
+  }, [workspace.reportMode])
   const phases = useMemo(() => {
     const groups = new Map<string, string>()
     for (const line of workspace.lines) {
@@ -90,6 +95,19 @@ export function ProjectEstimateClientReportSettings({
       setMessage(
         result.success ? "Phase description saved." : result.error
       )
+      if (result.success) router.refresh()
+    })
+  }
+
+  function saveReportMode(): void {
+    setMessage(null)
+    startTransition(async () => {
+      const result = await setProjectEstimateClientReportMode(
+        projectId,
+        estimate.id,
+        reportMode
+      )
+      setMessage(result.success ? "Client report view saved." : result.error)
       if (result.success) router.refresh()
     })
   }
@@ -151,12 +169,13 @@ export function ProjectEstimateClientReportSettings({
             <h2 className="font-semibold">Client report presentation</h2>
             <p className="mt-1 text-sm text-muted-foreground">
               The client view follows the {workspace.department}-department
-              estimate format. Internal quantities, markup, and tax details stay
-              in the working estimate.
+              estimate format. Internal markup and tax details stay in the
+              working estimate; quantity and unit cost appear only in the
+              line-item report view.
             </p>
           </div>
         </div>
-        <Badge variant="outline">{reportModeLabel(workspace)}</Badge>
+        <Badge variant="outline">{reportModeLabel(workspace.reportMode)}</Badge>
       </div>
 
       {message && (
@@ -165,7 +184,45 @@ export function ProjectEstimateClientReportSettings({
         </p>
       )}
 
-      {workspace.reportMode !== "cost_code" && phases.length > 0 && (
+      <div className="mt-5 grid gap-3 border-t pt-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+        <div className="space-y-1.5">
+          <Label htmlFor="client-report-view">Client report detail</Label>
+          <Select
+            value={reportMode}
+            onValueChange={(value) => {
+              if (isEstimateClientReportMode(value)) setReportMode(value)
+            }}
+            disabled={!editable}
+          >
+            <SelectTrigger id="client-report-view">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="division_summary">
+                Division subtotals and grand total
+              </SelectItem>
+              <SelectItem value="phase_summary">
+                Phase descriptions, subtotals, and grand total
+              </SelectItem>
+              <SelectItem value="line_items">
+                Individual line items with division totals
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        {editable && (
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isPending || reportMode === workspace.reportMode}
+            onClick={saveReportMode}
+          >
+            Save report view
+          </Button>
+        )}
+      </div>
+
+      {workspace.reportMode !== "division_summary" && phases.length > 0 && (
         <div className="mt-5 space-y-3 border-t pt-4">
           <div>
             <h3 className="text-sm font-semibold">Phase descriptions</h3>

--- a/src/components/projects/project-estimate-planswift-import-client.tsx
+++ b/src/components/projects/project-estimate-planswift-import-client.tsx
@@ -65,6 +65,10 @@ type ParsedWorkbook = {
 type EditablePreviewRow = {
   readonly costCode: string;
   readonly description: string;
+  readonly quantity: string;
+  readonly unit: string;
+  readonly unitCost: string;
+  readonly markupPercentage: string;
   readonly amount: string;
 };
 
@@ -121,10 +125,17 @@ function applyEdits(
 ): PlanSwiftImportPreviewRow {
   if (!edit) return row;
   const amount = Number(edit.amount);
+  const quantity = edit.quantity.trim() ? Number(edit.quantity) : null;
+  const unitCost = edit.unitCost.trim() ? Number(edit.unitCost) : null;
+  const markupPercentage = Number(edit.markupPercentage) || 0;
   return {
     ...row,
     costCode: edit.costCode,
     description: edit.description,
+    quantity,
+    unit: edit.unit.trim() || null,
+    unitCost,
+    markupPercentage,
     amount,
     issues: planSwiftPreviewIssues({
       costCode: edit.costCode,
@@ -163,6 +174,8 @@ export function ProjectEstimatePlanSwiftImportClient({
   const [excludedRows, setExcludedRows] = React.useState<ReadonlySet<number>>(
     new Set(),
   );
+  const [replaceExistingPlanSwiftLines, setReplaceExistingPlanSwiftLines] =
+    React.useState(false);
 
   const sheet = selectedSheet(workbook, sheetName);
   const sheetRows = sheet?.rows ?? EMPTY_ROWS;
@@ -184,6 +197,9 @@ export function ProjectEstimatePlanSwiftImportClient({
     (row) => row.issues.length > 0,
   ).length;
   const knownCostCodes = new Set(costCodes.map((option) => option.value));
+  const costCodeOptions = new Map(
+    costCodes.map((option) => [option.value, option]),
+  );
   const unmatchedCostCodeCount = selectedRows.filter(
     (row) => !knownCostCodes.has(row.costCode),
   ).length;
@@ -196,6 +212,7 @@ export function ProjectEstimatePlanSwiftImportClient({
     setMappings(autoMapPlanSwiftColumns([]));
     setEdits({});
     setExcludedRows(new Set());
+    setReplaceExistingPlanSwiftLines(false);
   }
 
   function configureSheet(nextSheet: ParsedSheet): void {
@@ -321,13 +338,44 @@ export function ProjectEstimatePlanSwiftImportClient({
           ? {
               costCode: parsedRow.costCode,
               description: parsedRow.description,
+              quantity:
+                parsedRow.quantity === null ? "" : String(parsedRow.quantity),
+              unit: parsedRow.unit ?? "",
+              unitCost:
+                parsedRow.unitCost === null ? "" : String(parsedRow.unitCost),
+              markupPercentage: String(parsedRow.markupPercentage),
               amount: parsedRow.amount > 0 ? String(parsedRow.amount) : "",
             }
           : null);
       if (!currentRow) return current;
+      const nextRow = { ...currentRow, [field]: value };
+      if (
+        field === "quantity" ||
+        field === "unitCost" ||
+        field === "markupPercentage"
+      ) {
+        const quantity = Number(nextRow.quantity);
+        const unitCost = Number(nextRow.unitCost);
+        const markup = Number(nextRow.markupPercentage) || 0;
+        if (quantity > 0 && unitCost > 0) {
+          nextRow.amount = String(
+            Math.round(quantity * unitCost * (1 + markup / 100) * 100) / 100,
+          );
+        }
+      }
+      if (field === "amount") {
+        const amount = Number(nextRow.amount);
+        const quantity = Number(nextRow.quantity) || 1;
+        const markup = Number(nextRow.markupPercentage) || 0;
+        if (amount > 0) {
+          nextRow.unitCost = String(
+            Math.round((amount / quantity / (1 + markup / 100)) * 100) / 100,
+          );
+        }
+      }
       return {
         ...current,
-        [rowNumber]: { ...currentRow, [field]: value },
+        [rowNumber]: nextRow,
       };
     });
   }
@@ -356,11 +404,16 @@ export function ProjectEstimatePlanSwiftImportClient({
       const result = await importPlanSwiftEstimateLines(projectId, estimateId, {
         sourceFileName: workbook.fileName,
         sourceSheetName: sheet.name,
+        replaceExistingPlanSwiftLines,
         lines: selectedRows.map((row) => ({
           rowNumber: row.rowNumber,
           costCode: row.costCode,
           description: row.description,
           notes: row.notes,
+          quantity: row.quantity,
+          unit: row.unit,
+          unitCost: row.unitCost,
+          markupPercentage: row.markupPercentage,
           amount: row.amount,
         })),
       });
@@ -574,9 +627,19 @@ export function ProjectEstimatePlanSwiftImportClient({
                   <IconAlertTriangle />
                   <AlertTitle>This estimate already has draft lines.</AlertTitle>
                   <AlertDescription>
-                    The selected PlanSwift rows will be appended to the existing
-                    {` ${existingLineCount} `}working estimate lines.
+                    Choose whether to append these rows or replace only the
+                    estimate lines previously imported from PlanSwift. Manual
+                    estimate lines are never removed by this option.
                   </AlertDescription>
+                  <label className="mt-3 flex items-center gap-2 text-sm">
+                    <Checkbox
+                      checked={replaceExistingPlanSwiftLines}
+                      onCheckedChange={(checked) =>
+                        setReplaceExistingPlanSwiftLines(checked === true)
+                      }
+                    />
+                    Replace prior PlanSwift-imported lines
+                  </label>
                 </Alert>
               )}
               {unmatchedCostCodeCount > 0 && (
@@ -607,13 +670,17 @@ export function ProjectEstimatePlanSwiftImportClient({
               </div>
 
               <div className="overflow-x-auto border">
-                <table className="w-full min-w-[900px] text-sm">
+                <table className="w-full min-w-[1320px] text-sm">
                   <thead className="sticky top-0 z-10 bg-muted">
                     <tr>
                       <th className="w-16 px-2 py-2 text-center font-medium">Use</th>
                       <th className="w-16 px-2 py-2 text-left font-medium">Row</th>
                       <th className="w-44 px-2 py-2 text-left font-medium">Cost code</th>
+                      <th className="w-44 px-2 py-2 text-left font-medium">Division</th>
                       <th className="px-2 py-2 text-left font-medium">Description</th>
+                      <th className="w-28 px-2 py-2 text-right font-medium">Quantity</th>
+                      <th className="w-28 px-2 py-2 text-left font-medium">Unit</th>
+                      <th className="w-32 px-2 py-2 text-right font-medium">Unit cost</th>
                       <th className="w-40 px-2 py-2 text-right font-medium">Amount</th>
                       <th className="w-56 px-2 py-2 text-left font-medium">Review</th>
                     </tr>
@@ -623,6 +690,7 @@ export function ProjectEstimatePlanSwiftImportClient({
                       const included = !excludedRows.has(row.rowNumber);
                       const knownCode =
                         knownCostCodes.has(row.costCode);
+                      const costCodeOption = costCodeOptions.get(row.costCode);
                       return (
                         <tr key={row.rowNumber} className="border-t align-top">
                           <td className="px-2 py-2 text-center">
@@ -657,6 +725,11 @@ export function ProjectEstimatePlanSwiftImportClient({
                               </p>
                             )}
                           </td>
+                          <td className="px-2 py-3 text-xs">
+                            {costCodeOption
+                              ? `${costCodeOption.divisionCode} · ${costCodeOption.divisionName}`
+                              : "Select a mapped cost code"}
+                          </td>
                           <td className="px-2 py-2">
                             <Input
                               value={row.description}
@@ -674,6 +747,40 @@ export function ProjectEstimatePlanSwiftImportClient({
                                 {row.notes}
                               </p>
                             )}
+                          </td>
+                          <td className="px-2 py-2">
+                            <Input
+                              type="number"
+                              inputMode="decimal"
+                              min="0.0001"
+                              step="any"
+                              className="text-right"
+                              value={row.quantity === null ? "" : String(row.quantity)}
+                              onChange={(event) =>
+                                changeRow(row.rowNumber, "quantity", event.target.value)
+                              }
+                            />
+                          </td>
+                          <td className="px-2 py-2">
+                            <Input
+                              value={row.unit ?? ""}
+                              onChange={(event) =>
+                                changeRow(row.rowNumber, "unit", event.target.value)
+                              }
+                            />
+                          </td>
+                          <td className="px-2 py-2">
+                            <Input
+                              type="number"
+                              inputMode="decimal"
+                              min="0.01"
+                              step="0.01"
+                              className="text-right"
+                              value={row.unitCost === null ? "" : String(row.unitCost)}
+                              onChange={(event) =>
+                                changeRow(row.rowNumber, "unitCost", event.target.value)
+                              }
+                            />
                           </td>
                           <td className="px-2 py-2">
                             <Input

--- a/src/components/projects/project-estimate-workspace.tsx
+++ b/src/components/projects/project-estimate-workspace.tsx
@@ -1,6 +1,12 @@
 "use client"
 
-import { useMemo, useState, useTransition, type FormEvent } from "react"
+import {
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+  type FormEvent,
+} from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import {
@@ -29,6 +35,7 @@ import {
   saveProjectEstimateLine,
   updateProjectEstimateHeader,
   type ProjectEstimateLineItem,
+  type ProjectEstimateTermsOption,
   type ProjectEstimateWorkspace,
 } from "@/app/actions/project-estimates"
 import { Badge } from "@/components/ui/badge"
@@ -72,6 +79,13 @@ function formNumber(formData: FormData, name: string): number | null {
 
 function statusLabel(value: string): string {
   return value.replaceAll("_", " ")
+}
+
+function selectedTemplateBody(
+  options: readonly ProjectEstimateTermsOption[],
+  templateId: string
+): string {
+  return options.find((option) => option.value === templateId)?.body ?? ""
 }
 
 type LineDraft = {
@@ -132,15 +146,48 @@ export function ProjectEstimateWorkspacePanel({
 }): React.ReactElement {
   const { developerModeEnabled } = useDeveloperMode()
   const router = useRouter()
+  const estimate = workspace.activeEstimate
   const [isPending, startTransition] = useTransition()
   const [message, setMessage] = useState<string | null>(null)
   const [line, setLine] = useState<LineDraft>(EMPTY_LINE)
   const [startTemplateId, setStartTemplateId] = useState("")
   const [startTaxEntityId, setStartTaxEntityId] = useState("")
-  const estimate = workspace.activeEstimate
+  const [termsTemplateId, setTermsTemplateId] = useState(
+    estimate?.termsTemplateId ?? ""
+  )
+  const [contractTerms, setContractTerms] = useState(
+    estimate?.contractTerms ?? ""
+  )
+  const [introductionTemplateId, setIntroductionTemplateId] = useState(
+    estimate?.introductionTemplateId ?? ""
+  )
+  const [introductionText, setIntroductionText] = useState(
+    estimate?.introductionText ?? ""
+  )
+  const [closingTemplateId, setClosingTemplateId] = useState(
+    estimate?.closingTemplateId ?? ""
+  )
+  const [closingText, setClosingText] = useState(estimate?.closingText ?? "")
   const editable =
     workspace.canEdit &&
     Boolean(estimate && ["draft", "internal_review"].includes(estimate.status))
+
+  useEffect(() => {
+    setTermsTemplateId(estimate?.termsTemplateId ?? "")
+    setContractTerms(estimate?.contractTerms ?? "")
+    setIntroductionTemplateId(estimate?.introductionTemplateId ?? "")
+    setIntroductionText(estimate?.introductionText ?? "")
+    setClosingTemplateId(estimate?.closingTemplateId ?? "")
+    setClosingText(estimate?.closingText ?? "")
+  }, [
+    estimate?.id,
+    estimate?.termsTemplateId,
+    estimate?.contractTerms,
+    estimate?.introductionTemplateId,
+    estimate?.introductionText,
+    estimate?.closingTemplateId,
+    estimate?.closingText,
+  ])
 
   const divisions = useMemo(() => {
     const options = new Map<string, string>()
@@ -584,7 +631,13 @@ export function ProjectEstimateWorkspacePanel({
             <Label htmlFor="termsTemplateId">Contract terms template</Label>
             <Select
               name="termsTemplateId"
-              defaultValue={estimate.termsTemplateId ?? undefined}
+              value={termsTemplateId}
+              onValueChange={(value) => {
+                setTermsTemplateId(value)
+                setContractTerms(
+                  selectedTemplateBody(workspace.termsTemplates, value)
+                )
+              }}
               disabled={!editable}
             >
               <SelectTrigger id="termsTemplateId">
@@ -611,7 +664,13 @@ export function ProjectEstimateWorkspacePanel({
             </Label>
             <Select
               name="introductionTemplateId"
-              defaultValue={estimate.introductionTemplateId ?? undefined}
+              value={introductionTemplateId}
+              onValueChange={(value) => {
+                setIntroductionTemplateId(value)
+                setIntroductionText(
+                  selectedTemplateBody(workspace.introductionTemplates, value)
+                )
+              }}
               disabled={!editable || workspace.introductionTemplates.length === 0}
             >
               <SelectTrigger id="introductionTemplateId">
@@ -630,7 +689,13 @@ export function ProjectEstimateWorkspacePanel({
             <Label htmlFor="closingTemplateId">Closing text template</Label>
             <Select
               name="closingTemplateId"
-              defaultValue={estimate.closingTemplateId ?? undefined}
+              value={closingTemplateId}
+              onValueChange={(value) => {
+                setClosingTemplateId(value)
+                setClosingText(
+                  selectedTemplateBody(workspace.closingTemplates, value)
+                )
+              }}
               disabled={!editable || workspace.closingTemplates.length === 0}
             >
               <SelectTrigger id="closingTemplateId">
@@ -653,7 +718,8 @@ export function ProjectEstimateWorkspacePanel({
               id="introductionText"
               name="introductionText"
               rows={4}
-              defaultValue={estimate.introductionText ?? ""}
+              value={introductionText}
+              onChange={(event) => setIntroductionText(event.target.value)}
               disabled={!editable}
               placeholder="Optional editable text shown before the estimate detail."
             />
@@ -664,7 +730,8 @@ export function ProjectEstimateWorkspacePanel({
               id="contractTerms"
               name="contractTerms"
               rows={6}
-              defaultValue={estimate.contractTerms ?? ""}
+              value={contractTerms}
+              onChange={(event) => setContractTerms(event.target.value)}
               disabled={!editable}
               placeholder="Use a template or draft the estimate-specific terms here."
             />
@@ -675,7 +742,8 @@ export function ProjectEstimateWorkspacePanel({
               id="closingText"
               name="closingText"
               rows={4}
-              defaultValue={estimate.closingText ?? ""}
+              value={closingText}
+              onChange={(event) => setClosingText(event.target.value)}
               disabled={!editable}
               placeholder="Optional editable text shown after the estimate detail."
             />

--- a/src/components/projects/project-estimate-workspace.tsx
+++ b/src/components/projects/project-estimate-workspace.tsx
@@ -3,6 +3,7 @@
 import {
   useEffect,
   useMemo,
+  useRef,
   useState,
   useTransition,
   type FormEvent,
@@ -150,6 +151,8 @@ export function ProjectEstimateWorkspacePanel({
   const [isPending, startTransition] = useTransition()
   const [message, setMessage] = useState<string | null>(null)
   const [line, setLine] = useState<LineDraft>(EMPTY_LINE)
+  const [insertAfterLineId, setInsertAfterLineId] = useState<string | null>(null)
+  const lineEditorRef = useRef<HTMLFormElement>(null)
   const [startTemplateId, setStartTemplateId] = useState("")
   const [startTaxEntityId, setStartTaxEntityId] = useState("")
   const [termsTemplateId, setTermsTemplateId] = useState(
@@ -298,9 +301,13 @@ export function ProjectEstimateWorkspacePanel({
           taxable: line.taxable,
           taxEntityId: line.taxEntityId || null,
           ownerVisible: line.ownerVisible,
+          insertAfterLineId,
         }
       )
-      if (result.success) setLine(EMPTY_LINE)
+      if (result.success) {
+        setLine(EMPTY_LINE)
+        setInsertAfterLineId(null)
+      }
       finish(result.success ? "Estimate line saved." : result.error)
     })
   }
@@ -315,6 +322,20 @@ export function ProjectEstimateWorkspacePanel({
         lineId
       )
       finish(result.success ? "Estimate line removed." : result.error)
+    })
+  }
+
+  function openLineEditor(
+    nextLine: LineDraft,
+    insertionPoint: string | null = null
+  ): void {
+    setLine(nextLine)
+    setInsertAfterLineId(insertionPoint)
+    window.requestAnimationFrame(() => {
+      lineEditorRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
+      lineEditorRef.current
+        ?.querySelector<HTMLInputElement>("#estimateDescription")
+        ?.focus({ preventScroll: true })
     })
   }
 
@@ -780,6 +801,14 @@ export function ProjectEstimateWorkspacePanel({
                 costCodes={workspace.costCodes}
                 existingLineCount={workspace.lines.length}
               />
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => openLineEditor(EMPTY_LINE)}
+              >
+                <IconPlus className="size-4" />
+                Add estimate line
+              </Button>
               {estimate.sourceWorkbookUrl && (
                 <Button
                   type="button"
@@ -850,9 +879,25 @@ export function ProjectEstimateWorkspacePanel({
                                 type="button"
                                 size="sm"
                                 variant="outline"
-                                onClick={() => setLine(lineDraft(item))}
+                                onClick={() => openLineEditor(lineDraft(item))}
                               >
                                 Edit
+                              </Button>
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant="ghost"
+                                onClick={() =>
+                                  openLineEditor(
+                                    {
+                                      ...EMPTY_LINE,
+                                      divisionCode: item.divisionCode,
+                                    },
+                                    item.id
+                                  )
+                                }
+                              >
+                                Insert below
                               </Button>
                               <Button
                                 type="button"
@@ -876,9 +921,17 @@ export function ProjectEstimateWorkspacePanel({
         )}
 
         {editable && (
-          <form className="mt-5 border-t pt-4" onSubmit={saveLine}>
+          <form
+            ref={lineEditorRef}
+            className="mt-5 scroll-mt-6 border-t pt-4"
+            onSubmit={saveLine}
+          >
             <h3 className="mb-3 text-sm font-semibold">
-              {line.id ? "Edit estimate line" : "Add estimate line"}
+              {line.id
+                ? "Edit estimate line"
+                : insertAfterLineId
+                  ? "Insert estimate line"
+                  : "Add estimate line"}
             </h3>
             <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
               <div className="space-y-1.5">
@@ -960,9 +1013,9 @@ export function ProjectEstimateWorkspacePanel({
                 Owner-visible
               </label>
               <div className="ml-auto flex gap-2">
-                {line.id && <Button type="button" variant="ghost" onClick={() => setLine(EMPTY_LINE)}>Cancel edit</Button>}
+                {(line.id || insertAfterLineId) && <Button type="button" variant="ghost" onClick={() => { setLine(EMPTY_LINE); setInsertAfterLineId(null) }}>Cancel</Button>}
                 <Button type="submit" disabled={isPending || !line.costCode}>
-                  <IconPlus className="size-4" /> {line.id ? "Save line" : "Add line"}
+                  <IconPlus className="size-4" /> {line.id ? "Save line" : insertAfterLineId ? "Insert line" : "Add line"}
                 </Button>
               </div>
             </div>

--- a/src/components/templates/estimate-text-template-library.tsx
+++ b/src/components/templates/estimate-text-template-library.tsx
@@ -1,0 +1,319 @@
+"use client"
+
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useState, useTransition, type FormEvent } from "react"
+import {
+  IconExternalLink,
+  IconFileText,
+  IconPencil,
+  IconPlus,
+} from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import {
+  saveEstimateTextTemplateLibraryItem,
+  type EstimateTextTemplateLibraryItem,
+} from "@/app/actions/estimate-text-templates"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import type { EstimateTextTemplateType } from "@/lib/estimates/client-report"
+import type { ProjectDepartment } from "@/lib/project-branding"
+
+const DEPARTMENTS: readonly {
+  readonly value: ProjectDepartment | "all"
+  readonly label: string
+}[] = [
+  { value: "all", label: "All departments" },
+  { value: "O", label: "O" },
+  { value: "H", label: "H" },
+  { value: "N", label: "N" },
+  { value: "D", label: "D" },
+]
+
+const TEMPLATE_TYPES: readonly {
+  readonly value: EstimateTextTemplateType
+  readonly label: string
+}[] = [
+  { value: "terms", label: "Terms and conditions" },
+  { value: "introduction", label: "Introduction" },
+  { value: "closing", label: "Closing text" },
+  { value: "acknowledgement", label: "Acknowledgement" },
+]
+
+function typeLabel(value: EstimateTextTemplateType): string {
+  return TEMPLATE_TYPES.find((item) => item.value === value)?.label ?? value
+}
+
+function departmentLabel(value: ProjectDepartment | null): string {
+  return value ?? "All departments"
+}
+
+function TemplateEditorDialog({
+  template,
+  canManage,
+}: {
+  readonly template: EstimateTextTemplateLibraryItem | null
+  readonly canManage: boolean
+}): React.ReactElement {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [pending, startTransition] = useTransition()
+  const [name, setName] = useState(template?.name ?? "")
+  const [departmentCode, setDepartmentCode] = useState<
+    ProjectDepartment | "all"
+  >(template?.departmentCode ?? "all")
+  const [templateType, setTemplateType] = useState<EstimateTextTemplateType>(
+    template?.templateType ?? "terms"
+  )
+  const [body, setBody] = useState(template?.body ?? "")
+  const identityLocked = template?.builtIn === true
+
+  function reset(): void {
+    setName(template?.name ?? "")
+    setDepartmentCode(template?.departmentCode ?? "all")
+    setTemplateType(template?.templateType ?? "terms")
+    setBody(template?.body ?? "")
+  }
+
+  function save(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    startTransition(async () => {
+      const result = await saveEstimateTextTemplateLibraryItem({
+        templateId: template?.id ?? null,
+        name,
+        departmentCode,
+        templateType,
+        body,
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(
+        template
+          ? "Estimate report text updated in Compass and Google Drive."
+          : "Estimate report text added to Compass and Google Drive."
+      )
+      setOpen(false)
+      router.refresh()
+    })
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen)
+        if (nextOpen) reset()
+      }}
+    >
+      <DialogTrigger asChild>
+        {template ? (
+          <Button size="sm" variant="outline" disabled={!canManage}>
+            <IconPencil className="mr-2 size-4" />
+            Edit
+          </Button>
+        ) : (
+          <Button disabled={!canManage}>
+            <IconPlus className="mr-2 size-4" />
+            Add report text
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+        <form onSubmit={save}>
+          <DialogHeader>
+            <DialogTitle>
+              {template ? `Edit ${template.name}` : "Add estimate report text"}
+            </DialogTitle>
+            <DialogDescription>
+              Saving updates the organization library and its text file in
+              ________Developer / Compass / Template Library. Estimates retain
+              the wording they already saved.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-5 sm:grid-cols-2">
+            <div className="space-y-1.5 sm:col-span-2">
+              <Label htmlFor={`text-template-name-${template?.id ?? "new"}`}>
+                Template name
+              </Label>
+              <Input
+                id={`text-template-name-${template?.id ?? "new"}`}
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                disabled={identityLocked || pending}
+                required
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Department</Label>
+              <Select
+                value={departmentCode}
+                onValueChange={(value) => {
+                  if (
+                    value === "all" ||
+                    value === "O" ||
+                    value === "H" ||
+                    value === "N" ||
+                    value === "D"
+                  ) {
+                    setDepartmentCode(value)
+                  }
+                }}
+                disabled={identityLocked || pending}
+              >
+                <SelectTrigger aria-label="Template department">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {DEPARTMENTS.map((department) => (
+                    <SelectItem key={department.value} value={department.value}>
+                      {department.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label>Text type</Label>
+              <Select
+                value={templateType}
+                onValueChange={(value) => {
+                  if (
+                    value === "terms" ||
+                    value === "introduction" ||
+                    value === "closing" ||
+                    value === "acknowledgement"
+                  ) {
+                    setTemplateType(value)
+                  }
+                }}
+                disabled={identityLocked || pending}
+              >
+                <SelectTrigger aria-label="Template text type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {TEMPLATE_TYPES.map((type) => (
+                    <SelectItem key={type.value} value={type.value}>
+                      {type.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5 sm:col-span-2">
+              <Label htmlFor={`text-template-body-${template?.id ?? "new"}`}>
+                Template text
+              </Label>
+              <Textarea
+                id={`text-template-body-${template?.id ?? "new"}`}
+                value={body}
+                onChange={(event) => setBody(event.target.value)}
+                rows={14}
+                disabled={pending}
+                required
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={pending}>
+              {pending ? "Saving…" : "Save report text"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function EstimateTextTemplateLibrary({
+  templates,
+  canManage,
+}: {
+  readonly templates: readonly EstimateTextTemplateLibraryItem[]
+  readonly canManage: boolean
+}): React.ReactElement {
+  return (
+    <section>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2 font-semibold">
+            <IconFileText className="size-5 text-primary" />
+            Estimate report text
+          </div>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            Reusable introductions, closing text, terms, and acknowledgements.
+            New and edited templates are saved by default in Google Drive under
+            ________Developer / Compass / Template Library.
+          </p>
+        </div>
+        <TemplateEditorDialog template={null} canManage={canManage} />
+      </div>
+
+      {templates.length === 0 ? (
+        <div className="mt-5 border-y py-10 text-sm text-muted-foreground">
+          No estimate report text is available.
+        </div>
+      ) : (
+        <div className="mt-5 divide-y border-y">
+          {templates.map((template) => (
+            <article
+              key={template.id}
+              className="grid gap-4 py-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start"
+            >
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3 className="font-medium">{template.name}</h3>
+                  <Badge variant="outline">
+                    {departmentLabel(template.departmentCode)}
+                  </Badge>
+                  <Badge variant="secondary">
+                    {typeLabel(template.templateType)}
+                  </Badge>
+                  {template.builtIn && <Badge>Built-in default</Badge>}
+                </div>
+                <p className="mt-2 line-clamp-3 whitespace-pre-line text-sm text-muted-foreground">
+                  {template.body}
+                </p>
+              </div>
+              <div className="flex items-center justify-end gap-1">
+                {template.sourceUrl && (
+                  <Button asChild size="sm" variant="ghost">
+                    <Link href={template.sourceUrl} target="_blank">
+                      Drive <IconExternalLink className="ml-1 size-3.5" />
+                    </Link>
+                  </Button>
+                )}
+                <TemplateEditorDialog template={template} canManage={canManage} />
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/templates/template-library-view.tsx
+++ b/src/components/templates/template-library-view.tsx
@@ -17,6 +17,7 @@ import {
   updateProjectTemplateCategory,
   type ProjectTemplateLibraryItem,
 } from "@/app/actions/project-templates"
+import type { EstimateTextTemplateLibraryItem } from "@/app/actions/estimate-text-templates"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -40,6 +41,8 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { EstimateTemplateCreateDialog } from "./estimate-template-create-dialog"
+import { EstimateTextTemplateLibrary } from "./estimate-text-template-library"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 export const TEMPLATE_CATEGORIES = [
   "Concrete",
@@ -57,8 +60,10 @@ export const TEMPLATE_CATEGORIES = [
 
 type Props = {
   readonly templates: readonly ProjectTemplateLibraryItem[]
+  readonly estimateTextTemplates: readonly EstimateTextTemplateLibraryItem[]
   readonly canManage: boolean
   readonly canCreateEstimate: boolean
+  readonly canManageEstimateText: boolean
 }
 
 function reviewLabel(reviewStatus: string): string {
@@ -223,8 +228,10 @@ function PublishTemplateButton({
 
 export function TemplateLibraryView({
   templates,
+  estimateTextTemplates,
   canManage,
   canCreateEstimate,
+  canManageEstimateText,
 }: Props): React.ReactElement {
   const { developerModeEnabled } = useDeveloperMode()
   const [categoryFilter, setCategoryFilter] = useState("all")
@@ -288,27 +295,35 @@ export function TemplateLibraryView({
       </header>
 
       <main className="flex-1 overflow-y-auto px-4 py-5 sm:px-6">
-        <div className="mb-5 border-y py-3 sm:max-w-sm">
-          <Select value={categoryFilter} onValueChange={setCategoryFilter}>
-            <SelectTrigger aria-label="Filter templates by category">
-              <SelectValue placeholder="All categories" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All categories</SelectItem>
-              {categories.map((category) => (
-                <SelectItem key={category} value={category}>{category}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+        <Tabs defaultValue="project-content">
+          <TabsList>
+            <TabsTrigger value="project-content">Project content</TabsTrigger>
+            <TabsTrigger value="estimate-report-text">
+              Estimate report text
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="project-content" className="mt-5">
+            <div className="mb-5 border-y py-3 sm:max-w-sm">
+              <Select value={categoryFilter} onValueChange={setCategoryFilter}>
+                <SelectTrigger aria-label="Filter templates by category">
+                  <SelectValue placeholder="All categories" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All categories</SelectItem>
+                  {categories.map((category) => (
+                    <SelectItem key={category} value={category}>{category}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
 
-        {filtered.length === 0 ? (
-          <div className="border-y py-10 text-sm text-muted-foreground">
-            No templates match those filters.
-          </div>
-        ) : (
-          <div className="divide-y border-y">
-            {filtered.map((template) => {
+            {filtered.length === 0 ? (
+              <div className="border-y py-10 text-sm text-muted-foreground">
+                No templates match those filters.
+              </div>
+            ) : (
+              <div className="divide-y border-y">
+                {filtered.map((template) => {
               const ready =
                 template.lifecycleStatus === "active" &&
                 template.reviewStatus === "verified" &&
@@ -317,8 +332,8 @@ export function TemplateLibraryView({
                 (total, module) => total + module.sourceItemCount,
                 0
               )
-              return (
-                <article key={template.id} className="grid gap-4 py-4 xl:grid-cols-[minmax(0,1fr)_24rem_auto] xl:items-center">
+                  return (
+                    <article key={template.id} className="grid gap-4 py-4 xl:grid-cols-[minmax(0,1fr)_24rem_auto] xl:items-center">
                   <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-2">
                       <Link className="truncate font-medium hover:underline" href={templateDetailHref(template.id)}>
@@ -364,11 +379,19 @@ export function TemplateLibraryView({
                     </Button>
                     {canManage && <DeleteTemplateButton template={template} />}
                   </div>
-                </article>
-              )
-            })}
-          </div>
-        )}
+                    </article>
+                  )
+                })}
+              </div>
+            )}
+          </TabsContent>
+          <TabsContent value="estimate-report-text" className="mt-5">
+            <EstimateTextTemplateLibrary
+              templates={estimateTextTemplates}
+              canManage={canManageEstimateText}
+            />
+          </TabsContent>
+        </Tabs>
       </main>
     </div>
   )

--- a/src/db/__tests__/estimate-client-report-schema.test.ts
+++ b/src/db/__tests__/estimate-client-report-schema.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
 
 import {
   estimateTermsTemplates,
@@ -19,6 +21,17 @@ describe("estimate client report persistence contract", () => {
   it("stores editable opening and closing estimate copy", () => {
     expect(projectEstimates.introductionText.name).toBe("introduction_text")
     expect(projectEstimates.closingText.name).toBe("closing_text")
+    expect(projectEstimates.clientReportMode.name).toBe("client_report_mode")
+  })
+
+  it("migrates report choice and repairs prior PlanSwift visibility", () => {
+    const migration = readFileSync(
+      resolve(process.cwd(), "drizzle/0125_estimate_client_report_mode.sql"),
+      "utf8"
+    )
+    expect(migration).toContain("ADD `client_report_mode` text")
+    expect(migration).toContain("`specifications` LIKE '%PlanSwift source:%'")
+    expect(migration).toContain("SET `owner_visible` = 1")
   })
 
   it("snapshots phase descriptions and selected acknowledgements", () => {

--- a/src/db/schema-estimates.ts
+++ b/src/db/schema-estimates.ts
@@ -120,6 +120,7 @@ export const projectEstimates = sqliteTable(
       { onDelete: "set null" }
     ),
     closingText: text("closing_text"),
+    clientReportMode: text("client_report_mode"),
     directCostCents: integer("direct_cost_cents").notNull().default(0),
     markupCents: integer("markup_cents").notNull().default(0),
     taxCents: integer("tax_cents").notNull().default(0),

--- a/src/lib/estimates/__tests__/client-report.test.ts
+++ b/src/lib/estimates/__tests__/client-report.test.ts
@@ -20,6 +20,9 @@ function line(
     costCode: "03 30 00",
     description: "Cast-in-place concrete",
     specifications: null,
+    quantity: 2,
+    unit: "CY",
+    unitCostCents: 5_000,
     lineTotalCents: 10_000,
     ownerVisible: true,
     sortOrder: 0,
@@ -30,9 +33,9 @@ function line(
 describe("estimate client report profiles", () => {
   it("selects the department-specific client detail level", () => {
     expect(estimateClientReportMode("H")).toBe("phase_summary")
-    expect(estimateClientReportMode("O")).toBe("ca22")
-    expect(estimateClientReportMode("N")).toBe("cost_code")
-    expect(estimateClientReportMode("D")).toBe("ca22")
+    expect(estimateClientReportMode("O")).toBe("line_items")
+    expect(estimateClientReportMode("N")).toBe("line_items")
+    expect(estimateClientReportMode("D")).toBe("division_summary")
   })
 
   it("does not label H or N estimates as CA22 by default", () => {

--- a/src/lib/estimates/__tests__/client-report.test.ts
+++ b/src/lib/estimates/__tests__/client-report.test.ts
@@ -5,6 +5,7 @@ import {
   clientEstimatePhases,
   defaultEstimateTitle,
   estimateClientReportMode,
+  mergeEstimateTextTemplates,
   estimateTitleForDepartment,
   type ClientEstimateLine,
 } from "@/lib/estimates/client-report"
@@ -134,5 +135,36 @@ describe("estimate client report profiles", () => {
         templateType: "closing",
       })
     ).toEqual([])
+  })
+
+  it("lets an organization template override matching built-in copy", () => {
+    const builtIns = builtInEstimateTextTemplates({ department: "H" })
+    const defaultIntroduction = builtIns.find(
+      (template) => template.name === "Default Introductory Text"
+    )
+    expect(defaultIntroduction).toBeDefined()
+    if (!defaultIntroduction) return
+
+    const templates = mergeEstimateTextTemplates({
+      organizationTemplates: [
+        {
+          ...defaultIntroduction,
+          id: "organization-introduction",
+          body: "Our organization-wide revised introduction.",
+        },
+      ],
+      builtInTemplates: builtIns,
+    })
+
+    expect(
+      templates.filter(
+        (template) => template.name === "Default Introductory Text"
+      )
+    ).toEqual([
+      expect.objectContaining({
+        id: "organization-introduction",
+        body: "Our organization-wide revised introduction.",
+      }),
+    ])
   })
 })

--- a/src/lib/estimates/__tests__/text-template-drive-store.test.ts
+++ b/src/lib/estimates/__tests__/text-template-drive-store.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest"
+
+import type {
+  DriveFile,
+  DriveFileList,
+  ListFilesOptions,
+} from "@/lib/google/client/types"
+import {
+  COMPASS_DEVELOPER_FOLDER_ID,
+  estimateTextTemplateDriveFileName,
+  syncEstimateTextTemplateToDrive,
+} from "@/lib/estimates/text-template-drive-store"
+
+class FakeDriveClient {
+  readonly files = new Map<string, DriveFile>()
+  readonly contents = new Map<string, string>()
+  createFolderCount = 0
+  uploadCount = 0
+  updateCount = 0
+
+  async listFiles(
+    _userEmail: string,
+    options: ListFilesOptions = {}
+  ): Promise<DriveFileList> {
+    const parentId = options.folderId
+    const nameMatch = options.query?.match(/name = '([^']+)'/)
+    const name = nameMatch?.[1] ?? null
+    return {
+      files: [...this.files.values()].filter(
+        (file) =>
+          (!parentId || file.parents?.includes(parentId)) &&
+          (!name || file.name === name)
+      ),
+    }
+  }
+
+  async getFile(_userEmail: string, fileId: string): Promise<DriveFile> {
+    const file = this.files.get(fileId)
+    if (!file) throw new Error("not found")
+    return file
+  }
+
+  async createFolder(
+    _userEmail: string,
+    options: {
+      readonly name: string
+      readonly parentId?: string
+      readonly driveId?: string
+    }
+  ): Promise<DriveFile> {
+    this.createFolderCount += 1
+    const folder: DriveFile = {
+      id: `folder-${this.createFolderCount}`,
+      name: options.name,
+      mimeType: "application/vnd.google-apps.folder",
+      parents: options.parentId ? [options.parentId] : [],
+    }
+    this.files.set(folder.id, folder)
+    return folder
+  }
+
+  async uploadFile(
+    _userEmail: string,
+    options: {
+      readonly name: string
+      readonly parentId?: string
+      readonly mimeType: string
+      readonly data: Blob
+      readonly appProperties?: Readonly<Record<string, string>>
+    }
+  ): Promise<DriveFile> {
+    this.uploadCount += 1
+    const file: DriveFile = {
+      id: `file-${this.uploadCount}`,
+      name: options.name,
+      mimeType: options.mimeType,
+      parents: options.parentId ? [options.parentId] : [],
+      webViewLink: `https://drive.google.com/file/d/file-${this.uploadCount}/view`,
+    }
+    this.files.set(file.id, file)
+    this.contents.set(file.id, await options.data.text())
+    return file
+  }
+
+  async updateFileContent(
+    _userEmail: string,
+    fileId: string,
+    data: Blob,
+    mimeType: string
+  ): Promise<DriveFile> {
+    const file = await this.getFile("", fileId)
+    expect(mimeType).toBe("text/plain")
+    this.updateCount += 1
+    this.contents.set(fileId, await data.text())
+    return file
+  }
+
+  async renameFile(
+    _userEmail: string,
+    fileId: string,
+    newName: string
+  ): Promise<DriveFile> {
+    const current = await this.getFile("", fileId)
+    const renamed: DriveFile = { ...current, name: newName }
+    this.files.set(fileId, renamed)
+    return renamed
+  }
+}
+
+describe("estimate text template Drive storage", () => {
+  it("builds readable and filesystem-safe names", () => {
+    expect(
+      estimateTextTemplateDriveFileName({
+        name: "Standard / Owner: Introduction",
+        departmentCode: "O",
+        templateType: "introduction",
+      })
+    ).toBe("O - Introduction - Standard - Owner- Introduction.txt")
+  })
+
+  it("creates the Template Library once and updates the same file", async () => {
+    const client = new FakeDriveClient()
+    const first = await syncEstimateTextTemplateToDrive({
+      client,
+      userEmail: "estimator@example.com",
+      currentFileId: null,
+      name: "Default Introductory Text",
+      departmentCode: null,
+      templateType: "introduction",
+      body: "First version",
+    })
+    const second = await syncEstimateTextTemplateToDrive({
+      client,
+      userEmail: "estimator@example.com",
+      currentFileId: first.fileId,
+      name: "Default Introductory Text",
+      departmentCode: null,
+      templateType: "introduction",
+      body: "Edited version",
+    })
+
+    expect(first.folderUrl).toBe(
+      "https://drive.google.com/drive/folders/folder-1"
+    )
+    expect(second.fileId).toBe(first.fileId)
+    expect(client.createFolderCount).toBe(1)
+    expect(client.uploadCount).toBe(1)
+    expect(client.updateCount).toBe(1)
+    expect(client.contents.get(first.fileId)).toBe("Edited version")
+    expect(
+      [...client.files.values()].find(
+        (file) => file.id === "folder-1"
+      )?.parents
+    ).toContain(COMPASS_DEVELOPER_FOLDER_ID)
+  })
+})

--- a/src/lib/estimates/client-report.ts
+++ b/src/lib/estimates/client-report.ts
@@ -10,10 +10,14 @@ export const ESTIMATE_TEXT_TEMPLATE_TYPES = [
 export type EstimateTextTemplateType =
   (typeof ESTIMATE_TEXT_TEMPLATE_TYPES)[number]
 
+export const ESTIMATE_CLIENT_REPORT_MODES = [
+  "division_summary",
+  "phase_summary",
+  "line_items",
+] as const
+
 export type EstimateClientReportMode =
-  | "phase_summary"
-  | "ca22"
-  | "cost_code"
+  (typeof ESTIMATE_CLIENT_REPORT_MODES)[number]
 
 export type EstimateTextTemplateOption = {
   readonly id: string
@@ -32,6 +36,9 @@ export type ClientEstimateLine = {
   readonly costCode: string
   readonly description: string
   readonly specifications: string | null
+  readonly quantity: number
+  readonly unit: string
+  readonly unitCostCents: number
   readonly lineTotalCents: number
   readonly ownerVisible: boolean
   readonly sortOrder: number
@@ -170,8 +177,14 @@ export function estimateClientReportMode(
   department: ProjectDepartment
 ): EstimateClientReportMode {
   if (department === "H") return "phase_summary"
-  if (department === "N") return "cost_code"
-  return "ca22"
+  if (department === "O" || department === "N") return "line_items"
+  return "division_summary"
+}
+
+export function isEstimateClientReportMode(
+  value: string | null
+): value is EstimateClientReportMode {
+  return ESTIMATE_CLIENT_REPORT_MODES.some((mode) => mode === value)
 }
 
 export function defaultEstimateTitle(

--- a/src/lib/estimates/client-report.ts
+++ b/src/lib/estimates/client-report.ts
@@ -209,6 +209,34 @@ export function builtInEstimateTextTemplates(input: {
   )
 }
 
+export function estimateTextTemplateIdentity(
+  template: Pick<
+    EstimateTextTemplateOption,
+    "departmentCode" | "templateType" | "name"
+  >
+): string {
+  return [
+    template.departmentCode ?? "all",
+    template.templateType,
+    template.name.trim().toLocaleLowerCase(),
+  ].join(":")
+}
+
+export function mergeEstimateTextTemplates(input: {
+  readonly organizationTemplates: readonly EstimateTextTemplateOption[]
+  readonly builtInTemplates: readonly EstimateTextTemplateOption[]
+}): readonly EstimateTextTemplateOption[] {
+  const organizationKeys = new Set(
+    input.organizationTemplates.map(estimateTextTemplateIdentity)
+  )
+  return [
+    ...input.organizationTemplates,
+    ...input.builtInTemplates.filter(
+      (template) => !organizationKeys.has(estimateTextTemplateIdentity(template))
+    ),
+  ]
+}
+
 export function clientEstimatePhases(input: {
   readonly lines: readonly ClientEstimateLine[]
   readonly phaseDescriptions: Readonly<Record<string, string>>

--- a/src/lib/estimates/text-template-drive-store.ts
+++ b/src/lib/estimates/text-template-drive-store.ts
@@ -1,0 +1,216 @@
+import type { DriveFile, DriveFileList, ListFilesOptions } from "@/lib/google/client/types"
+import type { EstimateTextTemplateType } from "@/lib/estimates/client-report"
+import type { ProjectDepartment } from "@/lib/project-branding"
+
+const GOOGLE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
+const TEMPLATE_FILE_MIME_TYPE = "text/plain"
+
+// This is the existing ________Developer/Compass folder. The child library is
+// created lazily so the authoritative path remains visible to Drive users.
+export const COMPASS_DEVELOPER_FOLDER_ID = "13_p_VESOdyETLrD3cZ8XWrAK1Yo-LAyG"
+export const ESTIMATE_TEMPLATE_LIBRARY_FOLDER_NAME = "Template Library"
+
+type EstimateTemplateDriveClient = {
+  readonly listFiles: (
+    userEmail: string,
+    options?: ListFilesOptions
+  ) => Promise<DriveFileList>
+  readonly getFile: (userEmail: string, fileId: string) => Promise<DriveFile>
+  readonly createFolder: (
+    userEmail: string,
+    options: {
+      readonly name: string
+      readonly parentId?: string
+      readonly driveId?: string
+    }
+  ) => Promise<DriveFile>
+  readonly uploadFile: (
+    userEmail: string,
+    options: {
+      readonly name: string
+      readonly parentId?: string
+      readonly mimeType: string
+      readonly data: Blob
+      readonly appProperties?: Readonly<Record<string, string>>
+    }
+  ) => Promise<DriveFile>
+  readonly updateFileContent: (
+    userEmail: string,
+    fileId: string,
+    data: Blob,
+    mimeType: string
+  ) => Promise<DriveFile>
+  readonly renameFile: (
+    userEmail: string,
+    fileId: string,
+    newName: string
+  ) => Promise<DriveFile>
+}
+
+export type EstimateTextTemplateDriveResult = {
+  readonly fileId: string
+  readonly fileName: string
+  readonly fileUrl: string
+  readonly folderId: string
+  readonly folderUrl: string
+}
+
+function driveQueryValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")
+}
+
+function safeFilePart(value: string): string {
+  const cleaned = value
+    .replace(/[/:\\]/g, "-")
+    .replace(/[\u0000-\u001f]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+  return cleaned.length > 0 ? cleaned.slice(0, 120) : "Untitled"
+}
+
+function departmentLabel(departmentCode: ProjectDepartment | null): string {
+  return departmentCode ?? "All Departments"
+}
+
+function templateTypeLabel(templateType: EstimateTextTemplateType): string {
+  switch (templateType) {
+    case "introduction":
+      return "Introduction"
+    case "closing":
+      return "Closing"
+    case "acknowledgement":
+      return "Acknowledgement"
+    default:
+      return "Terms"
+  }
+}
+
+export function estimateTextTemplateDriveFileName(input: {
+  readonly name: string
+  readonly departmentCode: ProjectDepartment | null
+  readonly templateType: EstimateTextTemplateType
+}): string {
+  return [
+    departmentLabel(input.departmentCode),
+    templateTypeLabel(input.templateType),
+    safeFilePart(input.name),
+  ].join(" - ") + ".txt"
+}
+
+async function findLibraryFolder(
+  client: EstimateTemplateDriveClient,
+  userEmail: string
+): Promise<DriveFile | null> {
+  const result = await client.listFiles(userEmail, {
+    folderId: COMPASS_DEVELOPER_FOLDER_ID,
+    query:
+      `mimeType = '${GOOGLE_FOLDER_MIME_TYPE}' and ` +
+      `name = '${driveQueryValue(ESTIMATE_TEMPLATE_LIBRARY_FOLDER_NAME)}'`,
+    pageSize: 10,
+    orderBy: "createdTime",
+  })
+  return result.files[0] ?? null
+}
+
+async function ensureLibraryFolder(
+  client: EstimateTemplateDriveClient,
+  userEmail: string
+): Promise<DriveFile> {
+  const existing = await findLibraryFolder(client, userEmail)
+  if (existing) return existing
+  return client.createFolder(userEmail, {
+    name: ESTIMATE_TEMPLATE_LIBRARY_FOLDER_NAME,
+    parentId: COMPASS_DEVELOPER_FOLDER_ID,
+  })
+}
+
+async function fileInsideLibrary(
+  client: EstimateTemplateDriveClient,
+  userEmail: string,
+  fileId: string | null,
+  folderId: string
+): Promise<DriveFile | null> {
+  if (!fileId) return null
+  try {
+    const file = await client.getFile(userEmail, fileId)
+    return file.parents?.includes(folderId) ? file : null
+  } catch {
+    return null
+  }
+}
+
+async function findFileByName(
+  client: EstimateTemplateDriveClient,
+  userEmail: string,
+  folderId: string,
+  fileName: string
+): Promise<DriveFile | null> {
+  const result = await client.listFiles(userEmail, {
+    folderId,
+    query: `name = '${driveQueryValue(fileName)}'`,
+    pageSize: 10,
+    orderBy: "createdTime",
+  })
+  return result.files[0] ?? null
+}
+
+export async function syncEstimateTextTemplateToDrive(input: {
+  readonly client: EstimateTemplateDriveClient
+  readonly userEmail: string
+  readonly currentFileId: string | null
+  readonly name: string
+  readonly departmentCode: ProjectDepartment | null
+  readonly templateType: EstimateTextTemplateType
+  readonly body: string
+}): Promise<EstimateTextTemplateDriveResult> {
+  const folder = await ensureLibraryFolder(input.client, input.userEmail)
+  const fileName = estimateTextTemplateDriveFileName(input)
+  const current = await fileInsideLibrary(
+    input.client,
+    input.userEmail,
+    input.currentFileId,
+    folder.id
+  )
+  const existing =
+    current ??
+    (await findFileByName(
+      input.client,
+      input.userEmail,
+      folder.id,
+      fileName
+    ))
+  const data = new Blob([input.body], { type: TEMPLATE_FILE_MIME_TYPE })
+  let saved: DriveFile
+
+  if (existing) {
+    if (existing.name !== fileName) {
+      await input.client.renameFile(input.userEmail, existing.id, fileName)
+    }
+    saved = await input.client.updateFileContent(
+      input.userEmail,
+      existing.id,
+      data,
+      TEMPLATE_FILE_MIME_TYPE
+    )
+  } else {
+    saved = await input.client.uploadFile(input.userEmail, {
+      name: fileName,
+      parentId: folder.id,
+      mimeType: TEMPLATE_FILE_MIME_TYPE,
+      data,
+      appProperties: {
+        compassContentType: "estimateTextTemplate",
+      },
+    })
+  }
+
+  return {
+    fileId: saved.id,
+    fileName,
+    fileUrl:
+      saved.webViewLink ??
+      `https://drive.google.com/file/d/${saved.id}/view`,
+    folderId: folder.id,
+    folderUrl: `https://drive.google.com/drive/folders/${folder.id}`,
+  }
+}

--- a/src/lib/google/client/drive-client.ts
+++ b/src/lib/google/client/drive-client.ts
@@ -329,6 +329,29 @@ export class DriveClient {
     return response.json() as Promise<DriveFile>
   }
 
+  async updateFileContent(
+    userEmail: string,
+    fileId: string,
+    data: Blob,
+    mimeType: string
+  ): Promise<DriveFile> {
+    const params = new URLSearchParams({
+      uploadType: "media",
+      supportsAllDrives: "true",
+      fields: DRIVE_FILE_FIELDS,
+    })
+    return this.request<DriveFile>(
+      userEmail,
+      `/files/${fileId}?${params.toString()}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": mimeType },
+        body: data,
+      },
+      true
+    )
+  }
+
   async downloadFile(
     userEmail: string,
     fileId: string,

--- a/src/lib/google/organization-drive.ts
+++ b/src/lib/google/organization-drive.ts
@@ -1,0 +1,50 @@
+import { eq } from "drizzle-orm"
+
+import { getDb } from "@/db"
+import { googleAuth } from "@/db/schema-google"
+import type { AuthUser } from "@/lib/auth"
+import { decrypt } from "@/lib/crypto"
+import { DriveClient } from "@/lib/google/client/drive-client"
+import {
+  getGoogleConfig,
+  getGoogleCryptoSalt,
+  parseServiceAccountKey,
+} from "@/lib/google/config"
+
+export type OrganizationDriveContext = {
+  readonly client: DriveClient
+  readonly userEmail: string
+}
+
+export async function getOrganizationDriveContext(input: {
+  readonly db: ReturnType<typeof getDb>
+  readonly environment: unknown
+  readonly organizationId: string
+  readonly user: AuthUser
+}): Promise<OrganizationDriveContext> {
+  const auth = await input.db
+    .select({
+      serviceAccountKeyEncrypted: googleAuth.serviceAccountKeyEncrypted,
+    })
+    .from(googleAuth)
+    .where(eq(googleAuth.organizationId, input.organizationId))
+    .get()
+  if (!auth) {
+    throw new Error(
+      "Connect Google Drive before saving estimate text templates."
+    )
+  }
+
+  const config = getGoogleConfig(input.environment)
+  const serviceAccountJson = await decrypt(
+    auth.serviceAccountKeyEncrypted,
+    config.encryptionKey,
+    getGoogleCryptoSalt()
+  )
+  return {
+    client: new DriveClient({
+      serviceAccountKey: parseServiceAccountKey(serviceAccountJson),
+    }),
+    userEmail: input.user.googleEmail ?? input.user.email,
+  }
+}


### PR DESCRIPTION
## Summary

- add a Google Drive-backed estimate report text template library by department
- preserve PlanSwift quantity, unit, unit cost, markup, and Sage-derived division during import
- make imported estimate lines client-visible and safely replaceable on re-import
- repair estimate-line editing and add insert-below support
- persist selectable division, phase, or detailed client report formats
- render CSI-style Project Totals with division subtotals and a client-visible grand total

## Validation

- `bun run test` — 200 files / 1,085 tests passed
- `bunx tsc --noEmit --pretty false`
- `bun run build`
- `bun lint` — 0 errors; 76 existing warnings

External Codex autoreview intentionally skipped at the user's request.
