### PR TITLE
feat(estimates): add editable version comparisons

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,11 +10,12 @@ const deploymentId =
 const nextConfig: NextConfig = {
     allowedDevOrigins: ["127.0.0.1"],
     deploymentId,
-    // Keep the native SQLite development shim out of the production Worker.
+    // OpenNext sets this flag before its Next.js build. Keep the native SQLite
+    // shim out of Workers without breaking production-mode local/E2E builds.
     turbopack: {
         resolveAlias: {
             "@/lib/cloudflare-context":
-                process.env.NODE_ENV === "production"
+                process.env.NEXT_PRIVATE_STANDALONE === "true"
                     ? "./src/lib/cloudflare-context.production.ts"
                     : "./src/lib/cloudflare-context.ts",
         },

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,15 @@ const deploymentId =
 const nextConfig: NextConfig = {
     allowedDevOrigins: ["127.0.0.1"],
     deploymentId,
+    // Keep the native SQLite development shim out of the production Worker.
+    turbopack: {
+        resolveAlias: {
+            "@/lib/cloudflare-context":
+                process.env.NODE_ENV === "production"
+                    ? "./src/lib/cloudflare-context.production.ts"
+                    : "./src/lib/cloudflare-context.ts",
+        },
+    },
     env: {
         NEXT_PUBLIC_COMPASS_DEPLOYMENT_ID: deploymentId ?? "development",
     },

--- a/src/app/actions/project-estimates.ts
+++ b/src/app/actions/project-estimates.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { and, asc, desc, eq, gt, like, ne, sql } from "drizzle-orm"
+import { and, asc, desc, eq, gt, inArray, like, ne, sql } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 
 import { saveEstimateTextTemplateLibraryItem } from "@/app/actions/estimate-text-templates"
@@ -49,6 +49,10 @@ import {
   projectEstimateCostCodeCatalog,
   type ProjectEstimateCostCodeCatalogItem,
 } from "@/lib/estimates/project-cost-code-catalog"
+import {
+  compareEstimateVersions,
+  type EstimateVersionComparison,
+} from "@/lib/estimates/version-comparison"
 import { SheetsClient } from "@/lib/google/client/sheets-client"
 import {
   getGoogleConfig,
@@ -93,6 +97,8 @@ export type ProjectEstimateSummary = {
   readonly signedAt: string | null
   readonly acceptedAt: string | null
   readonly sageStatus: string
+  readonly createdAt: string
+  readonly updatedAt: string
 }
 
 export type ProjectEstimateLineItem = {
@@ -192,6 +198,16 @@ export type ProjectEstimateWorkspace = {
   readonly selectedAcknowledgements: readonly ProjectEstimateAcknowledgementItem[]
 }
 
+export type ProjectEstimateVersionComparison = {
+  readonly canEdit: boolean
+  readonly projectNumber: string | null
+  readonly projectName: string
+  readonly estimates: readonly ProjectEstimateSummary[]
+  readonly baseEstimate: ProjectEstimateSummary | null
+  readonly revisedEstimate: ProjectEstimateSummary | null
+  readonly comparison: EstimateVersionComparison | null
+}
+
 export type ProjectEstimateHeaderInput = {
   readonly estimateNumber: string | null
   readonly title: string | null
@@ -279,6 +295,7 @@ type CompassDb = ReturnType<typeof getDb>
 
 type EstimateAccess = {
   readonly db: CompassDb
+  readonly rawDb: D1Database
   readonly user: AuthUser
   readonly projectNumber: string | null
   readonly projectName: string
@@ -312,6 +329,7 @@ async function estimateAccess(
   }
   return {
     db,
+    rawDb: env.DB,
     user,
     projectNumber: access.projectNumber,
     projectName: project.name,
@@ -407,6 +425,8 @@ function estimateSummary(
     signedAt: row.signedAt,
     acceptedAt: row.acceptedAt,
     sageStatus: row.sageStatus,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
   }
 }
 
@@ -478,7 +498,9 @@ function activeEstimate(
 
 function revalidateEstimate(projectId: string): void {
   revalidatePath(`/dashboard/projects/${projectId}/estimate`)
+  revalidatePath(`/dashboard/projects/${projectId}/estimate/compare`)
   revalidatePath(`/print/projects/${projectId}/estimate`)
+  revalidatePath(`/print/projects/${projectId}/estimate/compare`)
   revalidatePath(`/dashboard/projects/${projectId}/budget`)
   revalidatePath(`/dashboard/projects/${projectId}/financials`)
   revalidatePath(`/dashboard/projects/${projectId}/preview/owner`)
@@ -832,6 +854,237 @@ export async function createProjectEstimateDraft(
   }
 }
 
+export async function duplicateProjectEstimate(
+  projectId: string,
+  sourceEstimateId: string
+): Promise<ProjectEstimateActionResult> {
+  try {
+    const access = await estimateAccess(projectId, true)
+    const sourceRows = await access.db
+      .select()
+      .from(projectEstimates)
+      .where(
+        and(
+          eq(projectEstimates.id, sourceEstimateId),
+          eq(projectEstimates.projectId, projectId)
+        )
+      )
+      .limit(1)
+    const source = sourceRows[0]
+    if (!source || !isEstimateStatus(source.status)) {
+      throw new Error("Estimate version not found.")
+    }
+
+    const priorVersions = await access.db
+      .select({ versionNumber: projectEstimates.versionNumber })
+      .from(projectEstimates)
+      .where(
+        and(
+          eq(projectEstimates.projectId, projectId),
+          eq(projectEstimates.estimateNumber, source.estimateNumber)
+        )
+      )
+      .orderBy(desc(projectEstimates.versionNumber))
+      .limit(1)
+    const id = crypto.randomUUID()
+    const now = new Date().toISOString()
+    const versionNumber = (priorVersions[0]?.versionNumber ?? 0) + 1
+    const copyStatements: D1PreparedStatement[] = [
+      access.rawDb
+        .prepare(
+          `UPDATE project_estimates
+           SET status = 'superseded', updated_at = ?
+           WHERE project_id = ? AND estimate_number = ?
+             AND status IN ('draft', 'internal_review', 'signature_pending')`
+        )
+        .bind(now, projectId, source.estimateNumber),
+      access.rawDb
+        .prepare(
+          `INSERT INTO project_estimates (
+             id, project_id, estimate_number, version_number, title, status,
+             estimate_date, client_name, source_system, source_workbook_id,
+             source_workbook_url, source_revision, template_version_id,
+             template_application_id, default_tax_entity_id, default_tax_code,
+             default_tax_name, default_tax_rate_basis_points, terms_template_id,
+             contract_terms, introduction_template_id, introduction_text,
+             closing_template_id, closing_text, client_report_mode,
+             direct_cost_cents, markup_cents, tax_cents, estimate_total_cents,
+             foxit_status, foxit_envelope_id, signature_package_url,
+             signature_requested_at, signed_at, accepted_at, accepted_by,
+             sage_status, sage_record_id, last_sage_sync_at, source_hash,
+             created_by, created_at, updated_at
+           )
+           SELECT ?, project_id, estimate_number, ?, title, 'draft', ?,
+             client_name, 'compass_revision', source_workbook_id,
+             source_workbook_url, ?, template_version_id,
+             template_application_id, default_tax_entity_id, default_tax_code,
+             default_tax_name, default_tax_rate_basis_points, terms_template_id,
+             contract_terms, introduction_template_id, introduction_text,
+             closing_template_id, closing_text, client_report_mode,
+             direct_cost_cents, markup_cents, tax_cents, estimate_total_cents,
+             'not_started', NULL, NULL, NULL, NULL, NULL, NULL,
+             'not_ready', NULL, NULL, NULL, ?, ?, ?
+           FROM project_estimates
+           WHERE id = ? AND project_id = ?`
+        )
+        .bind(
+          id,
+          versionNumber,
+          now.slice(0, 10),
+          `Duplicated from version ${source.versionNumber} on ${now.slice(0, 10)}`,
+          access.user.id,
+          now,
+          now,
+          sourceEstimateId,
+          projectId
+        ),
+      access.rawDb
+        .prepare(
+          `INSERT INTO project_estimate_lines (
+             id, project_id, estimate_id, template_line_id, division_code,
+             division_name, cost_code, cost_code_name, description,
+             specifications, quantity, unit, unit_cost_cents, direct_cost_cents,
+             markup_rate_basis_points, markup_cents, taxable, tax_entity_id,
+             tax_code, tax_name, tax_rate_basis_points, tax_cents,
+             line_total_cents, owner_visible, sort_order, created_at, updated_at
+           )
+           SELECT lower(hex(randomblob(16))), project_id, ?, template_line_id,
+             division_code, division_name, cost_code, cost_code_name,
+             description, specifications, quantity, unit, unit_cost_cents,
+             direct_cost_cents, markup_rate_basis_points, markup_cents, taxable,
+             tax_entity_id, tax_code, tax_name, tax_rate_basis_points, tax_cents,
+             line_total_cents, owner_visible, sort_order, ?, ?
+           FROM project_estimate_lines
+           WHERE estimate_id = ? AND project_id = ?`
+        )
+        .bind(id, now, now, sourceEstimateId, projectId),
+      access.rawDb
+        .prepare(
+          `INSERT INTO project_estimate_basis_documents (
+             id, project_id, estimate_id, document_type, title, document_date,
+             revision, drive_file_id, drive_url, notes, sort_order, created_at,
+             updated_at
+           )
+           SELECT lower(hex(randomblob(16))), project_id, ?, document_type,
+             title, document_date, revision, drive_file_id, drive_url, notes,
+             sort_order, ?, ?
+           FROM project_estimate_basis_documents
+           WHERE estimate_id = ? AND project_id = ?`
+        )
+        .bind(id, now, now, sourceEstimateId, projectId),
+      access.rawDb
+        .prepare(
+          `INSERT INTO project_estimate_phase_descriptions (
+             id, project_id, estimate_id, division_code, description,
+             created_at, updated_at
+           )
+           SELECT lower(hex(randomblob(16))), project_id, ?, division_code,
+             description, ?, ?
+           FROM project_estimate_phase_descriptions
+           WHERE estimate_id = ? AND project_id = ?`
+        )
+        .bind(id, now, now, sourceEstimateId, projectId),
+      access.rawDb
+        .prepare(
+          `INSERT INTO project_estimate_acknowledgements (
+             id, project_id, estimate_id, template_id, title, body,
+             source_document_id, source_url, sort_order, created_at, updated_at
+           )
+           SELECT lower(hex(randomblob(16))), project_id, ?, template_id, title,
+             body, source_document_id, source_url, sort_order, ?, ?
+           FROM project_estimate_acknowledgements
+           WHERE estimate_id = ? AND project_id = ?`
+        )
+        .bind(id, now, now, sourceEstimateId, projectId),
+    ]
+    const copyResults = await access.rawDb.batch(copyStatements)
+    if (copyResults.some((result) => !result.success)) {
+      throw new Error("The estimate version copy did not complete.")
+    }
+
+    revalidateEstimate(projectId)
+    return { success: true, id }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to create the next estimate version.",
+    }
+  }
+}
+
+export async function getProjectEstimateVersionComparison(
+  projectId: string,
+  baseEstimateId?: string,
+  revisedEstimateId?: string
+): Promise<ProjectEstimateVersionComparison> {
+  const access = await estimateAccess(projectId, false)
+  const estimateRows = await access.db
+    .select()
+    .from(projectEstimates)
+    .where(eq(projectEstimates.projectId, projectId))
+    .orderBy(
+      desc(projectEstimates.versionNumber),
+      desc(projectEstimates.updatedAt)
+    )
+  const estimates = estimateRows.map((row) =>
+    estimateSummary(row, access.department)
+  )
+  const revisedEstimate =
+    estimates.find((estimate) => estimate.id === revisedEstimateId) ??
+    estimates[0] ??
+    null
+  const baseEstimate =
+    estimates.find(
+      (estimate) =>
+        estimate.id === baseEstimateId && estimate.id !== revisedEstimate?.id
+    ) ??
+    estimates.find((estimate) => estimate.id !== revisedEstimate?.id) ??
+    null
+  const selectedIds = [baseEstimate?.id, revisedEstimate?.id].filter(
+    (id): id is string => Boolean(id)
+  )
+  const lineRows =
+    selectedIds.length === 2
+      ? await access.db
+          .select()
+          .from(projectEstimateLines)
+          .where(
+            and(
+              eq(projectEstimateLines.projectId, projectId),
+              inArray(projectEstimateLines.estimateId, selectedIds)
+            )
+          )
+          .orderBy(
+            asc(projectEstimateLines.divisionCode),
+            asc(projectEstimateLines.sortOrder)
+          )
+      : []
+  const comparison =
+    baseEstimate && revisedEstimate
+      ? compareEstimateVersions({
+          baseLines: lineRows.filter(
+            (line) => line.estimateId === baseEstimate.id
+          ),
+          revisedLines: lineRows.filter(
+            (line) => line.estimateId === revisedEstimate.id
+          ),
+        })
+      : null
+
+  return {
+    canEdit: isInternalStaffRole(access.user.role),
+    projectNumber: access.projectNumber,
+    projectName: access.projectName,
+    estimates,
+    baseEstimate,
+    revisedEstimate,
+    comparison,
+  }
+}
+
 export async function updateProjectEstimateHeader(
   projectId: string,
   estimateId: string,
@@ -883,7 +1136,7 @@ export async function updateProjectEstimateHeader(
       .set({
         estimateNumber: requiredText(input.estimateNumber, "Estimate number"),
         title: requiredText(input.title, "Estimate title"),
-        estimateDate: cleanText(input.estimateDate),
+        estimateDate: requiredText(input.estimateDate, "Estimate date"),
         clientName: cleanText(input.clientName),
         sourceWorkbookUrl: safeUrl(input.sourceWorkbookUrl),
         defaultTaxEntityId: taxEntity?.id ?? null,
@@ -1743,6 +1996,9 @@ export async function prepareProjectEstimateForFoxit(
           .orderBy(asc(projectEstimateAcknowledgements.sortOrder)),
       ])
     if (lines.length === 0) throw new Error("Add estimate lines before signature.")
+    if (!cleanText(estimate.estimateDate)) {
+      throw new Error("Add the estimate date before signature.")
+    }
     const sourceCostCodes = [
       ...new Set(
         lines

--- a/src/app/dashboard/projects/[id]/estimate/compare/page.tsx
+++ b/src/app/dashboard/projects/[id]/estimate/compare/page.tsx
@@ -1,0 +1,39 @@
+export const dynamic = "force-dynamic"
+
+import { getProjectEstimateVersionComparison } from "@/app/actions/project-estimates"
+import { ProjectEstimateComparisonControls } from "@/components/projects/project-estimate-comparison-controls"
+import { ProjectEstimateVersionComparisonDocument } from "@/components/projects/project-estimate-version-comparison"
+
+export default async function ProjectEstimateComparisonPage({
+  params,
+  searchParams,
+}: {
+  readonly params: Promise<{ id: string }>
+  readonly searchParams: Promise<{
+    baseEstimateId?: string
+    revisedEstimateId?: string
+  }>
+}): Promise<React.ReactElement> {
+  const [{ id }, query] = await Promise.all([params, searchParams])
+  const data = await getProjectEstimateVersionComparison(
+    id,
+    query.baseEstimateId,
+    query.revisedEstimateId
+  )
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto p-4 md:p-6">
+      {data.baseEstimate && data.revisedEstimate && (
+        <div className="mb-5">
+          <ProjectEstimateComparisonControls
+            projectId={id}
+            estimates={data.estimates}
+            baseEstimate={data.baseEstimate}
+            revisedEstimate={data.revisedEstimate}
+          />
+        </div>
+      )}
+      <ProjectEstimateVersionComparisonDocument data={data} />
+    </div>
+  )
+}

--- a/src/app/print/projects/[id]/estimate/compare/page.tsx
+++ b/src/app/print/projects/[id]/estimate/compare/page.tsx
@@ -1,0 +1,52 @@
+export const dynamic = "force-dynamic"
+
+import { getProjectEstimateVersionComparison } from "@/app/actions/project-estimates"
+import { ProjectEstimateReportActions } from "@/components/projects/project-estimate-report-actions"
+import { ProjectEstimateVersionComparisonDocument } from "@/components/projects/project-estimate-version-comparison"
+
+export default async function ProjectEstimateComparisonPrintPage({
+  params,
+  searchParams,
+}: {
+  readonly params: Promise<{ id: string }>
+  readonly searchParams: Promise<{
+    baseEstimateId?: string
+    revisedEstimateId?: string
+  }>
+}): Promise<React.ReactElement> {
+  const [{ id }, query] = await Promise.all([params, searchParams])
+  const data = await getProjectEstimateVersionComparison(
+    id,
+    query.baseEstimateId,
+    query.revisedEstimateId
+  )
+  const baseEstimate = data.baseEstimate
+  const revisedEstimate = data.revisedEstimate
+
+  if (!baseEstimate || !revisedEstimate || !data.comparison) {
+    return <main className="p-8">Two estimate versions are required.</main>
+  }
+
+  return (
+    <>
+      <style>{`
+        @page { size: letter landscape; margin: 0.35in; }
+        @media print {
+          body { background: white !important; }
+          .estimate-report-actions { display: none !important; }
+          .estimate-comparison-document { margin: 0 !important; max-width: none !important; }
+        }
+      `}</style>
+      <title>
+        {data.projectName} Estimate Versions {baseEstimate.versionNumber} and {revisedEstimate.versionNumber}
+      </title>
+      <ProjectEstimateReportActions
+        title={`${data.projectName} estimate version comparison`}
+        estimateNumber={`${baseEstimate.estimateNumber} v${baseEstimate.versionNumber}–v${revisedEstimate.versionNumber}`}
+      />
+      <main className="mx-auto max-w-[11in] bg-white p-5 text-black print:max-w-none print:p-0">
+        <ProjectEstimateVersionComparisonDocument data={data} />
+      </main>
+    </>
+  )
+}

--- a/src/app/print/projects/[id]/estimate/page.tsx
+++ b/src/app/print/projects/[id]/estimate/page.tsx
@@ -24,6 +24,17 @@ function quantity(value: number): string {
   }).format(value)
 }
 
+function estimateDate(value: string | null, createdAt: string): string {
+  const dateValue = value ?? createdAt.slice(0, 10)
+  const date = new Date(`${dateValue}T12:00:00`)
+  if (Number.isNaN(date.valueOf())) return dateValue
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(date)
+}
+
 export default async function ProjectEstimatePrintPage({
   params,
   searchParams,
@@ -116,7 +127,10 @@ export default async function ProjectEstimatePrintPage({
             <p className="mt-1 font-semibold">
               {estimate.clientName ?? "Project client"}
             </p>
-            <p>{estimate.estimateDate ?? ""}</p>
+            <p className="mt-2 text-xs font-semibold uppercase tracking-wide">
+              Estimate date
+            </p>
+            <p>{estimateDate(estimate.estimateDate, estimate.createdAt)}</p>
           </div>
         </section>
 
@@ -264,7 +278,8 @@ export default async function ProjectEstimatePrintPage({
         )}
 
         <footer className="mt-10 border-t pt-3 text-xs text-neutral-600">
-          Estimate {estimate.estimateNumber}, version {estimate.versionNumber}.
+          Estimate {estimate.estimateNumber}, version {estimate.versionNumber}, dated{" "}
+          {estimateDate(estimate.estimateDate, estimate.createdAt)}.
         </footer>
 
         {workspace.selectedAcknowledgements.map((acknowledgement) => (

--- a/src/components/projects/__tests__/project-estimate-version-comparison.test.ts
+++ b/src/components/projects/__tests__/project-estimate-version-comparison.test.ts
@@ -1,0 +1,104 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import type {
+  ProjectEstimateSummary,
+  ProjectEstimateVersionComparison,
+} from "@/app/actions/project-estimates"
+import { ProjectEstimateVersionComparisonDocument } from "@/components/projects/project-estimate-version-comparison"
+
+function estimate(
+  id: string,
+  versionNumber: number,
+  estimateDate: string
+): ProjectEstimateSummary {
+  return {
+    id,
+    estimateNumber: "COMPASS-00",
+    versionNumber,
+    title: "Developer estimate",
+    status: versionNumber === 1 ? "superseded" : "draft",
+    estimateDate,
+    clientName: "Example Client",
+    sourceWorkbookUrl: null,
+    defaultTaxEntityId: null,
+    defaultTaxCode: null,
+    defaultTaxName: null,
+    defaultTaxRateBasisPoints: 0,
+    termsTemplateId: null,
+    contractTerms: null,
+    introductionTemplateId: null,
+    introductionText: null,
+    closingTemplateId: null,
+    closingText: null,
+    clientReportMode: "cost_code",
+    directCostCents: versionNumber === 1 ? 10_000 : 12_500,
+    markupCents: 0,
+    taxCents: 0,
+    estimateTotalCents: versionNumber === 1 ? 10_000 : 12_500,
+    foxitStatus: "not_started",
+    foxitEnvelopeId: null,
+    signaturePackageUrl: null,
+    signedAt: null,
+    acceptedAt: null,
+    sageStatus: "not_ready",
+    createdAt: `${estimateDate}T12:00:00.000Z`,
+    updatedAt: `${estimateDate}T12:00:00.000Z`,
+  }
+}
+
+describe("estimate version comparison document", () => {
+  it("prints both version dates, totals, and changed scope side by side", () => {
+    const baseEstimate = estimate("estimate-1", 1, "2026-08-01")
+    const revisedEstimate = estimate("estimate-2", 2, "2026-08-21")
+    const data: ProjectEstimateVersionComparison = {
+      canEdit: true,
+      projectNumber: "COMPASS",
+      projectName: "Compass Developer",
+      estimates: [revisedEstimate, baseEstimate],
+      baseEstimate,
+      revisedEstimate,
+      comparison: {
+        baseTotalCents: 10_000,
+        revisedTotalCents: 12_500,
+        deltaCents: 2_500,
+        changedRowCount: 1,
+        divisions: [
+          {
+            divisionCode: "01",
+            divisionName: "General Requirements",
+            baseTotalCents: 10_000,
+            revisedTotalCents: 12_500,
+            deltaCents: 2_500,
+            rows: [
+              {
+                key: "01|01-1000",
+                divisionCode: "01",
+                divisionName: "General Requirements",
+                costCode: "01-1000",
+                baseDescription: "Original supervision",
+                revisedDescription: "Revised supervision",
+                baseTotalCents: 10_000,
+                revisedTotalCents: 12_500,
+                deltaCents: 2_500,
+                change: "changed",
+              },
+            ],
+          },
+        ],
+      },
+    }
+
+    const html = renderToStaticMarkup(
+      createElement(ProjectEstimateVersionComparisonDocument, { data })
+    )
+
+    expect(html).toContain("Compass Developer")
+    expect(html).toContain("Estimate date: August 1, 2026")
+    expect(html).toContain("Estimate date: August 21, 2026")
+    expect(html).toContain("Original supervision")
+    expect(html).toContain("Revised supervision")
+    expect(html).toContain("+$25.00")
+  })
+})

--- a/src/components/projects/project-estimate-comparison-controls.tsx
+++ b/src/components/projects/project-estimate-comparison-controls.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { IconArrowLeft, IconPrinter } from "@tabler/icons-react"
+
+import type { ProjectEstimateSummary } from "@/app/actions/project-estimates"
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+function versionLabel(estimate: ProjectEstimateSummary): string {
+  const date = estimate.estimateDate ?? estimate.createdAt.slice(0, 10)
+  return `Version ${estimate.versionNumber} · ${date}`
+}
+
+export function ProjectEstimateComparisonControls({
+  projectId,
+  estimates,
+  baseEstimate,
+  revisedEstimate,
+}: {
+  readonly projectId: string
+  readonly estimates: readonly ProjectEstimateSummary[]
+  readonly baseEstimate: ProjectEstimateSummary
+  readonly revisedEstimate: ProjectEstimateSummary
+}): React.ReactElement {
+  const router = useRouter()
+
+  function comparisonHref(baseId: string, revisedId: string): string {
+    return `/dashboard/projects/${projectId}/estimate/compare?baseEstimateId=${baseId}&revisedEstimateId=${revisedId}`
+  }
+
+  function selectBase(baseId: string): void {
+    router.push(comparisonHref(baseId, revisedEstimate.id))
+  }
+
+  function selectRevised(revisedId: string): void {
+    router.push(comparisonHref(baseEstimate.id, revisedId))
+  }
+
+  const query = `baseEstimateId=${baseEstimate.id}&revisedEstimateId=${revisedEstimate.id}`
+
+  return (
+    <div className="estimate-comparison-controls flex flex-wrap items-end gap-3">
+      <Button variant="ghost" asChild>
+        <Link
+          href={`/dashboard/projects/${projectId}/estimate?estimateId=${revisedEstimate.id}`}
+        >
+          <IconArrowLeft className="size-4" />
+          Estimate
+        </Link>
+      </Button>
+      <div className="min-w-[210px] space-y-1">
+        <p className="text-xs font-medium text-muted-foreground">Base version</p>
+        <Select value={baseEstimate.id} onValueChange={selectBase}>
+          <SelectTrigger aria-label="Base estimate version">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {estimates.map((estimate) => (
+              <SelectItem
+                key={estimate.id}
+                value={estimate.id}
+                disabled={estimate.id === revisedEstimate.id}
+              >
+                {versionLabel(estimate)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="min-w-[210px] space-y-1">
+        <p className="text-xs font-medium text-muted-foreground">
+          Revised version
+        </p>
+        <Select value={revisedEstimate.id} onValueChange={selectRevised}>
+          <SelectTrigger aria-label="Revised estimate version">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {estimates.map((estimate) => (
+              <SelectItem
+                key={estimate.id}
+                value={estimate.id}
+                disabled={estimate.id === baseEstimate.id}
+              >
+                {versionLabel(estimate)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <Button className="ml-auto" asChild>
+        <Link
+          href={`/print/projects/${projectId}/estimate/compare?${query}`}
+          target="_blank"
+        >
+          <IconPrinter className="size-4" />
+          Print comparison
+        </Link>
+      </Button>
+    </div>
+  )
+}

--- a/src/components/projects/project-estimate-version-comparison.tsx
+++ b/src/components/projects/project-estimate-version-comparison.tsx
@@ -1,0 +1,201 @@
+import type {
+  ProjectEstimateSummary,
+  ProjectEstimateVersionComparison,
+} from "@/app/actions/project-estimates"
+
+function money(cents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(cents / 100)
+}
+
+function signedMoney(cents: number): string {
+  if (cents === 0) return money(0)
+  return `${cents > 0 ? "+" : "−"}${money(Math.abs(cents))}`
+}
+
+function estimateDate(estimate: ProjectEstimateSummary): string {
+  const value = estimate.estimateDate ?? estimate.createdAt.slice(0, 10)
+  const date = new Date(`${value}T12:00:00`)
+  if (Number.isNaN(date.valueOf())) return value
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(date)
+}
+
+function changeLabel(change: string): string {
+  if (change === "added") return "Added"
+  if (change === "removed") return "Removed"
+  if (change === "changed") return "Changed"
+  return "No change"
+}
+
+function VersionHeading({
+  label,
+  estimate,
+}: {
+  readonly label: string
+  readonly estimate: ProjectEstimateSummary
+}): React.ReactElement {
+  return (
+    <div className="border-l-2 border-l-primary pl-3 print:border-l-black">
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground print:text-neutral-600">
+        {label}
+      </p>
+      <p className="mt-1 font-semibold">
+        {estimate.title} · Version {estimate.versionNumber}
+      </p>
+      <p className="text-sm text-muted-foreground print:text-neutral-600">
+        Estimate date: {estimateDate(estimate)}
+      </p>
+      <p className="text-xs capitalize text-muted-foreground print:text-neutral-600">
+        {estimate.status.replaceAll("_", " ")}
+      </p>
+    </div>
+  )
+}
+
+export function ProjectEstimateVersionComparisonDocument({
+  data,
+}: {
+  readonly data: ProjectEstimateVersionComparison
+}): React.ReactElement {
+  const { baseEstimate, revisedEstimate, comparison } = data
+  if (!baseEstimate || !revisedEstimate || !comparison) {
+    return (
+      <section className="clarity-panel-strong p-6">
+        <h2 className="font-semibold">Two estimate versions are required</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Duplicate an estimate to create the next editable version, then return
+          here to compare them.
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <article className="estimate-comparison-document clarity-panel-strong overflow-hidden bg-background print:border-0 print:bg-white print:text-black print:shadow-none">
+      <header className="border-b p-5 print:border-black">
+        <p className="text-xs font-semibold uppercase tracking-wide text-primary print:text-black">
+          Estimate version comparison
+        </p>
+        <h1 className="mt-1 text-xl font-semibold">{data.projectName}</h1>
+        {data.projectNumber && (
+          <p className="text-sm text-muted-foreground print:text-neutral-600">
+            Project {data.projectNumber}
+          </p>
+        )}
+        <div className="mt-5 grid gap-5 sm:grid-cols-2 print:grid-cols-2">
+          <VersionHeading label="Base estimate" estimate={baseEstimate} />
+          <VersionHeading label="Revised estimate" estimate={revisedEstimate} />
+        </div>
+      </header>
+
+      <section className="grid divide-y border-b sm:grid-cols-3 sm:divide-x sm:divide-y-0 print:grid-cols-3 print:divide-x print:divide-y-0 print:border-black">
+        <div className="p-4">
+          <p className="text-xs text-muted-foreground print:text-neutral-600">
+            Base total
+          </p>
+          <p className="mt-1 text-lg font-semibold">
+            {money(comparison.baseTotalCents)}
+          </p>
+        </div>
+        <div className="p-4">
+          <p className="text-xs text-muted-foreground print:text-neutral-600">
+            Revised total
+          </p>
+          <p className="mt-1 text-lg font-semibold">
+            {money(comparison.revisedTotalCents)}
+          </p>
+        </div>
+        <div className="p-4">
+          <p className="text-xs text-muted-foreground print:text-neutral-600">
+            Net change
+          </p>
+          <p className="mt-1 text-lg font-semibold">
+            {signedMoney(comparison.deltaCents)}
+          </p>
+          <p className="text-xs text-muted-foreground print:text-neutral-600">
+            {comparison.changedRowCount} changed cost code
+            {comparison.changedRowCount === 1 ? "" : "s"}
+          </p>
+        </div>
+      </section>
+
+      <div className="space-y-6 p-5">
+        {comparison.divisions.map((division) => (
+          <section key={division.divisionCode} className="break-inside-avoid">
+            <div className="grid grid-cols-[minmax(0,1fr)_1.2in_1.2in_1.2in] gap-3 border-b-2 border-foreground pb-2 text-sm font-semibold print:border-black">
+              <span>
+                {division.divisionCode} · {division.divisionName}
+              </span>
+              <span className="text-right">
+                {money(division.baseTotalCents)}
+              </span>
+              <span className="text-right">
+                {money(division.revisedTotalCents)}
+              </span>
+              <span className="text-right">
+                {signedMoney(division.deltaCents)}
+              </span>
+            </div>
+            <div className="overflow-x-auto print:overflow-visible">
+              <table className="w-full min-w-[850px] border-collapse text-sm print:min-w-0 print:text-[10px]">
+                <thead>
+                  <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground print:text-[9px] print:text-neutral-600">
+                    <th className="w-[1.05in] py-2 pr-3">Cost code</th>
+                    <th className="py-2 pr-3">Base scope</th>
+                    <th className="w-[1.15in] py-2 pr-3 text-right">Base</th>
+                    <th className="py-2 pr-3">Revised scope</th>
+                    <th className="w-[1.15in] py-2 pr-3 text-right">Revised</th>
+                    <th className="w-[1.1in] py-2 text-right">Change</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {division.rows.map((row) => (
+                    <tr
+                      key={row.key}
+                      className="break-inside-avoid border-b align-top"
+                    >
+                      <td className="py-2 pr-3 font-medium">{row.costCode}</td>
+                      <td className="py-2 pr-3 text-muted-foreground print:text-neutral-700">
+                        {row.baseDescription ?? "—"}
+                      </td>
+                      <td className="py-2 pr-3 text-right">
+                        {row.change === "added" ? "—" : money(row.baseTotalCents)}
+                      </td>
+                      <td className="py-2 pr-3 text-muted-foreground print:text-neutral-700">
+                        {row.revisedDescription ?? "—"}
+                      </td>
+                      <td className="py-2 pr-3 text-right">
+                        {row.change === "removed"
+                          ? "—"
+                          : money(row.revisedTotalCents)}
+                      </td>
+                      <td className="py-2 text-right">
+                        <span className="font-medium">
+                          {signedMoney(row.deltaCents)}
+                        </span>
+                        <span className="block text-[10px] uppercase tracking-wide text-muted-foreground print:text-neutral-600">
+                          {changeLabel(row.change)}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        ))}
+      </div>
+      <footer className="border-t px-5 py-3 text-xs text-muted-foreground print:border-black print:text-neutral-600">
+        Compared {baseEstimate.estimateNumber} version {baseEstimate.versionNumber}
+        {` (${estimateDate(baseEstimate)}) with version ${revisedEstimate.versionNumber} (${estimateDate(revisedEstimate)}).`}
+      </footer>
+    </article>
+  )
+}

--- a/src/components/projects/project-estimate-version-controls.tsx
+++ b/src/components/projects/project-estimate-version-controls.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useTransition } from "react"
+import { IconColumns3, IconCopy } from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import {
+  duplicateProjectEstimate,
+  type ProjectEstimateSummary,
+} from "@/app/actions/project-estimates"
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+function versionLabel(estimate: ProjectEstimateSummary): string {
+  const date = estimate.estimateDate ?? estimate.createdAt.slice(0, 10)
+  return `Version ${estimate.versionNumber} · ${date}`
+}
+
+export function ProjectEstimateVersionControls({
+  projectId,
+  estimates,
+  activeEstimate,
+  canEdit,
+}: {
+  readonly projectId: string
+  readonly estimates: readonly ProjectEstimateSummary[]
+  readonly activeEstimate: ProjectEstimateSummary
+  readonly canEdit: boolean
+}): React.ReactElement {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const otherVersion = estimates.find(
+    (estimate) => estimate.id !== activeEstimate.id
+  )
+
+  function openVersion(estimateId: string): void {
+    router.push(
+      `/dashboard/projects/${projectId}/estimate?estimateId=${estimateId}`
+    )
+  }
+
+  function duplicateVersion(): void {
+    if (
+      !window.confirm(
+        `Create an editable next version from version ${activeEstimate.versionNumber}? The current working version will be preserved and locked.`
+      )
+    ) {
+      return
+    }
+    startTransition(async () => {
+      const result = await duplicateProjectEstimate(projectId, activeEstimate.id)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success("Editable next estimate version created.")
+      router.push(
+        `/dashboard/projects/${projectId}/estimate?estimateId=${result.id}`
+      )
+      router.refresh()
+    })
+  }
+
+  return (
+    <div className="flex flex-wrap items-center justify-end gap-2">
+      <Select value={activeEstimate.id} onValueChange={openVersion}>
+        <SelectTrigger className="w-[190px]" aria-label="Estimate version">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {estimates.map((estimate) => (
+            <SelectItem key={estimate.id} value={estimate.id}>
+              {versionLabel(estimate)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {otherVersion && (
+        <Button variant="outline" asChild>
+          <Link
+            href={`/dashboard/projects/${projectId}/estimate/compare?baseEstimateId=${otherVersion.id}&revisedEstimateId=${activeEstimate.id}`}
+          >
+            <IconColumns3 className="size-4" />
+            Compare versions
+          </Link>
+        </Button>
+      )}
+      {canEdit && (
+        <Button
+          type="button"
+          variant="outline"
+          onClick={duplicateVersion}
+          disabled={isPending}
+        >
+          <IconCopy className="size-4" />
+          {isPending ? "Creating version…" : "Duplicate as next version"}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/src/components/projects/project-estimate-workspace.tsx
+++ b/src/components/projects/project-estimate-workspace.tsx
@@ -43,6 +43,7 @@ import { Badge } from "@/components/ui/badge"
 import { useDeveloperMode } from "@/components/developer-mode-provider"
 import { ProjectEstimateClientReportSettings } from "@/components/projects/project-estimate-client-report-settings"
 import { ProjectEstimatePlanSwiftImport } from "@/components/projects/project-estimate-planswift-import"
+import { ProjectEstimateVersionControls } from "@/components/projects/project-estimate-version-controls"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
@@ -551,15 +552,23 @@ export function ProjectEstimateWorkspacePanel({
                 : ""}
             </p>
           </div>
-          <Button variant="outline" asChild>
-            <Link
-              href={`/print/projects/${projectId}/estimate?estimateId=${estimate.id}`}
-              target="_blank"
-            >
-              <IconFileExport className="size-4" />
-              Client report preview
-            </Link>
-          </Button>
+          <div className="flex flex-wrap justify-end gap-2">
+            <ProjectEstimateVersionControls
+              projectId={projectId}
+              estimates={workspace.estimates}
+              activeEstimate={estimate}
+              canEdit={workspace.canEdit}
+            />
+            <Button variant="outline" asChild>
+              <Link
+                href={`/print/projects/${projectId}/estimate?estimateId=${estimate.id}`}
+                target="_blank"
+              >
+                <IconFileExport className="size-4" />
+                Client report preview
+              </Link>
+            </Button>
+          </div>
         </div>
         <div className="grid divide-y sm:grid-cols-2 sm:divide-x sm:divide-y-0 xl:grid-cols-4">
           {[

--- a/src/lib/cloudflare-context.production.ts
+++ b/src/lib/cloudflare-context.production.ts
@@ -1,0 +1,3 @@
+export async function getCloudflareContext(): Promise<never> {
+    throw new Error("The local database context is unavailable in production.")
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -38,7 +38,7 @@ export async function getCloudflareContext(): Promise<CompassCloudflareContext> 
 
 async function getLocalCloudflareContext(): Promise<CompassCloudflareContext> {
     const { getCloudflareContext: getLocalContext } = await import(
-        "./cloudflare-context"
+        "@/lib/cloudflare-context"
     )
     return getLocalContext()
 }

--- a/src/lib/estimates/__tests__/version-comparison.test.ts
+++ b/src/lib/estimates/__tests__/version-comparison.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest"
+
+import { compareEstimateVersions } from "@/lib/estimates/version-comparison"
+
+describe("compareEstimateVersions", () => {
+  it("aggregates repeated cost codes and identifies cost changes", () => {
+    const comparison = compareEstimateVersions({
+      baseLines: [
+        {
+          divisionCode: "03",
+          divisionName: "Concrete",
+          costCode: "03-100",
+          description: "Footings",
+          lineTotalCents: 10_000,
+        },
+        {
+          divisionCode: "03",
+          divisionName: "Concrete",
+          costCode: "03-100",
+          description: "Slab",
+          lineTotalCents: 20_000,
+        },
+      ],
+      revisedLines: [
+        {
+          divisionCode: "03",
+          divisionName: "Concrete",
+          costCode: "03-100",
+          description: "Footings",
+          lineTotalCents: 15_000,
+        },
+        {
+          divisionCode: "03",
+          divisionName: "Concrete",
+          costCode: "03-100",
+          description: "Slab",
+          lineTotalCents: 20_000,
+        },
+      ],
+    })
+
+    expect(comparison.baseTotalCents).toBe(30_000)
+    expect(comparison.revisedTotalCents).toBe(35_000)
+    expect(comparison.deltaCents).toBe(5_000)
+    expect(comparison.changedRowCount).toBe(1)
+    expect(comparison.divisions[0]?.rows[0]).toMatchObject({
+      baseDescription: "Footings / Slab",
+      revisedDescription: "Footings / Slab",
+      baseTotalCents: 30_000,
+      revisedTotalCents: 35_000,
+      change: "changed",
+    })
+  })
+
+  it("marks added, removed, and unchanged cost codes", () => {
+    const comparison = compareEstimateVersions({
+      baseLines: [
+        {
+          divisionCode: "01",
+          divisionName: "General Requirements",
+          costCode: "01-100",
+          description: "Supervision",
+          lineTotalCents: 8_000,
+        },
+        {
+          divisionCode: "02",
+          divisionName: "Existing Conditions",
+          costCode: "02-100",
+          description: "Demo",
+          lineTotalCents: 2_000,
+        },
+      ],
+      revisedLines: [
+        {
+          divisionCode: "01",
+          divisionName: "General Requirements",
+          costCode: "01-100",
+          description: "Supervision",
+          lineTotalCents: 8_000,
+        },
+        {
+          divisionCode: "03",
+          divisionName: "Concrete",
+          costCode: "03-100",
+          description: "Foundations",
+          lineTotalCents: 5_000,
+        },
+      ],
+    })
+
+    const rows = comparison.divisions.flatMap((division) => division.rows)
+    expect(rows.map((row) => [row.costCode, row.change])).toEqual([
+      ["01-100", "unchanged"],
+      ["02-100", "removed"],
+      ["03-100", "added"],
+    ])
+    expect(comparison.changedRowCount).toBe(2)
+    expect(comparison.deltaCents).toBe(3_000)
+  })
+})

--- a/src/lib/estimates/version-comparison.ts
+++ b/src/lib/estimates/version-comparison.ts
@@ -1,0 +1,177 @@
+export type EstimateVersionComparisonLine = {
+  readonly divisionCode: string
+  readonly divisionName: string
+  readonly costCode: string
+  readonly description: string
+  readonly lineTotalCents: number
+}
+
+export type EstimateVersionComparisonChange =
+  | "added"
+  | "removed"
+  | "changed"
+  | "unchanged"
+
+export type EstimateVersionComparisonRow = {
+  readonly key: string
+  readonly divisionCode: string
+  readonly divisionName: string
+  readonly costCode: string
+  readonly baseDescription: string | null
+  readonly revisedDescription: string | null
+  readonly baseTotalCents: number
+  readonly revisedTotalCents: number
+  readonly deltaCents: number
+  readonly change: EstimateVersionComparisonChange
+}
+
+export type EstimateVersionComparisonDivision = {
+  readonly divisionCode: string
+  readonly divisionName: string
+  readonly baseTotalCents: number
+  readonly revisedTotalCents: number
+  readonly deltaCents: number
+  readonly rows: readonly EstimateVersionComparisonRow[]
+}
+
+export type EstimateVersionComparison = {
+  readonly baseTotalCents: number
+  readonly revisedTotalCents: number
+  readonly deltaCents: number
+  readonly changedRowCount: number
+  readonly divisions: readonly EstimateVersionComparisonDivision[]
+}
+
+type AggregatedLine = {
+  readonly divisionCode: string
+  readonly divisionName: string
+  readonly costCode: string
+  readonly descriptions: readonly string[]
+  readonly totalCents: number
+}
+
+function lineKey(line: EstimateVersionComparisonLine): string {
+  return `${line.divisionCode}|${line.costCode}`
+}
+
+function aggregateLines(
+  lines: readonly EstimateVersionComparisonLine[]
+): ReadonlyMap<string, AggregatedLine> {
+  const groups = new Map<string, AggregatedLine>()
+
+  for (const line of lines) {
+    const key = lineKey(line)
+    const prior = groups.get(key)
+    const descriptions = new Set(prior?.descriptions ?? [])
+    const description = line.description.trim()
+    if (description) descriptions.add(description)
+    groups.set(key, {
+      divisionCode: line.divisionCode,
+      divisionName: line.divisionName,
+      costCode: line.costCode,
+      descriptions: [...descriptions],
+      totalCents: (prior?.totalCents ?? 0) + line.lineTotalCents,
+    })
+  }
+
+  return groups
+}
+
+function description(group: AggregatedLine | undefined): string | null {
+  if (!group || group.descriptions.length === 0) return null
+  return group.descriptions.join(" / ")
+}
+
+function rowChange(input: {
+  readonly base: AggregatedLine | undefined
+  readonly revised: AggregatedLine | undefined
+}): EstimateVersionComparisonChange {
+  if (!input.base) return "added"
+  if (!input.revised) return "removed"
+  if (
+    input.base.totalCents === input.revised.totalCents &&
+    description(input.base) === description(input.revised)
+  ) {
+    return "unchanged"
+  }
+  return "changed"
+}
+
+export function compareEstimateVersions(input: {
+  readonly baseLines: readonly EstimateVersionComparisonLine[]
+  readonly revisedLines: readonly EstimateVersionComparisonLine[]
+}): EstimateVersionComparison {
+  const baseGroups = aggregateLines(input.baseLines)
+  const revisedGroups = aggregateLines(input.revisedLines)
+  const keys = new Set([...baseGroups.keys(), ...revisedGroups.keys()])
+  const rows = [...keys].map((key): EstimateVersionComparisonRow => {
+    const base = baseGroups.get(key)
+    const revised = revisedGroups.get(key)
+    const representative = revised ?? base
+    if (!representative) {
+      throw new Error("Estimate comparison row is missing its source line.")
+    }
+    const baseTotalCents = base?.totalCents ?? 0
+    const revisedTotalCents = revised?.totalCents ?? 0
+    return {
+      key,
+      divisionCode: representative.divisionCode,
+      divisionName: representative.divisionName,
+      costCode: representative.costCode,
+      baseDescription: description(base),
+      revisedDescription: description(revised),
+      baseTotalCents,
+      revisedTotalCents,
+      deltaCents: revisedTotalCents - baseTotalCents,
+      change: rowChange({ base, revised }),
+    }
+  })
+  rows.sort((left, right) => {
+    const divisionOrder = left.divisionCode.localeCompare(right.divisionCode)
+    if (divisionOrder !== 0) return divisionOrder
+    return left.costCode.localeCompare(right.costCode)
+  })
+
+  const divisionGroups = new Map<string, EstimateVersionComparisonRow[]>()
+  for (const row of rows) {
+    const current = divisionGroups.get(row.divisionCode) ?? []
+    current.push(row)
+    divisionGroups.set(row.divisionCode, current)
+  }
+  const divisions = [...divisionGroups.entries()].map(
+    ([divisionCode, divisionRows]): EstimateVersionComparisonDivision => {
+      const baseTotalCents = divisionRows.reduce(
+        (total, row) => total + row.baseTotalCents,
+        0
+      )
+      const revisedTotalCents = divisionRows.reduce(
+        (total, row) => total + row.revisedTotalCents,
+        0
+      )
+      return {
+        divisionCode,
+        divisionName: divisionRows[0]?.divisionName ?? `Division ${divisionCode}`,
+        baseTotalCents,
+        revisedTotalCents,
+        deltaCents: revisedTotalCents - baseTotalCents,
+        rows: divisionRows,
+      }
+    }
+  )
+  const baseTotalCents = rows.reduce(
+    (total, row) => total + row.baseTotalCents,
+    0
+  )
+  const revisedTotalCents = rows.reduce(
+    (total, row) => total + row.revisedTotalCents,
+    0
+  )
+
+  return {
+    baseTotalCents,
+    revisedTotalCents,
+    deltaCents: revisedTotalCents - baseTotalCents,
+    changedRowCount: rows.filter((row) => row.change !== "unchanged").length,
+    divisions,
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,7 @@
 	"name": "compass",
 	"account_id": "8716137c706ea3d5c209b330084fa9e2",
 	"main": "custom-worker.ts",
+	"minify": true,
 	"compatibility_date": "2025-12-01",
 	"compatibility_flags": [
 		"nodejs_compat",


### PR DESCRIPTION
## Summary
- duplicate an estimate into the next editable version while preserving prior versions
- compare two versions side by side by division and cost code, with printable and emailable output
- require and print the estimate date on standard and comparison reports

## Validation
- `bun run test` (203 files, 1,090 tests)
- `bun run build`
- `bun lint` (0 errors; existing warnings only)
- local project-hub smoke check

## Database
- no schema change or migration required
