### PR TITLE
feat(nutech): add catalog and Airlite order workflow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ The construction-specific modules that make up HPS Compass.
 - [scheduling](modules/scheduling.md) -- Gantt charts, critical path analysis, dependency management, baselines, workday exceptions
 - [financials](modules/financials.md) -- invoices, vendor bills, payments, credit memos, with legacy NetSuite sync notes and HPS Sage direction
 - [contracts](modules/contracts.md) -- versioned contract library, project packet assembly, CA22 insertion, Foxit execution, and budget handoff
+- [Nu-Tech orders](modules/nutech.md) -- Fox Blocks catalog, takeoffs, bracing rentals, Airlite purchase orders, and Sage-ready product mappings
 - [mobile](modules/mobile.md) -- Capacitor native app, offline photo queue, push notifications, biometric auth
 - [desktop](modules/desktop.md) -- Electron desktop app, hosted Compass runtime, native shell bridge, packaged app distribution
 - [claude code](modules/claude-code.md) -- local bridge daemon, own Anthropic API key, filesystem + terminal tools, WebSocket protocol

--- a/docs/modules/nutech.md
+++ b/docs/modules/nutech.md
@@ -1,0 +1,72 @@
+Nu-Tech orders
+===
+
+The Nu-Tech module coordinates Fox Blocks sales and bracing rentals without
+duplicating the existing Compass estimate, purchase-order, financial, and Drive
+systems. The project workflow is available only to N-numbered projects at
+`/dashboard/projects/[id]/nutech`; the department queue is at
+`/dashboard/nutech`.
+
+workflow
+---
+
+1. Choose the customer type and its published 2026 pricing folder. Standard
+   pricing is the non-discounted sheet and is not described to customers as
+   credit-card pricing. Cash-discount pricing applies to cash, wire, or check.
+2. Record whether quantities came from the customer or a Nu-Tech staff takeoff.
+   Customer-provided quantities do not require a takeoff acknowledgement. A
+   staff takeoff must have a signed acknowledgement before the Airlite PO can be
+   released.
+3. Build the client estimate in the shared Compass estimate workspace. Nu-Tech
+   acknowledgement forms remain estimate snapshots so later template changes do
+   not alter an issued estimate.
+4. Add Fox Blocks, panels, Web Boxes, and accessories from the active versioned
+   catalog. Compass enforces manufacturer package increments and snapshots the
+   applicable customer price and Airlite cost on each order line. Bracing rates
+   remain on the current customer price sheet.
+5. Create the vendor commitment in the shared Compass PO workspace, complete the
+   manufacturer-required 2026 Airlite order form, and link that Compass PO to the
+   Nu-Tech workflow. Compass copies the Airlite template into the project Drive
+   folder, fills mapped legacy rows, and places products missing from the legacy
+   form on a dedicated Compass Addendum tab. The form subtotal includes both.
+6. Office staff can record the Airlite PO release once the applicable workflow
+   gates pass. The linked Compass PO advances from draft/approved to sent.
+7. Record the Airlite confirmation and vendor invoice. Office staff can release
+   the vendor invoice after the PO release and invoice number are recorded.
+
+data and permissions
+---
+
+`src/db/schema-nutech.ts` separates stable product identity, catalog versions,
+versioned price records, order-line snapshots, and project workflow state.
+Estimates and POs remain authoritative in their existing module tables.
+
+The 2026 import reads all four published pricing workbooks and refuses the
+import if their SKU sets, product attributes, costs, or product counts disagree.
+The published tiers are stored exactly: new standard, new cash-discount,
+returning standard, and returning cash-discount. A draft import must be
+activated before new orders adopt it; an existing order retains the catalog
+version it started with.
+
+Each product has an optional foreign key to `sage_cost_codes`. Importing or
+activating a Nu-Tech catalog never creates or changes a Sage cost code and never
+guesses a mapping. Existing Sage codes can be selected deliberately. New or
+never-sold products remain `unmapped` until the cost code exists in the Sage
+read model, which keeps later Sage price/inventory integration additive instead
+of coupling product identity to a mutable accounting description.
+
+The `nutech-orders` permission feature uses the project resource. Internal office
+roles therefore retain create/edit/release access as requested, while project
+permission overrides can make the workflow read-only or hidden. Creating and
+editing the workflow is paired with a permission-appropriate delete action;
+deleting it does not delete the linked estimate or PO.
+
+manufacturer-template boundary
+---
+
+The Airlite template still contains legacy 6-inch SKUs and does not contain rows
+for panels, Web Boxes, or spray products. The catalog records the legacy aliases
+and exact target rows rather than silently changing SKUs. New products appear
+on the Compass Addendum worksheet, and the original order subtotal is replaced
+with the full catalog-line cost total. Changing quantities marks a previously
+generated workbook stale; PO release requires a fresh generated workbook.

--- a/docs/modules/overview.md
+++ b/docs/modules/overview.md
@@ -48,6 +48,7 @@ Modules are the parts specific to HPS's construction business:
 | Scheduling | Gantt charts, CPM, baseline tracking | `lib/schedule/`, `actions/schedule.ts`, `components/schedule/` |
 | Financials | invoices, bills, payments, credit memos | `actions/invoices.ts`, `actions/vendor-bills.ts`, `components/financials/` |
 | Contracts | versioned document library, project packets, CA22, Foxit execution | `lib/contracts/`, `actions/contract-*.ts`, `components/projects/project-contract-*` |
+| Nu-Tech orders | Fox Blocks catalog, takeoffs, pricing, bracing rentals, and Airlite purchase orders | `db/schema-nutech.ts`, `actions/nutech-orders.ts`, `components/nutech/` |
 | Mobile | Capacitor native wrapper, offline photos, push | `lib/native/`, `lib/push/`, `hooks/use-native*.ts`, `components/native/` |
 | Claude Code | local bridge daemon, own API key, filesystem + terminal access | `lib/mcp/`, `lib/agent/ws-transport.ts`, `packages/compass-bridge/` |
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     "./src/db/schema-sage.ts",
     "./src/db/schema-buildertrend.ts",
     "./src/db/schema-estimates.ts",
+    "./src/db/schema-nutech.ts",
     "./src/db/schema-templates.ts",
     "./src/lib/sync/schema.ts",
   ],

--- a/drizzle/0130_nutech_orders_catalog.sql
+++ b/drizzle/0130_nutech_orders_catalog.sql
@@ -1,0 +1,159 @@
+CREATE TABLE `nutech_catalog_versions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`name` text NOT NULL,
+	`effective_date` text NOT NULL,
+	`status` text DEFAULT 'draft' NOT NULL,
+	`new_standard_sheet_id` text NOT NULL,
+	`new_cash_sheet_id` text NOT NULL,
+	`returning_standard_sheet_id` text NOT NULL,
+	`returning_cash_sheet_id` text NOT NULL,
+	`airlite_template_id` text NOT NULL,
+	`source_hash` text NOT NULL,
+	`imported_at` text NOT NULL,
+	`imported_by` text,
+	`activated_at` text,
+	`activated_by` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`imported_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`activated_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `nutech_catalog_versions_org_name_uq` ON `nutech_catalog_versions` (`organization_id`,`name`);
+--> statement-breakpoint
+CREATE INDEX `nutech_catalog_versions_org_status_idx` ON `nutech_catalog_versions` (`organization_id`,`status`,`effective_date`);
+--> statement-breakpoint
+CREATE TABLE `nutech_products` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`manufacturer_sku` text NOT NULL,
+	`name` text NOT NULL,
+	`category` text NOT NULL,
+	`origin` text NOT NULL,
+	`price_unit` text NOT NULL,
+	`package_quantity` integer DEFAULT 1 NOT NULL,
+	`package_label` text NOT NULL,
+	`minimum_order_increment` integer DEFAULT 1 NOT NULL,
+	`square_feet_per_unit_mils` integer,
+	`airlite_template_sku` text,
+	`airlite_template_row` integer,
+	`airlite_mapping_status` text DEFAULT 'addendum_required' NOT NULL,
+	`sage_cost_code_id` text,
+	`sage_mapping_status` text DEFAULT 'unmapped' NOT NULL,
+	`sage_mapped_at` text,
+	`sage_mapped_by` text,
+	`active` integer DEFAULT true NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`sage_cost_code_id`) REFERENCES `sage_cost_codes`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`sage_mapped_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `nutech_products_org_sku_uq` ON `nutech_products` (`organization_id`,`manufacturer_sku`);
+--> statement-breakpoint
+CREATE INDEX `nutech_products_org_category_idx` ON `nutech_products` (`organization_id`,`category`,`active`);
+--> statement-breakpoint
+CREATE INDEX `nutech_products_sage_cost_code_idx` ON `nutech_products` (`sage_cost_code_id`);
+--> statement-breakpoint
+CREATE TABLE `nutech_catalog_prices` (
+	`id` text PRIMARY KEY NOT NULL,
+	`catalog_version_id` text NOT NULL,
+	`product_id` text NOT NULL,
+	`airlite_cost_cents` integer NOT NULL,
+	`new_standard_price_cents` integer NOT NULL,
+	`new_cash_price_cents` integer NOT NULL,
+	`returning_standard_price_cents` integer NOT NULL,
+	`returning_cash_price_cents` integer NOT NULL,
+	`new_standard_margin_basis_points` integer NOT NULL,
+	`new_cash_margin_basis_points` integer NOT NULL,
+	`returning_standard_margin_basis_points` integer NOT NULL,
+	`returning_cash_margin_basis_points` integer NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`catalog_version_id`) REFERENCES `nutech_catalog_versions`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`product_id`) REFERENCES `nutech_products`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `nutech_catalog_prices_version_product_uq` ON `nutech_catalog_prices` (`catalog_version_id`,`product_id`);
+--> statement-breakpoint
+CREATE INDEX `nutech_catalog_prices_product_idx` ON `nutech_catalog_prices` (`product_id`);
+--> statement-breakpoint
+CREATE TABLE `nutech_order_workflows` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`catalog_version_id` text,
+	`customer_type` text NOT NULL,
+	`pricing_mode` text NOT NULL,
+	`quantity_source` text NOT NULL,
+	`takeoff_acknowledgement_status` text DEFAULT 'not_required' NOT NULL,
+	`scope_type` text DEFAULT 'block_sale' NOT NULL,
+	`block_quantity_notes` text,
+	`bracing_included` integer DEFAULT false NOT NULL,
+	`bracing_rental_start_date` text,
+	`bracing_rental_end_date` text,
+	`bracing_notes` text,
+	`delivery_method` text DEFAULT 'delivery' NOT NULL,
+	`requested_delivery_date` text,
+	`airlite_purchase_order_operation_id` text,
+	`order_status` text DEFAULT 'intake' NOT NULL,
+	`vendor_confirmation_number` text,
+	`airlite_workbook_id` text,
+	`airlite_workbook_url` text,
+	`airlite_workbook_status` text DEFAULT 'not_generated' NOT NULL,
+	`airlite_workbook_generated_at` text,
+	`airlite_workbook_generated_by` text,
+	`purchase_order_released_at` text,
+	`purchase_order_released_by` text,
+	`vendor_invoice_number` text,
+	`vendor_invoice_status` text DEFAULT 'not_received' NOT NULL,
+	`vendor_invoice_received_at` text,
+	`vendor_invoice_released_at` text,
+	`vendor_invoice_released_by` text,
+	`notes` text,
+	`created_by` text,
+	`updated_by` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`catalog_version_id`) REFERENCES `nutech_catalog_versions`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`airlite_purchase_order_operation_id`) REFERENCES `project_operations`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`airlite_workbook_generated_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`purchase_order_released_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`vendor_invoice_released_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`updated_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `nutech_order_workflows_project_uq` ON `nutech_order_workflows` (`project_id`);
+--> statement-breakpoint
+CREATE INDEX `nutech_order_workflows_status_idx` ON `nutech_order_workflows` (`order_status`,`requested_delivery_date`);
+--> statement-breakpoint
+CREATE INDEX `nutech_order_workflows_po_idx` ON `nutech_order_workflows` (`airlite_purchase_order_operation_id`);
+--> statement-breakpoint
+CREATE INDEX `nutech_order_workflows_catalog_idx` ON `nutech_order_workflows` (`catalog_version_id`);
+--> statement-breakpoint
+CREATE TABLE `nutech_order_items` (
+	`id` text PRIMARY KEY NOT NULL,
+	`workflow_id` text NOT NULL,
+	`product_id` text NOT NULL,
+	`catalog_version_id` text NOT NULL,
+	`quantity` integer NOT NULL,
+	`manufacturer_sku_snapshot` text NOT NULL,
+	`product_name_snapshot` text NOT NULL,
+	`price_unit_snapshot` text NOT NULL,
+	`unit_cost_cents` integer NOT NULL,
+	`unit_price_cents` integer NOT NULL,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`workflow_id`) REFERENCES `nutech_order_workflows`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`product_id`) REFERENCES `nutech_products`(`id`) ON UPDATE no action ON DELETE restrict,
+	FOREIGN KEY (`catalog_version_id`) REFERENCES `nutech_catalog_versions`(`id`) ON UPDATE no action ON DELETE restrict
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `nutech_order_items_workflow_product_uq` ON `nutech_order_items` (`workflow_id`,`product_id`);
+--> statement-breakpoint
+CREATE INDEX `nutech_order_items_workflow_sort_idx` ON `nutech_order_items` (`workflow_id`,`sort_order`);

--- a/src/app/actions/nutech-catalog.ts
+++ b/src/app/actions/nutech-catalog.ts
@@ -1,0 +1,543 @@
+"use server"
+
+import { and, asc, desc, eq, inArray, ne, sql } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import { sageCostCodes } from "@/db/schema"
+import {
+  nuTechCatalogPrices,
+  nuTechCatalogVersions,
+  nuTechOrderWorkflows,
+  nuTechProducts,
+} from "@/db/schema-nutech"
+import { requireAuth } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import { getOrganizationDriveContext } from "@/lib/google/organization-drive"
+import { buildNuTechCatalogImport } from "@/lib/nutech/catalog-import"
+import { NUTECH_2026_CATALOG_SOURCES } from "@/lib/nutech/resources"
+import { requireOrg } from "@/lib/org-scope"
+import {
+  canFeature,
+  requireFeaturePermission,
+} from "@/lib/permission-enforcement"
+
+export type NuTechCatalogVersionSummary = {
+  readonly id: string
+  readonly name: string
+  readonly effectiveDate: string
+  readonly status: string
+  readonly productCount: number
+  readonly importedAt: string
+  readonly activatedAt: string | null
+}
+
+export type NuTechCatalogProductItem = {
+  readonly id: string
+  readonly manufacturerSku: string
+  readonly name: string
+  readonly category: string
+  readonly origin: string
+  readonly priceUnit: string
+  readonly packageLabel: string
+  readonly minimumOrderIncrement: number
+  readonly airliteMappingStatus: string
+  readonly airliteTemplateRow: number | null
+  readonly sageMappingStatus: string
+  readonly sageCostCodeId: string | null
+  readonly sageCostCodeLabel: string | null
+  readonly airliteCostCents: number
+  readonly newStandardPriceCents: number
+  readonly newCashPriceCents: number
+  readonly returningStandardPriceCents: number
+  readonly returningCashPriceCents: number
+}
+
+export type NuTechCatalogWorkspace = {
+  readonly canImport: boolean
+  readonly canDelete: boolean
+  readonly versions: readonly NuTechCatalogVersionSummary[]
+  readonly activeVersionId: string | null
+  readonly products: readonly NuTechCatalogProductItem[]
+  readonly sageCostCodes: readonly {
+    readonly id: string
+    readonly code: string
+    readonly description: string
+    readonly displayLabel: string
+  }[]
+}
+
+export type NuTechCatalogActionResult =
+  | { readonly success: true; readonly id: string; readonly productCount?: number }
+  | { readonly success: false; readonly error: string }
+
+function errorResult(error: unknown, fallback: string): NuTechCatalogActionResult {
+  return {
+    success: false,
+    error: error instanceof Error ? error.message : fallback,
+  }
+}
+
+function revalidateCatalogPaths(): void {
+  revalidatePath("/dashboard/nutech")
+  revalidatePath("/dashboard/nutech/catalog")
+}
+
+async function sourceHash(value: unknown): Promise<string> {
+  const bytes = new TextEncoder().encode(JSON.stringify(value))
+  const digest = await crypto.subtle.digest("SHA-256", bytes)
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0")
+  ).join("")
+}
+
+export async function getNuTechCatalogWorkspace(): Promise<NuTechCatalogWorkspace> {
+  const user = await requireAuth()
+  await requireFeaturePermission(user, "nutech-orders", "read")
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const [versionRows, priceRows, sageRows, canImport, canDelete] =
+    await Promise.all([
+      db
+        .select()
+        .from(nuTechCatalogVersions)
+        .where(eq(nuTechCatalogVersions.organizationId, organizationId))
+        .orderBy(desc(nuTechCatalogVersions.effectiveDate)),
+      db
+        .select({
+          versionId: nuTechCatalogPrices.catalogVersionId,
+          productId: nuTechProducts.id,
+          manufacturerSku: nuTechProducts.manufacturerSku,
+          name: nuTechProducts.name,
+          category: nuTechProducts.category,
+          origin: nuTechProducts.origin,
+          priceUnit: nuTechProducts.priceUnit,
+          packageLabel: nuTechProducts.packageLabel,
+          minimumOrderIncrement: nuTechProducts.minimumOrderIncrement,
+          airliteMappingStatus: nuTechProducts.airliteMappingStatus,
+          airliteTemplateRow: nuTechProducts.airliteTemplateRow,
+          sageMappingStatus: nuTechProducts.sageMappingStatus,
+          sageCostCodeId: nuTechProducts.sageCostCodeId,
+          sageCostCodeLabel: sageCostCodes.displayLabel,
+          airliteCostCents: nuTechCatalogPrices.airliteCostCents,
+          newStandardPriceCents: nuTechCatalogPrices.newStandardPriceCents,
+          newCashPriceCents: nuTechCatalogPrices.newCashPriceCents,
+          returningStandardPriceCents:
+            nuTechCatalogPrices.returningStandardPriceCents,
+          returningCashPriceCents: nuTechCatalogPrices.returningCashPriceCents,
+        })
+        .from(nuTechCatalogPrices)
+        .innerJoin(
+          nuTechProducts,
+          eq(nuTechProducts.id, nuTechCatalogPrices.productId)
+        )
+        .leftJoin(sageCostCodes, eq(sageCostCodes.id, nuTechProducts.sageCostCodeId))
+        .where(eq(nuTechProducts.organizationId, organizationId))
+        .orderBy(asc(nuTechProducts.category), asc(nuTechProducts.manufacturerSku)),
+      db
+        .select({
+          id: sageCostCodes.id,
+          code: sageCostCodes.code,
+          description: sageCostCodes.description,
+          displayLabel: sageCostCodes.displayLabel,
+        })
+        .from(sageCostCodes)
+        .where(eq(sageCostCodes.active, true))
+        .orderBy(asc(sageCostCodes.displayLabel)),
+      canFeature(user, "nutech-orders", "approve"),
+      canFeature(user, "nutech-orders", "delete"),
+    ])
+  const activeVersion = versionRows.find((version) => version.status === "active")
+  return {
+    canImport: canImport && !isDemoUser(user.id),
+    canDelete: canDelete && !isDemoUser(user.id),
+    activeVersionId: activeVersion?.id ?? null,
+    versions: versionRows.map((version) => ({
+      id: version.id,
+      name: version.name,
+      effectiveDate: version.effectiveDate,
+      status: version.status,
+      productCount: priceRows.filter((row) => row.versionId === version.id).length,
+      importedAt: version.importedAt,
+      activatedAt: version.activatedAt,
+    })),
+    products: activeVersion
+      ? priceRows
+          .filter((row) => row.versionId === activeVersion.id)
+          .map((row) => ({
+            id: row.productId,
+            manufacturerSku: row.manufacturerSku,
+            name: row.name,
+            category: row.category,
+            origin: row.origin,
+            priceUnit: row.priceUnit,
+            packageLabel: row.packageLabel,
+            minimumOrderIncrement: row.minimumOrderIncrement,
+            airliteMappingStatus: row.airliteMappingStatus,
+            airliteTemplateRow: row.airliteTemplateRow,
+            sageMappingStatus: row.sageMappingStatus,
+            sageCostCodeId: row.sageCostCodeId,
+            sageCostCodeLabel: row.sageCostCodeLabel,
+            airliteCostCents: row.airliteCostCents,
+            newStandardPriceCents: row.newStandardPriceCents,
+            newCashPriceCents: row.newCashPriceCents,
+            returningStandardPriceCents: row.returningStandardPriceCents,
+            returningCashPriceCents: row.returningCashPriceCents,
+          }))
+      : [],
+    sageCostCodes: sageRows,
+  }
+}
+
+export async function importNuTech2026Catalog(): Promise<NuTechCatalogActionResult> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) throw new Error("DEMO_READ_ONLY")
+    await requireFeaturePermission(user, "nutech-orders", "approve")
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const { sheetsClient, userEmail } = await getOrganizationDriveContext({
+      db,
+      environment: env,
+      organizationId,
+      user,
+    })
+    const sourceIds = [
+      NUTECH_2026_CATALOG_SOURCES.newStandardSheetId,
+      NUTECH_2026_CATALOG_SOURCES.newCashSheetId,
+      NUTECH_2026_CATALOG_SOURCES.returningStandardSheetId,
+      NUTECH_2026_CATALOG_SOURCES.returningCashSheetId,
+    ]
+    const sourceRows = await Promise.all(
+      sourceIds.map((spreadsheetId) =>
+        sheetsClient.getValues(userEmail, {
+          spreadsheetId,
+          range: NUTECH_2026_CATALOG_SOURCES.sourceRange,
+          valueRenderOption: "UNFORMATTED_VALUE",
+        })
+      )
+    )
+    const newStandardRows = sourceRows[0]
+    const newCashRows = sourceRows[1]
+    const returningStandardRows = sourceRows[2]
+    const returningCashRows = sourceRows[3]
+    if (
+      !newStandardRows ||
+      !newCashRows ||
+      !returningStandardRows ||
+      !returningCashRows
+    ) {
+      throw new Error("One or more 2026 Nu-Tech price sheets could not be read.")
+    }
+    const imported = buildNuTechCatalogImport({
+      newStandard: newStandardRows,
+      newCash: newCashRows,
+      returningStandard: returningStandardRows,
+      returningCash: returningCashRows,
+    })
+    const hash = await sourceHash(imported)
+    const now = new Date().toISOString()
+    const existingVersions = await db
+      .select({
+        id: nuTechCatalogVersions.id,
+        name: nuTechCatalogVersions.name,
+        status: nuTechCatalogVersions.status,
+        sourceHash: nuTechCatalogVersions.sourceHash,
+      })
+      .from(nuTechCatalogVersions)
+      .where(eq(nuTechCatalogVersions.organizationId, organizationId))
+    const matchingVersion = existingVersions.find(
+      (version) => version.sourceHash === hash
+    )
+    if (matchingVersion && matchingVersion.status !== "draft") {
+      return {
+        success: true,
+        id: matchingVersion.id,
+        productCount: imported.products.length,
+      }
+    }
+    const baseDraft = existingVersions.find(
+      (version) =>
+        version.name === NUTECH_2026_CATALOG_SOURCES.name &&
+        version.status === "draft"
+    )
+    const existingVersion = matchingVersion ?? baseDraft
+    const versionName =
+      existingVersion?.name ??
+      (existingVersions.some(
+        (version) => version.name === NUTECH_2026_CATALOG_SOURCES.name
+      )
+        ? `${NUTECH_2026_CATALOG_SOURCES.name} · revision ${hash.slice(0, 8)}`
+        : NUTECH_2026_CATALOG_SOURCES.name)
+    const versionId = existingVersion?.id ?? crypto.randomUUID()
+    await db
+      .insert(nuTechCatalogVersions)
+      .values({
+        id: versionId,
+        organizationId,
+        name: versionName,
+        effectiveDate: NUTECH_2026_CATALOG_SOURCES.effectiveDate,
+        status: existingVersion?.status ?? "draft",
+        newStandardSheetId: NUTECH_2026_CATALOG_SOURCES.newStandardSheetId,
+        newCashSheetId: NUTECH_2026_CATALOG_SOURCES.newCashSheetId,
+        returningStandardSheetId:
+          NUTECH_2026_CATALOG_SOURCES.returningStandardSheetId,
+        returningCashSheetId: NUTECH_2026_CATALOG_SOURCES.returningCashSheetId,
+        airliteTemplateId: NUTECH_2026_CATALOG_SOURCES.airliteTemplateId,
+        sourceHash: hash,
+        importedAt: now,
+        importedBy: user.id,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [nuTechCatalogVersions.organizationId, nuTechCatalogVersions.name],
+        set: {
+          sourceHash: hash,
+          importedAt: now,
+          importedBy: user.id,
+          updatedAt: now,
+        },
+      })
+
+    const existingProducts = await db
+      .select({ id: nuTechProducts.id, manufacturerSku: nuTechProducts.manufacturerSku })
+      .from(nuTechProducts)
+      .where(eq(nuTechProducts.organizationId, organizationId))
+    const existingIds = new Map(
+      existingProducts.map((product) => [product.manufacturerSku, product.id])
+    )
+    const productRows = imported.products.map((product) => ({
+      id: existingIds.get(product.manufacturerSku) ?? crypto.randomUUID(),
+      organizationId,
+      manufacturerSku: product.manufacturerSku,
+      name: product.name,
+      category: product.category,
+      origin: product.origin,
+      priceUnit: product.priceUnit,
+      packageQuantity: product.packageQuantity,
+      packageLabel: product.packageLabel,
+      minimumOrderIncrement: product.minimumOrderIncrement,
+      squareFeetPerUnitMils: product.squareFeetPerUnitMils,
+      airliteTemplateSku: product.airliteTemplateSku,
+      airliteTemplateRow: product.airliteTemplateRow,
+      airliteMappingStatus: product.airliteMappingStatus,
+      active: true,
+      createdAt: now,
+      updatedAt: now,
+    }))
+    await db
+      .insert(nuTechProducts)
+      .values(productRows)
+      .onConflictDoUpdate({
+        target: [nuTechProducts.organizationId, nuTechProducts.manufacturerSku],
+        set: {
+          name: sql`excluded.name`,
+          category: sql`excluded.category`,
+          origin: sql`excluded.origin`,
+          priceUnit: sql`excluded.price_unit`,
+          packageQuantity: sql`excluded.package_quantity`,
+          packageLabel: sql`excluded.package_label`,
+          minimumOrderIncrement: sql`excluded.minimum_order_increment`,
+          squareFeetPerUnitMils: sql`excluded.square_feet_per_unit_mils`,
+          airliteTemplateSku: sql`excluded.airlite_template_sku`,
+          airliteTemplateRow: sql`excluded.airlite_template_row`,
+          airliteMappingStatus: sql`excluded.airlite_mapping_status`,
+          active: true,
+          updatedAt: now,
+        },
+      })
+    const storedProducts = await db
+      .select({ id: nuTechProducts.id, manufacturerSku: nuTechProducts.manufacturerSku })
+      .from(nuTechProducts)
+      .where(
+        and(
+          eq(nuTechProducts.organizationId, organizationId),
+          inArray(
+            nuTechProducts.manufacturerSku,
+            imported.products.map((product) => product.manufacturerSku)
+          )
+        )
+      )
+    const storedIds = new Map(
+      storedProducts.map((product) => [product.manufacturerSku, product.id])
+    )
+    const priceRows = imported.products.map((product) => {
+      const productId = storedIds.get(product.manufacturerSku)
+      if (!productId) throw new Error(`Catalog product ${product.manufacturerSku} was not saved.`)
+      return {
+        id: crypto.randomUUID(),
+        catalogVersionId: versionId,
+        productId,
+        airliteCostCents: product.airliteCostCents,
+        newStandardPriceCents: product.newStandardPriceCents,
+        newCashPriceCents: product.newCashPriceCents,
+        returningStandardPriceCents: product.returningStandardPriceCents,
+        returningCashPriceCents: product.returningCashPriceCents,
+        newStandardMarginBasisPoints: product.newStandardMarginBasisPoints,
+        newCashMarginBasisPoints: product.newCashMarginBasisPoints,
+        returningStandardMarginBasisPoints:
+          product.returningStandardMarginBasisPoints,
+        returningCashMarginBasisPoints: product.returningCashMarginBasisPoints,
+        createdAt: now,
+        updatedAt: now,
+      }
+    })
+    await db.batch([
+      db
+        .delete(nuTechCatalogPrices)
+        .where(eq(nuTechCatalogPrices.catalogVersionId, versionId)),
+      db.insert(nuTechCatalogPrices).values(priceRows),
+    ])
+    revalidateCatalogPaths()
+    return { success: true, id: versionId, productCount: priceRows.length }
+  } catch (error) {
+    return errorResult(error, "Failed to import the 2026 Nu-Tech catalog.")
+  }
+}
+
+export async function activateNuTechCatalogVersion(
+  versionId: string
+): Promise<NuTechCatalogActionResult> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) throw new Error("DEMO_READ_ONLY")
+    await requireFeaturePermission(user, "nutech-orders", "approve")
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const version = await db
+      .select({ id: nuTechCatalogVersions.id })
+      .from(nuTechCatalogVersions)
+      .where(
+        and(
+          eq(nuTechCatalogVersions.id, versionId),
+          eq(nuTechCatalogVersions.organizationId, organizationId)
+        )
+      )
+      .limit(1)
+      .get()
+    if (!version) throw new Error("Nu-Tech catalog version not found.")
+    const now = new Date().toISOString()
+    await db.batch([
+      db
+        .update(nuTechCatalogVersions)
+        .set({ status: "archived", updatedAt: now })
+        .where(
+          and(
+            eq(nuTechCatalogVersions.organizationId, organizationId),
+            eq(nuTechCatalogVersions.status, "active"),
+            ne(nuTechCatalogVersions.id, versionId)
+          )
+        ),
+      db
+        .update(nuTechCatalogVersions)
+        .set({
+          status: "active",
+          activatedAt: now,
+          activatedBy: user.id,
+          updatedAt: now,
+        })
+        .where(eq(nuTechCatalogVersions.id, versionId)),
+    ])
+    revalidateCatalogPaths()
+    return { success: true, id: versionId }
+  } catch (error) {
+    return errorResult(error, "Failed to activate the Nu-Tech catalog.")
+  }
+}
+
+export async function mapNuTechProductToSageCostCode(
+  productId: string,
+  sageCostCodeId: string | null
+): Promise<NuTechCatalogActionResult> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) throw new Error("DEMO_READ_ONLY")
+    await requireFeaturePermission(user, "nutech-orders", "approve")
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const product = await db
+      .select({ id: nuTechProducts.id })
+      .from(nuTechProducts)
+      .where(
+        and(
+          eq(nuTechProducts.id, productId),
+          eq(nuTechProducts.organizationId, organizationId)
+        )
+      )
+      .limit(1)
+      .get()
+    if (!product) throw new Error("Nu-Tech product not found.")
+    if (sageCostCodeId !== null) {
+      const costCode = await db
+        .select({ id: sageCostCodes.id })
+        .from(sageCostCodes)
+        .where(and(eq(sageCostCodes.id, sageCostCodeId), eq(sageCostCodes.active, true)))
+        .limit(1)
+        .get()
+      if (!costCode) throw new Error("Choose an active Sage cost code.")
+    }
+    const now = new Date().toISOString()
+    await db
+      .update(nuTechProducts)
+      .set({
+        sageCostCodeId,
+        sageMappingStatus: sageCostCodeId === null ? "unmapped" : "mapped",
+        sageMappedAt: sageCostCodeId === null ? null : now,
+        sageMappedBy: sageCostCodeId === null ? null : user.id,
+        updatedAt: now,
+      })
+      .where(eq(nuTechProducts.id, productId))
+    revalidateCatalogPaths()
+    return { success: true, id: productId }
+  } catch (error) {
+    return errorResult(error, "Failed to update the Sage cost-code mapping.")
+  }
+}
+
+export async function deleteNuTechCatalogVersion(
+  versionId: string
+): Promise<NuTechCatalogActionResult> {
+  try {
+    const user = await requireAuth()
+    if (isDemoUser(user.id)) throw new Error("DEMO_READ_ONLY")
+    await requireFeaturePermission(user, "nutech-orders", "delete")
+    const organizationId = requireOrg(user)
+    const { env } = await getCloudflareContext()
+    const db = getDb(env.DB)
+    const version = await db
+      .select({ id: nuTechCatalogVersions.id, status: nuTechCatalogVersions.status })
+      .from(nuTechCatalogVersions)
+      .where(
+        and(
+          eq(nuTechCatalogVersions.id, versionId),
+          eq(nuTechCatalogVersions.organizationId, organizationId)
+        )
+      )
+      .limit(1)
+      .get()
+    if (!version) throw new Error("Nu-Tech catalog version not found.")
+    if (version.status !== "draft") {
+      throw new Error("Only a draft catalog version can be deleted.")
+    }
+    const linkedOrder = await db
+      .select({ id: nuTechOrderWorkflows.id })
+      .from(nuTechOrderWorkflows)
+      .where(eq(nuTechOrderWorkflows.catalogVersionId, versionId))
+      .limit(1)
+      .get()
+    if (linkedOrder) throw new Error("This catalog is already linked to a Nu-Tech order.")
+    await db
+      .delete(nuTechCatalogVersions)
+      .where(eq(nuTechCatalogVersions.id, versionId))
+    revalidateCatalogPaths()
+    return { success: true, id: versionId }
+  } catch (error) {
+    return errorResult(error, "Failed to delete the Nu-Tech catalog version.")
+  }
+}

--- a/src/app/actions/nutech-order-items.ts
+++ b/src/app/actions/nutech-order-items.ts
@@ -1,0 +1,420 @@
+"use server"
+
+import { and, asc, eq } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import { projectOperations, projects } from "@/db/schema"
+import {
+  nuTechCatalogPrices,
+  nuTechCatalogVersions,
+  nuTechOrderItems,
+  nuTechOrderWorkflows,
+  nuTechProducts,
+} from "@/db/schema-nutech"
+import { requireAuth, type AuthUser } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import { getOrganizationDriveContext } from "@/lib/google/organization-drive"
+import { buildNuTechAirliteWorkbookPlan } from "@/lib/nutech/airlite-workbook"
+import {
+  nuTechCustomerPriceCents,
+  validateNuTechOrderQuantity,
+} from "@/lib/nutech/catalog-pricing"
+import { requireOrg } from "@/lib/org-scope"
+import { requireFeaturePermission } from "@/lib/permission-enforcement"
+import { projectDepartment } from "@/lib/project-branding"
+
+type CompassDb = ReturnType<typeof getDb>
+
+type NuTechItemAccess = {
+  readonly db: CompassDb
+  readonly user: AuthUser
+  readonly organizationId: string
+  readonly project: {
+    readonly id: string
+    readonly projectNumber: string | null
+    readonly name: string
+    readonly clientName: string | null
+    readonly address: string | null
+    readonly googleDriveFolderId: string | null
+  }
+}
+
+export type NuTechOrderItemActionResult =
+  | { readonly success: true; readonly id: string; readonly workbookUrl?: string }
+  | { readonly success: false; readonly error: string }
+
+async function nuTechItemAccess(projectId: string): Promise<NuTechItemAccess> {
+  const user = await requireAuth()
+  if (isDemoUser(user.id)) throw new Error("DEMO_READ_ONLY")
+  await requireFeaturePermission(user, "nutech-orders", "update")
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const project = await db
+    .select({
+      id: projects.id,
+      projectNumber: projects.projectNumber,
+      name: projects.name,
+      clientName: projects.clientName,
+      address: projects.address,
+      googleDriveFolderId: projects.googleDriveFolderId,
+    })
+    .from(projects)
+    .where(
+      and(eq(projects.id, projectId), eq(projects.organizationId, organizationId))
+    )
+    .limit(1)
+    .get()
+  if (!project) throw new Error("Project not found.")
+  if (
+    projectDepartment({
+      projectId: project.id,
+      projectNumber: project.projectNumber,
+    }) !== "N"
+  ) {
+    throw new Error("The Nu-Tech order workflow is available only for N projects.")
+  }
+  return { db, user, organizationId, project }
+}
+
+function revalidateNuTechOrder(projectId: string): void {
+  revalidatePath("/dashboard/nutech")
+  revalidatePath(`/dashboard/projects/${projectId}/nutech`)
+}
+
+function actionError(error: unknown, fallback: string): NuTechOrderItemActionResult {
+  return {
+    success: false,
+    error: error instanceof Error ? error.message : fallback,
+  }
+}
+
+function storedCustomerType(value: string): "new" | "returning" {
+  return value === "returning" ? "returning" : "new"
+}
+
+function storedPricingMode(value: string): "standard" | "cash_discount" {
+  return value === "cash_discount" ? "cash_discount" : "standard"
+}
+
+export async function saveNuTechOrderItem(
+  projectId: string,
+  input: { readonly productId: string; readonly quantity: number }
+): Promise<NuTechOrderItemActionResult> {
+  try {
+    const access = await nuTechItemAccess(projectId)
+    const workflow = await access.db
+      .select()
+      .from(nuTechOrderWorkflows)
+      .where(eq(nuTechOrderWorkflows.projectId, projectId))
+      .limit(1)
+      .get()
+    if (!workflow) throw new Error("Save the Nu-Tech intake before adding products.")
+    if (workflow.purchaseOrderReleasedAt !== null) {
+      throw new Error("Released Airlite PO quantities are locked.")
+    }
+    if (!workflow.catalogVersionId) {
+      throw new Error("Activate a Nu-Tech product catalog before adding products.")
+    }
+    const product = await access.db
+      .select({
+        id: nuTechProducts.id,
+        manufacturerSku: nuTechProducts.manufacturerSku,
+        name: nuTechProducts.name,
+        priceUnit: nuTechProducts.priceUnit,
+        minimumOrderIncrement: nuTechProducts.minimumOrderIncrement,
+        airliteCostCents: nuTechCatalogPrices.airliteCostCents,
+        newStandardPriceCents: nuTechCatalogPrices.newStandardPriceCents,
+        newCashPriceCents: nuTechCatalogPrices.newCashPriceCents,
+        returningStandardPriceCents:
+          nuTechCatalogPrices.returningStandardPriceCents,
+        returningCashPriceCents: nuTechCatalogPrices.returningCashPriceCents,
+      })
+      .from(nuTechCatalogPrices)
+      .innerJoin(
+        nuTechProducts,
+        eq(nuTechProducts.id, nuTechCatalogPrices.productId)
+      )
+      .where(
+        and(
+          eq(nuTechCatalogPrices.catalogVersionId, workflow.catalogVersionId),
+          eq(nuTechProducts.id, input.productId),
+          eq(nuTechProducts.organizationId, access.organizationId),
+          eq(nuTechProducts.active, true)
+        )
+      )
+      .limit(1)
+      .get()
+    if (!product) throw new Error("Choose a product from this order's catalog.")
+    validateNuTechOrderQuantity({
+      manufacturerSku: product.manufacturerSku,
+      quantity: input.quantity,
+      minimumOrderIncrement: product.minimumOrderIncrement,
+    })
+    const existingItems = await access.db
+      .select({
+        id: nuTechOrderItems.id,
+        productId: nuTechOrderItems.productId,
+        sortOrder: nuTechOrderItems.sortOrder,
+      })
+      .from(nuTechOrderItems)
+      .where(eq(nuTechOrderItems.workflowId, workflow.id))
+    const existing = existingItems.find((item) => item.productId === product.id)
+    const id = existing?.id ?? crypto.randomUUID()
+    const now = new Date().toISOString()
+    const unitPriceCents = nuTechCustomerPriceCents(
+      product,
+      storedCustomerType(workflow.customerType),
+      storedPricingMode(workflow.pricingMode)
+    )
+    await access.db.batch([
+      access.db
+        .insert(nuTechOrderItems)
+        .values({
+          id,
+          workflowId: workflow.id,
+          productId: product.id,
+          catalogVersionId: workflow.catalogVersionId,
+          quantity: input.quantity,
+          manufacturerSkuSnapshot: product.manufacturerSku,
+          productNameSnapshot: product.name,
+          priceUnitSnapshot: product.priceUnit,
+          unitCostCents: product.airliteCostCents,
+          unitPriceCents,
+          sortOrder: existing?.sortOrder ?? existingItems.length,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: [nuTechOrderItems.workflowId, nuTechOrderItems.productId],
+          set: {
+            quantity: input.quantity,
+            unitCostCents: product.airliteCostCents,
+            unitPriceCents,
+            updatedAt: now,
+          },
+        }),
+      access.db
+        .update(nuTechOrderWorkflows)
+        .set({
+          orderStatus:
+            workflow.orderStatus === "intake"
+              ? "quantities_ready"
+              : workflow.orderStatus,
+          airliteWorkbookStatus:
+            workflow.airliteWorkbookStatus.startsWith("generated")
+              ? "stale"
+              : workflow.airliteWorkbookStatus,
+          updatedBy: access.user.id,
+          updatedAt: now,
+        })
+        .where(eq(nuTechOrderWorkflows.id, workflow.id)),
+    ])
+    revalidateNuTechOrder(projectId)
+    return { success: true, id }
+  } catch (error) {
+    return actionError(error, "Failed to save the Nu-Tech order item.")
+  }
+}
+
+export async function deleteNuTechOrderItem(
+  projectId: string,
+  itemId: string
+): Promise<NuTechOrderItemActionResult> {
+  try {
+    const access = await nuTechItemAccess(projectId)
+    const item = await access.db
+      .select({
+        id: nuTechOrderItems.id,
+        workflowId: nuTechOrderItems.workflowId,
+        airliteWorkbookStatus: nuTechOrderWorkflows.airliteWorkbookStatus,
+        purchaseOrderReleasedAt: nuTechOrderWorkflows.purchaseOrderReleasedAt,
+      })
+      .from(nuTechOrderItems)
+      .innerJoin(
+        nuTechOrderWorkflows,
+        eq(nuTechOrderWorkflows.id, nuTechOrderItems.workflowId)
+      )
+      .where(
+        and(
+          eq(nuTechOrderItems.id, itemId),
+          eq(nuTechOrderWorkflows.projectId, projectId)
+        )
+      )
+      .limit(1)
+      .get()
+    if (!item) throw new Error("Nu-Tech order item not found.")
+    if (item.purchaseOrderReleasedAt !== null) {
+      throw new Error("Released Airlite PO quantities are locked.")
+    }
+    const now = new Date().toISOString()
+    await access.db.batch([
+      access.db.delete(nuTechOrderItems).where(eq(nuTechOrderItems.id, item.id)),
+      access.db
+        .update(nuTechOrderWorkflows)
+        .set({
+          airliteWorkbookStatus: item.airliteWorkbookStatus.startsWith("generated")
+            ? "stale"
+            : item.airliteWorkbookStatus,
+          updatedBy: access.user.id,
+          updatedAt: now,
+        })
+        .where(eq(nuTechOrderWorkflows.id, item.workflowId)),
+    ])
+    revalidateNuTechOrder(projectId)
+    return { success: true, id: item.id }
+  } catch (error) {
+    return actionError(error, "Failed to delete the Nu-Tech order item.")
+  }
+}
+
+export async function generateNuTechAirliteWorkbook(
+  projectId: string
+): Promise<NuTechOrderItemActionResult> {
+  try {
+    const access = await nuTechItemAccess(projectId)
+    if (!access.project.googleDriveFolderId) {
+      throw new Error("Provision the project Google Drive folder before generating the Airlite workbook.")
+    }
+    const workflow = await access.db
+      .select()
+      .from(nuTechOrderWorkflows)
+      .where(eq(nuTechOrderWorkflows.projectId, projectId))
+      .limit(1)
+      .get()
+    if (!workflow?.catalogVersionId) {
+      throw new Error("Save the order with an active Nu-Tech catalog first.")
+    }
+    if (workflow.purchaseOrderReleasedAt !== null) {
+      throw new Error("The released Airlite PO workbook is locked.")
+    }
+    if (!workflow.airlitePurchaseOrderOperationId) {
+      throw new Error("Link the Compass Airlite purchase order before generating its workbook.")
+    }
+    const [catalogVersion, purchaseOrder, lineRows] = await Promise.all([
+      access.db
+        .select({ airliteTemplateId: nuTechCatalogVersions.airliteTemplateId })
+        .from(nuTechCatalogVersions)
+        .where(
+          and(
+            eq(nuTechCatalogVersions.id, workflow.catalogVersionId),
+            eq(nuTechCatalogVersions.organizationId, access.organizationId)
+          )
+        )
+        .limit(1)
+        .get(),
+      access.db
+        .select({ number: projectOperations.sourceRecordNumber })
+        .from(projectOperations)
+        .where(
+          and(
+            eq(projectOperations.id, workflow.airlitePurchaseOrderOperationId),
+            eq(projectOperations.projectId, projectId),
+            eq(projectOperations.sourceRecordType, "purchase_order")
+          )
+        )
+        .limit(1)
+        .get(),
+      access.db
+        .select({
+          manufacturerSku: nuTechOrderItems.manufacturerSkuSnapshot,
+          name: nuTechOrderItems.productNameSnapshot,
+          origin: nuTechProducts.origin,
+          category: nuTechProducts.category,
+          quantity: nuTechOrderItems.quantity,
+          minimumOrderIncrement: nuTechProducts.minimumOrderIncrement,
+          packageLabel: nuTechProducts.packageLabel,
+          priceUnit: nuTechOrderItems.priceUnitSnapshot,
+          airliteTemplateRow: nuTechProducts.airliteTemplateRow,
+          unitCostCents: nuTechOrderItems.unitCostCents,
+        })
+        .from(nuTechOrderItems)
+        .innerJoin(nuTechProducts, eq(nuTechProducts.id, nuTechOrderItems.productId))
+        .where(eq(nuTechOrderItems.workflowId, workflow.id))
+        .orderBy(asc(nuTechOrderItems.sortOrder)),
+    ])
+    if (!catalogVersion) throw new Error("The linked Nu-Tech catalog was not found.")
+    if (!purchaseOrder?.number) {
+      throw new Error("The linked Compass purchase order needs a PO number.")
+    }
+    const now = new Date().toISOString()
+    const plan = buildNuTechAirliteWorkbookPlan({
+      purchaseOrderNumber: purchaseOrder.number,
+      purchaseOrderDate: now.slice(0, 10),
+      requestedDeliveryDate: workflow.requestedDeliveryDate,
+      projectName: access.project.name,
+      jobsiteAddress: access.project.address,
+      orderContactName: access.user.displayName ?? access.user.email,
+      orderContactPhone: access.user.phone ?? null,
+      orderContactEmail: access.user.email,
+      deliveryContact: access.project.clientName,
+      lines: lineRows,
+    })
+    const { env } = await getCloudflareContext()
+    const { client, sheetsClient, userEmail } = await getOrganizationDriveContext({
+      db: access.db,
+      environment: env,
+      organizationId: access.organizationId,
+      user: access.user,
+    })
+    const workbook = await client.copyFile(
+      userEmail,
+      catalogVersion.airliteTemplateId,
+      {
+        name: `${access.project.projectNumber ?? access.project.name} Airlite Order ${now.slice(0, 10)}`,
+        parentId: access.project.googleDriveFolderId,
+      }
+    )
+    await sheetsClient.batchUpdateValues(userEmail, {
+      spreadsheetId: workbook.id,
+      updates: plan.updates,
+    })
+    if (plan.addendumValues.length > 0) {
+      await sheetsClient.addSheet(userEmail, {
+        spreadsheetId: workbook.id,
+        title: "Compass Addendum",
+        rowCount: Math.max(100, plan.addendumValues.length + 10),
+        columnCount: 8,
+      })
+      await sheetsClient.batchUpdateValues(userEmail, {
+        spreadsheetId: workbook.id,
+        updates: [
+          {
+            range: `'Compass Addendum'!A1:H${plan.addendumValues.length}`,
+            values: plan.addendumValues,
+          },
+        ],
+      })
+    }
+    const workbookUrl =
+      workbook.webViewLink ??
+      `https://docs.google.com/spreadsheets/d/${workbook.id}/edit`
+    await access.db
+      .update(nuTechOrderWorkflows)
+      .set({
+        airliteWorkbookId: workbook.id,
+        airliteWorkbookUrl: workbookUrl,
+        airliteWorkbookStatus:
+          plan.addendumItemCount > 0 ? "generated_with_addendum" : "generated",
+        airliteWorkbookGeneratedAt: now,
+        airliteWorkbookGeneratedBy: access.user.id,
+        orderStatus: [
+          "intake",
+          "quantities_ready",
+          "estimate_ready",
+          "customer_approved",
+        ].includes(workflow.orderStatus)
+          ? "po_ready"
+          : workflow.orderStatus,
+        updatedBy: access.user.id,
+        updatedAt: now,
+      })
+      .where(eq(nuTechOrderWorkflows.id, workflow.id))
+    revalidateNuTechOrder(projectId)
+    return { success: true, id: workflow.id, workbookUrl }
+  } catch (error) {
+    return actionError(error, "Failed to generate the Airlite workbook.")
+  }
+}

--- a/src/app/actions/nutech-orders.ts
+++ b/src/app/actions/nutech-orders.ts
@@ -1,0 +1,950 @@
+"use server"
+
+import { and, asc, desc, eq, inArray, like, sql } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
+
+import { getDb } from "@/db"
+import { projectOperations, projects } from "@/db/schema"
+import { projectEstimates } from "@/db/schema-estimates"
+import {
+  nuTechCatalogPrices,
+  nuTechCatalogVersions,
+  nuTechOrderItems,
+  nuTechOrderWorkflows,
+  nuTechProducts,
+  type NewNuTechOrderWorkflow,
+} from "@/db/schema-nutech"
+import { requireAuth, type AuthUser } from "@/lib/auth"
+import { getCloudflareContext } from "@/lib/db"
+import { isDemoUser } from "@/lib/demo"
+import {
+  NUTECH_CUSTOMER_TYPE_OPTIONS,
+  NUTECH_DELIVERY_METHOD_OPTIONS,
+  NUTECH_ORDER_STATUS_OPTIONS,
+  NUTECH_PRICING_MODE_OPTIONS,
+  NUTECH_QUANTITY_SOURCE_OPTIONS,
+  NUTECH_SCOPE_TYPE_OPTIONS,
+  NUTECH_TAKEOFF_STATUS_OPTIONS,
+  NUTECH_VENDOR_INVOICE_STATUS_OPTIONS,
+  normalizedNuTechTakeoffStatus,
+  nuTechPurchaseOrderReleaseReadiness,
+  nuTechReleaseAuditIssues,
+  type NuTechCustomerType,
+  type NuTechDeliveryMethod,
+  type NuTechOrderStatus,
+  type NuTechPricingMode,
+  type NuTechQuantitySource,
+  type NuTechScopeType,
+  type NuTechTakeoffAcknowledgementStatus,
+  type NuTechVendorInvoiceStatus,
+} from "@/lib/nutech/workflow"
+import { requireOrg } from "@/lib/org-scope"
+import {
+  canFeature,
+  requireFeaturePermission,
+} from "@/lib/permission-enforcement"
+import { projectDepartment } from "@/lib/project-branding"
+
+type CompassDb = ReturnType<typeof getDb>
+
+export type NuTechPurchaseOrderOption = {
+  readonly id: string
+  readonly number: string | null
+  readonly title: string
+  readonly companyName: string | null
+  readonly status: string
+  readonly amount: number | null
+}
+
+export type NuTechEstimateSummary = {
+  readonly id: string
+  readonly number: string
+  readonly status: string
+  readonly totalCents: number
+  readonly updatedAt: string
+}
+
+export type NuTechOrderRecord = {
+  readonly id: string
+  readonly catalogVersionId: string | null
+  readonly customerType: NuTechCustomerType
+  readonly pricingMode: NuTechPricingMode
+  readonly quantitySource: NuTechQuantitySource
+  readonly takeoffAcknowledgementStatus: NuTechTakeoffAcknowledgementStatus
+  readonly scopeType: NuTechScopeType
+  readonly blockQuantityNotes: string | null
+  readonly bracingIncluded: boolean
+  readonly bracingRentalStartDate: string | null
+  readonly bracingRentalEndDate: string | null
+  readonly bracingNotes: string | null
+  readonly deliveryMethod: NuTechDeliveryMethod
+  readonly requestedDeliveryDate: string | null
+  readonly airlitePurchaseOrderOperationId: string | null
+  readonly orderStatus: NuTechOrderStatus
+  readonly vendorConfirmationNumber: string | null
+  readonly airliteWorkbookUrl: string | null
+  readonly airliteWorkbookStatus: string
+  readonly airliteWorkbookGeneratedAt: string | null
+  readonly purchaseOrderReleasedAt: string | null
+  readonly vendorInvoiceNumber: string | null
+  readonly vendorInvoiceStatus: NuTechVendorInvoiceStatus
+  readonly vendorInvoiceReceivedAt: string | null
+  readonly vendorInvoiceReleasedAt: string | null
+  readonly notes: string | null
+  readonly updatedAt: string
+}
+
+export type NuTechCatalogProductOption = {
+  readonly id: string
+  readonly manufacturerSku: string
+  readonly name: string
+  readonly category: string
+  readonly origin: string
+  readonly priceUnit: string
+  readonly packageLabel: string
+  readonly minimumOrderIncrement: number
+  readonly airliteMappingStatus: string
+  readonly newStandardPriceCents: number
+  readonly newCashPriceCents: number
+  readonly returningStandardPriceCents: number
+  readonly returningCashPriceCents: number
+}
+
+export type NuTechOrderItemRecord = {
+  readonly id: string
+  readonly productId: string
+  readonly manufacturerSku: string
+  readonly name: string
+  readonly quantity: number
+  readonly priceUnit: string
+  readonly unitCostCents: number
+  readonly unitPriceCents: number
+  readonly sortOrder: number
+}
+
+export type ProjectNuTechOrderWorkspace = {
+  readonly canEdit: boolean
+  readonly canDelete: boolean
+  readonly projectId: string
+  readonly projectNumber: string | null
+  readonly projectName: string
+  readonly clientName: string | null
+  readonly address: string | null
+  readonly order: NuTechOrderRecord | null
+  readonly catalogVersionName: string | null
+  readonly catalogProducts: readonly NuTechCatalogProductOption[]
+  readonly orderItems: readonly NuTechOrderItemRecord[]
+  readonly estimate: NuTechEstimateSummary | null
+  readonly purchaseOrders: readonly NuTechPurchaseOrderOption[]
+}
+
+export type NuTechOrderDashboardItem = {
+  readonly projectId: string
+  readonly projectNumber: string | null
+  readonly projectName: string
+  readonly clientName: string | null
+  readonly orderStatus: string
+  readonly quantitySource: NuTechQuantitySource | null
+  readonly requestedDeliveryDate: string | null
+  readonly estimateStatus: string | null
+  readonly openPurchaseOrderCount: number
+}
+
+export type SaveNuTechOrderInput = {
+  readonly customerType: string
+  readonly pricingMode: string
+  readonly quantitySource: string
+  readonly takeoffAcknowledgementStatus: string
+  readonly scopeType: string
+  readonly blockQuantityNotes: string | null
+  readonly bracingIncluded: boolean
+  readonly bracingRentalStartDate: string | null
+  readonly bracingRentalEndDate: string | null
+  readonly bracingNotes: string | null
+  readonly deliveryMethod: string
+  readonly requestedDeliveryDate: string | null
+  readonly airlitePurchaseOrderOperationId: string | null
+  readonly orderStatus: string
+  readonly vendorConfirmationNumber: string | null
+  readonly vendorInvoiceNumber: string | null
+  readonly vendorInvoiceStatus: string
+  readonly vendorInvoiceReceivedAt: string | null
+  readonly notes: string | null
+}
+
+export type NuTechOrderActionResult =
+  | { readonly success: true; readonly id: string }
+  | { readonly success: false; readonly error: string }
+
+type NuTechAccess = {
+  readonly db: CompassDb
+  readonly user: AuthUser
+  readonly organizationId: string
+  readonly project: {
+    readonly id: string
+    readonly projectNumber: string | null
+    readonly name: string
+    readonly clientName: string | null
+    readonly address: string | null
+  }
+}
+
+function cleanText(value: string | null): string | null {
+  const cleaned = value?.trim() ?? ""
+  return cleaned.length > 0 ? cleaned : null
+}
+
+function cleanDate(value: string | null, label: string): string | null {
+  const cleaned = cleanText(value)
+  if (cleaned === null) return null
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(cleaned)) {
+    throw new Error(`${label} must be a valid date.`)
+  }
+  const parsed = new Date(`${cleaned}T12:00:00Z`)
+  if (
+    Number.isNaN(parsed.getTime()) ||
+    parsed.toISOString().slice(0, 10) !== cleaned
+  ) {
+    throw new Error(`${label} must be a valid date.`)
+  }
+  return cleaned
+}
+
+function customerType(value: string): NuTechCustomerType {
+  const match = NUTECH_CUSTOMER_TYPE_OPTIONS.find((option) => option.value === value)
+  if (!match) throw new Error("Choose new or returning customer pricing.")
+  return match.value
+}
+
+function storedCustomerType(value: string): NuTechCustomerType {
+  return value === "returning" ? "returning" : "new"
+}
+
+function pricingMode(value: string): NuTechPricingMode {
+  const match = NUTECH_PRICING_MODE_OPTIONS.find((option) => option.value === value)
+  if (!match) throw new Error("Choose standard or cash-discount pricing.")
+  return match.value
+}
+
+function storedPricingMode(value: string): NuTechPricingMode {
+  return value === "cash_discount" ? "cash_discount" : "standard"
+}
+
+function quantitySource(value: string): NuTechQuantitySource {
+  const match = NUTECH_QUANTITY_SOURCE_OPTIONS.find((option) => option.value === value)
+  if (!match) throw new Error("Record who supplied the order quantities.")
+  return match.value
+}
+
+function storedQuantitySource(value: string): NuTechQuantitySource {
+  return value === "staff_takeoff" ? "staff_takeoff" : "customer_provided"
+}
+
+function takeoffStatus(value: string): NuTechTakeoffAcknowledgementStatus {
+  const match = NUTECH_TAKEOFF_STATUS_OPTIONS.find((option) => option.value === value)
+  return match?.value ?? "pending"
+}
+
+function scopeType(value: string): NuTechScopeType {
+  const match = NUTECH_SCOPE_TYPE_OPTIONS.find((option) => option.value === value)
+  if (!match) throw new Error("Choose the Nu-Tech order scope.")
+  return match.value
+}
+
+function storedScopeType(value: string): NuTechScopeType {
+  if (value === "block_and_bracing" || value === "bracing_only") return value
+  return "block_sale"
+}
+
+function deliveryMethod(value: string): NuTechDeliveryMethod {
+  const match = NUTECH_DELIVERY_METHOD_OPTIONS.find((option) => option.value === value)
+  if (!match) throw new Error("Choose delivery, pickup, or will call.")
+  return match.value
+}
+
+function storedDeliveryMethod(value: string): NuTechDeliveryMethod {
+  if (value === "customer_pickup" || value === "will_call") return value
+  return "delivery"
+}
+
+function orderStatus(value: string): NuTechOrderStatus {
+  const match = NUTECH_ORDER_STATUS_OPTIONS.find((option) => option.value === value)
+  return match?.value ?? "intake"
+}
+
+function vendorInvoiceStatus(value: string): NuTechVendorInvoiceStatus {
+  const match = NUTECH_VENDOR_INVOICE_STATUS_OPTIONS.find(
+    (option) => option.value === value
+  )
+  return match?.value ?? "not_received"
+}
+
+function toOrderRecord(
+  row: typeof nuTechOrderWorkflows.$inferSelect
+): NuTechOrderRecord {
+  return {
+    id: row.id,
+    catalogVersionId: row.catalogVersionId,
+    customerType: storedCustomerType(row.customerType),
+    pricingMode: storedPricingMode(row.pricingMode),
+    quantitySource: storedQuantitySource(row.quantitySource),
+    takeoffAcknowledgementStatus: takeoffStatus(
+      row.takeoffAcknowledgementStatus
+    ),
+    scopeType: storedScopeType(row.scopeType),
+    blockQuantityNotes: row.blockQuantityNotes,
+    bracingIncluded: row.bracingIncluded,
+    bracingRentalStartDate: row.bracingRentalStartDate,
+    bracingRentalEndDate: row.bracingRentalEndDate,
+    bracingNotes: row.bracingNotes,
+    deliveryMethod: storedDeliveryMethod(row.deliveryMethod),
+    requestedDeliveryDate: row.requestedDeliveryDate,
+    airlitePurchaseOrderOperationId: row.airlitePurchaseOrderOperationId,
+    orderStatus: orderStatus(row.orderStatus),
+    vendorConfirmationNumber: row.vendorConfirmationNumber,
+    airliteWorkbookUrl: row.airliteWorkbookUrl,
+    airliteWorkbookStatus: row.airliteWorkbookStatus,
+    airliteWorkbookGeneratedAt: row.airliteWorkbookGeneratedAt,
+    purchaseOrderReleasedAt: row.purchaseOrderReleasedAt,
+    vendorInvoiceNumber: row.vendorInvoiceNumber,
+    vendorInvoiceStatus: vendorInvoiceStatus(row.vendorInvoiceStatus),
+    vendorInvoiceReceivedAt: row.vendorInvoiceReceivedAt,
+    vendorInvoiceReleasedAt: row.vendorInvoiceReleasedAt,
+    notes: row.notes,
+    updatedAt: row.updatedAt,
+  }
+}
+
+async function nuTechProjectAccess(
+  projectId: string,
+  action: "read" | "update" | "delete"
+): Promise<NuTechAccess> {
+  const user = await requireAuth()
+  if (action !== "read" && isDemoUser(user.id)) {
+    throw new Error("DEMO_READ_ONLY")
+  }
+  await requireFeaturePermission(user, "nutech-orders", action)
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const project = await db
+    .select({
+      id: projects.id,
+      projectNumber: projects.projectNumber,
+      name: projects.name,
+      clientName: projects.clientName,
+      address: projects.address,
+    })
+    .from(projects)
+    .where(
+      and(eq(projects.id, projectId), eq(projects.organizationId, organizationId))
+    )
+    .limit(1)
+    .get()
+  if (!project) throw new Error("Project not found.")
+  if (
+    projectDepartment({
+      projectId: project.id,
+      projectNumber: project.projectNumber,
+    }) !== "N"
+  ) {
+    throw new Error("The Nu-Tech order workflow is available only for N projects.")
+  }
+  return { db, user, organizationId, project }
+}
+
+function revalidateNuTechPaths(projectId: string): void {
+  revalidatePath("/dashboard/nutech")
+  revalidatePath(`/dashboard/projects/${projectId}`)
+  revalidatePath(`/dashboard/projects/${projectId}/nutech`)
+  revalidatePath(`/dashboard/projects/${projectId}/purchase-orders`)
+}
+
+export async function getProjectNuTechOrderWorkspace(
+  projectId: string
+): Promise<ProjectNuTechOrderWorkspace> {
+  const access = await nuTechProjectAccess(projectId, "read")
+  const [orderRow, estimateRow, purchaseOrderRows, canEdit, canDelete] =
+    await Promise.all([
+      access.db
+        .select()
+        .from(nuTechOrderWorkflows)
+        .where(eq(nuTechOrderWorkflows.projectId, projectId))
+        .limit(1)
+        .get(),
+      access.db
+        .select({
+          id: projectEstimates.id,
+          number: projectEstimates.estimateNumber,
+          status: projectEstimates.status,
+          totalCents: projectEstimates.estimateTotalCents,
+          updatedAt: projectEstimates.updatedAt,
+        })
+        .from(projectEstimates)
+        .where(eq(projectEstimates.projectId, projectId))
+        .orderBy(desc(projectEstimates.updatedAt))
+        .limit(1)
+        .get(),
+      access.db
+        .select({
+          id: projectOperations.id,
+          number: projectOperations.sourceRecordNumber,
+          title: projectOperations.title,
+          companyName: projectOperations.companyName,
+          status: projectOperations.status,
+          amount: projectOperations.amount,
+        })
+        .from(projectOperations)
+        .where(
+          and(
+            eq(projectOperations.projectId, projectId),
+            eq(projectOperations.sourceRecordType, "purchase_order")
+          )
+        )
+        .orderBy(desc(projectOperations.updatedAt)),
+      canFeature(access.user, "nutech-orders", "update"),
+      canFeature(access.user, "nutech-orders", "delete"),
+    ])
+  const catalogVersion = orderRow?.catalogVersionId
+    ? await access.db
+        .select({ id: nuTechCatalogVersions.id, name: nuTechCatalogVersions.name })
+        .from(nuTechCatalogVersions)
+        .where(
+          and(
+            eq(nuTechCatalogVersions.id, orderRow.catalogVersionId),
+            eq(nuTechCatalogVersions.organizationId, access.organizationId)
+          )
+        )
+        .limit(1)
+        .get()
+    : await access.db
+        .select({ id: nuTechCatalogVersions.id, name: nuTechCatalogVersions.name })
+        .from(nuTechCatalogVersions)
+        .where(
+          and(
+            eq(nuTechCatalogVersions.organizationId, access.organizationId),
+            eq(nuTechCatalogVersions.status, "active")
+          )
+        )
+        .orderBy(desc(nuTechCatalogVersions.effectiveDate))
+        .limit(1)
+        .get()
+  const [catalogProducts, orderItems] = await Promise.all([
+    catalogVersion
+      ? access.db
+          .select({
+            id: nuTechProducts.id,
+            manufacturerSku: nuTechProducts.manufacturerSku,
+            name: nuTechProducts.name,
+            category: nuTechProducts.category,
+            origin: nuTechProducts.origin,
+            priceUnit: nuTechProducts.priceUnit,
+            packageLabel: nuTechProducts.packageLabel,
+            minimumOrderIncrement: nuTechProducts.minimumOrderIncrement,
+            airliteMappingStatus: nuTechProducts.airliteMappingStatus,
+            newStandardPriceCents: nuTechCatalogPrices.newStandardPriceCents,
+            newCashPriceCents: nuTechCatalogPrices.newCashPriceCents,
+            returningStandardPriceCents:
+              nuTechCatalogPrices.returningStandardPriceCents,
+            returningCashPriceCents: nuTechCatalogPrices.returningCashPriceCents,
+          })
+          .from(nuTechCatalogPrices)
+          .innerJoin(
+            nuTechProducts,
+            eq(nuTechProducts.id, nuTechCatalogPrices.productId)
+          )
+          .where(
+            and(
+              eq(nuTechCatalogPrices.catalogVersionId, catalogVersion.id),
+              eq(nuTechProducts.organizationId, access.organizationId),
+              eq(nuTechProducts.active, true)
+            )
+          )
+          .orderBy(asc(nuTechProducts.category), asc(nuTechProducts.manufacturerSku))
+      : Promise.resolve([]),
+    orderRow
+      ? access.db
+          .select({
+            id: nuTechOrderItems.id,
+            productId: nuTechOrderItems.productId,
+            manufacturerSku: nuTechOrderItems.manufacturerSkuSnapshot,
+            name: nuTechOrderItems.productNameSnapshot,
+            quantity: nuTechOrderItems.quantity,
+            priceUnit: nuTechOrderItems.priceUnitSnapshot,
+            unitCostCents: nuTechOrderItems.unitCostCents,
+            unitPriceCents: nuTechOrderItems.unitPriceCents,
+            sortOrder: nuTechOrderItems.sortOrder,
+          })
+          .from(nuTechOrderItems)
+          .where(eq(nuTechOrderItems.workflowId, orderRow.id))
+          .orderBy(asc(nuTechOrderItems.sortOrder))
+      : Promise.resolve([]),
+  ])
+  return {
+    canEdit: canEdit && !isDemoUser(access.user.id),
+    canDelete: canDelete && !isDemoUser(access.user.id),
+    projectId,
+    projectNumber: access.project.projectNumber,
+    projectName: access.project.name,
+    clientName: access.project.clientName,
+    address: access.project.address,
+    order: orderRow ? toOrderRecord(orderRow) : null,
+    catalogVersionName: catalogVersion?.name ?? null,
+    catalogProducts,
+    orderItems,
+    estimate: estimateRow ?? null,
+    purchaseOrders: purchaseOrderRows,
+  }
+}
+
+export async function getNuTechOrderDashboard(): Promise<
+  readonly NuTechOrderDashboardItem[]
+> {
+  const user = await requireAuth()
+  await requireFeaturePermission(user, "nutech-orders", "read")
+  const organizationId = requireOrg(user)
+  const { env } = await getCloudflareContext()
+  const db = getDb(env.DB)
+  const projectRows = await db
+    .select({
+      id: projects.id,
+      projectNumber: projects.projectNumber,
+      name: projects.name,
+      clientName: projects.clientName,
+    })
+    .from(projects)
+    .where(
+      and(
+        eq(projects.organizationId, organizationId),
+        like(projects.projectNumber, "N-%")
+      )
+    )
+    .orderBy(desc(projects.updatedAt), desc(projects.createdAt))
+  const projectIds = projectRows.map((project) => project.id)
+  if (projectIds.length === 0) return []
+  const [workflowRows, estimateRows, purchaseOrderRows] = await Promise.all([
+    db
+      .select()
+      .from(nuTechOrderWorkflows)
+      .where(inArray(nuTechOrderWorkflows.projectId, projectIds)),
+    db
+      .select({
+        projectId: projectEstimates.projectId,
+        status: projectEstimates.status,
+        updatedAt: projectEstimates.updatedAt,
+      })
+      .from(projectEstimates)
+      .where(inArray(projectEstimates.projectId, projectIds))
+      .orderBy(desc(projectEstimates.updatedAt)),
+    db
+      .select({
+        projectId: projectOperations.projectId,
+        status: projectOperations.status,
+      })
+      .from(projectOperations)
+      .where(
+        and(
+          inArray(projectOperations.projectId, projectIds),
+          eq(projectOperations.sourceRecordType, "purchase_order")
+        )
+      ),
+  ])
+  return projectRows.map((project) => {
+    const workflow = workflowRows.find((row) => row.projectId === project.id)
+    const estimate = estimateRows.find((row) => row.projectId === project.id)
+    const openPurchaseOrderCount = purchaseOrderRows.filter(
+      (row) =>
+        row.projectId === project.id &&
+        !["complete", "closed", "void"].includes(row.status)
+    ).length
+    return {
+      projectId: project.id,
+      projectNumber: project.projectNumber,
+      projectName: project.name,
+      clientName: project.clientName,
+      orderStatus: workflow?.orderStatus ?? "not_started",
+      quantitySource: workflow
+        ? storedQuantitySource(workflow.quantitySource)
+        : null,
+      requestedDeliveryDate: workflow?.requestedDeliveryDate ?? null,
+      estimateStatus: estimate?.status ?? null,
+      openPurchaseOrderCount,
+    }
+  })
+}
+
+export async function saveProjectNuTechOrder(
+  projectId: string,
+  input: SaveNuTechOrderInput
+): Promise<NuTechOrderActionResult> {
+  try {
+    const access = await nuTechProjectAccess(projectId, "update")
+    const parsedCustomerType = customerType(input.customerType)
+    const parsedPricingMode = pricingMode(input.pricingMode)
+    const parsedQuantitySource = quantitySource(input.quantitySource)
+    const parsedTakeoffStatus = normalizedNuTechTakeoffStatus({
+      quantitySource: parsedQuantitySource,
+      requestedStatus: takeoffStatus(input.takeoffAcknowledgementStatus),
+    })
+    const parsedScopeType = scopeType(input.scopeType)
+    const bracingIncluded =
+      input.bracingIncluded ||
+      parsedScopeType === "block_and_bracing" ||
+      parsedScopeType === "bracing_only"
+    const bracingRentalStartDate = bracingIncluded
+      ? cleanDate(input.bracingRentalStartDate, "Bracing rental start")
+      : null
+    const bracingRentalEndDate = bracingIncluded
+      ? cleanDate(input.bracingRentalEndDate, "Bracing rental end")
+      : null
+    if (
+      bracingRentalStartDate !== null &&
+      bracingRentalEndDate !== null &&
+      bracingRentalEndDate < bracingRentalStartDate
+    ) {
+      throw new Error("Bracing rental end cannot be before its start date.")
+    }
+    const purchaseOrderId = cleanText(input.airlitePurchaseOrderOperationId)
+    if (purchaseOrderId !== null) {
+      const linkedPurchaseOrder = await access.db
+        .select({ id: projectOperations.id })
+        .from(projectOperations)
+        .where(
+          and(
+            eq(projectOperations.id, purchaseOrderId),
+            eq(projectOperations.projectId, projectId),
+            eq(projectOperations.sourceRecordType, "purchase_order")
+          )
+        )
+        .limit(1)
+        .get()
+      if (!linkedPurchaseOrder) {
+        throw new Error("Choose a purchase order from this Nu-Tech project.")
+      }
+    }
+    const vendorInvoiceReceivedAt = cleanDate(
+      input.vendorInvoiceReceivedAt,
+      "Vendor invoice received date"
+    )
+    const requestedDeliveryDate = cleanDate(
+      input.requestedDeliveryDate,
+      "Requested delivery date"
+    )
+    const parsedOrderStatus = orderStatus(input.orderStatus)
+    const parsedVendorInvoiceStatus = vendorInvoiceStatus(
+      input.vendorInvoiceStatus
+    )
+    const existing = await access.db
+      .select()
+      .from(nuTechOrderWorkflows)
+      .where(eq(nuTechOrderWorkflows.projectId, projectId))
+      .limit(1)
+      .get()
+    const releaseAuditIssues = nuTechReleaseAuditIssues({
+      orderStatus: parsedOrderStatus,
+      vendorInvoiceStatus: parsedVendorInvoiceStatus,
+      purchaseOrderReleasedAt: existing?.purchaseOrderReleasedAt ?? null,
+      vendorInvoiceReleasedAt: existing?.vendorInvoiceReleasedAt ?? null,
+    })
+    if (releaseAuditIssues.length > 0) {
+      throw new Error(releaseAuditIssues.join(" "))
+    }
+    if (
+      existing?.purchaseOrderReleasedAt !== null &&
+      existing?.purchaseOrderReleasedAt !== undefined &&
+      (parsedCustomerType !== storedCustomerType(existing.customerType) ||
+        parsedPricingMode !== storedPricingMode(existing.pricingMode) ||
+        purchaseOrderId !== existing.airlitePurchaseOrderOperationId ||
+        requestedDeliveryDate !== existing.requestedDeliveryDate)
+    ) {
+      throw new Error(
+        "Released Airlite PO pricing, delivery date, and linked purchase order are locked."
+      )
+    }
+    const activeCatalog = existing?.catalogVersionId
+      ? null
+      : await access.db
+          .select({ id: nuTechCatalogVersions.id })
+          .from(nuTechCatalogVersions)
+          .where(
+            and(
+              eq(nuTechCatalogVersions.organizationId, access.organizationId),
+              eq(nuTechCatalogVersions.status, "active")
+            )
+          )
+          .orderBy(desc(nuTechCatalogVersions.effectiveDate))
+          .limit(1)
+          .get()
+    const now = new Date().toISOString()
+    const id = existing?.id ?? crypto.randomUUID()
+    const values: NewNuTechOrderWorkflow = {
+      id,
+      projectId,
+      catalogVersionId: existing?.catalogVersionId ?? activeCatalog?.id ?? null,
+      customerType: parsedCustomerType,
+      pricingMode: parsedPricingMode,
+      quantitySource: parsedQuantitySource,
+      takeoffAcknowledgementStatus: parsedTakeoffStatus,
+      scopeType: parsedScopeType,
+      blockQuantityNotes: cleanText(input.blockQuantityNotes),
+      bracingIncluded,
+      bracingRentalStartDate,
+      bracingRentalEndDate,
+      bracingNotes: bracingIncluded ? cleanText(input.bracingNotes) : null,
+      deliveryMethod: deliveryMethod(input.deliveryMethod),
+      requestedDeliveryDate,
+      airlitePurchaseOrderOperationId: purchaseOrderId,
+      orderStatus: parsedOrderStatus,
+      vendorConfirmationNumber: cleanText(input.vendorConfirmationNumber),
+      purchaseOrderReleasedAt: existing?.purchaseOrderReleasedAt ?? null,
+      purchaseOrderReleasedBy: existing?.purchaseOrderReleasedBy ?? null,
+      vendorInvoiceNumber: cleanText(input.vendorInvoiceNumber),
+      vendorInvoiceStatus: parsedVendorInvoiceStatus,
+      vendorInvoiceReceivedAt,
+      vendorInvoiceReleasedAt: existing?.vendorInvoiceReleasedAt ?? null,
+      vendorInvoiceReleasedBy: existing?.vendorInvoiceReleasedBy ?? null,
+      notes: cleanText(input.notes),
+      createdBy: existing?.createdBy ?? access.user.id,
+      updatedBy: access.user.id,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    }
+    const workbookInputsChanged =
+      existing !== undefined &&
+      (purchaseOrderId !== existing.airlitePurchaseOrderOperationId ||
+        requestedDeliveryDate !== existing.requestedDeliveryDate)
+    const nextWorkbookStatus =
+      existing?.airliteWorkbookStatus.startsWith("generated") &&
+      workbookInputsChanged
+        ? "stale"
+        : existing?.airliteWorkbookStatus ?? "not_generated"
+    const saveWorkflowQuery = access.db
+      .insert(nuTechOrderWorkflows)
+      .values(values)
+      .onConflictDoUpdate({
+        target: nuTechOrderWorkflows.projectId,
+        set: {
+          catalogVersionId: values.catalogVersionId,
+          customerType: values.customerType,
+          pricingMode: values.pricingMode,
+          quantitySource: values.quantitySource,
+          takeoffAcknowledgementStatus: values.takeoffAcknowledgementStatus,
+          scopeType: values.scopeType,
+          blockQuantityNotes: values.blockQuantityNotes,
+          bracingIncluded: values.bracingIncluded,
+          bracingRentalStartDate: values.bracingRentalStartDate,
+          bracingRentalEndDate: values.bracingRentalEndDate,
+          bracingNotes: values.bracingNotes,
+          deliveryMethod: values.deliveryMethod,
+          requestedDeliveryDate: values.requestedDeliveryDate,
+          airlitePurchaseOrderOperationId: values.airlitePurchaseOrderOperationId,
+          orderStatus: values.orderStatus,
+          vendorConfirmationNumber: values.vendorConfirmationNumber,
+          vendorInvoiceNumber: values.vendorInvoiceNumber,
+          vendorInvoiceStatus: values.vendorInvoiceStatus,
+          vendorInvoiceReceivedAt: values.vendorInvoiceReceivedAt,
+          airliteWorkbookStatus: nextWorkbookStatus,
+          notes: values.notes,
+          updatedBy: access.user.id,
+          updatedAt: now,
+        },
+      })
+    if (values.catalogVersionId !== null) {
+      const selectedPriceColumn =
+        parsedCustomerType === "new"
+          ? parsedPricingMode === "cash_discount"
+            ? nuTechCatalogPrices.newCashPriceCents
+            : nuTechCatalogPrices.newStandardPriceCents
+          : parsedPricingMode === "cash_discount"
+            ? nuTechCatalogPrices.returningCashPriceCents
+            : nuTechCatalogPrices.returningStandardPriceCents
+      const repriceOrderItemsQuery = access.db
+        .update(nuTechOrderItems)
+        .set({
+          unitPriceCents: sql`(
+            SELECT ${selectedPriceColumn}
+            FROM ${nuTechCatalogPrices}
+            WHERE ${nuTechCatalogPrices.catalogVersionId} = ${values.catalogVersionId}
+              AND ${nuTechCatalogPrices.productId} = ${nuTechOrderItems.productId}
+            LIMIT 1
+          )`,
+          updatedAt: now,
+        })
+        .where(eq(nuTechOrderItems.workflowId, id))
+      await access.db.batch([saveWorkflowQuery, repriceOrderItemsQuery])
+    } else {
+      await saveWorkflowQuery
+    }
+    revalidateNuTechPaths(projectId)
+    return { success: true, id }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to save Nu-Tech order.",
+    }
+  }
+}
+
+export async function releaseNuTechAirlitePurchaseOrder(
+  projectId: string
+): Promise<NuTechOrderActionResult> {
+  try {
+    const access = await nuTechProjectAccess(projectId, "update")
+    const order = await access.db
+      .select()
+      .from(nuTechOrderWorkflows)
+      .where(eq(nuTechOrderWorkflows.projectId, projectId))
+      .limit(1)
+      .get()
+    if (!order) throw new Error("Start and save the Nu-Tech order first.")
+    if (order.purchaseOrderReleasedAt !== null) {
+      return { success: true, id: order.id }
+    }
+    const orderItemRows = await access.db
+      .select({ id: nuTechOrderItems.id })
+      .from(nuTechOrderItems)
+      .where(eq(nuTechOrderItems.workflowId, order.id))
+    const readiness = nuTechPurchaseOrderReleaseReadiness({
+      customerType: storedCustomerType(order.customerType),
+      pricingMode: storedPricingMode(order.pricingMode),
+      quantitySource: storedQuantitySource(order.quantitySource),
+      takeoffAcknowledgementStatus: takeoffStatus(
+        order.takeoffAcknowledgementStatus
+      ),
+      airlitePurchaseOrderOperationId: order.airlitePurchaseOrderOperationId,
+      orderItemCount: orderItemRows.length,
+      airliteWorkbookStatus: order.airliteWorkbookStatus,
+    })
+    if (!readiness.ready) throw new Error(readiness.issues.join(" "))
+    const purchaseOrderId = order.airlitePurchaseOrderOperationId
+    if (purchaseOrderId === null) throw new Error("Link the Airlite purchase order.")
+    const purchaseOrder = await access.db
+      .select({ id: projectOperations.id, status: projectOperations.status })
+      .from(projectOperations)
+      .where(
+        and(
+          eq(projectOperations.id, purchaseOrderId),
+          eq(projectOperations.projectId, projectId),
+          eq(projectOperations.sourceRecordType, "purchase_order")
+        )
+      )
+      .limit(1)
+      .get()
+    if (!purchaseOrder) throw new Error("The linked Airlite purchase order was not found.")
+    const now = new Date().toISOString()
+    const purchaseOrderStatus =
+      purchaseOrder.status === "draft" || purchaseOrder.status === "approved"
+        ? "sent"
+        : purchaseOrder.status
+    await access.db.batch([
+      access.db
+        .update(nuTechOrderWorkflows)
+        .set({
+          orderStatus: "po_released",
+          purchaseOrderReleasedAt: now,
+          purchaseOrderReleasedBy: access.user.id,
+          updatedBy: access.user.id,
+          updatedAt: now,
+        })
+        .where(eq(nuTechOrderWorkflows.id, order.id)),
+      access.db
+        .update(projectOperations)
+        .set({ status: purchaseOrderStatus, updatedAt: now })
+        .where(eq(projectOperations.id, purchaseOrderId)),
+    ])
+    revalidateNuTechPaths(projectId)
+    return { success: true, id: order.id }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to release the Airlite PO.",
+    }
+  }
+}
+
+export async function releaseNuTechVendorInvoice(
+  projectId: string
+): Promise<NuTechOrderActionResult> {
+  try {
+    const access = await nuTechProjectAccess(projectId, "update")
+    const order = await access.db
+      .select()
+      .from(nuTechOrderWorkflows)
+      .where(eq(nuTechOrderWorkflows.projectId, projectId))
+      .limit(1)
+      .get()
+    if (!order) throw new Error("Start and save the Nu-Tech order first.")
+    if (order.vendorInvoiceReleasedAt !== null) {
+      return { success: true, id: order.id }
+    }
+    if (cleanText(order.vendorInvoiceNumber) === null) {
+      throw new Error("Enter and save the Airlite vendor invoice number first.")
+    }
+    if (order.purchaseOrderReleasedAt === null) {
+      throw new Error("Record the Airlite PO release before releasing its invoice.")
+    }
+    const now = new Date().toISOString()
+    await access.db
+      .update(nuTechOrderWorkflows)
+      .set({
+        orderStatus: "invoice_released",
+        vendorInvoiceStatus: "released",
+        vendorInvoiceReceivedAt: order.vendorInvoiceReceivedAt ?? now.slice(0, 10),
+        vendorInvoiceReleasedAt: now,
+        vendorInvoiceReleasedBy: access.user.id,
+        updatedBy: access.user.id,
+        updatedAt: now,
+      })
+      .where(eq(nuTechOrderWorkflows.id, order.id))
+    revalidateNuTechPaths(projectId)
+    revalidatePath("/dashboard/financials")
+    return { success: true, id: order.id }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to release the Airlite vendor invoice.",
+    }
+  }
+}
+
+export async function deleteProjectNuTechOrder(
+  projectId: string
+): Promise<NuTechOrderActionResult> {
+  try {
+    const access = await nuTechProjectAccess(projectId, "delete")
+    const existing = await access.db
+      .select({
+        id: nuTechOrderWorkflows.id,
+        purchaseOrderReleasedAt: nuTechOrderWorkflows.purchaseOrderReleasedAt,
+        vendorInvoiceReleasedAt: nuTechOrderWorkflows.vendorInvoiceReleasedAt,
+      })
+      .from(nuTechOrderWorkflows)
+      .where(eq(nuTechOrderWorkflows.projectId, projectId))
+      .limit(1)
+      .get()
+    if (!existing) throw new Error("Nu-Tech order workflow not found.")
+    if (
+      existing.purchaseOrderReleasedAt !== null ||
+      existing.vendorInvoiceReleasedAt !== null
+    ) {
+      throw new Error(
+        "Released Nu-Tech workflows are retained for audit and cannot be deleted."
+      )
+    }
+    await access.db
+      .delete(nuTechOrderWorkflows)
+      .where(eq(nuTechOrderWorkflows.id, existing.id))
+    revalidateNuTechPaths(projectId)
+    return { success: true, id: existing.id }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to delete Nu-Tech order.",
+    }
+  }
+}

--- a/src/app/dashboard/nutech/catalog/page.tsx
+++ b/src/app/dashboard/nutech/catalog/page.tsx
@@ -1,0 +1,37 @@
+export const dynamic = "force-dynamic"
+
+import Link from "next/link"
+import { IconArrowLeft, IconPackages } from "@tabler/icons-react"
+
+import { getNuTechCatalogWorkspace } from "@/app/actions/nutech-catalog"
+import { NuTechCatalogWorkspacePanel } from "@/components/nutech/nutech-catalog-workspace"
+import { Button } from "@/components/ui/button"
+
+export default async function NuTechCatalogPage(): Promise<React.ReactElement> {
+  const workspace = await getNuTechCatalogWorkspace()
+  return (
+    <div className="flex-1 space-y-6 p-4 pt-6 sm:p-6 md:p-8">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <Button asChild variant="ghost" size="sm" className="-ml-2 mb-2">
+            <Link href="/dashboard/nutech">
+              <IconArrowLeft className="size-4" />
+              Nu-Tech orders
+            </Link>
+          </Button>
+          <div className="flex items-center gap-2">
+            <IconPackages className="size-5 text-brand-nutech-gold-foreground" />
+            <h1 className="text-2xl font-semibold tracking-tight">
+              Product Catalog
+            </h1>
+          </div>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            Versioned Airlite costs, published customer prices, manufacturer-form
+            rows, and deliberate Sage cost-code mappings.
+          </p>
+        </div>
+      </div>
+      <NuTechCatalogWorkspacePanel workspace={workspace} />
+    </div>
+  )
+}

--- a/src/app/dashboard/nutech/page.tsx
+++ b/src/app/dashboard/nutech/page.tsx
@@ -1,0 +1,126 @@
+export const dynamic = "force-dynamic"
+
+import Link from "next/link"
+import {
+  IconArrowRight,
+  IconCalendarEvent,
+  IconShoppingCart,
+  IconPackages,
+  IconTool,
+} from "@tabler/icons-react"
+
+import { getNuTechOrderDashboard } from "@/app/actions/nutech-orders"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { nuTechOrderStatusLabel } from "@/lib/nutech/workflow"
+
+function dateLabel(value: string | null): string {
+  if (!value) return "No delivery date"
+  return new Date(`${value}T12:00:00`).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+export default async function NuTechOrdersPage(): Promise<React.ReactElement> {
+  const orders = await getNuTechOrderDashboard()
+  const activeOrders = orders.filter(
+    (order) => !["complete", "cancelled"].includes(order.orderStatus)
+  )
+
+  return (
+    <div className="flex-1 space-y-6 p-4 pt-6 sm:p-6 md:p-8">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <IconTool className="size-5 text-brand-nutech-gold-foreground" />
+            <h1 className="text-2xl font-semibold tracking-tight">
+              Nu-Tech Orders
+            </h1>
+          </div>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            Fox Blocks sales, staff takeoffs, bracing rentals, Airlite purchase
+            orders, and vendor-invoice release tracking.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Badge variant="secondary">{activeOrders.length} active</Badge>
+          <Badge variant="outline">{orders.length} N projects</Badge>
+        </div>
+      </div>
+
+      <section className="space-y-3">
+        <div className="flex flex-wrap items-end justify-between gap-3 border-y py-3">
+          <div>
+            <h2 className="text-sm font-semibold">Department order queue</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Open a project to continue its quantity, estimate, PO, or invoice
+              handoff.
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Button asChild variant="outline" size="sm">
+              <Link href="/dashboard/nutech/catalog">
+                <IconPackages className="size-4" />
+                Product catalog
+              </Link>
+            </Button>
+            <Button asChild variant="outline" size="sm">
+              <Link href="/dashboard/projects?department=N">Nu-Tech projects</Link>
+            </Button>
+          </div>
+        </div>
+
+        {orders.length === 0 ? (
+          <div className="rounded-lg border bg-background p-8 text-center">
+            <IconTool className="mx-auto size-6 text-muted-foreground" />
+            <h2 className="mt-3 text-sm font-semibold">No Nu-Tech projects found</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Create or reconcile an N-numbered project to begin its order process.
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y rounded-lg border bg-background">
+            {orders.map((order) => (
+              <article
+                key={order.projectId}
+                className="grid gap-3 p-4 lg:grid-cols-[minmax(14rem,1fr)_minmax(12rem,0.8fr)_auto] lg:items-center"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-semibold">
+                    {order.projectNumber ?? order.projectName}
+                  </p>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {order.projectNumber ? order.projectName : order.clientName ?? "Nu-Tech project"}
+                  </p>
+                </div>
+                <div className="flex min-w-0 flex-wrap gap-2 text-xs text-muted-foreground">
+                  <Badge variant="secondary">
+                    {order.orderStatus === "not_started"
+                      ? "Not started"
+                      : nuTechOrderStatusLabel(order.orderStatus)}
+                  </Badge>
+                  <span className="inline-flex items-center gap-1">
+                    <IconCalendarEvent className="size-3.5" />
+                    {dateLabel(order.requestedDeliveryDate)}
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    <IconShoppingCart className="size-3.5" />
+                    {order.openPurchaseOrderCount} open PO
+                  </span>
+                </div>
+                <Button asChild size="sm">
+                  <Link href={`/dashboard/projects/${order.projectId}/nutech`}>
+                    Continue
+                    <IconArrowRight className="size-4" />
+                  </Link>
+                </Button>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/app/dashboard/projects/[id]/estimate/page.tsx
+++ b/src/app/dashboard/projects/[id]/estimate/page.tsx
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic"
 
 import Link from "next/link"
-import { IconArrowLeft, IconCalculator } from "@tabler/icons-react"
+import { IconArrowLeft, IconCalculator, IconPackageExport } from "@tabler/icons-react"
 
 import { getProjectEstimateWorkspace } from "@/app/actions/project-estimates"
 import { getPublishedEstimateTemplateOptions } from "@/app/actions/estimate-templates"
@@ -36,7 +36,18 @@ export default async function ProjectEstimatePage({
             Department-specific client estimate, contract basis, approval, and budget handoff.
           </p>
         </div>
-        <ProjectContextSwitcher currentProjectId={id} targetSection="estimate" placeholder="Switch estimate project..." className="w-full sm:w-[280px]" />
+        <div className="flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto">
+          {workspace.department === "N" && (
+            <Link
+              href={`/dashboard/projects/${id}/nutech`}
+              className="inline-flex h-9 items-center gap-2 rounded-lg border px-3 text-sm font-medium hover:bg-accent"
+            >
+              <IconPackageExport className="size-4" />
+              Nu-Tech process
+            </Link>
+          )}
+          <ProjectContextSwitcher currentProjectId={id} targetSection="estimate" placeholder="Switch estimate project..." className="w-full sm:w-[280px]" />
+        </div>
       </div>
       <ProjectEstimateWorkspacePanel
         projectId={id}

--- a/src/app/dashboard/projects/[id]/nutech/page.tsx
+++ b/src/app/dashboard/projects/[id]/nutech/page.tsx
@@ -1,0 +1,56 @@
+export const dynamic = "force-dynamic"
+
+import Link from "next/link"
+import { IconArrowLeft, IconTool } from "@tabler/icons-react"
+
+import { getProjectNuTechOrderWorkspace } from "@/app/actions/nutech-orders"
+import { NuTechOrderWorkspace } from "@/components/nutech/nutech-order-workspace"
+import { ProjectContextSwitcher } from "@/components/projects/project-context-switcher"
+
+export default async function ProjectNuTechOrderPage({
+  params,
+}: {
+  readonly params: Promise<{ readonly id: string }>
+}): Promise<React.ReactElement> {
+  const { id } = await params
+  const workspace = await getProjectNuTechOrderWorkspace(id)
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto p-4 md:p-6">
+      <div className="mb-5 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <Link
+            href={`/dashboard/projects/${id}`}
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+          >
+            <IconArrowLeft className="size-4" />
+            Project
+          </Link>
+          <div className="mt-3 flex items-center gap-2">
+            <IconTool className="size-5 text-brand-nutech-gold-foreground" />
+            <h1 className="text-2xl font-semibold tracking-tight">
+              Nu-Tech Order Process
+            </h1>
+          </div>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            {workspace.projectNumber ? `${workspace.projectNumber} · ` : ""}
+            {workspace.projectName}
+            {workspace.clientName ? ` · ${workspace.clientName}` : ""}
+          </p>
+          {workspace.address && (
+            <p className="mt-1 text-sm text-muted-foreground">
+              {workspace.address}
+            </p>
+          )}
+        </div>
+        <ProjectContextSwitcher
+          currentProjectId={id}
+          targetSection="nutech"
+          placeholder="Switch Nu-Tech project..."
+          className="w-full sm:w-[280px]"
+        />
+      </div>
+      <NuTechOrderWorkspace workspace={workspace} />
+    </div>
+  )
+}

--- a/src/app/dashboard/projects/[id]/purchase-orders/page.tsx
+++ b/src/app/dashboard/projects/[id]/purchase-orders/page.tsx
@@ -537,6 +537,14 @@ export default async function ProjectPurchaseOrdersPage({
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
+            {brand.department === "N" && (
+              <Button asChild variant="outline" size="sm">
+                <Link href={`/dashboard/projects/${id}/nutech`}>
+                  Nu-Tech order process
+                  <IconExternalLink className="size-4" />
+                </Link>
+              </Button>
+            )}
             <Button asChild variant="outline" size="sm">
               <Link href="/dashboard/financials?tab=bills">
                 Financials

--- a/src/components/nutech/nutech-catalog-workspace.tsx
+++ b/src/components/nutech/nutech-catalog-workspace.tsx
@@ -1,0 +1,263 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useTransition } from "react"
+import {
+  IconCheck,
+  IconDatabaseImport,
+  IconTrash,
+} from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import {
+  activateNuTechCatalogVersion,
+  deleteNuTechCatalogVersion,
+  importNuTech2026Catalog,
+  mapNuTechProductToSageCostCode,
+  type NuTechCatalogWorkspace,
+} from "@/app/actions/nutech-catalog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+
+const SELECT_CLASS =
+  "h-8 w-full min-w-56 rounded-md border border-input bg-background px-2 text-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+
+function money(cents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(cents / 100)
+}
+
+export function NuTechCatalogWorkspacePanel({
+  workspace,
+}: {
+  readonly workspace: NuTechCatalogWorkspace
+}): React.ReactElement {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+
+  function importCatalog(): void {
+    startTransition(async () => {
+      const result = await importNuTech2026Catalog()
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(`Imported ${result.productCount ?? 0} Nu-Tech products.`)
+      router.refresh()
+    })
+  }
+
+  function activateCatalog(versionId: string): void {
+    startTransition(async () => {
+      const result = await activateNuTechCatalogVersion(versionId)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success("Nu-Tech catalog activated.")
+      router.refresh()
+    })
+  }
+
+  function deleteCatalog(versionId: string): void {
+    if (!window.confirm("Delete this draft Nu-Tech catalog version?")) return
+    startTransition(async () => {
+      const result = await deleteNuTechCatalogVersion(versionId)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success("Draft catalog deleted.")
+      router.refresh()
+    })
+  }
+
+  function mapSageCostCode(productId: string, value: string): void {
+    startTransition(async () => {
+      const result = await mapNuTechProductToSageCostCode(
+        productId,
+        value.length > 0 ? value : null
+      )
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success("Sage mapping updated.")
+      router.refresh()
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border bg-background p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-sm font-semibold">Catalog versions</h2>
+            <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+              Imports validate all four published 2026 price sheets against the
+              same Airlite cost and SKU list before anything can be activated.
+            </p>
+          </div>
+          {workspace.canImport && (
+            <Button onClick={importCatalog} disabled={isPending}>
+              <IconDatabaseImport className="size-4" />
+              Import 2026 catalog
+            </Button>
+          )}
+        </div>
+        <div className="mt-4 divide-y border-y">
+          {workspace.versions.length === 0 ? (
+            <p className="py-4 text-sm text-muted-foreground">
+              No catalog version has been imported.
+            </p>
+          ) : (
+            workspace.versions.map((version) => (
+              <div
+                key={version.id}
+                className="flex flex-wrap items-center justify-between gap-3 py-3"
+              >
+                <div>
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-medium">{version.name}</p>
+                    <Badge
+                      variant={version.status === "active" ? "default" : "secondary"}
+                    >
+                      {version.status}
+                    </Badge>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Effective {version.effectiveDate} · {version.productCount} products
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  {workspace.canImport && version.status !== "active" && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={isPending || version.productCount === 0}
+                      onClick={() => activateCatalog(version.id)}
+                    >
+                      <IconCheck className="size-4" />
+                      Activate
+                    </Button>
+                  )}
+                  {workspace.canDelete && version.status === "draft" && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="text-destructive hover:text-destructive"
+                      disabled={isPending}
+                      onClick={() => deleteCatalog(version.id)}
+                    >
+                      <IconTrash className="size-4" />
+                      Delete
+                    </Button>
+                  )}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-lg border bg-background">
+        <div className="border-b p-4">
+          <h2 className="text-sm font-semibold">Active product catalog</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Published customer prices are versioned. Sage mappings remain optional
+            until the matching cost code exists and is deliberately selected.
+          </p>
+        </div>
+        {workspace.products.length === 0 ? (
+          <p className="p-6 text-sm text-muted-foreground">
+            Activate an imported catalog to review its products.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[1100px] text-left text-xs">
+              <thead className="border-b bg-muted/40 text-muted-foreground">
+                <tr>
+                  <th className="px-3 py-2 font-medium">SKU / product</th>
+                  <th className="px-3 py-2 font-medium">Package</th>
+                  <th className="px-3 py-2 text-right font-medium">Airlite cost</th>
+                  <th className="px-3 py-2 text-right font-medium">New standard</th>
+                  <th className="px-3 py-2 text-right font-medium">New cash</th>
+                  <th className="px-3 py-2 text-right font-medium">Returning</th>
+                  <th className="px-3 py-2 text-right font-medium">Returning cash</th>
+                  <th className="px-3 py-2 font-medium">Airlite form</th>
+                  <th className="px-3 py-2 font-medium">Sage cost code</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {workspace.products.map((product) => (
+                  <tr key={product.id}>
+                    <td className="px-3 py-2 align-top">
+                      <p className="font-medium">{product.manufacturerSku}</p>
+                      <p className="mt-0.5 text-muted-foreground">{product.name}</p>
+                    </td>
+                    <td className="px-3 py-2 align-top text-muted-foreground">
+                      {product.packageLabel} · {product.priceUnit}
+                    </td>
+                    <td className="px-3 py-2 text-right align-top">
+                      {money(product.airliteCostCents)}
+                    </td>
+                    <td className="px-3 py-2 text-right align-top">
+                      {money(product.newStandardPriceCents)}
+                    </td>
+                    <td className="px-3 py-2 text-right align-top">
+                      {money(product.newCashPriceCents)}
+                    </td>
+                    <td className="px-3 py-2 text-right align-top">
+                      {money(product.returningStandardPriceCents)}
+                    </td>
+                    <td className="px-3 py-2 text-right align-top">
+                      {money(product.returningCashPriceCents)}
+                    </td>
+                    <td className="px-3 py-2 align-top">
+                      <Badge
+                        variant={
+                          product.airliteMappingStatus === "mapped"
+                            ? "secondary"
+                            : "outline"
+                        }
+                      >
+                        {product.airliteTemplateRow
+                          ? `Row ${product.airliteTemplateRow}`
+                          : "Addendum"}
+                      </Badge>
+                    </td>
+                    <td className="px-3 py-2 align-top">
+                      {workspace.canImport ? (
+                        <select
+                          className={SELECT_CLASS}
+                          value={product.sageCostCodeId ?? ""}
+                          disabled={isPending}
+                          onChange={(event) =>
+                            mapSageCostCode(product.id, event.target.value)
+                          }
+                        >
+                          <option value="">Not mapped</option>
+                          {workspace.sageCostCodes.map((costCode) => (
+                            <option key={costCode.id} value={costCode.id}>
+                              {costCode.displayLabel}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <span className="text-muted-foreground">
+                          {product.sageCostCodeLabel ?? "Not mapped"}
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/components/nutech/nutech-order-workspace.tsx
+++ b/src/components/nutech/nutech-order-workspace.tsx
@@ -1,0 +1,997 @@
+"use client"
+
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useState, useTransition } from "react"
+import {
+  IconCalculator,
+  IconCheck,
+  IconExternalLink,
+  IconFileInvoice,
+  IconFileSpreadsheet,
+  IconPlus,
+  IconSend,
+  IconShoppingCart,
+  IconTrash,
+} from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import {
+  deleteProjectNuTechOrder,
+  releaseNuTechAirlitePurchaseOrder,
+  releaseNuTechVendorInvoice,
+  saveProjectNuTechOrder,
+  type ProjectNuTechOrderWorkspace,
+} from "@/app/actions/nutech-orders"
+import {
+  deleteNuTechOrderItem,
+  generateNuTechAirliteWorkbook,
+  saveNuTechOrderItem,
+} from "@/app/actions/nutech-order-items"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { NUTECH_RESOURCE_LINKS, nuTechPricingFolderUrl } from "@/lib/nutech/resources"
+import { nuTechCustomerPriceCents } from "@/lib/nutech/catalog-pricing"
+import {
+  NUTECH_CUSTOMER_TYPE_OPTIONS,
+  NUTECH_DELIVERY_METHOD_OPTIONS,
+  NUTECH_ORDER_STATUS_OPTIONS,
+  NUTECH_PRICING_MODE_OPTIONS,
+  NUTECH_QUANTITY_SOURCE_OPTIONS,
+  NUTECH_SCOPE_TYPE_OPTIONS,
+  NUTECH_TAKEOFF_STATUS_OPTIONS,
+  NUTECH_VENDOR_INVOICE_STATUS_OPTIONS,
+  nuTechOrderStatusLabel,
+  nuTechPurchaseOrderReleaseReadiness,
+  type NuTechCustomerType,
+  type NuTechPricingMode,
+  type NuTechQuantitySource,
+  type NuTechTakeoffAcknowledgementStatus,
+} from "@/lib/nutech/workflow"
+
+const SELECT_CLASS =
+  "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+
+function formText(formData: FormData, name: string): string {
+  const value = formData.get(name)
+  return typeof value === "string" ? value : ""
+}
+
+function optionalFormText(formData: FormData, name: string): string | null {
+  const value = formText(formData, name).trim()
+  return value.length > 0 ? value : null
+}
+
+function customerTypeValue(value: string): NuTechCustomerType {
+  return value === "returning" ? "returning" : "new"
+}
+
+function quantitySourceValue(value: string): NuTechQuantitySource {
+  return value === "staff_takeoff" ? "staff_takeoff" : "customer_provided"
+}
+
+function takeoffStatusValue(value: string): NuTechTakeoffAcknowledgementStatus {
+  if (value === "sent" || value === "signed" || value === "not_required") {
+    return value
+  }
+  return "pending"
+}
+
+function money(value: number | null): string {
+  if (value === null) return "Amount TBD"
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(value)
+}
+
+function formatDateTime(value: string | null): string {
+  if (value === null) return "Not recorded"
+  return new Date(value).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })
+}
+
+export function NuTechOrderWorkspace({
+  workspace,
+}: {
+  readonly workspace: ProjectNuTechOrderWorkspace
+}): React.ReactElement {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const order = workspace.order
+  const [customerType, setCustomerType] = useState<NuTechCustomerType>(
+    order?.customerType ?? "new"
+  )
+  const [quantitySource, setQuantitySource] = useState<NuTechQuantitySource>(
+    order?.quantitySource ?? "customer_provided"
+  )
+  const [pricingMode, setPricingMode] = useState<NuTechPricingMode>(
+    order?.pricingMode ?? "standard"
+  )
+  const [selectedProductId, setSelectedProductId] = useState(
+    workspace.catalogProducts[0]?.id ?? ""
+  )
+  const [itemQuantity, setItemQuantity] = useState("")
+  const [takeoffStatus, setTakeoffStatus] =
+    useState<NuTechTakeoffAcknowledgementStatus>(
+      order?.takeoffAcknowledgementStatus ?? "not_required"
+    )
+  const pricingFolderUrl = nuTechPricingFolderUrl(customerType)
+  const releaseReadiness = nuTechPurchaseOrderReleaseReadiness({
+    customerType: order?.customerType ?? null,
+    pricingMode: order?.pricingMode ?? null,
+    quantitySource: order?.quantitySource ?? null,
+    takeoffAcknowledgementStatus:
+      order?.takeoffAcknowledgementStatus ?? "not_required",
+    airlitePurchaseOrderOperationId:
+      order?.airlitePurchaseOrderOperationId ?? null,
+    orderItemCount: workspace.orderItems.length,
+    airliteWorkbookStatus: order?.airliteWorkbookStatus ?? "not_generated",
+  })
+  const selectedProduct = workspace.catalogProducts.find(
+    (product) => product.id === selectedProductId
+  )
+  const customerTotalCents = workspace.orderItems.reduce(
+    (total, item) => total + item.quantity * item.unitPriceCents,
+    0
+  )
+  const airliteTotalCents = workspace.orderItems.reduce(
+    (total, item) => total + item.quantity * item.unitCostCents,
+    0
+  )
+  const pricingBasisChanged =
+    order !== null &&
+    (customerType !== order.customerType || pricingMode !== order.pricingMode)
+  const purchaseOrderReleased =
+    order !== null && order.purchaseOrderReleasedAt !== null
+  const vendorInvoiceReleased =
+    order !== null && order.vendorInvoiceReleasedAt !== null
+  const availableOrderStatusOptions = NUTECH_ORDER_STATUS_OPTIONS.filter(
+    (option) => {
+      if (vendorInvoiceReleased) {
+        return ["invoice_released", "complete", "cancelled"].includes(
+          option.value
+        )
+      }
+      if (purchaseOrderReleased) {
+        return [
+          "po_released",
+          "vendor_confirmed",
+          "invoice_received",
+          "complete",
+          "cancelled",
+        ].includes(option.value)
+      }
+      return ![
+        "po_released",
+        "vendor_confirmed",
+        "invoice_received",
+        "invoice_released",
+      ].includes(option.value)
+    }
+  )
+  const availableVendorInvoiceStatusOptions =
+    NUTECH_VENDOR_INVOICE_STATUS_OPTIONS.filter(
+      (option) =>
+        vendorInvoiceReleased ||
+        (option.value !== "released" && option.value !== "posted")
+    )
+
+  function onQuantitySourceChange(value: string): void {
+    const nextSource = quantitySourceValue(value)
+    setQuantitySource(nextSource)
+    if (nextSource === "customer_provided") {
+      setTakeoffStatus("not_required")
+    } else if (takeoffStatus === "not_required") {
+      setTakeoffStatus("pending")
+    }
+  }
+
+  function submitOrder(event: React.FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    startTransition(async () => {
+      const result = await saveProjectNuTechOrder(workspace.projectId, {
+        customerType: formText(formData, "customerType"),
+        pricingMode: formText(formData, "pricingMode"),
+        quantitySource: formText(formData, "quantitySource"),
+        takeoffAcknowledgementStatus: formText(
+          formData,
+          "takeoffAcknowledgementStatus"
+        ),
+        scopeType: formText(formData, "scopeType"),
+        blockQuantityNotes: optionalFormText(formData, "blockQuantityNotes"),
+        bracingIncluded: formData.get("bracingIncluded") === "on",
+        bracingRentalStartDate: optionalFormText(
+          formData,
+          "bracingRentalStartDate"
+        ),
+        bracingRentalEndDate: optionalFormText(
+          formData,
+          "bracingRentalEndDate"
+        ),
+        bracingNotes: optionalFormText(formData, "bracingNotes"),
+        deliveryMethod: formText(formData, "deliveryMethod"),
+        requestedDeliveryDate: optionalFormText(
+          formData,
+          "requestedDeliveryDate"
+        ),
+        airlitePurchaseOrderOperationId: optionalFormText(
+          formData,
+          "airlitePurchaseOrderOperationId"
+        ),
+        orderStatus: formText(formData, "orderStatus"),
+        vendorConfirmationNumber: optionalFormText(
+          formData,
+          "vendorConfirmationNumber"
+        ),
+        vendorInvoiceNumber: optionalFormText(formData, "vendorInvoiceNumber"),
+        vendorInvoiceStatus: formText(formData, "vendorInvoiceStatus"),
+        vendorInvoiceReceivedAt: optionalFormText(
+          formData,
+          "vendorInvoiceReceivedAt"
+        ),
+        notes: optionalFormText(formData, "notes"),
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(order ? "Nu-Tech order updated." : "Nu-Tech order started.")
+      router.refresh()
+    })
+  }
+
+  function releasePurchaseOrder(): void {
+    startTransition(async () => {
+      const result = await releaseNuTechAirlitePurchaseOrder(workspace.projectId)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success("Airlite PO release recorded.")
+      router.refresh()
+    })
+  }
+
+  function saveOrderItem(): void {
+    const quantity = Number(itemQuantity)
+    if (!selectedProductId || !Number.isInteger(quantity) || quantity <= 0) {
+      toast.error("Choose a product and enter a positive whole-number quantity.")
+      return
+    }
+    startTransition(async () => {
+      const result = await saveNuTechOrderItem(workspace.projectId, {
+        productId: selectedProductId,
+        quantity,
+      })
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      setItemQuantity("")
+      toast.success("Nu-Tech catalog item saved.")
+      router.refresh()
+    })
+  }
+
+  function removeOrderItem(itemId: string): void {
+    startTransition(async () => {
+      const result = await deleteNuTechOrderItem(workspace.projectId, itemId)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success("Nu-Tech order item removed.")
+      router.refresh()
+    })
+  }
+
+  function generateAirliteWorkbook(): void {
+    startTransition(async () => {
+      const result = await generateNuTechAirliteWorkbook(workspace.projectId)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success("Airlite workbook generated in the project Drive folder.")
+      router.refresh()
+    })
+  }
+
+  function releaseVendorInvoice(): void {
+    startTransition(async () => {
+      const result = await releaseNuTechVendorInvoice(workspace.projectId)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success("Airlite vendor invoice released.")
+      router.refresh()
+    })
+  }
+
+  function deleteWorkflow(): void {
+    if (
+      !window.confirm(
+        "Delete this Nu-Tech workflow record? The linked estimate and purchase order will remain in Compass."
+      )
+    ) {
+      return
+    }
+    startTransition(async () => {
+      const result = await deleteProjectNuTechOrder(workspace.projectId)
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success("Nu-Tech workflow record deleted.")
+      router.refresh()
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="border-y py-4">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className="text-sm font-semibold">Current handoff</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {order
+                ? `${nuTechOrderStatusLabel(order.orderStatus)} · updated ${formatDateTime(order.updatedAt)}`
+                : "No Nu-Tech order workflow has been started for this project."}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="secondary">
+              {quantitySource === "staff_takeoff"
+                ? "Staff takeoff"
+                : "Customer quantities"}
+            </Badge>
+            <Badge variant="outline">
+              {takeoffStatus === "not_required"
+                ? "Acknowledgement not required"
+                : `Acknowledgement: ${takeoffStatus}`}
+            </Badge>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-3 md:grid-cols-3">
+        <a
+          href={pricingFolderUrl ?? NUTECH_RESOURCE_LINKS.newClientPricing}
+          target="_blank"
+          rel="noreferrer"
+          className="rounded-lg border bg-background p-4 transition-colors hover:bg-muted/40"
+        >
+          <div className="flex items-center justify-between gap-2">
+            <p className="font-semibold">2026 customer pricing</p>
+            <IconExternalLink className="size-4 text-muted-foreground" />
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {customerType === "new" ? "New Client" : "Returning Customer"}
+            {" folder · standard and cash-discount sheets."}
+          </p>
+        </a>
+        <a
+          href={NUTECH_RESOURCE_LINKS.airliteOrderForm}
+          target="_blank"
+          rel="noreferrer"
+          className="rounded-lg border bg-background p-4 transition-colors hover:bg-muted/40"
+        >
+          <div className="flex items-center justify-between gap-2">
+            <p className="font-semibold">2026 Airlite order form</p>
+            <IconExternalLink className="size-4 text-muted-foreground" />
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Manufacturer-required Fox Blocks purchase-order document.
+          </p>
+        </a>
+        <Link
+          href={`/dashboard/projects/${workspace.projectId}/estimate`}
+          className="rounded-lg border bg-background p-4 transition-colors hover:bg-muted/40"
+        >
+          <div className="flex items-center justify-between gap-2">
+            <p className="font-semibold">Compass estimate</p>
+            <IconCalculator className="size-4 text-muted-foreground" />
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {workspace.estimate
+              ? `${workspace.estimate.number} · ${workspace.estimate.status} · ${money(workspace.estimate.totalCents / 100)}`
+              : "Start the client estimate and takeoff acknowledgement here."}
+          </p>
+        </Link>
+      </section>
+
+      <form onSubmit={submitOrder} className="space-y-6">
+        <fieldset disabled={!workspace.canEdit || isPending} className="space-y-6">
+          <section className="space-y-4 rounded-lg border bg-background p-4">
+            <div>
+              <h2 className="font-semibold">1. Intake and pricing basis</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Choose the matching published price sheet and record who supplied
+                the quantities.
+              </p>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              <div className="space-y-2">
+                <Label htmlFor="nutech-customer-type">Customer type</Label>
+                <select
+                  id="nutech-customer-type"
+                  name="customerType"
+                  className={SELECT_CLASS}
+                  value={customerType}
+                  onChange={(event) =>
+                    setCustomerType(customerTypeValue(event.target.value))
+                  }
+                >
+                  {NUTECH_CUSTOMER_TYPE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="nutech-pricing-mode">Pricing</Label>
+                <select
+                  id="nutech-pricing-mode"
+                  name="pricingMode"
+                  className={SELECT_CLASS}
+                  value={pricingMode}
+                  onChange={(event) =>
+                    setPricingMode(
+                      event.target.value === "cash_discount"
+                        ? "cash_discount"
+                        : "standard"
+                    )
+                  }
+                >
+                  {NUTECH_PRICING_MODE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+                <p className="text-xs text-muted-foreground">
+                  Cash discount means cash, wire, or check.
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="nutech-quantity-source">Quantity source</Label>
+                <select
+                  id="nutech-quantity-source"
+                  name="quantitySource"
+                  className={SELECT_CLASS}
+                  value={quantitySource}
+                  onChange={(event) => onQuantitySourceChange(event.target.value)}
+                >
+                  {NUTECH_QUANTITY_SOURCE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="nutech-takeoff-status">
+                  Takeoff acknowledgement
+                </Label>
+                <select
+                  id="nutech-takeoff-status"
+                  name="takeoffAcknowledgementStatus"
+                  className={SELECT_CLASS}
+                  value={takeoffStatus}
+                  disabled={quantitySource === "customer_provided"}
+                  onChange={(event) =>
+                    setTakeoffStatus(takeoffStatusValue(event.target.value))
+                  }
+                >
+                  {NUTECH_TAKEOFF_STATUS_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+                {quantitySource === "customer_provided" && (
+                  <input
+                    type="hidden"
+                    name="takeoffAcknowledgementStatus"
+                    value="not_required"
+                  />
+                )}
+              </div>
+            </div>
+            <Alert>
+              <IconCheck className="size-4" />
+              <AlertTitle>
+                {quantitySource === "customer_provided"
+                  ? "No acknowledgement required"
+                  : "Signed acknowledgement required before PO release"}
+              </AlertTitle>
+              <AlertDescription>
+                {quantitySource === "customer_provided"
+                  ? "The customer supplied the order quantities, so Compass will not hold the Airlite PO for a takeoff acknowledgement."
+                  : "Attach the Nu-Tech takeoff acknowledgement to the client estimate and record it as signed before releasing the Airlite PO."}
+              </AlertDescription>
+            </Alert>
+          </section>
+
+          <section className="space-y-4 rounded-lg border bg-background p-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h2 className="font-semibold">2. Product quantities</h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {workspace.catalogVersionName
+                    ? `${workspace.catalogVersionName} · package increments are enforced automatically.`
+                    : "Import and activate the 2026 product catalog before entering quantities."}
+                </p>
+              </div>
+              <Button asChild variant="outline" size="sm">
+                <Link href="/dashboard/nutech/catalog">Product catalog</Link>
+              </Button>
+            </div>
+            {workspace.catalogProducts.length > 0 && (
+              <div className="grid gap-3 md:grid-cols-[minmax(16rem,1fr)_9rem_auto] md:items-end">
+                <div className="space-y-2">
+                  <Label htmlFor="nutech-product">Catalog product</Label>
+                  <select
+                    id="nutech-product"
+                    className={SELECT_CLASS}
+                    value={selectedProductId}
+                    onChange={(event) => setSelectedProductId(event.target.value)}
+                  >
+                    {workspace.catalogProducts.map((product) => (
+                      <option key={product.id} value={product.id}>
+                        {product.manufacturerSku} · {product.name} · {money(
+                          nuTechCustomerPriceCents(
+                            product,
+                            customerType,
+                            pricingMode
+                          ) / 100
+                        )}/{product.priceUnit}
+                      </option>
+                    ))}
+                  </select>
+                  {selectedProduct && (
+                    <p className="text-xs text-muted-foreground">
+                      Order in multiples of {selectedProduct.minimumOrderIncrement} · {selectedProduct.packageLabel}
+                      {selectedProduct.airliteMappingStatus === "mapped"
+                        ? " · Airlite form row mapped"
+                        : " · included in the Airlite addendum"}
+                    </p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="nutech-product-quantity">Quantity</Label>
+                  <Input
+                    id="nutech-product-quantity"
+                    type="number"
+                    min={selectedProduct?.minimumOrderIncrement ?? 1}
+                    step={selectedProduct?.minimumOrderIncrement ?? 1}
+                    value={itemQuantity}
+                    onChange={(event) => setItemQuantity(event.target.value)}
+                  />
+                </div>
+                <Button
+                  type="button"
+                  disabled={
+                    !order ||
+                    !selectedProduct ||
+                    isPending ||
+                    pricingBasisChanged ||
+                    purchaseOrderReleased
+                  }
+                  onClick={saveOrderItem}
+                >
+                  <IconPlus className="size-4" />
+                  Add / update
+                </Button>
+              </div>
+            )}
+            {!order && workspace.catalogProducts.length > 0 && (
+              <p className="text-sm text-muted-foreground">
+                Save the intake once before adding catalog quantities.
+              </p>
+            )}
+            {pricingBasisChanged && (
+              <p className="text-sm text-muted-foreground">
+                Save the revised customer/pricing basis before adding or updating
+                products. Existing line prices will refresh when the workflow is saved.
+              </p>
+            )}
+            {workspace.orderItems.length > 0 && (
+              <div className="overflow-x-auto border-y">
+                <table className="w-full min-w-[720px] text-left text-sm">
+                  <thead className="border-b text-xs text-muted-foreground">
+                    <tr>
+                      <th className="px-2 py-2 font-medium">Product</th>
+                      <th className="px-2 py-2 text-right font-medium">Quantity</th>
+                      <th className="px-2 py-2 text-right font-medium">Unit price</th>
+                      <th className="px-2 py-2 text-right font-medium">Customer total</th>
+                      <th className="w-10 px-2 py-2"><span className="sr-only">Remove</span></th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y">
+                    {workspace.orderItems.map((item) => (
+                      <tr key={item.id}>
+                        <td className="px-2 py-2">
+                          <p className="font-medium">{item.manufacturerSku}</p>
+                          <p className="text-xs text-muted-foreground">{item.name}</p>
+                        </td>
+                        <td className="px-2 py-2 text-right">
+                          {item.quantity} {item.priceUnit}
+                        </td>
+                        <td className="px-2 py-2 text-right">
+                          {money(item.unitPriceCents / 100)}
+                        </td>
+                        <td className="px-2 py-2 text-right font-medium">
+                          {money((item.quantity * item.unitPriceCents) / 100)}
+                        </td>
+                        <td className="px-2 py-2 text-right">
+                          <Button
+                            type="button"
+                            size="icon"
+                            variant="ghost"
+                            className="text-destructive hover:text-destructive"
+                            disabled={isPending || purchaseOrderReleased}
+                            onClick={() => removeOrderItem(item.id)}
+                          >
+                            <IconTrash className="size-4" />
+                            <span className="sr-only">Remove {item.manufacturerSku}</span>
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                  <tfoot className="border-t">
+                    <tr>
+                      <td colSpan={3} className="px-2 py-2 text-right text-muted-foreground">
+                        Airlite cost {money(airliteTotalCents / 100)}
+                      </td>
+                      <td className="px-2 py-2 text-right font-semibold">
+                        {money(customerTotalCents / 100)}
+                      </td>
+                      <td />
+                    </tr>
+                  </tfoot>
+                </table>
+              </div>
+            )}
+          </section>
+
+          <section className="space-y-4 rounded-lg border bg-background p-4">
+            <div>
+              <h2 className="font-semibold">3. Bracing and delivery</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Bracing rental rates remain on the applicable 2026 Fox Blocks price
+                sheet.
+              </p>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              <div className="space-y-2">
+                <Label htmlFor="nutech-scope">Order scope</Label>
+                <select
+                  id="nutech-scope"
+                  name="scopeType"
+                  className={SELECT_CLASS}
+                  defaultValue={order?.scopeType ?? "block_sale"}
+                >
+                  {NUTECH_SCOPE_TYPE_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="nutech-delivery-method">Fulfillment</Label>
+                <select
+                  id="nutech-delivery-method"
+                  name="deliveryMethod"
+                  className={SELECT_CLASS}
+                  defaultValue={order?.deliveryMethod ?? "delivery"}
+                >
+                  {NUTECH_DELIVERY_METHOD_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="nutech-requested-delivery">
+                  Requested delivery / pickup
+                </Label>
+                <Input
+                  id="nutech-requested-delivery"
+                  name="requestedDeliveryDate"
+                  type="date"
+                  defaultValue={order?.requestedDeliveryDate ?? ""}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="nutech-status">Workflow status</Label>
+                <select
+                  id="nutech-status"
+                  name="orderStatus"
+                  className={SELECT_CLASS}
+                  defaultValue={order?.orderStatus ?? "intake"}
+                >
+                  {availableOrderStatusOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="nutech-block-notes">
+                  Block quantities and accessory notes
+                </Label>
+                <Textarea
+                  id="nutech-block-notes"
+                  name="blockQuantityNotes"
+                  rows={5}
+                  defaultValue={order?.blockQuantityNotes ?? ""}
+                  placeholder="Fox Block sizes, Web Boxes, accessories, bundle quantities, waste, and takeoff notes"
+                />
+              </div>
+              <div className="space-y-3">
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="nutech-bracing-start">Bracing start</Label>
+                    <Input
+                      id="nutech-bracing-start"
+                      name="bracingRentalStartDate"
+                      type="date"
+                      defaultValue={order?.bracingRentalStartDate ?? ""}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="nutech-bracing-end">Bracing return due</Label>
+                    <Input
+                      id="nutech-bracing-end"
+                      name="bracingRentalEndDate"
+                      type="date"
+                      defaultValue={order?.bracingRentalEndDate ?? ""}
+                    />
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="nutech-bracing-notes">Bracing rental notes</Label>
+                  <Textarea
+                    id="nutech-bracing-notes"
+                    name="bracingNotes"
+                    rows={3}
+                    defaultValue={order?.bracingNotes ?? ""}
+                    placeholder="Sets, pickup or delivery, condition, extensions, and return coordination"
+                  />
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="space-y-4 rounded-lg border bg-background p-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h2 className="font-semibold">4. Airlite PO and vendor invoice</h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Link the Compass PO, then release it after the applicable intake
+                  gates are complete.
+                </p>
+              </div>
+              <Button asChild variant="outline" size="sm">
+                <Link href={`/dashboard/projects/${workspace.projectId}/purchase-orders`}>
+                  <IconShoppingCart className="size-4" />
+                  Open purchase orders
+                </Link>
+              </Button>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              <div className="space-y-2 md:col-span-2">
+                <Label htmlFor="nutech-airlite-po">Linked Airlite PO</Label>
+                <select
+                  id="nutech-airlite-po"
+                  name="airlitePurchaseOrderOperationId"
+                  className={SELECT_CLASS}
+                  defaultValue={order?.airlitePurchaseOrderOperationId ?? ""}
+                >
+                  <option value="">Choose a Compass purchase order</option>
+                  {workspace.purchaseOrders.map((purchaseOrder) => (
+                    <option key={purchaseOrder.id} value={purchaseOrder.id}>
+                      {purchaseOrder.number ?? "Unnumbered"} · {purchaseOrder.title}
+                      {purchaseOrder.companyName
+                        ? ` · ${purchaseOrder.companyName}`
+                        : ""}
+                      {` · ${money(purchaseOrder.amount)}`}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="nutech-vendor-confirmation">
+                  Airlite confirmation
+                </Label>
+                <Input
+                  id="nutech-vendor-confirmation"
+                  name="vendorConfirmationNumber"
+                  defaultValue={order?.vendorConfirmationNumber ?? ""}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>PO release recorded</Label>
+                <p className="flex h-9 items-center text-sm text-muted-foreground">
+                  {formatDateTime(order?.purchaseOrderReleasedAt ?? null)}
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="nutech-invoice-number">Vendor invoice number</Label>
+                <Input
+                  id="nutech-invoice-number"
+                  name="vendorInvoiceNumber"
+                  defaultValue={order?.vendorInvoiceNumber ?? ""}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="nutech-invoice-status">Invoice status</Label>
+                <select
+                  id="nutech-invoice-status"
+                  name="vendorInvoiceStatus"
+                  className={SELECT_CLASS}
+                  defaultValue={order?.vendorInvoiceStatus ?? "not_received"}
+                >
+                  {availableVendorInvoiceStatusOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="nutech-invoice-received">Invoice received</Label>
+                <Input
+                  id="nutech-invoice-received"
+                  name="vendorInvoiceReceivedAt"
+                  type="date"
+                  defaultValue={order?.vendorInvoiceReceivedAt ?? ""}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Invoice release recorded</Label>
+                <p className="flex h-9 items-center text-sm text-muted-foreground">
+                  {formatDateTime(order?.vendorInvoiceReleasedAt ?? null)}
+                </p>
+              </div>
+            </div>
+            {order && (
+              <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-4">
+                <div>
+                  <p className="text-sm font-medium">Airlite workbook</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {order.airliteWorkbookStatus === "stale"
+                      ? "Order quantities changed; generate a fresh workbook before release."
+                      : order.airliteWorkbookGeneratedAt
+                        ? `${order.airliteWorkbookStatus.replaceAll("_", " ")} · ${formatDateTime(order.airliteWorkbookGeneratedAt)}`
+                        : "Not generated"}
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {order.airliteWorkbookUrl && (
+                    <Button asChild type="button" variant="outline" size="sm">
+                      <a href={order.airliteWorkbookUrl} target="_blank" rel="noreferrer">
+                        <IconExternalLink className="size-4" />
+                        Open latest workbook
+                      </a>
+                    </Button>
+                  )}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={
+                      isPending ||
+                      workspace.orderItems.length === 0 ||
+                      !order.airlitePurchaseOrderOperationId ||
+                      purchaseOrderReleased
+                    }
+                    onClick={generateAirliteWorkbook}
+                  >
+                    <IconFileSpreadsheet className="size-4" />
+                    Generate workbook
+                  </Button>
+                </div>
+              </div>
+            )}
+            {order && !releaseReadiness.ready && (
+              <Alert>
+                <AlertTitle>PO release checklist</AlertTitle>
+                <AlertDescription>
+                  <ul className="mt-1 list-disc space-y-1 pl-5">
+                    {releaseReadiness.issues.map((issue) => (
+                      <li key={issue}>{issue}</li>
+                    ))}
+                  </ul>
+                </AlertDescription>
+              </Alert>
+            )}
+          </section>
+
+          <section className="space-y-2 rounded-lg border bg-background p-4">
+            <Label htmlFor="nutech-notes">Internal order notes</Label>
+            <Textarea
+              id="nutech-notes"
+              name="notes"
+              rows={4}
+              defaultValue={order?.notes ?? ""}
+              placeholder="Customer communications, takeoff help, availability, freight, and follow-up notes"
+            />
+          </section>
+
+          <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-4">
+            <div className="flex flex-wrap gap-2">
+              <Button type="submit" disabled={isPending}>
+                <IconCheck className="size-4" />
+                {order ? "Save workflow" : "Start Nu-Tech order"}
+              </Button>
+              {order && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={
+                    isPending ||
+                    !releaseReadiness.ready ||
+                    purchaseOrderReleased
+                  }
+                  onClick={releasePurchaseOrder}
+                >
+                  <IconSend className="size-4" />
+                  Record Airlite PO release
+                </Button>
+              )}
+              {order && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={isPending || vendorInvoiceReleased}
+                  onClick={releaseVendorInvoice}
+                >
+                  <IconFileInvoice className="size-4" />
+                  Release vendor invoice
+                </Button>
+              )}
+            </div>
+            {order && workspace.canDelete && !purchaseOrderReleased && (
+              <Button
+                type="button"
+                variant="ghost"
+                className="text-destructive hover:text-destructive"
+                disabled={isPending}
+                onClick={deleteWorkflow}
+              >
+                <IconTrash className="size-4" />
+                Delete workflow record
+              </Button>
+            )}
+          </div>
+        </fieldset>
+        {!workspace.canEdit && (
+          <p className="text-sm text-muted-foreground">
+            You have read-only access to this Nu-Tech workflow.
+          </p>
+        )}
+      </form>
+    </div>
+  )
+}

--- a/src/components/projects/projects-hub.tsx
+++ b/src/components/projects/projects-hub.tsx
@@ -205,10 +205,10 @@ const DEPARTMENT_TOOLS: readonly (DepartmentTool & {
   },
   {
     departments: ["N"],
-    label: "Nu-Tech PO Order Manager",
-    description: "Google-side order intake while Compass PO tools mature.",
+    label: "Nu-Tech Order Process",
+    description: "Block sales, bracing rentals, pricing, and Airlite orders.",
     kind: "link",
-    href: "/dashboard/automations",
+    href: "/dashboard/nutech",
   },
   {
     departments: ["D"],

--- a/src/db/__tests__/nutech-order-schema.test.ts
+++ b/src/db/__tests__/nutech-order-schema.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+import {
+  nuTechCatalogPrices,
+  nuTechOrderItems,
+  nuTechOrderWorkflows,
+  nuTechProducts,
+} from "@/db/schema-nutech"
+
+describe("Nu-Tech order persistence contract", () => {
+  it("stores one workflow per project with linked Compass PO and release audit fields", () => {
+    expect(nuTechOrderWorkflows.projectId.name).toBe("project_id")
+    expect(nuTechOrderWorkflows.airlitePurchaseOrderOperationId.name).toBe(
+      "airlite_purchase_order_operation_id"
+    )
+    expect(nuTechOrderWorkflows.purchaseOrderReleasedBy.name).toBe(
+      "purchase_order_released_by"
+    )
+    expect(nuTechOrderWorkflows.vendorInvoiceReleasedBy.name).toBe(
+      "vendor_invoice_released_by"
+    )
+  })
+
+  it("ships the project uniqueness and workflow indexes", () => {
+    const migration = readFileSync(
+      resolve(process.cwd(), "drizzle/0130_nutech_orders_catalog.sql"),
+      "utf8"
+    )
+    expect(migration).toContain("nutech_order_workflows_project_uq")
+    expect(migration).toContain("nutech_order_workflows_status_idx")
+    expect(migration).toContain("ON DELETE set null")
+  })
+
+  it("keeps catalog identity, price versions, order snapshots, and Sage mappings separate", () => {
+    expect(nuTechProducts.manufacturerSku.name).toBe("manufacturer_sku")
+    expect(nuTechProducts.sageCostCodeId.name).toBe("sage_cost_code_id")
+    expect(nuTechCatalogPrices.airliteCostCents.name).toBe("airlite_cost_cents")
+    expect(nuTechOrderItems.unitPriceCents.name).toBe("unit_price_cents")
+    expect(nuTechOrderItems.productNameSnapshot.name).toBe(
+      "product_name_snapshot"
+    )
+  })
+})

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -13,6 +13,7 @@ import * as jarvisSchema from "./schema-jarvis"
 import * as sageSchema from "./schema-sage"
 import * as buildertrendSchema from "./schema-buildertrend"
 import * as estimatesSchema from "./schema-estimates"
+import * as nuTechSchema from "./schema-nutech"
 import * as templateSchema from "./schema-templates"
 import * as warrantySchema from "./schema-warranty"
 import * as contractSchema from "./schema-contracts"
@@ -32,6 +33,7 @@ const allSchemas = {
   ...sageSchema,
   ...buildertrendSchema,
   ...estimatesSchema,
+  ...nuTechSchema,
   ...templateSchema,
   ...warrantySchema,
   ...contractSchema,

--- a/src/db/schema-nutech.ts
+++ b/src/db/schema-nutech.ts
@@ -1,0 +1,263 @@
+import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core"
+
+import {
+  organizations,
+  projectOperations,
+  projects,
+  sageCostCodes,
+  users,
+} from "./schema"
+
+export const nuTechCatalogVersions = sqliteTable(
+  "nutech_catalog_versions",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    effectiveDate: text("effective_date").notNull(),
+    status: text("status").notNull().default("draft"),
+    newStandardSheetId: text("new_standard_sheet_id").notNull(),
+    newCashSheetId: text("new_cash_sheet_id").notNull(),
+    returningStandardSheetId: text("returning_standard_sheet_id").notNull(),
+    returningCashSheetId: text("returning_cash_sheet_id").notNull(),
+    airliteTemplateId: text("airlite_template_id").notNull(),
+    sourceHash: text("source_hash").notNull(),
+    importedAt: text("imported_at").notNull(),
+    importedBy: text("imported_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    activatedAt: text("activated_at"),
+    activatedBy: text("activated_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("nutech_catalog_versions_org_name_uq").on(
+      table.organizationId,
+      table.name
+    ),
+    index("nutech_catalog_versions_org_status_idx").on(
+      table.organizationId,
+      table.status,
+      table.effectiveDate
+    ),
+  ]
+)
+
+export const nuTechProducts = sqliteTable(
+  "nutech_products",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    manufacturerSku: text("manufacturer_sku").notNull(),
+    name: text("name").notNull(),
+    category: text("category").notNull(),
+    origin: text("origin").notNull(),
+    priceUnit: text("price_unit").notNull(),
+    packageQuantity: integer("package_quantity").notNull().default(1),
+    packageLabel: text("package_label").notNull(),
+    minimumOrderIncrement: integer("minimum_order_increment")
+      .notNull()
+      .default(1),
+    squareFeetPerUnitMils: integer("square_feet_per_unit_mils"),
+    airliteTemplateSku: text("airlite_template_sku"),
+    airliteTemplateRow: integer("airlite_template_row"),
+    airliteMappingStatus: text("airlite_mapping_status")
+      .notNull()
+      .default("addendum_required"),
+    sageCostCodeId: text("sage_cost_code_id").references(
+      () => sageCostCodes.id,
+      { onDelete: "set null" }
+    ),
+    sageMappingStatus: text("sage_mapping_status")
+      .notNull()
+      .default("unmapped"),
+    sageMappedAt: text("sage_mapped_at"),
+    sageMappedBy: text("sage_mapped_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    active: integer("active", { mode: "boolean" }).notNull().default(true),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("nutech_products_org_sku_uq").on(
+      table.organizationId,
+      table.manufacturerSku
+    ),
+    index("nutech_products_org_category_idx").on(
+      table.organizationId,
+      table.category,
+      table.active
+    ),
+    index("nutech_products_sage_cost_code_idx").on(table.sageCostCodeId),
+  ]
+)
+
+export const nuTechCatalogPrices = sqliteTable(
+  "nutech_catalog_prices",
+  {
+    id: text("id").primaryKey(),
+    catalogVersionId: text("catalog_version_id")
+      .notNull()
+      .references(() => nuTechCatalogVersions.id, { onDelete: "cascade" }),
+    productId: text("product_id")
+      .notNull()
+      .references(() => nuTechProducts.id, { onDelete: "cascade" }),
+    airliteCostCents: integer("airlite_cost_cents").notNull(),
+    newStandardPriceCents: integer("new_standard_price_cents").notNull(),
+    newCashPriceCents: integer("new_cash_price_cents").notNull(),
+    returningStandardPriceCents: integer(
+      "returning_standard_price_cents"
+    ).notNull(),
+    returningCashPriceCents: integer("returning_cash_price_cents").notNull(),
+    newStandardMarginBasisPoints: integer(
+      "new_standard_margin_basis_points"
+    ).notNull(),
+    newCashMarginBasisPoints: integer(
+      "new_cash_margin_basis_points"
+    ).notNull(),
+    returningStandardMarginBasisPoints: integer(
+      "returning_standard_margin_basis_points"
+    ).notNull(),
+    returningCashMarginBasisPoints: integer(
+      "returning_cash_margin_basis_points"
+    ).notNull(),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("nutech_catalog_prices_version_product_uq").on(
+      table.catalogVersionId,
+      table.productId
+    ),
+    index("nutech_catalog_prices_product_idx").on(table.productId),
+  ]
+)
+
+export const nuTechOrderWorkflows = sqliteTable(
+  "nutech_order_workflows",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    catalogVersionId: text("catalog_version_id").references(
+      () => nuTechCatalogVersions.id,
+      { onDelete: "set null" }
+    ),
+    customerType: text("customer_type").notNull(),
+    pricingMode: text("pricing_mode").notNull(),
+    quantitySource: text("quantity_source").notNull(),
+    takeoffAcknowledgementStatus: text("takeoff_acknowledgement_status")
+      .notNull()
+      .default("not_required"),
+    scopeType: text("scope_type").notNull().default("block_sale"),
+    blockQuantityNotes: text("block_quantity_notes"),
+    bracingIncluded: integer("bracing_included", { mode: "boolean" })
+      .notNull()
+      .default(false),
+    bracingRentalStartDate: text("bracing_rental_start_date"),
+    bracingRentalEndDate: text("bracing_rental_end_date"),
+    bracingNotes: text("bracing_notes"),
+    deliveryMethod: text("delivery_method").notNull().default("delivery"),
+    requestedDeliveryDate: text("requested_delivery_date"),
+    airlitePurchaseOrderOperationId: text(
+      "airlite_purchase_order_operation_id"
+    ).references(() => projectOperations.id, { onDelete: "set null" }),
+    orderStatus: text("order_status").notNull().default("intake"),
+    vendorConfirmationNumber: text("vendor_confirmation_number"),
+    airliteWorkbookId: text("airlite_workbook_id"),
+    airliteWorkbookUrl: text("airlite_workbook_url"),
+    airliteWorkbookStatus: text("airlite_workbook_status")
+      .notNull()
+      .default("not_generated"),
+    airliteWorkbookGeneratedAt: text("airlite_workbook_generated_at"),
+    airliteWorkbookGeneratedBy: text(
+      "airlite_workbook_generated_by"
+    ).references(() => users.id, { onDelete: "set null" }),
+    purchaseOrderReleasedAt: text("purchase_order_released_at"),
+    purchaseOrderReleasedBy: text("purchase_order_released_by").references(
+      () => users.id,
+      { onDelete: "set null" }
+    ),
+    vendorInvoiceNumber: text("vendor_invoice_number"),
+    vendorInvoiceStatus: text("vendor_invoice_status")
+      .notNull()
+      .default("not_received"),
+    vendorInvoiceReceivedAt: text("vendor_invoice_received_at"),
+    vendorInvoiceReleasedAt: text("vendor_invoice_released_at"),
+    vendorInvoiceReleasedBy: text("vendor_invoice_released_by").references(
+      () => users.id,
+      { onDelete: "set null" }
+    ),
+    notes: text("notes"),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    updatedBy: text("updated_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("nutech_order_workflows_project_uq").on(table.projectId),
+    index("nutech_order_workflows_status_idx").on(
+      table.orderStatus,
+      table.requestedDeliveryDate
+    ),
+    index("nutech_order_workflows_po_idx").on(
+      table.airlitePurchaseOrderOperationId
+    ),
+    index("nutech_order_workflows_catalog_idx").on(table.catalogVersionId),
+  ]
+)
+
+export const nuTechOrderItems = sqliteTable(
+  "nutech_order_items",
+  {
+    id: text("id").primaryKey(),
+    workflowId: text("workflow_id")
+      .notNull()
+      .references(() => nuTechOrderWorkflows.id, { onDelete: "cascade" }),
+    productId: text("product_id")
+      .notNull()
+      .references(() => nuTechProducts.id, { onDelete: "restrict" }),
+    catalogVersionId: text("catalog_version_id")
+      .notNull()
+      .references(() => nuTechCatalogVersions.id, { onDelete: "restrict" }),
+    quantity: integer("quantity").notNull(),
+    manufacturerSkuSnapshot: text("manufacturer_sku_snapshot").notNull(),
+    productNameSnapshot: text("product_name_snapshot").notNull(),
+    priceUnitSnapshot: text("price_unit_snapshot").notNull(),
+    unitCostCents: integer("unit_cost_cents").notNull(),
+    unitPriceCents: integer("unit_price_cents").notNull(),
+    sortOrder: integer("sort_order").notNull().default(0),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("nutech_order_items_workflow_product_uq").on(
+      table.workflowId,
+      table.productId
+    ),
+    index("nutech_order_items_workflow_sort_idx").on(
+      table.workflowId,
+      table.sortOrder
+    ),
+  ]
+)
+
+export type NuTechOrderWorkflow = typeof nuTechOrderWorkflows.$inferSelect
+export type NewNuTechOrderWorkflow = typeof nuTechOrderWorkflows.$inferInsert
+export type NuTechCatalogVersion = typeof nuTechCatalogVersions.$inferSelect
+export type NuTechProduct = typeof nuTechProducts.$inferSelect
+export type NuTechCatalogPrice = typeof nuTechCatalogPrices.$inferSelect
+export type NuTechOrderItem = typeof nuTechOrderItems.$inferSelect

--- a/src/lib/google/client/sheets-client.ts
+++ b/src/lib/google/client/sheets-client.ts
@@ -26,6 +26,15 @@ export type GoogleSheetAppendResult = {
   readonly updatedRange: string | null
 }
 
+export type GoogleSheetValueUpdate = {
+  readonly range: string
+  readonly values: ReadonlyArray<ReadonlyArray<unknown>>
+}
+
+export type GoogleSheetCreateResult = {
+  readonly sheetId: number
+}
+
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
@@ -204,5 +213,91 @@ export class SheetsClient {
     const payload = objectValue(await response.json())
     const updates = objectValue(payload?.updates)
     return { updatedRange: stringValue(updates?.updatedRange) }
+  }
+
+  async batchUpdateValues(
+    userEmail: string,
+    input: {
+      readonly spreadsheetId: string
+      readonly updates: readonly GoogleSheetValueUpdate[]
+    }
+  ): Promise<void> {
+    if (input.updates.length === 0) return
+    const token = await getAccessToken(this.serviceAccountKey, userEmail)
+    const response = await fetch(
+      `${GOOGLE_SHEETS_API}/${input.spreadsheetId}/values:batchUpdate`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          valueInputOption: "RAW",
+          data: input.updates,
+        }),
+      }
+    )
+
+    if (!response.ok) {
+      const body = await response.text()
+      throw new Error(
+        `Google Sheets API error (${response.status}): ${body.slice(0, 500)}`
+      )
+    }
+  }
+
+  async addSheet(
+    userEmail: string,
+    input: {
+      readonly spreadsheetId: string
+      readonly title: string
+      readonly rowCount: number
+      readonly columnCount: number
+    }
+  ): Promise<GoogleSheetCreateResult> {
+    const token = await getAccessToken(this.serviceAccountKey, userEmail)
+    const response = await fetch(
+      `${GOOGLE_SHEETS_API}/${input.spreadsheetId}:batchUpdate`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          requests: [
+            {
+              addSheet: {
+                properties: {
+                  title: input.title,
+                  gridProperties: {
+                    rowCount: input.rowCount,
+                    columnCount: input.columnCount,
+                    frozenRowCount: 4,
+                  },
+                },
+              },
+            },
+          ],
+        }),
+      }
+    )
+    if (!response.ok) {
+      const body = await response.text()
+      throw new Error(
+        `Google Sheets API error (${response.status}): ${body.slice(0, 500)}`
+      )
+    }
+    const payload = objectValue(await response.json())
+    const replies = Array.isArray(payload?.replies) ? payload.replies : []
+    const reply = objectValue(replies[0])
+    const addedSheet = objectValue(reply?.addSheet)
+    const properties = objectValue(addedSheet?.properties)
+    const sheetId = numberValue(properties?.sheetId)
+    if (sheetId === null) {
+      throw new Error("Google Sheets did not return the created worksheet ID.")
+    }
+    return { sheetId }
   }
 }

--- a/src/lib/google/organization-drive.ts
+++ b/src/lib/google/organization-drive.ts
@@ -5,6 +5,7 @@ import { googleAuth } from "@/db/schema-google"
 import type { AuthUser } from "@/lib/auth"
 import { decrypt } from "@/lib/crypto"
 import { DriveClient } from "@/lib/google/client/drive-client"
+import { SheetsClient } from "@/lib/google/client/sheets-client"
 import {
   getGoogleConfig,
   getGoogleCryptoSalt,
@@ -13,6 +14,7 @@ import {
 
 export type OrganizationDriveContext = {
   readonly client: DriveClient
+  readonly sheetsClient: SheetsClient
   readonly userEmail: string
 }
 
@@ -30,9 +32,7 @@ export async function getOrganizationDriveContext(input: {
     .where(eq(googleAuth.organizationId, input.organizationId))
     .get()
   if (!auth) {
-    throw new Error(
-      "Connect Google Drive before saving estimate text templates."
-    )
+    throw new Error("Connect Google Drive before using organization Drive files.")
   }
 
   const config = getGoogleConfig(input.environment)
@@ -41,10 +41,12 @@ export async function getOrganizationDriveContext(input: {
     config.encryptionKey,
     getGoogleCryptoSalt()
   )
+  const serviceAccountKey = parseServiceAccountKey(serviceAccountJson)
   return {
     client: new DriveClient({
-      serviceAccountKey: parseServiceAccountKey(serviceAccountJson),
+      serviceAccountKey,
     }),
+    sheetsClient: new SheetsClient(serviceAccountKey),
     userEmail: input.user.googleEmail ?? input.user.email,
   }
 }

--- a/src/lib/nutech/__tests__/airlite-workbook.test.ts
+++ b/src/lib/nutech/__tests__/airlite-workbook.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest"
+
+import { buildNuTechAirliteWorkbookPlan } from "@/lib/nutech/airlite-workbook"
+
+describe("Nu-Tech Airlite workbook plan", () => {
+  it("fills legacy mapped rows and carries new products through the explicit addendum", () => {
+    const plan = buildNuTechAirliteWorkbookPlan({
+      purchaseOrderNumber: "N-2601-PO-1",
+      purchaseOrderDate: "2026-08-24",
+      requestedDeliveryDate: "2026-09-01",
+      projectName: "Test Fox Blocks order",
+      jobsiteAddress: "100 Test Way",
+      orderContactName: "Rebekah Example",
+      orderContactPhone: "719-686-0770",
+      orderContactEmail: "orders@nutechcolorado.com",
+      deliveryContact: "Client · 719-555-0100",
+      lines: [
+        {
+          manufacturerSku: "FOX-S600A",
+          name: "Straight",
+          origin: "CSC",
+          category: "block",
+          quantity: 24,
+          minimumOrderIncrement: 12,
+          packageLabel: "12",
+          priceUnit: "each",
+          airliteTemplateRow: 28,
+          unitCostCents: 2190,
+        },
+        {
+          manufacturerSku: "L921T809B",
+          name: "Fox Web 4 inch",
+          origin: "Omaha",
+          category: "web",
+          quantity: 2,
+          minimumOrderIncrement: 1,
+          packageLabel: "230/box",
+          priceUnit: "box",
+          airliteTemplateRow: null,
+          unitCostCents: 16100,
+        },
+      ],
+    })
+
+    expect(plan.addendumItemCount).toBe(1)
+    expect(plan.totalCostCents).toBe(84760)
+    expect(plan.updates).toContainEqual({
+      range: "USLvl3!H28",
+      values: [[2]],
+    })
+    expect(plan.updates).toContainEqual({
+      range: "USLvl3!J87",
+      values: [[847.6]],
+    })
+    expect(plan.addendumValues[4]).toEqual([
+      "L921T809B",
+      "Fox Web 4 inch",
+      "Omaha",
+      2,
+      "box",
+      "230/box",
+      161,
+      322,
+    ])
+  })
+
+  it("rejects quantities that do not satisfy manufacturer package increments", () => {
+    expect(() =>
+      buildNuTechAirliteWorkbookPlan({
+        purchaseOrderNumber: "PO-1",
+        purchaseOrderDate: "2026-08-24",
+        requestedDeliveryDate: null,
+        projectName: "Test",
+        jobsiteAddress: null,
+        orderContactName: "Staff",
+        orderContactPhone: null,
+        orderContactEmail: "staff@example.com",
+        deliveryContact: null,
+        lines: [
+          {
+            manufacturerSku: "FOX-S600A",
+            name: "Straight",
+            origin: "CSC",
+            category: "block",
+            quantity: 13,
+            minimumOrderIncrement: 12,
+            packageLabel: "12",
+            priceUnit: "each",
+            airliteTemplateRow: 28,
+            unitCostCents: 2190,
+          },
+        ],
+      })
+    ).toThrow("positive multiple of 12")
+  })
+})

--- a/src/lib/nutech/__tests__/catalog-import.test.ts
+++ b/src/lib/nutech/__tests__/catalog-import.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildNuTechCatalogImport,
+  nuTechSageCostCodeCandidates,
+} from "@/lib/nutech/catalog-import"
+
+type SourceRow = readonly [
+  string,
+  string,
+  string,
+  string | number,
+  number | null,
+  number,
+  number,
+]
+
+function sheet(
+  margin: number,
+  rows: readonly SourceRow[]
+): ReadonlyArray<ReadonlyArray<unknown>> {
+  return [
+    ["Nu-Tech 2026 Pricing Basis"],
+    ["Target gross margin", margin],
+    ["Effective date", "August 23, 2026"],
+    [
+      "Origin",
+      "Product",
+      "SKU",
+      "Bundle Qty",
+      "SF/Form",
+      "Airlite Cost",
+      "Gross Margin",
+      "Customer Price",
+    ],
+    ...rows.map((row) => [...row.slice(0, 6), margin, row[6]]),
+  ]
+}
+
+function withPrice(row: SourceRow, price: number): SourceRow {
+  return [row[0], row[1], row[2], row[3], row[4], row[5], price]
+}
+
+const sourceRows = [
+  ["CSC", "Straight", "FOX-S600A", 12, 5.33, 21.9, 26.4],
+  ["Omaha", "Fox Web 4\"", "L921T809B", "230/box", null, 161, 194],
+] as const
+
+describe("Nu-Tech catalog import", () => {
+  it("joins the four published price sheets and preserves exact price tiers", () => {
+    const catalog = buildNuTechCatalogImport({
+      newStandard: sheet(0.17, sourceRows),
+      newCash: sheet(0.145, [
+        withPrice(sourceRows[0], 25.6),
+        withPrice(sourceRows[1], 188.3),
+      ]),
+      returningStandard: sheet(0.145, [
+        withPrice(sourceRows[0], 25.6),
+        withPrice(sourceRows[1], 188.3),
+      ]),
+      returningCash: sheet(0.117, [
+        withPrice(sourceRows[0], 24.8),
+        withPrice(sourceRows[1], 182.35),
+      ]),
+    })
+
+    expect(catalog.targetMargins).toEqual({
+      newStandardBasisPoints: 1700,
+      newCashBasisPoints: 1450,
+      returningStandardBasisPoints: 1450,
+      returningCashBasisPoints: 1170,
+    })
+    expect(catalog.products[0]).toMatchObject({
+      manufacturerSku: "FOX-S600A",
+      category: "block",
+      minimumOrderIncrement: 12,
+      priceUnit: "each",
+      airliteTemplateSku: "FOX-S600",
+      airliteTemplateRow: 28,
+      airliteMappingStatus: "mapped",
+      newStandardPriceCents: 2640,
+      returningCashPriceCents: 2480,
+    })
+    expect(catalog.products[1]).toMatchObject({
+      manufacturerSku: "L921T809B",
+      category: "web",
+      packageQuantity: 230,
+      minimumOrderIncrement: 1,
+      priceUnit: "box",
+      airliteMappingStatus: "addendum_required",
+    })
+  })
+
+  it("rejects a tier whose cost no longer agrees with the source catalog", () => {
+    expect(() =>
+      buildNuTechCatalogImport({
+        newStandard: sheet(0.17, sourceRows),
+        newCash: sheet(0.145, [
+          ["CSC", "Straight", "FOX-S600A", 12, 5.33, 22, 25.6],
+          withPrice(sourceRows[1], 188.3),
+        ]),
+        returningStandard: sheet(0.145, sourceRows),
+        returningCash: sheet(0.117, sourceRows),
+      })
+    ).toThrow("does not match the product definition for FOX-S600A")
+  })
+
+  it("suggests Sage matches without automatically assigning them", () => {
+    expect(
+      nuTechSageCostCodeCandidates(
+        { manufacturerSku: "FOX-S600A", name: "6 inch straight block" },
+        [
+          {
+            id: "sage-1",
+            code: "FOX-S600A",
+            description: "Fox block material",
+          },
+          {
+            id: "sage-2",
+            code: "03 11 19",
+            description: "Insulating concrete form",
+          },
+        ]
+      )
+    ).toEqual([
+      {
+        id: "sage-1",
+        code: "FOX-S600A",
+        description: "Fox block material",
+        score: 100,
+      },
+    ])
+  })
+})

--- a/src/lib/nutech/__tests__/catalog-pricing.test.ts
+++ b/src/lib/nutech/__tests__/catalog-pricing.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  nuTechCustomerPriceCents,
+  validateNuTechOrderQuantity,
+} from "@/lib/nutech/catalog-pricing"
+
+const prices = {
+  newStandardPriceCents: 2640,
+  newCashPriceCents: 2560,
+  returningStandardPriceCents: 2560,
+  returningCashPriceCents: 2480,
+}
+
+describe("Nu-Tech catalog pricing", () => {
+  it("selects the published tier without calling standard pricing credit-card pricing", () => {
+    expect(nuTechCustomerPriceCents(prices, "new", "standard")).toBe(2640)
+    expect(nuTechCustomerPriceCents(prices, "new", "cash_discount")).toBe(2560)
+    expect(nuTechCustomerPriceCents(prices, "returning", "standard")).toBe(2560)
+    expect(nuTechCustomerPriceCents(prices, "returning", "cash_discount")).toBe(2480)
+  })
+
+  it("enforces manufacturer package increments", () => {
+    expect(() =>
+      validateNuTechOrderQuantity({
+        manufacturerSku: "FOX-S600A",
+        quantity: 13,
+        minimumOrderIncrement: 12,
+      })
+    ).toThrow("multiple of 12")
+  })
+})

--- a/src/lib/nutech/__tests__/workflow.test.ts
+++ b/src/lib/nutech/__tests__/workflow.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  normalizedNuTechTakeoffStatus,
+  nuTechPurchaseOrderReleaseReadiness,
+  nuTechReleaseAuditIssues,
+  nuTechTakeoffAcknowledgementRequired,
+} from "@/lib/nutech/workflow"
+
+describe("Nu-Tech order workflow", () => {
+  it("does not require an acknowledgement for customer-provided quantities", () => {
+    expect(nuTechTakeoffAcknowledgementRequired("customer_provided")).toBe(false)
+    expect(
+      normalizedNuTechTakeoffStatus({
+        quantitySource: "customer_provided",
+        requestedStatus: "signed",
+      })
+    ).toBe("not_required")
+  })
+
+  it("requires a signed acknowledgement for staff takeoffs before PO release", () => {
+    expect(nuTechTakeoffAcknowledgementRequired("staff_takeoff")).toBe(true)
+    expect(
+      nuTechPurchaseOrderReleaseReadiness({
+        customerType: "returning",
+        pricingMode: "cash_discount",
+        quantitySource: "staff_takeoff",
+        takeoffAcknowledgementStatus: "sent",
+        airlitePurchaseOrderOperationId: "po-1",
+      })
+    ).toEqual({
+      ready: false,
+      issues: ["Obtain the signed takeoff acknowledgement."],
+    })
+  })
+
+  it("allows a linked PO to release when the applicable intake checks are complete", () => {
+    expect(
+      nuTechPurchaseOrderReleaseReadiness({
+        customerType: "new",
+        pricingMode: "standard",
+        quantitySource: "customer_provided",
+        takeoffAcknowledgementStatus: "not_required",
+        airlitePurchaseOrderOperationId: "po-2",
+      })
+    ).toEqual({ ready: true, issues: [] })
+  })
+
+  it("holds PO release until catalog items and a current Airlite workbook exist", () => {
+    expect(
+      nuTechPurchaseOrderReleaseReadiness({
+        customerType: "new",
+        pricingMode: "standard",
+        quantitySource: "customer_provided",
+        takeoffAcknowledgementStatus: "not_required",
+        airlitePurchaseOrderOperationId: "po-2",
+        orderItemCount: 0,
+        airliteWorkbookStatus: "stale",
+      })
+    ).toEqual({
+      ready: false,
+      issues: [
+        "Add at least one catalog item to the order.",
+        "Generate the Airlite workbook from the saved order items.",
+      ],
+    })
+  })
+
+  it("requires release actions before audited release statuses can be saved", () => {
+    expect(
+      nuTechReleaseAuditIssues({
+        orderStatus: "po_released",
+        vendorInvoiceStatus: "not_received",
+        purchaseOrderReleasedAt: null,
+        vendorInvoiceReleasedAt: null,
+      })
+    ).toContain(
+      "Record the Airlite PO release before selecting a post-release status."
+    )
+    expect(
+      nuTechReleaseAuditIssues({
+        orderStatus: "invoice_released",
+        vendorInvoiceStatus: "released",
+        purchaseOrderReleasedAt: "2026-08-24T12:00:00.000Z",
+        vendorInvoiceReleasedAt: null,
+      })
+    ).toHaveLength(2)
+  })
+
+  it("keeps a released PO from moving back to intake", () => {
+    expect(
+      nuTechReleaseAuditIssues({
+        orderStatus: "intake",
+        vendorInvoiceStatus: "received",
+        purchaseOrderReleasedAt: "2026-08-24T12:00:00.000Z",
+        vendorInvoiceReleasedAt: null,
+      })
+    ).toEqual([
+      "A released Airlite PO cannot be moved back to a pre-release status.",
+    ])
+  })
+
+  it("keeps a released invoice in a final workflow state", () => {
+    expect(
+      nuTechReleaseAuditIssues({
+        orderStatus: "vendor_confirmed",
+        vendorInvoiceStatus: "released",
+        purchaseOrderReleasedAt: "2026-08-24T12:00:00.000Z",
+        vendorInvoiceReleasedAt: "2026-08-24T13:00:00.000Z",
+      })
+    ).toEqual([
+      "A released vendor invoice can only remain released, complete, or cancelled.",
+    ])
+  })
+})

--- a/src/lib/nutech/airlite-workbook.ts
+++ b/src/lib/nutech/airlite-workbook.ts
@@ -1,0 +1,164 @@
+import type { GoogleSheetValueUpdate } from "@/lib/google/client/sheets-client"
+
+export type NuTechAirliteOrderLine = {
+  readonly manufacturerSku: string
+  readonly name: string
+  readonly origin: string
+  readonly category: string
+  readonly quantity: number
+  readonly minimumOrderIncrement: number
+  readonly packageLabel: string
+  readonly priceUnit: string
+  readonly airliteTemplateRow: number | null
+  readonly unitCostCents: number
+}
+
+export type NuTechAirliteWorkbookPlan = {
+  readonly updates: readonly GoogleSheetValueUpdate[]
+  readonly addendumItemCount: number
+  readonly totalCostCents: number
+  readonly addendumValues: ReadonlyArray<ReadonlyArray<unknown>>
+}
+
+function cell(range: string, value: unknown): GoogleSheetValueUpdate {
+  return { range: `USLvl3!${range}`, values: [[value]] }
+}
+
+function lineTotalCents(line: NuTechAirliteOrderLine): number {
+  return line.quantity * line.unitCostCents
+}
+
+function packageCount(line: NuTechAirliteOrderLine): number {
+  return line.quantity / line.minimumOrderIncrement
+}
+
+export function buildNuTechAirliteWorkbookPlan(input: {
+  readonly purchaseOrderNumber: string
+  readonly purchaseOrderDate: string
+  readonly requestedDeliveryDate: string | null
+  readonly projectName: string
+  readonly jobsiteAddress: string | null
+  readonly orderContactName: string
+  readonly orderContactPhone: string | null
+  readonly orderContactEmail: string
+  readonly deliveryContact: string | null
+  readonly lines: readonly NuTechAirliteOrderLine[]
+}): NuTechAirliteWorkbookPlan {
+  if (input.lines.length === 0) {
+    throw new Error("Add at least one Nu-Tech catalog item before generating the Airlite workbook.")
+  }
+  const invalidLine = input.lines.find(
+    (line) =>
+      !Number.isInteger(line.quantity) ||
+      line.quantity <= 0 ||
+      line.quantity % line.minimumOrderIncrement !== 0
+  )
+  if (invalidLine) {
+    throw new Error(
+      `${invalidLine.manufacturerSku} quantity must be a positive multiple of ${invalidLine.minimumOrderIncrement}.`
+    )
+  }
+  const mappedLines = input.lines.filter(
+    (line) => line.airliteTemplateRow !== null
+  )
+  const addendumLines = input.lines.filter(
+    (line) => line.airliteTemplateRow === null
+  )
+  const updates: GoogleSheetValueUpdate[] = [
+    cell("B7", input.purchaseOrderNumber),
+    cell("B8", input.purchaseOrderDate),
+    cell("H8", input.requestedDeliveryDate ?? ""),
+    cell("H11", input.projectName),
+    cell("H12", input.jobsiteAddress ?? ""),
+    cell("B15", input.orderContactName),
+    cell("B16", input.orderContactPhone ?? ""),
+    cell("B18", input.orderContactEmail),
+    cell("H19", input.deliveryContact ?? ""),
+  ]
+  for (const line of mappedLines) {
+    const row = line.airliteTemplateRow
+    if (row === null) continue
+    updates.push(
+      cell(`A${row}`, line.quantity),
+      cell(`H${row}`, packageCount(line)),
+      cell(`I${row}`, line.unitCostCents / 100),
+      cell(`J${row}`, lineTotalCents(line) / 100)
+    )
+  }
+  const blockLines = mappedLines.filter((line) => line.category === "block")
+  const accessoryLines = mappedLines.filter((line) => line.category !== "block")
+  const totalQuantity = input.lines.reduce((sum, line) => sum + line.quantity, 0)
+  const totalPackages = input.lines.reduce(
+    (sum, line) => sum + packageCount(line),
+    0
+  )
+  const totalCostCents = input.lines.reduce(
+    (sum, line) => sum + lineTotalCents(line),
+    0
+  )
+  updates.push(
+    cell("A68", blockLines.reduce((sum, line) => sum + line.quantity, 0)),
+    cell("H68", blockLines.reduce((sum, line) => sum + packageCount(line), 0)),
+    cell(
+      "J68",
+      blockLines.reduce((sum, line) => sum + lineTotalCents(line), 0) / 100
+    ),
+    cell("A85", accessoryLines.reduce((sum, line) => sum + line.quantity, 0)),
+    cell(
+      "H85",
+      accessoryLines.reduce((sum, line) => sum + packageCount(line), 0)
+    ),
+    cell(
+      "J85",
+      accessoryLines.reduce((sum, line) => sum + lineTotalCents(line), 0) / 100
+    ),
+    cell("A87", totalQuantity),
+    cell("H87", totalPackages),
+    cell("J87", totalCostCents / 100),
+    cell(
+      "A94",
+      addendumLines.length === 0
+        ? ""
+        : "See the Compass Addendum tab for products not listed on this manufacturer form. Addendum items are included in Order Sub-total."
+    )
+  )
+  const addendumValues: ReadonlyArray<ReadonlyArray<unknown>> =
+    addendumLines.length === 0
+      ? []
+      : [
+          ["Compass Airlite Order Addendum"],
+          [input.purchaseOrderNumber, input.projectName, input.purchaseOrderDate],
+          ["Items below are included in the USLvl3 Order Sub-total."],
+          [
+            "SKU",
+            "Product",
+            "Origin",
+            "Quantity",
+            "Price unit",
+            "Package",
+            "Airlite unit cost",
+            "Line total",
+          ],
+          ...addendumLines.map((line) => [
+            line.manufacturerSku,
+            line.name,
+            line.origin,
+            line.quantity,
+            line.priceUnit,
+            line.packageLabel,
+            line.unitCostCents / 100,
+            lineTotalCents(line) / 100,
+          ]),
+          [],
+          ["Addendum total", "", "", "", "", "", "", addendumLines.reduce(
+            (sum, line) => sum + lineTotalCents(line),
+            0
+          ) / 100],
+        ]
+  return {
+    updates,
+    addendumItemCount: addendumLines.length,
+    totalCostCents,
+    addendumValues,
+  }
+}

--- a/src/lib/nutech/catalog-import.ts
+++ b/src/lib/nutech/catalog-import.ts
@@ -1,0 +1,449 @@
+export type NuTechProductCategory = "block" | "panel" | "web" | "accessory"
+
+export type NuTechAirliteMappingStatus = "mapped" | "addendum_required"
+
+export type NuTechImportedProduct = {
+  readonly manufacturerSku: string
+  readonly name: string
+  readonly category: NuTechProductCategory
+  readonly origin: string
+  readonly priceUnit: string
+  readonly packageQuantity: number
+  readonly packageLabel: string
+  readonly minimumOrderIncrement: number
+  readonly squareFeetPerUnitMils: number | null
+  readonly airliteTemplateSku: string | null
+  readonly airliteTemplateRow: number | null
+  readonly airliteMappingStatus: NuTechAirliteMappingStatus
+  readonly airliteCostCents: number
+  readonly newStandardPriceCents: number
+  readonly newCashPriceCents: number
+  readonly returningStandardPriceCents: number
+  readonly returningCashPriceCents: number
+  readonly newStandardMarginBasisPoints: number
+  readonly newCashMarginBasisPoints: number
+  readonly returningStandardMarginBasisPoints: number
+  readonly returningCashMarginBasisPoints: number
+}
+
+export type NuTechCatalogImport = {
+  readonly products: readonly NuTechImportedProduct[]
+  readonly targetMargins: {
+    readonly newStandardBasisPoints: number
+    readonly newCashBasisPoints: number
+    readonly returningStandardBasisPoints: number
+    readonly returningCashBasisPoints: number
+  }
+}
+
+type ParsedPriceRow = {
+  readonly origin: string
+  readonly name: string
+  readonly manufacturerSku: string
+  readonly packageValue: string | number
+  readonly squareFeetPerUnit: number | null
+  readonly airliteCostCents: number
+  readonly marginBasisPoints: number
+  readonly customerPriceCents: number
+}
+
+type ParsedPriceSheet = {
+  readonly targetMarginBasisPoints: number
+  readonly rows: readonly ParsedPriceRow[]
+}
+
+type AirliteTemplateMapping = {
+  readonly row: number
+  readonly sku: string
+}
+
+const BLOCK_SKUS = new Set([
+  "FOX-S400",
+  "FOX-EC490",
+  "FOX-EC445",
+  "FOX-TBT4T600",
+  "FOX-S400HB",
+  "FOX-EC490HB",
+  "FOX-S600A",
+  "FOX-EC690A",
+  "FOX-C645A",
+  "FOX-BL600A",
+  "FOX-TT600A",
+  "FOX-TB600A",
+  "FOX-TBT6T400",
+  "FOX-RB",
+  "FOX-S800",
+  "FOX-EC890",
+  "FOX-C845",
+  "FOX-BL800",
+  "FOX-TT800",
+  "FOX-TB800",
+  "FOX-TBT8T400",
+  "FOX-TBT8T600",
+  "FOX-S800CB",
+  "FOX-EC890CB",
+  "FOX-S800HB",
+  "FOX-EC890HB",
+  "FOX-S1000",
+  "FOX-EC1090",
+  "FOX-S1000CB",
+  "FOX-EC1090CB",
+  "FOX-S1000HB",
+  "FOX-EC1090HB",
+  "FOX-S1200",
+  "FOX-EC1290",
+  "FOX-S1200HB",
+  "FOX-EC1290HB",
+])
+
+const PACKAGE_PRICED_SKUS = new Set([
+  "L921T809B",
+  "L922T809B",
+  "L923T809B",
+  "L924T809B",
+  "L925T809B",
+  "WEBEX",
+  "FOX-HVCLIPS",
+  "FOX-TIE-KEY",
+  "FOX-TIE-KEY-SS",
+  "FOX-ZIPT36",
+  "FOX-SPRAYFOAM",
+  "FOX-BAGYD",
+])
+
+const AIRLITE_TEMPLATE_MAPPINGS: Readonly<
+  Record<string, AirliteTemplateMapping>
+> = {
+  "FOX-S400": { row: 22, sku: "FOX-S400" },
+  "FOX-EC490": { row: 23, sku: "FOX-EC490" },
+  "FOX-EC445": { row: 24, sku: "FOX-EC445" },
+  "FOX-TBT4T600": { row: 25, sku: "FOX-TBT4T600" },
+  "FOX-S400HB": { row: 26, sku: "FOX-S400HB" },
+  "FOX-EC490HB": { row: 27, sku: "FOX-EC490HB" },
+  "FOX-S600A": { row: 28, sku: "FOX-S600" },
+  "FOX-EC690A": { row: 29, sku: "FOX-EC690" },
+  "FOX-C645A": { row: 30, sku: "FOX-C645" },
+  "FOX-BL600A": { row: 31, sku: "FOX-BL600" },
+  "FOX-TT600A": { row: 32, sku: "FOX-TT600" },
+  "FOX-TB600A": { row: 33, sku: "FOX-TB600" },
+  "FOX-TBT6T400": { row: 34, sku: "FOX-TBT6T400" },
+  "FOX-RB": { row: 35, sku: "FOX-RB" },
+  "FOX-S800": { row: 44, sku: "FOX-S800" },
+  "FOX-EC890": { row: 45, sku: "FOX-EC890" },
+  "FOX-C845": { row: 46, sku: "FOX-C845" },
+  "FOX-BL800": { row: 47, sku: "FOX-BL800" },
+  "FOX-TT800": { row: 48, sku: "FOX-TT800" },
+  "FOX-TB800": { row: 49, sku: "FOX-TB800" },
+  "FOX-TBT8T400": { row: 50, sku: "FOX-TBT8T400" },
+  "FOX-TBT8T600": { row: 51, sku: "FOX-TBT8T600" },
+  "FOX-S800CB": { row: 52, sku: "FOX-S800CB" },
+  "FOX-EC890CB": { row: 53, sku: "FOX-EC890CB" },
+  "FOX-S800HB": { row: 54, sku: "FOX-S800HB" },
+  "FOX-EC890HB": { row: 55, sku: "FOX-EC890HB" },
+  "FOX-S1000": { row: 56, sku: "FOX-S1000" },
+  "FOX-EC1090": { row: 57, sku: "FOX-EC1090" },
+  "FOX-S1000CB": { row: 58, sku: "FOX-S1000CB" },
+  "FOX-EC1090CB": { row: 59, sku: "FOX-EC1090CB" },
+  "FOX-S1000HB": { row: 60, sku: "FOX-S1000HB" },
+  "FOX-EC1090HB": { row: 61, sku: "FOX-EC1090HB" },
+  "FOX-S1200": { row: 64, sku: "FOX-S1200" },
+  "FOX-EC1290": { row: 65, sku: "FOX-EC1290" },
+  "FOX-S1200HB": { row: 66, sku: "FOX-S1200HB" },
+  "FOX-EC1290HB": { row: 67, sku: "FOX-EC1290HB" },
+  "FOX-BUCK4": { row: 70, sku: "FOX-Buck4" },
+  "FOX-BUCK6": { row: 71, sku: "FOX-Buck6" },
+  "FOX-BUCK8": { row: 72, sku: "FOX-Buck8" },
+  "FOX-BUCK10": { row: 73, sku: "FOX-Buck10" },
+  "FOX-BUCK12": { row: 74, sku: "FOX-Buck12" },
+  "FOX-ESTICK": { row: 75, sku: "FOX-Estick" },
+  "FOX-EXTR": { row: 76, sku: "FOX-Extr" },
+  "FOX-HVCLIPS": { row: 77, sku: "FOX-HVClips" },
+  "FOX-TIE-KEY": { row: 78, sku: "FOX-Tie-Key" },
+  "FOX-TIE-KEY-SS": { row: 79, sku: "FOX-Tie-Key-ss" },
+  "FOX-XLERATOR": { row: 80, sku: "Fox-xLerator" },
+  "FOX-ZIPT36": { row: 81, sku: "FOX-ZipT36" },
+  "FOX-BAGYD": { row: 83, sku: "FOX-Bagyd" },
+  "FOX-SIGN": { row: 84, sku: "FOX-Sign" },
+}
+
+function stringCell(value: unknown): string | null {
+  if (typeof value !== "string") return null
+  const cleaned = value.trim()
+  return cleaned.length > 0 ? cleaned : null
+}
+
+function numberCell(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value !== "string") return null
+  const normalized = value.replace(/[$,%]/g, "").trim()
+  if (normalized.length === 0) return null
+  const parsed = Number(normalized)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function cents(value: unknown, label: string): number {
+  const parsed = numberCell(value)
+  if (parsed === null || parsed < 0) throw new Error(`${label} must be a number.`)
+  return Math.round(parsed * 100)
+}
+
+function basisPoints(value: unknown, label: string): number {
+  const parsed = numberCell(value)
+  if (parsed === null || parsed < 0 || parsed >= 1) {
+    throw new Error(`${label} must be a decimal gross margin.`)
+  }
+  return Math.round(parsed * 10_000)
+}
+
+function parsePriceSheet(
+  values: ReadonlyArray<ReadonlyArray<unknown>>,
+  label: string
+): ParsedPriceSheet {
+  const targetMarginRow = values.find(
+    (row) => stringCell(row[0])?.toLowerCase() === "target gross margin"
+  )
+  const headerIndex = values.findIndex(
+    (row) =>
+      stringCell(row[0])?.toLowerCase() === "origin" &&
+      stringCell(row[2])?.toLowerCase() === "sku"
+  )
+  if (!targetMarginRow || headerIndex < 0) {
+    throw new Error(`${label} is missing its pricing header or target margin.`)
+  }
+  const targetMarginBasisPoints = basisPoints(
+    targetMarginRow[1],
+    `${label} target margin`
+  )
+  const rows: ParsedPriceRow[] = []
+  for (const [offset, row] of values.slice(headerIndex + 1).entries()) {
+    const origin = stringCell(row[0])
+    const name = stringCell(row[1])
+    const manufacturerSku = stringCell(row[2])?.toUpperCase() ?? null
+    if (!origin && !name && !manufacturerSku) continue
+    if (!origin || !name || !manufacturerSku) {
+      throw new Error(`${label} row ${headerIndex + offset + 2} is incomplete.`)
+    }
+    const packageNumber = numberCell(row[3])
+    const packageText = stringCell(row[3])
+    const packageValue = packageText ?? packageNumber
+    if (packageValue === null) {
+      throw new Error(`${label} ${manufacturerSku} is missing its package quantity.`)
+    }
+    const squareFeet = numberCell(row[4])
+    rows.push({
+      origin,
+      name,
+      manufacturerSku,
+      packageValue,
+      squareFeetPerUnit: squareFeet,
+      airliteCostCents: cents(row[5], `${label} ${manufacturerSku} cost`),
+      marginBasisPoints: basisPoints(
+        row[6],
+        `${label} ${manufacturerSku} margin`
+      ),
+      customerPriceCents: cents(
+        row[7],
+        `${label} ${manufacturerSku} customer price`
+      ),
+    })
+  }
+  if (rows.length === 0) throw new Error(`${label} contains no catalog products.`)
+  return { targetMarginBasisPoints, rows }
+}
+
+function categoryForSku(sku: string): NuTechProductCategory {
+  if (BLOCK_SKUS.has(sku)) return "block"
+  if (sku.startsWith("FOX-PANEL")) return "panel"
+  if (sku.startsWith("L92") || sku === "WEBEX") return "web"
+  return "accessory"
+}
+
+function packageDetails(
+  sku: string,
+  packageValue: string | number
+): {
+  readonly priceUnit: string
+  readonly packageQuantity: number
+  readonly packageLabel: string
+  readonly minimumOrderIncrement: number
+} {
+  const packageLabel = String(packageValue).trim()
+  const match = /^(\d+)(?:\s*\/\s*([a-z]+))?$/i.exec(packageLabel)
+  if (!match) throw new Error(`${sku} has an unsupported package value: ${packageLabel}.`)
+  const quantityText = match[1]
+  if (!quantityText) throw new Error(`${sku} is missing its package quantity.`)
+  const packageQuantity = Number(quantityText)
+  const packageUnit = match[2]?.toLowerCase() ?? "each"
+  const packagePriced = PACKAGE_PRICED_SKUS.has(sku)
+  return {
+    priceUnit: packagePriced ? packageUnit : "each",
+    packageQuantity,
+    packageLabel,
+    minimumOrderIncrement: packagePriced ? 1 : packageQuantity,
+  }
+}
+
+function rowMap(sheet: ParsedPriceSheet, label: string): ReadonlyMap<string, ParsedPriceRow> {
+  const mapped = new Map<string, ParsedPriceRow>()
+  for (const row of sheet.rows) {
+    if (mapped.has(row.manufacturerSku)) {
+      throw new Error(`${label} contains duplicate SKU ${row.manufacturerSku}.`)
+    }
+    mapped.set(row.manufacturerSku, row)
+  }
+  return mapped
+}
+
+function matchingRow(
+  rows: ReadonlyMap<string, ParsedPriceRow>,
+  sku: string,
+  label: string
+): ParsedPriceRow {
+  const row = rows.get(sku)
+  if (!row) throw new Error(`${label} is missing SKU ${sku}.`)
+  return row
+}
+
+function assertSameProduct(
+  baseline: ParsedPriceRow,
+  candidate: ParsedPriceRow,
+  label: string
+): void {
+  if (
+    baseline.name !== candidate.name ||
+    baseline.origin !== candidate.origin ||
+    String(baseline.packageValue) !== String(candidate.packageValue) ||
+    baseline.squareFeetPerUnit !== candidate.squareFeetPerUnit ||
+    baseline.airliteCostCents !== candidate.airliteCostCents
+  ) {
+    throw new Error(`${label} does not match the product definition for ${baseline.manufacturerSku}.`)
+  }
+}
+
+export function buildNuTechCatalogImport(input: {
+  readonly newStandard: ReadonlyArray<ReadonlyArray<unknown>>
+  readonly newCash: ReadonlyArray<ReadonlyArray<unknown>>
+  readonly returningStandard: ReadonlyArray<ReadonlyArray<unknown>>
+  readonly returningCash: ReadonlyArray<ReadonlyArray<unknown>>
+}): NuTechCatalogImport {
+  const newStandard = parsePriceSheet(input.newStandard, "New standard pricing")
+  const newCash = parsePriceSheet(input.newCash, "New cash pricing")
+  const returningStandard = parsePriceSheet(
+    input.returningStandard,
+    "Returning standard pricing"
+  )
+  const returningCash = parsePriceSheet(
+    input.returningCash,
+    "Returning cash pricing"
+  )
+  const newCashRows = rowMap(newCash, "New cash pricing")
+  const returningStandardRows = rowMap(
+    returningStandard,
+    "Returning standard pricing"
+  )
+  const returningCashRows = rowMap(returningCash, "Returning cash pricing")
+  if (
+    newStandard.rows.length !== newCash.rows.length ||
+    newStandard.rows.length !== returningStandard.rows.length ||
+    newStandard.rows.length !== returningCash.rows.length
+  ) {
+    throw new Error("The four Nu-Tech price sheets do not contain the same product count.")
+  }
+
+  const products = newStandard.rows.map((baseline) => {
+    const newCashRow = matchingRow(
+      newCashRows,
+      baseline.manufacturerSku,
+      "New cash pricing"
+    )
+    const returningStandardRow = matchingRow(
+      returningStandardRows,
+      baseline.manufacturerSku,
+      "Returning standard pricing"
+    )
+    const returningCashRow = matchingRow(
+      returningCashRows,
+      baseline.manufacturerSku,
+      "Returning cash pricing"
+    )
+    assertSameProduct(baseline, newCashRow, "New cash pricing")
+    assertSameProduct(baseline, returningStandardRow, "Returning standard pricing")
+    assertSameProduct(baseline, returningCashRow, "Returning cash pricing")
+    const packageInfo = packageDetails(
+      baseline.manufacturerSku,
+      baseline.packageValue
+    )
+    const airlite = AIRLITE_TEMPLATE_MAPPINGS[baseline.manufacturerSku]
+    return {
+      manufacturerSku: baseline.manufacturerSku,
+      name: baseline.name,
+      category: categoryForSku(baseline.manufacturerSku),
+      origin: baseline.origin,
+      ...packageInfo,
+      squareFeetPerUnitMils:
+        baseline.squareFeetPerUnit === null
+          ? null
+          : Math.round(baseline.squareFeetPerUnit * 1_000),
+      airliteTemplateSku: airlite?.sku ?? null,
+      airliteTemplateRow: airlite?.row ?? null,
+      airliteMappingStatus: airlite ? "mapped" : "addendum_required",
+      airliteCostCents: baseline.airliteCostCents,
+      newStandardPriceCents: baseline.customerPriceCents,
+      newCashPriceCents: newCashRow.customerPriceCents,
+      returningStandardPriceCents: returningStandardRow.customerPriceCents,
+      returningCashPriceCents: returningCashRow.customerPriceCents,
+      newStandardMarginBasisPoints: baseline.marginBasisPoints,
+      newCashMarginBasisPoints: newCashRow.marginBasisPoints,
+      returningStandardMarginBasisPoints: returningStandardRow.marginBasisPoints,
+      returningCashMarginBasisPoints: returningCashRow.marginBasisPoints,
+    } satisfies NuTechImportedProduct
+  })
+
+  return {
+    products,
+    targetMargins: {
+      newStandardBasisPoints: newStandard.targetMarginBasisPoints,
+      newCashBasisPoints: newCash.targetMarginBasisPoints,
+      returningStandardBasisPoints: returningStandard.targetMarginBasisPoints,
+      returningCashBasisPoints: returningCash.targetMarginBasisPoints,
+    },
+  }
+}
+
+export type NuTechSageCostCodeCandidate = {
+  readonly id: string
+  readonly code: string
+  readonly description: string
+  readonly score: number
+}
+
+function normalizedSearchValue(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim()
+}
+
+export function nuTechSageCostCodeCandidates(
+  product: Pick<NuTechImportedProduct, "manufacturerSku" | "name">,
+  costCodes: readonly {
+    readonly id: string
+    readonly code: string
+    readonly description: string
+  }[]
+): readonly NuTechSageCostCodeCandidate[] {
+  const sku = normalizedSearchValue(product.manufacturerSku)
+  const name = normalizedSearchValue(product.name)
+  return costCodes
+    .flatMap((costCode) => {
+      const haystack = normalizedSearchValue(
+        `${costCode.code} ${costCode.description}`
+      )
+      const score = haystack.includes(sku)
+        ? 100
+        : haystack === name
+          ? 90
+          : haystack.includes(name) || name.includes(haystack)
+            ? 70
+            : 0
+      return score > 0 ? [{ ...costCode, score }] : []
+    })
+    .sort((left, right) => right.score - left.score || left.code.localeCompare(right.code))
+}

--- a/src/lib/nutech/catalog-pricing.ts
+++ b/src/lib/nutech/catalog-pricing.ts
@@ -1,0 +1,36 @@
+import type { NuTechCustomerType, NuTechPricingMode } from "@/lib/nutech/workflow"
+
+export function nuTechCustomerPriceCents(
+  prices: {
+    readonly newStandardPriceCents: number
+    readonly newCashPriceCents: number
+    readonly returningStandardPriceCents: number
+    readonly returningCashPriceCents: number
+  },
+  customerType: NuTechCustomerType,
+  pricingMode: NuTechPricingMode
+): number {
+  if (customerType === "new") {
+    return pricingMode === "cash_discount"
+      ? prices.newCashPriceCents
+      : prices.newStandardPriceCents
+  }
+  return pricingMode === "cash_discount"
+    ? prices.returningCashPriceCents
+    : prices.returningStandardPriceCents
+}
+
+export function validateNuTechOrderQuantity(input: {
+  readonly manufacturerSku: string
+  readonly quantity: number
+  readonly minimumOrderIncrement: number
+}): void {
+  if (!Number.isInteger(input.quantity) || input.quantity <= 0) {
+    throw new Error(`${input.manufacturerSku} quantity must be a positive whole number.`)
+  }
+  if (input.quantity % input.minimumOrderIncrement !== 0) {
+    throw new Error(
+      `${input.manufacturerSku} quantity must be a multiple of ${input.minimumOrderIncrement}.`
+    )
+  }
+}

--- a/src/lib/nutech/resources.ts
+++ b/src/lib/nutech/resources.ts
@@ -1,0 +1,31 @@
+export const NUTECH_RESOURCE_LINKS = {
+  airliteOrderForm:
+    "https://docs.google.com/spreadsheets/d/1WDYEMs5RgkoccbPSiFQsmeiNc7MRC_xsj6K0l1cmL6Y/edit",
+  newClientPricing:
+    "https://drive.google.com/drive/folders/1qmczWk5bOmqSTflGmKFfYO1nHa-Duz9s",
+  returningCustomerPricing:
+    "https://drive.google.com/drive/folders/1Dl1c2ZSOwOPatIB3fOOPwjShfwL7RDQh",
+  pricingArchive:
+    "https://drive.google.com/drive/folders/1cRrvPXkwF0nzZNurWF6A-E5_rG8fmOjB",
+} satisfies Readonly<Record<string, string>>
+
+export const NUTECH_2026_CATALOG_SOURCES = {
+  name: "2026 Fox Blocks pricing",
+  effectiveDate: "2026-08-23",
+  airliteTemplateId: "1WDYEMs5RgkoccbPSiFQsmeiNc7MRC_xsj6K0l1cmL6Y",
+  newStandardSheetId: "1_xx7UbkT4qd3UvZBI6RT8AOs-yjbfmnfpJAVkdebl48",
+  newCashSheetId: "19O7u_oq-sFZUZuExRDl4cDwQonD8sXcg5i4ZjfGlRJg",
+  returningStandardSheetId: "1zHRvncvRNGwWVf7RYWTbNY2H7wnQfvmNbx9Bh9EXD1o",
+  returningCashSheetId: "1uQygU-_QEsPYRQRpVMS4DEDH_DsTa2s88SC_EngxAWI",
+  sourceRange: "'2026 Cost & Margin'!A1:H100",
+} as const
+
+export function nuTechPricingFolderUrl(
+  customerType: "new" | "returning" | null
+): string | null {
+  if (customerType === "new") return NUTECH_RESOURCE_LINKS.newClientPricing
+  if (customerType === "returning") {
+    return NUTECH_RESOURCE_LINKS.returningCustomerPricing
+  }
+  return null
+}

--- a/src/lib/nutech/workflow.ts
+++ b/src/lib/nutech/workflow.ts
@@ -1,0 +1,249 @@
+export type NuTechCustomerType = "new" | "returning"
+export type NuTechPricingMode = "standard" | "cash_discount"
+export type NuTechQuantitySource = "customer_provided" | "staff_takeoff"
+export type NuTechTakeoffAcknowledgementStatus =
+  | "not_required"
+  | "pending"
+  | "sent"
+  | "signed"
+export type NuTechScopeType = "block_sale" | "block_and_bracing" | "bracing_only"
+export type NuTechDeliveryMethod = "delivery" | "customer_pickup" | "will_call"
+export type NuTechOrderStatus =
+  | "intake"
+  | "quantities_ready"
+  | "estimate_ready"
+  | "customer_approved"
+  | "po_ready"
+  | "po_released"
+  | "vendor_confirmed"
+  | "invoice_received"
+  | "invoice_released"
+  | "complete"
+  | "cancelled"
+export type NuTechVendorInvoiceStatus =
+  | "not_received"
+  | "received"
+  | "released"
+  | "posted"
+
+export const NUTECH_CUSTOMER_TYPE_OPTIONS: readonly {
+  readonly value: NuTechCustomerType
+  readonly label: string
+}[] = [
+  { value: "new", label: "New client" },
+  { value: "returning", label: "Returning customer" },
+]
+
+export const NUTECH_PRICING_MODE_OPTIONS: readonly {
+  readonly value: NuTechPricingMode
+  readonly label: string
+  readonly description: string
+}[] = [
+  {
+    value: "standard",
+    label: "Standard pricing",
+    description: "Use for non-discounted terms; do not label this credit-card pricing.",
+  },
+  {
+    value: "cash_discount",
+    label: "Cash-discount pricing",
+    description: "Cash, wire, or check terms.",
+  },
+]
+
+export const NUTECH_QUANTITY_SOURCE_OPTIONS: readonly {
+  readonly value: NuTechQuantitySource
+  readonly label: string
+}[] = [
+  { value: "customer_provided", label: "Customer provided quantities" },
+  { value: "staff_takeoff", label: "Nu-Tech staff prepared takeoff" },
+]
+
+export const NUTECH_TAKEOFF_STATUS_OPTIONS: readonly {
+  readonly value: NuTechTakeoffAcknowledgementStatus
+  readonly label: string
+}[] = [
+  { value: "not_required", label: "Not required" },
+  { value: "pending", label: "Required / pending" },
+  { value: "sent", label: "Sent for signature" },
+  { value: "signed", label: "Signed" },
+]
+
+export const NUTECH_SCOPE_TYPE_OPTIONS: readonly {
+  readonly value: NuTechScopeType
+  readonly label: string
+}[] = [
+  { value: "block_sale", label: "Fox Blocks sale" },
+  { value: "block_and_bracing", label: "Fox Blocks sale + bracing rental" },
+  { value: "bracing_only", label: "Bracing rental only" },
+]
+
+export const NUTECH_DELIVERY_METHOD_OPTIONS: readonly {
+  readonly value: NuTechDeliveryMethod
+  readonly label: string
+}[] = [
+  { value: "delivery", label: "Delivery" },
+  { value: "customer_pickup", label: "Customer pickup" },
+  { value: "will_call", label: "Airlite will call" },
+]
+
+export const NUTECH_ORDER_STATUS_OPTIONS: readonly {
+  readonly value: NuTechOrderStatus
+  readonly label: string
+}[] = [
+  { value: "intake", label: "Intake" },
+  { value: "quantities_ready", label: "Quantities ready" },
+  { value: "estimate_ready", label: "Estimate ready" },
+  { value: "customer_approved", label: "Customer approved" },
+  { value: "po_ready", label: "Airlite PO ready" },
+  { value: "po_released", label: "Airlite PO released" },
+  { value: "vendor_confirmed", label: "Vendor confirmed" },
+  { value: "invoice_received", label: "Vendor invoice received" },
+  { value: "invoice_released", label: "Vendor invoice released" },
+  { value: "complete", label: "Complete" },
+  { value: "cancelled", label: "Cancelled" },
+]
+
+export const NUTECH_VENDOR_INVOICE_STATUS_OPTIONS: readonly {
+  readonly value: NuTechVendorInvoiceStatus
+  readonly label: string
+}[] = [
+  { value: "not_received", label: "Not received" },
+  { value: "received", label: "Received" },
+  { value: "released", label: "Released" },
+  { value: "posted", label: "Posted" },
+]
+
+export function nuTechTakeoffAcknowledgementRequired(
+  quantitySource: NuTechQuantitySource
+): boolean {
+  return quantitySource === "staff_takeoff"
+}
+
+export function normalizedNuTechTakeoffStatus({
+  quantitySource,
+  requestedStatus,
+}: {
+  readonly quantitySource: NuTechQuantitySource
+  readonly requestedStatus: NuTechTakeoffAcknowledgementStatus
+}): NuTechTakeoffAcknowledgementStatus {
+  if (!nuTechTakeoffAcknowledgementRequired(quantitySource)) {
+    return "not_required"
+  }
+  if (requestedStatus === "not_required") return "pending"
+  return requestedStatus
+}
+
+export type NuTechPurchaseOrderReleaseReadiness = {
+  readonly ready: boolean
+  readonly issues: readonly string[]
+}
+
+const NUTECH_PRE_RELEASE_ORDER_STATUSES = new Set<NuTechOrderStatus>([
+  "intake",
+  "quantities_ready",
+  "estimate_ready",
+  "customer_approved",
+  "po_ready",
+])
+
+const NUTECH_POST_RELEASE_ORDER_STATUSES = new Set<NuTechOrderStatus>([
+  "po_released",
+  "vendor_confirmed",
+  "invoice_received",
+  "invoice_released",
+])
+
+export function nuTechReleaseAuditIssues({
+  orderStatus,
+  vendorInvoiceStatus,
+  purchaseOrderReleasedAt,
+  vendorInvoiceReleasedAt,
+}: {
+  readonly orderStatus: NuTechOrderStatus
+  readonly vendorInvoiceStatus: NuTechVendorInvoiceStatus
+  readonly purchaseOrderReleasedAt: string | null
+  readonly vendorInvoiceReleasedAt: string | null
+}): readonly string[] {
+  const issues: string[] = []
+  if (
+    purchaseOrderReleasedAt === null &&
+    NUTECH_POST_RELEASE_ORDER_STATUSES.has(orderStatus)
+  ) {
+    issues.push("Record the Airlite PO release before selecting a post-release status.")
+  }
+  if (
+    purchaseOrderReleasedAt !== null &&
+    NUTECH_PRE_RELEASE_ORDER_STATUSES.has(orderStatus)
+  ) {
+    issues.push("A released Airlite PO cannot be moved back to a pre-release status.")
+  }
+  if (orderStatus === "invoice_released" && vendorInvoiceReleasedAt === null) {
+    issues.push("Use the vendor-invoice release action before selecting invoice released.")
+  }
+  if (
+    vendorInvoiceReleasedAt !== null &&
+    orderStatus !== "invoice_released" &&
+    orderStatus !== "complete" &&
+    orderStatus !== "cancelled"
+  ) {
+    issues.push(
+      "A released vendor invoice can only remain released, complete, or cancelled."
+    )
+  }
+  if (
+    (vendorInvoiceStatus === "released" || vendorInvoiceStatus === "posted") &&
+    vendorInvoiceReleasedAt === null
+  ) {
+    issues.push("Release the vendor invoice before marking it released or posted.")
+  }
+  return issues
+}
+
+export function nuTechPurchaseOrderReleaseReadiness({
+  customerType,
+  pricingMode,
+  quantitySource,
+  takeoffAcknowledgementStatus,
+  airlitePurchaseOrderOperationId,
+  orderItemCount,
+  airliteWorkbookStatus,
+}: {
+  readonly customerType: NuTechCustomerType | null
+  readonly pricingMode: NuTechPricingMode | null
+  readonly quantitySource: NuTechQuantitySource | null
+  readonly takeoffAcknowledgementStatus: NuTechTakeoffAcknowledgementStatus
+  readonly airlitePurchaseOrderOperationId: string | null
+  readonly orderItemCount?: number | null
+  readonly airliteWorkbookStatus?: string | null
+}): NuTechPurchaseOrderReleaseReadiness {
+  const issues: string[] = []
+  if (customerType === null) issues.push("Select new or returning customer pricing.")
+  if (pricingMode === null) issues.push("Select standard or cash-discount pricing.")
+  if (quantitySource === null) issues.push("Record who supplied the quantities.")
+  if (
+    quantitySource === "staff_takeoff" &&
+    takeoffAcknowledgementStatus !== "signed"
+  ) {
+    issues.push("Obtain the signed takeoff acknowledgement.")
+  }
+  if (airlitePurchaseOrderOperationId === null) {
+    issues.push("Link the Compass Airlite purchase order.")
+  }
+  if (orderItemCount !== null && orderItemCount !== undefined && orderItemCount < 1) {
+    issues.push("Add at least one catalog item to the order.")
+  }
+  if (
+    airliteWorkbookStatus !== null &&
+    airliteWorkbookStatus !== undefined &&
+    !airliteWorkbookStatus.startsWith("generated")
+  ) {
+    issues.push("Generate the Airlite workbook from the saved order items.")
+  }
+  return { ready: issues.length === 0, issues }
+}
+
+export function nuTechOrderStatusLabel(value: string): string {
+  const match = NUTECH_ORDER_STATUS_OPTIONS.find((option) => option.value === value)
+  return match?.label ?? value
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -151,6 +151,14 @@ export const PERMISSION_FEATURES: readonly PermissionFeature[] = [
     resource: "project",
   },
   {
+    id: "nutech-orders",
+    group: "Operations",
+    label: "Nu-Tech Orders",
+    description:
+      "Fox Blocks catalog, takeoffs, pricing, bracing rentals, Airlite orders, and invoice release.",
+    resource: "project",
+  },
+  {
     id: "change-orders",
     group: "Operations",
     label: "Change Orders",


### PR DESCRIPTION
## Summary

- add a versioned four-tier Nu-Tech product catalog with deliberate Sage cost-code mapping
- add N-department takeoff, bracing rental, PO, and vendor-invoice workflow controls
- generate project Airlite workbook copies with a Compass addendum for new products
- add audited release locks, permissions, migration, documentation, and project navigation

## Verification

- 17 focused Nu-Tech tests pass
- targeted ESLint passes
- full TypeScript check passes
- production Next.js build passes
- D1 migration smoke test passes