### PR TITLE
feat(contracts): add versioned contract packet workflow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ The construction-specific modules that make up HPS Compass.
 - [google drive](modules/google-drive.md) -- domain-wide delegation, JWT auth, drive client, two-layer permissions, file browser
 - [scheduling](modules/scheduling.md) -- Gantt charts, critical path analysis, dependency management, baselines, workday exceptions
 - [financials](modules/financials.md) -- invoices, vendor bills, payments, credit memos, with legacy NetSuite sync notes and HPS Sage direction
+- [contracts](modules/contracts.md) -- versioned contract library, project packet assembly, CA22 insertion, Foxit execution, and budget handoff
 - [mobile](modules/mobile.md) -- Capacitor native app, offline photo queue, push notifications, biometric auth
 - [desktop](modules/desktop.md) -- Electron desktop app, hosted Compass runtime, native shell bridge, packaged app distribution
 - [claude code](modules/claude-code.md) -- local bridge daemon, own Anthropic API key, filesystem + terminal tools, WebSocket protocol

--- a/docs/modules/contracts.md
+++ b/docs/modules/contracts.md
@@ -1,0 +1,81 @@
+Contract Library and Project Packets
+===
+
+The contracts module turns approved source documents into versioned templates,
+then snapshots selected versions into a project-specific contract packet. A
+packet always links to one exact estimate version, which is inserted as CA22.
+Published library changes never alter an existing project packet.
+
+
+document lifecycle
+---
+
+Internal staff manage contract templates in the Contract documents tab of the
+Template Library. Importing the approved source workbook creates the initial
+published versions. A later source refresh creates drafts when content has
+changed; staff must review and publish those versions explicitly. Each version
+also has a Markdown copy in the configured Google Drive Template Library under
+`Contracts`.
+
+Templates define an inclusion mode and a signing stage:
+
+- `embedded`: render the document body in a packet.
+- `reference`: list the document in CA00 without embedding its full body.
+- `generated`: create the document from current Compass data, such as CA22.
+- `contract`: include the document in the initial signing envelope.
+- `construction`: retain it for a later construction event.
+- `closeout`: retain it for final walk-through or closeout signing.
+- `reference`: make it part of the contract schedule without a signing event.
+
+The Homeowner's Warranty Manual is reference-only. Inspection and limited
+warranty forms can be retained as closeout documents without appearing in the
+initial Foxit envelope.
+
+
+project packets
+---
+
+The Estimate workspace offers two signature routes: estimate-only, or a full
+construction contract. Creating a full packet copies every currently published,
+department-eligible template and links the selected estimate version. Staff can
+remove documents, add a missing published document, or edit the project snapshot
+without changing the global template.
+
+CA00's contract-document schedule is generated from the exact selected packet
+documents, including dates, revisions, reference treatment, and closeout
+treatment. Project department determines the default contractor legal entity.
+The entity remains editable on a draft packet.
+
+
+PDF and signature workflow
+---
+
+Compass creates one letter-size PDF by rendering contract-stage Markdown,
+inserting the linked CA22 estimate, and appending a consolidated signature page.
+The final pass adds `Page # of #` to every page, required Foxit initials fields
+to every page except the full-signature page, and signature plus system date
+fields for every owner signer and the company representative.
+
+Preparing a Foxit envelope does not freeze the draft. If a user edits the packet
+after preparation, Compass invalidates the prepared session so a fresh PDF must
+be created. Foxit's `folder_sent` event freezes both packet and linked estimate.
+Its `folder_executed` event executes the packet, accepts the exact estimate,
+supersedes the previous contractual baseline, and rebuilds the project contract
+budget. Revisions after sending use packet duplication.
+
+For documents signed outside Compass, internal staff first mark the packet as
+sent or printed. They then upload or link the complete signed copy, attest that
+all required signatures are present, and record the execution date. This path
+performs the same estimate approval, locking, and contract-budget rebuild.
+
+
+implementation map
+---
+
+- Schema: `src/db/schema-contracts.ts`
+- Migration: `drizzle/0130_contract_packets.sql`
+- Template actions: `src/app/actions/contract-templates.ts`
+- Packet actions: `src/app/actions/contract-packets.ts`
+- Source normalization: `src/lib/contracts/source.ts`
+- PDF assembly: `src/lib/contracts/packet-pdf.ts`
+- Foxit completion: `src/app/api/integrations/foxit/webhook/route.ts`

--- a/docs/modules/overview.md
+++ b/docs/modules/overview.md
@@ -47,6 +47,7 @@ Modules are the parts specific to HPS's construction business:
 | Google Drive | document management via workspace delegation | `lib/google/`, `actions/google-drive.ts`, `components/files/` |
 | Scheduling | Gantt charts, CPM, baseline tracking | `lib/schedule/`, `actions/schedule.ts`, `components/schedule/` |
 | Financials | invoices, bills, payments, credit memos | `actions/invoices.ts`, `actions/vendor-bills.ts`, `components/financials/` |
+| Contracts | versioned document library, project packets, CA22, Foxit execution | `lib/contracts/`, `actions/contract-*.ts`, `components/projects/project-contract-*` |
 | Mobile | Capacitor native wrapper, offline photos, push | `lib/native/`, `lib/push/`, `hooks/use-native*.ts`, `components/native/` |
 | Claude Code | local bridge daemon, own API key, filesystem + terminal access | `lib/mcp/`, `lib/agent/ws-transport.ts`, `packages/compass-bridge/` |
 

--- a/drizzle/0130_contract_packets.sql
+++ b/drizzle/0130_contract_packets.sql
@@ -1,0 +1,126 @@
+CREATE TABLE `contract_document_templates` (
+  `id` text PRIMARY KEY NOT NULL,
+  `organization_id` text NOT NULL,
+  `code` text NOT NULL,
+  `name` text NOT NULL,
+  `category` text DEFAULT 'exhibit' NOT NULL,
+  `signing_stage` text DEFAULT 'contract' NOT NULL,
+  `default_inclusion_mode` text DEFAULT 'embedded' NOT NULL,
+  `department_codes_json` text DEFAULT '[]' NOT NULL,
+  `source_workbook_id` text,
+  `source_sheet_names_json` text,
+  `source_url` text,
+  `sort_order` integer DEFAULT 0 NOT NULL,
+  `active` integer DEFAULT true NOT NULL,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `contract_document_templates_org_code_uq` ON `contract_document_templates` (`organization_id`,`code`);
+--> statement-breakpoint
+CREATE INDEX `contract_document_templates_org_order_idx` ON `contract_document_templates` (`organization_id`,`active`,`sort_order`);
+--> statement-breakpoint
+CREATE TABLE `contract_document_template_versions` (
+  `id` text PRIMARY KEY NOT NULL,
+  `template_id` text NOT NULL,
+  `version_number` integer NOT NULL,
+  `status` text DEFAULT 'draft' NOT NULL,
+  `content_markdown` text NOT NULL,
+  `source_fingerprint` text,
+  `source_captured_at` text,
+  `drive_document_id` text,
+  `drive_document_url` text,
+  `change_note` text,
+  `created_by` text,
+  `published_by` text,
+  `published_at` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`template_id`) REFERENCES `contract_document_templates`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`published_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `contract_document_template_versions_number_uq` ON `contract_document_template_versions` (`template_id`,`version_number`);
+--> statement-breakpoint
+CREATE INDEX `contract_document_template_versions_status_idx` ON `contract_document_template_versions` (`template_id`,`status`,`version_number`);
+--> statement-breakpoint
+CREATE TABLE `contract_packets` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_id` text NOT NULL,
+  `estimate_id` text NOT NULL,
+  `packet_number` text NOT NULL,
+  `version_number` integer DEFAULT 1 NOT NULL,
+  `title` text DEFAULT 'Construction Contract' NOT NULL,
+  `status` text DEFAULT 'draft' NOT NULL,
+  `legal_entity_name` text NOT NULL,
+  `contract_draft_date` text,
+  `approximate_commencement_date` text,
+  `approximate_completion_date` text,
+  `deposit_cents` integer DEFAULT 0 NOT NULL,
+  `late_payment_rate_basis_points` integer DEFAULT 1200 NOT NULL,
+  `details_json` text DEFAULT '{}' NOT NULL,
+  `client_signers_json` text DEFAULT '[]' NOT NULL,
+  `company_signer_name` text,
+  `company_signer_title` text,
+  `company_signer_email` text,
+  `company_signer_initials` text,
+  `foxit_status` text DEFAULT 'not_started' NOT NULL,
+  `foxit_envelope_id` text,
+  `foxit_embedded_session_url` text,
+  `prepared_source_hash` text,
+  `prepared_at` text,
+  `signature_requested_at` text,
+  `signature_package_url` text,
+  `signed_at` text,
+  `acceptance_method` text,
+  `acceptance_evidence_label` text,
+  `acceptance_recorded_by_name` text,
+  `accepted_at` text,
+  `accepted_by` text,
+  `source_hash` text,
+  `created_by` text,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`estimate_id`) REFERENCES `project_estimates`(`id`) ON UPDATE no action ON DELETE restrict,
+  FOREIGN KEY (`accepted_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `contract_packets_project_number_version_uq` ON `contract_packets` (`project_id`,`packet_number`,`version_number`);
+--> statement-breakpoint
+CREATE INDEX `contract_packets_project_status_idx` ON `contract_packets` (`project_id`,`status`,`version_number`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `contract_packets_foxit_envelope_uq` ON `contract_packets` (`foxit_envelope_id`);
+--> statement-breakpoint
+CREATE TABLE `contract_packet_documents` (
+  `id` text PRIMARY KEY NOT NULL,
+  `project_id` text NOT NULL,
+  `packet_id` text NOT NULL,
+  `template_id` text,
+  `template_version_id` text,
+  `code` text NOT NULL,
+  `title` text NOT NULL,
+  `content_markdown` text DEFAULT '' NOT NULL,
+  `inclusion_mode` text DEFAULT 'embedded' NOT NULL,
+  `signing_stage` text DEFAULT 'contract' NOT NULL,
+  `signature_policy` text DEFAULT 'all_signers' NOT NULL,
+  `document_date` text,
+  `revision` text,
+  `source_url` text,
+  `sort_order` integer DEFAULT 0 NOT NULL,
+  `created_at` text NOT NULL,
+  `updated_at` text NOT NULL,
+  FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`packet_id`) REFERENCES `contract_packets`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`template_id`) REFERENCES `contract_document_templates`(`id`) ON UPDATE no action ON DELETE set null,
+  FOREIGN KEY (`template_version_id`) REFERENCES `contract_document_template_versions`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `contract_packet_documents_packet_order_idx` ON `contract_packet_documents` (`packet_id`,`sort_order`);
+--> statement-breakpoint
+CREATE INDEX `contract_packet_documents_project_idx` ON `contract_packet_documents` (`project_id`,`packet_id`);

--- a/src/app/actions/contract-packets.ts
+++ b/src/app/actions/contract-packets.ts
@@ -1,0 +1,1258 @@
+"use server"
+
+import { and, asc, desc, eq, inArray, ne } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+import { cookies } from "next/headers"
+
+import { getDb } from "@/db"
+import { projectContacts, projects } from "@/db/schema"
+import {
+  contractDocumentTemplates,
+  contractDocumentTemplateVersions,
+  contractPacketDocuments,
+  contractPackets,
+} from "@/db/schema-contracts"
+import { projectEstimates } from "@/db/schema-estimates"
+import { requireAuth, type AuthUser } from "@/lib/auth"
+import {
+  contractPacketCanBeEdited,
+  parsePacketSigners,
+  signerInitials,
+  type ContractPacketSigner,
+} from "@/lib/contracts/packet"
+import { prepareContractPacketPdf } from "@/lib/contracts/packet-pdf"
+import { getCloudflareContext } from "@/lib/db"
+import { rebuildProjectContractBudget } from "@/lib/financials/contract-budget-store"
+import { createFoxitPreparedEnvelope } from "@/lib/foxit/esign"
+import { requirePermission } from "@/lib/permissions"
+import { assertProjectAccess } from "@/lib/project-access"
+import {
+  projectDepartment,
+  projectLegalEntityName,
+  type ProjectDepartment,
+} from "@/lib/project-branding"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+type CompassDb = ReturnType<typeof getDb>
+
+type ContractPacketAccess = {
+  readonly db: CompassDb
+  readonly env: CloudflareEnv
+  readonly user: AuthUser
+  readonly projectName: string
+  readonly projectNumber: string | null
+  readonly projectAddress: string | null
+  readonly projectClientName: string | null
+  readonly organizationId: string
+  readonly department: ProjectDepartment
+  readonly canEdit: boolean
+}
+
+export type ProjectContractPacketDocumentItem = {
+  readonly id: string
+  readonly templateId: string | null
+  readonly templateVersionId: string | null
+  readonly code: string
+  readonly title: string
+  readonly contentMarkdown: string
+  readonly inclusionMode: string
+  readonly signingStage: string
+  readonly signaturePolicy: string
+  readonly documentDate: string | null
+  readonly revision: string | null
+  readonly sourceUrl: string | null
+  readonly sortOrder: number
+}
+
+export type ProjectContractPacketSummary = {
+  readonly id: string
+  readonly estimateId: string
+  readonly packetNumber: string
+  readonly versionNumber: number
+  readonly title: string
+  readonly status: string
+  readonly legalEntityName: string
+  readonly contractDraftDate: string | null
+  readonly approximateCommencementDate: string | null
+  readonly approximateCompletionDate: string | null
+  readonly depositCents: number
+  readonly latePaymentRateBasisPoints: number
+  readonly details: Readonly<Record<string, string>>
+  readonly clientSigners: readonly ContractPacketSigner[]
+  readonly companySignerName: string | null
+  readonly companySignerTitle: string | null
+  readonly companySignerEmail: string | null
+  readonly companySignerInitials: string | null
+  readonly foxitStatus: string
+  readonly foxitEnvelopeId: string | null
+  readonly foxitEmbeddedSessionUrl: string | null
+  readonly signaturePackageUrl: string | null
+  readonly signedAt: string | null
+  readonly acceptanceMethod: string | null
+  readonly acceptanceEvidenceLabel: string | null
+  readonly acceptanceRecordedByName: string | null
+  readonly acceptedAt: string | null
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+export type ProjectContractTemplateOption = {
+  readonly id: string
+  readonly versionId: string
+  readonly versionNumber: number
+  readonly code: string
+  readonly name: string
+  readonly category: string
+  readonly signingStage: string
+  readonly inclusionMode: string
+  readonly contentMarkdown: string
+  readonly sourceUrl: string | null
+  readonly sortOrder: number
+}
+
+export type ProjectContractPacketEstimateOption = {
+  readonly id: string
+  readonly estimateNumber: string
+  readonly versionNumber: number
+  readonly title: string
+  readonly status: string
+  readonly estimateDate: string | null
+  readonly clientName: string | null
+  readonly builderFeeCents: number
+  readonly builderFeeRateBasisPoints: number
+  readonly estimateTotalCents: number
+}
+
+export type ProjectContractSignerOption = {
+  readonly id: string
+  readonly name: string
+  readonly title: string | null
+  readonly companyName: string | null
+  readonly email: string | null
+  readonly contactType: string
+}
+
+export type ProjectContractPacketWorkspace = {
+  readonly canEdit: boolean
+  readonly projectName: string
+  readonly projectNumber: string | null
+  readonly projectAddress: string | null
+  readonly department: ProjectDepartment
+  readonly packets: readonly ProjectContractPacketSummary[]
+  readonly activePacket: ProjectContractPacketSummary | null
+  readonly documents: readonly ProjectContractPacketDocumentItem[]
+  readonly templateOptions: readonly ProjectContractTemplateOption[]
+  readonly estimateOptions: readonly ProjectContractPacketEstimateOption[]
+  readonly signerContacts: readonly ProjectContractSignerOption[]
+}
+
+export type ContractPacketActionResult =
+  | { readonly success: true; readonly id: string; readonly message?: string }
+  | { readonly success: false; readonly error: string }
+
+export type ContractPacketFoxitPreparationResult =
+  | {
+      readonly success: true
+      readonly id: string
+      readonly embeddedSessionUrl: string
+    }
+  | { readonly success: false; readonly error: string }
+
+export type ContractPacketManualExecutionInput = {
+  readonly signedAt: string | null
+  readonly evidenceUrl: string | null
+  readonly evidenceLabel: string | null
+  readonly attested: boolean
+}
+
+function cleanText(value: string | null): string | null {
+  const cleaned = value?.trim() ?? ""
+  return cleaned ? cleaned : null
+}
+
+function requiredText(value: string | null, label: string): string {
+  const cleaned = cleanText(value)
+  if (!cleaned) throw new Error(`${label} is required.`)
+  return cleaned
+}
+
+function safeStringRecord(value: string): Readonly<Record<string, string>> {
+  try {
+    const parsed: unknown = JSON.parse(value)
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {}
+    return Object.fromEntries(
+      Object.entries(parsed).flatMap(([key, item]) =>
+        typeof item === "string" ? [[key, item]] : []
+      )
+    )
+  } catch {
+    return {}
+  }
+}
+
+function stringArray(value: string): readonly string[] {
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === "string")
+      : []
+  } catch {
+    return []
+  }
+}
+
+function estimateSigners(
+  estimate: typeof projectEstimates.$inferSelect
+): readonly ContractPacketSigner[] {
+  const parsed = parsePacketSigners(estimate.clientSignersJson ?? "[]")
+  if (parsed.length > 0) return parsed
+  const name = cleanText(estimate.clientSignerName)
+  if (!name) return []
+  return [{
+    contactId: estimate.clientSignerContactId,
+    name,
+    title: estimate.clientSignerTitle ?? "",
+    email: estimate.clientSignerEmail ?? "",
+    initials: signerInitials(name),
+  }]
+}
+
+function packetSummary(
+  row: typeof contractPackets.$inferSelect,
+  includeFoxitSession: boolean
+): ProjectContractPacketSummary {
+  return {
+    id: row.id,
+    estimateId: row.estimateId,
+    packetNumber: row.packetNumber,
+    versionNumber: row.versionNumber,
+    title: row.title,
+    status: row.status,
+    legalEntityName: row.legalEntityName,
+    contractDraftDate: row.contractDraftDate,
+    approximateCommencementDate: row.approximateCommencementDate,
+    approximateCompletionDate: row.approximateCompletionDate,
+    depositCents: row.depositCents,
+    latePaymentRateBasisPoints: row.latePaymentRateBasisPoints,
+    details: safeStringRecord(row.detailsJson),
+    clientSigners: parsePacketSigners(row.clientSignersJson),
+    companySignerName: row.companySignerName,
+    companySignerTitle: row.companySignerTitle,
+    companySignerEmail: row.companySignerEmail,
+    companySignerInitials: row.companySignerInitials,
+    foxitStatus: row.foxitStatus,
+    foxitEnvelopeId: row.foxitEnvelopeId,
+    foxitEmbeddedSessionUrl: includeFoxitSession
+      ? row.foxitEmbeddedSessionUrl
+      : null,
+    signaturePackageUrl: row.signaturePackageUrl,
+    signedAt: row.signedAt,
+    acceptanceMethod: row.acceptanceMethod,
+    acceptanceEvidenceLabel: row.acceptanceEvidenceLabel,
+    acceptanceRecordedByName: row.acceptanceRecordedByName,
+    acceptedAt: row.acceptedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}
+
+async function packetAccess(
+  projectId: string,
+  update: boolean
+): Promise<ContractPacketAccess> {
+  const user = await requireAuth()
+  requirePermission(user, "budget", update ? "update" : "read")
+  if (!isInternalStaffRole(user.role)) {
+    throw new Error("Contract packet preparation is limited to internal staff.")
+  }
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const projectAccess = await assertProjectAccess(db, user, projectId)
+  const project = await db
+    .select({
+      name: projects.name,
+      number: projects.projectNumber,
+      address: projects.address,
+      clientName: projects.clientName,
+      organizationId: projects.organizationId,
+    })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .get()
+  if (!project?.organizationId) throw new Error("Project organization not found.")
+  const canEdit = update
+  const projectNumber = project.number ?? projectAccess.projectNumber
+  return {
+    db,
+    env,
+    user,
+    projectName: project.name,
+    projectNumber,
+    projectAddress: project.address,
+    projectClientName: project.clientName,
+    organizationId: project.organizationId,
+    department: projectDepartment({ projectId, projectNumber }),
+    canEdit,
+  }
+}
+
+function revalidateContractPacket(projectId: string): void {
+  revalidatePath(`/dashboard/projects/${projectId}/estimate`)
+  revalidatePath(`/dashboard/projects/${projectId}/contracts`)
+  revalidatePath(`/print/projects/${projectId}/contract-packet`)
+}
+
+async function requireEditablePacket(
+  db: CompassDb,
+  projectId: string,
+  packetId: string
+): Promise<typeof contractPackets.$inferSelect> {
+  const packet = await db
+    .select()
+    .from(contractPackets)
+    .where(
+      and(eq(contractPackets.id, packetId), eq(contractPackets.projectId, projectId))
+    )
+    .get()
+  if (!packet) throw new Error("Contract packet not found.")
+  if (!contractPacketCanBeEdited(packet.status)) {
+    throw new Error(
+      "This packet is frozen. Duplicate it to make contract changes."
+    )
+  }
+  return packet
+}
+
+async function resetPreparedPacketIfNeeded(
+  db: CompassDb,
+  packet: typeof contractPackets.$inferSelect,
+  updatedAt: string
+): Promise<void> {
+  if (packet.foxitStatus !== "preparing") return
+  await db
+    .update(contractPackets)
+    .set({
+      foxitStatus: "not_started",
+      foxitEnvelopeId: null,
+      foxitEmbeddedSessionUrl: null,
+      preparedSourceHash: null,
+      preparedAt: null,
+      updatedAt,
+    })
+    .where(eq(contractPackets.id, packet.id))
+    .run()
+}
+
+async function publishedTemplateOptions(
+  access: ContractPacketAccess
+): Promise<readonly ProjectContractTemplateOption[]> {
+  const templates = await access.db
+    .select()
+    .from(contractDocumentTemplates)
+    .where(
+      and(
+        eq(contractDocumentTemplates.organizationId, access.organizationId),
+        eq(contractDocumentTemplates.active, true)
+      )
+    )
+    .orderBy(asc(contractDocumentTemplates.sortOrder))
+  const eligible = templates.filter((template) => {
+    const departments = stringArray(template.departmentCodesJson)
+    return departments.length === 0 || departments.includes(access.department)
+  })
+  if (eligible.length === 0) return []
+  const versions = await access.db
+    .select()
+    .from(contractDocumentTemplateVersions)
+    .where(
+      and(
+        inArray(contractDocumentTemplateVersions.templateId, eligible.map((item) => item.id)),
+        eq(contractDocumentTemplateVersions.status, "published")
+      )
+    )
+    .orderBy(desc(contractDocumentTemplateVersions.versionNumber))
+  return eligible.flatMap((template): readonly ProjectContractTemplateOption[] => {
+    const version = versions.find((item) => item.templateId === template.id)
+    if (!version) return []
+    return [{
+      id: template.id,
+      versionId: version.id,
+      versionNumber: version.versionNumber,
+      code: template.code,
+      name: template.name,
+      category: template.category,
+      signingStage: template.signingStage,
+      inclusionMode: template.defaultInclusionMode,
+      contentMarkdown: version.contentMarkdown,
+      sourceUrl: template.sourceUrl,
+      sortOrder: template.sortOrder,
+    }]
+  })
+}
+
+export async function getProjectContractPacketWorkspace(
+  projectId: string,
+  packetId?: string
+): Promise<ProjectContractPacketWorkspace> {
+  const access = await packetAccess(projectId, false)
+  const canEdit = isInternalStaffRole(access.user.role)
+  const [packetRows, templates, estimateRows, contactRows] = await Promise.all([
+    access.db
+      .select()
+      .from(contractPackets)
+      .where(eq(contractPackets.projectId, projectId))
+      .orderBy(desc(contractPackets.versionNumber), desc(contractPackets.updatedAt)),
+    publishedTemplateOptions(access),
+    access.db
+      .select({
+        id: projectEstimates.id,
+        estimateNumber: projectEstimates.estimateNumber,
+        versionNumber: projectEstimates.versionNumber,
+        title: projectEstimates.title,
+        status: projectEstimates.status,
+        estimateDate: projectEstimates.estimateDate,
+        clientName: projectEstimates.clientName,
+        builderFeeCents: projectEstimates.builderFeeCents,
+        overheadRateBasisPoints: projectEstimates.overheadRateBasisPoints,
+        marginRateBasisPoints: projectEstimates.marginRateBasisPoints,
+        contingencyRateBasisPoints: projectEstimates.contingencyRateBasisPoints,
+        estimateTotalCents: projectEstimates.estimateTotalCents,
+      })
+      .from(projectEstimates)
+      .where(eq(projectEstimates.projectId, projectId))
+      .orderBy(desc(projectEstimates.versionNumber)),
+    access.db
+      .select({
+        id: projectContacts.id,
+        name: projectContacts.displayName,
+        title: projectContacts.role,
+        companyName: projectContacts.companyName,
+        email: projectContacts.email,
+        contactType: projectContacts.contactType,
+      })
+      .from(projectContacts)
+      .where(
+        and(eq(projectContacts.projectId, projectId), eq(projectContacts.active, true))
+      )
+      .orderBy(desc(projectContacts.primaryContact), asc(projectContacts.sortOrder)),
+  ])
+  const active = packetRows.find((row) => row.id === packetId) ?? packetRows[0] ?? null
+  const documents = active
+    ? await access.db
+        .select()
+        .from(contractPacketDocuments)
+        .where(eq(contractPacketDocuments.packetId, active.id))
+        .orderBy(asc(contractPacketDocuments.sortOrder))
+    : []
+  return {
+    canEdit,
+    projectName: access.projectName,
+    projectNumber: access.projectNumber,
+    projectAddress: access.projectAddress,
+    department: access.department,
+    packets: packetRows.map((row) => packetSummary(row, canEdit)),
+    activePacket: active ? packetSummary(active, canEdit) : null,
+    documents,
+    templateOptions: templates,
+    estimateOptions: estimateRows.map((estimate) => ({
+      id: estimate.id,
+      estimateNumber: estimate.estimateNumber,
+      versionNumber: estimate.versionNumber,
+      title: estimate.title,
+      status: estimate.status,
+      estimateDate: estimate.estimateDate,
+      clientName: estimate.clientName,
+      builderFeeCents: estimate.builderFeeCents,
+      builderFeeRateBasisPoints:
+        estimate.overheadRateBasisPoints +
+        estimate.marginRateBasisPoints +
+        estimate.contingencyRateBasisPoints,
+      estimateTotalCents: estimate.estimateTotalCents,
+    })),
+    signerContacts: contactRows,
+  }
+}
+
+export async function createProjectContractPacket(
+  projectId: string,
+  estimateId: string
+): Promise<ContractPacketActionResult> {
+  try {
+    const access = await packetAccess(projectId, true)
+    const estimate = await access.db
+      .select()
+      .from(projectEstimates)
+      .where(
+        and(eq(projectEstimates.id, estimateId), eq(projectEstimates.projectId, projectId))
+      )
+      .get()
+    if (!estimate) throw new Error("Choose an estimate for the contract packet.")
+    const templates = await publishedTemplateOptions(access)
+    if (templates.length === 0) {
+      throw new Error("Import and publish the Contract Library before creating a packet.")
+    }
+    const existing = await access.db
+      .select({ versionNumber: contractPackets.versionNumber })
+      .from(contractPackets)
+      .where(
+        and(
+          eq(contractPackets.projectId, projectId),
+          eq(contractPackets.packetNumber, estimate.estimateNumber)
+        )
+      )
+      .orderBy(desc(contractPackets.versionNumber))
+      .limit(1)
+    const packetId = crypto.randomUUID()
+    const now = new Date().toISOString()
+    const versionNumber = (existing[0]?.versionNumber ?? 0) + 1
+    const clientSigners = estimateSigners(estimate)
+    await access.db.batch([
+      access.db.insert(contractPackets).values({
+        id: packetId,
+        projectId,
+        estimateId,
+        packetNumber: estimate.estimateNumber,
+        versionNumber,
+        title: "Construction Contract",
+        status: "draft",
+        legalEntityName: projectLegalEntityName(access.department),
+        contractDraftDate: new Date().toISOString().slice(0, 10),
+        detailsJson: JSON.stringify({
+          projectName: access.projectName,
+          projectNumber: access.projectNumber ?? "",
+          projectAddress: access.projectAddress ?? "",
+          ownerName: estimate.clientName ?? access.projectClientName ?? "",
+          county: "",
+        }),
+        clientSignersJson: JSON.stringify(clientSigners),
+        companySignerName: estimate.companySignerName,
+        companySignerTitle: estimate.companySignerTitle,
+        companySignerEmail: estimate.companySignerEmail,
+        companySignerInitials: estimate.companySignerInitials,
+        createdBy: access.user.id,
+        createdAt: now,
+        updatedAt: now,
+      }),
+      ...templates.map((template) =>
+        access.db.insert(contractPacketDocuments).values({
+          id: crypto.randomUUID(),
+          projectId,
+          packetId,
+          templateId: template.id,
+          templateVersionId: template.versionId,
+          code: template.code,
+          title: template.name,
+          contentMarkdown: template.contentMarkdown,
+          inclusionMode: template.inclusionMode,
+          signingStage: template.signingStage,
+          signaturePolicy: template.signingStage === "contract" ? "all_signers" : "stage_signers",
+          documentDate: template.code === "CA22" ? estimate.estimateDate : null,
+          revision: template.code === "CA22" ? `Estimate v${estimate.versionNumber}` : `Template v${template.versionNumber}`,
+          sourceUrl: template.sourceUrl,
+          sortOrder: template.sortOrder,
+          createdAt: now,
+          updatedAt: now,
+        })
+      ),
+    ])
+    revalidateContractPacket(projectId)
+    return { success: true, id: packetId, message: `Contract packet v${versionNumber} created.` }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unable to create contract packet.",
+    }
+  }
+}
+
+export async function saveProjectContractPacket(
+  projectId: string,
+  packetId: string,
+  input: {
+    readonly title: string | null
+    readonly legalEntityName: string | null
+    readonly contractDraftDate: string | null
+    readonly approximateCommencementDate: string | null
+    readonly approximateCompletionDate: string | null
+    readonly depositDollars: number | null
+    readonly latePaymentPercent: number | null
+    readonly details: Readonly<Record<string, string>>
+    readonly clientSigners: readonly ContractPacketSigner[]
+    readonly companySignerName: string | null
+    readonly companySignerTitle: string | null
+    readonly companySignerEmail: string | null
+    readonly companySignerInitials: string | null
+  }
+): Promise<ContractPacketActionResult> {
+  try {
+    const access = await packetAccess(projectId, true)
+    const packet = await requireEditablePacket(access.db, projectId, packetId)
+    const clients = input.clientSigners.flatMap((signer): readonly ContractPacketSigner[] => {
+      const name = cleanText(signer.name)
+      if (!name) return []
+      const email = cleanText(signer.email) ?? ""
+      if (email && !/^\S+@\S+\.\S+$/.test(email)) {
+        throw new Error(`Enter a valid email for ${name}.`)
+      }
+      return [{
+        contactId: cleanText(signer.contactId),
+        name,
+        title: cleanText(signer.title) ?? "",
+        email,
+        initials: (cleanText(signer.initials) ?? signerInitials(name)).toUpperCase(),
+      }]
+    })
+    const depositCents = Math.round((input.depositDollars ?? 0) * 100)
+    const latePaymentRateBasisPoints = Math.round((input.latePaymentPercent ?? 0) * 100)
+    if (!Number.isFinite(depositCents) || depositCents < 0) {
+      throw new Error("Deposit must be zero or greater.")
+    }
+    if (
+      !Number.isFinite(latePaymentRateBasisPoints) ||
+      latePaymentRateBasisPoints < 0 ||
+      latePaymentRateBasisPoints > 1_000_000
+    ) {
+      throw new Error("Late-payment rate must be between 0% and 10,000%.")
+    }
+    const now = new Date().toISOString()
+    await access.db
+      .update(contractPackets)
+      .set({
+        title: requiredText(input.title, "Packet title"),
+        legalEntityName: requiredText(input.legalEntityName, "Legal entity"),
+        contractDraftDate: cleanText(input.contractDraftDate),
+        approximateCommencementDate: cleanText(input.approximateCommencementDate),
+        approximateCompletionDate: cleanText(input.approximateCompletionDate),
+        depositCents,
+        latePaymentRateBasisPoints,
+        detailsJson: JSON.stringify(input.details),
+        clientSignersJson: JSON.stringify(clients),
+        companySignerName: cleanText(input.companySignerName),
+        companySignerTitle: cleanText(input.companySignerTitle),
+        companySignerEmail: cleanText(input.companySignerEmail),
+        companySignerInitials: cleanText(input.companySignerInitials)?.toUpperCase() ?? null,
+        updatedAt: now,
+      })
+      .where(eq(contractPackets.id, packetId))
+      .run()
+    await resetPreparedPacketIfNeeded(access.db, packet, now)
+    revalidateContractPacket(projectId)
+    return { success: true, id: packetId, message: "Contract packet details saved." }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unable to save contract packet.",
+    }
+  }
+}
+
+export async function saveProjectContractPacketDocument(
+  projectId: string,
+  packetId: string,
+  documentId: string,
+  input: {
+    readonly title: string | null
+    readonly contentMarkdown: string | null
+    readonly inclusionMode: string | null
+    readonly signingStage: string | null
+    readonly documentDate: string | null
+    readonly revision: string | null
+  }
+): Promise<ContractPacketActionResult> {
+  try {
+    const access = await packetAccess(projectId, true)
+    const packet = await requireEditablePacket(access.db, projectId, packetId)
+    const document = await access.db
+      .select()
+      .from(contractPacketDocuments)
+      .where(
+        and(
+          eq(contractPacketDocuments.id, documentId),
+          eq(contractPacketDocuments.packetId, packetId),
+          eq(contractPacketDocuments.projectId, projectId)
+        )
+      )
+      .get()
+    if (!document) throw new Error("Contract packet document not found.")
+    const inclusionMode = input.inclusionMode
+    if (inclusionMode !== "embedded" && inclusionMode !== "reference" && inclusionMode !== "generated") {
+      throw new Error("Choose a supported packet treatment.")
+    }
+    const signingStage = input.signingStage
+    if (signingStage !== "contract" && signingStage !== "construction" && signingStage !== "closeout" && signingStage !== "reference") {
+      throw new Error("Choose a supported signing stage.")
+    }
+    await access.db
+      .update(contractPacketDocuments)
+      .set({
+        title: requiredText(input.title, "Document title"),
+        contentMarkdown: inclusionMode === "generated"
+          ? document.contentMarkdown
+          : requiredText(input.contentMarkdown, "Document content"),
+        inclusionMode,
+        signingStage,
+        documentDate: cleanText(input.documentDate),
+        revision: cleanText(input.revision),
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(contractPacketDocuments.id, documentId))
+      .run()
+    await resetPreparedPacketIfNeeded(access.db, packet, new Date().toISOString())
+    revalidateContractPacket(projectId)
+    return { success: true, id: documentId, message: `${document.code} snapshot saved.` }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unable to save packet document.",
+    }
+  }
+}
+
+export async function addProjectContractPacketDocument(
+  projectId: string,
+  packetId: string,
+  templateId: string
+): Promise<ContractPacketActionResult> {
+  try {
+    const access = await packetAccess(projectId, true)
+    const packet = await requireEditablePacket(access.db, projectId, packetId)
+    const templates = await publishedTemplateOptions(access)
+    const template = templates.find((item) => item.id === templateId)
+    if (!template) throw new Error("Choose a published contract document.")
+    const existing = await access.db
+      .select({ id: contractPacketDocuments.id })
+      .from(contractPacketDocuments)
+      .where(
+        and(
+          eq(contractPacketDocuments.packetId, packetId),
+          eq(contractPacketDocuments.templateId, template.id)
+        )
+      )
+      .get()
+    if (existing) throw new Error(`${template.code} is already in this packet.`)
+    const id = crypto.randomUUID()
+    const now = new Date().toISOString()
+    await access.db.insert(contractPacketDocuments).values({
+      id,
+      projectId,
+      packetId,
+      templateId: template.id,
+      templateVersionId: template.versionId,
+      code: template.code,
+      title: template.name,
+      contentMarkdown: template.contentMarkdown,
+      inclusionMode: template.inclusionMode,
+      signingStage: template.signingStage,
+      signaturePolicy: template.signingStage === "contract" ? "all_signers" : "stage_signers",
+      revision: `Template v${template.versionNumber}`,
+      sourceUrl: template.sourceUrl,
+      sortOrder: template.sortOrder,
+      createdAt: now,
+      updatedAt: now,
+    }).run()
+    await resetPreparedPacketIfNeeded(access.db, packet, now)
+    revalidateContractPacket(projectId)
+    return { success: true, id, message: `${template.code} added.` }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unable to add contract document.",
+    }
+  }
+}
+
+export async function deleteProjectContractPacketDocument(
+  projectId: string,
+  packetId: string,
+  documentId: string
+): Promise<ContractPacketActionResult> {
+  try {
+    const access = await packetAccess(projectId, true)
+    const packet = await requireEditablePacket(access.db, projectId, packetId)
+    const document = await access.db
+      .select({ id: contractPacketDocuments.id, code: contractPacketDocuments.code })
+      .from(contractPacketDocuments)
+      .where(
+        and(
+          eq(contractPacketDocuments.id, documentId),
+          eq(contractPacketDocuments.packetId, packetId),
+          eq(contractPacketDocuments.projectId, projectId)
+        )
+      )
+      .get()
+    if (!document) throw new Error("Contract packet document not found.")
+    await access.db.delete(contractPacketDocuments)
+      .where(eq(contractPacketDocuments.id, document.id)).run()
+    await resetPreparedPacketIfNeeded(access.db, packet, new Date().toISOString())
+    revalidateContractPacket(projectId)
+    return { success: true, id: document.id, message: `${document.code} removed.` }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unable to remove contract document.",
+    }
+  }
+}
+
+export async function duplicateProjectContractPacket(
+  projectId: string,
+  packetId: string
+): Promise<ContractPacketActionResult> {
+  try {
+    const access = await packetAccess(projectId, true)
+    const source = await access.db
+      .select()
+      .from(contractPackets)
+      .where(
+        and(eq(contractPackets.id, packetId), eq(contractPackets.projectId, projectId))
+      )
+      .get()
+    if (!source) throw new Error("Contract packet not found.")
+    const documents = await access.db
+      .select()
+      .from(contractPacketDocuments)
+      .where(eq(contractPacketDocuments.packetId, source.id))
+      .orderBy(asc(contractPacketDocuments.sortOrder))
+    const latest = await access.db
+      .select({ versionNumber: contractPackets.versionNumber })
+      .from(contractPackets)
+      .where(
+        and(
+          eq(contractPackets.projectId, projectId),
+          eq(contractPackets.packetNumber, source.packetNumber)
+        )
+      )
+      .orderBy(desc(contractPackets.versionNumber))
+      .limit(1)
+    const nextId = crypto.randomUUID()
+    const nextVersion = (latest[0]?.versionNumber ?? source.versionNumber) + 1
+    const now = new Date().toISOString()
+    await access.db.batch([
+      access.db.insert(contractPackets).values({
+        id: nextId,
+        projectId,
+        estimateId: source.estimateId,
+        packetNumber: source.packetNumber,
+        versionNumber: nextVersion,
+        title: source.title,
+        status: "draft",
+        legalEntityName: source.legalEntityName,
+        contractDraftDate: now.slice(0, 10),
+        approximateCommencementDate: source.approximateCommencementDate,
+        approximateCompletionDate: source.approximateCompletionDate,
+        depositCents: source.depositCents,
+        latePaymentRateBasisPoints: source.latePaymentRateBasisPoints,
+        detailsJson: source.detailsJson,
+        clientSignersJson: source.clientSignersJson,
+        companySignerName: source.companySignerName,
+        companySignerTitle: source.companySignerTitle,
+        companySignerEmail: source.companySignerEmail,
+        companySignerInitials: source.companySignerInitials,
+        createdBy: access.user.id,
+        createdAt: now,
+        updatedAt: now,
+      }),
+      ...documents.map((document) =>
+        access.db.insert(contractPacketDocuments).values({
+          id: crypto.randomUUID(),
+          projectId,
+          packetId: nextId,
+          templateId: document.templateId,
+          templateVersionId: document.templateVersionId,
+          code: document.code,
+          title: document.title,
+          contentMarkdown: document.contentMarkdown,
+          inclusionMode: document.inclusionMode,
+          signingStage: document.signingStage,
+          signaturePolicy: document.signaturePolicy,
+          documentDate: document.documentDate,
+          revision: document.revision,
+          sourceUrl: document.sourceUrl,
+          sortOrder: document.sortOrder,
+          createdAt: now,
+          updatedAt: now,
+        })
+      ),
+    ])
+    revalidateContractPacket(projectId)
+    return { success: true, id: nextId, message: `Editable packet v${nextVersion} created.` }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unable to duplicate contract packet.",
+    }
+  }
+}
+
+export async function deleteProjectContractPacket(
+  projectId: string,
+  packetId: string
+): Promise<ContractPacketActionResult> {
+  try {
+    const access = await packetAccess(projectId, true)
+    const packet = await requireEditablePacket(access.db, projectId, packetId)
+    await access.db.delete(contractPackets).where(eq(contractPackets.id, packet.id)).run()
+    revalidateContractPacket(projectId)
+    return { success: true, id: packet.id, message: "Draft contract packet deleted." }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unable to delete contract packet.",
+    }
+  }
+}
+
+async function sha256(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value)
+  )
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+async function renderContractEstimatePdf(input: {
+  readonly env: CloudflareEnv
+  readonly projectId: string
+  readonly estimateId: string
+}): Promise<ArrayBuffer> {
+  const quickAction = Reflect.get(input.env.BROWSER, "quickAction")
+  if (typeof quickAction !== "function") {
+    throw new Error("Cloudflare Browser Run is not available for contract PDFs.")
+  }
+  const origin = new URL(input.env.WORKOS_REDIRECT_URI).origin
+  const url = new URL(`/print/projects/${input.projectId}/estimate`, origin)
+  url.searchParams.set("estimateId", input.estimateId)
+  const requestCookies = await cookies()
+  const rendered: unknown = await Reflect.apply(quickAction, input.env.BROWSER, [
+    "pdf",
+    {
+      url: url.toString(),
+      setExtraHTTPHeaders: { Cookie: requestCookies.toString() },
+      gotoOptions: { waitUntil: "networkidle2", timeout: 60_000 },
+      waitForSelector: { selector: ".estimate-signature-page", timeout: 60_000 },
+      pdfOptions: {
+        format: "letter",
+        printBackground: true,
+        preferCSSPageSize: true,
+        margin: { top: "0", right: "0", bottom: "0", left: "0" },
+      },
+    },
+  ])
+  if (!(rendered instanceof Response) || !rendered.ok) {
+    throw new Error("Unable to render the selected CA22 estimate.")
+  }
+  return rendered.arrayBuffer()
+}
+
+export async function prepareProjectContractPacketForSignature(
+  projectId: string,
+  packetId: string
+): Promise<ContractPacketFoxitPreparationResult> {
+  try {
+    const access = await packetAccess(projectId, true)
+    const packet = await requireEditablePacket(access.db, projectId, packetId)
+    const workspace = await getProjectContractPacketWorkspace(projectId, packetId)
+    const estimate = workspace.estimateOptions.find(
+      (item) => item.id === packet.estimateId
+    )
+    if (!estimate) throw new Error("The linked CA22 estimate was not found.")
+    if (!cleanText(packet.contractDraftDate)) {
+      throw new Error("Add the contract date before signature.")
+    }
+    if (!cleanText(packet.approximateCommencementDate)) {
+      throw new Error("Add the approximate commencement date before signature.")
+    }
+    if (!cleanText(packet.approximateCompletionDate)) {
+      throw new Error("Add the approximate completion date before signature.")
+    }
+    const details = safeStringRecord(packet.detailsJson)
+    if (!cleanText(details.projectAddress ?? null)) {
+      throw new Error("Add the project location before signature.")
+    }
+    if (!cleanText(details.county ?? null)) {
+      throw new Error("Add the project county before signature.")
+    }
+    if (!cleanText(details.ownerName ?? null)) {
+      throw new Error("Add the owner or client name before signature.")
+    }
+    const clients = parsePacketSigners(packet.clientSignersJson)
+    if (clients.length === 0) {
+      throw new Error("Add at least one owner signer before signature.")
+    }
+    for (const signer of clients) {
+      if (!cleanText(signer.email)) {
+        throw new Error(`Add an email address for ${signer.name}.`)
+      }
+      if (!cleanText(signer.initials)) {
+        throw new Error(`Add initials for ${signer.name}.`)
+      }
+    }
+    if (!cleanText(packet.companySignerName)) {
+      throw new Error("Choose or type the company representative before signature.")
+    }
+    if (!cleanText(packet.companySignerEmail)) {
+      throw new Error("Add the company representative email before signature.")
+    }
+    if (!cleanText(packet.companySignerTitle)) {
+      throw new Error("Add the company representative title before signature.")
+    }
+    if (!cleanText(packet.companySignerInitials)) {
+      throw new Error("Add the company representative initials before signature.")
+    }
+    const sourceHash = await sha256(JSON.stringify({
+      packet: packetSummary(packet, false),
+      documents: workspace.documents,
+      estimate,
+    }))
+    const clientId = cleanText(access.env.FOXIT_ESIGN_CLIENT_ID)
+    const clientSecret = cleanText(access.env.FOXIT_ESIGN_CLIENT_SECRET)
+    if (!clientId || !clientSecret) {
+      throw new Error("Foxit eSign credentials are not configured for Compass.")
+    }
+    const estimatePdf = await renderContractEstimatePdf({
+      env: access.env,
+      projectId,
+      estimateId: estimate.id,
+    })
+    const prepared = await prepareContractPacketPdf({
+      packet: packetSummary(packet, false),
+      documents: workspace.documents,
+      estimate,
+      projectName: workspace.projectName,
+      projectNumber: workspace.projectNumber,
+      projectAddress: workspace.projectAddress,
+      estimatePdf,
+    })
+    const origin = new URL(access.env.WORKOS_REDIRECT_URI).origin
+    const successUrl = new URL(`/dashboard/projects/${projectId}/contracts`, origin)
+    successUrl.searchParams.set("packetId", packetId)
+    successUrl.searchParams.set("foxit", "sent")
+    const errorUrl = new URL(successUrl)
+    errorUrl.searchParams.set("foxit", "error")
+    const parties = [
+      ...clients.map((signer, index) => ({
+        name: signer.name,
+        email: signer.email,
+        sequence: index + 1,
+      })),
+      {
+        name: packet.companySignerName ?? "Company representative",
+        email: packet.companySignerEmail ?? "",
+        sequence: clients.length + 1,
+      },
+    ]
+    const foxit = await createFoxitPreparedEnvelope({
+      clientId,
+      clientSecret,
+      folderName: `${packet.packetNumber} contract version ${packet.versionNumber}`,
+      pdfBase64: prepared.pdfBase64,
+      parties,
+      fields: prepared.fields,
+      successUrl: successUrl.toString(),
+      errorUrl: errorUrl.toString(),
+      estimateId: packet.estimateId,
+      contractPacketId: packet.id,
+      sourceHash,
+    })
+    const now = new Date().toISOString()
+    await access.db
+      .update(contractPackets)
+      .set({
+        foxitStatus: "preparing",
+        foxitEnvelopeId: foxit.envelopeId,
+        foxitEmbeddedSessionUrl: foxit.embeddedSessionUrl,
+        preparedSourceHash: sourceHash,
+        preparedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(contractPackets.id, packet.id))
+      .run()
+    revalidateContractPacket(projectId)
+    return {
+      success: true,
+      id: packet.id,
+      embeddedSessionUrl: foxit.embeddedSessionUrl,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unable to prepare contract signature.",
+    }
+  }
+}
+
+export async function markProjectContractPacketSentOutsideCompass(
+  projectId: string,
+  packetId: string
+): Promise<ContractPacketActionResult> {
+  try {
+    const access = await packetAccess(projectId, true)
+    const packet = await requireEditablePacket(access.db, projectId, packetId)
+    const documents = await access.db
+      .select()
+      .from(contractPacketDocuments)
+      .where(eq(contractPacketDocuments.packetId, packet.id))
+      .orderBy(asc(contractPacketDocuments.sortOrder))
+    if (!documents.some((item) => item.code === "CA00")) {
+      throw new Error("Add CA00 before sending the contract packet.")
+    }
+    if (!documents.some((item) => item.code === "CA22")) {
+      throw new Error("Add CA22 before sending the contract packet.")
+    }
+    if (!packet.contractDraftDate || !packet.approximateCommencementDate || !packet.approximateCompletionDate) {
+      throw new Error("Add the required contract and approximate construction dates.")
+    }
+    const details = safeStringRecord(packet.detailsJson)
+    if (!details.projectAddress || !details.county || !details.ownerName) {
+      throw new Error("Add the required project location, county, and owner name.")
+    }
+    const clients = parsePacketSigners(packet.clientSignersJson)
+    if (clients.length === 0 || clients.some((signer) => !signer.name)) {
+      throw new Error("Add at least one owner signer.")
+    }
+    if (!packet.companySignerName) {
+      throw new Error("Add the company representative.")
+    }
+    const sourceHash = await sha256(JSON.stringify({ packet, documents }))
+    const now = new Date().toISOString()
+    await access.db.batch([
+      access.db
+        .update(contractPackets)
+        .set({
+          status: "signature_pending",
+          foxitStatus: "not_applicable",
+          foxitEnvelopeId: null,
+          foxitEmbeddedSessionUrl: null,
+          signatureRequestedAt: now,
+          sourceHash,
+          updatedAt: now,
+        })
+        .where(eq(contractPackets.id, packet.id)),
+      access.db
+        .update(projectEstimates)
+        .set({
+          status: "signature_pending",
+          foxitStatus: "included_in_manual_contract_packet",
+          signatureRequestedAt: now,
+          updatedAt: now,
+        })
+        .where(eq(projectEstimates.id, packet.estimateId)),
+    ])
+    revalidateContractPacket(projectId)
+    return { success: true, id: packet.id, message: "Packet frozen for outside signatures." }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unable to freeze the contract packet.",
+    }
+  }
+}
+
+export async function recordManualProjectContractPacketExecution(
+  projectId: string,
+  packetId: string,
+  input: ContractPacketManualExecutionInput
+): Promise<ContractPacketActionResult> {
+  try {
+    const access = await packetAccess(projectId, true)
+    const packet = await access.db
+      .select()
+      .from(contractPackets)
+      .where(
+        and(eq(contractPackets.id, packetId), eq(contractPackets.projectId, projectId))
+      )
+      .get()
+    if (!packet || packet.status !== "signature_pending") {
+      throw new Error("Send or print the final packet for signature before recording execution.")
+    }
+    if (!input.attested) {
+      throw new Error("Confirm that every required owner and company representative signed the complete packet.")
+    }
+    const evidenceUrl = cleanText(input.evidenceUrl)
+    if (!evidenceUrl) throw new Error("Upload or link the saved signed packet.")
+    const url = new URL(evidenceUrl)
+    if (url.protocol !== "https:") {
+      throw new Error("The signed packet must use a secure HTTPS link.")
+    }
+    const evidenceLabel = requiredText(input.evidenceLabel, "Signed packet label")
+    const signedDate = requiredText(input.signedAt, "Contract execution date")
+    const signedAt = new Date(`${signedDate.slice(0, 10)}T12:00:00Z`)
+    if (Number.isNaN(signedAt.valueOf()) || signedAt > new Date()) {
+      throw new Error("Choose a valid contract execution date that is not in the future.")
+    }
+    const now = new Date().toISOString()
+    const signedAtIso = signedAt.toISOString()
+    await access.db.batch([
+      access.db
+        .update(contractPackets)
+        .set({ status: "superseded", updatedAt: now })
+        .where(
+          and(
+            eq(contractPackets.projectId, projectId),
+            eq(contractPackets.status, "executed"),
+            ne(contractPackets.id, packet.id)
+          )
+        ),
+      access.db
+        .update(projectEstimates)
+        .set({ status: "superseded", updatedAt: now })
+        .where(
+          and(
+            eq(projectEstimates.projectId, projectId),
+            eq(projectEstimates.status, "accepted")
+          )
+        ),
+      access.db
+        .update(contractPackets)
+        .set({
+          status: "executed",
+          foxitStatus: "not_applicable",
+          signaturePackageUrl: url.toString(),
+          signedAt: signedAtIso,
+          acceptanceMethod: "manual",
+          acceptanceEvidenceLabel: evidenceLabel,
+          acceptanceRecordedByName: access.user.displayName ?? access.user.email,
+          acceptedAt: now,
+          acceptedBy: access.user.id,
+          updatedAt: now,
+        })
+        .where(eq(contractPackets.id, packet.id)),
+      access.db
+        .update(projectEstimates)
+        .set({
+          status: "accepted",
+          foxitStatus: "completed_in_manual_contract_packet",
+          signaturePackageUrl: url.toString(),
+          signedAt: signedAtIso,
+          acceptanceMethod: "manual_contract_packet",
+          acceptanceEvidenceLabel: evidenceLabel,
+          acceptanceRecordedByName: access.user.displayName ?? access.user.email,
+          acceptedAt: now,
+          acceptedBy: access.user.id,
+          sageStatus: "ready",
+          updatedAt: now,
+        })
+        .where(eq(projectEstimates.id, packet.estimateId)),
+    ])
+    const budget = await rebuildProjectContractBudget({
+      db: access.db,
+      projectId,
+      actorUserId: access.user.id,
+    })
+    revalidateContractPacket(projectId)
+    if (!budget.success) {
+      return {
+        success: false,
+        error: `Contract executed, but the budget needs review: ${budget.error}`,
+      }
+    }
+    return { success: true, id: packet.id, message: "Manually signed contract packet recorded and locked." }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unable to record contract execution.",
+    }
+  }
+}

--- a/src/app/actions/contract-templates.ts
+++ b/src/app/actions/contract-templates.ts
@@ -1,0 +1,663 @@
+"use server"
+
+import { and, asc, desc, eq, inArray } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import {
+  contractDocumentTemplates,
+  contractDocumentTemplateVersions,
+} from "@/db/schema-contracts"
+import { googleAuth } from "@/db/schema-google"
+import { requireAuth } from "@/lib/auth"
+import { decrypt } from "@/lib/crypto"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import { syncContractTemplateVersionToDrive } from "@/lib/contracts/drive-store"
+import {
+  ORC_CONTRACT_SOURCE_DEFINITIONS,
+  ORC_CONTRACT_SOURCE_URL,
+  ORC_CONTRACT_SOURCE_WORKBOOK_ID,
+  contractSourceRanges,
+  normalizeContractSourceDocument,
+  type ContractInclusionMode,
+  type ContractSigningStage,
+  type ContractSourceRows,
+} from "@/lib/contracts/source"
+import { SheetsClient } from "@/lib/google/client/sheets-client"
+import {
+  getGoogleConfig,
+  getGoogleCryptoSalt,
+  parseServiceAccountKey,
+} from "@/lib/google/config"
+import { getOrganizationDriveContext } from "@/lib/google/organization-drive"
+import { requireOrg } from "@/lib/org-scope"
+import { requirePermission } from "@/lib/permissions"
+import { isInternalStaffRole } from "@/lib/user-roles"
+
+const WARRANTY_MANUAL_URL =
+  "https://drive.google.com/file/d/1ArwPZO9qH1sLkKkSHftK9nNg6hHCkj95/view"
+
+export type ContractTemplateLibraryItem = {
+  readonly id: string
+  readonly code: string
+  readonly name: string
+  readonly category: string
+  readonly signingStage: string
+  readonly defaultInclusionMode: string
+  readonly departmentCodes: readonly string[]
+  readonly sourceUrl: string | null
+  readonly sortOrder: number
+  readonly active: boolean
+  readonly version: {
+    readonly id: string
+    readonly versionNumber: number
+    readonly status: string
+    readonly contentMarkdown: string
+    readonly sourceCapturedAt: string | null
+    readonly driveDocumentUrl: string | null
+    readonly changeNote: string | null
+  } | null
+}
+
+export type ContractTemplateActionResult =
+  | { readonly success: true; readonly id: string; readonly message: string }
+  | { readonly success: false; readonly error: string }
+
+function cleanText(value: string | null, label: string): string {
+  const cleaned = value?.trim() ?? ""
+  if (!cleaned) throw new Error(`${label} is required.`)
+  return cleaned
+}
+
+function templateStage(value: string | null): ContractSigningStage {
+  if (
+    value === "contract" ||
+    value === "construction" ||
+    value === "closeout" ||
+    value === "reference"
+  ) {
+    return value
+  }
+  throw new Error("Choose a supported signing stage.")
+}
+
+function inclusionMode(value: string | null): ContractInclusionMode {
+  if (value === "embedded" || value === "reference" || value === "generated") {
+    return value
+  }
+  throw new Error("Choose a supported inclusion mode.")
+}
+
+function stringArray(value: string): readonly string[] {
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === "string")
+      : []
+  } catch {
+    return []
+  }
+}
+
+async function sha256(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value)
+  )
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+async function templateManagementContext(): Promise<{
+  readonly db: ReturnType<typeof getDb>
+  readonly env: CloudflareEnv
+  readonly user: Awaited<ReturnType<typeof requireAuth>>
+  readonly organizationId: string
+}> {
+  const user = await requireAuth()
+  if (isDemoUser(user.id)) throw new Error("DEMO_READ_ONLY")
+  requirePermission(user, "budget", "update")
+  if (!isInternalStaffRole(user.role)) {
+    throw new Error("Contract template management is limited to internal staff.")
+  }
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  return { db: getDb(env.DB), env, user, organizationId }
+}
+
+export async function getContractTemplateLibrary(): Promise<
+  readonly ContractTemplateLibraryItem[]
+> {
+  const user = await requireAuth()
+  requirePermission(user, "budget", "read")
+  if (!isInternalStaffRole(user.role)) return []
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const templates = await db
+    .select()
+    .from(contractDocumentTemplates)
+    .where(
+      and(
+        eq(contractDocumentTemplates.organizationId, organizationId),
+        eq(contractDocumentTemplates.active, true)
+      )
+    )
+    .orderBy(
+      asc(contractDocumentTemplates.sortOrder),
+      asc(contractDocumentTemplates.code)
+    )
+  const ids = templates.map((template) => template.id)
+  const versions =
+    ids.length === 0
+      ? []
+      : await db
+          .select()
+          .from(contractDocumentTemplateVersions)
+          .where(inArray(contractDocumentTemplateVersions.templateId, ids))
+          .orderBy(
+            desc(contractDocumentTemplateVersions.versionNumber),
+            desc(contractDocumentTemplateVersions.updatedAt)
+          )
+  return templates.map((template) => {
+    const version = versions.find((candidate) => candidate.templateId === template.id)
+    return {
+      id: template.id,
+      code: template.code,
+      name: template.name,
+      category: template.category,
+      signingStage: template.signingStage,
+      defaultInclusionMode: template.defaultInclusionMode,
+      departmentCodes: stringArray(template.departmentCodesJson),
+      sourceUrl: template.sourceUrl,
+      sortOrder: template.sortOrder,
+      active: template.active,
+      version: version
+        ? {
+            id: version.id,
+            versionNumber: version.versionNumber,
+            status: version.status,
+            contentMarkdown: version.contentMarkdown,
+            sourceCapturedAt: version.sourceCapturedAt,
+            driveDocumentUrl: version.driveDocumentUrl,
+            changeNote: version.changeNote,
+          }
+        : null,
+    }
+  })
+}
+
+export async function importOrcContractTemplateLibrary(): Promise<
+  ContractTemplateActionResult
+> {
+  try {
+    const context = await templateManagementContext()
+    const auth = await context.db
+      .select({ key: googleAuth.serviceAccountKeyEncrypted })
+      .from(googleAuth)
+      .where(eq(googleAuth.organizationId, context.organizationId))
+      .get()
+    if (!auth) throw new Error("Connect Google Workspace before importing contracts.")
+    const config = getGoogleConfig(context.env)
+    const keyJson = await decrypt(
+      auth.key,
+      config.encryptionKey,
+      getGoogleCryptoSalt()
+    )
+    const sheets = new SheetsClient(parseServiceAccountKey(keyJson))
+    const userEmail = context.user.googleEmail ?? context.user.email
+    const metadata = await sheets.getSpreadsheetMetadata(
+      userEmail,
+      ORC_CONTRACT_SOURCE_WORKBOOK_ID
+    )
+    const visibleTitles = new Set(
+      metadata.sheets.filter((sheet) => !sheet.hidden).map((sheet) => sheet.title)
+    )
+    const ranges = contractSourceRanges()
+    const missing = ranges
+      .map((item) => item.sheetName)
+      .filter((sheetName) => !visibleTitles.has(sheetName))
+    if (missing.length > 0) {
+      throw new Error(`The contract source is missing: ${missing.join(", ")}.`)
+    }
+    const rangeRows = await Promise.all(
+      ranges.map(async (item) => ({
+        sheetName: item.sheetName,
+        rows: await sheets.getValues(userEmail, {
+          spreadsheetId: ORC_CONTRACT_SOURCE_WORKBOOK_ID,
+          range: item.range,
+          valueRenderOption: "FORMATTED_VALUE",
+        }),
+      }))
+    )
+    const rows: ContractSourceRows = Object.fromEntries(
+      rangeRows.map((item) => [item.sheetName, item.rows])
+    )
+    const drive = await getOrganizationDriveContext({
+      db: context.db,
+      environment: context.env,
+      organizationId: context.organizationId,
+      user: context.user,
+    })
+    const now = new Date().toISOString()
+    let created = 0
+    let refreshed = 0
+    let unchanged = 0
+    let lastId = "contract-library"
+
+    for (const definition of ORC_CONTRACT_SOURCE_DEFINITIONS) {
+      const contentMarkdown = normalizeContractSourceDocument({ definition, rows })
+      if (!contentMarkdown) {
+        throw new Error(`${definition.code} did not produce contract content.`)
+      }
+      const fingerprint = await sha256(contentMarkdown)
+      const existing = await context.db
+        .select()
+        .from(contractDocumentTemplates)
+        .where(
+          and(
+            eq(contractDocumentTemplates.organizationId, context.organizationId),
+            eq(contractDocumentTemplates.code, definition.code)
+          )
+        )
+        .get()
+      const templateId = existing?.id ?? crypto.randomUUID()
+      lastId = templateId
+      const versions = existing
+        ? await context.db
+            .select()
+            .from(contractDocumentTemplateVersions)
+            .where(eq(contractDocumentTemplateVersions.templateId, templateId))
+            .orderBy(desc(contractDocumentTemplateVersions.versionNumber))
+        : []
+      const latest = versions[0]
+      if (latest?.sourceFingerprint === fingerprint) {
+        unchanged += 1
+        continue
+      }
+      const versionNumber = (latest?.versionNumber ?? 0) + 1
+      const versionId = crypto.randomUUID()
+      const driveFile = await syncContractTemplateVersionToDrive({
+        client: drive.client,
+        userEmail: drive.userEmail,
+        currentFileId: null,
+        code: definition.code,
+        name: definition.name,
+        versionNumber,
+        contentMarkdown,
+      })
+      if (!existing) {
+        await context.db
+          .insert(contractDocumentTemplates)
+          .values({
+            id: templateId,
+            organizationId: context.organizationId,
+            code: definition.code,
+            name: definition.name,
+            category: definition.category,
+            signingStage: definition.signingStage,
+            defaultInclusionMode: definition.defaultInclusionMode,
+            departmentCodesJson: JSON.stringify(["O", "D", "H", "N"]),
+            sourceWorkbookId:
+              definition.sheetNames.length > 0
+                ? ORC_CONTRACT_SOURCE_WORKBOOK_ID
+                : null,
+            sourceSheetNamesJson: JSON.stringify(definition.sheetNames),
+            sourceUrl:
+              definition.code === "CA18"
+                ? WARRANTY_MANUAL_URL
+                : definition.code === "CA22"
+                  ? null
+                  : ORC_CONTRACT_SOURCE_URL,
+            sortOrder: definition.sortOrder,
+            active: true,
+            createdBy: context.user.id,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .run()
+        created += 1
+      } else {
+        await context.db
+          .update(contractDocumentTemplates)
+          .set({
+            name: definition.name,
+            category: definition.category,
+            signingStage: definition.signingStage,
+            defaultInclusionMode: definition.defaultInclusionMode,
+            sourceSheetNamesJson: JSON.stringify(definition.sheetNames),
+            sourceUrl:
+              definition.code === "CA18"
+                ? WARRANTY_MANUAL_URL
+                : definition.code === "CA22"
+                  ? null
+                  : ORC_CONTRACT_SOURCE_URL,
+            sortOrder: definition.sortOrder,
+            active: true,
+            updatedAt: now,
+          })
+          .where(eq(contractDocumentTemplates.id, templateId))
+          .run()
+        refreshed += 1
+      }
+      await context.db
+        .insert(contractDocumentTemplateVersions)
+        .values({
+          id: versionId,
+          templateId,
+          versionNumber,
+          status: existing ? "draft" : "published",
+          contentMarkdown,
+          sourceFingerprint: fingerprint,
+          sourceCapturedAt: now,
+          driveDocumentId: driveFile.fileId,
+          driveDocumentUrl: driveFile.fileUrl,
+          changeNote: existing
+            ? "Refreshed from the approved Google Sheets source."
+            : "Initial approved source import.",
+          createdBy: context.user.id,
+          publishedBy: existing ? null : context.user.id,
+          publishedAt: existing ? null : now,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run()
+    }
+
+    revalidatePath("/dashboard/templates")
+    revalidatePath("/dashboard/projects")
+    return {
+      success: true,
+      id: lastId,
+      message: `${created} created, ${refreshed} refreshed as drafts, ${unchanged} unchanged.`,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to import the contract library.",
+    }
+  }
+}
+
+export async function createContractTemplateDraft(input: {
+  readonly code: string | null
+  readonly name: string | null
+  readonly contentMarkdown: string | null
+}): Promise<ContractTemplateActionResult> {
+  try {
+    const context = await templateManagementContext()
+    const code = cleanText(input.code, "Document code").toUpperCase()
+    if (!/^[A-Z0-9][A-Z0-9-]{1,19}$/.test(code)) {
+      throw new Error("Document code must use 2–20 letters, numbers, or hyphens.")
+    }
+    const name = cleanText(input.name, "Document name")
+    const contentMarkdown = cleanText(input.contentMarkdown, "Document content")
+    const existing = await context.db
+      .select({ id: contractDocumentTemplates.id })
+      .from(contractDocumentTemplates)
+      .where(
+        and(
+          eq(contractDocumentTemplates.organizationId, context.organizationId),
+          eq(contractDocumentTemplates.code, code)
+        )
+      )
+      .get()
+    if (existing) throw new Error(`${code} already exists in the Contract Library.`)
+    const drive = await getOrganizationDriveContext({
+      db: context.db,
+      environment: context.env,
+      organizationId: context.organizationId,
+      user: context.user,
+    })
+    const driveFile = await syncContractTemplateVersionToDrive({
+      client: drive.client,
+      userEmail: drive.userEmail,
+      currentFileId: null,
+      code,
+      name,
+      versionNumber: 1,
+      contentMarkdown,
+    })
+    const templateId = crypto.randomUUID()
+    const versionId = crypto.randomUUID()
+    const now = new Date().toISOString()
+    await context.db.batch([
+      context.db.insert(contractDocumentTemplates).values({
+        id: templateId,
+        organizationId: context.organizationId,
+        code,
+        name,
+        category: "exhibit",
+        signingStage: "contract",
+        defaultInclusionMode: "embedded",
+        departmentCodesJson: JSON.stringify(["O", "D", "H", "N"]),
+        sortOrder: 1_000,
+        active: true,
+        createdBy: context.user.id,
+        createdAt: now,
+        updatedAt: now,
+      }),
+      context.db.insert(contractDocumentTemplateVersions).values({
+        id: versionId,
+        templateId,
+        versionNumber: 1,
+        status: "draft",
+        contentMarkdown,
+        driveDocumentId: driveFile.fileId,
+        driveDocumentUrl: driveFile.fileUrl,
+        changeNote: "New Compass contract document.",
+        createdBy: context.user.id,
+        createdAt: now,
+        updatedAt: now,
+      }),
+    ])
+    revalidatePath("/dashboard/templates")
+    return {
+      success: true,
+      id: templateId,
+      message: `${code} draft created. Review and publish it before project use.`,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unable to create contract document.",
+    }
+  }
+}
+
+export async function saveContractTemplateDraft(input: {
+  readonly templateId: string
+  readonly name: string | null
+  readonly category: string | null
+  readonly signingStage: string | null
+  readonly inclusionMode: string | null
+  readonly contentMarkdown: string | null
+  readonly changeNote: string | null
+}): Promise<ContractTemplateActionResult> {
+  try {
+    const context = await templateManagementContext()
+    const template = await context.db
+      .select()
+      .from(contractDocumentTemplates)
+      .where(
+        and(
+          eq(contractDocumentTemplates.id, input.templateId),
+          eq(contractDocumentTemplates.organizationId, context.organizationId),
+          eq(contractDocumentTemplates.active, true)
+        )
+      )
+      .get()
+    if (!template) throw new Error("Contract template not found.")
+    const versions = await context.db
+      .select()
+      .from(contractDocumentTemplateVersions)
+      .where(eq(contractDocumentTemplateVersions.templateId, template.id))
+      .orderBy(desc(contractDocumentTemplateVersions.versionNumber))
+    const latest = versions[0]
+    if (!latest) throw new Error("Contract template version not found.")
+    const name = cleanText(input.name, "Document name")
+    const category = cleanText(input.category, "Category")
+    const signingStage = templateStage(input.signingStage)
+    const defaultInclusionMode = inclusionMode(input.inclusionMode)
+    const contentMarkdown = cleanText(input.contentMarkdown, "Document content")
+    const now = new Date().toISOString()
+    const draftId = latest.status === "draft" ? latest.id : crypto.randomUUID()
+    const draftNumber =
+      latest.status === "draft" ? latest.versionNumber : latest.versionNumber + 1
+    const drive = await getOrganizationDriveContext({
+      db: context.db,
+      environment: context.env,
+      organizationId: context.organizationId,
+      user: context.user,
+    })
+    const driveFile = await syncContractTemplateVersionToDrive({
+      client: drive.client,
+      userEmail: drive.userEmail,
+      currentFileId: latest.status === "draft" ? latest.driveDocumentId : null,
+      code: template.code,
+      name,
+      versionNumber: draftNumber,
+      contentMarkdown,
+    })
+    await context.db
+      .update(contractDocumentTemplates)
+      .set({
+        name,
+        category,
+        signingStage,
+        defaultInclusionMode,
+        updatedAt: now,
+      })
+      .where(eq(contractDocumentTemplates.id, template.id))
+      .run()
+    if (latest.status === "draft") {
+      await context.db
+        .update(contractDocumentTemplateVersions)
+        .set({
+          contentMarkdown,
+          driveDocumentId: driveFile.fileId,
+          driveDocumentUrl: driveFile.fileUrl,
+          changeNote: input.changeNote?.trim() || null,
+          updatedAt: now,
+        })
+        .where(eq(contractDocumentTemplateVersions.id, draftId))
+        .run()
+    } else {
+      await context.db
+        .insert(contractDocumentTemplateVersions)
+        .values({
+          id: draftId,
+          templateId: template.id,
+          versionNumber: draftNumber,
+          status: "draft",
+          contentMarkdown,
+          sourceFingerprint: null,
+          sourceCapturedAt: null,
+          driveDocumentId: driveFile.fileId,
+          driveDocumentUrl: driveFile.fileUrl,
+          changeNote: input.changeNote?.trim() || null,
+          createdBy: context.user.id,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run()
+    }
+    revalidatePath("/dashboard/templates")
+    return { success: true, id: template.id, message: `Draft v${draftNumber} saved.` }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unable to save contract draft.",
+    }
+  }
+}
+
+export async function publishContractTemplateVersion(
+  templateId: string,
+  versionId: string
+): Promise<ContractTemplateActionResult> {
+  try {
+    const context = await templateManagementContext()
+    const rows = await context.db
+      .select({ version: contractDocumentTemplateVersions })
+      .from(contractDocumentTemplateVersions)
+      .innerJoin(
+        contractDocumentTemplates,
+        eq(contractDocumentTemplates.id, contractDocumentTemplateVersions.templateId)
+      )
+      .where(
+        and(
+          eq(contractDocumentTemplates.id, templateId),
+          eq(contractDocumentTemplates.organizationId, context.organizationId),
+          eq(contractDocumentTemplateVersions.id, versionId),
+          eq(contractDocumentTemplateVersions.status, "draft")
+        )
+      )
+      .limit(1)
+    const version = rows[0]?.version
+    if (!version) throw new Error("Choose an unpublished contract draft.")
+    const now = new Date().toISOString()
+    await context.db
+      .update(contractDocumentTemplateVersions)
+      .set({
+        status: "published",
+        publishedBy: context.user.id,
+        publishedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(contractDocumentTemplateVersions.id, version.id))
+      .run()
+    revalidatePath("/dashboard/templates")
+    revalidatePath("/dashboard/projects")
+    return {
+      success: true,
+      id: templateId,
+      message: `Version ${version.versionNumber} published.`,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unable to publish contract template.",
+    }
+  }
+}
+
+export async function archiveContractTemplate(
+  templateId: string
+): Promise<ContractTemplateActionResult> {
+  try {
+    const context = await templateManagementContext()
+    const template = await context.db
+      .select({ id: contractDocumentTemplates.id })
+      .from(contractDocumentTemplates)
+      .where(
+        and(
+          eq(contractDocumentTemplates.id, templateId),
+          eq(contractDocumentTemplates.organizationId, context.organizationId)
+        )
+      )
+      .get()
+    if (!template) throw new Error("Contract template not found.")
+    await context.db
+      .update(contractDocumentTemplates)
+      .set({ active: false, updatedAt: new Date().toISOString() })
+      .where(eq(contractDocumentTemplates.id, template.id))
+      .run()
+    revalidatePath("/dashboard/templates")
+    return {
+      success: true,
+      id: template.id,
+      message: "Contract template archived. Existing packets retain their snapshot.",
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unable to archive contract template.",
+    }
+  }
+}

--- a/src/app/api/integrations/foxit/webhook/route.ts
+++ b/src/app/api/integrations/foxit/webhook/route.ts
@@ -1,6 +1,7 @@
 import { and, eq, ne } from "drizzle-orm"
 
 import { getDb } from "@/db"
+import { contractPackets } from "@/db/schema-contracts"
 import { projectEstimates } from "@/db/schema-estimates"
 import { getCloudflareContext } from "@/lib/db"
 import { rebuildProjectContractBudget } from "@/lib/financials/contract-budget-store"
@@ -54,6 +55,136 @@ export async function POST(request: Request): Promise<Response> {
     return Response.json({ success: true, ignored: true })
   }
   const db = getDb(env.DB)
+  const packetRows = await db
+    .select()
+    .from(contractPackets)
+    .where(eq(contractPackets.foxitEnvelopeId, envelopeId))
+    .limit(1)
+  const packet = packetRows[0]
+  if (packet) {
+    const now = new Date().toISOString()
+    const linkedEstimate = await db
+      .select()
+      .from(projectEstimates)
+      .where(eq(projectEstimates.id, packet.estimateId))
+      .get()
+    if (!linkedEstimate) {
+      return Response.json(
+        { success: false, error: "Linked estimate not found." },
+        { status: 500 }
+      )
+    }
+    if (event === "folder_sent") {
+      if (packet.status === "draft" || packet.status === "internal_review") {
+        await db.batch([
+          db
+            .update(contractPackets)
+            .set({
+              status: "signature_pending",
+              foxitStatus: "sent",
+              signatureRequestedAt: now,
+              sourceHash: packet.preparedSourceHash,
+              foxitEmbeddedSessionUrl: null,
+              updatedAt: now,
+            })
+            .where(eq(contractPackets.id, packet.id)),
+          db
+            .update(projectEstimates)
+            .set({
+              status: "signature_pending",
+              foxitStatus: "included_in_contract_packet",
+              signatureRequestedAt: now,
+              updatedAt: now,
+            })
+            .where(eq(projectEstimates.id, linkedEstimate.id)),
+        ])
+      }
+      return Response.json({ success: true })
+    }
+
+    if (event === "folder_cancelled" || event === "folder_declined") {
+      await db
+        .update(contractPackets)
+        .set({ foxitStatus: event.replace("folder_", ""), updatedAt: now })
+        .where(eq(contractPackets.id, packet.id))
+        .run()
+      return Response.json({ success: true })
+    }
+
+    if (
+      event !== "folder_executed" ||
+      (packet.status !== "signature_pending" && packet.status !== "executed")
+    ) {
+      return Response.json({ success: true, ignored: true })
+    }
+
+    if (packet.status === "signature_pending") {
+      const signedUrl = `/api/integrations/foxit/envelopes/${encodeURIComponent(envelopeId)}/document`
+      await db.batch([
+        db
+          .update(contractPackets)
+          .set({ status: "superseded", updatedAt: now })
+          .where(
+            and(
+              eq(contractPackets.projectId, packet.projectId),
+              eq(contractPackets.status, "executed"),
+              ne(contractPackets.id, packet.id)
+            )
+          ),
+        db
+          .update(projectEstimates)
+          .set({ status: "superseded", updatedAt: now })
+          .where(
+            and(
+              eq(projectEstimates.projectId, linkedEstimate.projectId),
+              eq(projectEstimates.status, "accepted"),
+              ne(projectEstimates.id, linkedEstimate.id)
+            )
+          ),
+        db
+          .update(contractPackets)
+          .set({
+            status: "executed",
+            foxitStatus: "completed",
+            signaturePackageUrl: signedUrl,
+            signedAt: now,
+            acceptanceMethod: "foxit",
+            acceptanceEvidenceLabel: "Completed Foxit contract packet",
+            acceptanceRecordedByName: "Foxit eSign",
+            acceptedAt: now,
+            acceptedBy: packet.createdBy,
+            updatedAt: now,
+          })
+          .where(eq(contractPackets.id, packet.id)),
+        db
+          .update(projectEstimates)
+          .set({
+            status: "accepted",
+            foxitStatus: "completed_in_contract_packet",
+            signaturePackageUrl: signedUrl,
+            signedAt: now,
+            acceptanceMethod: "foxit_contract_packet",
+            acceptanceEvidenceLabel: "Completed Foxit contract packet",
+            acceptanceRecordedByName: "Foxit eSign",
+            acceptedAt: now,
+            acceptedBy: packet.createdBy,
+            sageStatus: "ready",
+            updatedAt: now,
+          })
+          .where(eq(projectEstimates.id, linkedEstimate.id)),
+      ])
+    }
+    const budget = await rebuildProjectContractBudget({
+      db,
+      projectId: packet.projectId,
+      actorUserId: packet.createdBy,
+    })
+    if (!budget.success) {
+      return Response.json({ success: false, error: budget.error }, { status: 500 })
+    }
+    return Response.json({ success: true })
+  }
+
   const rows = await db
     .select()
     .from(projectEstimates)

--- a/src/app/api/projects/[id]/contract-packets/[packetId]/pdf/route.ts
+++ b/src/app/api/projects/[id]/contract-packets/[packetId]/pdf/route.ts
@@ -1,0 +1,90 @@
+import { getProjectContractPacketWorkspace } from "@/app/actions/contract-packets"
+import { base64PdfBytes, prepareContractPacketPdf } from "@/lib/contracts/packet-pdf"
+import { getCloudflareContext } from "@/lib/db"
+
+async function renderEstimatePdf(input: {
+  readonly env: CloudflareEnv
+  readonly origin: string
+  readonly cookie: string
+  readonly projectId: string
+  readonly estimateId: string
+}): Promise<ArrayBuffer> {
+  const quickAction = Reflect.get(input.env.BROWSER, "quickAction")
+  if (typeof quickAction !== "function") {
+    throw new Error("Cloudflare Browser Run is not available for contract PDFs.")
+  }
+  const url = new URL(`/print/projects/${input.projectId}/estimate`, input.origin)
+  url.searchParams.set("estimateId", input.estimateId)
+  const rendered: unknown = await Reflect.apply(quickAction, input.env.BROWSER, [
+    "pdf",
+    {
+      url: url.toString(),
+      setExtraHTTPHeaders: { Cookie: input.cookie },
+      gotoOptions: { waitUntil: "networkidle2", timeout: 60_000 },
+      waitForSelector: { selector: ".estimate-signature-page", timeout: 60_000 },
+      pdfOptions: {
+        format: "letter",
+        printBackground: true,
+        preferCSSPageSize: true,
+        margin: { top: "0", right: "0", bottom: "0", left: "0" },
+      },
+    },
+  ])
+  if (!(rendered instanceof Response) || !rendered.ok) {
+    throw new Error("Unable to render the selected CA22 estimate.")
+  }
+  return rendered.arrayBuffer()
+}
+
+export async function GET(
+  request: Request,
+  context: { readonly params: Promise<{ id: string; packetId: string }> }
+): Promise<Response> {
+  try {
+    const { id, packetId } = await context.params
+    const workspace = await getProjectContractPacketWorkspace(id, packetId)
+    const packet = workspace.activePacket
+    if (!packet || packet.id !== packetId) {
+      return Response.json({ success: false, error: "Contract packet not found." }, { status: 404 })
+    }
+    const estimate = workspace.estimateOptions.find((item) => item.id === packet.estimateId)
+    if (!estimate) {
+      return Response.json({ success: false, error: "Linked estimate not found." }, { status: 404 })
+    }
+    const { env } = await getCloudflareContext()
+    const estimatePdf = await renderEstimatePdf({
+      env,
+      origin: new URL(request.url).origin,
+      cookie: request.headers.get("cookie") ?? "",
+      projectId: id,
+      estimateId: estimate.id,
+    })
+    const prepared = await prepareContractPacketPdf({
+      packet,
+      documents: workspace.documents,
+      estimate,
+      projectName: workspace.projectName,
+      projectNumber: workspace.projectNumber,
+      projectAddress: workspace.projectAddress,
+      estimatePdf,
+    })
+    const bytes = base64PdfBytes(prepared.pdfBase64)
+    const body = new Uint8Array(bytes.byteLength)
+    body.set(bytes)
+    return new Response(body.buffer, {
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `inline; filename="${packet.packetNumber}-contract-v${packet.versionNumber}.pdf"`,
+        "Cache-Control": "private, no-store",
+      },
+    })
+  } catch (error) {
+    return Response.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unable to create contract packet PDF.",
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/dashboard/projects/[id]/contracts/page.tsx
+++ b/src/app/dashboard/projects/[id]/contracts/page.tsx
@@ -1,0 +1,39 @@
+export const dynamic = "force-dynamic"
+
+import Link from "next/link"
+import { IconArrowLeft, IconFileDescription } from "@tabler/icons-react"
+
+import { getProjectContractPacketWorkspace } from "@/app/actions/contract-packets"
+import { ProjectContextSwitcher } from "@/components/projects/project-context-switcher"
+import { ProjectContractPacketWorkspacePanel } from "@/components/projects/project-contract-packet-workspace"
+
+export default async function ProjectContractsPage({
+  params,
+  searchParams,
+}: {
+  readonly params: Promise<{ id: string }>
+  readonly searchParams: Promise<{ packetId?: string }>
+}): Promise<React.ReactElement> {
+  const [{ id }, query] = await Promise.all([params, searchParams])
+  const workspace = await getProjectContractPacketWorkspace(id, query.packetId)
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto p-4 md:p-6">
+      <div className="mb-5 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <Link href={`/dashboard/projects/${id}/estimate`} className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground">
+            <IconArrowLeft className="size-4" />Estimate
+          </Link>
+          <div className="mt-3 flex items-center gap-2">
+            <IconFileDescription className="size-5 text-primary" />
+            <h1 className="text-2xl font-semibold tracking-tight">Contract packet</h1>
+          </div>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            Assemble versioned contract documents, the exact CA22 estimate, required signers, and later-stage closeout forms.
+          </p>
+        </div>
+        <ProjectContextSwitcher currentProjectId={id} targetSection="contracts" placeholder="Switch contract project..." className="w-full sm:w-[280px]" />
+      </div>
+      <ProjectContractPacketWorkspacePanel projectId={id} workspace={workspace} />
+    </div>
+  )
+}

--- a/src/app/dashboard/templates/page.tsx
+++ b/src/app/dashboard/templates/page.tsx
@@ -4,6 +4,7 @@ import { TemplateLibraryView } from "@/components/templates/template-library-vie
 import { getCurrentUser } from "@/lib/auth"
 import { can } from "@/lib/permissions"
 import { isInternalStaffRole } from "@/lib/user-roles"
+import { getContractTemplateLibrary } from "@/app/actions/contract-templates"
 
 export const dynamic = "force-dynamic"
 
@@ -12,9 +13,10 @@ export default async function TemplateLibraryPage() {
   const canViewEstimateText =
     Boolean(user && isInternalStaffRole(user.role)) &&
     can(user, "budget", "read")
-  const [templates, estimateTextTemplates] = await Promise.all([
+  const [templates, estimateTextTemplates, contractTemplates] = await Promise.all([
     getProjectTemplateLibrary(),
     canViewEstimateText ? getEstimateTextTemplateLibrary() : Promise.resolve([]),
+    canViewEstimateText ? getContractTemplateLibrary() : Promise.resolve([]),
   ])
   const canManage =
     Boolean(user && isInternalStaffRole(user.role)) &&
@@ -29,6 +31,7 @@ export default async function TemplateLibraryPage() {
       canManage={canManage}
       canCreateEstimate={canCreateEstimate}
       canManageEstimateText={canCreateEstimate}
+      contractTemplates={contractTemplates}
     />
   )
 }

--- a/src/components/projects/project-contract-packet-workspace.tsx
+++ b/src/components/projects/project-contract-packet-workspace.tsx
@@ -1,0 +1,686 @@
+"use client"
+
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useMemo, useState, useTransition, type FormEvent } from "react"
+import {
+  IconCopy,
+  IconFileDescription,
+  IconPlus,
+  IconPrinter,
+  IconTrash,
+} from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import {
+  addProjectContractPacketDocument,
+  createProjectContractPacket,
+  deleteProjectContractPacket,
+  deleteProjectContractPacketDocument,
+  duplicateProjectContractPacket,
+  markProjectContractPacketSentOutsideCompass,
+  prepareProjectContractPacketForSignature,
+  recordManualProjectContractPacketExecution,
+  saveProjectContractPacket,
+  saveProjectContractPacketDocument,
+  type ProjectContractPacketDocumentItem,
+  type ProjectContractPacketWorkspace,
+} from "@/app/actions/contract-packets"
+import { uploadEstimateAcceptanceEvidence } from "@/components/projects/project-estimate-acceptance-upload"
+import { ProjectEstimateSignerPicker } from "@/components/projects/project-estimate-signer-picker"
+import { SearchableCombobox } from "@/components/searchable-combobox"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { contractPacketCanBeEdited, signerInitials, type ContractPacketSigner } from "@/lib/contracts/packet"
+
+function money(cents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(cents / 100)
+}
+
+function statusLabel(value: string): string {
+  return value.replaceAll("_", " ")
+}
+
+function localDateInput(): string {
+  const now = new Date()
+  const local = new Date(now.valueOf() - now.getTimezoneOffset() * 60_000)
+  return local.toISOString().slice(0, 10)
+}
+
+function ContractDocumentEditor({
+  projectId,
+  packetId,
+  document,
+  editable,
+}: {
+  readonly projectId: string
+  readonly packetId: string
+  readonly document: ProjectContractPacketDocumentItem
+  readonly editable: boolean
+}): React.ReactElement {
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+  const [title, setTitle] = useState(document.title)
+  const [content, setContent] = useState(document.contentMarkdown)
+  const [inclusionMode, setInclusionMode] = useState(document.inclusionMode)
+  const [signingStage, setSigningStage] = useState(document.signingStage)
+  const [documentDate, setDocumentDate] = useState(document.documentDate ?? "")
+  const [revision, setRevision] = useState(document.revision ?? "")
+
+  function save(): void {
+    startTransition(async () => {
+      const result = await saveProjectContractPacketDocument(
+        projectId,
+        packetId,
+        document.id,
+        {
+          title,
+          contentMarkdown: content,
+          inclusionMode,
+          signingStage,
+          documentDate,
+          revision,
+        }
+      )
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(result.message)
+      router.refresh()
+    })
+  }
+
+  function remove(): void {
+    startTransition(async () => {
+      const result = await deleteProjectContractPacketDocument(
+        projectId,
+        packetId,
+        document.id
+      )
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(result.message)
+      router.refresh()
+    })
+  }
+
+  return (
+    <article className="border-b py-4 last:border-b-0">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-semibold">{document.code}</span>
+            <span>{document.title}</span>
+            <Badge variant="outline">{statusLabel(document.inclusionMode)}</Badge>
+            <Badge variant="secondary">{statusLabel(document.signingStage)}</Badge>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {document.revision ?? "Packet snapshot"}
+            {document.signingStage === "closeout"
+              ? " · retained for the final walk-through, not the initial signing envelope"
+              : ""}
+          </p>
+        </div>
+        {document.sourceUrl && (
+          <Button asChild size="sm" variant="outline">
+            <Link href={document.sourceUrl} target="_blank">Source</Link>
+          </Button>
+        )}
+      </div>
+      <details className="mt-3">
+        <summary className="cursor-pointer text-sm font-medium">
+          Review packet copy
+        </summary>
+        <div className="mt-4 grid gap-4 border-t pt-4 md:grid-cols-2 xl:grid-cols-4">
+          <div className="space-y-1.5 md:col-span-2">
+            <Label htmlFor={`packet-document-title-${document.id}`}>Document title *</Label>
+            <Input
+              id={`packet-document-title-${document.id}`}
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              disabled={!editable}
+              required
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Packet treatment *</Label>
+            <Select value={inclusionMode} onValueChange={setInclusionMode} disabled={!editable}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="embedded">Include in packet</SelectItem>
+                <SelectItem value="reference">Reference only</SelectItem>
+                <SelectItem value="generated">Generate from Compass</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <Label>Lifecycle stage *</Label>
+            <Select value={signingStage} onValueChange={setSigningStage} disabled={!editable}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="contract">Initial contract execution</SelectItem>
+                <SelectItem value="construction">During construction</SelectItem>
+                <SelectItem value="closeout">Closeout / walk-through</SelectItem>
+                <SelectItem value="reference">Reference only</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor={`packet-document-date-${document.id}`}>Document date</Label>
+            <Input
+              id={`packet-document-date-${document.id}`}
+              type="date"
+              value={documentDate}
+              onChange={(event) => setDocumentDate(event.target.value)}
+              disabled={!editable}
+            />
+          </div>
+          <div className="space-y-1.5 md:col-span-2 xl:col-span-3">
+            <Label htmlFor={`packet-document-revision-${document.id}`}>Revision</Label>
+            <Input
+              id={`packet-document-revision-${document.id}`}
+              value={revision}
+              onChange={(event) => setRevision(event.target.value)}
+              disabled={!editable}
+            />
+          </div>
+          {inclusionMode !== "generated" && (
+            <div className="space-y-1.5 md:col-span-2 xl:col-span-4">
+              <Label htmlFor={`packet-document-content-${document.id}`}>Packet-specific document text *</Label>
+              <Textarea
+                id={`packet-document-content-${document.id}`}
+                rows={16}
+                value={content}
+                onChange={(event) => setContent(event.target.value)}
+                disabled={!editable || inclusionMode === "reference"}
+                className="font-mono text-xs"
+              />
+              <p className="text-xs text-muted-foreground">
+                This is a project snapshot. Editing it does not change the published library template.
+              </p>
+            </div>
+          )}
+        </div>
+        {editable && (
+          <div className="mt-4 flex justify-end gap-2 border-t pt-4">
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="ghost" className="text-destructive" disabled={pending}>
+                  <IconTrash className="size-4" />Remove
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Remove {document.code}?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    It will be omitted from this packet and from CA00&apos;s generated document schedule. The published library copy is unchanged.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={remove}>Remove document</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+            <Button onClick={save} disabled={pending}>Save document snapshot</Button>
+          </div>
+        )}
+      </details>
+    </article>
+  )
+}
+
+export function ProjectContractPacketWorkspacePanel({
+  projectId,
+  workspace,
+}: {
+  readonly projectId: string
+  readonly workspace: ProjectContractPacketWorkspace
+}): React.ReactElement {
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+  const [estimateId, setEstimateId] = useState(workspace.estimateOptions[0]?.id ?? "")
+  const packet = workspace.activePacket
+  const editable = Boolean(packet && workspace.canEdit && contractPacketCanBeEdited(packet.status))
+  const [title, setTitle] = useState(packet?.title ?? "Construction Contract")
+  const [legalEntityName, setLegalEntityName] = useState(packet?.legalEntityName ?? "")
+  const [contractDraftDate, setContractDraftDate] = useState(packet?.contractDraftDate ?? "")
+  const [commencementDate, setCommencementDate] = useState(packet?.approximateCommencementDate ?? "")
+  const [completionDate, setCompletionDate] = useState(packet?.approximateCompletionDate ?? "")
+  const [deposit, setDeposit] = useState(packet ? String(packet.depositCents / 100) : "0")
+  const [latePaymentRate, setLatePaymentRate] = useState(packet ? String(packet.latePaymentRateBasisPoints / 100) : "12")
+  const [projectAddress, setProjectAddress] = useState(packet?.details.projectAddress ?? workspace.projectAddress ?? "")
+  const [county, setCounty] = useState(packet?.details.county ?? "")
+  const [ownerName, setOwnerName] = useState(packet?.details.ownerName ?? "")
+  const [clientSigners, setClientSigners] = useState<readonly ContractPacketSigner[]>(packet?.clientSigners ?? [])
+  const [companySigner, setCompanySigner] = useState<ContractPacketSigner>({
+    contactId: null,
+    name: packet?.companySignerName ?? "",
+    title: packet?.companySignerTitle ?? "",
+    email: packet?.companySignerEmail ?? "",
+    initials: packet?.companySignerInitials ?? "",
+  })
+  const missingTemplates = useMemo(
+    () => workspace.templateOptions.filter(
+      (template) => !workspace.documents.some((document) => document.templateId === template.id)
+    ),
+    [workspace.documents, workspace.templateOptions]
+  )
+  const [templateId, setTemplateId] = useState(missingTemplates[0]?.id ?? "")
+  const [evidenceUrl, setEvidenceUrl] = useState("")
+  const [evidenceLabel, setEvidenceLabel] = useState("")
+  const [signedAt, setSignedAt] = useState(localDateInput())
+  const [attested, setAttested] = useState(false)
+
+  function create(): void {
+    if (!estimateId) return
+    startTransition(async () => {
+      const result = await createProjectContractPacket(projectId, estimateId)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(result.message)
+      router.push(`/dashboard/projects/${projectId}/contracts?packetId=${result.id}`)
+      router.refresh()
+    })
+  }
+
+  function save(): void {
+    if (!packet) return
+    startTransition(async () => {
+      const result = await saveProjectContractPacket(projectId, packet.id, {
+        title,
+        legalEntityName,
+        contractDraftDate,
+        approximateCommencementDate: commencementDate,
+        approximateCompletionDate: completionDate,
+        depositDollars: Number(deposit),
+        latePaymentPercent: Number(latePaymentRate),
+        details: {
+          ...packet.details,
+          projectName: workspace.projectName,
+          projectNumber: workspace.projectNumber ?? "",
+          projectAddress,
+          ownerName,
+          county,
+        },
+        clientSigners,
+        companySignerName: companySigner.name,
+        companySignerTitle: companySigner.title,
+        companySignerEmail: companySigner.email,
+        companySignerInitials: companySigner.initials || signerInitials(companySigner.name),
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(result.message)
+      router.refresh()
+    })
+  }
+
+  function addSigner(): void {
+    setClientSigners([
+      ...clientSigners,
+      { contactId: null, name: "", title: "", email: "", initials: "" },
+    ])
+  }
+
+  function updateSigner(index: number, value: ContractPacketSigner): void {
+    setClientSigners(clientSigners.map((signer, signerIndex) =>
+      signerIndex === index ? value : signer
+    ))
+  }
+
+  function duplicate(): void {
+    if (!packet) return
+    startTransition(async () => {
+      const result = await duplicateProjectContractPacket(projectId, packet.id)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(result.message)
+      router.push(`/dashboard/projects/${projectId}/contracts?packetId=${result.id}`)
+      router.refresh()
+    })
+  }
+
+  function addDocument(): void {
+    if (!packet || !templateId) return
+    startTransition(async () => {
+      const result = await addProjectContractPacketDocument(projectId, packet.id, templateId)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(result.message)
+      router.refresh()
+    })
+  }
+
+  function deletePacket(): void {
+    if (!packet) return
+    startTransition(async () => {
+      const result = await deleteProjectContractPacket(projectId, packet.id)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(result.message)
+      router.push(`/dashboard/projects/${projectId}/contracts`)
+      router.refresh()
+    })
+  }
+
+  function prepareForSignature(): void {
+    if (!packet) return
+    const foxitWindow = window.open("about:blank", "_blank")
+    if (foxitWindow) {
+      foxitWindow.opener = null
+      foxitWindow.document.title = "Preparing Foxit contract packet"
+      foxitWindow.document.body.textContent =
+        "Compass is assembling the numbered contract packet and Foxit fields..."
+    }
+    startTransition(async () => {
+      const result = await prepareProjectContractPacketForSignature(
+        projectId,
+        packet.id
+      )
+      if (!result.success) {
+        foxitWindow?.close()
+        toast.error(result.error)
+        return
+      }
+      if (foxitWindow) {
+        foxitWindow.location.replace(result.embeddedSessionUrl)
+      } else {
+        window.open(result.embeddedSessionUrl, "_blank", "noopener,noreferrer")
+      }
+      router.refresh()
+    })
+  }
+
+  function markOutside(): void {
+    if (!packet) return
+    startTransition(async () => {
+      const result = await markProjectContractPacketSentOutsideCompass(
+        projectId,
+        packet.id
+      )
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(result.message)
+      router.refresh()
+    })
+  }
+
+  async function uploadEvidence(file: File): Promise<void> {
+    try {
+      const uploaded = await uploadEstimateAcceptanceEvidence(file, projectId)
+      setEvidenceUrl(uploaded.url)
+      setEvidenceLabel(uploaded.label)
+      toast.success("Signed packet uploaded to the project Drive folder.")
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Unable to upload signed packet.")
+    }
+  }
+
+  function recordManualExecution(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    if (!packet) return
+    startTransition(async () => {
+      const result = await recordManualProjectContractPacketExecution(
+        projectId,
+        packet.id,
+        { signedAt, evidenceUrl, evidenceLabel, attested }
+      )
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(result.message)
+      router.refresh()
+    })
+  }
+
+  if (!packet) {
+    return (
+      <section className="clarity-panel-strong p-5">
+        <h2 className="font-semibold">Create a full construction contract packet</h2>
+        <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+          Choose the exact estimate that will become CA22. Compass will copy the current published contract documents into an independent, editable project packet.
+        </p>
+        <div className="mt-4 flex max-w-3xl flex-col gap-3 sm:flex-row">
+          <SearchableCombobox
+            ariaLabel="Choose estimate for contract"
+            placeholder="Choose an estimate"
+            searchPlaceholder="Search estimate versions..."
+            value={estimateId}
+            onValueChange={setEstimateId}
+            options={workspace.estimateOptions.map((estimate) => ({
+              value: estimate.id,
+              label: `${estimate.estimateNumber} · v${estimate.versionNumber} · ${estimate.title}`,
+              description: `${statusLabel(estimate.status)} · ${money(estimate.estimateTotalCents)}`,
+            }))}
+          />
+          <Button onClick={create} disabled={pending || !estimateId || !workspace.canEdit}>
+            <IconPlus className="size-4" />Create contract packet
+          </Button>
+        </div>
+        {workspace.templateOptions.length === 0 && (
+          <p className="mt-4 text-sm text-destructive">
+            The Contract Library has not been imported and published yet. Open Templates in Settings first.
+          </p>
+        )}
+      </section>
+    )
+  }
+
+  return (
+    <div className="space-y-5">
+      <section className="clarity-panel-strong p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <IconFileDescription className="size-5 text-primary" />
+              <h2 className="font-semibold">{packet.packetNumber} · contract packet v{packet.versionNumber}</h2>
+              <Badge variant="outline">{statusLabel(packet.status)}</Badge>
+              <Badge variant="secondary">Foxit {statusLabel(packet.foxitStatus)}</Badge>
+            </div>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Linked to estimate version {workspace.estimateOptions.find((estimate) => estimate.id === packet.estimateId)?.versionNumber ?? "—"}. Sent packets are frozen; duplicate one to revise it.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Select
+              value={packet.id}
+              onValueChange={(value) => router.push(`/dashboard/projects/${projectId}/contracts?packetId=${value}`)}
+            >
+              <SelectTrigger className="w-[220px]"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {workspace.packets.map((item) => (
+                  <SelectItem key={item.id} value={item.id}>
+                    {item.packetNumber} · v{item.versionNumber} · {statusLabel(item.status)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button variant="outline" onClick={duplicate} disabled={pending || !workspace.canEdit}>
+              <IconCopy className="size-4" />Duplicate version
+            </Button>
+            <Button variant="outline" asChild>
+              <Link href={`/api/projects/${projectId}/contract-packets/${packet.id}/pdf`} target="_blank">
+                <IconPrinter className="size-4" />Preview PDF
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <section className="clarity-panel-strong p-4">
+        <h2 className="font-semibold">Contract information</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Asterisks identify information required before the initial contract can be sent for signature.
+        </p>
+        <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <div className="space-y-1.5 md:col-span-2"><Label htmlFor="contract-title">Packet title *</Label><Input id="contract-title" value={title} onChange={(event) => setTitle(event.target.value)} disabled={!editable} /></div>
+          <div className="space-y-1.5 md:col-span-2"><Label htmlFor="contract-entity">Contractor legal entity *</Label><Input id="contract-entity" value={legalEntityName} onChange={(event) => setLegalEntityName(event.target.value)} disabled={!editable} /></div>
+          <div className="space-y-1.5"><Label htmlFor="contract-date">Contract date *</Label><Input id="contract-date" type="date" value={contractDraftDate} onChange={(event) => setContractDraftDate(event.target.value)} disabled={!editable} /></div>
+          <div className="space-y-1.5"><Label htmlFor="contract-start">Approximate commencement *</Label><Input id="contract-start" type="date" value={commencementDate} onChange={(event) => setCommencementDate(event.target.value)} disabled={!editable} /></div>
+          <div className="space-y-1.5"><Label htmlFor="contract-completion">Approximate completion *</Label><Input id="contract-completion" type="date" value={completionDate} onChange={(event) => setCompletionDate(event.target.value)} disabled={!editable} /></div>
+          <div className="space-y-1.5"><Label htmlFor="contract-county">Project county *</Label><Input id="contract-county" value={county} onChange={(event) => setCounty(event.target.value)} disabled={!editable} /></div>
+          <div className="space-y-1.5 md:col-span-2"><Label htmlFor="contract-address">Project location *</Label><Input id="contract-address" value={projectAddress} onChange={(event) => setProjectAddress(event.target.value)} disabled={!editable} /></div>
+          <div className="space-y-1.5 md:col-span-2"><Label htmlFor="contract-owner">Owner / client name *</Label><Input id="contract-owner" value={ownerName} onChange={(event) => setOwnerName(event.target.value)} disabled={!editable} /></div>
+          <div className="space-y-1.5"><Label htmlFor="contract-deposit">Deposit</Label><Input id="contract-deposit" type="number" min="0" step="0.01" value={deposit} onChange={(event) => setDeposit(event.target.value)} disabled={!editable} /></div>
+          <div className="space-y-1.5"><Label htmlFor="contract-late-rate">Late-payment annual rate (%)</Label><Input id="contract-late-rate" type="number" min="0" step="0.01" value={latePaymentRate} onChange={(event) => setLatePaymentRate(event.target.value)} disabled={!editable} /></div>
+        </div>
+      </section>
+
+      <section className="clarity-panel-strong p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div><h2 className="font-semibold">Required signers</h2><p className="mt-1 text-sm text-muted-foreground">Every signer receives Foxit signature, date-signed, and page-initial fields.</p></div>
+          {editable && <Button variant="outline" size="sm" onClick={addSigner}><IconPlus className="size-4" />Add owner signer</Button>}
+        </div>
+        <div className="mt-4 space-y-4">
+          {clientSigners.map((signer, index) => (
+            <div key={`${index}-${signer.contactId ?? "typed"}`} className="grid gap-3 border-b pb-4 md:grid-cols-2 xl:grid-cols-5">
+              <div className="space-y-1.5 xl:col-span-2">
+                <Label>Owner signer {index + 1} *</Label>
+                <ProjectEstimateSignerPicker
+                  value={signer}
+                  options={workspace.signerContacts}
+                  onValueChange={(value) => updateSigner(index, { ...value, initials: signer.initials || signerInitials(value.name) })}
+                  placeholder="Choose or type signer"
+                  disabled={!editable}
+                />
+              </div>
+              <div className="space-y-1.5"><Label>Email *</Label><Input type="email" value={signer.email} onChange={(event) => updateSigner(index, { ...signer, email: event.target.value })} disabled={!editable} /></div>
+              <div className="space-y-1.5"><Label>Title</Label><Input value={signer.title} onChange={(event) => updateSigner(index, { ...signer, title: event.target.value })} disabled={!editable} /></div>
+              <div className="flex items-end gap-2"><div className="flex-1 space-y-1.5"><Label>Initials *</Label><Input value={signer.initials} maxLength={6} onChange={(event) => updateSigner(index, { ...signer, initials: event.target.value.toUpperCase() })} disabled={!editable} /></div>{editable && <Button variant="ghost" size="icon" className="text-destructive" aria-label={`Remove owner signer ${index + 1}`} onClick={() => setClientSigners(clientSigners.filter((_, signerIndex) => signerIndex !== index))}><IconTrash className="size-4" /></Button>}</div>
+            </div>
+          ))}
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+            <div className="space-y-1.5 xl:col-span-2"><Label>Company representative *</Label><ProjectEstimateSignerPicker value={companySigner} options={workspace.signerContacts} onValueChange={(value) => setCompanySigner({ ...value, initials: companySigner.initials || signerInitials(value.name) })} placeholder="Choose or type company signer" disabled={!editable} /></div>
+            <div className="space-y-1.5"><Label>Email *</Label><Input type="email" value={companySigner.email} onChange={(event) => setCompanySigner({ ...companySigner, email: event.target.value })} disabled={!editable} /></div>
+            <div className="space-y-1.5"><Label>Title *</Label><Input value={companySigner.title} onChange={(event) => setCompanySigner({ ...companySigner, title: event.target.value })} disabled={!editable} /></div>
+            <div className="space-y-1.5"><Label>Initials *</Label><Input value={companySigner.initials} maxLength={6} onChange={(event) => setCompanySigner({ ...companySigner, initials: event.target.value.toUpperCase() })} disabled={!editable} /></div>
+          </div>
+        </div>
+        {editable && <div className="mt-4 flex justify-end border-t pt-4"><Button onClick={save} disabled={pending}>Save contract information</Button></div>}
+      </section>
+
+      <section className="clarity-panel-strong p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div><h2 className="font-semibold">Contract documents</h2><p className="mt-1 text-sm text-muted-foreground">CA00&apos;s document list is generated from these exact packet snapshots. The Warranty Handbook remains a separate reference.</p></div>
+          {editable && missingTemplates.length > 0 && (
+            <div className="flex min-w-[320px] gap-2">
+              <SearchableCombobox ariaLabel="Add contract document" placeholder="Choose document" value={templateId} onValueChange={setTemplateId} options={missingTemplates.map((template) => ({ value: template.id, label: `${template.code} · ${template.name}`, description: `${statusLabel(template.signingStage)} · template v${template.versionNumber}` }))} />
+              <Button variant="outline" onClick={addDocument} disabled={pending || !templateId}><IconPlus className="size-4" />Add</Button>
+            </div>
+          )}
+        </div>
+        <div className="mt-3">
+          {workspace.documents.map((document) => <ContractDocumentEditor key={document.id} projectId={projectId} packetId={packet.id} document={document} editable={editable} />)}
+        </div>
+      </section>
+
+      <section className="clarity-panel-strong p-4">
+        <h2 className="font-semibold">Prepare and execute</h2>
+        <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+          Review the combined PDF first. Preparing opens Foxit for final field review; sending freezes this version. It locks as executed only after all signers finish, or when a complete manually signed copy is recorded.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-2">
+          <Button onClick={prepareForSignature} disabled={pending || !editable}>Prepare full contract packet for signature</Button>
+          <Button variant="outline" onClick={markOutside} disabled={pending || !editable}>Printed / sent for signatures outside Compass</Button>
+          {packet.foxitEmbeddedSessionUrl && <Button variant="outline" asChild><Link href={packet.foxitEmbeddedSessionUrl} target="_blank">Review and send in Foxit</Link></Button>}
+          {packet.signaturePackageUrl && <Button variant="outline" asChild><Link href={packet.signaturePackageUrl} target="_blank">Open signed packet</Link></Button>}
+        </div>
+        {packet.status === "signature_pending" && workspace.canEdit && (
+          <form className="mt-5 space-y-4 border-t pt-4" onSubmit={recordManualExecution}>
+            <div>
+              <h3 className="text-sm font-semibold">Complete a manually signed packet</h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Upload the complete scanned packet to the project&apos;s Google Drive folder or paste its saved HTTPS link. Recording it executes and locks both the packet and its linked estimate.
+              </p>
+            </div>
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="packet-signed-date">Contract execution date *</Label>
+                <Input id="packet-signed-date" type="date" max={localDateInput()} value={signedAt} onChange={(event) => setSignedAt(event.target.value)} required />
+              </div>
+              <div className="space-y-1.5 md:col-span-2">
+                <Label htmlFor="packet-evidence-url">Saved signed packet link *</Label>
+                <Input id="packet-evidence-url" type="url" value={evidenceUrl} onChange={(event) => setEvidenceUrl(event.target.value)} placeholder="https://drive.google.com/..." required />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="packet-evidence-label">Document label *</Label>
+                <Input id="packet-evidence-label" value={evidenceLabel} onChange={(event) => setEvidenceLabel(event.target.value)} placeholder="Executed contract.pdf" required />
+              </div>
+              <div className="space-y-1.5 md:col-span-2">
+                <Label htmlFor="packet-evidence-file">Or upload the complete signed packet</Label>
+                <Input
+                  id="packet-evidence-file"
+                  type="file"
+                  accept="application/pdf,image/jpeg,image/png,image/heic,image/heif,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                  onChange={(event) => {
+                    const file = event.target.files?.[0]
+                    if (file) void uploadEvidence(file)
+                  }}
+                  disabled={pending}
+                />
+              </div>
+            </div>
+            <label className="flex items-start gap-2 text-sm">
+              <Checkbox checked={attested} onCheckedChange={(checked) => setAttested(checked === true)} />
+              <span>I confirm the uploaded or linked packet is complete and contains every required owner and company representative signature. *</span>
+            </label>
+            <Button type="submit" disabled={pending || !attested}>Record execution and lock packet</Button>
+          </form>
+        )}
+        {editable && (
+          <div className="mt-5 border-t pt-4">
+            <AlertDialog>
+              <AlertDialogTrigger asChild><Button variant="ghost" className="text-destructive" disabled={pending}><IconTrash className="size-4" />Delete draft packet</Button></AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader><AlertDialogTitle>Delete this draft contract packet?</AlertDialogTitle><AlertDialogDescription>This removes only this unsent project packet and its document snapshots. The estimate and published Contract Library are unchanged.</AlertDialogDescription></AlertDialogHeader>
+                <AlertDialogFooter><AlertDialogCancel>Cancel</AlertDialogCancel><AlertDialogAction onClick={deletePacket}>Delete draft</AlertDialogAction></AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/components/projects/project-estimate-workspace.tsx
+++ b/src/components/projects/project-estimate-workspace.tsx
@@ -1542,9 +1542,21 @@ export function ProjectEstimateWorkspacePanel({
               It locks automatically only after every required signer finishes,
               or after a complete manually signed copy is recorded.
             </p>
+            <div className="mt-3 border-y py-3">
+              <p className="text-sm font-medium">Choose the signature route</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Send this estimate by itself for H, N, D, and change-order work,
+                or assemble the estimate as CA22 inside a full construction contract packet.
+              </p>
+              <Button className="mt-3" variant="outline" asChild>
+                <Link href={`/dashboard/projects/${projectId}/contracts`}>
+                  <IconFileDescription className="size-4" />Full construction contract
+                </Link>
+              </Button>
+            </div>
             {editable && (
               <Button className="mt-3" onClick={prepareForSignature} disabled={isPending || workspace.lines.length === 0}>
-                <IconSend className="size-4" />Prepare final version for client signature
+                <IconSend className="size-4" />Prepare estimate-only version for client signature
               </Button>
             )}
             {editable && (

--- a/src/components/templates/contract-template-library.tsx
+++ b/src/components/templates/contract-template-library.tsx
@@ -1,0 +1,388 @@
+"use client"
+
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useState, useTransition } from "react"
+import {
+  IconArchive,
+  IconFileImport,
+  IconFileText,
+  IconUpload,
+} from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import {
+  archiveContractTemplate,
+  createContractTemplateDraft,
+  importOrcContractTemplateLibrary,
+  publishContractTemplateVersion,
+  saveContractTemplateDraft,
+  type ContractTemplateLibraryItem,
+} from "@/app/actions/contract-templates"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+
+function statusLabel(value: string): string {
+  return value.replaceAll("_", " ")
+}
+
+function TemplateEditor({
+  template,
+  canManage,
+}: {
+  readonly template: ContractTemplateLibraryItem
+  readonly canManage: boolean
+}): React.ReactElement {
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+  const [name, setName] = useState(template.name)
+  const [category, setCategory] = useState(template.category)
+  const [signingStage, setSigningStage] = useState(template.signingStage)
+  const [inclusionMode, setInclusionMode] = useState(
+    template.defaultInclusionMode
+  )
+  const [content, setContent] = useState(template.version?.contentMarkdown ?? "")
+  const [changeNote, setChangeNote] = useState(template.version?.changeNote ?? "")
+
+  function save(): void {
+    startTransition(async () => {
+      const result = await saveContractTemplateDraft({
+        templateId: template.id,
+        name,
+        category,
+        signingStage,
+        inclusionMode,
+        contentMarkdown: content,
+        changeNote,
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(result.message)
+      router.refresh()
+    })
+  }
+
+  function publish(): void {
+    if (!template.version) return
+    startTransition(async () => {
+      const result = await publishContractTemplateVersion(
+        template.id,
+        template.version?.id ?? ""
+      )
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(result.message)
+      router.refresh()
+    })
+  }
+
+  return (
+    <article className="border-b py-4 last:border-b-0">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-semibold">{template.code}</span>
+            <span>{template.name}</span>
+            <Badge variant="outline">{statusLabel(template.category)}</Badge>
+            <Badge variant="secondary">
+              {statusLabel(template.signingStage)}
+            </Badge>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {template.version
+              ? `Version ${template.version.versionNumber} · ${statusLabel(template.version.status)}`
+              : "No version imported"}
+            {template.defaultInclusionMode === "reference"
+              ? " · referenced, not embedded"
+              : ""}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          {template.version?.driveDocumentUrl && (
+            <Button asChild size="sm" variant="outline">
+              <Link href={template.version.driveDocumentUrl} target="_blank">
+                <IconFileText className="size-4" />Drive copy
+              </Link>
+            </Button>
+          )}
+          {template.sourceUrl && (
+            <Button asChild size="sm" variant="outline">
+              <Link href={template.sourceUrl} target="_blank">Source</Link>
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <details className="mt-3">
+        <summary className="cursor-pointer text-sm font-medium">
+          Review and edit template
+        </summary>
+        <div className="mt-4 grid gap-4 border-t pt-4 md:grid-cols-2 xl:grid-cols-4">
+          <div className="space-y-1.5 md:col-span-2">
+            <Label htmlFor={`contract-name-${template.id}`}>Document name</Label>
+            <Input
+              id={`contract-name-${template.id}`}
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              disabled={!canManage}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Category</Label>
+            <Select value={category} onValueChange={setCategory} disabled={!canManage}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="agreement">Agreement</SelectItem>
+                <SelectItem value="general_conditions">General conditions</SelectItem>
+                <SelectItem value="exhibit">Exhibit</SelectItem>
+                <SelectItem value="form">Operational form</SelectItem>
+                <SelectItem value="manual">Manual</SelectItem>
+                <SelectItem value="generated">Compass-generated</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <Label>Signing stage</Label>
+            <Select value={signingStage} onValueChange={setSigningStage} disabled={!canManage}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="contract">Contract execution</SelectItem>
+                <SelectItem value="construction">During construction</SelectItem>
+                <SelectItem value="closeout">Closeout / walk-through</SelectItem>
+                <SelectItem value="reference">Reference only</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <Label>Packet treatment</Label>
+            <Select value={inclusionMode} onValueChange={setInclusionMode} disabled={!canManage}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="embedded">Embed content</SelectItem>
+                <SelectItem value="reference">Reference only</SelectItem>
+                <SelectItem value="generated">Generate from Compass</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5 md:col-span-2 xl:col-span-3">
+            <Label htmlFor={`contract-note-${template.id}`}>Version note</Label>
+            <Input
+              id={`contract-note-${template.id}`}
+              value={changeNote}
+              onChange={(event) => setChangeNote(event.target.value)}
+              disabled={!canManage}
+              placeholder="What changed in this version?"
+            />
+          </div>
+          <div className="space-y-1.5 md:col-span-2 xl:col-span-4">
+            <Label htmlFor={`contract-content-${template.id}`}>
+              Document content
+            </Label>
+            <Textarea
+              id={`contract-content-${template.id}`}
+              rows={18}
+              value={content}
+              onChange={(event) => setContent(event.target.value)}
+              disabled={!canManage || template.defaultInclusionMode === "generated"}
+              className="font-mono text-xs"
+            />
+            <p className="text-xs text-muted-foreground">
+              Markdown headings, lists, and tables are supported. Compass tokens
+              such as {"{{project.address}}"} are filled from the packet snapshot.
+            </p>
+          </div>
+        </div>
+        {canManage && (
+          <div className="mt-4 flex flex-wrap justify-end gap-2 border-t pt-4">
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="ghost" className="text-destructive" disabled={pending}>
+                  <IconArchive className="size-4" />Archive
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Archive {template.code}?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    It will no longer be available for new packets. Existing
+                    project packets retain their document snapshots.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() =>
+                      startTransition(async () => {
+                        const result = await archiveContractTemplate(template.id)
+                        if (!result.success) {
+                          toast.error(result.error)
+                          return
+                        }
+                        toast.success(result.message)
+                        router.refresh()
+                      })
+                    }
+                  >Archive template</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+            <Button variant="outline" onClick={save} disabled={pending}>
+              Save as draft
+            </Button>
+            {template.version?.status === "draft" && (
+              <Button onClick={publish} disabled={pending}>
+                <IconUpload className="size-4" />Publish v{template.version.versionNumber}
+              </Button>
+            )}
+          </div>
+        )}
+      </details>
+    </article>
+  )
+}
+
+export function ContractTemplateLibrary({
+  templates,
+  canManage,
+}: {
+  readonly templates: readonly ContractTemplateLibraryItem[]
+  readonly canManage: boolean
+}): React.ReactElement {
+  const router = useRouter()
+  const [pending, startTransition] = useTransition()
+  const [newCode, setNewCode] = useState("")
+  const [newName, setNewName] = useState("")
+  const [newContent, setNewContent] = useState("")
+
+  function createTemplate(): void {
+    startTransition(async () => {
+      const result = await createContractTemplateDraft({
+        code: newCode,
+        name: newName,
+        contentMarkdown: newContent,
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      setNewCode("")
+      setNewName("")
+      setNewContent("")
+      toast.success(result.message)
+      router.refresh()
+    })
+  }
+  return (
+    <section>
+      <div className="flex flex-wrap items-start justify-between gap-4 border-y py-4">
+        <div>
+          <h2 className="font-semibold">Contract document library</h2>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            Published versions are copied into project packets. Editing a
+            template creates an independent draft; existing packets never change.
+          </p>
+        </div>
+        {canManage && (
+          <Button
+            onClick={() =>
+              startTransition(async () => {
+                const result = await importOrcContractTemplateLibrary()
+                if (!result.success) {
+                  toast.error(result.error)
+                  return
+                }
+                toast.success(result.message)
+                router.refresh()
+              })
+            }
+            disabled={pending}
+          >
+            <IconFileImport className="size-4" />
+            {templates.length === 0 ? "Import ORC contract library" : "Refresh from approved source"}
+          </Button>
+        )}
+      </div>
+      {templates.length === 0 ? (
+        <div className="border-b py-10 text-sm text-muted-foreground">
+          Import the approved ORC workbook to create the initial published library.
+        </div>
+      ) : (
+        <div>{templates.map((template) => (
+          <TemplateEditor key={template.id} template={template} canManage={canManage} />
+        ))}</div>
+      )}
+      {canManage && (
+        <details className="border-b py-4">
+          <summary className="cursor-pointer text-sm font-medium">
+            Create a new contract document or addendum
+          </summary>
+          <div className="mt-4 grid gap-4 border-t pt-4 md:grid-cols-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="new-contract-code">Document code *</Label>
+              <Input
+                id="new-contract-code"
+                value={newCode}
+                onChange={(event) => setNewCode(event.target.value.toUpperCase())}
+                placeholder="ADD-01"
+                maxLength={20}
+              />
+            </div>
+            <div className="space-y-1.5 md:col-span-2">
+              <Label htmlFor="new-contract-name">Document name *</Label>
+              <Input
+                id="new-contract-name"
+                value={newName}
+                onChange={(event) => setNewName(event.target.value)}
+                placeholder="Project-specific addendum"
+              />
+            </div>
+            <div className="space-y-1.5 md:col-span-3">
+              <Label htmlFor="new-contract-content">Initial document text *</Label>
+              <Textarea
+                id="new-contract-content"
+                rows={10}
+                value={newContent}
+                onChange={(event) => setNewContent(event.target.value)}
+                className="font-mono text-xs"
+                placeholder="# Addendum title"
+              />
+            </div>
+          </div>
+          <div className="mt-4 flex justify-end border-t pt-4">
+            <Button
+              onClick={createTemplate}
+              disabled={pending || !newCode.trim() || !newName.trim() || !newContent.trim()}
+            >
+              <IconFileText className="size-4" />Create draft
+            </Button>
+          </div>
+        </details>
+      )}
+    </section>
+  )
+}

--- a/src/components/templates/template-library-view.tsx
+++ b/src/components/templates/template-library-view.tsx
@@ -42,6 +42,8 @@ import {
 } from "@/components/ui/select"
 import { EstimateTemplateCreateDialog } from "./estimate-template-create-dialog"
 import { EstimateTextTemplateLibrary } from "./estimate-text-template-library"
+import { ContractTemplateLibrary } from "./contract-template-library"
+import type { ContractTemplateLibraryItem } from "@/app/actions/contract-templates"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 export const TEMPLATE_CATEGORIES = [
@@ -64,6 +66,7 @@ type Props = {
   readonly canManage: boolean
   readonly canCreateEstimate: boolean
   readonly canManageEstimateText: boolean
+  readonly contractTemplates: readonly ContractTemplateLibraryItem[]
 }
 
 function reviewLabel(reviewStatus: string): string {
@@ -232,6 +235,7 @@ export function TemplateLibraryView({
   canManage,
   canCreateEstimate,
   canManageEstimateText,
+  contractTemplates,
 }: Props): React.ReactElement {
   const { developerModeEnabled } = useDeveloperMode()
   const [categoryFilter, setCategoryFilter] = useState("all")
@@ -300,6 +304,9 @@ export function TemplateLibraryView({
             <TabsTrigger value="project-content">Project content</TabsTrigger>
             <TabsTrigger value="estimate-report-text">
               Estimate report text
+            </TabsTrigger>
+            <TabsTrigger value="contract-documents">
+              Contract documents
             </TabsTrigger>
           </TabsList>
           <TabsContent value="project-content" className="mt-5">
@@ -388,6 +395,12 @@ export function TemplateLibraryView({
           <TabsContent value="estimate-report-text" className="mt-5">
             <EstimateTextTemplateLibrary
               templates={estimateTextTemplates}
+              canManage={canManageEstimateText}
+            />
+          </TabsContent>
+          <TabsContent value="contract-documents" className="mt-5">
+            <ContractTemplateLibrary
+              templates={contractTemplates}
               canManage={canManageEstimateText}
             />
           </TabsContent>

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -15,6 +15,7 @@ import * as buildertrendSchema from "./schema-buildertrend"
 import * as estimatesSchema from "./schema-estimates"
 import * as templateSchema from "./schema-templates"
 import * as warrantySchema from "./schema-warranty"
+import * as contractSchema from "./schema-contracts"
 
 const allSchemas = {
   ...schema,
@@ -33,6 +34,7 @@ const allSchemas = {
   ...estimatesSchema,
   ...templateSchema,
   ...warrantySchema,
+  ...contractSchema,
 }
 
 // Legacy function - kept for backwards compatibility

--- a/src/db/schema-contracts.ts
+++ b/src/db/schema-contracts.ts
@@ -1,0 +1,201 @@
+import {
+  index,
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core"
+
+import { organizations, projects, users } from "./schema"
+import { projectEstimates } from "./schema-estimates"
+
+export const contractDocumentTemplates = sqliteTable(
+  "contract_document_templates",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    code: text("code").notNull(),
+    name: text("name").notNull(),
+    category: text("category").notNull().default("exhibit"),
+    signingStage: text("signing_stage").notNull().default("contract"),
+    defaultInclusionMode: text("default_inclusion_mode")
+      .notNull()
+      .default("embedded"),
+    departmentCodesJson: text("department_codes_json").notNull().default("[]"),
+    sourceWorkbookId: text("source_workbook_id"),
+    sourceSheetNamesJson: text("source_sheet_names_json"),
+    sourceUrl: text("source_url"),
+    sortOrder: integer("sort_order").notNull().default(0),
+    active: integer("active", { mode: "boolean" }).notNull().default(true),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("contract_document_templates_org_code_uq").on(
+      table.organizationId,
+      table.code
+    ),
+    index("contract_document_templates_org_order_idx").on(
+      table.organizationId,
+      table.active,
+      table.sortOrder
+    ),
+  ]
+)
+
+export const contractDocumentTemplateVersions = sqliteTable(
+  "contract_document_template_versions",
+  {
+    id: text("id").primaryKey(),
+    templateId: text("template_id")
+      .notNull()
+      .references(() => contractDocumentTemplates.id, { onDelete: "cascade" }),
+    versionNumber: integer("version_number").notNull(),
+    status: text("status").notNull().default("draft"),
+    contentMarkdown: text("content_markdown").notNull(),
+    sourceFingerprint: text("source_fingerprint"),
+    sourceCapturedAt: text("source_captured_at"),
+    driveDocumentId: text("drive_document_id"),
+    driveDocumentUrl: text("drive_document_url"),
+    changeNote: text("change_note"),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    publishedBy: text("published_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    publishedAt: text("published_at"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("contract_document_template_versions_number_uq").on(
+      table.templateId,
+      table.versionNumber
+    ),
+    index("contract_document_template_versions_status_idx").on(
+      table.templateId,
+      table.status,
+      table.versionNumber
+    ),
+  ]
+)
+
+export const contractPackets = sqliteTable(
+  "contract_packets",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    estimateId: text("estimate_id")
+      .notNull()
+      .references(() => projectEstimates.id, { onDelete: "restrict" }),
+    packetNumber: text("packet_number").notNull(),
+    versionNumber: integer("version_number").notNull().default(1),
+    title: text("title").notNull().default("Construction Contract"),
+    status: text("status").notNull().default("draft"),
+    legalEntityName: text("legal_entity_name").notNull(),
+    contractDraftDate: text("contract_draft_date"),
+    approximateCommencementDate: text("approximate_commencement_date"),
+    approximateCompletionDate: text("approximate_completion_date"),
+    depositCents: integer("deposit_cents").notNull().default(0),
+    latePaymentRateBasisPoints: integer("late_payment_rate_basis_points")
+      .notNull()
+      .default(1200),
+    detailsJson: text("details_json").notNull().default("{}"),
+    clientSignersJson: text("client_signers_json").notNull().default("[]"),
+    companySignerName: text("company_signer_name"),
+    companySignerTitle: text("company_signer_title"),
+    companySignerEmail: text("company_signer_email"),
+    companySignerInitials: text("company_signer_initials"),
+    foxitStatus: text("foxit_status").notNull().default("not_started"),
+    foxitEnvelopeId: text("foxit_envelope_id"),
+    foxitEmbeddedSessionUrl: text("foxit_embedded_session_url"),
+    preparedSourceHash: text("prepared_source_hash"),
+    preparedAt: text("prepared_at"),
+    signatureRequestedAt: text("signature_requested_at"),
+    signaturePackageUrl: text("signature_package_url"),
+    signedAt: text("signed_at"),
+    acceptanceMethod: text("acceptance_method"),
+    acceptanceEvidenceLabel: text("acceptance_evidence_label"),
+    acceptanceRecordedByName: text("acceptance_recorded_by_name"),
+    acceptedAt: text("accepted_at"),
+    acceptedBy: text("accepted_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    sourceHash: text("source_hash"),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("contract_packets_project_number_version_uq").on(
+      table.projectId,
+      table.packetNumber,
+      table.versionNumber
+    ),
+    index("contract_packets_project_status_idx").on(
+      table.projectId,
+      table.status,
+      table.versionNumber
+    ),
+    uniqueIndex("contract_packets_foxit_envelope_uq").on(table.foxitEnvelopeId),
+  ]
+)
+
+export const contractPacketDocuments = sqliteTable(
+  "contract_packet_documents",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    packetId: text("packet_id")
+      .notNull()
+      .references(() => contractPackets.id, { onDelete: "cascade" }),
+    templateId: text("template_id").references(() => contractDocumentTemplates.id, {
+      onDelete: "set null",
+    }),
+    templateVersionId: text("template_version_id").references(
+      () => contractDocumentTemplateVersions.id,
+      { onDelete: "set null" }
+    ),
+    code: text("code").notNull(),
+    title: text("title").notNull(),
+    contentMarkdown: text("content_markdown").notNull().default(""),
+    inclusionMode: text("inclusion_mode").notNull().default("embedded"),
+    signingStage: text("signing_stage").notNull().default("contract"),
+    signaturePolicy: text("signature_policy").notNull().default("all_signers"),
+    documentDate: text("document_date"),
+    revision: text("revision"),
+    sourceUrl: text("source_url"),
+    sortOrder: integer("sort_order").notNull().default(0),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    index("contract_packet_documents_packet_order_idx").on(
+      table.packetId,
+      table.sortOrder
+    ),
+    index("contract_packet_documents_project_idx").on(
+      table.projectId,
+      table.packetId
+    ),
+  ]
+)
+
+export type ContractDocumentTemplate =
+  typeof contractDocumentTemplates.$inferSelect
+export type ContractDocumentTemplateVersion =
+  typeof contractDocumentTemplateVersions.$inferSelect
+export type ContractPacket = typeof contractPackets.$inferSelect
+export type ContractPacketDocument = typeof contractPacketDocuments.$inferSelect

--- a/src/lib/contracts/__tests__/drive-store.test.ts
+++ b/src/lib/contracts/__tests__/drive-store.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest"
+
+import { contractTemplateDriveFileName } from "@/lib/contracts/drive-store"
+
+describe("contract template Drive storage", () => {
+  it("uses a stable versioned Markdown filename", () => {
+    expect(
+      contractTemplateDriveFileName({
+        code: "CA00",
+        name: "Cost Plus / Fixed Fee Contract",
+        versionNumber: 2,
+      })
+    ).toBe("CA00 - Cost Plus - Fixed Fee Contract - v2.md")
+  })
+})

--- a/src/lib/contracts/__tests__/legal-entity.test.ts
+++ b/src/lib/contracts/__tests__/legal-entity.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+
+import { projectLegalEntityName } from "@/lib/project-branding"
+
+describe("project contract legal entities", () => {
+  it("uses ORC's legal entity for O and D projects", () => {
+    const expected =
+      "High Performance Structures Inc. dba Open Range Construction, Ltd."
+    expect(projectLegalEntityName("O")).toBe(expected)
+    expect(projectLegalEntityName("D")).toBe(expected)
+  })
+
+  it("uses the Nu-Tech DBA for N projects", () => {
+    expect(projectLegalEntityName("N")).toBe(
+      "High Performance Structures Inc. dba Nu-Tech Systems"
+    )
+  })
+
+  it("uses HPS without a DBA for H projects", () => {
+    expect(projectLegalEntityName("H")).toBe("High Performance Structures Inc.")
+  })
+})

--- a/src/lib/contracts/__tests__/packet-pdf.test.ts
+++ b/src/lib/contracts/__tests__/packet-pdf.test.ts
@@ -1,0 +1,75 @@
+import { PDFDocument } from "pdf-lib"
+import { describe, expect, test } from "vitest"
+
+import { base64PdfBytes, prepareContractPacketPdf } from "@/lib/contracts/packet-pdf"
+
+describe("contract packet PDF", () => {
+  test("merges CA22, withholds closeout bodies, and adds Foxit fields", async () => {
+    const estimateDocument = await PDFDocument.create()
+    estimateDocument.addPage([612, 792])
+    estimateDocument.addPage([612, 792])
+    const estimateBytes = await estimateDocument.save()
+    const estimateBuffer = new Uint8Array(estimateBytes.byteLength)
+    estimateBuffer.set(estimateBytes)
+    const prepared = await prepareContractPacketPdf({
+      packet: {
+        id: "packet-1",
+        estimateId: "estimate-1",
+        packetNumber: "CA22-001",
+        versionNumber: 1,
+        title: "Construction Contract",
+        status: "draft",
+        legalEntityName: "High Performance Structures Inc.",
+        contractDraftDate: "2026-08-23",
+        approximateCommencementDate: "2026-09-01",
+        approximateCompletionDate: "2027-08-31",
+        depositCents: 10_000_00,
+        latePaymentRateBasisPoints: 1200,
+        details: { projectAddress: "1 Main Street", county: "Teller", ownerName: "Alex Owner" },
+        clientSigners: [{ contactId: null, name: "Alex Owner", title: "Owner", email: "alex@example.com", initials: "AO" }],
+        companySignerName: "Casey Builder",
+        companySignerTitle: "President",
+        companySignerEmail: "casey@example.com",
+        companySignerInitials: "CB",
+        foxitStatus: "not_started",
+        foxitEnvelopeId: null,
+        foxitEmbeddedSessionUrl: null,
+        signaturePackageUrl: null,
+        signedAt: null,
+        acceptanceMethod: null,
+        acceptanceEvidenceLabel: null,
+        acceptanceRecordedByName: null,
+        acceptedAt: null,
+        createdAt: "2026-08-23T00:00:00.000Z",
+        updatedAt: "2026-08-23T00:00:00.000Z",
+      },
+      documents: [
+        { id: "ca00", templateId: null, templateVersionId: null, code: "CA00", title: "Agreement", contentMarkdown: "# Agreement\n\n{{contract.document_schedule}}", inclusionMode: "embedded", signingStage: "contract", signaturePolicy: "all_signers", documentDate: null, revision: null, sourceUrl: null, sortOrder: 0 },
+        { id: "ca11", templateId: null, templateVersionId: null, code: "CA11", title: "Inspection Checklist", contentMarkdown: "This closeout body must not be in the initial envelope.", inclusionMode: "embedded", signingStage: "closeout", signaturePolicy: "stage_signers", documentDate: null, revision: null, sourceUrl: null, sortOrder: 10 },
+        { id: "ca18", templateId: null, templateVersionId: null, code: "CA18", title: "Warranty Handbook", contentMarkdown: "Reference only.", inclusionMode: "reference", signingStage: "reference", signaturePolicy: "stage_signers", documentDate: null, revision: null, sourceUrl: null, sortOrder: 20 },
+        { id: "ca22", templateId: null, templateVersionId: null, code: "CA22", title: "Construction Estimate", contentMarkdown: "Generated", inclusionMode: "generated", signingStage: "contract", signaturePolicy: "all_signers", documentDate: "2026-08-23", revision: "v1", sourceUrl: null, sortOrder: 30 },
+      ],
+      estimate: {
+        id: "estimate-1",
+        estimateNumber: "CA22-001",
+        versionNumber: 1,
+        title: "Construction Estimate",
+        status: "draft",
+        estimateDate: "2026-08-23",
+        clientName: "Alex Owner",
+        builderFeeCents: 15_000_00,
+        builderFeeRateBasisPoints: 1500,
+        estimateTotalCents: 115_000_00,
+      },
+      projectName: "Compass Developer",
+      projectNumber: "H-001",
+      projectAddress: "1 Main Street",
+      estimatePdf: estimateBuffer.buffer,
+    })
+    const finalPdf = await PDFDocument.load(base64PdfBytes(prepared.pdfBase64))
+    expect(finalPdf.getPageCount()).toBe(3)
+    expect(prepared.fields.filter((field) => field.type === "initial")).toHaveLength(4)
+    expect(prepared.fields.filter((field) => field.type === "signature")).toHaveLength(2)
+    expect(prepared.fields.filter((field) => field.type === "date")).toHaveLength(2)
+  })
+})

--- a/src/lib/contracts/__tests__/packet.test.ts
+++ b/src/lib/contracts/__tests__/packet.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest"
+
+import {
+  contractDocumentSchedule,
+  dollarsInWords,
+  fillContractTokens,
+  parsePacketSigners,
+} from "@/lib/contracts/packet"
+
+describe("contract packet domain", () => {
+  test("spells contract currency with cents", () => {
+    expect(dollarsInWords(1_234_567_89)).toBe(
+      "One million two hundred thirty-four thousand five hundred sixty-seven dollars and 89/100"
+    )
+  })
+
+  test("builds CA00's schedule from the actual selected documents", () => {
+    const schedule = contractDocumentSchedule([{
+      code: "CA18",
+      title: "Homeowner's Warranty Manual",
+      documentDate: null,
+      revision: null,
+      inclusionMode: "reference",
+      signingStage: "reference",
+    }])
+    expect(schedule).toContain("CA18")
+    expect(schedule).toContain("Incorporated by reference")
+  })
+
+  test("preserves visibly unresolved tokens", () => {
+    expect(fillContractTokens("{{project.name}} / {{project.county}}", {
+      "project.name": "Compass Developer",
+    })).toBe("Compass Developer / {{project.county}}")
+  })
+
+  test("normalizes multiple client signers", () => {
+    expect(parsePacketSigners(JSON.stringify([
+      { name: "Alex Owner", email: "alex@example.com" },
+      { name: "Pat Owner", initials: "PO" },
+    ]))).toEqual([
+      { contactId: null, name: "Alex Owner", title: "", email: "alex@example.com", initials: "AO" },
+      { contactId: null, name: "Pat Owner", title: "", email: "", initials: "PO" },
+    ])
+  })
+})

--- a/src/lib/contracts/__tests__/source.test.ts
+++ b/src/lib/contracts/__tests__/source.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ORC_CONTRACT_SOURCE_DEFINITIONS,
+  contractSourceRanges,
+  normalizeContractSourceDocument,
+} from "@/lib/contracts/source"
+
+describe("contract source normalization", () => {
+  it("builds bounded reads for every source sheet", () => {
+    const ranges = contractSourceRanges()
+    expect(ranges.some((item) => item.sheetName === "CA00 Cost Plus")).toBe(true)
+    expect(ranges.some((item) => item.sheetName === "CA11 Inspection Check List (3)")).toBe(true)
+    expect(ranges.every((item) => !item.range.includes("1000"))).toBe(true)
+  })
+
+  it("replaces CA00's static document list with the packet schedule token", () => {
+    const definition = ORC_CONTRACT_SOURCE_DEFINITIONS.find(
+      (item) => item.code === "CA00"
+    )
+    expect(definition).toBeDefined()
+    if (!definition) return
+    const rows = Array.from({ length: 125 }, () => [] as readonly unknown[])
+    rows[24] = ["Article 1. CONTRACT DOCUMENTS"]
+    rows[25] = ["Article 1.1 Source text"]
+    rows[26] = ["Article 1.2 Specific contract documents include:"]
+    const content = normalizeContractSourceDocument({
+      definition,
+      rows: { "CA00 Cost Plus": rows },
+    })
+    expect(content).toContain("{{contract.document_schedule}}")
+    expect(content).not.toContain("CA07")
+  })
+
+  it("keeps the handbook as a reference instead of embedded content", () => {
+    const definition = ORC_CONTRACT_SOURCE_DEFINITIONS.find(
+      (item) => item.code === "CA18"
+    )
+    expect(definition).toBeDefined()
+    if (!definition) return
+    expect(definition.defaultInclusionMode).toBe("reference")
+    expect(normalizeContractSourceDocument({ definition, rows: {} })).toContain(
+      "not embedded"
+    )
+  })
+
+  it("marks the inspection checklist for closeout signing", () => {
+    const definition = ORC_CONTRACT_SOURCE_DEFINITIONS.find(
+      (item) => item.code === "CA11"
+    )
+    expect(definition?.signingStage).toBe("closeout")
+  })
+})

--- a/src/lib/contracts/drive-store.ts
+++ b/src/lib/contracts/drive-store.ts
@@ -1,0 +1,174 @@
+import type { DriveFile, DriveFileList, ListFilesOptions } from "@/lib/google/client/types"
+import {
+  COMPASS_DEVELOPER_FOLDER_ID,
+  ESTIMATE_TEMPLATE_LIBRARY_FOLDER_NAME,
+} from "@/lib/estimates/text-template-drive-store"
+
+const GOOGLE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
+const CONTRACT_LIBRARY_FOLDER_NAME = "Contracts"
+const MARKDOWN_MIME_TYPE = "text/markdown"
+
+type ContractTemplateDriveClient = {
+  readonly listFiles: (
+    userEmail: string,
+    options?: ListFilesOptions
+  ) => Promise<DriveFileList>
+  readonly getFile: (userEmail: string, fileId: string) => Promise<DriveFile>
+  readonly createFolder: (
+    userEmail: string,
+    options: { readonly name: string; readonly parentId?: string }
+  ) => Promise<DriveFile>
+  readonly uploadFile: (
+    userEmail: string,
+    options: {
+      readonly name: string
+      readonly parentId?: string
+      readonly mimeType: string
+      readonly data: Blob
+      readonly appProperties?: Readonly<Record<string, string>>
+    }
+  ) => Promise<DriveFile>
+  readonly updateFileContent: (
+    userEmail: string,
+    fileId: string,
+    data: Blob,
+    mimeType: string
+  ) => Promise<DriveFile>
+  readonly renameFile: (
+    userEmail: string,
+    fileId: string,
+    newName: string
+  ) => Promise<DriveFile>
+}
+
+function queryValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")
+}
+
+function safeFilePart(value: string): string {
+  return (
+    value
+      .replace(/[/:\\]/g, "-")
+      .replace(/[\u0000-\u001f]/g, "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 120) || "Untitled"
+  )
+}
+
+async function findFolder(
+  client: ContractTemplateDriveClient,
+  userEmail: string,
+  parentId: string,
+  name: string
+): Promise<DriveFile | null> {
+  const result = await client.listFiles(userEmail, {
+    folderId: parentId,
+    query:
+      `mimeType = '${GOOGLE_FOLDER_MIME_TYPE}' and ` +
+      `name = '${queryValue(name)}'`,
+    pageSize: 10,
+    orderBy: "createdTime",
+  })
+  return result.files[0] ?? null
+}
+
+async function ensureFolder(
+  client: ContractTemplateDriveClient,
+  userEmail: string,
+  parentId: string,
+  name: string
+): Promise<DriveFile> {
+  return (
+    (await findFolder(client, userEmail, parentId, name)) ??
+    client.createFolder(userEmail, { name, parentId })
+  )
+}
+
+async function existingFile(
+  client: ContractTemplateDriveClient,
+  userEmail: string,
+  fileId: string | null,
+  folderId: string,
+  fileName: string
+): Promise<DriveFile | null> {
+  if (fileId) {
+    try {
+      const file = await client.getFile(userEmail, fileId)
+      if (file.parents?.includes(folderId)) return file
+    } catch {
+      // A deleted or moved Drive copy is recreated below.
+    }
+  }
+  const result = await client.listFiles(userEmail, {
+    folderId,
+    query: `name = '${queryValue(fileName)}'`,
+    pageSize: 10,
+    orderBy: "createdTime",
+  })
+  return result.files[0] ?? null
+}
+
+export function contractTemplateDriveFileName(input: {
+  readonly code: string
+  readonly name: string
+  readonly versionNumber: number
+}): string {
+  return `${safeFilePart(input.code)} - ${safeFilePart(input.name)} - v${input.versionNumber}.md`
+}
+
+export async function syncContractTemplateVersionToDrive(input: {
+  readonly client: ContractTemplateDriveClient
+  readonly userEmail: string
+  readonly currentFileId: string | null
+  readonly code: string
+  readonly name: string
+  readonly versionNumber: number
+  readonly contentMarkdown: string
+}): Promise<{ readonly fileId: string; readonly fileUrl: string }> {
+  const templateLibrary = await ensureFolder(
+    input.client,
+    input.userEmail,
+    COMPASS_DEVELOPER_FOLDER_ID,
+    ESTIMATE_TEMPLATE_LIBRARY_FOLDER_NAME
+  )
+  const contractLibrary = await ensureFolder(
+    input.client,
+    input.userEmail,
+    templateLibrary.id,
+    CONTRACT_LIBRARY_FOLDER_NAME
+  )
+  const fileName = contractTemplateDriveFileName(input)
+  const current = await existingFile(
+    input.client,
+    input.userEmail,
+    input.currentFileId,
+    contractLibrary.id,
+    fileName
+  )
+  const data = new Blob([input.contentMarkdown], { type: MARKDOWN_MIME_TYPE })
+  const saved = current
+    ? await (async (): Promise<DriveFile> => {
+        if (current.name !== fileName) {
+          await input.client.renameFile(input.userEmail, current.id, fileName)
+        }
+        return input.client.updateFileContent(
+          input.userEmail,
+          current.id,
+          data,
+          MARKDOWN_MIME_TYPE
+        )
+      })()
+    : await input.client.uploadFile(input.userEmail, {
+        name: fileName,
+        parentId: contractLibrary.id,
+        mimeType: MARKDOWN_MIME_TYPE,
+        data,
+        appProperties: { compassContentType: "contractTemplateVersion" },
+      })
+  return {
+    fileId: saved.id,
+    fileUrl:
+      saved.webViewLink ?? `https://drive.google.com/file/d/${saved.id}/view`,
+  }
+}

--- a/src/lib/contracts/packet-pdf.ts
+++ b/src/lib/contracts/packet-pdf.ts
@@ -1,0 +1,343 @@
+import {
+  PDFDocument,
+  PDFFont,
+  PDFPage,
+  StandardFonts,
+  rgb,
+} from "pdf-lib"
+
+import type {
+  ProjectContractPacketDocumentItem,
+  ProjectContractPacketEstimateOption,
+  ProjectContractPacketSummary,
+} from "@/app/actions/contract-packets"
+import {
+  contractDocumentSchedule,
+  dollarsInWords,
+  fillContractTokens,
+} from "@/lib/contracts/packet"
+import {
+  prepareEstimateSignaturePdf,
+  type PreparedEstimateSignaturePdf,
+} from "@/lib/estimates/signature-pdf"
+
+const PAGE_WIDTH = 612
+const PAGE_HEIGHT = 792
+const MARGIN = 54
+const FOOTER_RESERVE = 42
+
+type TextStyle = {
+  readonly font: PDFFont
+  readonly size: number
+  readonly lineHeight: number
+  readonly before: number
+  readonly after: number
+}
+
+type Writer = {
+  readonly document: PDFDocument
+  readonly regular: PDFFont
+  readonly bold: PDFFont
+  page: PDFPage
+  y: number
+}
+
+function money(cents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(cents / 100)
+}
+
+function percent(basisPoints: number): string {
+  return `${(basisPoints / 100).toFixed(2)}%`
+}
+
+function displayDate(value: string | null): string {
+  if (!value) return ""
+  const date = new Date(`${value.slice(0, 10)}T12:00:00`)
+  if (Number.isNaN(date.valueOf())) return value
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(date)
+}
+
+function cleanMarkdown(value: string): string {
+  return value
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/<[^>]+>/g, "")
+    .trim()
+}
+
+function wrappedLines(text: string, font: PDFFont, size: number, width: number): readonly string[] {
+  const words = cleanMarkdown(text).split(/\s+/).filter(Boolean)
+  if (words.length === 0) return []
+  const lines: string[] = []
+  let current = ""
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word
+    if (font.widthOfTextAtSize(candidate, size) <= width || !current) {
+      current = candidate
+    } else {
+      lines.push(current)
+      current = word
+    }
+  }
+  if (current) lines.push(current)
+  return lines
+}
+
+function newPage(writer: Writer): void {
+  writer.page = writer.document.addPage([PAGE_WIDTH, PAGE_HEIGHT])
+  writer.y = PAGE_HEIGHT - MARGIN
+}
+
+function ensureSpace(writer: Writer, height: number): void {
+  if (writer.y - height < FOOTER_RESERVE) newPage(writer)
+}
+
+function drawBlock(writer: Writer, text: string, style: TextStyle, indent = 0): void {
+  const lines = wrappedLines(text, style.font, style.size, PAGE_WIDTH - MARGIN * 2 - indent)
+  if (lines.length === 0) {
+    writer.y -= style.after
+    return
+  }
+  ensureSpace(writer, style.before + lines.length * style.lineHeight + style.after)
+  writer.y -= style.before
+  for (const line of lines) {
+    writer.page.drawText(line, {
+      x: MARGIN + indent,
+      y: writer.y,
+      size: style.size,
+      font: style.font,
+      color: rgb(0.08, 0.08, 0.08),
+    })
+    writer.y -= style.lineHeight
+  }
+  writer.y -= style.after
+}
+
+function drawTable(writer: Writer, rows: readonly string[]): void {
+  const cells = rows.map((row) =>
+    row.split("|").slice(1, -1).map((cell) => cleanMarkdown(cell))
+  )
+  const contentRows = cells.filter((row) =>
+    !row.every((cell) => /^:?-{3,}:?$/.test(cell))
+  )
+  for (const [rowIndex, row] of contentRows.entries()) {
+    const text = row.filter(Boolean).join("  ·  ")
+    drawBlock(writer, text, {
+      font: rowIndex === 0 ? writer.bold : writer.regular,
+      size: 8,
+      lineHeight: 11,
+      before: rowIndex === 0 ? 5 : 1,
+      after: 2,
+    }, rowIndex === 0 ? 0 : 8)
+  }
+}
+
+function drawMarkdown(writer: Writer, markdown: string): void {
+  const lines = markdown.replaceAll("\r\n", "\n").split("\n")
+  for (let index = 0; index < lines.length; index += 1) {
+    const raw = lines[index]?.trim() ?? ""
+    if (!raw) {
+      writer.y -= 4
+      continue
+    }
+    if (raw.startsWith("|")) {
+      const table: string[] = []
+      let cursor = index
+      while ((lines[cursor]?.trim() ?? "").startsWith("|")) {
+        table.push(lines[cursor]?.trim() ?? "")
+        cursor += 1
+      }
+      drawTable(writer, table)
+      index = cursor - 1
+      continue
+    }
+    const heading = raw.match(/^(#{1,4})\s+(.+)$/)
+    if (heading) {
+      const level = heading[1]?.length ?? 2
+      drawBlock(writer, heading[2] ?? "", {
+        font: writer.bold,
+        size: level === 1 ? 15 : level === 2 ? 12 : 10,
+        lineHeight: level === 1 ? 19 : level === 2 ? 16 : 14,
+        before: level === 1 ? 12 : 8,
+        after: 4,
+      })
+      continue
+    }
+    const list = raw.match(/^[-*]\s+(.+)$/)
+    drawBlock(writer, list ? `• ${list[1] ?? ""}` : raw, {
+      font: writer.regular,
+      size: 9,
+      lineHeight: 13,
+      before: 1,
+      after: 3,
+    }, list ? 10 : 0)
+  }
+}
+
+async function renderContractDocuments(input: {
+  readonly packet: ProjectContractPacketSummary
+  readonly documents: readonly ProjectContractPacketDocumentItem[]
+  readonly estimate: ProjectContractPacketEstimateOption
+  readonly projectName: string
+  readonly projectNumber: string | null
+  readonly projectAddress: string | null
+}): Promise<PDFDocument> {
+  const document = await PDFDocument.create()
+  const regular = await document.embedFont(StandardFonts.TimesRoman)
+  const bold = await document.embedFont(StandardFonts.TimesRomanBold)
+  const first = document.addPage([PAGE_WIDTH, PAGE_HEIGHT])
+  const writer: Writer = { document, regular, bold, page: first, y: PAGE_HEIGHT - MARGIN }
+  const schedule = contractDocumentSchedule(input.documents)
+  const values = {
+    "project.name": input.projectName,
+    "project.number": input.projectNumber ?? "",
+    "project.address": input.packet.details.projectAddress ?? input.projectAddress ?? "",
+    "project.location": input.packet.details.projectAddress ?? input.projectAddress ?? "",
+    "project.county": input.packet.details.county ?? "",
+    "project.owner_name": input.packet.details.ownerName ?? input.estimate.clientName ?? "",
+    "contract.document_schedule": schedule,
+    "contract.execution_date": displayDate(input.packet.contractDraftDate),
+    "contract.commencement_date": displayDate(input.packet.approximateCommencementDate),
+    "contract.completion_date": displayDate(input.packet.approximateCompletionDate),
+    "contract.deposit": money(input.packet.depositCents),
+    "contract.deposit_words": dollarsInWords(input.packet.depositCents),
+    "contract.late_payment_percent": percent(input.packet.latePaymentRateBasisPoints),
+    "estimate.date": displayDate(input.estimate.estimateDate),
+    "estimate.total": money(input.estimate.estimateTotalCents),
+    "estimate.total_words": dollarsInWords(input.estimate.estimateTotalCents),
+    "estimate.builder_fee_percent": percent(input.estimate.builderFeeRateBasisPoints),
+    "estimate.builder_fee_total": money(input.estimate.builderFeeCents),
+    "estimate.builder_fee_words": dollarsInWords(input.estimate.builderFeeCents),
+  }
+  const embedded = input.documents.filter(
+    (item) => item.inclusionMode === "embedded" && item.signingStage === "contract"
+  )
+  for (const [index, item] of embedded.entries()) {
+    if (index > 0) newPage(writer)
+    drawBlock(writer, `${item.code} · ${item.title}`, {
+      font: bold,
+      size: 16,
+      lineHeight: 20,
+      before: 0,
+      after: 4,
+    })
+    drawBlock(writer, `${input.packet.legalEntityName} · ${input.projectName}`, {
+      font: regular,
+      size: 8,
+      lineHeight: 11,
+      before: 0,
+      after: 12,
+    })
+    drawMarkdown(writer, fillContractTokens(item.contentMarkdown, values))
+  }
+  return document
+}
+
+async function appendEstimateWithoutSignaturePage(
+  target: PDFDocument,
+  estimatePdf: ArrayBuffer
+): Promise<void> {
+  const estimate = await PDFDocument.load(estimatePdf)
+  const pageCount = estimate.getPageCount()
+  if (pageCount < 2) throw new Error("The selected CA22 estimate is missing its signature page.")
+  const pages = await target.copyPages(
+    estimate,
+    Array.from({ length: pageCount - 1 }, (_, index) => index)
+  )
+  for (const page of pages) target.addPage(page)
+}
+
+async function appendPacketSignaturePage(input: {
+  readonly document: PDFDocument
+  readonly packet: ProjectContractPacketSummary
+  readonly estimate: ProjectContractPacketEstimateOption
+}): Promise<void> {
+  const page = input.document.addPage([PAGE_WIDTH, PAGE_HEIGHT])
+  const regular = await input.document.embedFont(StandardFonts.Helvetica)
+  const bold = await input.document.embedFont(StandardFonts.HelveticaBold)
+  page.drawText("Contract packet signatures", { x: 40, y: 752, size: 18, font: bold })
+  page.drawText(`${input.packet.packetNumber} · version ${input.packet.versionNumber}`, { x: 40, y: 732, size: 10, font: regular })
+  page.drawText(`CA22 estimate: ${input.estimate.estimateNumber} · version ${input.estimate.versionNumber}`, { x: 40, y: 716, size: 9, font: regular })
+  page.drawText("By signing, each party acknowledges the complete numbered contract packet.", { x: 40, y: 700, size: 9, font: regular })
+  const signers = [
+    ...input.packet.clientSigners.map((signer, index) => ({
+      label: `Owner ${index + 1}`,
+      name: signer.name,
+      title: signer.title,
+    })),
+    {
+      label: "Company representative",
+      name: input.packet.companySignerName ?? "",
+      title: input.packet.companySignerTitle ?? "",
+    },
+  ]
+  const margin = 40
+  const gap = 30
+  const width = Math.floor((PAGE_WIDTH - margin * 2 - gap) / 2)
+  for (const [index, signer] of signers.entries()) {
+    const row = Math.floor(index / 2)
+    const column = index % 2
+    const x = margin + column * (width + gap)
+    // These rows deliberately match prepareEstimateSignaturePdf's fixed Foxit
+    // signature/date coordinates, with labels just above each editable field.
+    const topY = PAGE_HEIGHT - 102 - row * 126
+    page.drawText(`${signer.label}: ${signer.name}`, { x, y: topY, size: 8, font: bold })
+    if (signer.title) page.drawText(signer.title, { x, y: topY - 12, size: 7, font: regular })
+    page.drawText("Signature", { x, y: topY - 55, size: 7, font: regular })
+    page.drawLine({ start: { x, y: topY - 59 }, end: { x: x + width, y: topY - 59 }, thickness: 0.6 })
+    page.drawText("Date signed", { x, y: topY - 104, size: 7, font: regular })
+    page.drawLine({ start: { x, y: topY - 108 }, end: { x: x + width, y: topY - 108 }, thickness: 0.6 })
+  }
+}
+
+export async function prepareContractPacketPdf(input: {
+  readonly packet: ProjectContractPacketSummary
+  readonly documents: readonly ProjectContractPacketDocumentItem[]
+  readonly estimate: ProjectContractPacketEstimateOption
+  readonly projectName: string
+  readonly projectNumber: string | null
+  readonly projectAddress: string | null
+  readonly estimatePdf: ArrayBuffer
+}): Promise<PreparedEstimateSignaturePdf> {
+  if (!input.documents.some((item) => item.code === "CA00")) {
+    throw new Error("Add CA00 before preparing the full contract packet.")
+  }
+  if (!input.documents.some((item) => item.code === "CA22")) {
+    throw new Error("Add CA22 before preparing the full contract packet.")
+  }
+  const contract = await renderContractDocuments(input)
+  await appendEstimateWithoutSignaturePage(contract, input.estimatePdf)
+  await appendPacketSignaturePage({
+    document: contract,
+    packet: input.packet,
+    estimate: input.estimate,
+  })
+  const saved = await contract.save()
+  const copy = new Uint8Array(saved.byteLength)
+  copy.set(saved)
+  return prepareEstimateSignaturePdf({
+    pdf: copy.buffer,
+    signerLabels: [
+      ...input.packet.clientSigners.map((_, index) => `Owner ${index + 1}`),
+      "Company",
+    ],
+  })
+}
+
+export function base64PdfBytes(value: string): Uint8Array {
+  const binary = atob(value)
+  const bytes = new Uint8Array(binary.length)
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index)
+  }
+  return bytes
+}

--- a/src/lib/contracts/packet.ts
+++ b/src/lib/contracts/packet.ts
@@ -1,0 +1,164 @@
+export type ContractPacketSigner = {
+  readonly contactId: string | null
+  readonly name: string
+  readonly title: string
+  readonly email: string
+  readonly initials: string
+}
+
+export type ContractPacketScheduleItem = {
+  readonly code: string
+  readonly title: string
+  readonly documentDate: string | null
+  readonly revision: string | null
+  readonly inclusionMode: string
+  readonly signingStage: string
+}
+
+export type ContractPacketTokenValues = Readonly<Record<string, string>>
+
+const SMALL_NUMBERS = [
+  "zero",
+  "one",
+  "two",
+  "three",
+  "four",
+  "five",
+  "six",
+  "seven",
+  "eight",
+  "nine",
+  "ten",
+  "eleven",
+  "twelve",
+  "thirteen",
+  "fourteen",
+  "fifteen",
+  "sixteen",
+  "seventeen",
+  "eighteen",
+  "nineteen",
+] as const
+
+const TENS = [
+  "",
+  "",
+  "twenty",
+  "thirty",
+  "forty",
+  "fifty",
+  "sixty",
+  "seventy",
+  "eighty",
+  "ninety",
+] as const
+
+function underThousand(value: number): string {
+  const hundreds = Math.floor(value / 100)
+  const remainder = value % 100
+  const words: string[] = []
+  if (hundreds > 0) words.push(`${SMALL_NUMBERS[hundreds]} hundred`)
+  if (remainder < 20) {
+    if (remainder > 0) words.push(SMALL_NUMBERS[remainder] ?? "")
+  } else {
+    const tens = TENS[Math.floor(remainder / 10)] ?? ""
+    const ones = remainder % 10
+    words.push(ones > 0 ? `${tens}-${SMALL_NUMBERS[ones]}` : tens)
+  }
+  return words.filter(Boolean).join(" ")
+}
+
+export function dollarsInWords(cents: number): string {
+  const safeCents = Math.max(0, Math.round(cents))
+  const dollars = Math.floor(safeCents / 100)
+  const remainder = safeCents % 100
+  if (dollars === 0) return `Zero dollars and ${remainder.toString().padStart(2, "0")}/100`
+  const groups = [
+    { size: 1_000_000_000, label: "billion" },
+    { size: 1_000_000, label: "million" },
+    { size: 1_000, label: "thousand" },
+    { size: 1, label: "" },
+  ] as const
+  let remaining = dollars
+  const words: string[] = []
+  for (const group of groups) {
+    const amount = Math.floor(remaining / group.size)
+    if (amount === 0) continue
+    words.push([underThousand(amount), group.label].filter(Boolean).join(" "))
+    remaining %= group.size
+  }
+  const label = dollars === 1 ? "dollar" : "dollars"
+  const result = `${words.join(" ")} ${label} and ${remainder.toString().padStart(2, "0")}/100`
+  return result.charAt(0).toUpperCase() + result.slice(1)
+}
+
+export function signerInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part[0] ?? "")
+    .join("")
+    .slice(0, 6)
+    .toUpperCase()
+}
+
+export function parsePacketSigners(value: string): readonly ContractPacketSigner[] {
+  try {
+    const parsed: unknown = JSON.parse(value)
+    if (!Array.isArray(parsed)) return []
+    return parsed.flatMap((item): readonly ContractPacketSigner[] => {
+      if (!item || typeof item !== "object") return []
+      const stringValue = (key: string): string => {
+        const candidate = Reflect.get(item, key)
+        return typeof candidate === "string" ? candidate.trim() : ""
+      }
+      const name = stringValue("name")
+      if (!name) return []
+      const contactId = Reflect.get(item, "contactId")
+      return [{
+        contactId: typeof contactId === "string" && contactId ? contactId : null,
+        name,
+        title: stringValue("title"),
+        email: stringValue("email"),
+        initials: stringValue("initials") || signerInitials(name),
+      }]
+    })
+  } catch {
+    return []
+  }
+}
+
+export function contractDocumentSchedule(
+  documents: readonly ContractPacketScheduleItem[]
+): string {
+  if (documents.length === 0) return "No contract documents selected."
+  return [
+    "| Document | Title | Date / revision | Treatment |",
+    "| --- | --- | --- | --- |",
+    ...documents.map((document) => {
+      const dateRevision = [document.documentDate, document.revision]
+        .filter(Boolean)
+        .join(" · ") || "Packet version"
+      const treatment = document.inclusionMode === "reference"
+        ? "Incorporated by reference"
+        : document.signingStage === "closeout"
+          ? "Closeout document"
+          : "Included"
+      return `| ${document.code} | ${document.title} | ${dateRevision} | ${treatment} |`
+    }),
+  ].join("\n")
+}
+
+export function fillContractTokens(
+  content: string,
+  values: ContractPacketTokenValues
+): string {
+  return content.replace(/\{\{([a-z0-9_.-]+)\}\}/gi, (token, key: string) => {
+    const value = values[key]
+    return value === undefined || value === "" ? token : value
+  })
+}
+
+export function contractPacketCanBeEdited(status: string): boolean {
+  return status === "draft" || status === "internal_review"
+}

--- a/src/lib/contracts/source.ts
+++ b/src/lib/contracts/source.ts
@@ -1,0 +1,313 @@
+export const ORC_CONTRACT_SOURCE_WORKBOOK_ID =
+  "1KvlCuzkcMMX6FNIOEJdbAXGlbJKvosMuZVv0JWGSwYg"
+
+export const ORC_CONTRACT_SOURCE_URL =
+  `https://docs.google.com/spreadsheets/d/${ORC_CONTRACT_SOURCE_WORKBOOK_ID}/edit`
+
+export type ContractSigningStage =
+  | "contract"
+  | "construction"
+  | "closeout"
+  | "reference"
+
+export type ContractInclusionMode = "embedded" | "reference" | "generated"
+
+type SourceSegment = {
+  readonly sheetName: string
+  readonly startRow: number
+  readonly endRow: number
+  readonly kind: "paragraphs" | "table"
+}
+
+export type OrcContractSourceDefinition = {
+  readonly code: string
+  readonly name: string
+  readonly category: "agreement" | "general_conditions" | "exhibit" | "form" | "manual" | "generated"
+  readonly signingStage: ContractSigningStage
+  readonly defaultInclusionMode: ContractInclusionMode
+  readonly sheetNames: readonly string[]
+  readonly segments: readonly SourceSegment[]
+  readonly sortOrder: number
+}
+
+export const ORC_CONTRACT_SOURCE_DEFINITIONS: readonly OrcContractSourceDefinition[] = [
+  {
+    code: "CA00",
+    name: "Cost Plus - Fixed Fee Contract",
+    category: "agreement",
+    signingStage: "contract",
+    defaultInclusionMode: "embedded",
+    sheetNames: ["CA00 Cost Plus"],
+    segments: [
+      { sheetName: "CA00 Cost Plus", startRow: 25, endRow: 27, kind: "paragraphs" },
+      { sheetName: "CA00 Cost Plus", startRow: 45, endRow: 125, kind: "paragraphs" },
+    ],
+    sortOrder: 0,
+  },
+  {
+    code: "CA01",
+    name: "General Conditions",
+    category: "general_conditions",
+    signingStage: "contract",
+    defaultInclusionMode: "embedded",
+    sheetNames: ["CA01 General Conditions"],
+    segments: [
+      { sheetName: "CA01 General Conditions", startRow: 25, endRow: 127, kind: "paragraphs" },
+    ],
+    sortOrder: 10,
+  },
+  {
+    code: "CA11",
+    name: "Inspection Checklist and Walk-Through Process",
+    category: "form",
+    signingStage: "closeout",
+    defaultInclusionMode: "embedded",
+    sheetNames: [
+      "CA11 Inspection Check List",
+      "CA11 Inspection Check List (2)",
+      "CA11 Inspection Check List (3)",
+    ],
+    segments: [
+      { sheetName: "CA11 Inspection Check List", startRow: 23, endRow: 23, kind: "paragraphs" },
+      { sheetName: "CA11 Inspection Check List (2)", startRow: 1, endRow: 38, kind: "table" },
+      { sheetName: "CA11 Inspection Check List (3)", startRow: 1, endRow: 2, kind: "paragraphs" },
+      { sheetName: "CA11 Inspection Check List (3)", startRow: 15, endRow: 16, kind: "paragraphs" },
+    ],
+    sortOrder: 20,
+  },
+  {
+    code: "CA12",
+    name: "Limited Warranty",
+    category: "exhibit",
+    signingStage: "closeout",
+    defaultInclusionMode: "embedded",
+    sheetNames: ["CA12 Limited Warranty"],
+    segments: [
+      { sheetName: "CA12 Limited Warranty", startRow: 22, endRow: 54, kind: "paragraphs" },
+    ],
+    sortOrder: 30,
+  },
+  {
+    code: "CA15",
+    name: "Change Order Basics",
+    category: "exhibit",
+    signingStage: "contract",
+    defaultInclusionMode: "embedded",
+    sheetNames: ["CA15 Change Order Basics"],
+    segments: [
+      { sheetName: "CA15 Change Order Basics", startRow: 27, endRow: 80, kind: "paragraphs" },
+      { sheetName: "CA15 Change Order Basics", startRow: 81, endRow: 89, kind: "table" },
+      { sheetName: "CA15 Change Order Basics", startRow: 90, endRow: 93, kind: "paragraphs" },
+    ],
+    sortOrder: 40,
+  },
+  {
+    code: "CA17",
+    name: "Reimbursable Expenses",
+    category: "exhibit",
+    signingStage: "contract",
+    defaultInclusionMode: "embedded",
+    sheetNames: ["CA17 Reimbursable Expenses"],
+    segments: [
+      { sheetName: "CA17 Reimbursable Expenses", startRow: 23, endRow: 23, kind: "paragraphs" },
+      { sheetName: "CA17 Reimbursable Expenses", startRow: 24, endRow: 36, kind: "table" },
+      { sheetName: "CA17 Reimbursable Expenses", startRow: 37, endRow: 38, kind: "paragraphs" },
+    ],
+    sortOrder: 50,
+  },
+  {
+    code: "CA18",
+    name: "Homeowner's Warranty Manual",
+    category: "manual",
+    signingStage: "reference",
+    defaultInclusionMode: "reference",
+    sheetNames: [],
+    segments: [],
+    sortOrder: 60,
+  },
+  {
+    code: "CA19",
+    name: "Allowances and Finish Schedules",
+    category: "exhibit",
+    signingStage: "contract",
+    defaultInclusionMode: "embedded",
+    sheetNames: ["CA19 Allowances and Finishes Sc"],
+    segments: [
+      { sheetName: "CA19 Allowances and Finishes Sc", startRow: 24, endRow: 46, kind: "paragraphs" },
+      { sheetName: "CA19 Allowances and Finishes Sc", startRow: 47, endRow: 53, kind: "table" },
+      { sheetName: "CA19 Allowances and Finishes Sc", startRow: 54, endRow: 55, kind: "paragraphs" },
+    ],
+    sortOrder: 70,
+  },
+  {
+    code: "CA20",
+    name: "HPS Inspection Process",
+    category: "exhibit",
+    signingStage: "contract",
+    defaultInclusionMode: "embedded",
+    sheetNames: ["CA20 HPS Inspection Process"],
+    segments: [
+      { sheetName: "CA20 HPS Inspection Process", startRow: 24, endRow: 30, kind: "paragraphs" },
+    ],
+    sortOrder: 80,
+  },
+  {
+    code: "CA21",
+    name: "HPS Labor Scope",
+    category: "exhibit",
+    signingStage: "contract",
+    defaultInclusionMode: "embedded",
+    sheetNames: ["CA21 HPS Labor Scope"],
+    segments: [
+      { sheetName: "CA21 HPS Labor Scope", startRow: 21, endRow: 32, kind: "paragraphs" },
+    ],
+    sortOrder: 90,
+  },
+  {
+    code: "CA22",
+    name: "Construction Estimate",
+    category: "generated",
+    signingStage: "contract",
+    defaultInclusionMode: "generated",
+    sheetNames: [],
+    segments: [],
+    sortOrder: 100,
+  },
+] as const
+
+const SOURCE_ROW_OVERRIDES: Readonly<Record<string, Readonly<Record<number, string>>>> = {
+  "CA00 Cost Plus": {
+    27: "## Article 1.2 Specific Contract Documents\n\n{{contract.document_schedule}}",
+    48: "{{project.location}}",
+    52: "{{contract.commencement_date}}",
+    54: "{{contract.completion_date}}",
+    56: "{{contract.execution_date}}",
+    59: "The construction coordination services fee (overhead/margin/builder contingency) shall be charged at {{estimate.builder_fee_percent}} of the Construction Estimate dated {{estimate.date}}.",
+    60: "",
+    61: "The construction coordination services fee is {{estimate.builder_fee_words}},",
+    62: "{{estimate.builder_fee_total}}.",
+    65: "Article 4.2. Pre-construction estimates for construction costs and coordination are approximately {{estimate.total_words}},",
+    66: "{{estimate.total}}.",
+    68: "Article 4.3. The Owner and the Contractor acknowledge that the Owner will pay {{contract.deposit_words}},",
+    69: "{{contract.deposit}}, upon signing of this contract, after Owner receives construction financing, and before construction begins as a deposit and part of the purchase price of the project.",
+    70: "",
+    73: "Article 5.1. The Owner will make payments to the Contractor monthly based on invoices for labor and materials submitted. Construction coordination fees shall also be paid with those draws. Owner shall make payments to Contractor within 10 days after request. Should the Owner fail to make payment within 30 days, Contractor may charge a penalty of {{contract.late_payment_percent}} annually upon the unpaid amount until paid. Should the lender require additional information, documentation, or verification after inspection that delays the release of funds, no penalties shall be applied.",
+  },
+  "CA12 Limited Warranty": {
+    22: "Whereas, Contractor has built a Project located in the County of {{project.county}}, State of Colorado, at {{project.address}}, and",
+    23: "",
+  },
+}
+
+export type ContractSourceRows = Readonly<Record<string, readonly (readonly unknown[])[]>>
+
+function cleanCell(value: unknown): string {
+  return typeof value === "string" || typeof value === "number"
+    ? String(value).replace(/\u00a0/g, " ").replace(/\s+/g, " ").trim()
+    : ""
+}
+
+function markdownCell(value: string): string {
+  return value.replaceAll("|", "\\|")
+}
+
+function paragraphLine(value: string): string {
+  if (/^·\s*/.test(value)) return `- ${value.replace(/^·\s*/, "")}`
+  if (
+    /^(Article\s+\d+\.?\s+[A-Z][A-Z\s,&/-]+|What\s|Why\s|How\s|When\s|Change Order Fees$|Value Engineering and Value Engineering Fees$|Allowance vs\. Option$|Finish Schedule$|Finish Schedule Requirements$|Cutoff Points for Changes$|First Inspection$|Second Inspection$)/.test(
+      value
+    )
+  ) {
+    return `## ${value}`
+  }
+  return value
+}
+
+function sourceRow(
+  sheetName: string,
+  rowNumber: number,
+  rows: readonly (readonly unknown[])[]
+): readonly string[] {
+  const override = SOURCE_ROW_OVERRIDES[sheetName]?.[rowNumber]
+  if (override !== undefined) return override ? [override] : []
+  const row = rows[rowNumber - 1] ?? []
+  return row.map(cleanCell).filter(Boolean)
+}
+
+function paragraphSegment(
+  segment: SourceSegment,
+  rows: readonly (readonly unknown[])[]
+): string {
+  const output: string[] = []
+  for (let rowNumber = segment.startRow; rowNumber <= segment.endRow; rowNumber += 1) {
+    const cells = sourceRow(segment.sheetName, rowNumber, rows)
+    if (cells.length === 0) continue
+    const value = cells.join(" — ")
+    output.push(paragraphLine(value))
+  }
+  return output.join("\n\n")
+}
+
+function tableSegment(
+  segment: SourceSegment,
+  rows: readonly (readonly unknown[])[]
+): string {
+  const tableRows: readonly string[][] = Array.from(
+    { length: segment.endRow - segment.startRow + 1 },
+    (_, index) => sourceRow(segment.sheetName, segment.startRow + index, rows).map(markdownCell)
+  ).filter((row) => row.length > 0)
+  if (tableRows.length === 0) return ""
+  const width = Math.max(...tableRows.map((row) => row.length))
+  const normalized = tableRows.map((row) => [
+    ...row,
+    ...Array.from({ length: width - row.length }, () => ""),
+  ])
+  const [header, ...body] = normalized
+  if (!header) return ""
+  return [
+    `| ${header.join(" | ")} |`,
+    `| ${header.map(() => "---").join(" | ")} |`,
+    ...body.map((row) => `| ${row.join(" | ")} |`),
+  ].join("\n")
+}
+
+export function normalizeContractSourceDocument(input: {
+  readonly definition: OrcContractSourceDefinition
+  readonly rows: ContractSourceRows
+}): string {
+  if (input.definition.code === "CA18") {
+    return "The Homeowner's Warranty Manual is incorporated by reference and delivered separately. The full handbook is not embedded in the contract packet."
+  }
+  if (input.definition.code === "CA22") {
+    return "The selected Compass construction estimate is generated and inserted at packet preparation time."
+  }
+  return input.definition.segments
+    .map((segment) => {
+      const rows = input.rows[segment.sheetName] ?? []
+      return segment.kind === "table"
+        ? tableSegment(segment, rows)
+        : paragraphSegment(segment, rows)
+    })
+    .filter(Boolean)
+    .join("\n\n")
+    .trim()
+}
+
+export function contractSourceRanges(): readonly {
+  readonly sheetName: string
+  readonly range: string
+}[] {
+  const bySheet = new Map<string, number>()
+  for (const definition of ORC_CONTRACT_SOURCE_DEFINITIONS) {
+    for (const segment of definition.segments) {
+      bySheet.set(
+        segment.sheetName,
+        Math.max(bySheet.get(segment.sheetName) ?? 0, segment.endRow)
+      )
+    }
+  }
+  return [...bySheet.entries()].map(([sheetName, endRow]) => ({
+    sheetName,
+    range: `'${sheetName.replaceAll("'", "''")}'!A1:Z${endRow}`,
+  }))
+}

--- a/src/lib/foxit/esign.ts
+++ b/src/lib/foxit/esign.ts
@@ -67,6 +67,7 @@ export async function createFoxitPreparedEnvelope(input: {
   readonly successUrl: string
   readonly errorUrl: string
   readonly estimateId: string
+  readonly contractPacketId?: string
   readonly sourceHash: string
 }): Promise<FoxitPreparedEnvelope> {
   const response = await fetch(`${FOXIT_ESIGN_BASE_URL}/folders/createfolder`, {
@@ -108,6 +109,9 @@ export async function createFoxitPreparedEnvelope(input: {
       sendErrorUrl: input.errorUrl,
       metadata: {
         compassEstimateId: input.estimateId,
+        ...(input.contractPacketId
+          ? { compassContractPacketId: input.contractPacketId }
+          : {}),
         compassSourceHash: input.sourceHash,
       },
     }),

--- a/src/lib/project-branding.ts
+++ b/src/lib/project-branding.ts
@@ -11,6 +11,13 @@ export type ProjectBrand = {
   readonly telephone: string
 }
 
+const PROJECT_LEGAL_ENTITY_NAMES: Readonly<Record<ProjectDepartment, string>> = {
+  O: "High Performance Structures Inc. dba Open Range Construction, Ltd.",
+  D: "High Performance Structures Inc. dba Open Range Construction, Ltd.",
+  N: "High Performance Structures Inc. dba Nu-Tech Systems",
+  H: "High Performance Structures Inc.",
+}
+
 type BrandIdentity = Omit<ProjectBrand, "contactLines" | "department">
 
 const ORC_BRAND: BrandIdentity = {
@@ -96,4 +103,10 @@ export function projectBrandFor({
     ],
     department,
   }
+}
+
+export function projectLegalEntityName(
+  department: ProjectDepartment
+): string {
+  return PROJECT_LEGAL_ENTITY_NAMES[department]
 }


### PR DESCRIPTION
## Summary

- add a versioned contract-template library sourced from the ORC contract workbook and backed up to Google Drive
- add project contract packets tied to an exact estimate version, with editable document snapshots, duplication, and generated CA00 document schedules
- assemble numbered contract PDFs with signer initials, Foxit signature/date fields, multiple owner signers, and one company signer
- preserve the Warranty Handbook as a reference and defer inspection/walk-through documents to closeout
- support Foxit execution and manual signed-document evidence, automatically accepting the exact estimate and rebuilding the contract budget/G703
- select the legal entity by project department (O/D, N, or H)

## Data migration

- adds `0130_contract_packets.sql`
- verified against a fresh local D1 database
- production migration is intentionally deferred until release approval

## Verification

- `bunx tsc --noEmit --pretty false`
- `bunx eslint . --quiet`
- `bun run test` — 215 files / 1,132 tests passed
- `bun run build`
- contract PDF render and visual inspection, including page numbering, initials, and signature page layout

## Release notes

- external Codex autoreview was intentionally skipped at the product owner's request
- merge, production migration, and deployment remain separate release actions
