### PR TITLE
fix(contracts): standardize corporate signatures

### DIFF
--- a/src/app/actions/project-estimates.ts
+++ b/src/app/actions/project-estimates.ts
@@ -2605,6 +2605,7 @@ async function renderEstimateSignaturePdf(input: {
   readonly projectId: string
   readonly estimateId: string
   readonly signerLabels: readonly string[]
+  readonly corporateSignerIndex: number
 }): Promise<PreparedEstimateSignaturePdf> {
   const quickAction = Reflect.get(input.env.BROWSER, "quickAction")
   if (typeof quickAction !== "function") {
@@ -2635,6 +2636,7 @@ async function renderEstimateSignaturePdf(input: {
   return prepareEstimateSignaturePdf({
     pdf: await rendered.arrayBuffer(),
     signerLabels: input.signerLabels,
+    corporateSignerIndex: input.corporateSignerIndex,
   })
 }
 
@@ -2687,6 +2689,9 @@ export async function prepareProjectEstimateForClientSignature(
       throw new Error(
         "Choose or type the company representative before signature."
       )
+    }
+    if (!cleanText(estimate.companySignerTitle)) {
+      throw new Error("Add the company representative title before signature.")
     }
     if (!cleanText(estimate.companySignerEmail)) {
       throw new Error("Add the company representative email before signature.")
@@ -2798,6 +2803,7 @@ export async function prepareProjectEstimateForClientSignature(
         ...clientSigners.map((_, index) => `Client ${index + 1}`),
         "Company",
       ],
+      corporateSignerIndex: clientSigners.length,
     })
     const origin = new URL(env.WORKOS_REDIRECT_URI).origin
     const returnUrl = new URL(
@@ -2886,6 +2892,9 @@ export async function markProjectEstimateSentOutsideCompass(
     }
     if (!cleanText(estimate.companySignerName)) {
       throw new Error("Add the company representative before signature.")
+    }
+    if (!cleanText(estimate.companySignerTitle)) {
+      throw new Error("Add the company representative title before signature.")
     }
     if (!cleanText(estimate.contractTerms)) {
       throw new Error("Add the contract terms before signature.")

--- a/src/app/actions/project-registry.ts
+++ b/src/app/actions/project-registry.ts
@@ -17,6 +17,7 @@ import {
   canManageProjectRegistry,
   requirePermission,
 } from "@/lib/permissions"
+import { projectDepartmentDisplayName } from "@/lib/project-branding"
 
 type ProjectRegistryProject = {
   readonly id: string
@@ -57,13 +58,13 @@ type LinkInput = {
 function projectNumberPrefixName(prefix: string): string | null {
   switch (prefix) {
     case "O":
-      return "Open Range Construction, Ltd."
+      return projectDepartmentDisplayName("O")
     case "N":
-      return "NuTech Systems"
+      return projectDepartmentDisplayName("N")
     case "H":
-      return "High Performance Structures"
+      return projectDepartmentDisplayName("H")
     case "D":
-      return "Design only"
+      return projectDepartmentDisplayName("D")
     default:
       return null
   }
@@ -88,7 +89,7 @@ function projectNumberValue(formData: FormData): UpdateResult | string | null {
     return {
       success: false,
       error:
-        "Project number must start with O (Open Range Construction, Ltd.), N (NuTech Systems), H (High Performance Structures), or D (Design only).",
+        `Project number must start with O (${projectDepartmentDisplayName("O")}), N (${projectDepartmentDisplayName("N")}), H (${projectDepartmentDisplayName("H")}), or D (${projectDepartmentDisplayName("D")}).`,
     }
   }
 

--- a/src/app/actions/project-registry.ts
+++ b/src/app/actions/project-registry.ts
@@ -57,7 +57,7 @@ type LinkInput = {
 function projectNumberPrefixName(prefix: string): string | null {
   switch (prefix) {
     case "O":
-      return "Open Range Construction"
+      return "Open Range Construction, Ltd."
     case "N":
       return "NuTech Systems"
     case "H":
@@ -88,7 +88,7 @@ function projectNumberValue(formData: FormData): UpdateResult | string | null {
     return {
       success: false,
       error:
-        "Project number must start with O (Open Range Construction), N (NuTech Systems), H (High Performance Structures), or D (Design only).",
+        "Project number must start with O (Open Range Construction, Ltd.), N (NuTech Systems), H (High Performance Structures), or D (Design only).",
     }
   }
 

--- a/src/app/api/projects/[id]/estimates/[estimateId]/pdf/route.ts
+++ b/src/app/api/projects/[id]/estimates/[estimateId]/pdf/route.ts
@@ -52,6 +52,7 @@ export async function GET(
         ...estimate.clientSigners.map((_, index) => `Client ${index + 1}`),
         "Company",
       ],
+      corporateSignerIndex: estimate.clientSigners.length,
     })
     const binary = atob(preparedPdf.pdfBase64)
     const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0))

--- a/src/app/print/projects/[id]/estimate/page.tsx
+++ b/src/app/print/projects/[id]/estimate/page.tsx
@@ -8,7 +8,7 @@ import { ProjectBrandContactDetails } from "@/components/projects/project-brand-
 import { ProjectBrandLogo } from "@/components/projects/project-brand-logo"
 import { ProjectEstimateReportActions } from "@/components/projects/project-estimate-report-actions"
 import { clientEstimatePhases } from "@/lib/estimates/client-report"
-import { projectBrandFor } from "@/lib/project-branding"
+import { projectBrandFor, projectLegalEntityName } from "@/lib/project-branding"
 
 function money(cents: number): string {
   return new Intl.NumberFormat("en-US", {
@@ -57,6 +57,7 @@ export default async function ProjectEstimatePrintPage({
     projectId: id,
     projectNumber: workspace.projectNumber,
   })
+  const legalEntityName = projectLegalEntityName(brand.department)
 
   if (!estimate) {
     return <main className="p-8">Estimate not found.</main>
@@ -393,17 +394,23 @@ export default async function ProjectEstimatePrintPage({
                 <p className="mt-1 text-xs">Date</p>
               </div>
             ))}
-            <div>
-              <p className="font-semibold">{brand.companyName}</p>
-              <div className="mt-7 border-b border-black" />
-              <p className="mt-1 text-xs">Company representative signature</p>
-              <p className="mt-2 font-medium">
+            <div className="break-inside-avoid">
+              <p className="text-[8px] font-semibold leading-3">
+                {legalEntityName}
+              </p>
+              <div className="mt-7 flex items-end gap-2">
+                <span className="text-xs font-semibold">By:</span>
+                <div className="flex-1 border-b border-black" />
+              </div>
+              <p className="mt-2 text-xs">
+                <span className="font-semibold">Name:</span>{" "}
                 {estimate.companySignerName ?? "Company representative"}
               </p>
-              {estimate.companySignerTitle && (
-                <p className="text-xs">{estimate.companySignerTitle}</p>
-              )}
-              <div className="mt-4 border-b border-black" />
+              <p className="text-xs">
+                <span className="font-semibold">Title:</span>{" "}
+                {estimate.companySignerTitle ?? "Title required"}
+              </p>
+              <div className="mt-12 border-b border-black" />
               <p className="mt-1 text-xs">Date</p>
             </div>
           </div>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -27,7 +27,7 @@ export default function PrivacyPolicyPage(): React.ReactElement {
         <p className="text-muted-foreground mt-4 leading-7">
           Compass is a construction project-management service operated by High
           Performance Structures Inc. dba Open Range Construction, Ltd. for its
-          operating departments, including Open Range Construction, High
+          operating departments, including Open Range Construction, Ltd., High
           Performance Structures, Nu-Tech, and Design. This policy explains how
           Compass handles information when staff, owners, subcontractors,
           suppliers, and invited project participants use the service.

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -23,7 +23,7 @@ export default function TermsPage(): React.ReactElement {
           These terms govern authorized use of Compass, a construction
           project-management service operated by High Performance Structures
           Inc. dba Open Range Construction, Ltd. for its operating departments,
-          including Open Range Construction, High Performance Structures,
+          including Open Range Construction, Ltd., High Performance Structures,
           Nu-Tech, and Design.
         </p>
 

--- a/src/components/org-switcher.tsx
+++ b/src/components/org-switcher.tsx
@@ -45,6 +45,7 @@ function sidebarCompanyName(activeOrgName: string | null): string {
   if (
     activeOrgName === null ||
     activeOrgName === "Open Range Construction" ||
+    activeOrgName === "Open Range Construction, Ltd." ||
     activeOrgName.startsWith("High Performance Structures")
   ) {
     return COMPASS_COMPANY_NAME

--- a/src/components/projects/project-estimate-workspace.tsx
+++ b/src/components/projects/project-estimate-workspace.tsx
@@ -957,7 +957,9 @@ export function ProjectEstimateWorkspacePanel({
             </div>
             <div className="grid gap-3 sm:grid-cols-[1fr_1.4fr_.55fr]">
               <div className="space-y-1.5">
-                <Label htmlFor="companySignerTitle">Title</Label>
+                <Label htmlFor="companySignerTitle">
+                  Title<SignatureRequiredMark />
+                </Label>
                 <Input
                   id="companySignerTitle"
                   value={companySigner.title}

--- a/src/components/projects/project-video-upload.tsx
+++ b/src/components/projects/project-video-upload.tsx
@@ -19,7 +19,10 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
-import { projectDepartment } from "@/lib/project-branding"
+import {
+  projectDepartment,
+  projectDepartmentDisplayName,
+} from "@/lib/project-branding"
 import { youtubeChannelForDepartment } from "@/lib/videos/channel-routing"
 import {
   isProjectVideoFile,
@@ -57,9 +60,9 @@ function titleFromFileName(fileName: string): string {
 }
 
 function channelLabel(channelKey: string): string {
-  if (channelKey === "hps") return "High Performance Structures"
-  if (channelKey === "nutech") return "Nu-Tech Systems"
-  return "Open Range Construction, Ltd."
+  if (channelKey === "hps") return projectDepartmentDisplayName("H")
+  if (channelKey === "nutech") return projectDepartmentDisplayName("N")
+  return projectDepartmentDisplayName("O")
 }
 
 function uploadToGoogleDrive(input: {

--- a/src/components/projects/project-video-upload.tsx
+++ b/src/components/projects/project-video-upload.tsx
@@ -59,7 +59,7 @@ function titleFromFileName(fileName: string): string {
 function channelLabel(channelKey: string): string {
   if (channelKey === "hps") return "High Performance Structures"
   if (channelKey === "nutech") return "Nu-Tech Systems"
-  return "Open Range Construction"
+  return "Open Range Construction, Ltd."
 }
 
 function uploadToGoogleDrive(input: {

--- a/src/components/projects/projects-hub.tsx
+++ b/src/components/projects/projects-hub.tsx
@@ -61,6 +61,7 @@ import {
   SAGE_CLIENT_STATUS_OPTIONS,
   SAGE_JOB_TYPE_OPTIONS,
 } from "@/lib/sage/client-project-write"
+import { projectDepartmentDisplayName } from "@/lib/project-branding"
 
 type DepartmentId = "O" | "H" | "N" | "D" | "UNASSIGNED"
 type ProjectStatusBucket = ProjectJobStatusBucket
@@ -104,7 +105,7 @@ const DEPARTMENTS: readonly DepartmentConfig[] = [
     id: "O",
     label: "ORC Projects",
     shortLabel: "ORC",
-    description: "Open Range Construction, Ltd. jobs and owner-facing builds.",
+    description: `${projectDepartmentDisplayName("O")} jobs and owner-facing builds.`,
     accentClassName: "border-brand-orc-brown bg-brand-orc-brown text-white",
     logoSrc: "/department-logos/orc-mark.png",
     icon: <IconHome className="size-4" />,
@@ -1278,7 +1279,7 @@ export function ProjectsHub({
               </div>
             </div>
             <p className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground">
-              Open Range Construction, Ltd.; HPS; Nu-Tech; and Design projects stay visible from
+              {projectDepartmentDisplayName("O")}; HPS; Nu-Tech; and Design projects stay visible from
               one place, with search still cutting directly to the project when
               you already know the number, address, or client.
             </p>

--- a/src/components/projects/projects-hub.tsx
+++ b/src/components/projects/projects-hub.tsx
@@ -104,7 +104,7 @@ const DEPARTMENTS: readonly DepartmentConfig[] = [
     id: "O",
     label: "ORC Projects",
     shortLabel: "ORC",
-    description: "Open Range Construction jobs and owner-facing builds.",
+    description: "Open Range Construction, Ltd. jobs and owner-facing builds.",
     accentClassName: "border-brand-orc-brown bg-brand-orc-brown text-white",
     logoSrc: "/department-logos/orc-mark.png",
     icon: <IconHome className="size-4" />,
@@ -1278,7 +1278,7 @@ export function ProjectsHub({
               </div>
             </div>
             <p className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground">
-              Open Range, HPS, Nu-Tech, and Design projects stay visible from
+              Open Range Construction, Ltd.; HPS; Nu-Tech; and Design projects stay visible from
               one place, with search still cutting directly to the project when
               you already know the number, address, or client.
             </p>

--- a/src/lib/__tests__/project-branding.test.ts
+++ b/src/lib/__tests__/project-branding.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "vitest"
 import { statSync } from "node:fs"
 import { join } from "node:path"
 
-import { projectBrandFor, projectDepartment } from "@/lib/project-branding"
+import {
+  projectBrandFor,
+  projectDepartment,
+  projectDepartmentDisplayName,
+  projectLegalEntityName,
+} from "@/lib/project-branding"
 
 describe("project branding", () => {
   it.each([
@@ -103,5 +108,17 @@ describe("project branding", () => {
       department: "H",
       companyName: "High Performance Structures, Inc.",
     })
+  })
+
+  it("keeps O document and department branding on the canonical names", () => {
+    expect(projectDepartmentDisplayName("O")).toBe(
+      "Open Range Construction, Ltd."
+    )
+    expect(projectBrandFor({ projectNumber: "O-202-595" }).companyName).toBe(
+      projectDepartmentDisplayName("O")
+    )
+    expect(projectLegalEntityName("O")).toBe(
+      "High Performance Structures Inc. dba Open Range Construction, Ltd."
+    )
   })
 })

--- a/src/lib/__tests__/project-branding.test.ts
+++ b/src/lib/__tests__/project-branding.test.ts
@@ -81,8 +81,8 @@ describe("project branding", () => {
   })
 
   it.each([
-    ["O-202-595", "Open Range Construction", "/department-logos/orc-mark.png"],
-    ["D-18-00", "Open Range Construction", "/department-logos/orc-mark.png"],
+    ["O-202-595", "Open Range Construction, Ltd.", "/department-logos/orc-mark.png"],
+    ["D-18-00", "Open Range Construction, Ltd.", "/department-logos/orc-mark.png"],
     ["H-OFFICE", "High Performance Structures, Inc.", "/department-logos/hps-h-green.svg"],
     ["N-830-8220", "Nu-Tech Systems", "/department-logos/nu-tech-n.png"],
   ])(

--- a/src/lib/contracts/__tests__/packet-pdf.test.ts
+++ b/src/lib/contracts/__tests__/packet-pdf.test.ts
@@ -80,5 +80,13 @@ describe("contract packet PDF", () => {
     expect(prepared.fields.filter((field) => field.type === "initial")).toHaveLength(4)
     expect(prepared.fields.filter((field) => field.type === "signature")).toHaveLength(2)
     expect(prepared.fields.filter((field) => field.type === "date")).toHaveLength(2)
+    expect(
+      prepared.fields.find(
+        (field) => field.type === "signature" && field.party === 2
+      )
+    ).toMatchObject({ x: 339, width: 233 })
+    expect(
+      prepared.fields.find((field) => field.type === "date" && field.party === 2)
+    ).toMatchObject({ x: 321, width: 251, y: 205 })
   })
 })

--- a/src/lib/contracts/packet-pdf.ts
+++ b/src/lib/contracts/packet-pdf.ts
@@ -373,16 +373,24 @@ async function appendPacketSignaturePage(input: {
       ],
     }
   )
-  const signers = [
+  type PacketSignatureSigner = {
+    readonly label: string
+    readonly name: string
+    readonly title: string
+    readonly corporate: boolean
+  }
+  const signers: readonly PacketSignatureSigner[] = [
     ...input.packet.clientSigners.map((signer, index) => ({
       label: `Owner ${index + 1}`,
       name: signer.name,
       title: signer.title,
+      corporate: false,
     })),
     {
-      label: "Company representative",
+      label: input.packet.legalEntityName,
       name: input.packet.companySignerName ?? "",
       title: input.packet.companySignerTitle ?? "",
+      corporate: true,
     },
   ]
   const margin = 40
@@ -395,6 +403,18 @@ async function appendPacketSignaturePage(input: {
     // These rows deliberately match prepareEstimateSignaturePdf's fixed Foxit
     // signature/date coordinates, with labels just above each editable field.
     const topY = PAGE_HEIGHT - 102 - row * 126
+    if (signer.corporate) {
+      const legalNameWidth = bold.widthOfTextAtSize(signer.label, 8)
+      const legalNameSize = Math.max(5.5, Math.min(8, (width / legalNameWidth) * 8))
+      page.drawText(signer.label, { x, y: topY, size: legalNameSize, font: bold })
+      page.drawText("By:", { x, y: topY - 30, size: 7, font: bold })
+      page.drawLine({ start: { x: x + 18, y: topY - 59 }, end: { x: x + width, y: topY - 59 }, thickness: 0.6 })
+      page.drawText(`Name: ${signer.name}`, { x, y: topY - 71, size: 7, font: regular })
+      page.drawText(`Title: ${signer.title}`, { x, y: topY - 82, size: 7, font: regular })
+      page.drawLine({ start: { x, y: topY - 125 }, end: { x: x + width, y: topY - 125 }, thickness: 0.6 })
+      page.drawText("Date signed", { x, y: topY - 137, size: 7, font: regular })
+      continue
+    }
     page.drawText(`${signer.label}: ${signer.name}`, { x, y: topY, size: 8, font: bold })
     if (signer.title) page.drawText(signer.title, { x, y: topY - 12, size: 7, font: regular })
     page.drawText("Signature", { x, y: topY - 55, size: 7, font: regular })
@@ -438,6 +458,8 @@ export async function prepareContractPacketPdf(input: {
       ...input.packet.clientSigners.map((_, index) => `Owner ${index + 1}`),
       "Company",
     ],
+    corporateSignerIndex: input.packet.clientSigners.length,
+    corporateDateFieldTop: 205,
   })
 }
 

--- a/src/lib/estimates/__tests__/signature-pdf.test.ts
+++ b/src/lib/estimates/__tests__/signature-pdf.test.ts
@@ -16,6 +16,7 @@ describe("estimate signature PDFs", () => {
     const prepared = await prepareEstimateSignaturePdf({
       pdf: copy.buffer,
       signerLabels: ["Client 1", "Client 2", "Company"],
+      corporateSignerIndex: 2,
     })
 
     expect(prepared.pdfBase64.length).toBeGreaterThan(0)
@@ -61,5 +62,17 @@ describe("estimate signature PDFs", () => {
             field.dateFormat === "MM-DD-YYYY"
         )
     ).toBe(true)
+    const clientSignature = prepared.fields.find(
+      (field) => field.type === "signature" && field.party === 1
+    )
+    const companySignature = prepared.fields.find(
+      (field) => field.type === "signature" && field.party === 3
+    )
+    const companyDate = prepared.fields.find(
+      (field) => field.type === "date" && field.party === 3
+    )
+    expect(clientSignature).toMatchObject({ x: 40, width: 251 })
+    expect(companySignature).toMatchObject({ x: 58, width: 233, y: 236, height: 27 })
+    expect(companyDate).toMatchObject({ x: 40, width: 251, y: 304 })
   })
 })

--- a/src/lib/estimates/signature-pdf.ts
+++ b/src/lib/estimates/signature-pdf.ts
@@ -20,6 +20,8 @@ export type PreparedEstimateSignaturePdf = {
 export async function prepareEstimateSignaturePdf(input: {
   readonly pdf: ArrayBuffer
   readonly signerLabels: readonly string[]
+  readonly corporateSignerIndex?: number
+  readonly corporateDateFieldTop?: number
 }): Promise<PreparedEstimateSignaturePdf> {
   const document = await PDFDocument.load(input.pdf)
   const pages = document.getPages()
@@ -132,10 +134,22 @@ export async function prepareEstimateSignaturePdf(input: {
   input.signerLabels.forEach((signerLabel, signerIndex) => {
     const row = Math.floor(signerIndex / 2)
     const column = signerIndex % 2
-    const x =
+    const columnX =
       signatureMargin + column * (signatureColumnWidth + signatureColumnGap)
-    const signatureY = signatureFieldTop + row * signatureRowStride
-    const dateY = dateFieldTop + row * signatureRowStride
+    const isCorporateSigner = signerIndex === input.corporateSignerIndex
+    // Keep the corporate "By:" prefix visible beside the Foxit signature field.
+    const signaturePrefixWidth = isCorporateSigner ? 18 : 0
+    const signatureX = columnX + signaturePrefixWidth
+    const signatureWidth = signatureColumnWidth - signaturePrefixWidth
+    const signatureY =
+      (isCorporateSigner ? signatureFieldTop + 5 : signatureFieldTop) +
+      row * signatureRowStride
+    const signatureHeight = isCorporateSigner ? 27 : signatureFieldHeight
+    const dateY =
+      (isCorporateSigner
+        ? input.corporateDateFieldTop ?? dateFieldTop
+        : dateFieldTop) +
+      row * signatureRowStride
     if (
       dateY + dateFieldHeight >
       signaturePage.getHeight() - signaturePageBottomReserve
@@ -149,10 +163,10 @@ export async function prepareEstimateSignaturePdf(input: {
     fields.push(
       {
         type: "signature",
-        x,
+        x: signatureX,
         y: signatureY,
-        width: signatureColumnWidth,
-        height: signatureFieldHeight,
+        width: signatureWidth,
+        height: signatureHeight,
         documentNumber: 1,
         pageNumber: totalPages,
         tabOrder: tabOrder + 1,
@@ -164,7 +178,7 @@ export async function prepareEstimateSignaturePdf(input: {
       },
       {
         type: "date",
-        x,
+        x: columnX,
         y: dateY,
         width: signatureColumnWidth,
         height: dateFieldHeight,

--- a/src/lib/project-branding.ts
+++ b/src/lib/project-branding.ts
@@ -110,3 +110,14 @@ export function projectLegalEntityName(
 ): string {
   return PROJECT_LEGAL_ENTITY_NAMES[department]
 }
+
+// Department displays and project documents must resolve names here so the
+// operating brand and contracting entity cannot drift between surfaces.
+export function projectDepartmentDisplayName(
+  department: ProjectDepartment
+): string {
+  if (department === "H") return "High Performance Structures"
+  if (department === "N") return NUTECH_BRAND.companyName
+  if (department === "D") return "Design only"
+  return ORC_BRAND.companyName
+}

--- a/src/lib/project-branding.ts
+++ b/src/lib/project-branding.ts
@@ -21,9 +21,9 @@ const PROJECT_LEGAL_ENTITY_NAMES: Readonly<Record<ProjectDepartment, string>> = 
 type BrandIdentity = Omit<ProjectBrand, "contactLines" | "department">
 
 const ORC_BRAND: BrandIdentity = {
-  companyName: "Open Range Construction",
+  companyName: "Open Range Construction, Ltd.",
   email: "accounting@openrangeconstruction.com",
-  logoAlt: "Open Range Construction",
+  logoAlt: "Open Range Construction, Ltd.",
   logoSrc: "/department-logos/orc-mark.png",
   mailingAddress: ["PO Box 9046", "Woodland Park, CO 80866"],
   telephone: "719.630.8767",


### PR DESCRIPTION
## Summary

- correct O-department displays to `Open Range Construction, Ltd.`
- format estimate and contract-packet corporate signature blocks with the legal entity, `By`, printed name, title, and date
- require the company signer title and preserve Foxit field alignment

## Validation

- `bun run test` — 215 files and 1,133 tests passed
- `bun lint` — 0 errors; existing warnings only
- `bun run build`
- rendered and visually inspected estimate and contract-packet PDFs with Foxit field overlays

External autoreview intentionally skipped per user request.
