### PR TITLE
feat(compass): add managed previews and schedule print ranges

### DIFF
--- a/e2e/desktop/electron-runtime.spec.ts
+++ b/e2e/desktop/electron-runtime.spec.ts
@@ -31,6 +31,23 @@ test.describe("Electron runtime", () => {
           page.evaluate(() => window.compassDesktop?.window.isFocused()),
         )
         .toBe(true)
+
+      const previewWindowPromise = app.waitForEvent("window")
+      await page.evaluate(() => {
+        window.open(
+          `${window.location.origin}/preview/projects/desktop-preview-test/owner`,
+          "compass-project-audience-preview",
+          "popup=yes,width=1180,height=800"
+        )
+      })
+      const previewWindow = await previewWindowPromise
+      await previewWindow.close()
+
+      await expect
+        .poll(async () =>
+          page.evaluate(() => window.compassDesktop?.window.isFocused())
+        )
+        .toBe(true)
     } finally {
       await app.close()
     }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -8,6 +8,7 @@ import {
   globalShortcut,
   ipcMain,
   shell,
+  type BrowserWindowConstructorOptions,
   type IpcMainInvokeEvent,
 } from "electron"
 import log from "electron-log"
@@ -30,6 +31,8 @@ const AUTH_NAVIGATION_HOSTS = new Set([
   "appleid.apple.com",
   "login.microsoftonline.com",
 ])
+const PROJECT_AUDIENCE_PREVIEW_PATH =
+  /^\/preview\/projects\/[^/]+\/(?:owner|sub-vendor)(?:\/|$)/
 
 const syncState: DesktopSyncState = {
   status: "idle",
@@ -125,7 +128,58 @@ async function createMainWindow(): Promise<void> {
     },
   })
 
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+  configureWindowNavigation(mainWindow)
+
+  mainWindow.once("ready-to-show", () => {
+    mainWindow?.show()
+  })
+
+  await mainWindow.loadURL(appUrl)
+}
+
+function isProjectAudiencePreviewUrl(url: string): boolean {
+  if (!isAllowedAppNavigationUrl(url)) return false
+  try {
+    return PROJECT_AUDIENCE_PREVIEW_PATH.test(new URL(url).pathname)
+  } catch {
+    return false
+  }
+}
+
+function previewWindowOptions(): BrowserWindowConstructorOptions {
+  return {
+    parent: mainWindow ?? undefined,
+    modal: false,
+    width: 1180,
+    height: 800,
+    minWidth: 800,
+    minHeight: 600,
+    title: "Compass",
+    autoHideMenuBar: true,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+      webSecurity: true,
+    },
+  }
+}
+
+function restoreMainWindowFocus(): void {
+  if (!mainWindow || mainWindow.isDestroyed()) return
+  if (mainWindow.isMinimized()) mainWindow.restore()
+  mainWindow.show()
+  mainWindow.focus()
+}
+
+function configureWindowNavigation(window: BrowserWindow): void {
+  window.webContents.setWindowOpenHandler(({ url }) => {
+    if (isProjectAudiencePreviewUrl(url)) {
+      return {
+        action: "allow",
+        overrideBrowserWindowOptions: previewWindowOptions(),
+      }
+    }
     if (isAllowedAppNavigationUrl(url) || isAllowedAuthNavigationUrl(url)) {
       return { action: "allow" }
     }
@@ -135,17 +189,17 @@ async function createMainWindow(): Promise<void> {
     return { action: "deny" }
   })
 
-  mainWindow.webContents.on("will-navigate", (event, url) => {
+  window.webContents.on("will-navigate", (event, url) => {
     if (!isAllowedAppNavigationUrl(url) && !isAllowedAuthNavigationUrl(url)) {
       event.preventDefault()
     }
   })
 
-  mainWindow.once("ready-to-show", () => {
-    mainWindow?.show()
+  window.webContents.on("did-create-window", (childWindow, details) => {
+    configureWindowNavigation(childWindow)
+    if (!isProjectAudiencePreviewUrl(details.url)) return
+    childWindow.once("closed", restoreMainWindowFocus)
   })
-
-  await mainWindow.loadURL(appUrl)
 }
 
 function isAllowedExternalUrl(url: string): boolean {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -604,6 +604,164 @@ em-emoji-picker {
     margin-top: 0.08in;
   }
 
+  .schedule-print-gantt {
+    border: 1px solid #a3a3a3;
+    font-size: 7pt;
+  }
+
+  .schedule-print-gantt-header,
+  .schedule-print-gantt-row {
+    display: grid;
+    grid-template-columns: 2.1in minmax(0, 1fr);
+  }
+
+  .schedule-print-gantt-header {
+    background: #e5e7eb !important;
+    border-bottom: 1px solid #a3a3a3;
+    font-size: 6.5pt;
+    font-weight: 800;
+    min-height: 0.3in;
+    text-transform: uppercase;
+  }
+
+  .schedule-print-gantt-header > div:first-child,
+  .schedule-print-task-label {
+    border-right: 1px solid #a3a3a3;
+    padding: 0.055in 0.06in;
+  }
+
+  .schedule-print-gantt-row {
+    border-bottom: 1px solid #d4d4d4;
+    break-inside: avoid;
+    min-height: 0.34in;
+    page-break-inside: avoid;
+  }
+
+  .schedule-print-gantt-row:last-child {
+    border-bottom: 0;
+  }
+
+  .schedule-print-task-label strong,
+  .schedule-print-task-label span {
+    display: block;
+  }
+
+  .schedule-print-task-label span {
+    color: #525252 !important;
+    font-size: 5.8pt;
+    margin-top: 0.02in;
+  }
+
+  .schedule-print-timeline-header,
+  .schedule-print-timeline-row {
+    min-width: 0;
+    position: relative;
+  }
+
+  .schedule-print-timeline-header span {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    white-space: nowrap;
+  }
+
+  .schedule-print-timeline-row {
+    background-image: repeating-linear-gradient(
+      to right,
+      transparent,
+      transparent calc(14.285% - 1px),
+      #e5e5e5 calc(14.285% - 1px),
+      #e5e5e5 14.285%
+    ) !important;
+  }
+
+  .schedule-print-bar {
+    border: 1px solid rgb(0 0 0 / 0.2);
+    border-radius: 2px;
+    color: #ffffff !important;
+    font-size: 5.8pt;
+    font-weight: 700;
+    line-height: 0.18in;
+    min-width: 1px;
+    overflow: hidden;
+    padding: 0 0.035in;
+    position: absolute;
+    text-overflow: ellipsis;
+    top: 0.075in;
+    white-space: nowrap;
+  }
+
+  .schedule-print-empty {
+    margin: 0;
+    padding: 0.3in;
+    text-align: center;
+  }
+
+  .schedule-print-calendar {
+    border-left: 1px solid #a3a3a3;
+    border-top: 1px solid #a3a3a3;
+  }
+
+  .schedule-print-weekdays,
+  .schedule-print-week {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+
+  .schedule-print-weekdays {
+    background: #e5e7eb !important;
+    font-size: 6pt;
+    font-weight: 800;
+    text-align: center;
+    text-transform: uppercase;
+  }
+
+  .schedule-print-weekdays > div,
+  .schedule-print-day {
+    border-bottom: 1px solid #a3a3a3;
+    border-right: 1px solid #a3a3a3;
+    padding: 0.04in;
+  }
+
+  .schedule-print-week {
+    break-inside: avoid;
+    min-height: 0.82in;
+    page-break-inside: avoid;
+  }
+
+  .schedule-print-day {
+    font-size: 6pt;
+    min-width: 0;
+  }
+
+  .schedule-print-day-outside {
+    background: #f5f5f5 !important;
+    color: #a3a3a3 !important;
+  }
+
+  .schedule-print-day-items {
+    display: grid;
+    gap: 0.02in;
+    margin-top: 0.035in;
+  }
+
+  .schedule-print-calendar-item {
+    background: #f5f5f5 !important;
+    border-left: 0.035in solid #737373;
+    font-size: 5.5pt;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
+    padding: 0.025in 0.03in;
+  }
+
+  .schedule-print-task-complete {
+    opacity: 0.72;
+  }
+
+  .schedule-print-task-blocked {
+    outline: 1px solid #b91c1c;
+  }
+
   body.po-printing-selected > * {
     visibility: hidden;
   }

--- a/src/components/nav-projects.tsx
+++ b/src/components/nav-projects.tsx
@@ -34,6 +34,7 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
 import { ProjectQuickSwitcher } from "@/components/projects/project-quick-switcher"
+import { ProjectAudiencePreviewLink } from "@/components/projects/project-audience-preview-link"
 import { cn } from "@/lib/utils"
 import type { ProjectListItem } from "@/app/actions/projects"
 import { projectAudiencePreviewHref } from "@/lib/project-audience-preview-routes"
@@ -202,10 +203,6 @@ function projectSectionHref(projectId: string, suffix: string): string {
   return suffix ? `${baseHref}/${suffix}` : baseHref
 }
 
-function isPreviewSection(section: ProjectSectionKey): boolean {
-  return section === "preview-owner" || section === "preview-sub-vendor"
-}
-
 function projectTargetSection(
   section: ProjectSectionKey
 ): string | undefined {
@@ -306,31 +303,43 @@ export function NavProjects({
                 </SidebarMenuButton>
               </SidebarMenuItem>
             ) : (
-              PROJECT_SECTION_ITEMS.map((item) => (
-                <SidebarMenuItem key={`${activeId}-${item.section}`}>
-                  <SidebarMenuButton
-                    asChild
-                    tooltip={item.title}
-                    className={cn(
-                      activeSection === item.section &&
-                        "bg-sidebar-foreground/10 font-medium"
-                    )}
-                  >
-                    <Link
-                      href={projectSectionHref(activeId, item.hrefSuffix)}
-                      target={isPreviewSection(item.section) ? "_blank" : undefined}
-                      rel={
-                        isPreviewSection(item.section)
-                          ? "noopener noreferrer"
-                          : undefined
-                      }
+              PROJECT_SECTION_ITEMS.map((item) => {
+                const previewAudience =
+                  item.section === "preview-owner"
+                    ? "owner"
+                    : item.section === "preview-sub-vendor"
+                      ? "sub-vendor"
+                      : null
+                return (
+                  <SidebarMenuItem key={`${activeId}-${item.section}`}>
+                    <SidebarMenuButton
+                      asChild
+                      tooltip={item.title}
+                      className={cn(
+                        activeSection === item.section &&
+                          "bg-sidebar-foreground/10 font-medium"
+                      )}
                     >
-                      <item.icon />
-                      <span>{item.title}</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))
+                      {previewAudience ? (
+                        <ProjectAudiencePreviewLink
+                          audience={previewAudience}
+                          projectId={activeId}
+                        >
+                          <item.icon />
+                          <span>{item.title}</span>
+                        </ProjectAudiencePreviewLink>
+                      ) : (
+                        <Link
+                          href={projectSectionHref(activeId, item.hrefSuffix)}
+                        >
+                          <item.icon />
+                          <span>{item.title}</span>
+                        </Link>
+                      )}
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                )
+              })
             )}
           </SidebarMenu>
         </SidebarGroupContent>

--- a/src/components/projects/project-actions-menu.tsx
+++ b/src/components/projects/project-actions-menu.tsx
@@ -20,7 +20,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { projectAudiencePreviewHref } from "@/lib/project-audience-preview-routes"
+import { ProjectAudiencePreviewLink } from "@/components/projects/project-audience-preview-link"
 
 export function ProjectActionsMenu({
   projectId,
@@ -89,24 +89,19 @@ export function ProjectActionsMenu({
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild>
-          <Link
-            href={projectAudiencePreviewHref(projectId, "owner")}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <ProjectAudiencePreviewLink audience="owner" projectId={projectId}>
             <IconEye />
             Owner preview
-          </Link>
+          </ProjectAudiencePreviewLink>
         </DropdownMenuItem>
         <DropdownMenuItem asChild>
-          <Link
-            href={projectAudiencePreviewHref(projectId, "sub-vendor")}
-            target="_blank"
-            rel="noopener noreferrer"
+          <ProjectAudiencePreviewLink
+            audience="sub-vendor"
+            projectId={projectId}
           >
             <IconUsers />
             Sub/vendor preview
-          </Link>
+          </ProjectAudiencePreviewLink>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/projects/project-audience-preview-link.tsx
+++ b/src/components/projects/project-audience-preview-link.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import * as React from "react"
+
+import {
+  projectAudiencePreviewHref,
+  type ProjectAudiencePreviewRoute,
+} from "@/lib/project-audience-preview-routes"
+import {
+  openProjectAudiencePreviewWindow,
+  PROJECT_AUDIENCE_PREVIEW_WINDOW_NAME,
+} from "@/lib/project-audience-preview-window"
+
+type ProjectAudiencePreviewLinkProps = Omit<
+  React.ComponentPropsWithoutRef<"a">,
+  "href" | "rel" | "target"
+> & {
+  readonly audience: ProjectAudiencePreviewRoute
+  readonly projectId: string
+}
+
+export const ProjectAudiencePreviewLink = React.forwardRef<
+  HTMLAnchorElement,
+  ProjectAudiencePreviewLinkProps
+>(function ProjectAudiencePreviewLink(
+  { audience, projectId, onClick, ...props },
+  ref
+) {
+  const href = projectAudiencePreviewHref(projectId, audience)
+
+  function handleClick(event: React.MouseEvent<HTMLAnchorElement>): void {
+    onClick?.(event)
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return
+    }
+
+    // Preserve native anchor navigation if the browser blocks popup creation.
+    if (openProjectAudiencePreviewWindow(href)) event.preventDefault()
+  }
+
+  return (
+    <a
+      {...props}
+      ref={ref}
+      href={href}
+      target={PROJECT_AUDIENCE_PREVIEW_WINDOW_NAME}
+      rel="opener"
+      onClick={handleClick}
+    />
+  )
+})
+
+ProjectAudiencePreviewLink.displayName = "ProjectAudiencePreviewLink"

--- a/src/components/projects/project-rfi-panel.tsx
+++ b/src/components/projects/project-rfi-panel.tsx
@@ -6,7 +6,7 @@ import {
   IconMessageQuestion,
   IconUsers,
 } from "@tabler/icons-react"
-import { projectAudiencePreviewHref } from "@/lib/project-audience-preview-routes"
+import { ProjectAudiencePreviewLink } from "@/components/projects/project-audience-preview-link"
 
 import type {
   ProjectRfiItem,
@@ -148,24 +148,22 @@ export function ProjectRfiPanel({
             Manage RFIs
             <IconExternalLink className="size-4" />
           </Link>
-          <Link
-            href={projectAudiencePreviewHref(projectId, "sub-vendor")}
-            target="_blank"
-            rel="noopener noreferrer"
+          <ProjectAudiencePreviewLink
+            audience="sub-vendor"
+            projectId={projectId}
             className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent"
           >
             <IconUsers className="size-4" />
             Sub/vendor view
-          </Link>
-          <Link
-            href={projectAudiencePreviewHref(projectId, "owner")}
-            target="_blank"
-            rel="noopener noreferrer"
+          </ProjectAudiencePreviewLink>
+          <ProjectAudiencePreviewLink
+            audience="owner"
+            projectId={projectId}
             className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent"
           >
             <IconEye className="size-4" />
             Owner view
-          </Link>
+          </ProjectAudiencePreviewLink>
         </div>
       </div>
 

--- a/src/components/schedule/__tests__/schedule-print-document.test.ts
+++ b/src/components/schedule/__tests__/schedule-print-document.test.ts
@@ -103,4 +103,54 @@ describe("SchedulePrintDocument", () => {
     window.dispatchEvent(new Event("afterprint"))
     expect(document.body.classList.contains("schedule-printing")).toBe(false)
   })
+
+  it("renders only overlapping items in the selected Gantt timeframe", async () => {
+    const items = [
+      ...scheduleItems(1),
+      {
+        ...scheduleItems(1)[0],
+        id: "outside-range",
+        title: "Outside range",
+        startDate: "2026-09-10",
+        endDate: "2026-09-12",
+      },
+    ]
+    await act(async () => {
+      root.render(
+        React.createElement(SchedulePrintDocument, {
+          audienceLabel: "Project schedule",
+          brand: null,
+          items,
+          layout: "gantt",
+          paletteScopeId: "project-202",
+          projectName: "Bishop and Loeffler",
+          range: { start: "2026-08-21", end: "2026-08-27" },
+        })
+      )
+    })
+
+    expect(
+      document.querySelectorAll(".schedule-print-gantt-row")
+    ).toHaveLength(1)
+    expect(document.body.textContent).not.toContain("Outside range")
+  })
+
+  it("renders the selected calendar timeframe", async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(SchedulePrintDocument, {
+          audienceLabel: "Project schedule",
+          brand: null,
+          items: scheduleItems(2),
+          layout: "calendar",
+          paletteScopeId: "project-202",
+          projectName: "Bishop and Loeffler",
+          range: { start: "2026-08-21", end: "2026-08-27" },
+        })
+      )
+    })
+
+    expect(document.querySelectorAll(".schedule-print-week")).toHaveLength(2)
+    expect(document.body.textContent).toContain("Aug 21, 2026 – Aug 27, 2026")
+  })
 })

--- a/src/components/schedule/schedule-print-dialog.tsx
+++ b/src/components/schedule/schedule-print-dialog.tsx
@@ -1,0 +1,214 @@
+"use client"
+
+import * as React from "react"
+import {
+  IconCalendar,
+  IconList,
+  IconPrinter,
+  IconTimeline,
+} from "@tabler/icons-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  filterScheduleItemsForPrint,
+  normalizeSchedulePrintRange,
+  schedulePrintPresetRange,
+  type SchedulePrintDateRange,
+  type SchedulePrintLayout,
+  type SchedulePrintPreset,
+  type SchedulePrintRangeItem,
+} from "@/lib/schedule/print-range"
+
+export interface SchedulePrintSelection {
+  readonly layout: SchedulePrintLayout
+  readonly range: SchedulePrintDateRange
+}
+
+function todayDateKey(): string {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, "0")
+  const day = String(now.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+function isPrintPreset(value: string): value is SchedulePrintPreset {
+  return (
+    value === "next_7" ||
+    value === "next_14" ||
+    value === "next_30" ||
+    value === "entire_schedule" ||
+    value === "custom"
+  )
+}
+
+const LAYOUT_OPTIONS = [
+  { value: "list" as const, label: "List", icon: IconList },
+  { value: "gantt" as const, label: "Gantt", icon: IconTimeline },
+  { value: "calendar" as const, label: "Calendar", icon: IconCalendar },
+]
+
+export function SchedulePrintDialog({
+  defaultLayout,
+  items,
+  onOpenChange,
+  onPrint,
+  open,
+}: {
+  readonly defaultLayout: SchedulePrintLayout
+  readonly items: readonly SchedulePrintRangeItem[]
+  readonly onOpenChange: (open: boolean) => void
+  readonly onPrint: (selection: SchedulePrintSelection) => void
+  readonly open: boolean
+}): React.ReactElement {
+  const today = React.useMemo(todayDateKey, [])
+  const initialRange = React.useMemo(
+    () => schedulePrintPresetRange("next_7", today, items),
+    [items, today]
+  )
+  const [layout, setLayout] =
+    React.useState<SchedulePrintLayout>(defaultLayout)
+  const [preset, setPreset] =
+    React.useState<SchedulePrintPreset>("next_7")
+  const [start, setStart] = React.useState(initialRange.start)
+  const [end, setEnd] = React.useState(initialRange.end)
+
+  React.useEffect(() => {
+    if (!open) return
+    setLayout(defaultLayout)
+  }, [defaultLayout, open])
+
+  const range = normalizeSchedulePrintRange(start, end)
+  const itemCount = range
+    ? filterScheduleItemsForPrint(items, range).length
+    : 0
+
+  function selectPreset(value: string): void {
+    if (!isPrintPreset(value)) return
+    setPreset(value)
+    if (value === "custom") return
+    const nextRange = schedulePrintPresetRange(value, today, items)
+    setStart(nextRange.start)
+    setEnd(nextRange.end)
+  }
+
+  function submit(): void {
+    if (!range) return
+    onPrint({ layout, range })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Print schedule</DialogTitle>
+          <DialogDescription>
+            Choose a layout and timeframe. Items that cross either date remain
+            visible in the report.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 py-2">
+          <div className="space-y-2">
+            <Label>Layout</Label>
+            <div className="grid grid-cols-3 gap-2">
+              {LAYOUT_OPTIONS.map((option) => (
+                <Button
+                  key={option.value}
+                  type="button"
+                  variant={layout === option.value ? "default" : "outline"}
+                  onClick={() => setLayout(option.value)}
+                >
+                  <option.icon className="size-4" />
+                  {option.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="schedule-print-range">Timeframe</Label>
+            <Select value={preset} onValueChange={selectPreset}>
+              <SelectTrigger id="schedule-print-range">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="next_7">Next 7 days</SelectItem>
+                <SelectItem value="next_14">Next 14 days</SelectItem>
+                <SelectItem value="next_30">Next 30 days</SelectItem>
+                <SelectItem value="entire_schedule">
+                  Entire schedule
+                </SelectItem>
+                <SelectItem value="custom">Custom range</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="schedule-print-start">From</Label>
+              <Input
+                id="schedule-print-start"
+                type="date"
+                value={start}
+                onChange={(event) => {
+                  setStart(event.currentTarget.value)
+                  setPreset("custom")
+                }}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="schedule-print-end">Through</Label>
+              <Input
+                id="schedule-print-end"
+                type="date"
+                value={end}
+                onChange={(event) => {
+                  setEnd(event.currentTarget.value)
+                  setPreset("custom")
+                }}
+              />
+            </div>
+          </div>
+
+          <p className="border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+            {range
+              ? `${itemCount} schedule item${itemCount === 1 ? "" : "s"} will be included.`
+              : "The ending date must be on or after the starting date."}
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={submit} disabled={!range}>
+            <IconPrinter className="size-4" />
+            Print
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/schedule/schedule-print-document.tsx
+++ b/src/components/schedule/schedule-print-document.tsx
@@ -2,6 +2,15 @@
 
 import * as React from "react"
 import { createPortal } from "react-dom"
+import {
+  addDays,
+  differenceInCalendarDays,
+  eachDayOfInterval,
+  endOfWeek,
+  format,
+  parseISO,
+  startOfWeek,
+} from "date-fns"
 
 import { ProjectBrandContactDetails } from "@/components/projects/project-brand-contact-details"
 import { ProjectBrandLogo } from "@/components/projects/project-brand-logo"
@@ -14,6 +23,12 @@ import {
   waitForPrintLayout,
 } from "@/lib/print/readiness"
 import { getScheduleItemDisplayColor } from "@/lib/schedule/appearance"
+import {
+  filterScheduleItemsForPrint,
+  type SchedulePrintDateRange,
+  type SchedulePrintLayout,
+} from "@/lib/schedule/print-range"
+import { cn } from "@/lib/utils"
 
 export type SchedulePrintItem = {
   readonly id: string
@@ -61,6 +76,185 @@ function projectLabel(project: SchedulePrintProject): string {
     : project.name
 }
 
+function formatRange(range: SchedulePrintDateRange): string {
+  return `${format(parseISO(range.start), "MMM d, yyyy")} – ${format(parseISO(range.end), "MMM d, yyyy")}`
+}
+
+function statusClassName(status: string): string {
+  if (status === "COMPLETE") return "schedule-print-task-complete"
+  if (status === "IN_PROGRESS") return "schedule-print-task-progress"
+  if (status === "BLOCKED") return "schedule-print-task-blocked"
+  return "schedule-print-task-pending"
+}
+
+function SchedulePrintGantt({
+  colorFor,
+  items,
+  range,
+}: {
+  readonly colorFor: (item: SchedulePrintItem) => string
+  readonly items: readonly SchedulePrintItem[]
+  readonly range: SchedulePrintDateRange
+}): React.ReactElement {
+  const rangeStart = parseISO(range.start)
+  const totalDays =
+    differenceInCalendarDays(parseISO(range.end), rangeStart) + 1
+  const tickStep = totalDays <= 14 ? 1 : totalDays <= 62 ? 7 : 30
+  const ticks = Array.from(
+    { length: Math.ceil(totalDays / tickStep) },
+    (_, index) => addDays(rangeStart, index * tickStep)
+  )
+
+  return (
+    <section className="schedule-print-gantt">
+      <div className="schedule-print-gantt-header">
+        <div>Schedule item</div>
+        <div className="schedule-print-timeline-header">
+          {ticks.map((date) => {
+            const left =
+              (differenceInCalendarDays(date, rangeStart) / totalDays) * 100
+            const label =
+              totalDays <= 14
+                ? "EEE M/d"
+                : totalDays <= 62
+                  ? "M/d"
+                  : "MMM yyyy"
+            return (
+              <span key={date.toISOString()} style={{ left: `${left}%` }}>
+                {format(date, label)}
+              </span>
+            )
+          })}
+        </div>
+      </div>
+      {items.length === 0 ? (
+        <p className="schedule-print-empty">
+          No schedule items overlap this timeframe.
+        </p>
+      ) : (
+        items.map((item) => {
+          const clippedStart =
+            item.startDate < range.start ? range.start : item.startDate
+          const clippedEnd =
+            item.endDate > range.end ? range.end : item.endDate
+          const left =
+            (differenceInCalendarDays(parseISO(clippedStart), rangeStart) /
+              totalDays) *
+            100
+          const width =
+            ((differenceInCalendarDays(
+              parseISO(clippedEnd),
+              parseISO(clippedStart)
+            ) +
+              1) /
+              totalDays) *
+            100
+          return (
+            <div className="schedule-print-gantt-row" key={item.id}>
+              <div className="schedule-print-task-label">
+                <strong>{item.title}</strong>
+                <span>
+                  {formatDate(item.startDate)} – {formatDate(item.endDate)}
+                </span>
+              </div>
+              <div className="schedule-print-timeline-row">
+                <div
+                  className={cn(
+                    "schedule-print-bar",
+                    statusClassName(item.status)
+                  )}
+                  style={{
+                    backgroundColor: colorFor(item),
+                    left: `${left}%`,
+                    width: `${Math.max(width, 0.6)}%`,
+                  }}
+                >
+                  {width >= 12 ? item.title : ""}
+                </div>
+              </div>
+            </div>
+          )
+        })
+      )}
+    </section>
+  )
+}
+
+function SchedulePrintCalendar({
+  colorFor,
+  items,
+  range,
+}: {
+  readonly colorFor: (item: SchedulePrintItem) => string
+  readonly items: readonly SchedulePrintItem[]
+  readonly range: SchedulePrintDateRange
+}): React.ReactElement {
+  const calendarDays = eachDayOfInterval({
+    start: startOfWeek(parseISO(range.start)),
+    end: endOfWeek(parseISO(range.end)),
+  })
+  const weeks: Date[][] = []
+  for (let index = 0; index < calendarDays.length; index += 7) {
+    weeks.push(calendarDays.slice(index, index + 7))
+  }
+
+  return (
+    <section className="schedule-print-calendar">
+      <div className="schedule-print-weekdays">
+        {[
+          "Sunday",
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday",
+        ].map((day) => (
+          <div key={day}>{day}</div>
+        ))}
+      </div>
+      {weeks.map((week) => (
+        <div className="schedule-print-week" key={week[0].toISOString()}>
+          {week.map((day) => {
+            const dateKey = format(day, "yyyy-MM-dd")
+            const inRange = dateKey >= range.start && dateKey <= range.end
+            const dayItems = items.filter(
+              (item) =>
+                item.startDate <= dateKey && item.endDate >= dateKey
+            )
+            return (
+              <div
+                className={cn(
+                  "schedule-print-day",
+                  !inRange && "schedule-print-day-outside"
+                )}
+                key={dateKey}
+              >
+                <strong>{format(day, "MMM d")}</strong>
+                <div className="schedule-print-day-items">
+                  {inRange &&
+                    dayItems.map((item) => (
+                      <div
+                        className={cn(
+                          "schedule-print-calendar-item",
+                          statusClassName(item.status)
+                        )}
+                        key={item.id}
+                        style={{ borderLeftColor: colorFor(item) }}
+                      >
+                        {item.title}
+                      </div>
+                    ))}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      ))}
+    </section>
+  )
+}
+
 export async function printScheduleDocument(): Promise<void> {
   const printRoot = document.querySelector(
     '[data-project-schedule-print-document="true"]'
@@ -92,18 +286,22 @@ export function SchedulePrintDocument({
   audienceLabel,
   brand,
   items,
+  layout = "list",
   paletteScopeId,
   projectName,
   projectNumber,
   projects = [],
+  range,
 }: {
   readonly audienceLabel: string
   readonly brand: ProjectBrand | null
   readonly items: readonly SchedulePrintItem[]
+  readonly layout?: SchedulePrintLayout
   readonly paletteScopeId: string
   readonly projectName: string
   readonly projectNumber?: string | null
   readonly projects?: readonly SchedulePrintProject[]
+  readonly range?: SchedulePrintDateRange
 }): React.ReactElement | null {
   const [mounted, setMounted] = React.useState(false)
   const displayColorPalette = useScheduleDisplayPalette(paletteScopeId)
@@ -118,6 +316,11 @@ export function SchedulePrintDocument({
   const title = projectNumber
     ? `${projectNumber} · ${projectName}`
     : projectName
+  const printableItems = range
+    ? filterScheduleItemsForPrint(items, range)
+    : items
+  const colorFor = (item: SchedulePrintItem): string =>
+    getScheduleItemDisplayColor(item, displayColorPalette)
 
   return createPortal(
     <section
@@ -146,14 +349,31 @@ export function SchedulePrintDocument({
           </div>
         </div>
         <div className="schedule-print-title">
-          <p>{audienceLabel}</p>
+          <p>
+            {audienceLabel} · {formatLabel(layout)}
+          </p>
           <h1>{title}</h1>
           <span>
-            {items.length} schedule item{items.length === 1 ? "" : "s"}
+            {range ? `${formatRange(range)} · ` : ""}
+            {printableItems.length} schedule item
+            {printableItems.length === 1 ? "" : "s"}
           </span>
         </div>
       </header>
 
+      {layout === "gantt" && range ? (
+        <SchedulePrintGantt
+          colorFor={colorFor}
+          items={printableItems}
+          range={range}
+        />
+      ) : layout === "calendar" && range ? (
+        <SchedulePrintCalendar
+          colorFor={colorFor}
+          items={printableItems}
+          range={range}
+        />
+      ) : (
       <table className="schedule-print-table">
         <thead>
           <tr>
@@ -168,7 +388,7 @@ export function SchedulePrintDocument({
           </tr>
         </thead>
         <tbody>
-          {items.map((item) => {
+          {printableItems.map((item) => {
             const itemProject = item.projectId
               ? projectById.get(item.projectId)
               : undefined
@@ -202,6 +422,7 @@ export function SchedulePrintDocument({
           })}
         </tbody>
       </table>
+      )}
 
       <footer className="schedule-print-footer">
         <span>Printed {new Date().toLocaleDateString()}</span>

--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -9,6 +9,7 @@ import {
 } from "react"
 import Link from "next/link"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { flushSync } from "react-dom"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
@@ -88,6 +89,10 @@ import {
   printScheduleDocument,
   SchedulePrintDocument,
 } from "./schedule-print-document"
+import {
+  SchedulePrintDialog,
+  type SchedulePrintSelection,
+} from "./schedule-print-dialog"
 import { ScheduleScopeSwitcher } from "./schedule-scope-switcher"
 import { OwnerScheduleVisibilityControl } from "./owner-schedule-visibility-control"
 import type { ProjectListItem } from "@/app/actions/projects"
@@ -243,6 +248,9 @@ export function ScheduleView({
   const [baselinesOpen, setBaselinesOpen] = useState(false)
   const [exceptionsOpen, setExceptionsOpen] = useState(false)
   const [importDialogOpen, setImportDialogOpen] = useState(false)
+  const [printDialogOpen, setPrintDialogOpen] = useState(false)
+  const [printSelection, setPrintSelection] =
+    useState<SchedulePrintSelection | null>(null)
   const [templateDialogOpen, setTemplateDialogOpen] = useState(false)
   const [bulkTemplateDialogOpen, setBulkTemplateDialogOpen] = useState(false)
   const [isImporting, setIsImporting] = useState(false)
@@ -683,8 +691,14 @@ export function ScheduleView({
     }
   }
 
-  async function printSchedule(): Promise<void> {
-    await printScheduleDocument()
+  function printSchedule(selection: SchedulePrintSelection): void {
+    // Commit the selected print layout before invoking the synchronous iOS
+    // print path; desktop browsers can still await layout readiness normally.
+    flushSync(() => {
+      setPrintDialogOpen(false)
+      setPrintSelection(selection)
+    })
+    void printScheduleDocument().finally(() => setPrintSelection(null))
   }
 
   return (
@@ -696,10 +710,19 @@ export function ScheduleView({
         audienceLabel={projectId ? "Project schedule" : "Company schedule"}
         brand={printBrand}
         items={printItems}
+        layout={printSelection?.layout}
         paletteScopeId={preferenceScopeKey}
         projectName={projectName}
         projectNumber={activeProject?.projectNumber}
         projects={scheduleProjects}
+        range={printSelection?.range}
+      />
+      <SchedulePrintDialog
+        defaultLayout={view}
+        items={printItems}
+        onOpenChange={setPrintDialogOpen}
+        onPrint={printSchedule}
+        open={printDialogOpen}
       />
       <div
         className="mb-1 flex h-8 w-max min-w-full shrink-0 flex-nowrap items-center gap-1"
@@ -1177,9 +1200,9 @@ export function ScheduleView({
                 <IconUpload className="size-4 mr-2" />
                 Import CSV
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={printSchedule}>
+              <DropdownMenuItem onClick={() => setPrintDialogOpen(true)}>
                 <IconPrinter className="size-4 mr-2" />
-                Print
+                Print timeframe…
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => setBaselinesOpen(true)}>

--- a/src/lib/__tests__/project-audience-preview-window.test.ts
+++ b/src/lib/__tests__/project-audience-preview-window.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  openProjectAudiencePreviewWindow,
+  PROJECT_AUDIENCE_PREVIEW_WINDOW_NAME,
+} from "@/lib/project-audience-preview-window"
+
+describe("project audience preview windows", () => {
+  it("opens previews in the reusable managed Compass window", () => {
+    const focus = vi.fn()
+    const opener = vi.fn(() => ({ focus }))
+
+    expect(openProjectAudiencePreviewWindow("/preview/example", opener)).toBe(
+      true
+    )
+    expect(opener).toHaveBeenCalledWith(
+      "/preview/example",
+      PROJECT_AUDIENCE_PREVIEW_WINDOW_NAME,
+      expect.stringContaining("popup=yes")
+    )
+    expect(focus).toHaveBeenCalledOnce()
+  })
+
+  it("keeps native anchor navigation available when popups are blocked", () => {
+    expect(
+      openProjectAudiencePreviewWindow("/preview/example", () => null)
+    ).toBe(false)
+  })
+})

--- a/src/lib/project-audience-preview-window.ts
+++ b/src/lib/project-audience-preview-window.ts
@@ -1,0 +1,43 @@
+export const PROJECT_AUDIENCE_PREVIEW_WINDOW_NAME =
+  "compass-project-audience-preview"
+
+const PROJECT_AUDIENCE_PREVIEW_WINDOW_FEATURES = [
+  "popup=yes",
+  "width=1180",
+  "height=800",
+  "resizable=yes",
+  "scrollbars=yes",
+].join(",")
+
+type PreviewWindow = {
+  focus: () => void
+}
+
+type PreviewWindowOpener = (
+  href: string,
+  target: string,
+  features: string
+) => PreviewWindow | null
+
+export function openProjectAudiencePreviewWindow(
+  href: string,
+  opener?: PreviewWindowOpener
+): boolean {
+  if (!opener && typeof window === "undefined") return false
+
+  const previewWindow = opener
+    ? opener(
+        href,
+        PROJECT_AUDIENCE_PREVIEW_WINDOW_NAME,
+        PROJECT_AUDIENCE_PREVIEW_WINDOW_FEATURES
+      )
+    : window.open(
+        href,
+        PROJECT_AUDIENCE_PREVIEW_WINDOW_NAME,
+        PROJECT_AUDIENCE_PREVIEW_WINDOW_FEATURES
+      )
+
+  if (!previewWindow) return false
+  previewWindow.focus()
+  return true
+}

--- a/src/lib/schedule/__tests__/print-range.test.ts
+++ b/src/lib/schedule/__tests__/print-range.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  filterScheduleItemsForPrint,
+  normalizeSchedulePrintRange,
+  schedulePrintPresetRange,
+} from "@/lib/schedule/print-range"
+
+describe("schedule print ranges", () => {
+  it("builds inclusive rolling presets", () => {
+    expect(schedulePrintPresetRange("next_7", "2026-08-21", [])).toEqual({
+      start: "2026-08-21",
+      end: "2026-08-27",
+    })
+  })
+
+  it("includes schedule items that overlap either edge", () => {
+    const items = [
+      { id: "old", startDate: "2026-08-01", endDate: "2026-08-10" },
+      { id: "spanning", startDate: "2026-08-15", endDate: "2026-08-25" },
+      { id: "inside", startDate: "2026-08-22", endDate: "2026-08-23" },
+      { id: "future", startDate: "2026-09-01", endDate: "2026-09-02" },
+    ]
+
+    expect(
+      filterScheduleItemsForPrint(items, {
+        start: "2026-08-21",
+        end: "2026-08-27",
+      }).map((item) => item.id)
+    ).toEqual(["spanning", "inside"])
+  })
+
+  it("rejects reversed and invalid custom ranges", () => {
+    expect(
+      normalizeSchedulePrintRange("2026-08-27", "2026-08-21")
+    ).toBeNull()
+    expect(
+      normalizeSchedulePrintRange("2026-02-30", "2026-03-02")
+    ).toBeNull()
+  })
+})

--- a/src/lib/schedule/print-range.ts
+++ b/src/lib/schedule/print-range.ts
@@ -1,0 +1,85 @@
+export type SchedulePrintLayout = "list" | "gantt" | "calendar"
+export type SchedulePrintPreset =
+  | "next_7"
+  | "next_14"
+  | "next_30"
+  | "entire_schedule"
+  | "custom"
+
+export interface SchedulePrintDateRange {
+  readonly start: string
+  readonly end: string
+}
+
+export interface SchedulePrintRangeItem {
+  readonly startDate: string
+  readonly endDate: string
+}
+
+const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+export function isDateKey(value: string): boolean {
+  if (!DATE_KEY_PATTERN.test(value)) return false
+  const parsed = new Date(`${value}T00:00:00Z`)
+  return (
+    !Number.isNaN(parsed.getTime()) &&
+    parsed.toISOString().slice(0, 10) === value
+  )
+}
+
+export function addDaysToDateKey(value: string, days: number): string {
+  const parsed = new Date(`${value}T00:00:00Z`)
+  parsed.setUTCDate(parsed.getUTCDate() + days)
+  return parsed.toISOString().slice(0, 10)
+}
+
+export function normalizeSchedulePrintRange(
+  start: string,
+  end: string
+): SchedulePrintDateRange | null {
+  if (!isDateKey(start) || !isDateKey(end) || start > end) return null
+  return { start, end }
+}
+
+export function scheduleItemOverlapsRange(
+  item: SchedulePrintRangeItem,
+  range: SchedulePrintDateRange
+): boolean {
+  return item.startDate <= range.end && item.endDate >= range.start
+}
+
+export function filterScheduleItemsForPrint<
+  Item extends SchedulePrintRangeItem,
+>(
+  items: readonly Item[],
+  range: SchedulePrintDateRange
+): readonly Item[] {
+  return items.filter((item) => scheduleItemOverlapsRange(item, range))
+}
+
+export function schedulePrintBounds(
+  items: readonly SchedulePrintRangeItem[],
+  fallbackDate: string
+): SchedulePrintDateRange {
+  if (items.length === 0) return { start: fallbackDate, end: fallbackDate }
+
+  let start = items[0].startDate
+  let end = items[0].endDate
+  for (const item of items.slice(1)) {
+    if (item.startDate < start) start = item.startDate
+    if (item.endDate > end) end = item.endDate
+  }
+  return { start, end }
+}
+
+export function schedulePrintPresetRange(
+  preset: Exclude<SchedulePrintPreset, "custom">,
+  today: string,
+  items: readonly SchedulePrintRangeItem[]
+): SchedulePrintDateRange {
+  if (preset === "entire_schedule") {
+    return schedulePrintBounds(items, today)
+  }
+  const days = preset === "next_7" ? 7 : preset === "next_14" ? 14 : 30
+  return { start: today, end: addDaysToDateKey(today, days - 1) }
+}


### PR DESCRIPTION
Summary

- keep owner and sub/vendor previews in a managed Compass window and restore the main window when previews close
- add date-range presets and custom dates to schedule printing
- print filtered schedules as list, Gantt, or calendar layouts

Verification

- targeted ESLint: passed
- Vitest schedule/preview suite: 9 passed
- Electron TypeScript compile: passed
- production Next.js build: passed (existing NFT trace warnings only)