### PR TITLE
fix(contracts): expose contract navigation

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -28,6 +28,7 @@ import {
   IconShieldCheck,
   IconShoppingCart,
   IconShoppingCartQuestion,
+  IconTemplate,
   IconUsers,
   IconVideo,
 } from "@tabler/icons-react"
@@ -186,10 +187,12 @@ const NAV_GROUPS: ReadonlyArray<SidebarNavGroupSource> = [
             icon: IconFiles,
           },
           {
-            kind: "coming-soon",
+            kind: "link",
             title: "Contract Documents",
-            note: "Coming soon",
+            url: "/dashboard/projects",
             icon: IconFileText,
+            projectPath: "/contracts",
+            internalOnly: true,
           },
           {
             kind: "link",
@@ -359,6 +362,13 @@ const NAV_GROUPS: ReadonlyArray<SidebarNavGroupSource> = [
         title: "Contacts",
         url: "/dashboard/contacts",
         icon: IconAddressBook,
+      },
+      {
+        kind: "link",
+        title: "Template Library",
+        url: "/dashboard/templates",
+        icon: IconTemplate,
+        internalOnly: true,
       },
       {
         kind: "link",


### PR DESCRIPTION
## Summary

- replace the grey Contract Documents placeholder with the live project contract-packet route
- add an internal Template Library navigation item under Office
- preserve project selection behavior when no active project is selected

## Verification

- `node --max-old-space-size=8192 node_modules/typescript/bin/tsc --noEmit --pretty false`
- `bunx eslint src/components/app-sidebar.tsx --quiet`
- `bun run test` — 215 files / 1,132 tests passed
- production build passed in the pre-push hook

## Release notes

- no database migration required
- external Codex autoreview remains skipped at the product owner's request
