### PR TITLE
fix(schedule): keep print chooser open after preview

### DIFF
--- a/src/components/schedule/schedule-view.tsx
+++ b/src/components/schedule/schedule-view.tsx
@@ -693,9 +693,9 @@ export function ScheduleView({
 
   function printSchedule(selection: SchedulePrintSelection): void {
     // Commit the selected print layout before invoking the synchronous iOS
-    // print path; desktop browsers can still await layout readiness normally.
+    // print path. Keep the chooser mounted so it returns after print preview
+    // and only closes when the user explicitly dismisses it.
     flushSync(() => {
-      setPrintDialogOpen(false)
       setPrintSelection(selection)
     })
     void printScheduleDocument().finally(() => setPrintSelection(null))


### PR DESCRIPTION
## Summary
- keep the schedule print chooser mounted while browser print preview is open
- restore the chooser after printing or canceling preview
- continue allowing explicit dismissal with Cancel, close, Escape, or outside click

## Verification
- focused ESLint passed
- 7 focused print tests passed
- production Next.js build passed
