### PR TITLE
fix(feedback): enforce feature issue-approval invariant

### DIFF
--- a/drizzle/0044_feedback_issue_creation_claim.sql
+++ b/drizzle/0044_feedback_issue_creation_claim.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `feedback_desk_items` ADD `github_issue_creation_claim_token` text;
+--> statement-breakpoint
+ALTER TABLE `feedback_desk_items` ADD `github_issue_creation_claimed_at` text;
+--> statement-breakpoint
+CREATE INDEX `feedback_desk_github_claim_idx` ON `feedback_desk_items` (`organization_id`,`github_issue_url`,`github_issue_creation_claim_token`);

--- a/drizzle/0044_feedback_issue_creation_claim.sql
+++ b/drizzle/0044_feedback_issue_creation_claim.sql
@@ -1,5 +1,0 @@
-ALTER TABLE `feedback_desk_items` ADD `github_issue_creation_claim_token` text;
---> statement-breakpoint
-ALTER TABLE `feedback_desk_items` ADD `github_issue_creation_claimed_at` text;
---> statement-breakpoint
-CREATE INDEX `feedback_desk_github_claim_idx` ON `feedback_desk_items` (`organization_id`,`github_issue_url`,`github_issue_creation_claim_token`);

--- a/drizzle/0132_feedback_issue_creation_claim.sql
+++ b/drizzle/0132_feedback_issue_creation_claim.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `feedback_desk_items` ADD `github_issue_creation_claim_token` text;
+--> statement-breakpoint
+ALTER TABLE `feedback_desk_items` ADD `github_issue_creation_claimed_at` text;
+--> statement-breakpoint
+CREATE INDEX `feedback_desk_github_claim_idx` ON `feedback_desk_items` (`organization_id`,`github_issue_url`,`github_issue_creation_claim_token`);

--- a/drizzle/0133_feedback_issue_claim_lease.sql
+++ b/drizzle/0133_feedback_issue_claim_lease.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `feedback_desk_items` ADD `github_issue_creation_claim_expires_at` text;
+--> statement-breakpoint
+CREATE INDEX `feedback_desk_github_claim_expiry_idx` ON `feedback_desk_items` (`organization_id`,`github_issue_url`,`github_issue_creation_claim_expires_at`);

--- a/drizzle/0134_feedback_issue_provider_attempt.sql
+++ b/drizzle/0134_feedback_issue_provider_attempt.sql
@@ -1,0 +1,4 @@
+ALTER TABLE feedback_desk_items ADD github_issue_creation_provider_attempted_at text;
+
+CREATE INDEX IF NOT EXISTS feedback_desk_github_provider_attempt_idx
+  ON feedback_desk_items (organization_id, github_issue_url, github_issue_creation_provider_attempted_at);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1787622163436,
       "tag": "0132_feedback_issue_creation_claim",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "6",
+      "when": 1787625649287,
+      "tag": "0133_feedback_issue_claim_lease",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1780107300000,
       "tag": "0043_photo_phase_override",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "6",
+      "when": 1787622163436,
+      "tag": "0044_feedback_issue_creation_claim",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1787625649287,
       "tag": "0133_feedback_issue_claim_lease",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "6",
+      "when": 1787628396205,
+      "tag": "0134_feedback_issue_provider_attempt",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -314,7 +314,7 @@
       "idx": 44,
       "version": "6",
       "when": 1787622163436,
-      "tag": "0044_feedback_issue_creation_claim",
+      "tag": "0132_feedback_issue_creation_claim",
       "breakpoints": true
     }
   ]

--- a/src/app/actions/__tests__/feedback-admin.test.ts
+++ b/src/app/actions/__tests__/feedback-admin.test.ts
@@ -82,6 +82,8 @@ describe("setFeedbackGithubIssueCreationApproval concurrency gate", () => {
       kind: "feature",
       githubIssueUrl: null,
       featurePriorityApprovedAt: "2026-08-12T00:00:00.000Z",
+      githubIssueCreationClaimToken: null,
+      updatedAt: "2026-08-12T00:00:00.000Z",
     })
     const updateChain = { set: vi.fn(), where: vi.fn(), returning: vi.fn() }
     updateChain.set.mockReturnValue(updateChain)
@@ -102,7 +104,7 @@ describe("setFeedbackGithubIssueCreationApproval concurrency gate", () => {
 
     expect(result).toEqual({
       success: false,
-      error: "Approve this feature's priority before approving a new GitHub issue",
+      error: "This request changed while its GitHub approval was being updated",
     })
   })
 })

--- a/src/app/actions/__tests__/feedback-admin.test.ts
+++ b/src/app/actions/__tests__/feedback-admin.test.ts
@@ -22,7 +22,10 @@ vi.mock("@/lib/jarvis/feedback-status-update", () => ({
   applyFeedbackLifecycleUpdate: mocks.applyFeedbackLifecycleUpdate,
 }))
 
-import { updateFeedbackAdminItem } from "@/app/actions/feedback-admin"
+import {
+  setFeedbackGithubIssueCreationApproval,
+  updateFeedbackAdminItem,
+} from "@/app/actions/feedback-admin"
 
 const unprovenBug = {
   id: "feedback-1",
@@ -66,5 +69,40 @@ describe("updateFeedbackAdminItem lifecycle evidence", () => {
       error: "A bug must have a complete durable delivery graph before implementation starts",
     })
     expect(mocks.applyFeedbackLifecycleUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe("setFeedbackGithubIssueCreationApproval concurrency gate", () => {
+  it("rejects when priority is revoked before the conditional approval write", async () => {
+    const selectChain = { from: vi.fn(), where: vi.fn(), get: vi.fn() }
+    selectChain.from.mockReturnValue(selectChain)
+    selectChain.where.mockReturnValue(selectChain)
+    selectChain.get.mockResolvedValue({
+      id: "feature-1",
+      kind: "feature",
+      githubIssueUrl: null,
+      featurePriorityApprovedAt: "2026-08-12T00:00:00.000Z",
+    })
+    const updateChain = { set: vi.fn(), where: vi.fn(), returning: vi.fn() }
+    updateChain.set.mockReturnValue(updateChain)
+    updateChain.where.mockReturnValue(updateChain)
+    updateChain.returning.mockResolvedValue([])
+    mocks.getDb.mockReturnValue({
+      select: vi.fn().mockReturnValue(selectChain),
+      update: vi.fn().mockReturnValue(updateChain),
+    })
+    mocks.requireAuth.mockResolvedValue({ id: "admin-1", organizationId: "org-1" })
+    mocks.canManageUserAccess.mockReturnValue(true)
+    mocks.getCloudflareContext.mockResolvedValue({ env: { DB: {} } })
+
+    const result = await setFeedbackGithubIssueCreationApproval({
+      id: "feature-1",
+      approved: true,
+    })
+
+    expect(result).toEqual({
+      success: false,
+      error: "Approve this feature's priority before approving a new GitHub issue",
+    })
   })
 })

--- a/src/app/actions/__tests__/feedback-github-issue-approval-race.test.ts
+++ b/src/app/actions/__tests__/feedback-github-issue-approval-race.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import Database from "better-sqlite3"
+import { drizzle } from "drizzle-orm/d1"
+import { eq } from "drizzle-orm"
+
+import { feedbackDeskItems } from "@/db/schema-jarvis"
+import { linkFeedbackDeskItemToGithub } from "@/lib/jarvis/feedback-github"
+
+const mocks = vi.hoisted(() => ({
+  canManageUserAccess: vi.fn(),
+  getCloudflareContext: vi.fn(),
+  getDb: vi.fn(),
+  requireAuth: vi.fn(),
+  revalidatePath: vi.fn(),
+}))
+
+vi.mock("@/lib/auth", () => ({ requireAuth: mocks.requireAuth }))
+vi.mock("@/lib/db", () => ({ getCloudflareContext: mocks.getCloudflareContext }))
+vi.mock("@/db", () => ({ getDb: mocks.getDb }))
+vi.mock("@/lib/permissions", () => ({ canManageUserAccess: mocks.canManageUserAccess }))
+vi.mock("@/lib/user-roles", () => ({
+  isInternalStaffRole: vi.fn(() => true),
+}))
+vi.mock("@/lib/jarvis/feedback-maintenance", () => ({
+  runFeedbackMaintenance: vi.fn(),
+}))
+vi.mock("@/lib/jarvis/feedback-status-update", () => ({
+  applyFeedbackLifecycleUpdate: vi.fn(),
+}))
+vi.mock("next/cache", () => ({ revalidatePath: mocks.revalidatePath }))
+
+import { setFeedbackGithubIssueCreationApproval } from "@/app/actions/feedback-admin"
+
+type Sqlite = InstanceType<typeof Database>
+
+type PauseAfterWrite = Readonly<{
+  paused: Promise<void>
+  shouldPause: (query: string) => boolean
+  signal: () => void
+}>
+
+function createD1(sqlite: Sqlite, pauseAfterWrite?: PauseAfterWrite): unknown {
+  function statementFor(query: string, values: readonly unknown[] = []): Record<string, unknown> {
+    const statement = sqlite.prepare(query)
+    const maybePause = async (): Promise<void> => {
+      if (!pauseAfterWrite?.shouldPause(query)) return
+      pauseAfterWrite.signal()
+      await pauseAfterWrite.paused
+    }
+    return {
+      bind: (...nextValues: unknown[]): unknown => statementFor(query, nextValues),
+      run: async (): Promise<unknown> => {
+        const info = statement.run(...values)
+        await maybePause()
+        return {
+          success: true,
+          meta: {
+            changes: Number(info.changes),
+            duration: 0,
+            last_row_id: Number(info.lastInsertRowid),
+            rows_read: 0,
+            rows_written: Number(info.changes),
+          },
+        }
+      },
+      all: async (): Promise<unknown> => {
+        const results = statement.all(...values)
+        await maybePause()
+        return { success: true, results }
+      },
+      raw: async (): Promise<unknown> => {
+        const results = statement.raw().all(...values)
+        await maybePause()
+        return results
+      },
+      first: async (): Promise<unknown> => {
+        const results = statement.all(...values)
+        await maybePause()
+        return results[0] ?? null
+      },
+    }
+  }
+
+  return {
+    prepare(query: string): unknown {
+      return statementFor(query)
+    },
+    async batch(statements: readonly { run: () => Promise<unknown> }[]): Promise<readonly unknown[]> {
+      return Promise.all(statements.map((statement) => statement.run()))
+    },
+    async exec(query: string): Promise<Readonly<{ count: number; duration: number }>> {
+      sqlite.exec(query)
+      return { count: 0, duration: 0 }
+    },
+    async dump(): Promise<ArrayBuffer> {
+      return new ArrayBuffer(0)
+    },
+  }
+}
+
+function createSchema(sqlite: Sqlite): void {
+  sqlite.exec(`
+    CREATE TABLE feedback_desk_items (
+      id TEXT PRIMARY KEY NOT NULL,
+      organization_id TEXT,
+      source TEXT NOT NULL,
+      source_id TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'new',
+      priority TEXT NOT NULL DEFAULT 'normal',
+      title TEXT NOT NULL,
+      description TEXT NOT NULL,
+      internal_summary TEXT,
+      reporter_name TEXT,
+      reporter_email TEXT,
+      channel_id TEXT,
+      message_id TEXT,
+      thread_id TEXT,
+      github_issue_url TEXT,
+      github_issue_node_id TEXT,
+      github_issue_creation_approved_at TEXT,
+      github_issue_creation_approved_by TEXT,
+      github_issue_creation_claim_token TEXT,
+      github_issue_creation_claimed_at TEXT,
+      github_issue_creation_claim_expires_at TEXT,
+      github_issue_creation_provider_attempted_at TEXT,
+      feature_priority_approved_at TEXT,
+      feature_priority_approved_by TEXT,
+      github_draft_pull_request_url TEXT,
+      assigned_to_user_id TEXT,
+      assigned_to_name TEXT,
+      sla_target_at TEXT,
+      triaged_at TEXT,
+      resolved_at TEXT,
+      last_requester_update_at TEXT,
+      last_github_sync_at TEXT,
+      privacy_scrubbed_at TEXT,
+      delivery_graph_id TEXT,
+      delivery_graph_status TEXT,
+      delivery_graph_implementation_task_id TEXT,
+      delivery_graph_review_task_id TEXT,
+      delivery_graph_release_task_id TEXT,
+      delivery_graph_last_error TEXT,
+      delivery_graph_updated_at TEXT,
+      metadata TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+  `)
+}
+
+function seedApprovedFeature(sqlite: Sqlite): void {
+  sqlite.prepare(`
+    INSERT INTO feedback_desk_items (
+      id, organization_id, source, source_id, kind, status, priority,
+      title, description, feature_priority_approved_at,
+      github_issue_creation_approved_at, github_issue_creation_approved_by,
+      triaged_at, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "feature-1",
+    "org-1",
+    "feedback-widget",
+    "source-1",
+    "feature",
+    "triaged",
+    "normal",
+    "Redacted feature",
+    "Redacted description",
+    "2026-08-24T17:00:00.000Z",
+    "2026-08-24T18:00:00.000Z",
+    "admin-1",
+    "2026-08-24T17:00:00.000Z",
+    "2026-08-24T17:00:00.000Z",
+    "2026-08-24T17:00:00.000Z",
+  )
+}
+
+function postCount(fetchMock: ReturnType<typeof vi.fn>): number {
+  return fetchMock.mock.calls.filter((call) => {
+    const options = call[1]
+    return typeof call[0] === "string" && call[0].endsWith("/issues") &&
+      typeof options === "object" && options !== null &&
+      Reflect.get(options, "method") === "POST"
+  }).length
+}
+
+describe("GitHub issue approval revocation provider fence", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it("rejects approval removal after the provider marker commits before POST", async () => {
+    let releaseProviderMarker: () => void = () => undefined
+    const providerMarkerPaused = new Promise<void>((resolve) => {
+      releaseProviderMarker = resolve
+    })
+    let signalProviderMarker: () => void = () => undefined
+    const providerMarkerCommitted = new Promise<void>((resolve) => {
+      signalProviderMarker = resolve
+    })
+    let markerSignaled = false
+    const sqlite = new Database(":memory:")
+    createSchema(sqlite)
+    seedApprovedFeature(sqlite)
+    const clientOne = createD1(sqlite, {
+      paused: providerMarkerPaused,
+      shouldPause: (query) =>
+        query.startsWith('update "feedback_desk_items"') &&
+        query.includes("provider_attempted_at"),
+      signal: () => {
+        if (markerSignaled) return
+        markerSignaled = true
+        signalProviderMarker()
+      },
+    })
+    const clientTwo = createD1(sqlite)
+    // @ts-expect-error The SQLite adapter implements the D1 methods exercised here.
+    const actorOne = drizzle(clientOne, { schema: { feedbackDeskItems } })
+    // @ts-expect-error The SQLite adapter implements the D1 methods exercised here.
+    const actorTwo = drizzle(clientTwo, { schema: { feedbackDeskItems } })
+    const item = await actorOne.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    if (!item) throw new Error("seed row missing")
+
+    mocks.requireAuth.mockResolvedValue({ id: "admin-2", organizationId: "org-1" })
+    mocks.canManageUserAccess.mockReturnValue(true)
+    mocks.getCloudflareContext.mockResolvedValue({ env: { DB: clientTwo } })
+    mocks.getDb.mockReturnValue(actorTwo)
+    const fetchMock = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes("/search/issues")) {
+        return { ok: true, json: async () => ({ items: [] }) }
+      }
+      if (init?.method === "POST") {
+        return {
+          ok: true,
+          json: async () => ({
+            html_url: "https://github.com/example/compass/issues/48",
+            node_id: "issue-node-48",
+          }),
+        }
+      }
+      throw new Error(`unexpected fetch ${url}`)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const env = Object.assign(Object.create(null), {
+      GITHUB_TOKEN: "token",
+      GITHUB_REPO: "example/compass",
+    })
+
+    // @ts-expect-error The focused actor contains the schema used by this integration path.
+    const linkPromise = linkFeedbackDeskItemToGithub(actorOne, env, item)
+    await providerMarkerCommitted
+    const revocation = await setFeedbackGithubIssueCreationApproval({
+      id: "feature-1",
+      approved: false,
+    })
+
+    expect(revocation).toEqual({
+      success: false,
+      error: "This request changed while its GitHub approval was being updated",
+    })
+    releaseProviderMarker()
+
+    expect(await linkPromise).toBe("https://github.com/example/compass/issues/48")
+    expect(postCount(fetchMock)).toBe(1)
+    const stored = await actorTwo.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    expect(stored?.githubIssueCreationApprovedAt).toBe("2026-08-24T18:00:00.000Z")
+    expect(stored?.githubIssueUrl).toBe("https://github.com/example/compass/issues/48")
+    sqlite.close()
+  })
+})

--- a/src/app/actions/feedback-admin.ts
+++ b/src/app/actions/feedback-admin.ts
@@ -282,6 +282,14 @@ export async function setFeedbackGithubIssueCreationApproval(
       ...(parsed.approved && item.kind === "feature"
         ? [isNotNull(feedbackDeskItems.featurePriorityApprovedAt)]
         : []),
+      ...(parsed.approved
+        ? []
+        : [
+            // Once the durable provider marker commits, the in-flight worker
+            // owns the external-effect boundary. Approval removal must fail
+            // until that attempt links or recovers, never succeed before POST.
+            isNull(feedbackDeskItems.githubIssueCreationProviderAttemptedAt),
+          ]),
     )).returning({ id: feedbackDeskItems.id })
     if (updatedRows.length === 0) {
       return {

--- a/src/app/actions/feedback-admin.ts
+++ b/src/app/actions/feedback-admin.ts
@@ -317,6 +317,8 @@ export async function setFeedbackFeaturePriorityApproval(
       status: feedbackDeskItems.status,
       featurePriorityApprovedAt: feedbackDeskItems.featurePriorityApprovedAt,
       githubIssueCreationClaimToken: feedbackDeskItems.githubIssueCreationClaimToken,
+      githubIssueCreationProviderAttemptedAt:
+        feedbackDeskItems.githubIssueCreationProviderAttemptedAt,
       updatedAt: feedbackDeskItems.updatedAt,
     }).from(feedbackDeskItems).where(and(
       eq(feedbackDeskItems.id, parsed.id),
@@ -351,7 +353,13 @@ export async function setFeedbackFeaturePriorityApproval(
       approvalFence,
       ...(parsed.approved
         ? []
-        : [notInArray(feedbackDeskItems.status, ["planned", "in_progress", "testing", "deployed"])]),
+        : [
+            notInArray(feedbackDeskItems.status, ["planned", "in_progress", "testing", "deployed"]),
+            // A committed provider marker owns the external-effect boundary. Do
+            // not report revocation success until that attempt has recovered or
+            // linked, otherwise the stale worker could POST after revocation.
+            isNull(feedbackDeskItems.githubIssueCreationProviderAttemptedAt),
+          ]),
     )).returning({ id: feedbackDeskItems.id })
     if (updatedRows.length === 0) {
       return {

--- a/src/app/actions/feedback-admin.ts
+++ b/src/app/actions/feedback-admin.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { and, desc, eq, isNotNull } from "drizzle-orm"
+import { and, desc, eq, isNotNull, isNull, notInArray } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { z } from "zod/v4"
 
@@ -246,6 +246,8 @@ export async function setFeedbackGithubIssueCreationApproval(
       kind: feedbackDeskItems.kind,
       githubIssueUrl: feedbackDeskItems.githubIssueUrl,
       featurePriorityApprovedAt: feedbackDeskItems.featurePriorityApprovedAt,
+      githubIssueCreationClaimToken: feedbackDeskItems.githubIssueCreationClaimToken,
+      updatedAt: feedbackDeskItems.updatedAt,
     }).from(feedbackDeskItems).where(and(
       eq(feedbackDeskItems.id, parsed.id),
       eq(feedbackDeskItems.organizationId, admin.organizationId),
@@ -265,26 +267,27 @@ export async function setFeedbackGithubIssueCreationApproval(
       }
     }
     const now = new Date().toISOString()
-    // Re-check priority in the write predicate so revocation cannot race this read.
-    const approvalWhere = parsed.approved && item.kind === "feature"
-      ? and(
-          eq(feedbackDeskItems.id, item.id),
-          eq(feedbackDeskItems.organizationId, admin.organizationId),
-          isNotNull(feedbackDeskItems.featurePriorityApprovedAt),
-        )
-      : and(
-          eq(feedbackDeskItems.id, item.id),
-          eq(feedbackDeskItems.organizationId, admin.organizationId),
-        )
+    const priorityFence = item.featurePriorityApprovedAt === null
+      ? isNull(feedbackDeskItems.featurePriorityApprovedAt)
+      : eq(feedbackDeskItems.featurePriorityApprovedAt, item.featurePriorityApprovedAt)
     const updatedRows = await db.update(feedbackDeskItems).set({
       githubIssueCreationApprovedAt: parsed.approved ? now : null,
       githubIssueCreationApprovedBy: parsed.approved ? admin.id : null,
       updatedAt: now,
-    }).where(approvalWhere).returning({ id: feedbackDeskItems.id })
-    if (parsed.approved && item.kind === "feature" && updatedRows.length === 0) {
+    }).where(and(
+      eq(feedbackDeskItems.id, item.id),
+      eq(feedbackDeskItems.organizationId, admin.organizationId),
+      eq(feedbackDeskItems.updatedAt, item.updatedAt),
+      priorityFence,
+      isNull(feedbackDeskItems.githubIssueCreationClaimToken),
+      ...(parsed.approved && item.kind === "feature"
+        ? [isNotNull(feedbackDeskItems.featurePriorityApprovedAt)]
+        : []),
+    )).returning({ id: feedbackDeskItems.id })
+    if (updatedRows.length === 0) {
       return {
         success: false,
-        error: "Approve this feature's priority before approving a new GitHub issue",
+        error: "This request changed while its GitHub approval was being updated",
       }
     }
     revalidatePath("/dashboard/requests")
@@ -313,6 +316,9 @@ export async function setFeedbackFeaturePriorityApproval(
       id: feedbackDeskItems.id,
       kind: feedbackDeskItems.kind,
       status: feedbackDeskItems.status,
+      featurePriorityApprovedAt: feedbackDeskItems.featurePriorityApprovedAt,
+      githubIssueCreationClaimToken: feedbackDeskItems.githubIssueCreationClaimToken,
+      updatedAt: feedbackDeskItems.updatedAt,
     }).from(feedbackDeskItems).where(and(
       eq(feedbackDeskItems.id, parsed.id),
       eq(feedbackDeskItems.organizationId, admin.organizationId),
@@ -328,7 +334,10 @@ export async function setFeedbackFeaturePriorityApproval(
       }
     }
     const now = new Date().toISOString()
-    await db.update(feedbackDeskItems).set({
+    const approvalFence = item.featurePriorityApprovedAt === null
+      ? isNull(feedbackDeskItems.featurePriorityApprovedAt)
+      : eq(feedbackDeskItems.featurePriorityApprovedAt, item.featurePriorityApprovedAt)
+    const updatedRows = await db.update(feedbackDeskItems).set({
       featurePriorityApprovedAt: parsed.approved ? now : null,
       featurePriorityApprovedBy: parsed.approved ? admin.id : null,
       ...(parsed.approved ? {} : {
@@ -339,7 +348,21 @@ export async function setFeedbackFeaturePriorityApproval(
     }).where(and(
       eq(feedbackDeskItems.id, item.id),
       eq(feedbackDeskItems.organizationId, admin.organizationId),
-    ))
+      eq(feedbackDeskItems.updatedAt, item.updatedAt),
+      approvalFence,
+      isNull(feedbackDeskItems.githubIssueCreationClaimToken),
+      ...(parsed.approved
+        ? []
+        : [notInArray(feedbackDeskItems.status, ["planned", "in_progress", "testing", "deployed"])]),
+    )).returning({ id: feedbackDeskItems.id })
+    if (updatedRows.length === 0) {
+      return {
+        success: false,
+        error: parsed.approved
+          ? "This request changed while its priority decision was being saved"
+          : "A feature already in implementation cannot have its priority approval removed",
+      }
+    }
     revalidatePath("/dashboard/requests")
     revalidatePath("/dashboard/requests/manage")
     return { success: true }

--- a/src/app/actions/feedback-admin.ts
+++ b/src/app/actions/feedback-admin.ts
@@ -279,7 +279,6 @@ export async function setFeedbackGithubIssueCreationApproval(
       eq(feedbackDeskItems.organizationId, admin.organizationId),
       eq(feedbackDeskItems.updatedAt, item.updatedAt),
       priorityFence,
-      isNull(feedbackDeskItems.githubIssueCreationClaimToken),
       ...(parsed.approved && item.kind === "feature"
         ? [isNotNull(feedbackDeskItems.featurePriorityApprovedAt)]
         : []),
@@ -350,7 +349,6 @@ export async function setFeedbackFeaturePriorityApproval(
       eq(feedbackDeskItems.organizationId, admin.organizationId),
       eq(feedbackDeskItems.updatedAt, item.updatedAt),
       approvalFence,
-      isNull(feedbackDeskItems.githubIssueCreationClaimToken),
       ...(parsed.approved
         ? []
         : [notInArray(feedbackDeskItems.status, ["planned", "in_progress", "testing", "deployed"])]),

--- a/src/app/actions/feedback-admin.ts
+++ b/src/app/actions/feedback-admin.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { and, desc, eq } from "drizzle-orm"
+import { and, desc, eq, isNotNull } from "drizzle-orm"
 import { revalidatePath } from "next/cache"
 import { z } from "zod/v4"
 
@@ -265,14 +265,28 @@ export async function setFeedbackGithubIssueCreationApproval(
       }
     }
     const now = new Date().toISOString()
-    await db.update(feedbackDeskItems).set({
+    // Re-check priority in the write predicate so revocation cannot race this read.
+    const approvalWhere = parsed.approved && item.kind === "feature"
+      ? and(
+          eq(feedbackDeskItems.id, item.id),
+          eq(feedbackDeskItems.organizationId, admin.organizationId),
+          isNotNull(feedbackDeskItems.featurePriorityApprovedAt),
+        )
+      : and(
+          eq(feedbackDeskItems.id, item.id),
+          eq(feedbackDeskItems.organizationId, admin.organizationId),
+        )
+    const updatedRows = await db.update(feedbackDeskItems).set({
       githubIssueCreationApprovedAt: parsed.approved ? now : null,
       githubIssueCreationApprovedBy: parsed.approved ? admin.id : null,
       updatedAt: now,
-    }).where(and(
-      eq(feedbackDeskItems.id, item.id),
-      eq(feedbackDeskItems.organizationId, admin.organizationId),
-    ))
+    }).where(approvalWhere).returning({ id: feedbackDeskItems.id })
+    if (parsed.approved && item.kind === "feature" && updatedRows.length === 0) {
+      return {
+        success: false,
+        error: "Approve this feature's priority before approving a new GitHub issue",
+      }
+    }
     revalidatePath("/dashboard/requests")
     revalidatePath("/dashboard/requests/manage")
     return { success: true }

--- a/src/db/schema-jarvis.ts
+++ b/src/db/schema-jarvis.ts
@@ -30,6 +30,7 @@ export const feedbackDeskItems = sqliteTable(
     githubIssueCreationApprovedBy: text("github_issue_creation_approved_by"),
     githubIssueCreationClaimToken: text("github_issue_creation_claim_token"),
     githubIssueCreationClaimedAt: text("github_issue_creation_claimed_at"),
+    githubIssueCreationClaimExpiresAt: text("github_issue_creation_claim_expires_at"),
     featurePriorityApprovedAt: text("feature_priority_approved_at"),
     featurePriorityApprovedBy: text("feature_priority_approved_by"),
     githubDraftPullRequestUrl: text("github_draft_pull_request_url"),

--- a/src/db/schema-jarvis.ts
+++ b/src/db/schema-jarvis.ts
@@ -31,6 +31,7 @@ export const feedbackDeskItems = sqliteTable(
     githubIssueCreationClaimToken: text("github_issue_creation_claim_token"),
     githubIssueCreationClaimedAt: text("github_issue_creation_claimed_at"),
     githubIssueCreationClaimExpiresAt: text("github_issue_creation_claim_expires_at"),
+    githubIssueCreationProviderAttemptedAt: text("github_issue_creation_provider_attempted_at"),
     featurePriorityApprovedAt: text("feature_priority_approved_at"),
     featurePriorityApprovedBy: text("feature_priority_approved_by"),
     githubDraftPullRequestUrl: text("github_draft_pull_request_url"),

--- a/src/db/schema-jarvis.ts
+++ b/src/db/schema-jarvis.ts
@@ -28,6 +28,8 @@ export const feedbackDeskItems = sqliteTable(
     githubIssueNodeId: text("github_issue_node_id"),
     githubIssueCreationApprovedAt: text("github_issue_creation_approved_at"),
     githubIssueCreationApprovedBy: text("github_issue_creation_approved_by"),
+    githubIssueCreationClaimToken: text("github_issue_creation_claim_token"),
+    githubIssueCreationClaimedAt: text("github_issue_creation_claimed_at"),
     featurePriorityApprovedAt: text("feature_priority_approved_at"),
     featurePriorityApprovedBy: text("feature_priority_approved_by"),
     githubDraftPullRequestUrl: text("github_draft_pull_request_url"),
@@ -69,6 +71,11 @@ export const feedbackDeskItems = sqliteTable(
       table.organizationId,
       table.githubIssueUrl,
       table.githubIssueCreationApprovedAt,
+    ),
+    index("feedback_desk_github_claim_idx").on(
+      table.organizationId,
+      table.githubIssueUrl,
+      table.githubIssueCreationClaimToken,
     ),
   ],
 )

--- a/src/lib/jarvis/__tests__/feedback-approval-races.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-approval-races.test.ts
@@ -11,14 +11,14 @@ type Sqlite = InstanceType<typeof Database>
 
 function createD1(sqlite: Sqlite, pauseAfterRead?: {
   readonly paused: Promise<void>
-  readonly shouldPause: () => boolean
-}, shouldFailWrite?: () => boolean): unknown {
+  readonly shouldPause: (query?: string) => boolean
+}, shouldFailWrite?: (query?: string) => boolean): unknown {
   function statementFor(query: string, values: readonly unknown[] = []): Record<string, unknown> {
     const statement = sqlite.prepare(query)
     const result = {
       bind: (...nextValues: unknown[]): unknown => statementFor(query, nextValues),
       run: async (): Promise<unknown> => {
-        if (shouldFailWrite?.()) throw new Error("simulated crash")
+        if (shouldFailWrite?.(query)) throw new Error("simulated crash")
         const info = statement.run(...values)
         return {
           success: true,
@@ -32,15 +32,15 @@ function createD1(sqlite: Sqlite, pauseAfterRead?: {
         }
       },
       all: async (): Promise<unknown> => {
-        if (shouldFailWrite?.()) throw new Error("simulated crash")
+        if (shouldFailWrite?.(query)) throw new Error("simulated crash")
         const results = statement.all(...values)
-        if (pauseAfterRead?.shouldPause()) await pauseAfterRead.paused
+        if (pauseAfterRead?.shouldPause(query)) await pauseAfterRead.paused
         return { success: true, results }
       },
       raw: async (): Promise<unknown> => {
-        if (shouldFailWrite?.()) throw new Error("simulated crash")
+        if (shouldFailWrite?.(query)) throw new Error("simulated crash")
         const results = statement.raw().all(...values)
-        if (pauseAfterRead?.shouldPause()) await pauseAfterRead.paused
+        if (pauseAfterRead?.shouldPause(query)) await pauseAfterRead.paused
         return results
       },
       first: async (): Promise<unknown> => {
@@ -93,6 +93,7 @@ function createSchema(sqlite: Sqlite): void {
       github_issue_creation_claim_token TEXT,
       github_issue_creation_claimed_at TEXT,
       github_issue_creation_claim_expires_at TEXT,
+      github_issue_creation_provider_attempted_at TEXT,
       feature_priority_approved_at TEXT,
       feature_priority_approved_by TEXT,
       github_draft_pull_request_url TEXT,
@@ -352,8 +353,7 @@ describe("Feedback Desk real approval race fences", () => {
       GITHUB_REPO: "example/compass",
     })
 
-    await expect(linkFeedbackDeskItemToGithub(actorOne, env, item))
-      .rejects.toThrow()
+    expect(await linkFeedbackDeskItemToGithub(actorOne, env, item)).toBeNull()
     failWrites = false
     await actorTwo.update(feedbackDeskItems).set({
       githubIssueCreationClaimExpiresAt: "2026-08-24T17:01:00.000Z",
@@ -444,6 +444,132 @@ describe("Feedback Desk real approval race fences", () => {
     expect(stored?.githubIssueUrl).toBeNull()
     expect(stored?.featurePriorityApprovedAt).toBeNull()
     expect(stored?.githubIssueCreationClaimToken).toBeNull()
+    sqlite.close()
+  })
+
+  it("fences the provider request start when revocation wins after the approval read", async () => {
+    let releaseApprovalRead: () => void = () => undefined
+    const approvalReadPaused = new Promise<void>((resolve) => {
+      releaseApprovalRead = resolve
+    })
+    let pauseApprovalRead = false
+    const sqlite = new Database(":memory:")
+    createSchema(sqlite)
+    seedFeature(sqlite)
+    const clientOne = createD1(sqlite, {
+      paused: approvalReadPaused,
+      shouldPause: () => pauseApprovalRead,
+    })
+    const clientTwo = createD1(sqlite)
+    // @ts-expect-error The SQLite-backed adapter implements the D1 methods used by this integration test.
+    const actorOne = getDb(clientOne)
+    // @ts-expect-error The SQLite-backed adapter implements the D1 methods used by this integration test.
+    const actorTwo = getDb(clientTwo)
+    const item = await actorOne.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    if (!item) throw new Error("seed row missing")
+    const fetchMock = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes("/search/issues")) {
+        pauseApprovalRead = true
+        return { ok: true, json: async () => ({ items: [] }) }
+      }
+      if (init?.method === "POST") {
+        return {
+          ok: true,
+          json: async () => ({
+            html_url: "https://github.com/example/compass/issues/45",
+            node_id: "issue-node-45",
+          }),
+        }
+      }
+      throw new Error(`unexpected fetch ${url}`)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const env = Object.assign(Object.create(null), {
+      GITHUB_TOKEN: "token",
+      GITHUB_REPO: "example/compass",
+    })
+
+    const linkPromise = linkFeedbackDeskItemToGithub(actorOne, env, item)
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    await actorTwo.update(feedbackDeskItems).set({
+      featurePriorityApprovedAt: null,
+      featurePriorityApprovedBy: null,
+      githubIssueCreationApprovedAt: null,
+      githubIssueCreationApprovedBy: null,
+      updatedAt: "2026-08-24T19:00:00.000Z",
+    }).where(eq(feedbackDeskItems.id, "feature-1")).run()
+    releaseApprovalRead()
+
+    expect(await linkPromise).toBeNull()
+    expect(fetchMock.mock.calls.filter((call) => {
+      const options = call[1]
+      return typeof options === "object" && options !== null &&
+        Reflect.get(options, "method") === "POST"
+    })).toHaveLength(0)
+    sqlite.close()
+  })
+
+  it("preserves post uncertainty instead of clearing the claim for a duplicate retry", async () => {
+    const sqlite = new Database(":memory:")
+    createSchema(sqlite)
+    seedFeature(sqlite)
+    let failLinkWrite = false
+    const clientOne = createD1(
+      sqlite,
+      undefined,
+      (query) => failLinkWrite &&
+        query?.startsWith('update "feedback_desk_items"') === true &&
+        query.includes('set "github_issue_url"') === true,
+    )
+    const clientTwo = createD1(sqlite)
+    // @ts-expect-error The SQLite-backed adapter implements the D1 methods used by this integration test.
+    const actorOne = getDb(clientOne)
+    // @ts-expect-error The SQLite-backed adapter implements the D1 methods used by this integration test.
+    const actorTwo = getDb(clientTwo)
+    const item = await actorOne.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    if (!item) throw new Error("seed row missing")
+    failLinkWrite = true
+    const fetchMock = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes("/search/issues")) {
+        return { ok: true, json: async () => ({ items: [] }) }
+      }
+      if (init?.method === "POST") {
+        return {
+          ok: true,
+          json: async () => ({
+            html_url: "https://github.com/example/compass/issues/46",
+            node_id: "issue-node-46",
+          }),
+        }
+      }
+      throw new Error(`unexpected fetch ${url}`)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const env = Object.assign(Object.create(null), {
+      GITHUB_TOKEN: "token",
+      GITHUB_REPO: "example/compass",
+    })
+
+    expect(await linkFeedbackDeskItemToGithub(actorOne, env, item)).toBeNull()
+    failLinkWrite = false
+    await actorTwo.update(feedbackDeskItems).set({
+      githubIssueCreationClaimExpiresAt: "2026-08-24T17:01:00.000Z",
+    }).where(eq(feedbackDeskItems.id, "feature-1")).run()
+    const retryItem = await actorTwo.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    if (!retryItem) throw new Error("retry row missing")
+
+    expect(await linkFeedbackDeskItemToGithub(actorTwo, env, retryItem)).toBeNull()
+    expect(fetchMock.mock.calls.filter((call) => {
+      const options = call[1]
+      return typeof call[0] === "string" && call[0].endsWith("/issues") &&
+        typeof options === "object" && options !== null &&
+        Reflect.get(options, "method") === "POST"
+    })).toHaveLength(1)
     sqlite.close()
   })
 

--- a/src/lib/jarvis/__tests__/feedback-approval-races.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-approval-races.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import Database from "better-sqlite3"
+
+import { getDb } from "@/db"
+import { feedbackDeskItems, jarvisBridgeEvents } from "@/db/schema-jarvis"
+import { linkFeedbackDeskItemToGithub } from "@/lib/jarvis/feedback-github"
+import { applyFeedbackLifecycleUpdate } from "@/lib/jarvis/feedback-status-update"
+import { eq } from "drizzle-orm"
+
+type Sqlite = InstanceType<typeof Database>
+
+function createD1(sqlite: Sqlite, pauseAfterRead?: {
+  readonly paused: Promise<void>
+  readonly shouldPause: () => boolean
+}): unknown {
+  function statementFor(query: string, values: readonly unknown[] = []): Record<string, unknown> {
+    const statement = sqlite.prepare(query)
+    const result = {
+      bind: (...nextValues: unknown[]): unknown => statementFor(query, nextValues),
+      run: async (): Promise<unknown> => {
+        const info = statement.run(...values)
+        return {
+          success: true,
+          meta: {
+            changes: Number(info.changes),
+            duration: 0,
+            last_row_id: Number(info.lastInsertRowid),
+            rows_read: 0,
+            rows_written: Number(info.changes),
+          },
+        }
+      },
+      all: async (): Promise<unknown> => {
+        const results = statement.all(...values)
+        if (pauseAfterRead?.shouldPause()) await pauseAfterRead.paused
+        return { success: true, results }
+      },
+      raw: async (): Promise<unknown> => {
+        const results = statement.raw().all(...values)
+        if (pauseAfterRead?.shouldPause()) await pauseAfterRead.paused
+        return results
+      },
+      first: async (): Promise<unknown> => {
+        const results = statement.all(...values)
+        return results[0] ?? null
+      },
+    }
+    return result
+  }
+
+  return {
+    prepare(query: string): unknown {
+      return statementFor(query)
+    },
+    async batch(statements: readonly { run: () => Promise<unknown> }[]): Promise<readonly unknown[]> {
+      return Promise.all(statements.map((statement) => statement.run()))
+    },
+    async exec(query: string): Promise<Readonly<{ count: number; duration: number }>> {
+      sqlite.exec(query)
+      return { count: 0, duration: 0 }
+    },
+    async dump(): Promise<ArrayBuffer> {
+      return new ArrayBuffer(0)
+    },
+  }
+}
+
+function createSchema(sqlite: Sqlite): void {
+  sqlite.exec(`
+    CREATE TABLE feedback_desk_items (
+      id TEXT PRIMARY KEY NOT NULL,
+      organization_id TEXT,
+      source TEXT NOT NULL,
+      source_id TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'new',
+      priority TEXT NOT NULL DEFAULT 'normal',
+      title TEXT NOT NULL,
+      description TEXT NOT NULL,
+      internal_summary TEXT,
+      reporter_name TEXT,
+      reporter_email TEXT,
+      channel_id TEXT,
+      message_id TEXT,
+      thread_id TEXT,
+      github_issue_url TEXT,
+      github_issue_node_id TEXT,
+      github_issue_creation_approved_at TEXT,
+      github_issue_creation_approved_by TEXT,
+      github_issue_creation_claim_token TEXT,
+      github_issue_creation_claimed_at TEXT,
+      feature_priority_approved_at TEXT,
+      feature_priority_approved_by TEXT,
+      github_draft_pull_request_url TEXT,
+      assigned_to_user_id TEXT,
+      assigned_to_name TEXT,
+      sla_target_at TEXT,
+      triaged_at TEXT,
+      resolved_at TEXT,
+      last_requester_update_at TEXT,
+      last_github_sync_at TEXT,
+      privacy_scrubbed_at TEXT,
+      delivery_graph_id TEXT,
+      delivery_graph_status TEXT,
+      delivery_graph_implementation_task_id TEXT,
+      delivery_graph_review_task_id TEXT,
+      delivery_graph_release_task_id TEXT,
+      delivery_graph_last_error TEXT,
+      delivery_graph_updated_at TEXT,
+      metadata TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE jarvis_bridge_events (
+      id TEXT PRIMARY KEY NOT NULL,
+      organization_id TEXT,
+      direction TEXT NOT NULL,
+      source TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      idempotency_key TEXT NOT NULL UNIQUE,
+      feedback_desk_item_id TEXT,
+      payload TEXT NOT NULL,
+      result TEXT,
+      attempt_count INTEGER NOT NULL DEFAULT 0,
+      available_at TEXT NOT NULL,
+      claim_token TEXT,
+      claimed_at TEXT,
+      completed_at TEXT,
+      last_error TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+  `)
+}
+
+function seedFeature(sqlite: Sqlite): void {
+  sqlite.prepare(`
+    INSERT INTO feedback_desk_items (
+      id, organization_id, source, source_id, kind, status, priority,
+      title, description, feature_priority_approved_at,
+      github_issue_creation_approved_at, github_issue_creation_approved_by,
+      triaged_at, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "feature-1",
+    null,
+    "feedback-widget",
+    "source-1",
+    "feature",
+    "triaged",
+    "normal",
+    "Redacted feature",
+    "Redacted description",
+    "2026-08-24T17:00:00.000Z",
+    "2026-08-24T18:00:00.000Z",
+    "admin-1",
+    "2026-08-24T17:00:00.000Z",
+    "2026-08-24T17:00:00.000Z",
+    "2026-08-24T17:00:00.000Z",
+  )
+}
+
+describe("Feedback Desk real approval race fences", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("allows only one of two database actors to claim GitHub issue creation", async () => {
+    const sqlite = new Database(":memory:")
+    createSchema(sqlite)
+    seedFeature(sqlite)
+    const client = createD1(sqlite)
+    // @ts-expect-error The SQLite-backed adapter implements the D1 methods used by this integration test.
+    const actorOne = getDb(client)
+    // @ts-expect-error The SQLite-backed adapter implements the D1 methods used by this integration test.
+    const actorTwo = getDb(client)
+    const item = await actorOne.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    if (!item) throw new Error("seed row missing")
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        html_url: "https://github.com/example/compass/issues/42",
+        node_id: "issue-node-42",
+      }),
+    }))
+    const fetchMock = vi.mocked(fetch)
+    const env = Object.assign(Object.create(null), {
+      GITHUB_TOKEN: "token",
+      GITHUB_REPO: "example/compass",
+    })
+
+    const results = await Promise.all([
+      linkFeedbackDeskItemToGithub(actorOne, env, item),
+      linkFeedbackDeskItemToGithub(actorTwo, env, item),
+    ])
+
+    expect(results.filter((value) => value !== null)).toHaveLength(1)
+    expect(fetchMock.mock.calls.filter((call) => {
+      const options = call[1]
+      return typeof call[0] === "string" && call[0].endsWith("/issues") &&
+        typeof options === "object" && options !== null &&
+        Reflect.get(options, "method") === "POST"
+    })).toHaveLength(1)
+    const stored = await actorOne.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    expect(stored?.githubIssueUrl).toBe("https://github.com/example/compass/issues/42")
+    expect(stored?.githubIssueCreationClaimToken).toBeNull()
+    sqlite.close()
+  })
+
+  it("rolls back a lifecycle advancement when another database actor revokes priority", async () => {
+    let releaseRead: () => void = () => undefined
+    const paused = new Promise<void>((resolve) => {
+      releaseRead = resolve
+    })
+    let pauseNextRead = true
+    const sqlite = new Database(":memory:")
+    createSchema(sqlite)
+    seedFeature(sqlite)
+    const clientOne = createD1(sqlite, {
+      paused,
+      shouldPause: () => {
+        if (!pauseNextRead) return false
+        pauseNextRead = false
+        return true
+      },
+    })
+    const clientTwo = createD1(sqlite)
+    // @ts-expect-error The SQLite-backed adapter implements the D1 methods used by this integration test.
+    const actorOne = getDb(clientOne)
+    // @ts-expect-error The SQLite-backed adapter implements the D1 methods used by this integration test.
+    const actorTwo = getDb(clientTwo)
+    const snapshot = await actorTwo.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    if (!snapshot) throw new Error("seed row missing")
+    const lifecycle = applyFeedbackLifecycleUpdate(actorOne, snapshot, {
+      status: "planned",
+      actorSource: "compass-admin",
+      idempotencyKey: "race-lifecycle-1",
+    })
+
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    await actorTwo.update(feedbackDeskItems).set({
+      featurePriorityApprovedAt: null,
+      featurePriorityApprovedBy: null,
+      githubIssueCreationApprovedAt: null,
+      githubIssueCreationApprovedBy: null,
+      updatedAt: "2026-08-24T19:00:00.000Z",
+    }).where(eq(feedbackDeskItems.id, "feature-1")).run()
+    releaseRead()
+
+    await expect(lifecycle).rejects.toThrow(
+      "Feedback request changed before the lifecycle update could be saved",
+    )
+    const stored = await actorTwo.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    expect(stored?.status).toBe("triaged")
+    expect(stored?.featurePriorityApprovedAt).toBeNull()
+    const events = await actorTwo.select().from(jarvisBridgeEvents)
+    expect(events).toHaveLength(0)
+    sqlite.close()
+  })
+})

--- a/src/lib/jarvis/__tests__/feedback-approval-races.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-approval-races.test.ts
@@ -12,12 +12,13 @@ type Sqlite = InstanceType<typeof Database>
 function createD1(sqlite: Sqlite, pauseAfterRead?: {
   readonly paused: Promise<void>
   readonly shouldPause: () => boolean
-}): unknown {
+}, shouldFailWrite?: () => boolean): unknown {
   function statementFor(query: string, values: readonly unknown[] = []): Record<string, unknown> {
     const statement = sqlite.prepare(query)
     const result = {
       bind: (...nextValues: unknown[]): unknown => statementFor(query, nextValues),
       run: async (): Promise<unknown> => {
+        if (shouldFailWrite?.()) throw new Error("simulated crash")
         const info = statement.run(...values)
         return {
           success: true,
@@ -31,11 +32,13 @@ function createD1(sqlite: Sqlite, pauseAfterRead?: {
         }
       },
       all: async (): Promise<unknown> => {
+        if (shouldFailWrite?.()) throw new Error("simulated crash")
         const results = statement.all(...values)
         if (pauseAfterRead?.shouldPause()) await pauseAfterRead.paused
         return { success: true, results }
       },
       raw: async (): Promise<unknown> => {
+        if (shouldFailWrite?.()) throw new Error("simulated crash")
         const results = statement.raw().all(...values)
         if (pauseAfterRead?.shouldPause()) await pauseAfterRead.paused
         return results
@@ -89,6 +92,7 @@ function createSchema(sqlite: Sqlite): void {
       github_issue_creation_approved_by TEXT,
       github_issue_creation_claim_token TEXT,
       github_issue_creation_claimed_at TEXT,
+      github_issue_creation_claim_expires_at TEXT,
       feature_priority_approved_at TEXT,
       feature_priority_approved_by TEXT,
       github_draft_pull_request_url TEXT,
@@ -178,12 +182,17 @@ describe("Feedback Desk real approval race fences", () => {
     const item = await actorOne.select().from(feedbackDeskItems)
       .where(eq(feedbackDeskItems.id, "feature-1")).get()
     if (!item) throw new Error("seed row missing")
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        html_url: "https://github.com/example/compass/issues/42",
-        node_id: "issue-node-42",
-      }),
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input).includes("/search/issues")) {
+        return { ok: true, json: async () => ({ items: [] }) }
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          html_url: "https://github.com/example/compass/issues/42",
+          node_id: "issue-node-42",
+        }),
+      }
     }))
     const fetchMock = vi.mocked(fetch)
     const env = Object.assign(Object.create(null), {
@@ -206,6 +215,234 @@ describe("Feedback Desk real approval race fences", () => {
     const stored = await actorOne.select().from(feedbackDeskItems)
       .where(eq(feedbackDeskItems.id, "feature-1")).get()
     expect(stored?.githubIssueUrl).toBe("https://github.com/example/compass/issues/42")
+    expect(stored?.githubIssueCreationClaimToken).toBeNull()
+    sqlite.close()
+  })
+
+  it("reclaims an expired claim by recovering the provider issue without a duplicate POST", async () => {
+    const sqlite = new Database(":memory:")
+    createSchema(sqlite)
+    seedFeature(sqlite)
+    sqlite.prepare(`
+      UPDATE feedback_desk_items
+      SET github_issue_creation_claim_token = ?,
+          github_issue_creation_claimed_at = ?,
+          github_issue_creation_claim_expires_at = ?
+      WHERE id = ?
+    `).run(
+      "orphaned-claim",
+      "2026-08-24T17:00:00.000Z",
+      "2026-08-24T17:01:00.000Z",
+      "feature-1",
+    )
+    const client = createD1(sqlite)
+    // @ts-expect-error The SQLite-backed adapter implements the D1 methods used by this integration test.
+    const actor = getDb(client)
+    const item = await actor.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    if (!item) throw new Error("seed row missing")
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [{
+          html_url: "https://github.com/example/compass/issues/42",
+          node_id: "issue-node-42",
+          title: "[Compass feedback] feature · CFD-feature-1",
+        }],
+      }),
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const env = Object.assign(Object.create(null), {
+      GITHUB_TOKEN: "token",
+      GITHUB_REPO: "example/compass",
+    })
+
+    const result = await linkFeedbackDeskItemToGithub(actor, env, item)
+
+    expect(result).toBe("https://github.com/example/compass/issues/42")
+    expect(fetchMock.mock.calls.filter((call) => {
+      const options = call[1]
+      return typeof call[0] === "string" && call[0].endsWith("/issues") &&
+        typeof options === "object" && options !== null &&
+        Reflect.get(options, "method") === "POST"
+    })).toHaveLength(0)
+    const stored = await actor.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    expect(stored?.githubIssueUrl).toBe("https://github.com/example/compass/issues/42")
+    expect(stored?.githubIssueCreationClaimToken).toBeNull()
+    sqlite.close()
+  })
+
+  it("fails closed without a provider recovery lookup instead of risking a duplicate POST", async () => {
+    const sqlite = new Database(":memory:")
+    createSchema(sqlite)
+    seedFeature(sqlite)
+    const client = createD1(sqlite)
+    // @ts-expect-error The SQLite-backed adapter implements the D1 methods used by this integration test.
+    const actor = getDb(client)
+    const item = await actor.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    if (!item) throw new Error("seed row missing")
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 503 })
+    vi.stubGlobal("fetch", fetchMock)
+    const env = Object.assign(Object.create(null), {
+      GITHUB_TOKEN: "token",
+      GITHUB_REPO: "example/compass",
+    })
+
+    const result = await linkFeedbackDeskItemToGithub(actor, env, item)
+
+    expect(result).toBeNull()
+    expect(fetchMock.mock.calls).toHaveLength(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toContain("/search/issues")
+    const stored = await actor.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    expect(stored?.githubIssueUrl).toBeNull()
+    expect(stored?.githubIssueCreationClaimToken).toBeNull()
+    sqlite.close()
+  })
+
+  it("recovers a provider issue when the process crashes after POST before linking locally", async () => {
+    const sqlite = new Database(":memory:")
+    createSchema(sqlite)
+    seedFeature(sqlite)
+    let failWrites = false
+    const clientOne = createD1(sqlite, undefined, () => failWrites)
+    const clientTwo = createD1(sqlite)
+    // @ts-expect-error The SQLite-backed adapter implements the D1 methods used by this integration test.
+    const actorOne = getDb(clientOne)
+    // @ts-expect-error The SQLite-backed adapter implements the D1 methods used by this integration test.
+    const actorTwo = getDb(clientTwo)
+    const item = await actorOne.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    if (!item) throw new Error("seed row missing")
+    let providerIssueCreated = false
+    const fetchMock = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes("/search/issues")) {
+        return {
+          ok: true,
+          json: async () => ({
+            items: providerIssueCreated
+              ? [{
+                  html_url: "https://github.com/example/compass/issues/44",
+                  node_id: "issue-node-44",
+                  title: "[Compass feedback] feature · CFD-feature-1",
+                }]
+              : [],
+          }),
+        }
+      }
+      if (init?.method === "POST") {
+        providerIssueCreated = true
+        failWrites = true
+        return {
+          ok: true,
+          json: async () => ({
+            html_url: "https://github.com/example/compass/issues/44",
+            node_id: "issue-node-44",
+          }),
+        }
+      }
+      throw new Error(`unexpected fetch ${url}`)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const env = Object.assign(Object.create(null), {
+      GITHUB_TOKEN: "token",
+      GITHUB_REPO: "example/compass",
+    })
+
+    await expect(linkFeedbackDeskItemToGithub(actorOne, env, item))
+      .rejects.toThrow()
+    failWrites = false
+    await actorTwo.update(feedbackDeskItems).set({
+      githubIssueCreationClaimExpiresAt: "2026-08-24T17:01:00.000Z",
+    }).where(eq(feedbackDeskItems.id, "feature-1")).run()
+    const retryItem = await actorTwo.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    if (!retryItem) throw new Error("retry row missing")
+
+    const result = await linkFeedbackDeskItemToGithub(actorTwo, env, retryItem)
+
+    expect(result).toBe("https://github.com/example/compass/issues/44")
+    expect(fetchMock.mock.calls.filter((call) => {
+      const options = call[1]
+      return typeof call[0] === "string" && call[0].endsWith("/issues") &&
+        typeof options === "object" && options !== null &&
+        Reflect.get(options, "method") === "POST"
+    })).toHaveLength(1)
+    const stored = await actorTwo.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    expect(stored?.githubIssueUrl).toBe("https://github.com/example/compass/issues/44")
+    expect(stored?.githubIssueCreationClaimToken).toBeNull()
+    sqlite.close()
+  })
+
+  it("does not let a claimed issue create or link after priority is revoked by another actor", async () => {
+    let releaseSearch: () => void = () => undefined
+    const searchPaused = new Promise<void>((resolve) => {
+      releaseSearch = resolve
+    })
+    const sqlite = new Database(":memory:")
+    createSchema(sqlite)
+    seedFeature(sqlite)
+    const clientOne = createD1(sqlite)
+    const clientTwo = createD1(sqlite)
+    // @ts-expect-error The SQLite-backed adapter implements the D1 methods used by this integration test.
+    const actorOne = getDb(clientOne)
+    // @ts-expect-error The SQLite-backed adapter implements the D1 methods used by this integration test.
+    const actorTwo = getDb(clientTwo)
+    const item = await actorOne.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    if (!item) throw new Error("seed row missing")
+    const fetchMock = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = init?.method ?? "GET"
+      if (url.includes("/search/issues")) {
+        await searchPaused
+        return {
+          ok: true,
+          json: async () => ({ items: [] }),
+        }
+      }
+      if (method === "POST") {
+        return {
+          ok: true,
+          json: async () => ({
+            html_url: "https://github.com/example/compass/issues/43",
+            node_id: "issue-node-43",
+          }),
+        }
+      }
+      throw new Error(`unexpected fetch ${method} ${url}`)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const env = Object.assign(Object.create(null), {
+      GITHUB_TOKEN: "token",
+      GITHUB_REPO: "example/compass",
+    })
+
+    const linkPromise = linkFeedbackDeskItemToGithub(actorOne, env, item)
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    await actorTwo.update(feedbackDeskItems).set({
+      featurePriorityApprovedAt: null,
+      featurePriorityApprovedBy: null,
+      githubIssueCreationApprovedAt: null,
+      githubIssueCreationApprovedBy: null,
+      updatedAt: "2026-08-24T19:00:00.000Z",
+    }).where(eq(feedbackDeskItems.id, "feature-1")).run()
+    releaseSearch()
+
+    expect(await linkPromise).toBeNull()
+    expect(fetchMock.mock.calls.filter((call) => {
+      const options = call[1]
+      return typeof options === "object" && options !== null &&
+        Reflect.get(options, "method") === "POST"
+    })).toHaveLength(0)
+    const stored = await actorTwo.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    expect(stored?.githubIssueUrl).toBeNull()
+    expect(stored?.featurePriorityApprovedAt).toBeNull()
     expect(stored?.githubIssueCreationClaimToken).toBeNull()
     sqlite.close()
   })

--- a/src/lib/jarvis/__tests__/feedback-approval-races.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-approval-races.test.ts
@@ -5,7 +5,7 @@ import { getDb } from "@/db"
 import { feedbackDeskItems, jarvisBridgeEvents } from "@/db/schema-jarvis"
 import { linkFeedbackDeskItemToGithub } from "@/lib/jarvis/feedback-github"
 import { applyFeedbackLifecycleUpdate } from "@/lib/jarvis/feedback-status-update"
-import { eq } from "drizzle-orm"
+import { and, eq, isNull } from "drizzle-orm"
 
 type Sqlite = InstanceType<typeof Database>
 
@@ -508,6 +508,76 @@ describe("Feedback Desk real approval race fences", () => {
       return typeof options === "object" && options !== null &&
         Reflect.get(options, "method") === "POST"
     })).toHaveLength(0)
+    sqlite.close()
+  })
+
+  it("does not let a successful revocation race past a committed provider marker", async () => {
+    let releaseProviderMarker: () => void = () => undefined
+    const providerMarkerPaused = new Promise<void>((resolve) => {
+      releaseProviderMarker = resolve
+    })
+    const sqlite = new Database(":memory:")
+    createSchema(sqlite)
+    seedFeature(sqlite)
+    const clientOne = createD1(sqlite, {
+      paused: providerMarkerPaused,
+      shouldPause: (query) =>
+        query?.startsWith('update "feedback_desk_items"') === true &&
+        query.includes("provider_attempted_at"),
+    })
+    const clientTwo = createD1(sqlite)
+    // @ts-expect-error The SQLite-backed adapter implements the D1 methods used by this integration test.
+    const actorOne = getDb(clientOne)
+    // @ts-expect-error The SQLite-backed adapter implements the D1 methods used by this integration test.
+    const actorTwo = getDb(clientTwo)
+    const item = await actorOne.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    if (!item) throw new Error("seed row missing")
+    let providerPostCount = 0
+    const fetchMock = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes("/search/issues")) {
+        return { ok: true, json: async () => ({ items: [] }) }
+      }
+      if (init?.method === "POST") {
+        if (url.endsWith("/issues")) providerPostCount += 1
+        return {
+          ok: true,
+          json: async () => ({
+            html_url: "https://github.com/example/compass/issues/47",
+            node_id: "issue-node-47",
+          }),
+        }
+      }
+      throw new Error(`unexpected fetch ${url}`)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const env = Object.assign(Object.create(null), {
+      GITHUB_TOKEN: "token",
+      GITHUB_REPO: "example/compass",
+    })
+
+    const linkPromise = linkFeedbackDeskItemToGithub(actorOne, env, item)
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    const revocationRows = await actorTwo.update(feedbackDeskItems).set({
+      featurePriorityApprovedAt: null,
+      featurePriorityApprovedBy: null,
+      githubIssueCreationApprovedAt: null,
+      githubIssueCreationApprovedBy: null,
+      updatedAt: "2026-08-24T19:00:00.000Z",
+    }).where(and(
+      eq(feedbackDeskItems.id, "feature-1"),
+      isNull(feedbackDeskItems.githubIssueCreationProviderAttemptedAt),
+    )).returning({ id: feedbackDeskItems.id })
+    expect(revocationRows).toHaveLength(0)
+    releaseProviderMarker()
+
+    expect(await linkPromise).toBe("https://github.com/example/compass/issues/47")
+    expect(providerPostCount).toBe(1)
+    const stored = await actorTwo.select().from(feedbackDeskItems)
+      .where(eq(feedbackDeskItems.id, "feature-1")).get()
+    expect(stored?.featurePriorityApprovedAt).toBe("2026-08-24T17:00:00.000Z")
+    expect(stored?.githubIssueUrl).toBe("https://github.com/example/compass/issues/47")
     sqlite.close()
   })
 

--- a/src/lib/jarvis/__tests__/feedback-feature-priority.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-feature-priority.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   feedbackFeatureGithubIssueCreationIsBlocked,
+  feedbackFeatureGithubIssueApprovalIsStale,
   feedbackFeatureTransitionRequiresPriorityApproval,
   feedbackFeatureTransitionIsBlocked,
   isFeatureImplementationStatus,
@@ -74,6 +75,24 @@ describe("Feedback Desk feature priority gate", () => {
     })).toBe(false)
     expect(feedbackFeatureGithubIssueCreationIsBlocked({
       featurePriorityApprovedAt: null,
+      kind: "bug",
+    })).toBe(false)
+  })
+
+  it("identifies a stale feature issue approval after priority revocation", () => {
+    expect(feedbackFeatureGithubIssueApprovalIsStale({
+      featurePriorityApprovedAt: null,
+      githubIssueCreationApprovedAt: "2026-08-12T00:00:00.000Z",
+      kind: "feature",
+    })).toBe(true)
+    expect(feedbackFeatureGithubIssueApprovalIsStale({
+      featurePriorityApprovedAt: "2026-08-12T00:00:00.000Z",
+      githubIssueCreationApprovedAt: "2026-08-12T00:00:00.000Z",
+      kind: "feature",
+    })).toBe(false)
+    expect(feedbackFeatureGithubIssueApprovalIsStale({
+      featurePriorityApprovedAt: null,
+      githubIssueCreationApprovedAt: "2026-08-12T00:00:00.000Z",
       kind: "bug",
     })).toBe(false)
   })

--- a/src/lib/jarvis/__tests__/feedback-github-sync.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-github-sync.test.ts
@@ -37,6 +37,7 @@ const item: FeedbackDeskItem = {
   githubIssueCreationApprovedBy: null,
   githubIssueCreationClaimToken: null,
   githubIssueCreationClaimedAt: null,
+  githubIssueCreationClaimExpiresAt: null,
   featurePriorityApprovedAt: null,
   featurePriorityApprovedBy: null,
   githubDraftPullRequestUrl: null,

--- a/src/lib/jarvis/__tests__/feedback-github-sync.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-github-sync.test.ts
@@ -38,6 +38,7 @@ const item: FeedbackDeskItem = {
   githubIssueCreationClaimToken: null,
   githubIssueCreationClaimedAt: null,
   githubIssueCreationClaimExpiresAt: null,
+  githubIssueCreationProviderAttemptedAt: null,
   featurePriorityApprovedAt: null,
   featurePriorityApprovedBy: null,
   githubDraftPullRequestUrl: null,

--- a/src/lib/jarvis/__tests__/feedback-github-sync.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-github-sync.test.ts
@@ -35,6 +35,8 @@ const item: FeedbackDeskItem = {
   githubIssueNodeId: "issue-node-1",
   githubIssueCreationApprovedAt: null,
   githubIssueCreationApprovedBy: null,
+  githubIssueCreationClaimToken: null,
+  githubIssueCreationClaimedAt: null,
   featurePriorityApprovedAt: null,
   featurePriorityApprovedBy: null,
   githubDraftPullRequestUrl: null,

--- a/src/lib/jarvis/__tests__/feedback-github.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-github.test.ts
@@ -35,6 +35,8 @@ const staleFeature: FeedbackDeskItem = {
   githubIssueNodeId: null,
   githubIssueCreationApprovedAt: "2026-08-12T00:00:00.000Z",
   githubIssueCreationApprovedBy: "admin-1",
+  githubIssueCreationClaimToken: null,
+  githubIssueCreationClaimedAt: null,
   featurePriorityApprovedAt: null,
   featurePriorityApprovedBy: null,
   githubDraftPullRequestUrl: null,
@@ -88,8 +90,18 @@ describe("Feedback Desk GitHub export", () => {
   })
 
   it("fails closed at the GitHub creation primitive for stale feature approval", async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            get: async () => staleFeature,
+          }),
+        }),
+      }),
+    }
     const result = await linkFeedbackDeskItemToGithub(
-      Object.create(null),
+      // @ts-expect-error This unit test only exercises the current-row read.
+      db,
       Object.create(null),
       staleFeature,
     )

--- a/src/lib/jarvis/__tests__/feedback-github.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-github.test.ts
@@ -37,6 +37,7 @@ const staleFeature: FeedbackDeskItem = {
   githubIssueCreationApprovedBy: "admin-1",
   githubIssueCreationClaimToken: null,
   githubIssueCreationClaimedAt: null,
+  githubIssueCreationClaimExpiresAt: null,
   featurePriorityApprovedAt: null,
   featurePriorityApprovedBy: null,
   githubDraftPullRequestUrl: null,

--- a/src/lib/jarvis/__tests__/feedback-github.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-github.test.ts
@@ -1,11 +1,77 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  getJarvisEnvValue: vi.fn(),
+}))
+
+vi.mock("@/lib/jarvis/auth", () => ({
+  getJarvisEnvValue: mocks.getJarvisEnvValue,
+}))
 
 import {
   feedbackReference,
   githubFeedbackIssueContent,
 } from "@/lib/jarvis/feedback-github-content"
+import { linkFeedbackDeskItemToGithub } from "@/lib/jarvis/feedback-github"
+import type { FeedbackDeskItem } from "@/db/schema-jarvis"
+
+const staleFeature: FeedbackDeskItem = {
+  id: "feature-1",
+  organizationId: "org-1",
+  source: "feedback-widget",
+  sourceId: "source-1",
+  kind: "feature",
+  status: "new",
+  priority: "normal",
+  title: "redacted",
+  description: "redacted",
+  internalSummary: null,
+  reporterName: null,
+  reporterEmail: null,
+  channelId: null,
+  messageId: null,
+  threadId: null,
+  githubIssueUrl: null,
+  githubIssueNodeId: null,
+  githubIssueCreationApprovedAt: "2026-08-12T00:00:00.000Z",
+  githubIssueCreationApprovedBy: "admin-1",
+  featurePriorityApprovedAt: null,
+  featurePriorityApprovedBy: null,
+  githubDraftPullRequestUrl: null,
+  assignedToUserId: null,
+  assignedToName: null,
+  slaTargetAt: null,
+  triagedAt: null,
+  resolvedAt: null,
+  lastRequesterUpdateAt: null,
+  lastGithubSyncAt: null,
+  privacyScrubbedAt: null,
+  deliveryGraphId: null,
+  deliveryGraphStatus: null,
+  deliveryGraphImplementationTaskId: null,
+  deliveryGraphReviewTaskId: null,
+  deliveryGraphReleaseTaskId: null,
+  deliveryGraphLastError: null,
+  deliveryGraphUpdatedAt: null,
+  metadata: null,
+  createdAt: "2026-08-12T00:00:00.000Z",
+  updatedAt: "2026-08-12T00:00:00.000Z",
+}
 
 describe("Feedback Desk GitHub export", () => {
+  beforeEach(() => {
+    mocks.getJarvisEnvValue.mockImplementation((_env: unknown, key: string) => {
+      if (key === "GITHUB_TOKEN") return "token"
+      if (key === "GITHUB_REPO") return "example/compass"
+      return null
+    })
+    vi.stubGlobal("fetch", vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it("uses only a kind and opaque reference in a GitHub issue", () => {
     const issue = githubFeedbackIssueContent({
       id: "f43e6e9a-1889-4ce0-9d16-6b6f13d57b58",
@@ -19,5 +85,16 @@ describe("Feedback Desk GitHub export", () => {
     expect(issue.body).not.toContain("telegram")
     expect(issue.body).not.toContain("@example.com")
     expect(issue.labels).toEqual(["bug", "feedback"])
+  })
+
+  it("fails closed at the GitHub creation primitive for stale feature approval", async () => {
+    const result = await linkFeedbackDeskItemToGithub(
+      Object.create(null),
+      Object.create(null),
+      staleFeature,
+    )
+
+    expect(result).toBeNull()
+    expect(fetch).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/jarvis/__tests__/feedback-github.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-github.test.ts
@@ -38,6 +38,7 @@ const staleFeature: FeedbackDeskItem = {
   githubIssueCreationClaimToken: null,
   githubIssueCreationClaimedAt: null,
   githubIssueCreationClaimExpiresAt: null,
+  githubIssueCreationProviderAttemptedAt: null,
   featurePriorityApprovedAt: null,
   featurePriorityApprovedBy: null,
   githubDraftPullRequestUrl: null,

--- a/src/lib/jarvis/__tests__/feedback-maintenance.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-maintenance.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/db", () => ({
+  getDb: vi.fn(),
+}))
+vi.mock("@/db/schema", () => ({
+  feedback: Object.create(null),
+}))
+vi.mock("@/lib/jarvis/feedback-confirmation", () => ({
+  confirmedFeedbackReportFromPayload: vi.fn(),
+  feedbackCandidateFromReport: vi.fn(),
+}))
+vi.mock("@/lib/jarvis/feedback-desk", () => ({
+  enqueueFeedbackDeskItem: vi.fn(),
+}))
+vi.mock("@/lib/jarvis/feedback-github", () => ({
+  linkFeedbackDeskItemToGithub: vi.fn(),
+}))
+vi.mock("@/lib/jarvis/feedback-github-sync", () => ({
+  syncFeedbackDeskItemsFromGithub: vi.fn(),
+}))
+vi.mock("@/lib/jarvis/feedback-delivery", () => ({
+  feedbackDeliveryGraphEvent: vi.fn(),
+}))
+vi.mock("@/lib/jarvis/auth", () => ({
+  getJarvisEnvValue: vi.fn(),
+}))
+
+import { reconcileStaleFeatureGithubIssueApprovals } from "@/lib/jarvis/feedback-maintenance"
+
+describe("Feedback Desk approval reconciliation", () => {
+  it("clears only stale issue approvals through the maintenance write", async () => {
+    const updateChain = {
+      set: vi.fn(),
+      where: vi.fn(),
+      returning: vi.fn(),
+    }
+    updateChain.set.mockReturnValue(updateChain)
+    updateChain.where.mockReturnValue(updateChain)
+    updateChain.returning.mockResolvedValue([{ id: "feature-1" }])
+    const db = Object.assign(Object.create(null), {
+      update: vi.fn().mockReturnValue(updateChain),
+    })
+
+    const result = await reconcileStaleFeatureGithubIssueApprovals(db, "org-1")
+
+    expect(result).toBe(1)
+    expect(updateChain.set).toHaveBeenCalledWith({
+      githubIssueCreationApprovedAt: null,
+      githubIssueCreationApprovedBy: null,
+      updatedAt: expect.any(String),
+    })
+  })
+})

--- a/src/lib/jarvis/__tests__/feedback-maintenance.test.ts
+++ b/src/lib/jarvis/__tests__/feedback-maintenance.test.ts
@@ -26,9 +26,36 @@ vi.mock("@/lib/jarvis/auth", () => ({
   getJarvisEnvValue: vi.fn(),
 }))
 
-import { reconcileStaleFeatureGithubIssueApprovals } from "@/lib/jarvis/feedback-maintenance"
+import {
+  reclaimStaleGithubIssueCreationClaims,
+  reconcileStaleFeatureGithubIssueApprovals,
+} from "@/lib/jarvis/feedback-maintenance"
 
 describe("Feedback Desk approval reconciliation", () => {
+  it("clears expired issue-creation claims for maintenance recovery", async () => {
+    const updateChain = {
+      set: vi.fn(),
+      where: vi.fn(),
+      returning: vi.fn(),
+    }
+    updateChain.set.mockReturnValue(updateChain)
+    updateChain.where.mockReturnValue(updateChain)
+    updateChain.returning.mockResolvedValue([{ id: "feature-1" }])
+    const db = Object.assign(Object.create(null), {
+      update: vi.fn().mockReturnValue(updateChain),
+    })
+
+    const result = await reclaimStaleGithubIssueCreationClaims(db, "org-1")
+
+    expect(result).toBe(1)
+    expect(updateChain.set).toHaveBeenCalledWith({
+      githubIssueCreationClaimToken: null,
+      githubIssueCreationClaimedAt: null,
+      githubIssueCreationClaimExpiresAt: null,
+      updatedAt: expect.any(String),
+    })
+  })
+
   it("clears only stale issue approvals through the maintenance write", async () => {
     const updateChain = {
       set: vi.fn(),

--- a/src/lib/jarvis/feedback-feature-priority.ts
+++ b/src/lib/jarvis/feedback-feature-priority.ts
@@ -34,6 +34,20 @@ export function feedbackFeatureGithubIssueCreationIsBlocked(
   return item.kind === "feature" && item.featurePriorityApprovedAt === null
 }
 
+export function feedbackFeatureGithubIssueApprovalIsStale(
+  item: Readonly<{
+    kind: string
+    featurePriorityApprovedAt: string | null
+    githubIssueCreationApprovedAt: string | null
+  }>,
+): boolean {
+  return (
+    item.kind === "feature" &&
+    item.featurePriorityApprovedAt === null &&
+    item.githubIssueCreationApprovedAt !== null
+  )
+}
+
 export function feedbackFeatureTransitionIsBlocked(
   transition: FeedbackFeaturePriorityTransition & Readonly<{
     featurePriorityApprovedAt: string | null

--- a/src/lib/jarvis/feedback-github.ts
+++ b/src/lib/jarvis/feedback-github.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm"
+import { and, eq, isNull, isNotNull, ne, or } from "drizzle-orm"
 
 import type { getDb } from "@/db"
 import {
@@ -145,10 +145,18 @@ export async function linkFeedbackDeskItemToGithub(
   const config = githubConfig(env)
   if (!config) return null
 
-  if (item.githubIssueUrl) {
-    let nodeId = item.githubIssueNodeId
+  const currentItem = await db.select().from(feedbackDeskItems).where(and(
+    eq(feedbackDeskItems.id, item.id),
+    item.organizationId === null
+      ? isNull(feedbackDeskItems.organizationId)
+      : eq(feedbackDeskItems.organizationId, item.organizationId),
+  )).get()
+  if (!currentItem) return null
+
+  if (currentItem.githubIssueUrl) {
+    let nodeId = currentItem.githubIssueNodeId
     if (!nodeId) {
-      const match = item.githubIssueUrl.match(
+      const match = currentItem.githubIssueUrl.match(
         /^https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)(?:\/|$)/,
       )
       if (match?.[1] === config.repo && match[2]) {
@@ -164,7 +172,12 @@ export async function linkFeedbackDeskItemToGithub(
               await db.update(feedbackDeskItems).set({
                 githubIssueNodeId: nodeId,
                 updatedAt: new Date().toISOString(),
-              }).where(eq(feedbackDeskItems.id, item.id))
+              }).where(and(
+                eq(feedbackDeskItems.id, currentItem.id),
+                item.organizationId === null
+                  ? isNull(feedbackDeskItems.organizationId)
+                  : eq(feedbackDeskItems.organizationId, item.organizationId),
+              ))
             }
           }
         } catch {
@@ -175,14 +188,44 @@ export async function linkFeedbackDeskItemToGithub(
     if (nodeId) {
       await addIssueToFeedbackProject(config, nodeId)
     }
-    return item.githubIssueUrl
+    return currentItem.githubIssueUrl
   }
 
-  if (feedbackFeatureGithubIssueCreationIsBlocked(item)) {
+  if (feedbackFeatureGithubIssueCreationIsBlocked(currentItem)) {
     return null
   }
 
-  const issueContent = githubFeedbackIssueContent(item)
+  const claimToken = crypto.randomUUID()
+  const claimedAt = new Date().toISOString()
+  const claimRows = await db.update(feedbackDeskItems).set({
+    githubIssueCreationClaimToken: claimToken,
+    githubIssueCreationClaimedAt: claimedAt,
+    updatedAt: claimedAt,
+  }).where(and(
+    eq(feedbackDeskItems.id, currentItem.id),
+    currentItem.organizationId === null
+      ? isNull(feedbackDeskItems.organizationId)
+      : eq(feedbackDeskItems.organizationId, currentItem.organizationId),
+    isNull(feedbackDeskItems.githubIssueUrl),
+    isNull(feedbackDeskItems.githubIssueCreationClaimToken),
+    or(
+      ne(feedbackDeskItems.kind, "feature"),
+      isNotNull(feedbackDeskItems.featurePriorityApprovedAt),
+    ),
+  )).returning({ id: feedbackDeskItems.id })
+  if (claimRows.length === 0) return null
+
+  const issueContent = githubFeedbackIssueContent(currentItem)
+  const releaseClaim = async (): Promise<void> => {
+    await db.update(feedbackDeskItems).set({
+      githubIssueCreationClaimToken: null,
+      githubIssueCreationClaimedAt: null,
+      updatedAt: new Date().toISOString(),
+    }).where(and(
+      eq(feedbackDeskItems.id, currentItem.id),
+      eq(feedbackDeskItems.githubIssueCreationClaimToken, claimToken),
+    ))
+  }
   try {
     const response = await fetch(
       `https://api.github.com/repos/${config.repo}/issues`,
@@ -193,6 +236,7 @@ export async function linkFeedbackDeskItemToGithub(
       },
     )
     if (!response.ok) {
+      await releaseClaim()
       console.error("feedback_github_issue_failed", {
         feedbackDeskItemId: item.id,
         status: response.status,
@@ -200,25 +244,37 @@ export async function linkFeedbackDeskItemToGithub(
       return null
     }
     const issue = await response.json() as GitHubIssueResponse
-    if (typeof issue.html_url !== "string") return null
+    if (typeof issue.html_url !== "string") {
+      await releaseClaim()
+      return null
+    }
 
-    await db
+    const linkedRows = await db
       .update(feedbackDeskItems)
       .set({
         githubIssueUrl: issue.html_url,
         githubIssueNodeId:
           typeof issue.node_id === "string" ? issue.node_id : null,
+        githubIssueCreationClaimToken: null,
+        githubIssueCreationClaimedAt: null,
         updatedAt: new Date().toISOString(),
       })
-      .where(eq(feedbackDeskItems.id, item.id))
+      .where(and(
+        eq(feedbackDeskItems.id, currentItem.id),
+        eq(feedbackDeskItems.githubIssueCreationClaimToken, claimToken),
+      ))
+      .returning({ id: feedbackDeskItems.id })
+
+    if (linkedRows.length === 0) return null
 
     if (typeof issue.node_id === "string") {
       await addIssueToFeedbackProject(config, issue.node_id)
     }
     return issue.html_url
   } catch (error) {
+    await releaseClaim()
     console.error("feedback_github_issue_failed", {
-      feedbackDeskItemId: item.id,
+      feedbackDeskItemId: currentItem.id,
       error: error instanceof Error ? error.message : "Unknown error",
     })
     return null

--- a/src/lib/jarvis/feedback-github.ts
+++ b/src/lib/jarvis/feedback-github.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, isNotNull, ne, or } from "drizzle-orm"
+import { and, eq, isNull, isNotNull, lt, or } from "drizzle-orm"
 
 import type { getDb } from "@/db"
 import {
@@ -11,6 +11,7 @@ import {
 } from "@/lib/jarvis/feedback-feature-priority"
 import {
   GITHUB_FEEDBACK_PROJECT_TITLE,
+  feedbackReference,
   githubFeedbackIssueContent,
 } from "@/lib/jarvis/feedback-github-content"
 
@@ -25,7 +26,15 @@ type GitHubFeedbackConfig = Readonly<{
 type GitHubIssueResponse = Readonly<{
   html_url?: unknown
   node_id?: unknown
+  title?: unknown
   state?: unknown
+}>
+
+const GITHUB_ISSUE_CLAIM_LEASE_MS = 5 * 60 * 1_000
+
+type GitHubIssueLookup = Readonly<{
+  available: boolean
+  issue: GitHubIssueResponse | null
 }>
 
 type GraphqlResponse = Readonly<{
@@ -137,6 +146,92 @@ async function addIssueToFeedbackProject(
   }
 }
 
+function issueResponse(value: unknown): GitHubIssueResponse | null {
+  if (typeof value !== "object" || value === null) return null
+  const htmlUrl = Reflect.get(value, "html_url")
+  const nodeId = Reflect.get(value, "node_id")
+  const title = Reflect.get(value, "title")
+  return {
+    html_url: typeof htmlUrl === "string" ? htmlUrl : undefined,
+    node_id: typeof nodeId === "string" ? nodeId : undefined,
+    title: typeof title === "string" ? title : undefined,
+  }
+}
+
+function issueUrlForRepo(value: unknown, repo: string): string | null {
+  if (typeof value !== "string") return null
+  const escapedRepo = repo.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  return new RegExp(
+    `^https://github\\.com/${escapedRepo}/issues/\\d+(?:/|$)`,
+  ).test(value)
+    ? value
+    : null
+}
+
+async function findGithubIssueByReference(
+  config: GitHubFeedbackConfig,
+  item: Pick<FeedbackDeskItem, "id" | "kind">,
+): Promise<GitHubIssueLookup> {
+  // GitHub's issue-create endpoint has no documented idempotency contract.
+  // Recover by the opaque Compass reference, and fail closed if the lookup is
+  // unavailable so a retry never creates an unverified second issue.
+  const reference = feedbackReference(item.id)
+  const query = encodeURIComponent(
+    `repo:${config.repo} is:issue in:title "${reference}"`,
+  )
+  try {
+    const response = await fetch(
+      `https://api.github.com/search/issues?q=${query}&per_page=10`,
+      { headers: githubHeaders(config.token) },
+    )
+    if (!response.ok) return { available: false, issue: null }
+    const payload: unknown = await response.json()
+    if (typeof payload !== "object" || payload === null) {
+      return { available: false, issue: null }
+    }
+    const items = Reflect.get(payload, "items")
+    if (!Array.isArray(items)) return { available: false, issue: null }
+    const expectedTitle = githubFeedbackIssueContent(item).title
+    for (const candidate of items) {
+      const issue = issueResponse(candidate)
+      if (
+        issue?.title === expectedTitle &&
+        issueUrlForRepo(issue.html_url, config.repo)
+      ) {
+        return { available: true, issue }
+      }
+    }
+    return { available: true, issue: null }
+  } catch {
+    return { available: false, issue: null }
+  }
+}
+
+function rowIdentity(
+  item: Pick<FeedbackDeskItem, "organizationId">,
+): ReturnType<typeof eq> {
+  return item.organizationId === null
+    ? isNull(feedbackDeskItems.organizationId)
+    : eq(feedbackDeskItems.organizationId, item.organizationId)
+}
+
+async function clearGithubIssueCreationClaim(
+  db: CompassDb,
+  item: Pick<FeedbackDeskItem, "id" | "organizationId">,
+  claimToken: string,
+): Promise<void> {
+  await db.update(feedbackDeskItems).set({
+    githubIssueCreationClaimToken: null,
+    githubIssueCreationClaimedAt: null,
+    githubIssueCreationClaimExpiresAt: null,
+    updatedAt: new Date().toISOString(),
+  }).where(and(
+    eq(feedbackDeskItems.id, item.id),
+    rowIdentity(item),
+    eq(feedbackDeskItems.githubIssueCreationClaimToken, claimToken),
+  ))
+}
+
 export async function linkFeedbackDeskItemToGithub(
   db: CompassDb,
   env: CloudflareEnv,
@@ -197,36 +292,102 @@ export async function linkFeedbackDeskItemToGithub(
 
   const claimToken = crypto.randomUUID()
   const claimedAt = new Date().toISOString()
+  const claimExpiresAt = new Date(
+    Date.now() + GITHUB_ISSUE_CLAIM_LEASE_MS,
+  ).toISOString()
   const claimRows = await db.update(feedbackDeskItems).set({
     githubIssueCreationClaimToken: claimToken,
     githubIssueCreationClaimedAt: claimedAt,
+    githubIssueCreationClaimExpiresAt: claimExpiresAt,
     updatedAt: claimedAt,
   }).where(and(
     eq(feedbackDeskItems.id, currentItem.id),
-    currentItem.organizationId === null
-      ? isNull(feedbackDeskItems.organizationId)
-      : eq(feedbackDeskItems.organizationId, currentItem.organizationId),
+    rowIdentity(currentItem),
     isNull(feedbackDeskItems.githubIssueUrl),
-    isNull(feedbackDeskItems.githubIssueCreationClaimToken),
     or(
-      ne(feedbackDeskItems.kind, "feature"),
-      isNotNull(feedbackDeskItems.featurePriorityApprovedAt),
+      isNull(feedbackDeskItems.githubIssueCreationClaimToken),
+      isNull(feedbackDeskItems.githubIssueCreationClaimExpiresAt),
+      lt(feedbackDeskItems.githubIssueCreationClaimExpiresAt, claimedAt),
     ),
+    isNotNull(feedbackDeskItems.githubIssueCreationApprovedAt),
+    ...(currentItem.kind === "feature"
+      ? [isNotNull(feedbackDeskItems.featurePriorityApprovedAt)]
+      : []),
   )).returning({ id: feedbackDeskItems.id })
   if (claimRows.length === 0) return null
 
-  const issueContent = githubFeedbackIssueContent(currentItem)
+  const claimedItem = await db.select().from(feedbackDeskItems).where(and(
+    eq(feedbackDeskItems.id, currentItem.id),
+    rowIdentity(currentItem),
+    eq(feedbackDeskItems.githubIssueCreationClaimToken, claimToken),
+    isNull(feedbackDeskItems.githubIssueUrl),
+    isNotNull(feedbackDeskItems.githubIssueCreationApprovedAt),
+    ...(currentItem.kind === "feature"
+      ? [isNotNull(feedbackDeskItems.featurePriorityApprovedAt)]
+      : []),
+  )).get()
+  if (!claimedItem) {
+    await clearGithubIssueCreationClaim(db, currentItem, claimToken)
+    return null
+  }
+
+  const issueContent = githubFeedbackIssueContent(claimedItem)
   const releaseClaim = async (): Promise<void> => {
-    await db.update(feedbackDeskItems).set({
-      githubIssueCreationClaimToken: null,
-      githubIssueCreationClaimedAt: null,
-      updatedAt: new Date().toISOString(),
-    }).where(and(
-      eq(feedbackDeskItems.id, currentItem.id),
-      eq(feedbackDeskItems.githubIssueCreationClaimToken, claimToken),
-    ))
+    await clearGithubIssueCreationClaim(db, currentItem, claimToken)
   }
   try {
+    const recoveredLookup = await findGithubIssueByReference(config, claimedItem)
+    if (!recoveredLookup.available) {
+      await releaseClaim()
+      return null
+    }
+    const recoveredIssue = recoveredLookup.issue
+    const recoveredUrl = issueUrlForRepo(recoveredIssue?.html_url, config.repo)
+    if (recoveredIssue && recoveredUrl) {
+      const recoveredRows = await db.update(feedbackDeskItems).set({
+        githubIssueUrl: recoveredUrl,
+        githubIssueNodeId:
+          typeof recoveredIssue.node_id === "string" ? recoveredIssue.node_id : null,
+        githubIssueCreationClaimToken: null,
+        githubIssueCreationClaimedAt: null,
+        githubIssueCreationClaimExpiresAt: null,
+        updatedAt: new Date().toISOString(),
+      }).where(and(
+        eq(feedbackDeskItems.id, claimedItem.id),
+        rowIdentity(claimedItem),
+        isNull(feedbackDeskItems.githubIssueUrl),
+        eq(feedbackDeskItems.githubIssueCreationClaimToken, claimToken),
+        isNotNull(feedbackDeskItems.githubIssueCreationApprovedAt),
+        ...(claimedItem.kind === "feature"
+          ? [isNotNull(feedbackDeskItems.featurePriorityApprovedAt)]
+          : []),
+      )).returning({ id: feedbackDeskItems.id })
+      if (recoveredRows.length === 0) {
+        await releaseClaim()
+        return null
+      }
+      if (typeof recoveredIssue.node_id === "string") {
+        await addIssueToFeedbackProject(config, recoveredIssue.node_id)
+      }
+      return recoveredUrl
+    }
+
+    const stillApproved = await db.select({ id: feedbackDeskItems.id })
+      .from(feedbackDeskItems).where(and(
+        eq(feedbackDeskItems.id, claimedItem.id),
+        rowIdentity(claimedItem),
+        isNull(feedbackDeskItems.githubIssueUrl),
+        eq(feedbackDeskItems.githubIssueCreationClaimToken, claimToken),
+        isNotNull(feedbackDeskItems.githubIssueCreationApprovedAt),
+        ...(claimedItem.kind === "feature"
+          ? [isNotNull(feedbackDeskItems.featurePriorityApprovedAt)]
+          : []),
+      )).get()
+    if (!stillApproved) {
+      await releaseClaim()
+      return null
+    }
+
     const response = await fetch(
       `https://api.github.com/repos/${config.repo}/issues`,
       {
@@ -243,8 +404,9 @@ export async function linkFeedbackDeskItemToGithub(
       })
       return null
     }
-    const issue = await response.json() as GitHubIssueResponse
-    if (typeof issue.html_url !== "string") {
+    const issue = issueResponse(await response.json())
+    const issueUrl = issueUrlForRepo(issue?.html_url, config.repo)
+    if (!issue || !issueUrl) {
       await releaseClaim()
       return null
     }
@@ -252,16 +414,23 @@ export async function linkFeedbackDeskItemToGithub(
     const linkedRows = await db
       .update(feedbackDeskItems)
       .set({
-        githubIssueUrl: issue.html_url,
+        githubIssueUrl: issueUrl,
         githubIssueNodeId:
           typeof issue.node_id === "string" ? issue.node_id : null,
         githubIssueCreationClaimToken: null,
         githubIssueCreationClaimedAt: null,
+        githubIssueCreationClaimExpiresAt: null,
         updatedAt: new Date().toISOString(),
       })
       .where(and(
-        eq(feedbackDeskItems.id, currentItem.id),
+        eq(feedbackDeskItems.id, claimedItem.id),
+        rowIdentity(claimedItem),
+        isNull(feedbackDeskItems.githubIssueUrl),
         eq(feedbackDeskItems.githubIssueCreationClaimToken, claimToken),
+        isNotNull(feedbackDeskItems.githubIssueCreationApprovedAt),
+        ...(claimedItem.kind === "feature"
+          ? [isNotNull(feedbackDeskItems.featurePriorityApprovedAt)]
+          : []),
       ))
       .returning({ id: feedbackDeskItems.id })
 
@@ -270,7 +439,7 @@ export async function linkFeedbackDeskItemToGithub(
     if (typeof issue.node_id === "string") {
       await addIssueToFeedbackProject(config, issue.node_id)
     }
-    return issue.html_url
+    return issueUrl
   } catch (error) {
     await releaseClaim()
     console.error("feedback_github_issue_failed", {

--- a/src/lib/jarvis/feedback-github.ts
+++ b/src/lib/jarvis/feedback-github.ts
@@ -335,6 +335,7 @@ export async function linkFeedbackDeskItemToGithub(
   const releaseClaim = async (): Promise<void> => {
     await clearGithubIssueCreationClaim(db, currentItem, claimToken)
   }
+  let providerRequestStarted = false
   try {
     const recoveredLookup = await findGithubIssueByReference(config, claimedItem)
     if (!recoveredLookup.available) {
@@ -351,12 +352,14 @@ export async function linkFeedbackDeskItemToGithub(
         githubIssueCreationClaimToken: null,
         githubIssueCreationClaimedAt: null,
         githubIssueCreationClaimExpiresAt: null,
+        githubIssueCreationProviderAttemptedAt: null,
         updatedAt: new Date().toISOString(),
       }).where(and(
         eq(feedbackDeskItems.id, claimedItem.id),
         rowIdentity(claimedItem),
         isNull(feedbackDeskItems.githubIssueUrl),
         eq(feedbackDeskItems.githubIssueCreationClaimToken, claimToken),
+        eq(feedbackDeskItems.updatedAt, claimedItem.updatedAt),
         isNotNull(feedbackDeskItems.githubIssueCreationApprovedAt),
         ...(claimedItem.kind === "feature"
           ? [isNotNull(feedbackDeskItems.featurePriorityApprovedAt)]
@@ -372,12 +375,20 @@ export async function linkFeedbackDeskItemToGithub(
       return recoveredUrl
     }
 
+    if (claimedItem.githubIssueCreationProviderAttemptedAt) {
+      // A prior POST may have succeeded even if the provider lookup is still
+      // eventually consistent. Never create a second issue without recovery.
+      await releaseClaim()
+      return null
+    }
+
     const stillApproved = await db.select({ id: feedbackDeskItems.id })
       .from(feedbackDeskItems).where(and(
         eq(feedbackDeskItems.id, claimedItem.id),
         rowIdentity(claimedItem),
         isNull(feedbackDeskItems.githubIssueUrl),
         eq(feedbackDeskItems.githubIssueCreationClaimToken, claimToken),
+        eq(feedbackDeskItems.updatedAt, claimedItem.updatedAt),
         isNotNull(feedbackDeskItems.githubIssueCreationApprovedAt),
         ...(claimedItem.kind === "feature"
           ? [isNotNull(feedbackDeskItems.featurePriorityApprovedAt)]
@@ -388,6 +399,26 @@ export async function linkFeedbackDeskItemToGithub(
       return null
     }
 
+    const providerAttemptedAt = new Date().toISOString()
+    const providerStartRows = await db.update(feedbackDeskItems).set({
+      githubIssueCreationProviderAttemptedAt: providerAttemptedAt,
+    }).where(and(
+      eq(feedbackDeskItems.id, claimedItem.id),
+      rowIdentity(claimedItem),
+      isNull(feedbackDeskItems.githubIssueUrl),
+      eq(feedbackDeskItems.githubIssueCreationClaimToken, claimToken),
+      eq(feedbackDeskItems.updatedAt, claimedItem.updatedAt),
+      isNotNull(feedbackDeskItems.githubIssueCreationApprovedAt),
+      ...(claimedItem.kind === "feature"
+        ? [isNotNull(feedbackDeskItems.featurePriorityApprovedAt)]
+        : []),
+    )).returning({ id: feedbackDeskItems.id })
+    if (providerStartRows.length === 0) {
+      await releaseClaim()
+      return null
+    }
+    providerRequestStarted = true
+
     const response = await fetch(
       `https://api.github.com/repos/${config.repo}/issues`,
       {
@@ -397,7 +428,6 @@ export async function linkFeedbackDeskItemToGithub(
       },
     )
     if (!response.ok) {
-      await releaseClaim()
       console.error("feedback_github_issue_failed", {
         feedbackDeskItemId: item.id,
         status: response.status,
@@ -407,7 +437,6 @@ export async function linkFeedbackDeskItemToGithub(
     const issue = issueResponse(await response.json())
     const issueUrl = issueUrlForRepo(issue?.html_url, config.repo)
     if (!issue || !issueUrl) {
-      await releaseClaim()
       return null
     }
 
@@ -420,6 +449,7 @@ export async function linkFeedbackDeskItemToGithub(
         githubIssueCreationClaimToken: null,
         githubIssueCreationClaimedAt: null,
         githubIssueCreationClaimExpiresAt: null,
+        githubIssueCreationProviderAttemptedAt: null,
         updatedAt: new Date().toISOString(),
       })
       .where(and(
@@ -427,6 +457,7 @@ export async function linkFeedbackDeskItemToGithub(
         rowIdentity(claimedItem),
         isNull(feedbackDeskItems.githubIssueUrl),
         eq(feedbackDeskItems.githubIssueCreationClaimToken, claimToken),
+        eq(feedbackDeskItems.updatedAt, claimedItem.updatedAt),
         isNotNull(feedbackDeskItems.githubIssueCreationApprovedAt),
         ...(claimedItem.kind === "feature"
           ? [isNotNull(feedbackDeskItems.featurePriorityApprovedAt)]
@@ -441,7 +472,7 @@ export async function linkFeedbackDeskItemToGithub(
     }
     return issueUrl
   } catch (error) {
-    await releaseClaim()
+    if (!providerRequestStarted) await releaseClaim()
     console.error("feedback_github_issue_failed", {
       feedbackDeskItemId: currentItem.id,
       error: error instanceof Error ? error.message : "Unknown error",

--- a/src/lib/jarvis/feedback-maintenance.ts
+++ b/src/lib/jarvis/feedback-maintenance.ts
@@ -72,6 +72,7 @@ export async function reconcileStaleFeatureGithubIssueApprovals(
     eq(feedbackDeskItems.kind, "feature"),
     isNull(feedbackDeskItems.featurePriorityApprovedAt),
     isNotNull(feedbackDeskItems.githubIssueCreationApprovedAt),
+    isNull(feedbackDeskItems.githubIssueCreationClaimToken),
   )).returning({ id: feedbackDeskItems.id })
   return rows.length
 }

--- a/src/lib/jarvis/feedback-maintenance.ts
+++ b/src/lib/jarvis/feedback-maintenance.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull, or } from "drizzle-orm"
+import { and, desc, eq, isNotNull, isNull, or } from "drizzle-orm"
 
 import { getDb } from "@/db"
 import { feedback } from "@/db/schema"
@@ -19,7 +19,10 @@ import {
   type FeedbackDeskKind,
 } from "@/lib/jarvis/feedback-desk"
 import { linkFeedbackDeskItemToGithub } from "@/lib/jarvis/feedback-github"
-import { feedbackFeatureGithubIssueCreationIsBlocked } from "@/lib/jarvis/feedback-feature-priority"
+import {
+  feedbackFeatureGithubIssueApprovalIsStale,
+  feedbackFeatureGithubIssueCreationIsBlocked,
+} from "@/lib/jarvis/feedback-feature-priority"
 import { githubFeedbackIssueContent } from "@/lib/jarvis/feedback-github-content"
 import { syncFeedbackDeskItemsFromGithub } from "@/lib/jarvis/feedback-github-sync"
 import { feedbackDeliveryGraphEvent } from "@/lib/jarvis/feedback-delivery"
@@ -35,6 +38,7 @@ export type FeedbackMaintenanceResult = Readonly<{
   recoveredCount: number
   linkedCount: number
   missingLinkReviewCount: number
+  staleIssueApprovalReconciledCount: number
   syncedCount: number
   deliveryRequestedCount: number
   scrubbedCount: number
@@ -49,9 +53,27 @@ export function feedbackGithubLinkAction(
   >,
 ): "repair" | "create" | "review" | "skip" {
   if (item.githubIssueUrl) return "repair"
+  if (feedbackFeatureGithubIssueApprovalIsStale(item)) return "review"
   if (item.githubIssueCreationApprovedAt && !feedbackFeatureGithubIssueCreationIsBlocked(item)) return "create"
   if (feedbackIsResolved(item.status)) return "skip"
   return "review"
+}
+
+export async function reconcileStaleFeatureGithubIssueApprovals(
+  db: CompassDb,
+  organizationId: string,
+): Promise<number> {
+  const rows = await db.update(feedbackDeskItems).set({
+    githubIssueCreationApprovedAt: null,
+    githubIssueCreationApprovedBy: null,
+    updatedAt: new Date().toISOString(),
+  }).where(and(
+    eq(feedbackDeskItems.organizationId, organizationId),
+    eq(feedbackDeskItems.kind, "feature"),
+    isNull(feedbackDeskItems.featurePriorityApprovedAt),
+    isNotNull(feedbackDeskItems.githubIssueCreationApprovedAt),
+  )).returning({ id: feedbackDeskItems.id })
+  return rows.length
 }
 
 function objectValue(value: unknown): Record<string, unknown> | null {
@@ -330,6 +352,8 @@ export async function runFeedbackMaintenance(
     const recoveredCount =
       await recoverLegacyFeedback(db, organizationId) +
       await recoverConfirmedPrompts(db, organizationId)
+    const staleIssueApprovalReconciledCount =
+      await reconcileStaleFeatureGithubIssueApprovals(db, organizationId)
     const items = await db.select().from(feedbackDeskItems).where(and(
       eq(feedbackDeskItems.organizationId, organizationId),
       or(
@@ -383,6 +407,7 @@ export async function runFeedbackMaintenance(
       recoveredCount,
       linkedCount,
       missingLinkReviewCount,
+      staleIssueApprovalReconciledCount,
       syncedCount,
       deliveryRequestedCount,
       scrubbedCount: privacy.scrubbed,
@@ -394,7 +419,8 @@ export async function runFeedbackMaintenance(
       status: failedCount > 0 ? "partial" : "success",
       processedCount: result.processedCount,
       updatedCount:
-        recoveredCount + linkedCount + syncedCount + privacy.scrubbed +
+        recoveredCount + linkedCount + staleIssueApprovalReconciledCount +
+        syncedCount + privacy.scrubbed +
         slaBackfilledCount + deliveryRequestedCount,
       failedCount,
       summary: JSON.stringify(result),

--- a/src/lib/jarvis/feedback-maintenance.ts
+++ b/src/lib/jarvis/feedback-maintenance.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNotNull, isNull, or } from "drizzle-orm"
+import { and, desc, eq, isNotNull, isNull, lt, or } from "drizzle-orm"
 
 import { getDb } from "@/db"
 import { feedback } from "@/db/schema"
@@ -59,6 +59,28 @@ export function feedbackGithubLinkAction(
   return "review"
 }
 
+export async function reclaimStaleGithubIssueCreationClaims(
+  db: CompassDb,
+  organizationId: string,
+): Promise<number> {
+  const now = new Date().toISOString()
+  const rows = await db.update(feedbackDeskItems).set({
+    githubIssueCreationClaimToken: null,
+    githubIssueCreationClaimedAt: null,
+    githubIssueCreationClaimExpiresAt: null,
+    updatedAt: now,
+  }).where(and(
+    eq(feedbackDeskItems.organizationId, organizationId),
+    isNull(feedbackDeskItems.githubIssueUrl),
+    isNotNull(feedbackDeskItems.githubIssueCreationClaimToken),
+    or(
+      isNull(feedbackDeskItems.githubIssueCreationClaimExpiresAt),
+      lt(feedbackDeskItems.githubIssueCreationClaimExpiresAt, now),
+    ),
+  )).returning({ id: feedbackDeskItems.id })
+  return rows.length
+}
+
 export async function reconcileStaleFeatureGithubIssueApprovals(
   db: CompassDb,
   organizationId: string,
@@ -72,7 +94,6 @@ export async function reconcileStaleFeatureGithubIssueApprovals(
     eq(feedbackDeskItems.kind, "feature"),
     isNull(feedbackDeskItems.featurePriorityApprovedAt),
     isNotNull(feedbackDeskItems.githubIssueCreationApprovedAt),
-    isNull(feedbackDeskItems.githubIssueCreationClaimToken),
   )).returning({ id: feedbackDeskItems.id })
   return rows.length
 }
@@ -351,6 +372,7 @@ export async function runFeedbackMaintenance(
   let failedCount = 0
   try {
     const recoveredCount =
+      await reclaimStaleGithubIssueCreationClaims(db, organizationId) +
       await recoverLegacyFeedback(db, organizationId) +
       await recoverConfirmedPrompts(db, organizationId)
     const staleIssueApprovalReconciledCount =

--- a/src/lib/jarvis/feedback-status-update.ts
+++ b/src/lib/jarvis/feedback-status-update.ts
@@ -1,4 +1,4 @@
-import { and, eq, or, sql } from "drizzle-orm"
+import { and, eq, isNotNull, isNull, or, sql } from "drizzle-orm"
 
 import type { getDb } from "@/db"
 import { organizationMembers, users } from "@/db/schema"
@@ -17,7 +17,10 @@ import {
   feedbackStatusUsesEmail,
   type FeedbackDeskStatus,
 } from "@/lib/jarvis/feedback-lifecycle"
-import { feedbackFeatureTransitionIsBlocked } from "@/lib/jarvis/feedback-feature-priority"
+import {
+  feedbackFeatureTransitionIsBlocked,
+  isFeatureImplementationStatus,
+} from "@/lib/jarvis/feedback-feature-priority"
 import {
   feedbackDeliveryGraphEvent,
   shouldRequestFeedbackDeliveryGraph,
@@ -94,13 +97,21 @@ export type FeedbackLifecycleUpdate = Readonly<{
 
 export async function applyFeedbackLifecycleUpdate(
   db: CompassDb,
-  item: FeedbackDeskItem,
+  itemSnapshot: FeedbackDeskItem,
   update: FeedbackLifecycleUpdate,
 ): Promise<Readonly<{
   changed: boolean
   notifiedUserCount: number
   requesterUpdateQueued: boolean
 }>> {
+  const item = await db.select().from(feedbackDeskItems).where(and(
+    eq(feedbackDeskItems.id, itemSnapshot.id),
+    itemSnapshot.organizationId === null
+      ? isNull(feedbackDeskItems.organizationId)
+      : eq(feedbackDeskItems.organizationId, itemSnapshot.organizationId),
+  )).get()
+  if (!item) throw new Error("Feedback request not found")
+
   if (feedbackFeatureTransitionIsBlocked({
     currentStatus: item.status,
     featurePriorityApprovedAt: item.featurePriorityApprovedAt,
@@ -205,33 +216,6 @@ export async function applyFeedbackLifecycleUpdate(
       : feedbackStatusMessage(update.status, item.title)
   )
 
-  const updateStatement = db.update(feedbackDeskItems).set({
-    status: update.status,
-    priority,
-    githubIssueUrl: issueUrl,
-    githubIssueNodeId: issueNodeId,
-    githubDraftPullRequestUrl: draftUrl,
-    assignedToUserId,
-    assignedToName,
-    internalSummary,
-    deliveryGraphId,
-    deliveryGraphStatus,
-    deliveryGraphImplementationTaskId,
-    deliveryGraphReviewTaskId,
-    deliveryGraphReleaseTaskId,
-    deliveryGraphLastError,
-    deliveryGraphUpdatedAt,
-    slaTargetAt:
-      item.slaTargetAt === null || priorityChanged
-        ? feedbackSlaTarget(priority)
-        : item.slaTargetAt,
-    triagedAt: firstTriage ? now : item.triagedAt,
-    resolvedAt: firstResolution ? now : item.resolvedAt,
-    lastRequesterUpdateAt: requesterUpdateKind ? now : item.lastRequesterUpdateAt,
-    lastGithubSyncAt: update.actorSource === "github" ? now : item.lastGithubSyncAt,
-    updatedAt: now,
-  }).where(eq(feedbackDeskItems.id, item.id))
-
   const recipients = requesterUpdateKind
     ? await requesterRecipients(db, item)
     : []
@@ -260,27 +244,69 @@ export async function applyFeedbackLifecycleUpdate(
     notificationKind: requesterUpdateKind,
     updatedAt: now,
   })
-  const inboundStatement = db.insert(jarvisBridgeEvents).values({
-    id: crypto.randomUUID(),
-    organizationId: item.organizationId,
-    direction: "inbound",
-    source: update.actorSource,
-    eventType: "feedback.status_updated",
-    status: "completed",
-    idempotencyKey: update.idempotencyKey,
-    feedbackDeskItemId: item.id,
-    payload,
-    result: payload,
-    availableAt: now,
-    completedAt: now,
-    createdAt: now,
-    updatedAt: now,
-  }).onConflictDoNothing()
   const deliveryEvent = shouldRequestFeedbackDeliveryGraph(item, update.status)
     ? feedbackDeliveryGraphEvent(item)
     : null
-  const deliveryStatement = deliveryEvent
-    ? db.insert(jarvisBridgeEvents).values({
+  const rowIdentity = item.organizationId === null
+    ? isNull(feedbackDeskItems.organizationId)
+    : eq(feedbackDeskItems.organizationId, item.organizationId)
+  const finalFence = item.kind === "feature" && isFeatureImplementationStatus(update.status)
+    ? isNotNull(feedbackDeskItems.featurePriorityApprovedAt)
+    : undefined
+  await db.transaction(async (tx) => {
+    const persisted = await tx.update(feedbackDeskItems).set({
+      status: update.status,
+      priority,
+      githubIssueUrl: issueUrl,
+      githubIssueNodeId: issueNodeId,
+      githubDraftPullRequestUrl: draftUrl,
+      assignedToUserId,
+      assignedToName,
+      internalSummary,
+      deliveryGraphId,
+      deliveryGraphStatus,
+      deliveryGraphImplementationTaskId,
+      deliveryGraphReviewTaskId,
+      deliveryGraphReleaseTaskId,
+      deliveryGraphLastError,
+      deliveryGraphUpdatedAt,
+      slaTargetAt:
+        item.slaTargetAt === null || priorityChanged
+          ? feedbackSlaTarget(priority)
+          : item.slaTargetAt,
+      triagedAt: firstTriage ? now : item.triagedAt,
+      resolvedAt: firstResolution ? now : item.resolvedAt,
+      lastRequesterUpdateAt: requesterUpdateKind ? now : item.lastRequesterUpdateAt,
+      lastGithubSyncAt: update.actorSource === "github" ? now : item.lastGithubSyncAt,
+      updatedAt: now,
+    }).where(and(
+      eq(feedbackDeskItems.id, item.id),
+      rowIdentity,
+      eq(feedbackDeskItems.updatedAt, item.updatedAt),
+      ...(finalFence ? [finalFence] : []),
+    )).returning({ id: feedbackDeskItems.id }).get()
+    if (!persisted) {
+      throw new Error("Feedback request changed before the lifecycle update could be saved")
+    }
+
+    await tx.insert(jarvisBridgeEvents).values({
+      id: crypto.randomUUID(),
+      organizationId: item.organizationId,
+      direction: "inbound",
+      source: update.actorSource,
+      eventType: "feedback.status_updated",
+      status: "completed",
+      idempotencyKey: update.idempotencyKey,
+      feedbackDeskItemId: item.id,
+      payload,
+      result: payload,
+      availableAt: now,
+      completedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoNothing()
+    if (deliveryEvent) {
+      await tx.insert(jarvisBridgeEvents).values({
         id: crypto.randomUUID(),
         organizationId: item.organizationId,
         direction: "outbound",
@@ -293,31 +319,23 @@ export async function applyFeedbackLifecycleUpdate(
         createdAt: now,
         updatedAt: now,
       }).onConflictDoNothing()
-    : null
-  if (requesterUpdateKind) {
-    const outboundStatement = db.insert(jarvisBridgeEvents).values({
-      id: crypto.randomUUID(),
-      organizationId: item.organizationId,
-      direction: "outbound",
-      source: item.source,
-      eventType: "feedback.status_changed",
-      idempotencyKey: `notify:${update.idempotencyKey}`,
-      feedbackDeskItemId: item.id,
-      payload,
-      availableAt: now,
-      createdAt: now,
-      updatedAt: now,
-    }).onConflictDoNothing()
-    if (deliveryStatement) {
-      await db.batch([updateStatement, inboundStatement, outboundStatement, deliveryStatement])
-    } else {
-      await db.batch([updateStatement, inboundStatement, outboundStatement])
     }
-  } else if (deliveryStatement) {
-    await db.batch([updateStatement, inboundStatement, deliveryStatement])
-  } else {
-    await db.batch([updateStatement, inboundStatement])
-  }
+    if (requesterUpdateKind) {
+      await tx.insert(jarvisBridgeEvents).values({
+        id: crypto.randomUUID(),
+        organizationId: item.organizationId,
+        direction: "outbound",
+        source: item.source,
+        eventType: "feedback.status_changed",
+        idempotencyKey: `notify:${update.idempotencyKey}`,
+        feedbackDeskItemId: item.id,
+        payload,
+        availableAt: now,
+        createdAt: now,
+        updatedAt: now,
+      }).onConflictDoNothing()
+    }
+  })
 
   if (requesterUpdateKind && item.organizationId && recipients.length > 0) {
     try {


### PR DESCRIPTION
## Summary
- Enforce the feature-priority and GitHub issue-creation approval invariant across admin, signed lifecycle, maintenance, sync, and centralized GitHub issue-creation paths.
- Make GitHub issue creation claim-based, lease-bounded, and crash-recoverable, with durable provider-attempt uncertainty and exact-reference recovery that fails closed rather than issuing a duplicate POST.
- Fence both feature-priority revocation and GitHub issue-approval removal once the durable provider-attempt marker commits, so a successful revocation/removal cannot race ahead of a later external POST or local link.
- Retain the append-only D1 migrations required by the claim, lease, and provider-attempt state.

## Safety and scope
- Fix-only follow-up for #490. It does not implement or reprioritize the protected feature request.
- No protected feedback content or identity is disclosed.
- No merge, production D1 migration, production reconciliation, live lifecycle call, feature-priority change, or requester-delivery claim was performed by the remediation task.
- This PR remains draft and requires a fresh independent exact-head CLEAR before the separate release steward may proceed.

## Authorized production D1 migration gate
Production is currently recorded through migration `0131_contract_deposit_rate.sql`. Read-only listing at head `5164a11d919c0fb4692c767e719df0d4210aeb01` reports these exact migrations pending:

1. `0132_feedback_issue_creation_claim.sql`
2. `0133_feedback_issue_claim_lease.sql`
3. `0134_feedback_issue_provider_attempt.sql`

A Cloudflare Worker build/deployment does **not** apply D1 migrations and must not be treated as a completed release while these remain pending. Only the authorized release steward, after a fresh independent CLEAR of the immutable live PR head and a current-main/merge-state recheck, may apply the production schema from a clean release worktree using the repository-approved gate:

```bash
bunx wrangler d1 migrations list compass-db --remote
bun run db:migrate:prod
bunx wrangler d1 migrations list compass-db --remote
```

The release gate must verify that no migration remains pending and that `feedback_desk_items` contains `github_issue_creation_claim_token`, `github_issue_creation_claimed_at`, `github_issue_creation_claim_expires_at`, and `github_issue_creation_provider_attempted_at` before describing the database-backed workflow as production-ready. Migration application, Worker publication, and production behavior verification are separate reportable stages.

## Verification
- Exact two-actor SQLite/D1 regression `rejects approval removal after the provider marker commits before POST` failed on the prior PR head (`{ success: true }`) and passes after the fence.
- Focused feedback race/admin/GitHub/sync/maintenance/priority suite: 7 files / 23 tests passed.
- Full suite: 226 files / 1,178 tests passed.
- `bun run lint`: 0 errors / 76 existing warnings.
- `bun run build`: passed, including TypeScript and static page generation, with existing NFT/framework warnings.
- `bunx tsc --noEmit`: only four pre-existing `app-sidebar-navigation.test.ts` errors outside this PR's changed paths; no new candidate-path error.
- Clean local migration replay through `0134` passed; all four required columns, all three claim/provider indexes, and an empty `foreign_key_check` were verified.
- `git diff --check` passed. Independent pre-commit review passed staged patch SHA-256 `d691f0c87f05e08674e1a8578acb66a34db88ac9a9f267b2798a1f43e8b9bfac` with no security or logic blockers.
- Immutable descendant pushed: `5164a11d919c0fb4692c767e719df0d4210aeb01`, based on current `origin/main` `124e4c414dc7dae7057210585980553998bf6f3d` and descending prior PR head `713c07a38e441e8599db310a44049c23e98b297b`.

Closes #490
