### PR TITLE
test(schedule): cover Gantt scroll restoration

### DIFF
--- a/e2e/web/usable-areas.spec.ts
+++ b/e2e/web/usable-areas.spec.ts
@@ -516,6 +516,48 @@ test.describe("usable Compass areas", () => {
     )
   })
 
+  test("Gantt keeps its horizontal position across a schedule refresh", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1366, height: 768 })
+    const schedulePath =
+      "/dashboard/projects/e2e-project-001/schedule?view=gantt&order=chronological"
+    const response = await page.goto(schedulePath)
+    await expectHealthyNavigation(page, response, schedulePath)
+
+    const chart = page.locator(".gantt-container:visible").first()
+    await expect(chart).toBeVisible()
+
+    const expectedLeft = await chart.evaluate((element) => {
+      const maximumLeft = element.scrollWidth - element.clientWidth
+      element.scrollLeft = Math.max(1, Math.round(maximumLeft * 0.7))
+      return element.scrollLeft
+    })
+    expect(expectedLeft).toBeGreaterThan(0)
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const stored = window.sessionStorage.getItem(
+            "compass:schedule-scroll:e2e-project-001"
+          )
+          if (!stored) return 0
+          const parsed: unknown = JSON.parse(stored)
+          if (!parsed || typeof parsed !== "object" || !("left" in parsed)) {
+            return 0
+          }
+          return typeof parsed.left === "number" ? parsed.left : 0
+        })
+      )
+      .toBeGreaterThan(0)
+
+    await page.reload()
+    await expect(chart).toBeVisible()
+
+    await expect
+      .poll(() => chart.evaluate((element) => element.scrollLeft))
+      .toBeGreaterThan(expectedLeft * 0.5)
+  })
+
   test("Gantt releases edge wheel input to the surrounding Schedule workspace", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
- Recover the Gantt viewport regression test onto current `origin/main`.
- Cover horizontal scroll persistence across a schedule refresh.
- Keep the change scoped to the existing usable-areas Playwright coverage.

## Current-main preflight
- `origin/main`: `16c19575966af7cde2ec4e2cef2919d333258162`
- HEAD: `66becf9f06f16b991612a878238dcf2c2ec397d5`
- Issue: #232 remains a standalone Compass feedback intake item with no newer open PR covering this behavior.
- Related Gantt PRs were inspected and are already merged; no duplicate delivery graph was created.
- The source implementation is unchanged from current `origin/main`; this branch adds only the regression test.

## Verification
- `bun test src/lib/schedule/__tests__/gantt-scroll.test.ts` — 17 passed.
- Full `bun run test` — 1,085 passed; 2 tests timed out at the repository's default 5-second limit. Both passed when isolated with `--testTimeout=20000`.
- `bun run lint` — passed with existing warnings only.
- `bun run build` — passed, including TypeScript.
- `git diff --check origin/main...HEAD` — passed.
- Rendered Gantt replay against the current-main implementation with a current-schema local fixture: scroll restored from 1,597px to 1,591px after reload; Today moved to 1,311px. Screenshots/video were captured under `/tmp/gantt-dogfood/`.

## Notes
- The repository's canonical Playwright demo setup redirects to an empty synthetic project in this isolated worktree, so the focused test was also replayed directly against a current-schema seeded local fixture to verify the rendered behavior. The local fixture is ignored and was not committed.
- No merge, deployment, or D1 migration was performed.
