### PR TITLE
feat(navigation): group sidebar menu items

### DIFF
--- a/src/app/dashboard/projects/select/page.tsx
+++ b/src/app/dashboard/projects/select/page.tsx
@@ -1,15 +1,24 @@
 import type * as React from "react"
 import {
   IconAddressBook,
+  IconCalculator,
+  IconClipboardCheck,
   IconClipboardText,
+  IconEye,
   IconFileDollar,
   IconFileInvoice,
   IconFolderSearch,
   IconMailForward,
   IconMessageCircleQuestion,
+  IconMessages,
   IconPalette,
   IconPhoto,
+  IconReceipt,
+  IconShieldCheck,
+  IconShoppingCart,
   IconShoppingCartQuestion,
+  IconUsers,
+  IconVideo,
 } from "@tabler/icons-react"
 
 import { getProjects } from "@/app/actions/projects"
@@ -54,12 +63,28 @@ const TARGETS: readonly ProjectTarget[] = [
     icon: <IconPhoto className="size-5 text-muted-foreground" />,
   },
   {
+    section: "videos",
+    title: "Videos",
+    description: "Choose a project before reviewing videos.",
+    placeholder: "Search projects for videos...",
+    badge: "Video context",
+    icon: <IconVideo className="size-5 text-muted-foreground" />,
+  },
+  {
     section: "selections",
     title: "Finish Selections",
     description: "Choose a project before reviewing finish selections.",
     placeholder: "Search projects for selections...",
     badge: "Selection context",
     icon: <IconPalette className="size-5 text-muted-foreground" />,
+  },
+  {
+    section: "estimate",
+    title: "Estimates",
+    description: "Choose a project before opening its estimate workspace.",
+    placeholder: "Search projects for estimates...",
+    badge: "Estimate context",
+    icon: <IconCalculator className="size-5 text-muted-foreground" />,
   },
   {
     section: "budget",
@@ -70,12 +95,29 @@ const TARGETS: readonly ProjectTarget[] = [
     icon: <IconFileDollar className="size-5 text-muted-foreground" />,
   },
   {
+    section: "financials",
+    title: "Project Financials",
+    description:
+      "Choose a project before reviewing bills and pay applications.",
+    placeholder: "Search projects for financials...",
+    badge: "Financial context",
+    icon: <IconReceipt className="size-5 text-muted-foreground" />,
+  },
+  {
     section: "contacts",
     title: "Project Contacts",
     description: "Choose a project before assigning contacts.",
     placeholder: "Search projects for contacts...",
     badge: "Contact context",
     icon: <IconAddressBook className="size-5 text-muted-foreground" />,
+  },
+  {
+    section: "warranty",
+    title: "Warranty",
+    description: "Choose a project before reviewing warranty work.",
+    placeholder: "Search projects for warranty...",
+    badge: "Warranty context",
+    icon: <IconShieldCheck className="size-5 text-muted-foreground" />,
   },
   {
     section: "rfis",
@@ -94,6 +136,14 @@ const TARGETS: readonly ProjectTarget[] = [
     icon: <IconShoppingCartQuestion className="size-5 text-muted-foreground" />,
   },
   {
+    section: "purchase-orders",
+    title: "Purchase Orders",
+    description: "Choose a project before reviewing purchase orders.",
+    placeholder: "Search projects for purchase orders...",
+    badge: "Purchase-order context",
+    icon: <IconShoppingCart className="size-5 text-muted-foreground" />,
+  },
+  {
     section: "change-orders",
     title: "Change Orders",
     description: "Choose a project before requesting or reviewing scope changes.",
@@ -108,6 +158,39 @@ const TARGETS: readonly ProjectTarget[] = [
     placeholder: "Search projects for schedule...",
     badge: "Schedule context",
     icon: <IconFolderSearch className="size-5 text-muted-foreground" />,
+  },
+  {
+    section: "todos",
+    title: "Project To-Dos",
+    description: "Choose a project before reviewing its to-dos.",
+    placeholder: "Search projects for to-dos...",
+    badge: "To-do context",
+    icon: <IconClipboardCheck className="size-5 text-muted-foreground" />,
+  },
+  {
+    section: "conversations",
+    title: "Project Conversations",
+    description: "Choose a project before opening its conversations.",
+    placeholder: "Search projects for conversations...",
+    badge: "Conversation context",
+    icon: <IconMessages className="size-5 text-muted-foreground" />,
+  },
+  {
+    section: "preview/owner",
+    title: "Owner Preview",
+    description: "Choose a project before opening its owner-facing preview.",
+    placeholder: "Search projects for owner preview...",
+    badge: "Owner preview context",
+    icon: <IconEye className="size-5 text-muted-foreground" />,
+  },
+  {
+    section: "preview/sub-vendor",
+    title: "Sub/Vendor Preview",
+    description:
+      "Choose a project before opening its subcontractor and vendor preview.",
+    placeholder: "Search projects for sub/vendor preview...",
+    badge: "Sub/vendor preview context",
+    icon: <IconUsers className="size-5 text-muted-foreground" />,
   },
 ]
 

--- a/src/components/__tests__/nav-main-behavior.test.ts
+++ b/src/components/__tests__/nav-main-behavior.test.ts
@@ -1,8 +1,93 @@
 import { expect, test } from "vitest"
-import { shouldOpenConversationPanel } from "@/components/nav-main"
+import {
+  getActiveNavItemUrl,
+  shouldOpenConversationPanel,
+  type NavLinkItem,
+} from "@/components/nav-main"
 
 test("uses the side drawer only for the Conversations link when the panel is available", () => {
   expect(shouldOpenConversationPanel("Conversations", true)).toBe(true)
   expect(shouldOpenConversationPanel("Projects", true)).toBe(false)
   expect(shouldOpenConversationPanel("Conversations", false)).toBe(false)
+})
+
+test("selects the most specific submenu item for nested routes", () => {
+  const items: ReadonlyArray<NavLinkItem> = [
+    {
+      kind: "link",
+      title: "All Projects",
+      url: "/dashboard/projects",
+    },
+    {
+      kind: "link",
+      title: "Change Orders",
+      url: "/dashboard/projects/select?target=change-orders",
+    },
+  ]
+
+  expect(
+    getActiveNavItemUrl(
+      items,
+      "/dashboard/projects/select",
+      new URLSearchParams("target=change-orders"),
+    ),
+  ).toBe("/dashboard/projects/select?target=change-orders")
+})
+
+test("distinguishes planning submenu items that share a pathname", () => {
+  const items: ReadonlyArray<NavLinkItem> = [
+    {
+      kind: "link",
+      title: "To-Dos",
+      url: "/dashboard/schedule?kind=task",
+    },
+    {
+      kind: "link",
+      title: "Work Calendar",
+      url: "/dashboard/schedule",
+    },
+    {
+      kind: "link",
+      title: "Project Schedule",
+      url: "/dashboard/schedule?mode=projects&scope=all&view=gantt",
+    },
+  ]
+
+  expect(
+    getActiveNavItemUrl(
+      items,
+      "/dashboard/schedule",
+      new URLSearchParams("kind=task"),
+    ),
+  ).toBe("/dashboard/schedule?kind=task")
+  expect(
+    getActiveNavItemUrl(
+      items,
+      "/dashboard/schedule",
+      new URLSearchParams("mode=projects&scope=all&view=gantt"),
+    ),
+  ).toBe("/dashboard/schedule?mode=projects&scope=all&view=gantt")
+  expect(
+    getActiveNavItemUrl(
+      items,
+      "/dashboard/schedule",
+      new URLSearchParams("view=week"),
+    ),
+  ).toBe("/dashboard/schedule")
+})
+
+test("does not treat the dashboard root as active on every dashboard page", () => {
+  const dashboard: NavLinkItem = {
+    kind: "link",
+    title: "Dashboard",
+    url: "/dashboard",
+  }
+
+  expect(
+    getActiveNavItemUrl(
+      [dashboard],
+      "/dashboard/projects",
+      new URLSearchParams(),
+    ),
+  ).toBeNull()
 })

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import {
   IconAddressBook,
   IconActivity,
+  IconCalculator,
   IconCalendarStats,
   IconClipboardCheck,
   IconTimeline,
@@ -11,6 +12,8 @@ import {
   IconFiles,
   IconFileDollar,
   IconFileInvoice,
+  IconFileText,
+  IconEye,
   IconHeartHandshake,
   IconFolder,
   IconHome2,
@@ -22,13 +25,21 @@ import {
   IconPhone,
   IconPhoto,
   IconReceipt,
+  IconShieldCheck,
   IconShoppingCart,
   IconShoppingCartQuestion,
+  IconUsers,
   IconVideo,
 } from "@tabler/icons-react"
 import { usePathname } from "next/navigation"
 
-import { NavMain } from "@/components/nav-main"
+import {
+  NavMain,
+  type NavGroupChildItem,
+  type NavItem,
+  type NavLinkItem,
+  type NavSubgroupChildItem,
+} from "@/components/nav-main"
 import { NavFiles } from "@/components/nav-files"
 import { NavProjects } from "@/components/nav-projects"
 import { NavConversations } from "@/components/nav-conversations"
@@ -52,142 +63,414 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar"
 
-const PERSISTENT_NAV = [
+const DASHBOARD_NAV: NavLinkItem = {
+  kind: "link",
+  title: "Dashboard",
+  url: "/dashboard",
+  icon: IconHome2,
+}
+
+const PLANNING_NAV: ReadonlyArray<NavLinkItem> = [
   {
-    title: "Dashboard",
-    url: "/dashboard",
-    icon: IconHome2,
-  },
-  {
+    kind: "link",
     title: "To-Dos",
     url: "/dashboard/schedule?kind=task",
     icon: IconClipboardCheck,
   },
   {
+    kind: "link",
     title: "Work Calendar",
     url: "/dashboard/schedule",
     icon: IconCalendarStats,
   },
   {
-    title: "Schedule",
+    kind: "link",
+    title: "Project Schedule",
     url: "/dashboard/schedule?mode=projects&scope=all&view=gantt",
     icon: IconTimeline,
   },
 ]
 
-const NAV_MAIN = [
-  {
-    title: "Activity",
-    url: "/dashboard/activity",
-    icon: IconActivity,
-    internalOnly: true,
-  },
-  {
-    title: "Staff Message Desk",
-    url: "/dashboard/office-maintenance/message-desk",
-    icon: IconPhone,
-    internalOnly: true,
-  },
+interface SidebarNavLinkSource {
+  readonly kind: "link"
+  readonly title: string
+  readonly url: string
+  readonly icon: NonNullable<NavLinkItem["icon"]>
+  readonly projectPath?: string
+  readonly internalOnly?: boolean
+  readonly adminOnly?: boolean
+}
+
+interface SidebarNavSubgroupSource {
+  readonly kind: "subgroup"
+  readonly title: string
+  readonly icon: NonNullable<NavLinkItem["icon"]>
+  readonly items: ReadonlyArray<SidebarNavSubgroupChildSource>
+}
+
+interface SidebarNavComingSoonSource {
+  readonly kind: "coming-soon"
+  readonly title: string
+  readonly note: string
+  readonly icon: NonNullable<NavLinkItem["icon"]>
+}
+
+type SidebarNavSubgroupChildSource =
+  | SidebarNavLinkSource
+  | SidebarNavComingSoonSource
+
+type SidebarNavGroupChildSource =
+  | SidebarNavLinkSource
+  | SidebarNavSubgroupSource
+
+interface SidebarNavGroupSource {
+  readonly title: string
+  readonly icon: NonNullable<NavLinkItem["icon"]>
+  readonly items: ReadonlyArray<SidebarNavGroupChildSource>
+}
+
+const NAV_GROUPS: ReadonlyArray<SidebarNavGroupSource> = [
   {
     title: "Projects",
-    url: "/dashboard/projects",
     icon: IconFolder,
+    items: [
+      {
+        kind: "link",
+        title: "All Projects",
+        url: "/dashboard/projects",
+        icon: IconFolder,
+      },
+      {
+        kind: "subgroup",
+        title: "Updates & Logs",
+        icon: IconClipboardText,
+        items: [
+          {
+            kind: "link",
+            title: "Owner Updates",
+            url: "/dashboard/projects",
+            icon: IconMailForward,
+            projectPath: "/owner-updates",
+          },
+          {
+            kind: "link",
+            title: "Daily Logs",
+            url: "/dashboard/projects",
+            icon: IconClipboardText,
+            projectPath: "/daily-logs",
+          },
+        ],
+      },
+      {
+        kind: "subgroup",
+        title: "Project Records",
+        icon: IconFiles,
+        items: [
+          {
+            kind: "link",
+            title: "Photos",
+            url: "/dashboard/projects",
+            icon: IconPhoto,
+            projectPath: "/photos",
+          },
+          {
+            kind: "link",
+            title: "Videos",
+            url: "/dashboard/projects",
+            icon: IconVideo,
+            projectPath: "/videos",
+          },
+          {
+            kind: "link",
+            title: "Project Files",
+            url: "/dashboard/files?view=projects",
+            icon: IconFiles,
+          },
+          {
+            kind: "coming-soon",
+            title: "Contract Documents",
+            note: "Coming soon",
+            icon: IconFileText,
+          },
+          {
+            kind: "link",
+            title: "Project Contacts",
+            url: "/dashboard/projects",
+            icon: IconAddressBook,
+            projectPath: "/contacts",
+          },
+          {
+            kind: "link",
+            title: "Warranty",
+            url: "/dashboard/projects",
+            icon: IconShieldCheck,
+            projectPath: "/warranty",
+          },
+        ],
+      },
+      {
+        kind: "subgroup",
+        title: "Planning & Procurement",
+        icon: IconPalette,
+        items: [
+          {
+            kind: "link",
+            title: "Project Schedule",
+            url: "/dashboard/projects",
+            icon: IconCalendarStats,
+            projectPath: "/schedule",
+          },
+          {
+            kind: "link",
+            title: "Project To-Dos",
+            url: "/dashboard/projects",
+            icon: IconClipboardCheck,
+            projectPath: "/todos",
+          },
+          {
+            kind: "link",
+            title: "Selections",
+            url: "/dashboard/projects",
+            icon: IconPalette,
+            projectPath: "/selections",
+          },
+          {
+            kind: "link",
+            title: "RFIs",
+            url: "/dashboard/rfis",
+            icon: IconMessageCircleQuestion,
+          },
+          {
+            kind: "link",
+            title: "RFQs",
+            url: "/dashboard/projects",
+            icon: IconShoppingCartQuestion,
+            projectPath: "/rfqs",
+          },
+        ],
+      },
+      {
+        kind: "subgroup",
+        title: "Project Financials",
+        icon: IconReceipt,
+        items: [
+          {
+            kind: "link",
+            title: "Financial Overview",
+            url: "/dashboard/financials",
+            icon: IconReceipt,
+          },
+          {
+            kind: "link",
+            title: "Estimates",
+            url: "/dashboard/projects",
+            icon: IconCalculator,
+            projectPath: "/estimate",
+          },
+          {
+            kind: "link",
+            title: "Project Budget",
+            url: "/dashboard/projects",
+            icon: IconFileDollar,
+            projectPath: "/budget",
+          },
+          {
+            kind: "link",
+            title: "Bills & Pay Applications",
+            url: "/dashboard/projects",
+            icon: IconReceipt,
+            projectPath: "/financials",
+          },
+          {
+            kind: "link",
+            title: "Purchase Orders",
+            url: "/dashboard/purchase-orders",
+            icon: IconShoppingCart,
+          },
+          {
+            kind: "link",
+            title: "Change Orders",
+            url: "/dashboard/projects",
+            icon: IconFileInvoice,
+            projectPath: "/change-orders",
+          },
+        ],
+      },
+      {
+        kind: "subgroup",
+        title: "Collaboration & Access",
+        icon: IconUsers,
+        items: [
+          {
+            kind: "link",
+            title: "Project Conversations",
+            url: "/dashboard/projects",
+            icon: IconMessageCircle,
+            projectPath: "/conversations",
+          },
+          {
+            kind: "link",
+            title: "Owner Preview",
+            url: "/dashboard/projects",
+            icon: IconEye,
+            projectPath: "/preview/owner",
+          },
+          {
+            kind: "link",
+            title: "Sub/Vendor Preview",
+            url: "/dashboard/projects",
+            icon: IconUsers,
+            projectPath: "/preview/sub-vendor",
+          },
+        ],
+      },
+    ],
   },
   {
-    title: "Owner Updates",
-    url: "/dashboard/projects",
-    icon: IconMailForward,
-    projectPath: "/owner-updates",
-  },
-  {
-    title: "Daily Logs",
-    url: "/dashboard/projects",
-    icon: IconClipboardText,
-    projectPath: "/daily-logs",
-  },
-  {
-    title: "Photos",
-    url: "/dashboard/projects",
-    icon: IconPhoto,
-    projectPath: "/photos",
-  },
-  {
-    title: "Videos",
-    url: "/dashboard/projects",
-    icon: IconVideo,
-    projectPath: "/videos",
-  },
-  {
-    title: "Selections",
-    url: "/dashboard/projects",
-    icon: IconPalette,
-    projectPath: "/selections",
-  },
-  {
-    title: "Budget",
-    url: "/dashboard/projects",
-    icon: IconFileDollar,
-    projectPath: "/budget",
-  },
-  {
-    title: "Project Contacts",
-    url: "/dashboard/projects",
-    icon: IconAddressBook,
-    projectPath: "/contacts",
-  },
-  {
-    title: "RFIs",
-    url: "/dashboard/rfis",
-    icon: IconMessageCircleQuestion,
-  },
-  {
-    title: "RFQs",
-    url: "/dashboard/projects",
-    icon: IconShoppingCartQuestion,
-    projectPath: "/rfqs",
-  },
-  {
-    title: "Conversations",
-    url: "/dashboard/conversations",
+    title: "Communication",
     icon: IconMessageCircle,
+    items: [
+      {
+        kind: "link",
+        title: "Conversations",
+        url: "/dashboard/conversations",
+        icon: IconMessageCircle,
+      },
+      {
+        kind: "link",
+        title: "My Requests",
+        url: "/dashboard/requests",
+        icon: IconMessageReport,
+      },
+    ],
   },
   {
-    title: "My Requests",
-    url: "/dashboard/requests",
-    icon: IconMessageReport,
-  },
-  {
-    title: "Feedback Desk",
-    url: "/dashboard/requests/manage",
-    icon: IconMessageReport,
-    adminOnly: true,
-  },
-  {
-    title: "Files",
-    url: "/dashboard/files",
-    icon: IconFiles,
-  },
-  {
-    title: "Contacts",
-    url: "/dashboard/contacts",
-    icon: IconAddressBook,
-  },
-  {
-    title: "Financials",
-    url: "/dashboard/financials",
-    icon: IconReceipt,
-  },
-  {
-    title: "Purchase Orders",
-    url: "/dashboard/purchase-orders",
-    icon: IconShoppingCart,
-  },
-  {
-    title: "Change Orders",
-    url: "/dashboard/projects/select?target=change-orders",
-    icon: IconFileInvoice,
+    title: "Office",
+    icon: IconActivity,
+    items: [
+      {
+        kind: "link",
+        title: "Activity",
+        url: "/dashboard/activity",
+        icon: IconActivity,
+        internalOnly: true,
+      },
+      {
+        kind: "link",
+        title: "Contacts",
+        url: "/dashboard/contacts",
+        icon: IconAddressBook,
+      },
+      {
+        kind: "link",
+        title: "Feedback Desk",
+        url: "/dashboard/requests/manage",
+        icon: IconMessageReport,
+        adminOnly: true,
+      },
+    ],
   },
 ]
+
+function isNavLinkVisible(
+  item: SidebarNavLinkSource,
+  canViewActivity: boolean,
+  canManageFeedback: boolean,
+): boolean {
+  return (
+    (!item.internalOnly || canViewActivity) &&
+    (!item.adminOnly || canManageFeedback)
+  )
+}
+
+function resolveNavLink(
+  item: SidebarNavLinkSource,
+  activeProjectId: string | null,
+): NavLinkItem {
+  return {
+    kind: "link",
+    title: item.title,
+    url:
+      typeof item.projectPath === "string"
+        ? activeProjectId
+          ? `/dashboard/projects/${activeProjectId}${item.projectPath}`
+          : `/dashboard/projects/select?target=${encodeURIComponent(
+              item.projectPath.replace(/^\//, ""),
+            )}`
+        : item.url,
+    icon: item.icon,
+  }
+}
+
+function buildGroupChildren({
+  items,
+  activeProjectId,
+  canViewActivity,
+  canManageFeedback,
+}: {
+  readonly items: ReadonlyArray<SidebarNavGroupChildSource>
+  readonly activeProjectId: string | null
+  readonly canViewActivity: boolean
+  readonly canManageFeedback: boolean
+}): ReadonlyArray<NavGroupChildItem> {
+  const children: NavGroupChildItem[] = []
+
+  for (const item of items) {
+    if (item.kind === "link") {
+      if (isNavLinkVisible(item, canViewActivity, canManageFeedback)) {
+        children.push(resolveNavLink(item, activeProjectId))
+      }
+      continue
+    }
+
+    const subgroupLinks: NavSubgroupChildItem[] = []
+
+    for (const child of item.items) {
+      if (child.kind === "coming-soon") {
+        subgroupLinks.push(child)
+        continue
+      }
+
+      if (isNavLinkVisible(child, canViewActivity, canManageFeedback)) {
+        subgroupLinks.push(resolveNavLink(child, activeProjectId))
+      }
+    }
+
+    if (subgroupLinks.length > 0) {
+      children.push({
+        kind: "subgroup",
+        title: item.title,
+        icon: item.icon,
+        items: subgroupLinks,
+      })
+    }
+  }
+
+  return children
+}
+
+function buildMainNavigation({
+  activeProjectId,
+  canViewActivity,
+  canManageFeedback,
+}: {
+  readonly activeProjectId: string | null
+  readonly canViewActivity: boolean
+  readonly canManageFeedback: boolean
+}): ReadonlyArray<NavItem> {
+  return NAV_GROUPS.flatMap((group) => {
+    const items = buildGroupChildren({
+      items: group.items,
+      activeProjectId,
+      canViewActivity,
+      canManageFeedback,
+    })
+
+    return items.length > 0
+      ? [{ kind: "group", title: group.title, icon: group.icon, items }]
+      : []
+  })
+}
 
 function SidebarNav({
   projects,
@@ -222,7 +505,7 @@ function SidebarNav({
         ? "projects"
         : "main"
 
-  const projectScopedPersistentNav = PERSISTENT_NAV.map((item) =>
+  const projectScopedPlanningNav = PLANNING_NAV.map((item) =>
     item.title === "To-Dos" && activeProjectId
       ? {
           ...item,
@@ -230,33 +513,42 @@ function SidebarNav({
         }
       : item
   )
-  const navMain = NAV_MAIN.filter(
-    (item) =>
-      (!item.internalOnly || canViewActivity) &&
-      (!item.adminOnly || canManageFeedback)
-  ).map((item) =>
-    typeof item.projectPath === "string"
-      ? {
-          ...item,
-          url: activeProjectId
-            ? `/dashboard/projects/${activeProjectId}${item.projectPath}`
-            : `/dashboard/projects/select?target=${encodeURIComponent(
-                item.projectPath.replace(/^\//, "")
-              )}`,
-        }
-      : item
-  )
-
-  const persistentNav = canUseFieldDesk
+  const navMain = buildMainNavigation({
+    activeProjectId,
+    canViewActivity,
+    canManageFeedback,
+  })
+  const staffMessageDeskNav: ReadonlyArray<NavLinkItem> = canViewActivity
     ? [
-        ...projectScopedPersistentNav,
         {
+          kind: "link",
+          title: "Staff Message Desk",
+          url: "/dashboard/office-maintenance/message-desk",
+          icon: IconPhone,
+        },
+      ]
+    : []
+  const fieldNav: ReadonlyArray<NavLinkItem> = canUseFieldDesk
+    ? [
+        {
+          kind: "link",
           title: "CHERISH",
           url: "/dashboard/field",
           icon: IconHeartHandshake,
         },
       ]
-    : projectScopedPersistentNav
+    : []
+  const persistentNav: ReadonlyArray<NavItem> = [
+    DASHBOARD_NAV,
+    ...staffMessageDeskNav,
+    {
+      kind: "group",
+      title: "Planning",
+      icon: IconCalendarStats,
+      items: projectScopedPlanningNav,
+    },
+    ...fieldNav,
+  ]
 
   return (
     <div key={mode} className="animate-in fade-in slide-in-from-left-1 flex flex-1 flex-col duration-150">

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -1,57 +1,340 @@
 "use client"
 
-import type { Icon } from "@tabler/icons-react"
+import * as React from "react"
+import { IconChevronRight, type Icon } from "@tabler/icons-react"
 import Link from "next/link"
+import { usePathname, useSearchParams } from "next/navigation"
 
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
 import {
   SidebarGroup,
   SidebarGroupContent,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  useSidebar,
 } from "@/components/ui/sidebar"
 import { useConversationPanelOptional } from "@/components/conversations/conversation-panel-provider"
+
+export interface NavLinkItem {
+  readonly kind: "link"
+  readonly title: string
+  readonly url: string
+  readonly icon?: Icon
+}
+
+export interface NavGroupItem {
+  readonly kind: "group"
+  readonly title: string
+  readonly icon: Icon
+  readonly items: ReadonlyArray<NavGroupChildItem>
+}
+
+export interface NavSubgroupItem {
+  readonly kind: "subgroup"
+  readonly title: string
+  readonly icon: Icon
+  readonly items: ReadonlyArray<NavSubgroupChildItem>
+}
+
+export interface NavComingSoonItem {
+  readonly kind: "coming-soon"
+  readonly title: string
+  readonly note: string
+  readonly icon: Icon
+}
+
+export type NavSubgroupChildItem = NavLinkItem | NavComingSoonItem
+export type NavGroupChildItem = NavLinkItem | NavSubgroupItem
+export type NavItem = NavLinkItem | NavGroupItem
+
+interface SearchParamsReader {
+  readonly get: (name: string) => string | null
+}
 
 export function shouldOpenConversationPanel(title: string, panelAvailable: boolean): boolean {
   return title === "Conversations" && panelAvailable
 }
 
+function navigationItemMatches(
+  item: NavLinkItem,
+  pathname: string,
+  searchParams: SearchParamsReader,
+): boolean {
+  const target = new URL(item.url, "https://compass.local")
+
+  // The dashboard is the navigation root, not the parent of every dashboard page.
+  if (target.pathname === "/dashboard") return pathname === target.pathname
+
+  if (
+    pathname !== target.pathname &&
+    !pathname.startsWith(`${target.pathname}/`)
+  ) {
+    return false
+  }
+
+  for (const [name, value] of target.searchParams) {
+    if (searchParams.get(name) !== value) return false
+  }
+
+  return true
+}
+
+function navigationItemSpecificity(item: NavLinkItem): number {
+  const target = new URL(item.url, "https://compass.local")
+  return target.pathname.length + Array.from(target.searchParams).length * 1_000
+}
+
+export function getActiveNavItemUrl(
+  items: ReadonlyArray<NavLinkItem>,
+  pathname: string,
+  searchParams: SearchParamsReader,
+): string | null {
+  let activeItem: NavLinkItem | null = null
+
+  for (const item of items) {
+    if (!navigationItemMatches(item, pathname, searchParams)) continue
+    if (
+      activeItem === null ||
+      navigationItemSpecificity(item) > navigationItemSpecificity(activeItem)
+    ) {
+      activeItem = item
+    }
+  }
+
+  return activeItem?.url ?? null
+}
+
+function flattenNavLinks(
+  items: ReadonlyArray<NavGroupChildItem>,
+): ReadonlyArray<NavLinkItem> {
+  return items.flatMap((item) => {
+    if (item.kind === "link") return [item]
+    return item.items.filter((child) => child.kind === "link")
+  })
+}
+
+function NavLink({
+  item,
+  isActive,
+  nested = false,
+}: {
+  readonly item: NavLinkItem
+  readonly isActive: boolean
+  readonly nested?: boolean
+}) {
+  const conversationPanel = useConversationPanelOptional()
+  const opensPanel = shouldOpenConversationPanel(
+    item.title,
+    conversationPanel !== null,
+  )
+  const content = (
+    <>
+      {item.icon && <item.icon />}
+      <span>{item.title}</span>
+    </>
+  )
+
+  if (nested) {
+    return (
+      <SidebarMenuSubItem>
+        <SidebarMenuSubButton asChild isActive={isActive}>
+          {opensPanel ? (
+            <button type="button" onClick={() => conversationPanel?.open()}>
+              {content}
+            </button>
+          ) : (
+            <Link href={item.url}>{content}</Link>
+          )}
+        </SidebarMenuSubButton>
+      </SidebarMenuSubItem>
+    )
+  }
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        asChild
+        tooltip={item.title}
+        isActive={isActive}
+        aria-label={item.title}
+      >
+        {opensPanel ? (
+          <button type="button" onClick={() => conversationPanel?.open()}>
+            {content}
+          </button>
+        ) : (
+          <Link href={item.url}>{content}</Link>
+        )}
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  )
+}
+
+function NavSubmenu({
+  item,
+  activeUrl,
+}: {
+  readonly item: NavGroupItem
+  readonly activeUrl: string | null
+}) {
+  const { state, setOpen } = useSidebar()
+  const hasActiveItem = flattenNavLinks(item.items).some(
+    (child) => child.url === activeUrl,
+  )
+
+  return (
+    <Collapsible
+      asChild
+      key={`${item.title}-${hasActiveItem ? "active" : "inactive"}`}
+      defaultOpen={hasActiveItem}
+      className="group/collapsible"
+    >
+      <SidebarMenuItem>
+        <CollapsibleTrigger asChild>
+          <SidebarMenuButton
+            tooltip={item.title}
+            isActive={hasActiveItem}
+            aria-label={item.title}
+            onClick={() => {
+              if (state === "collapsed") setOpen(true)
+            }}
+          >
+            <item.icon />
+            <span>{item.title}</span>
+            <IconChevronRight className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-90" />
+          </SidebarMenuButton>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <SidebarMenuSub>
+            {item.items.map((child) => (
+              child.kind === "subgroup" ? (
+                <NavNestedSubmenu
+                  key={child.title}
+                  item={child}
+                  activeUrl={activeUrl}
+                />
+              ) : (
+                <NavLink
+                  key={child.title}
+                  item={child}
+                  isActive={child.url === activeUrl}
+                  nested
+                />
+              )
+            ))}
+          </SidebarMenuSub>
+        </CollapsibleContent>
+      </SidebarMenuItem>
+    </Collapsible>
+  )
+}
+
+function NavNestedSubmenu({
+  item,
+  activeUrl,
+}: {
+  readonly item: NavSubgroupItem
+  readonly activeUrl: string | null
+}) {
+  const hasActiveItem = item.items.some(
+    (child) => child.kind === "link" && child.url === activeUrl,
+  )
+
+  return (
+    <Collapsible
+      asChild
+      key={`${item.title}-${hasActiveItem ? "active" : "inactive"}`}
+      defaultOpen={hasActiveItem}
+      className="group/nested-collapsible"
+    >
+      <SidebarMenuSubItem>
+        <CollapsibleTrigger asChild>
+          <SidebarMenuSubButton asChild isActive={hasActiveItem}>
+            <button type="button" aria-label={item.title}>
+              <item.icon />
+              <span>{item.title}</span>
+              <IconChevronRight className="ml-auto transition-transform group-data-[state=open]/nested-collapsible:rotate-90" />
+            </button>
+          </SidebarMenuSubButton>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <SidebarMenuSub className="mr-0 ml-3">
+            {item.items.map((child) =>
+              child.kind === "coming-soon" ? (
+                <SidebarMenuSubItem key={child.title}>
+                  <SidebarMenuSubButton asChild>
+                    <button
+                      type="button"
+                      disabled
+                      aria-label={`${child.title} — ${child.note}`}
+                    >
+                      <child.icon />
+                      <span>{child.title}</span>
+                      <span className="ml-auto shrink-0 text-[10px] text-sidebar-foreground/60">
+                        {child.note}
+                      </span>
+                    </button>
+                  </SidebarMenuSubButton>
+                </SidebarMenuSubItem>
+              ) : (
+                <NavLink
+                  key={child.title}
+                  item={child}
+                  isActive={child.url === activeUrl}
+                  nested
+                />
+              ),
+            )}
+          </SidebarMenuSub>
+        </CollapsibleContent>
+      </SidebarMenuSubItem>
+    </Collapsible>
+  )
+}
+
 export function NavMain({
   items,
 }: {
-  items: {
-    title: string
-    url: string
-    icon?: Icon
-  }[]
+  readonly items: ReadonlyArray<NavItem>
 }) {
-  const conversationPanel = useConversationPanelOptional()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const links = items.flatMap((item) =>
+    item.kind === "group" ? flattenNavLinks(item.items) : [item],
+  )
+  const activeUrl = getActiveNavItemUrl(
+    links,
+    pathname,
+    searchParams,
+  )
 
   return (
     <SidebarGroup>
       <SidebarGroupContent>
         <SidebarMenu>
-          {items.map((item) => {
-            const opensPanel = shouldOpenConversationPanel(item.title, conversationPanel !== null)
-
-            return (
-              <SidebarMenuItem key={item.title}>
-                <SidebarMenuButton asChild tooltip={item.title}>
-                  {opensPanel ? (
-                    <button type="button" onClick={() => conversationPanel?.open()}>
-                      {item.icon && <item.icon />}
-                      <span>{item.title}</span>
-                    </button>
-                  ) : (
-                    <Link href={item.url}>
-                      {item.icon && <item.icon />}
-                      <span>{item.title}</span>
-                    </Link>
-                  )}
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            )
-          })}
+          {items.map((item) =>
+            item.kind === "group" ? (
+              <NavSubmenu
+                key={item.title}
+                item={item}
+                activeUrl={activeUrl}
+              />
+            ) : (
+              <NavLink
+                key={item.title}
+                item={item}
+                isActive={item.url === activeUrl}
+              />
+            ),
+          )}
         </SidebarMenu>
       </SidebarGroupContent>
     </SidebarGroup>


### PR DESCRIPTION
## Summary

- reorganize the Compass sidebar into logical nested menus
- keep Staff Message Desk prominent near the dashboard
- group project records, planning, financials, and collaboration routes under Projects
- include Estimates under Project Financials and Contract Documents as coming soon
- expand project selection routing so every working menu destination is accounted for

## Validation

- `bun test src/components/__tests__/nav-main-behavior.test.ts` (4 passed)
- `bunx tsc --noEmit --pretty false`
- `bun lint` (0 errors; 77 existing warnings)
- `bun run build`
- route destination audit and `git diff --check`

The full `bun test` baseline remains red on unrelated environment-dependent suites (1087 pass, 61 fail, 10 errors), including Bun's lack of `better-sqlite3`, unavailable `vi.hoisted`, and a missing `server-only` test dependency. The focused navigation tests and production build pass.
