### PR TITLE
fix(contracts): persist deposits and improve preview

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,6 +98,7 @@
         "next": "16.2.6",
         "next-themes": "^0.4.6",
         "pdf-lib": "^1.17.1",
+        "pdfjs-dist": "^6.2.108",
         "radix-ui": "^1.4.3",
         "react": "19.2.6",
         "react-day-picker": "^10.0.0",
@@ -646,6 +647,30 @@
     "@mermaid-js/parser": ["@mermaid-js/parser@1.1.1", "", { "dependencies": { "@chevrotain/types": "~11.1.1" } }, "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@napi-rs/canvas": ["@napi-rs/canvas@1.0.8", "", { "optionalDependencies": { "@napi-rs/canvas-android-arm64": "1.0.8", "@napi-rs/canvas-darwin-arm64": "1.0.8", "@napi-rs/canvas-darwin-x64": "1.0.8", "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.8", "@napi-rs/canvas-linux-arm64-gnu": "1.0.8", "@napi-rs/canvas-linux-arm64-musl": "1.0.8", "@napi-rs/canvas-linux-riscv64-gnu": "1.0.8", "@napi-rs/canvas-linux-x64-gnu": "1.0.8", "@napi-rs/canvas-linux-x64-musl": "1.0.8", "@napi-rs/canvas-win32-arm64-msvc": "1.0.8", "@napi-rs/canvas-win32-x64-msvc": "1.0.8" } }, "sha512-/SaLcvlqGWdm0HSCWMgHu7cjJiQXfP8/mOY+6dUyV9flQz7sPBBZ+ed2zYtoukojPmxOaL7bm+d/G4GeWWoN7g=="],
+
+    "@napi-rs/canvas-android-arm64": ["@napi-rs/canvas-android-arm64@1.0.8", "", { "os": "android", "cpu": "arm64" }, "sha512-5+nkh8i3gt6lqS/d2jTZ1xAn6tdgtB4Lf1mW6T0Qm5/rXNwBuV1sAEyLEWan5o9gJPU/GuvHR3rvSeZ+FaGrbw=="],
+
+    "@napi-rs/canvas-darwin-arm64": ["@napi-rs/canvas-darwin-arm64@1.0.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7jQ47gi+fZ7KJmfc/5rNyy1CYw/cu4kZ0KPIYbo9UUgSdW0bKQJpt+WihEor6s4Lyp7+xc3a+3HeyXmAEbbnPg=="],
+
+    "@napi-rs/canvas-darwin-x64": ["@napi-rs/canvas-darwin-x64@1.0.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-rRjDMZs9pIRKGxgijwezplKc1RnJsqUokrA9h88bbTkqQ+7ePj0ZN4ZnZDy8Vu0tXs7KRlI2tQLaK4mx9QlxHg=="],
+
+    "@napi-rs/canvas-linux-arm-gnueabihf": ["@napi-rs/canvas-linux-arm-gnueabihf@1.0.8", "", { "os": "linux", "cpu": "arm" }, "sha512-jGcCd+8ra6Q61xKqZeiItujTpp9a9eRLcQ0jW6qYNku+WpupqOPFPY0SrsuSnXFviJwkpKYT9p7QrB4lsf3LNQ=="],
+
+    "@napi-rs/canvas-linux-arm64-gnu": ["@napi-rs/canvas-linux-arm64-gnu@1.0.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-od6I2Y7kU7i1SwZYG2EKW8rWz6JiedtPpko4WEe1DDsiikrfaotVBCRaUTM5/yeZKaZ92EatoAS+5xG+6uJlYA=="],
+
+    "@napi-rs/canvas-linux-arm64-musl": ["@napi-rs/canvas-linux-arm64-musl@1.0.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-yYkPbJDJiWj6N0gASA3CAvRypZmVpJnxU0DQg3aBhneLDQde9TPLKADsQkobNoJUtTT/lj46aWpzT48PDb3Qcg=="],
+
+    "@napi-rs/canvas-linux-riscv64-gnu": ["@napi-rs/canvas-linux-riscv64-gnu@1.0.8", "", { "os": "linux", "cpu": "none" }, "sha512-PB00MSKAp4VwK/xwe6duKxRKmH8UH4GIl1pqHSbxng0jnU9Dr7FwaDypDiqwNFZ774N+8G7mJLGuLtg9NTcQsg=="],
+
+    "@napi-rs/canvas-linux-x64-gnu": ["@napi-rs/canvas-linux-x64-gnu@1.0.8", "", { "os": "linux", "cpu": "x64" }, "sha512-TWM2XWJoitLiIPCvgJh7SriC+L/T9qkYCVzC66AidsZy0QP1hkKzBzVwshCdcA3q6fIn3yE0ISbq4lMJSy8jFw=="],
+
+    "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@1.0.8", "", { "os": "linux", "cpu": "x64" }, "sha512-hb20MxKXXb5IB7AAwN8UHz9WRsa2HmdZfjsDCzjElwJoeV1aotVEwFU4FrFQcYQVzsJQLeaCc/2Qdt/0Q72mMg=="],
+
+    "@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@1.0.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-WwPN08IXE4SkL+FhJyPz/iFnycMAUkbphFIT4cmKLlvbSU0Zfn1R7BGJ3Hqky1S89QUYc0Q4IOScXb/42Re9wQ=="],
+
+    "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@1.0.8", "", { "os": "win32", "cpu": "x64" }, "sha512-XkrVqKb+pxyba7kjy2LJvABFVBTE0DNpEl7MrG4OYUmaWarrXH+t54z/Czj2YxCKtizYTV4mg6phNm3x24qjhQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -2502,6 +2527,8 @@
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pdf-lib": ["pdf-lib@1.17.1", "", { "dependencies": { "@pdf-lib/standard-fonts": "^1.0.0", "@pdf-lib/upng": "^1.0.1", "pako": "^1.0.11", "tslib": "^1.11.1" } }, "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw=="],
+
+    "pdfjs-dist": ["pdfjs-dist@6.2.108", "", { "optionalDependencies": { "@napi-rs/canvas": "^1.0.0" } }, "sha512-YxFb+SQcodN2rnX9Tn3dHYlqfb7NjlzzfONPpJd+AKoKtUjEdevTfbC07d5TcczzOK6261auRkP/M8OBHs9vFQ=="],
 
     "pe-library": ["pe-library@0.4.1", "", {}, "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw=="],
 

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
 		"next": "16.2.6",
 		"next-themes": "^0.4.6",
 		"pdf-lib": "^1.17.1",
+		"pdfjs-dist": "^6.2.108",
 		"radix-ui": "^1.4.3",
 		"react": "19.2.6",
 		"react-day-picker": "^10.0.0",

--- a/src/app/dashboard/projects/[id]/contracts/page.tsx
+++ b/src/app/dashboard/projects/[id]/contracts/page.tsx
@@ -33,7 +33,13 @@ export default async function ProjectContractsPage({
         </div>
         <ProjectContextSwitcher currentProjectId={id} targetSection="contracts" placeholder="Switch contract project..." className="w-full sm:w-[280px]" />
       </div>
-      <ProjectContractPacketWorkspacePanel projectId={id} workspace={workspace} />
+      <ProjectContractPacketWorkspacePanel
+        key={workspace.activePacket
+          ? `${workspace.activePacket.id}:${workspace.activePacket.updatedAt}`
+          : "new-contract-packet"}
+        projectId={id}
+        workspace={workspace}
+      />
     </div>
   )
 }

--- a/src/app/print/projects/[id]/contract-packet/page.tsx
+++ b/src/app/print/projects/[id]/contract-packet/page.tsx
@@ -1,0 +1,29 @@
+export const dynamic = "force-dynamic"
+
+import { getProjectContractPacketWorkspace } from "@/app/actions/contract-packets"
+import { ProjectContractPacketPreview } from "@/components/projects/project-contract-packet-preview"
+
+export default async function ProjectContractPacketPrintPage({
+  params,
+  searchParams,
+}: {
+  readonly params: Promise<{ id: string }>
+  readonly searchParams: Promise<{ packetId?: string }>
+}): Promise<React.ReactElement> {
+  const [{ id }, query] = await Promise.all([params, searchParams])
+  const workspace = await getProjectContractPacketWorkspace(id, query.packetId)
+  const packet = workspace.activePacket
+
+  if (!packet || (query.packetId && packet.id !== query.packetId)) {
+    return <main className="p-8">Contract packet not found.</main>
+  }
+
+  return (
+    <ProjectContractPacketPreview
+      projectId={id}
+      packetId={packet.id}
+      packetNumber={packet.packetNumber}
+      versionNumber={packet.versionNumber}
+    />
+  )
+}

--- a/src/components/projects/project-contract-packet-preview.tsx
+++ b/src/components/projects/project-contract-packet-preview.tsx
@@ -1,0 +1,196 @@
+"use client"
+
+import Link from "next/link"
+import { useEffect, useRef, useState } from "react"
+import {
+  IconArrowLeft,
+  IconDownload,
+  IconLoader2,
+  IconRefresh,
+} from "@tabler/icons-react"
+import type {
+  PDFDocumentLoadingTask,
+  PDFDocumentProxy,
+  PDFPageProxy,
+} from "pdfjs-dist/types/src/display/api"
+
+import { Button } from "@/components/ui/button"
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : "Unable to render the contract packet preview."
+}
+
+function PdfPageCanvas({
+  document,
+  pageNumber,
+}: {
+  readonly document: PDFDocumentProxy
+  readonly pageNumber: number
+}): React.ReactElement {
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [page, setPage] = useState<PDFPageProxy | null>(null)
+  const [width, setWidth] = useState(0)
+
+  useEffect(() => {
+    let active = true
+    void document.getPage(pageNumber).then((loadedPage) => {
+      if (active) setPage(loadedPage)
+    })
+    return () => {
+      active = false
+    }
+  }, [document, pageNumber])
+
+  useEffect(() => {
+    const wrapper = wrapperRef.current
+    if (!wrapper) return
+    const updateWidth = (): void => setWidth(wrapper.clientWidth)
+    updateWidth()
+    const observer = new ResizeObserver(updateWidth)
+    observer.observe(wrapper)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas || !page || width <= 0) return
+    const baseViewport = page.getViewport({ scale: 1 })
+    const cssScale = width / baseViewport.width
+    const outputScale = Math.min(window.devicePixelRatio || 1, 2)
+    const viewport = page.getViewport({ scale: cssScale * outputScale })
+    canvas.width = Math.floor(viewport.width)
+    canvas.height = Math.floor(viewport.height)
+    canvas.style.width = `${Math.floor(viewport.width / outputScale)}px`
+    canvas.style.height = `${Math.floor(viewport.height / outputScale)}px`
+    const task = page.render({ canvas, viewport })
+    void task.promise.catch(() => undefined)
+    return () => task.cancel()
+  }, [page, width])
+
+  return (
+    <article
+      ref={wrapperRef}
+      className="contract-preview-page mx-auto w-full max-w-[8.5in] overflow-hidden bg-white shadow-lg print:shadow-none"
+      aria-label={`Contract page ${pageNumber}`}
+    >
+      <canvas ref={canvasRef} className="block h-auto w-full bg-white" />
+    </article>
+  )
+}
+
+export function ProjectContractPacketPreview({
+  projectId,
+  packetId,
+  packetNumber,
+  versionNumber,
+}: {
+  readonly projectId: string
+  readonly packetId: string
+  readonly packetNumber: string
+  readonly versionNumber: number
+}): React.ReactElement {
+  const [document, setDocument] = useState<PDFDocumentProxy | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
+  const pdfUrl = `/api/projects/${projectId}/contract-packets/${packetId}/pdf`
+
+  useEffect(() => {
+    let active = true
+    let loadingTask: PDFDocumentLoadingTask | null = null
+    setDocument(null)
+    setError(null)
+    void import("pdfjs-dist").then(async (pdfjs) => {
+      if (!active) return
+      pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+        "pdfjs-dist/build/pdf.worker.min.mjs",
+        import.meta.url
+      ).toString()
+      loadingTask = pdfjs.getDocument({ url: pdfUrl })
+      try {
+        const loadedDocument = await loadingTask.promise
+        if (active) setDocument(loadedDocument)
+      } catch (loadError) {
+        if (active) setError(errorMessage(loadError))
+      }
+    }).catch((loadError: unknown) => {
+      if (active) setError(errorMessage(loadError))
+    })
+    return () => {
+      active = false
+      if (loadingTask) void loadingTask.destroy()
+    }
+  }, [pdfUrl, reloadKey])
+
+  return (
+    <div className="min-h-screen bg-muted/50 text-foreground">
+      <style>{`
+        @page { size: letter; margin: 0; }
+        @media print {
+          body { background: white !important; }
+          .contract-preview-actions { display: none !important; }
+          .contract-preview-pages { gap: 0 !important; padding: 0 !important; }
+          .contract-preview-page { break-after: page; max-width: none !important; }
+          .contract-preview-page:last-child { break-after: auto; }
+        }
+      `}</style>
+      <header className="contract-preview-actions sticky top-0 z-10 border-b bg-background/95 px-4 py-3 backdrop-blur">
+        <div className="mx-auto flex max-w-[8.5in] flex-wrap items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <Button variant="ghost" size="sm" asChild>
+              <Link href={`/dashboard/projects/${projectId}/contracts?packetId=${packetId}`}>
+                <IconArrowLeft className="size-4" />Contract packet
+              </Link>
+            </Button>
+            <div className="min-w-0 border-l pl-3">
+              <h1 className="truncate text-sm font-semibold">
+                {packetNumber} · contract packet preview
+              </h1>
+              <p className="text-xs text-muted-foreground">Version {versionNumber}</p>
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" asChild>
+              <a
+                href={pdfUrl}
+                download={`${packetNumber}-contract-v${versionNumber}.pdf`}
+              >
+                <IconDownload className="size-4" />Download PDF
+              </a>
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      {error && (
+        <main className="mx-auto max-w-2xl p-8 text-center">
+          <h2 className="font-semibold">The preview could not be displayed</h2>
+          <p className="mt-2 text-sm text-muted-foreground">{error}</p>
+          <Button className="mt-4" onClick={() => setReloadKey((value) => value + 1)}>
+            <IconRefresh className="size-4" />Try again
+          </Button>
+        </main>
+      )}
+
+      {!error && !document && (
+        <main className="flex min-h-[70vh] items-center justify-center gap-2 text-sm text-muted-foreground">
+          <IconLoader2 className="size-5 animate-spin" />Preparing the numbered contract packet...
+        </main>
+      )}
+
+      {document && (
+        <main className="contract-preview-pages space-y-6 p-4 md:p-8">
+          {Array.from({ length: document.numPages }, (_, index) => (
+            <PdfPageCanvas
+              key={`${packetId}-${index + 1}`}
+              document={document}
+              pageNumber={index + 1}
+            />
+          ))}
+        </main>
+      )}
+    </div>
+  )
+}

--- a/src/components/projects/project-contract-packet-workspace.tsx
+++ b/src/components/projects/project-contract-packet-workspace.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation"
 import { useMemo, useState, useTransition, type FormEvent } from "react"
 import {
   IconCopy,
-  IconDownload,
   IconFileDescription,
   IconPlus,
   IconPrinter,
@@ -46,12 +45,6 @@ import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
 import {
   Select,
   SelectContent,
@@ -323,7 +316,6 @@ export function ProjectContractPacketWorkspacePanel({
   const [evidenceLabel, setEvidenceLabel] = useState("")
   const [signedAt, setSignedAt] = useState(localDateInput())
   const [attested, setAttested] = useState(false)
-  const [previewOpen, setPreviewOpen] = useState(false)
   const parsedDepositPercent = Number(depositPercent)
   const depositRateBasisPoints = Number.isFinite(parsedDepositPercent)
     ? Math.round(parsedDepositPercent * 100)
@@ -346,36 +338,68 @@ export function ProjectContractPacketWorkspacePanel({
     })
   }
 
+  async function saveCurrentContractInformation(
+    showSuccessMessage: boolean
+  ): Promise<boolean> {
+    if (!packet) return false
+    const result = await saveProjectContractPacket(projectId, packet.id, {
+      title,
+      legalEntityName,
+      contractDraftDate,
+      approximateCommencementDate: commencementDate,
+      approximateCompletionDate: completionDate,
+      depositPercent: parsedDepositPercent,
+      latePaymentPercent: Number(latePaymentRate),
+      details: {
+        ...packet.details,
+        projectName: workspace.projectName,
+        projectNumber: workspace.projectNumber ?? "",
+        projectAddress,
+        ownerName,
+        county,
+      },
+      clientSigners,
+      companySignerName: companySigner.name,
+      companySignerTitle: companySigner.title,
+      companySignerEmail: companySigner.email,
+      companySignerInitials: companySigner.initials || signerInitials(companySigner.name),
+    })
+    if (!result.success) {
+      toast.error(result.error)
+      return false
+    }
+    if (showSuccessMessage) {
+      toast.success(result.message)
+    }
+    return true
+  }
+
   function save(): void {
-    if (!packet) return
     startTransition(async () => {
-      const result = await saveProjectContractPacket(projectId, packet.id, {
-        title,
-        legalEntityName,
-        contractDraftDate,
-        approximateCommencementDate: commencementDate,
-        approximateCompletionDate: completionDate,
-        depositPercent: parsedDepositPercent,
-        latePaymentPercent: Number(latePaymentRate),
-        details: {
-          ...packet.details,
-          projectName: workspace.projectName,
-          projectNumber: workspace.projectNumber ?? "",
-          projectAddress,
-          ownerName,
-          county,
-        },
-        clientSigners,
-        companySignerName: companySigner.name,
-        companySignerTitle: companySigner.title,
-        companySignerEmail: companySigner.email,
-        companySignerInitials: companySigner.initials || signerInitials(companySigner.name),
-      })
-      if (!result.success) {
-        toast.error(result.error)
+      if (await saveCurrentContractInformation(true)) router.refresh()
+    })
+  }
+
+  function preview(): void {
+    if (!packet) return
+    const previewWindow = window.open("about:blank", "_blank")
+    if (previewWindow) {
+      previewWindow.opener = null
+      previewWindow.document.title = "Preparing contract packet preview"
+      previewWindow.document.body.textContent =
+        "Compass is saving the contract information and preparing the preview..."
+    }
+    startTransition(async () => {
+      if (editable && !(await saveCurrentContractInformation(false))) {
+        previewWindow?.close()
         return
       }
-      toast.success(result.message)
+      const previewUrl = `/print/projects/${projectId}/contract-packet?packetId=${packet.id}`
+      if (previewWindow) {
+        previewWindow.location.replace(previewUrl)
+      } else {
+        window.location.href = previewUrl
+      }
       router.refresh()
     })
   }
@@ -444,6 +468,10 @@ export function ProjectContractPacketWorkspacePanel({
         "Compass is assembling the numbered contract packet and Foxit fields..."
     }
     startTransition(async () => {
+      if (editable && !(await saveCurrentContractInformation(false))) {
+        foxitWindow?.close()
+        return
+      }
       const result = await prepareProjectContractPacketForSignature(
         projectId,
         packet.id
@@ -572,7 +600,7 @@ export function ProjectContractPacketWorkspacePanel({
             <Button variant="outline" onClick={duplicate} disabled={pending || !workspace.canEdit}>
               <IconCopy className="size-4" />Duplicate version
             </Button>
-            <Button variant="outline" onClick={() => setPreviewOpen(true)}>
+            <Button variant="outline" onClick={preview} disabled={pending}>
               <IconPrinter className="size-4" />Preview PDF
             </Button>
           </div>
@@ -615,31 +643,6 @@ export function ProjectContractPacketWorkspacePanel({
           <div className="space-y-1.5"><Label htmlFor="contract-late-rate">Late-payment annual rate (%)</Label><Input id="contract-late-rate" type="number" min="0" step="0.01" value={latePaymentRate} onChange={(event) => setLatePaymentRate(event.target.value)} disabled={!editable} /></div>
         </div>
       </section>
-
-      <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
-        <DialogContent className="h-[92vh] max-w-[min(96vw,72rem)] grid-rows-[auto_1fr_auto] p-4">
-          <DialogHeader>
-            <DialogTitle>{packet.packetNumber} · contract packet preview</DialogTitle>
-          </DialogHeader>
-          <iframe
-            title={`${packet.packetNumber} contract packet PDF preview`}
-            src={previewOpen
-              ? `/api/projects/${projectId}/contract-packets/${packet.id}/pdf`
-              : undefined}
-            className="h-full min-h-0 w-full rounded-lg border bg-background"
-          />
-          <div className="flex justify-end">
-            <Button variant="outline" asChild>
-              <a
-                href={`/api/projects/${projectId}/contract-packets/${packet.id}/pdf`}
-                download={`${packet.packetNumber}-contract-v${packet.versionNumber}.pdf`}
-              >
-                <IconDownload className="size-4" />Download PDF
-              </a>
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
 
       <section className="clarity-panel-strong p-4">
         <div className="flex items-start justify-between gap-3">


### PR DESCRIPTION
## Summary
- save the current contract information before previewing or preparing the Foxit packet, so the displayed deposit percentage is persisted before server validation
- remount packet form state when the selected or freshly saved packet changes
- replace the cramped embedded Acrobat frame with a dedicated Compass page-by-page contract preview
- keep the exact generated PDF available as a download

## Verification
- 1,133 Vitest tests passed
- ESLint passed with existing warnings only
- Next.js production build passed
- OpenNext Cloudflare production build passed
- browser visual check rendered a three-page letter-size packet with no horizontal overflow

External autoreview intentionally skipped at the user's request.
