### PR TITLE
feat(cherish): add executive review desk

### DIFF
--- a/src/app/actions/cherish-pulse.ts
+++ b/src/app/actions/cherish-pulse.ts
@@ -1,13 +1,14 @@
 "use server"
 
 import { and, desc, eq } from "drizzle-orm"
+import { revalidatePath } from "next/cache"
 
 import { getDb } from "@/db"
 import { cherishPulseResponses } from "@/db/schema"
 import { getCloudflareContext } from "@/lib/db"
 import { requireAuth, type AuthUser } from "@/lib/auth"
 import { requireOrg } from "@/lib/org-scope"
-import { canManageProjectRegistry } from "@/lib/permissions"
+import { canUseExecutiveAdmin, canUseFieldDesk } from "@/lib/permissions"
 import { isInternalStaffRole } from "@/lib/user-roles"
 
 export type CherishValue =
@@ -233,10 +234,10 @@ export async function getCherishPulseReviewQueue(): Promise<
 > {
   try {
     const user = await requireAuth()
-    if (!canManageProjectRegistry(user)) {
+    if (!canUseExecutiveAdmin(user)) {
       return {
         success: false,
-        error: "Only admins can review CHERISH Pulse responses.",
+        error: "Executive Admin access is required to review CHERISH responses.",
       }
     }
 
@@ -359,10 +360,10 @@ export async function getCherishPulseLeadershipStream(): Promise<
 > {
   try {
     const user = await requireAuth()
-    if (!canManageProjectRegistry(user)) {
+    if (!canUseExecutiveAdmin(user)) {
       return {
         success: false,
-        error: "Only admins can view private CHERISH concerns.",
+        error: "Executive Admin access is required to view private CHERISH concerns.",
       }
     }
 
@@ -424,10 +425,10 @@ export async function reviewCherishPulseResponse(
 ): Promise<ActionResult<{ readonly id: string; readonly reviewStatus: CherishPulseReviewStatus }>> {
   try {
     const user = await requireAuth()
-    if (!canManageProjectRegistry(user)) {
+    if (!canUseExecutiveAdmin(user)) {
       return {
         success: false,
-        error: "Only admins can review CHERISH Pulse responses.",
+        error: "Executive Admin access is required to review CHERISH responses.",
       }
     }
 
@@ -488,6 +489,9 @@ export async function reviewCherishPulseResponse(
       )
       .run()
 
+    revalidatePath("/dashboard")
+    revalidatePath("/dashboard/executive-admin/cherish")
+
     return {
       success: true,
       data: {
@@ -507,13 +511,7 @@ export async function reviewCherishPulseResponse(
 }
 
 function canSubmitCherishPulse(user: AuthUser): boolean {
-  return (
-    user.isActive &&
-    (user.role === "admin" ||
-      user.role === "secondary_admin" ||
-      user.role === "office" ||
-      user.role === "field")
-  )
+  return canUseFieldDesk(user)
 }
 
 function canViewCherishPulse(user: AuthUser): boolean {

--- a/src/app/dashboard/executive-admin/cherish/page.tsx
+++ b/src/app/dashboard/executive-admin/cherish/page.tsx
@@ -1,0 +1,40 @@
+import type * as React from "react"
+import { redirect } from "next/navigation"
+import { IconHeartHandshake, IconLock } from "@tabler/icons-react"
+
+import { CherishPulseStream } from "@/components/dashboard/cherish-pulse-stream"
+import { getCurrentUser } from "@/lib/auth"
+import { canUseExecutiveAdmin } from "@/lib/permissions"
+
+export const dynamic = "force-dynamic"
+
+export default async function CherishReviewPage(): Promise<React.ReactElement> {
+  const user = await getCurrentUser()
+  if (!canUseExecutiveAdmin(user)) {
+    redirect("/dashboard/access-restricted?action=review%20CHERISH")
+  }
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col overflow-y-auto px-4 py-6 sm:px-6">
+      <header className="border-b pb-5">
+        <div className="flex items-center gap-2">
+          <IconHeartHandshake className="size-5 text-[var(--department-primary)]" />
+          <h1 className="text-2xl font-semibold tracking-tight">
+            CHERISH review
+          </h1>
+        </div>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
+          Approve shout-outs and project wins for the team stream, acknowledge
+          private concerns, or archive submissions that should not be shared.
+        </p>
+        <p className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground">
+          <IconLock className="size-3.5" /> Executive Admin only
+        </p>
+      </header>
+
+      <section className="py-5" aria-label="CHERISH review queue">
+        <CherishPulseStream canReview refreshKey={0} />
+      </section>
+    </main>
+  )
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -34,6 +34,7 @@ import { DemoBanner } from "@/components/demo/demo-banner"
 import { isDemoUser } from "@/lib/demo"
 import {
   canUseAskCompass,
+  canUseExecutiveAdmin,
   canUseFieldDesk,
   canUseOfficeTalk,
   canManageUserAccess,
@@ -70,6 +71,7 @@ export default async function DashboardLayout({
     : false
   const canUseDirectMessages = canViewActivity
   const canManageFeedback = canManageUserAccess(authUser)
+  const canAccessExecutiveAdmin = canUseExecutiveAdmin(authUser)
   const canUseDeveloperMode = canManageProjectRegistry(authUser)
   const developerModeEnabled = developerModeFromCookie(
     cookieStore.get(DEVELOPER_MODE_COOKIE)?.value,
@@ -117,6 +119,7 @@ export default async function DashboardLayout({
           canUseFieldDesk={canUseCompassFieldDesk}
           canViewActivity={canViewActivity}
           canManageFeedback={canManageFeedback}
+          canUseExecutiveAdmin={canAccessExecutiveAdmin}
         />
         <SidebarInset className="overflow-hidden">
           <DesktopOfflineBanner />

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,7 +11,10 @@ import { getWorkCalendar } from "@/app/actions/work-calendar"
 import { DashboardLaunchpad } from "@/components/dashboard/dashboard-launchpad"
 import type { DashboardOfficeEvent } from "@/components/dashboard/dashboard-launchpad"
 import { getCurrentUser, toSidebarUser } from "@/lib/auth"
-import { canManageProjectRegistry } from "@/lib/permissions"
+import {
+  canManageProjectRegistry,
+  canUseExecutiveAdmin,
+} from "@/lib/permissions"
 
 export default async function Page(): Promise<React.ReactElement> {
   const currentUser = await getCurrentUser()
@@ -78,6 +81,7 @@ export default async function Page(): Promise<React.ReactElement> {
       officeCalendarEvents={officeCalendarEvents}
       officeProjectId={workCalendar?.defaultProjectId ?? null}
       canManageOfficeMaintenance={canManageProjectRegistry(currentUser)}
+      canReviewCherish={canUseExecutiveAdmin(currentUser)}
     />
   )
 }

--- a/src/components/__tests__/app-sidebar-navigation.test.ts
+++ b/src/components/__tests__/app-sidebar-navigation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+
+import { buildMainNavigation } from "@/components/app-sidebar"
+
+function officeNavigation(canUseExecutiveAdmin: boolean) {
+  return buildMainNavigation({
+    activeProjectId: null,
+    canViewActivity: true,
+    canManageFeedback: false,
+    canUseExecutiveAdmin,
+  }).find((item) => item.kind === "group" && item.title === "Office")
+}
+
+describe("Executive Admin sidebar navigation", () => {
+  it("shows the nested CHERISH review link to Executive Admin users", () => {
+    const office = officeNavigation(true)
+    const executiveAdmin = office?.items.find(
+      (item) => item.kind === "subgroup" && item.title === "Executive Admin",
+    )
+
+    expect(executiveAdmin).toMatchObject({
+      kind: "subgroup",
+      title: "Executive Admin",
+      items: [
+        {
+          kind: "link",
+          title: "CHERISH Review",
+          url: "/dashboard/executive-admin/cherish",
+        },
+      ],
+    })
+  })
+
+  it("removes the entire Executive Admin subgroup for everyone else", () => {
+    const office = officeNavigation(false)
+
+    expect(
+      office?.items.some(
+        (item) => item.kind === "subgroup" && item.title === "Executive Admin",
+      ),
+    ).toBe(false)
+  })
+})

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -99,6 +99,7 @@ interface SidebarNavLinkSource {
   readonly projectPath?: string
   readonly internalOnly?: boolean
   readonly adminOnly?: boolean
+  readonly executiveAdminOnly?: boolean
 }
 
 interface SidebarNavSubgroupSource {
@@ -371,6 +372,20 @@ const NAV_GROUPS: ReadonlyArray<SidebarNavGroupSource> = [
         internalOnly: true,
       },
       {
+        kind: "subgroup",
+        title: "Executive Admin",
+        icon: IconShieldCheck,
+        items: [
+          {
+            kind: "link",
+            title: "CHERISH Review",
+            url: "/dashboard/executive-admin/cherish",
+            icon: IconHeartHandshake,
+            executiveAdminOnly: true,
+          },
+        ],
+      },
+      {
         kind: "link",
         title: "Feedback Desk",
         url: "/dashboard/requests/manage",
@@ -385,10 +400,12 @@ function isNavLinkVisible(
   item: SidebarNavLinkSource,
   canViewActivity: boolean,
   canManageFeedback: boolean,
+  canUseExecutiveAdmin: boolean,
 ): boolean {
   return (
     (!item.internalOnly || canViewActivity) &&
-    (!item.adminOnly || canManageFeedback)
+    (!item.adminOnly || canManageFeedback) &&
+    (!item.executiveAdminOnly || canUseExecutiveAdmin)
   )
 }
 
@@ -416,17 +433,26 @@ function buildGroupChildren({
   activeProjectId,
   canViewActivity,
   canManageFeedback,
+  canUseExecutiveAdmin,
 }: {
   readonly items: ReadonlyArray<SidebarNavGroupChildSource>
   readonly activeProjectId: string | null
   readonly canViewActivity: boolean
   readonly canManageFeedback: boolean
+  readonly canUseExecutiveAdmin: boolean
 }): ReadonlyArray<NavGroupChildItem> {
   const children: NavGroupChildItem[] = []
 
   for (const item of items) {
     if (item.kind === "link") {
-      if (isNavLinkVisible(item, canViewActivity, canManageFeedback)) {
+      if (
+        isNavLinkVisible(
+          item,
+          canViewActivity,
+          canManageFeedback,
+          canUseExecutiveAdmin,
+        )
+      ) {
         children.push(resolveNavLink(item, activeProjectId))
       }
       continue
@@ -440,7 +466,14 @@ function buildGroupChildren({
         continue
       }
 
-      if (isNavLinkVisible(child, canViewActivity, canManageFeedback)) {
+      if (
+        isNavLinkVisible(
+          child,
+          canViewActivity,
+          canManageFeedback,
+          canUseExecutiveAdmin,
+        )
+      ) {
         subgroupLinks.push(resolveNavLink(child, activeProjectId))
       }
     }
@@ -458,14 +491,16 @@ function buildGroupChildren({
   return children
 }
 
-function buildMainNavigation({
+export function buildMainNavigation({
   activeProjectId,
   canViewActivity,
   canManageFeedback,
+  canUseExecutiveAdmin,
 }: {
   readonly activeProjectId: string | null
   readonly canViewActivity: boolean
   readonly canManageFeedback: boolean
+  readonly canUseExecutiveAdmin: boolean
 }): ReadonlyArray<NavItem> {
   return NAV_GROUPS.flatMap((group) => {
     const items = buildGroupChildren({
@@ -473,6 +508,7 @@ function buildMainNavigation({
       activeProjectId,
       canViewActivity,
       canManageFeedback,
+      canUseExecutiveAdmin,
     })
 
     return items.length > 0
@@ -485,10 +521,12 @@ function SidebarNav({
   canUseFieldDesk,
   canViewActivity,
   canManageFeedback,
+  canUseExecutiveAdmin,
 }: {
   readonly canUseFieldDesk: boolean
   readonly canViewActivity: boolean
   readonly canManageFeedback: boolean
+  readonly canUseExecutiveAdmin: boolean
 }) {
   const pathname = usePathname()
   const { state } = useSidebar()
@@ -508,6 +546,7 @@ function SidebarNav({
     activeProjectId,
     canViewActivity,
     canManageFeedback,
+    canUseExecutiveAdmin,
   })
   const staffMessageDeskNav: ReadonlyArray<NavLinkItem> = canViewActivity
     ? [
@@ -568,6 +607,7 @@ export function AppSidebar({
   canUseFieldDesk = false,
   canViewActivity = false,
   canManageFeedback = false,
+  canUseExecutiveAdmin = false,
   ...props
 }: React.ComponentProps<typeof Sidebar> & {
   readonly user: SidebarUser | null
@@ -576,6 +616,7 @@ export function AppSidebar({
   readonly canUseFieldDesk?: boolean
   readonly canViewActivity?: boolean
   readonly canManageFeedback?: boolean
+  readonly canUseExecutiveAdmin?: boolean
 }) {
   const { isMobile } = useSidebar()
   const { channelId } = useVoiceState()
@@ -593,6 +634,7 @@ export function AppSidebar({
           canUseFieldDesk={canUseFieldDesk}
           canViewActivity={canViewActivity}
           canManageFeedback={canManageFeedback}
+          canUseExecutiveAdmin={canUseExecutiveAdmin}
         />
       </SidebarContent>
       <SidebarFooter className="border-t border-sidebar-border/60">

--- a/src/components/dashboard/dashboard-launchpad.tsx
+++ b/src/components/dashboard/dashboard-launchpad.tsx
@@ -1306,6 +1306,7 @@ export function DashboardLaunchpad({
   officeCalendarEvents,
   officeProjectId,
   canManageOfficeMaintenance,
+  canReviewCherish,
 }: {
   readonly overview: DashboardOverview
   readonly user: SidebarUser | null
@@ -1314,6 +1315,7 @@ export function DashboardLaunchpad({
   readonly officeCalendarEvents: readonly DashboardOfficeEvent[]
   readonly officeProjectId: string | null
   readonly canManageOfficeMaintenance: boolean
+  readonly canReviewCherish: boolean
 }): React.ReactElement {
   const [mode, setMode] = useState<DashboardMode>("office")
   const [deskStatus, setDeskStatus] = useState<DeskStatus>(() =>
@@ -1370,7 +1372,7 @@ export function DashboardLaunchpad({
           <CherishComposer onSubmitted={handleCherishSubmitted} />
           <TeamPulseDrawer
             overview={overview}
-            canReviewCherish={canManageOfficeMaintenance}
+            canReviewCherish={canReviewCherish}
             cherishRefreshKey={cherishRefreshKey}
             onCherishSubmitted={handleCherishSubmitted}
           />

--- a/src/lib/__tests__/permissions.test.ts
+++ b/src/lib/__tests__/permissions.test.ts
@@ -5,6 +5,7 @@ import {
   canCreateProject,
   canManageWorkCalendarEvents,
   canUseAskCompass,
+  canUseExecutiveAdmin,
   canUseFieldDesk,
   canUseOfficeTalk,
 } from "@/lib/permissions"
@@ -163,6 +164,47 @@ describe("canUseOfficeTalk", () => {
 
   it("keeps the production meeting out of the demo workspace", () => {
     expect(canUseOfficeTalk(DEMO_USER)).toBe(false)
+  })
+})
+
+describe("canUseExecutiveAdmin", () => {
+  it.each([
+    "martine@hps-colorado.com",
+    "martine@openrangeconstruction.com",
+    "dan@hps-colorado.com",
+  ])("allows approved Executive Admin identity %s", (email) => {
+    expect(
+      canUseExecutiveAdmin({
+        ...userWithRole("office"),
+        email,
+      }),
+    ).toBe(true)
+  })
+
+  it("does not trust an administrator-editable Google email override", () => {
+    expect(
+      canUseExecutiveAdmin({
+        ...userWithRole("admin"),
+        googleEmail: "martine@hps-colorado.com",
+      }),
+    ).toBe(false)
+  })
+
+  it("does not grant access from a broad admin role", () => {
+    expect(canUseExecutiveAdmin(userWithRole("admin"))).toBe(false)
+  })
+
+  it("denies approved identities outside the active internal workspace", () => {
+    const martine = {
+      ...userWithRole("admin"),
+      email: "martine@hps-colorado.com",
+    }
+
+    expect(canUseExecutiveAdmin({ ...martine, isActive: false })).toBe(false)
+    expect(
+      canUseExecutiveAdmin({ ...martine, organizationType: "client" }),
+    ).toBe(false)
+    expect(canUseExecutiveAdmin(null)).toBe(false)
   })
 })
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -5,6 +5,12 @@ import {
   isInternalStaffRole,
 } from "@/lib/user-roles"
 
+const EXECUTIVE_ADMIN_EMAILS: readonly string[] = [
+  "dan@hps-colorado.com",
+  "martine@hps-colorado.com",
+  "martine@openrangeconstruction.com",
+]
+
 export type Resource =
   | "project"
   | "schedule"
@@ -524,6 +530,24 @@ export function canUseOfficeTalk(user: AuthUser | null): boolean {
     isInternalStaffRole(user.role) &&
     can(user, "channels", "read")
   )
+}
+
+/**
+ * Executive Admin includes confidential employee feedback, so access is
+ * intentionally tied to the approved people instead of a broad Compass role.
+ */
+export function canUseExecutiveAdmin(user: AuthUser | null): boolean {
+  if (
+    !user ||
+    !user.isActive ||
+    user.organizationType !== "internal" ||
+    isDemoUser(user.id) ||
+    (user.organizationId !== null && isDemoOrg(user.organizationId))
+  ) {
+    return false
+  }
+
+  return EXECUTIVE_ADMIN_EMAILS.includes(user.email.trim().toLowerCase())
 }
 
 /**


### PR DESCRIPTION
## Summary
- add Office > Executive Admin > CHERISH Review navigation
- restrict Executive Admin visibility and server actions to Martine and Dan
- align CHERISH submission authorization with the Field Desk permission
- revalidate the dashboard and review page after approval or archive

## Verification
- 77 focused tests passed
- touched-file ESLint passed
- diff checks passed

## Notes
- full TypeScript verification remains blocked by unrelated existing pdfjs-dist resolution errors in project-contract-packet-preview.tsx
