### PR TITLE
fix(contracts): refine deposits branding and preview

### DIFF
--- a/docs/modules/contracts.md
+++ b/docs/modules/contracts.md
@@ -44,7 +44,9 @@ without changing the global template.
 CA00's contract-document schedule is generated from the exact selected packet
 documents, including dates, revisions, reference treatment, and closeout
 treatment. Project department determines the default contractor legal entity.
-The entity remains editable on a draft packet.
+The entity remains editable on a draft packet. The deposit is entered as a
+required percentage of the linked estimate total; Compass calculates and stores
+the corresponding dollar amount so the contract text cannot drift from CA22.
 
 
 PDF and signature workflow
@@ -52,6 +54,9 @@ PDF and signature workflow
 
 Compass creates one letter-size PDF by rendering contract-stage Markdown,
 inserting the linked CA22 estimate, and appending a consolidated signature page.
+Every Compass-rendered contract page carries the project department's company
+logo and contact details. Draft previews open inside the Contract workspace,
+with a separate download action when a local copy is needed.
 The final pass adds `Page # of #` to every page, required Foxit initials fields
 to every page except the full-signature page, and signature plus system date
 fields for every owner signer and the company representative.
@@ -73,7 +78,8 @@ implementation map
 ---
 
 - Schema: `src/db/schema-contracts.ts`
-- Migration: `drizzle/0130_contract_packets.sql`
+- Migrations: `drizzle/0130_contract_packets.sql`,
+  `drizzle/0131_contract_deposit_rate.sql`
 - Template actions: `src/app/actions/contract-templates.ts`
 - Packet actions: `src/app/actions/contract-packets.ts`
 - Source normalization: `src/lib/contracts/source.ts`

--- a/drizzle/0131_contract_deposit_rate.sql
+++ b/drizzle/0131_contract_deposit_rate.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `contract_packets` ADD `deposit_rate_basis_points` integer DEFAULT 0 NOT NULL;

--- a/src/app/actions/contract-packets.ts
+++ b/src/app/actions/contract-packets.ts
@@ -15,12 +15,16 @@ import {
 import { projectEstimates } from "@/db/schema-estimates"
 import { requireAuth, type AuthUser } from "@/lib/auth"
 import {
+  contractDepositCents,
   contractPacketCanBeEdited,
   parsePacketSigners,
   signerInitials,
   type ContractPacketSigner,
 } from "@/lib/contracts/packet"
-import { prepareContractPacketPdf } from "@/lib/contracts/packet-pdf"
+import {
+  loadContractPacketPdfBranding,
+  prepareContractPacketPdf,
+} from "@/lib/contracts/packet-pdf"
 import { getCloudflareContext } from "@/lib/db"
 import { rebuildProjectContractBudget } from "@/lib/financials/contract-budget-store"
 import { createFoxitPreparedEnvelope } from "@/lib/foxit/esign"
@@ -75,6 +79,7 @@ export type ProjectContractPacketSummary = {
   readonly contractDraftDate: string | null
   readonly approximateCommencementDate: string | null
   readonly approximateCompletionDate: string | null
+  readonly depositRateBasisPoints: number
   readonly depositCents: number
   readonly latePaymentRateBasisPoints: number
   readonly details: Readonly<Record<string, string>>
@@ -232,6 +237,7 @@ function packetSummary(
     contractDraftDate: row.contractDraftDate,
     approximateCommencementDate: row.approximateCommencementDate,
     approximateCompletionDate: row.approximateCompletionDate,
+    depositRateBasisPoints: row.depositRateBasisPoints,
     depositCents: row.depositCents,
     latePaymentRateBasisPoints: row.latePaymentRateBasisPoints,
     details: safeStringRecord(row.detailsJson),
@@ -574,7 +580,7 @@ export async function saveProjectContractPacket(
     readonly contractDraftDate: string | null
     readonly approximateCommencementDate: string | null
     readonly approximateCompletionDate: string | null
-    readonly depositDollars: number | null
+    readonly depositPercent: number | null
     readonly latePaymentPercent: number | null
     readonly details: Readonly<Record<string, string>>
     readonly clientSigners: readonly ContractPacketSigner[]
@@ -602,10 +608,14 @@ export async function saveProjectContractPacket(
         initials: (cleanText(signer.initials) ?? signerInitials(name)).toUpperCase(),
       }]
     })
-    const depositCents = Math.round((input.depositDollars ?? 0) * 100)
+    const depositRateBasisPoints = Math.round((input.depositPercent ?? 0) * 100)
     const latePaymentRateBasisPoints = Math.round((input.latePaymentPercent ?? 0) * 100)
-    if (!Number.isFinite(depositCents) || depositCents < 0) {
-      throw new Error("Deposit must be zero or greater.")
+    if (
+      !Number.isFinite(depositRateBasisPoints) ||
+      depositRateBasisPoints <= 0 ||
+      depositRateBasisPoints > 10_000
+    ) {
+      throw new Error("Deposit percentage is required and must be between 0% and 100%.")
     }
     if (
       !Number.isFinite(latePaymentRateBasisPoints) ||
@@ -614,6 +624,21 @@ export async function saveProjectContractPacket(
     ) {
       throw new Error("Late-payment rate must be between 0% and 10,000%.")
     }
+    const estimate = await access.db
+      .select({ estimateTotalCents: projectEstimates.estimateTotalCents })
+      .from(projectEstimates)
+      .where(
+        and(
+          eq(projectEstimates.id, packet.estimateId),
+          eq(projectEstimates.projectId, projectId)
+        )
+      )
+      .get()
+    if (!estimate) throw new Error("The linked CA22 estimate was not found.")
+    const depositCents = contractDepositCents(
+      estimate.estimateTotalCents,
+      depositRateBasisPoints
+    )
     const now = new Date().toISOString()
     await access.db
       .update(contractPackets)
@@ -623,6 +648,7 @@ export async function saveProjectContractPacket(
         contractDraftDate: cleanText(input.contractDraftDate),
         approximateCommencementDate: cleanText(input.approximateCommencementDate),
         approximateCompletionDate: cleanText(input.approximateCompletionDate),
+        depositRateBasisPoints,
         depositCents,
         latePaymentRateBasisPoints,
         detailsJson: JSON.stringify(input.details),
@@ -840,6 +866,7 @@ export async function duplicateProjectContractPacket(
         contractDraftDate: now.slice(0, 10),
         approximateCommencementDate: source.approximateCommencementDate,
         approximateCompletionDate: source.approximateCompletionDate,
+        depositRateBasisPoints: source.depositRateBasisPoints,
         depositCents: source.depositCents,
         latePaymentRateBasisPoints: source.latePaymentRateBasisPoints,
         detailsJson: source.detailsJson,
@@ -1001,6 +1028,19 @@ export async function prepareProjectContractPacketForSignature(
     if (!cleanText(packet.companySignerInitials)) {
       throw new Error("Add the company representative initials before signature.")
     }
+    if (
+      packet.depositRateBasisPoints <= 0 ||
+      packet.depositRateBasisPoints > 10_000
+    ) {
+      throw new Error("Add a deposit percentage between 0% and 100% before signature.")
+    }
+    const expectedDepositCents = contractDepositCents(
+      estimate.estimateTotalCents,
+      packet.depositRateBasisPoints
+    )
+    if (packet.depositCents !== expectedDepositCents) {
+      throw new Error("Save the contract information again so the deposit matches the estimate total.")
+    }
     const sourceHash = await sha256(JSON.stringify({
       packet: packetSummary(packet, false),
       documents: workspace.documents,
@@ -1011,11 +1051,22 @@ export async function prepareProjectContractPacketForSignature(
     if (!clientId || !clientSecret) {
       throw new Error("Foxit eSign credentials are not configured for Compass.")
     }
-    const estimatePdf = await renderContractEstimatePdf({
-      env: access.env,
-      projectId,
-      estimateId: estimate.id,
-    })
+    const origin = new URL(access.env.WORKOS_REDIRECT_URI).origin
+    const assets = access.env.ASSETS
+    if (!assets) throw new Error("Cloudflare Assets is unavailable for contract branding.")
+    const [estimatePdf, brand] = await Promise.all([
+      renderContractEstimatePdf({
+        env: access.env,
+        projectId,
+        estimateId: estimate.id,
+      }),
+      loadContractPacketPdfBranding({
+        assets,
+        origin,
+        projectId,
+        projectNumber: workspace.projectNumber,
+      }),
+    ])
     const prepared = await prepareContractPacketPdf({
       packet: packetSummary(packet, false),
       documents: workspace.documents,
@@ -1023,9 +1074,9 @@ export async function prepareProjectContractPacketForSignature(
       projectName: workspace.projectName,
       projectNumber: workspace.projectNumber,
       projectAddress: workspace.projectAddress,
+      brand,
       estimatePdf,
     })
-    const origin = new URL(access.env.WORKOS_REDIRECT_URI).origin
     const successUrl = new URL(`/dashboard/projects/${projectId}/contracts`, origin)
     successUrl.searchParams.set("packetId", packetId)
     successUrl.searchParams.set("foxit", "sent")

--- a/src/app/api/projects/[id]/contract-packets/[packetId]/pdf/route.ts
+++ b/src/app/api/projects/[id]/contract-packets/[packetId]/pdf/route.ts
@@ -1,5 +1,9 @@
 import { getProjectContractPacketWorkspace } from "@/app/actions/contract-packets"
-import { base64PdfBytes, prepareContractPacketPdf } from "@/lib/contracts/packet-pdf"
+import {
+  base64PdfBytes,
+  loadContractPacketPdfBranding,
+  prepareContractPacketPdf,
+} from "@/lib/contracts/packet-pdf"
 import { getCloudflareContext } from "@/lib/db"
 
 async function renderEstimatePdf(input: {
@@ -52,13 +56,25 @@ export async function GET(
       return Response.json({ success: false, error: "Linked estimate not found." }, { status: 404 })
     }
     const { env } = await getCloudflareContext()
-    const estimatePdf = await renderEstimatePdf({
-      env,
-      origin: new URL(request.url).origin,
-      cookie: request.headers.get("cookie") ?? "",
-      projectId: id,
-      estimateId: estimate.id,
-    })
+    const assets = env.ASSETS
+    if (!assets) throw new Error("Cloudflare Assets is unavailable for contract branding.")
+    const origin = new URL(request.url).origin
+    const cookie = request.headers.get("cookie") ?? ""
+    const [estimatePdf, brand] = await Promise.all([
+      renderEstimatePdf({
+        env,
+        origin,
+        cookie,
+        projectId: id,
+        estimateId: estimate.id,
+      }),
+      loadContractPacketPdfBranding({
+        assets,
+        origin,
+        projectId: id,
+        projectNumber: workspace.projectNumber,
+      }),
+    ])
     const prepared = await prepareContractPacketPdf({
       packet,
       documents: workspace.documents,
@@ -66,6 +82,7 @@ export async function GET(
       projectName: workspace.projectName,
       projectNumber: workspace.projectNumber,
       projectAddress: workspace.projectAddress,
+      brand,
       estimatePdf,
     })
     const bytes = base64PdfBytes(prepared.pdfBase64)

--- a/src/components/projects/project-contract-packet-workspace.tsx
+++ b/src/components/projects/project-contract-packet-workspace.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation"
 import { useMemo, useState, useTransition, type FormEvent } from "react"
 import {
   IconCopy,
+  IconDownload,
   IconFileDescription,
   IconPlus,
   IconPrinter,
@@ -46,6 +47,12 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -53,7 +60,12 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
-import { contractPacketCanBeEdited, signerInitials, type ContractPacketSigner } from "@/lib/contracts/packet"
+import {
+  contractDepositCents,
+  contractPacketCanBeEdited,
+  signerInitials,
+  type ContractPacketSigner,
+} from "@/lib/contracts/packet"
 
 function money(cents: number): string {
   return new Intl.NumberFormat("en-US", {
@@ -270,12 +282,24 @@ export function ProjectContractPacketWorkspacePanel({
   const [estimateId, setEstimateId] = useState(workspace.estimateOptions[0]?.id ?? "")
   const packet = workspace.activePacket
   const editable = Boolean(packet && workspace.canEdit && contractPacketCanBeEdited(packet.status))
+  const linkedEstimate = workspace.estimateOptions.find(
+    (estimate) => estimate.id === packet?.estimateId
+  )
+  const initialDepositRateBasisPoints = packet?.depositRateBasisPoints || (
+    packet && linkedEstimate && linkedEstimate.estimateTotalCents > 0
+      ? Math.round(packet.depositCents * 10_000 / linkedEstimate.estimateTotalCents)
+      : 0
+  )
   const [title, setTitle] = useState(packet?.title ?? "Construction Contract")
   const [legalEntityName, setLegalEntityName] = useState(packet?.legalEntityName ?? "")
   const [contractDraftDate, setContractDraftDate] = useState(packet?.contractDraftDate ?? "")
   const [commencementDate, setCommencementDate] = useState(packet?.approximateCommencementDate ?? "")
   const [completionDate, setCompletionDate] = useState(packet?.approximateCompletionDate ?? "")
-  const [deposit, setDeposit] = useState(packet ? String(packet.depositCents / 100) : "0")
+  const [depositPercent, setDepositPercent] = useState(
+    initialDepositRateBasisPoints > 0
+      ? String(initialDepositRateBasisPoints / 100)
+      : ""
+  )
   const [latePaymentRate, setLatePaymentRate] = useState(packet ? String(packet.latePaymentRateBasisPoints / 100) : "12")
   const [projectAddress, setProjectAddress] = useState(packet?.details.projectAddress ?? workspace.projectAddress ?? "")
   const [county, setCounty] = useState(packet?.details.county ?? "")
@@ -299,6 +323,14 @@ export function ProjectContractPacketWorkspacePanel({
   const [evidenceLabel, setEvidenceLabel] = useState("")
   const [signedAt, setSignedAt] = useState(localDateInput())
   const [attested, setAttested] = useState(false)
+  const [previewOpen, setPreviewOpen] = useState(false)
+  const parsedDepositPercent = Number(depositPercent)
+  const depositRateBasisPoints = Number.isFinite(parsedDepositPercent)
+    ? Math.round(parsedDepositPercent * 100)
+    : 0
+  const calculatedDepositCents = linkedEstimate
+    ? contractDepositCents(linkedEstimate.estimateTotalCents, depositRateBasisPoints)
+    : 0
 
   function create(): void {
     if (!estimateId) return
@@ -323,7 +355,7 @@ export function ProjectContractPacketWorkspacePanel({
         contractDraftDate,
         approximateCommencementDate: commencementDate,
         approximateCompletionDate: completionDate,
-        depositDollars: Number(deposit),
+        depositPercent: parsedDepositPercent,
         latePaymentPercent: Number(latePaymentRate),
         details: {
           ...packet.details,
@@ -540,10 +572,8 @@ export function ProjectContractPacketWorkspacePanel({
             <Button variant="outline" onClick={duplicate} disabled={pending || !workspace.canEdit}>
               <IconCopy className="size-4" />Duplicate version
             </Button>
-            <Button variant="outline" asChild>
-              <Link href={`/api/projects/${projectId}/contract-packets/${packet.id}/pdf`} target="_blank">
-                <IconPrinter className="size-4" />Preview PDF
-              </Link>
+            <Button variant="outline" onClick={() => setPreviewOpen(true)}>
+              <IconPrinter className="size-4" />Preview PDF
             </Button>
           </div>
         </div>
@@ -563,10 +593,53 @@ export function ProjectContractPacketWorkspacePanel({
           <div className="space-y-1.5"><Label htmlFor="contract-county">Project county *</Label><Input id="contract-county" value={county} onChange={(event) => setCounty(event.target.value)} disabled={!editable} /></div>
           <div className="space-y-1.5 md:col-span-2"><Label htmlFor="contract-address">Project location *</Label><Input id="contract-address" value={projectAddress} onChange={(event) => setProjectAddress(event.target.value)} disabled={!editable} /></div>
           <div className="space-y-1.5 md:col-span-2"><Label htmlFor="contract-owner">Owner / client name *</Label><Input id="contract-owner" value={ownerName} onChange={(event) => setOwnerName(event.target.value)} disabled={!editable} /></div>
-          <div className="space-y-1.5"><Label htmlFor="contract-deposit">Deposit</Label><Input id="contract-deposit" type="number" min="0" step="0.01" value={deposit} onChange={(event) => setDeposit(event.target.value)} disabled={!editable} /></div>
+          <div className="space-y-1.5">
+            <Label htmlFor="contract-deposit-percent">Deposit (% of estimate) *</Label>
+            <Input
+              id="contract-deposit-percent"
+              type="number"
+              min="0.01"
+              max="100"
+              step="0.01"
+              value={depositPercent}
+              onChange={(event) => setDepositPercent(event.target.value)}
+              disabled={!editable}
+              required
+            />
+            <p className="text-xs text-muted-foreground">
+              {linkedEstimate
+                ? `${money(calculatedDepositCents)} deposit from ${money(linkedEstimate.estimateTotalCents)} estimate total.`
+                : "The linked estimate total is unavailable."}
+            </p>
+          </div>
           <div className="space-y-1.5"><Label htmlFor="contract-late-rate">Late-payment annual rate (%)</Label><Input id="contract-late-rate" type="number" min="0" step="0.01" value={latePaymentRate} onChange={(event) => setLatePaymentRate(event.target.value)} disabled={!editable} /></div>
         </div>
       </section>
+
+      <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
+        <DialogContent className="h-[92vh] max-w-[min(96vw,72rem)] grid-rows-[auto_1fr_auto] p-4">
+          <DialogHeader>
+            <DialogTitle>{packet.packetNumber} · contract packet preview</DialogTitle>
+          </DialogHeader>
+          <iframe
+            title={`${packet.packetNumber} contract packet PDF preview`}
+            src={previewOpen
+              ? `/api/projects/${projectId}/contract-packets/${packet.id}/pdf`
+              : undefined}
+            className="h-full min-h-0 w-full rounded-lg border bg-background"
+          />
+          <div className="flex justify-end">
+            <Button variant="outline" asChild>
+              <a
+                href={`/api/projects/${projectId}/contract-packets/${packet.id}/pdf`}
+                download={`${packet.packetNumber}-contract-v${packet.versionNumber}.pdf`}
+              >
+                <IconDownload className="size-4" />Download PDF
+              </a>
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
 
       <section className="clarity-panel-strong p-4">
         <div className="flex items-start justify-between gap-3">

--- a/src/db/schema-contracts.ts
+++ b/src/db/schema-contracts.ts
@@ -104,6 +104,9 @@ export const contractPackets = sqliteTable(
     contractDraftDate: text("contract_draft_date"),
     approximateCommencementDate: text("approximate_commencement_date"),
     approximateCompletionDate: text("approximate_completion_date"),
+    depositRateBasisPoints: integer("deposit_rate_basis_points")
+      .notNull()
+      .default(0),
     depositCents: integer("deposit_cents").notNull().default(0),
     latePaymentRateBasisPoints: integer("late_payment_rate_basis_points")
       .notNull()

--- a/src/lib/contracts/__tests__/packet-pdf.test.ts
+++ b/src/lib/contracts/__tests__/packet-pdf.test.ts
@@ -23,6 +23,7 @@ describe("contract packet PDF", () => {
         contractDraftDate: "2026-08-23",
         approximateCommencementDate: "2026-09-01",
         approximateCompletionDate: "2027-08-31",
+        depositRateBasisPoints: 1_000,
         depositCents: 10_000_00,
         latePaymentRateBasisPoints: 1200,
         details: { projectAddress: "1 Main Street", county: "Teller", ownerName: "Alex Owner" },
@@ -64,6 +65,14 @@ describe("contract packet PDF", () => {
       projectName: "Compass Developer",
       projectNumber: "H-001",
       projectAddress: "1 Main Street",
+      brand: {
+        companyName: "High Performance Structures, Inc.",
+        contactLines: ["PO Box 1813", "Woodland Park, CO 80866", "Tel: 719.900.8850"],
+        logoBytes: new Uint8Array(Buffer.from(
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+AvV1AAAAAElFTkSuQmCC",
+          "base64"
+        )),
+      },
       estimatePdf: estimateBuffer.buffer,
     })
     const finalPdf = await PDFDocument.load(base64PdfBytes(prepared.pdfBase64))

--- a/src/lib/contracts/__tests__/packet.test.ts
+++ b/src/lib/contracts/__tests__/packet.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest"
 
 import {
+  contractDepositCents,
   contractDocumentSchedule,
   dollarsInWords,
   fillContractTokens,
@@ -8,6 +9,10 @@ import {
 } from "@/lib/contracts/packet"
 
 describe("contract packet domain", () => {
+  test("calculates a deposit from the estimate total and percentage", () => {
+    expect(contractDepositCents(123_456_78, 1_250)).toBe(15_432_10)
+  })
+
   test("spells contract currency with cents", () => {
     expect(dollarsInWords(1_234_567_89)).toBe(
       "One million two hundred thirty-four thousand five hundred sixty-seven dollars and 89/100"

--- a/src/lib/contracts/packet-pdf.ts
+++ b/src/lib/contracts/packet-pdf.ts
@@ -1,6 +1,7 @@
 import {
   PDFDocument,
   PDFFont,
+  PDFImage,
   PDFPage,
   StandardFonts,
   rgb,
@@ -20,6 +21,7 @@ import {
   prepareEstimateSignaturePdf,
   type PreparedEstimateSignaturePdf,
 } from "@/lib/estimates/signature-pdf"
+import { projectBrandFor, type ProjectDepartment } from "@/lib/project-branding"
 
 const PAGE_WIDTH = 612
 const PAGE_HEIGHT = 792
@@ -38,8 +40,16 @@ type Writer = {
   readonly document: PDFDocument
   readonly regular: PDFFont
   readonly bold: PDFFont
+  readonly brand: ContractPacketPdfBranding
+  readonly brandLogo: PDFImage
   page: PDFPage
   y: number
+}
+
+export type ContractPacketPdfBranding = {
+  readonly companyName: string
+  readonly contactLines: readonly string[]
+  readonly logoBytes: Uint8Array
 }
 
 function money(cents: number): string {
@@ -92,9 +102,76 @@ function wrappedLines(text: string, font: PDFFont, size: number, width: number):
   return lines
 }
 
+function drawBrandHeader(
+  writer: Writer,
+  context?: {
+    readonly title: string
+    readonly lines: readonly string[]
+  }
+): void {
+  const logoSize = 32
+  const logo = writer.brandLogo.scaleToFit(logoSize, logoSize)
+  const logoAreaY = PAGE_HEIGHT - MARGIN - 22
+  writer.page.drawImage(writer.brandLogo, {
+    x: MARGIN + (logoSize - logo.width) / 2,
+    y: logoAreaY + (logoSize - logo.height) / 2,
+    width: logo.width,
+    height: logo.height,
+  })
+  writer.page.drawText(writer.brand.companyName, {
+    x: MARGIN + logoSize + 12,
+    y: PAGE_HEIGHT - MARGIN + 1,
+    size: 11,
+    font: writer.bold,
+    color: rgb(0.08, 0.08, 0.08),
+  })
+  const contactWidth = context ? 275 : PAGE_WIDTH - MARGIN * 2 - logoSize - 12
+  const contactLines = wrappedLines(
+    writer.brand.contactLines.join(" · "),
+    writer.regular,
+    6.5,
+    contactWidth
+  ).slice(0, 2)
+  contactLines.forEach((line, index) => {
+    writer.page.drawText(line, {
+      x: MARGIN + logoSize + 12,
+      y: PAGE_HEIGHT - MARGIN - 12 - index * 9,
+      size: 6.5,
+      font: writer.regular,
+      color: rgb(0.25, 0.25, 0.25),
+    })
+  })
+  if (context) {
+    const x = 390
+    writer.page.drawText(context.title, {
+      x,
+      y: PAGE_HEIGHT - MARGIN + 1,
+      size: 10,
+      font: writer.bold,
+      color: rgb(0.08, 0.08, 0.08),
+    })
+    context.lines.slice(0, 2).forEach((line, index) => {
+      writer.page.drawText(line, {
+        x,
+        y: PAGE_HEIGHT - MARGIN - 12 - index * 9,
+        size: 6.5,
+        font: writer.regular,
+        color: rgb(0.25, 0.25, 0.25),
+      })
+    })
+  }
+  writer.page.drawLine({
+    start: { x: MARGIN, y: PAGE_HEIGHT - 80 },
+    end: { x: PAGE_WIDTH - MARGIN, y: PAGE_HEIGHT - 80 },
+    thickness: 1,
+    color: rgb(0.12, 0.12, 0.12),
+  })
+  writer.y = PAGE_HEIGHT - 110
+}
+
 function newPage(writer: Writer): void {
   writer.page = writer.document.addPage([PAGE_WIDTH, PAGE_HEIGHT])
-  writer.y = PAGE_HEIGHT - MARGIN
+  drawBrandHeader(writer)
 }
 
 function ensureSpace(writer: Writer, height: number): void {
@@ -190,12 +267,23 @@ async function renderContractDocuments(input: {
   readonly projectName: string
   readonly projectNumber: string | null
   readonly projectAddress: string | null
-}): Promise<PDFDocument> {
+  readonly brand: ContractPacketPdfBranding
+}): Promise<{ readonly document: PDFDocument; readonly brandLogo: PDFImage }> {
   const document = await PDFDocument.create()
   const regular = await document.embedFont(StandardFonts.TimesRoman)
   const bold = await document.embedFont(StandardFonts.TimesRomanBold)
+  const brandLogo = await document.embedPng(input.brand.logoBytes)
   const first = document.addPage([PAGE_WIDTH, PAGE_HEIGHT])
-  const writer: Writer = { document, regular, bold, page: first, y: PAGE_HEIGHT - MARGIN }
+  const writer: Writer = {
+    document,
+    regular,
+    bold,
+    brand: input.brand,
+    brandLogo,
+    page: first,
+    y: 0,
+  }
+  drawBrandHeader(writer)
   const schedule = contractDocumentSchedule(input.documents)
   const values = {
     "project.name": input.projectName,
@@ -210,6 +298,7 @@ async function renderContractDocuments(input: {
     "contract.completion_date": displayDate(input.packet.approximateCompletionDate),
     "contract.deposit": money(input.packet.depositCents),
     "contract.deposit_words": dollarsInWords(input.packet.depositCents),
+    "contract.deposit_percent": percent(input.packet.depositRateBasisPoints),
     "contract.late_payment_percent": percent(input.packet.latePaymentRateBasisPoints),
     "estimate.date": displayDate(input.estimate.estimateDate),
     "estimate.total": money(input.estimate.estimateTotalCents),
@@ -239,7 +328,7 @@ async function renderContractDocuments(input: {
     })
     drawMarkdown(writer, fillContractTokens(item.contentMarkdown, values))
   }
-  return document
+  return { document, brandLogo }
 }
 
 async function appendEstimateWithoutSignaturePage(
@@ -260,14 +349,30 @@ async function appendPacketSignaturePage(input: {
   readonly document: PDFDocument
   readonly packet: ProjectContractPacketSummary
   readonly estimate: ProjectContractPacketEstimateOption
+  readonly brand: ContractPacketPdfBranding
+  readonly brandLogo: PDFImage
 }): Promise<void> {
   const page = input.document.addPage([PAGE_WIDTH, PAGE_HEIGHT])
   const regular = await input.document.embedFont(StandardFonts.Helvetica)
   const bold = await input.document.embedFont(StandardFonts.HelveticaBold)
-  page.drawText("Contract packet signatures", { x: 40, y: 752, size: 18, font: bold })
-  page.drawText(`${input.packet.packetNumber} · version ${input.packet.versionNumber}`, { x: 40, y: 732, size: 10, font: regular })
-  page.drawText(`CA22 estimate: ${input.estimate.estimateNumber} · version ${input.estimate.versionNumber}`, { x: 40, y: 716, size: 9, font: regular })
-  page.drawText("By signing, each party acknowledges the complete numbered contract packet.", { x: 40, y: 700, size: 9, font: regular })
+  drawBrandHeader(
+    {
+      document: input.document,
+      regular,
+      bold,
+      brand: input.brand,
+      brandLogo: input.brandLogo,
+      page,
+      y: 0,
+    },
+    {
+      title: "Contract packet signatures",
+      lines: [
+        `${input.packet.packetNumber} · version ${input.packet.versionNumber}`,
+        `CA22 ${input.estimate.estimateNumber} · version ${input.estimate.versionNumber}`,
+      ],
+    }
+  )
   const signers = [
     ...input.packet.clientSigners.map((signer, index) => ({
       label: `Owner ${index + 1}`,
@@ -306,6 +411,7 @@ export async function prepareContractPacketPdf(input: {
   readonly projectName: string
   readonly projectNumber: string | null
   readonly projectAddress: string | null
+  readonly brand: ContractPacketPdfBranding
   readonly estimatePdf: ArrayBuffer
 }): Promise<PreparedEstimateSignaturePdf> {
   if (!input.documents.some((item) => item.code === "CA00")) {
@@ -315,13 +421,15 @@ export async function prepareContractPacketPdf(input: {
     throw new Error("Add CA22 before preparing the full contract packet.")
   }
   const contract = await renderContractDocuments(input)
-  await appendEstimateWithoutSignaturePage(contract, input.estimatePdf)
+  await appendEstimateWithoutSignaturePage(contract.document, input.estimatePdf)
   await appendPacketSignaturePage({
-    document: contract,
+    document: contract.document,
     packet: input.packet,
     estimate: input.estimate,
+    brand: input.brand,
+    brandLogo: contract.brandLogo,
   })
-  const saved = await contract.save()
+  const saved = await contract.document.save()
   const copy = new Uint8Array(saved.byteLength)
   copy.set(saved)
   return prepareEstimateSignaturePdf({
@@ -331,6 +439,35 @@ export async function prepareContractPacketPdf(input: {
       "Company",
     ],
   })
+}
+
+function contractBrandLogoPath(department: ProjectDepartment, defaultPath: string): string {
+  return department === "H" ? "/hps-h-logo.png" : defaultPath
+}
+
+export async function loadContractPacketPdfBranding(input: {
+  readonly assets: Fetcher
+  readonly origin: string
+  readonly projectId: string
+  readonly projectNumber: string | null
+}): Promise<ContractPacketPdfBranding> {
+  const brand = projectBrandFor({
+    projectId: input.projectId,
+    projectNumber: input.projectNumber,
+  })
+  const url = new URL(
+    contractBrandLogoPath(brand.department, brand.logoSrc),
+    input.origin
+  )
+  const response = await input.assets.fetch(new Request(url))
+  if (!response.ok) {
+    throw new Error(`Unable to load ${brand.companyName} contract branding.`)
+  }
+  return {
+    companyName: brand.companyName,
+    contactLines: brand.contactLines,
+    logoBytes: new Uint8Array(await response.arrayBuffer()),
+  }
 }
 
 export function base64PdfBytes(value: string): Uint8Array {

--- a/src/lib/contracts/packet.ts
+++ b/src/lib/contracts/packet.ts
@@ -92,6 +92,15 @@ export function dollarsInWords(cents: number): string {
   return result.charAt(0).toUpperCase() + result.slice(1)
 }
 
+export function contractDepositCents(
+  estimateTotalCents: number,
+  depositRateBasisPoints: number
+): number {
+  if (!Number.isFinite(estimateTotalCents) || estimateTotalCents < 0) return 0
+  if (!Number.isFinite(depositRateBasisPoints) || depositRateBasisPoints < 0) return 0
+  return Math.round(estimateTotalCents * depositRateBasisPoints / 10_000)
+}
+
 export function signerInitials(name: string): string {
   return name
     .split(/\s+/)


### PR DESCRIPTION
## Summary
- require a deposit percentage and calculate the dollar deposit from the linked estimate total
- restore department-specific company branding on generated contract and signature pages
- keep contract PDF previews inside Compass with a separate download action

## Data change
- add `contract_packets.deposit_rate_basis_points` in migration `0131_contract_deposit_rate.sql`
- preserve the calculated dollar deposit in `deposit_cents` for contract tokens and historical packet snapshots

## Verification
- `bunx tsc --noEmit`
- `bun lint` (existing warnings only; no errors)
- `bun run test` (215 files, 1,133 tests passed)
- `bun run build`
- `bun run db:migrate:local`
- rendered the combined PDF and visually checked the branded contract body and signature page, page numbering, initials footer, and Foxit signature/date placement

External autoreview intentionally skipped per project owner preference.
