### PR TITLE
feat(cherish): publish recognition across dashboard and field

### DIFF
--- a/mobile-shell-src/app.ts
+++ b/mobile-shell-src/app.ts
@@ -13,15 +13,17 @@ import { z } from "zod/v4"
 import {
   cherishResponseTypeSchema,
   cherishValueSchema,
+  fieldCherishRecognitionSchema,
   fieldOutboxSchema,
   fieldDocumentSchema,
   fieldProjectPacketSchema,
   fieldProjectSchema,
   fieldUserProfileSchema,
-  type FieldOutboxItem,
+  type FieldCherishRecognition,
   type FieldCherishResponseType,
   type FieldCherishValue,
   type FieldDocument,
+  type FieldOutboxItem,
   type FieldProject,
   type FieldProjectPacket,
   type FieldQueuedAttachment,
@@ -108,6 +110,11 @@ const nativeFieldFolderResponseSchema = z.object({
   folder: z.object({ id: z.string(), name: z.string() }).optional(),
   documents: z.array(fieldDocumentSchema).optional(),
 })
+const nativeCherishStreamResponseSchema = z.object({
+  success: z.boolean(),
+  error: z.string().optional(),
+  items: z.array(fieldCherishRecognitionSchema).optional(),
+})
 
 const app = document.querySelector<HTMLDivElement>("#app")
 let projects: Project[] = []
@@ -146,6 +153,10 @@ let cherishResponseType: FieldCherishResponseType = "shoutout"
 let cherishMessage = ""
 let cherishFeedback = ""
 let syncingCherish = false
+let cherishRecognitions: FieldCherishRecognition[] = []
+let cherishRecognitionError = ""
+let loadingCherishRecognitions = false
+let lastCherishRecognitionRefreshAt = 0
 let biometricEnabled = false
 let biometricLocked = false
 let backgroundedAt: number | null = null
@@ -286,7 +297,11 @@ function todayView(): string {
   const schedule = open.filter((task) => task.kind === "schedule" && task.endDate >= today).sort((left, right) => left.startDate.localeCompare(right.startDate)).slice(0, 14)
   const assignedRows = assigned.length ? `<div class="rows">${assigned.map((task) => `<div class="row"><div class="row-main"><p class="row-title">${escapeHtml(task.title)}</p><p class="row-note">${escapeHtml(task.assignedTo ?? task.description ?? "Assigned task")}</p></div><span class="row-date">${escapeHtml(shortDate(task.endDate))}</span></div>`).join("")}</div>` : empty("No open tasks are assigned to you for this project.")
   const scheduleRows = schedule.length ? `<div class="rows">${schedule.map((task) => `<div class="row"><span class="row-date">${escapeHtml(shortDate(task.startDate))}</span><div class="row-main"><p class="row-title">${escapeHtml(task.title)}</p><p class="row-note">${escapeHtml(task.phase)} - ${task.percentComplete}%</p></div></div>`).join("")}</div>` : empty("No upcoming schedule items.")
-  return sectionHead("My tasks", "Assigned work for this job.") + assignedRows + `<div class="block">${sectionHead("Project schedule")}${scheduleRows}</div>`
+  const latestRecognition = cherishRecognitions[0]
+  const cherishSpotlight = online && latestRecognition
+    ? `<button id="today-cherish" class="cherish-spotlight" type="button"><span>CHERISH · ${escapeHtml(latestRecognition.cherishValue)}</span><strong>${escapeHtml(latestRecognition.message)}</strong><small>${latestRecognition.responseType === "win" ? "Project win" : "Shoutout"} · ${escapeHtml(latestRecognition.submittedByName ?? "Team member")}</small></button>`
+    : ""
+  return cherishSpotlight + sectionHead("My tasks", "Assigned work for this job.") + assignedRows + `<div class="block">${sectionHead("Project schedule")}${scheduleRows}</div>`
 }
 
 function logView(): string {
@@ -476,7 +491,15 @@ function cherishView(): string {
     { value: "concern", label: "Private concern" },
   ]
 
-  return `${sectionHead("CHERISH feedback", "Save a shoutout, project win, or private concern without leaving Field Mode.")}
+  const recognitionRows = cherishRecognitions
+    .map(
+      (item) =>
+        `<article class="cherish-recognition"><div><span>${escapeHtml(item.cherishValue)}</span><small>${item.responseType === "win" ? "Project win" : "Shoutout"} · ${escapeHtml(shortDate(item.createdAt))}</small></div><p>${escapeHtml(item.message)}</p><footer>Shared by ${escapeHtml(item.submittedByName ?? "a team member")}</footer></article>`,
+    )
+    .join("")
+  const recognitionStream = `<section class="cherish-stream">${sectionHead("Team recognition", "Approved shoutouts and project wins from across HPS.")}${loadingCherishRecognitions ? `<p class="cherish-stream-status">Loading team recognition...</p>` : recognitionRows ? `<div class="cherish-recognition-list">${recognitionRows}</div>` : `<p class="cherish-stream-status">${escapeHtml(cherishRecognitionError || (online ? "No approved recognition yet." : "Connect to load approved recognition."))}</p>`}</section>`
+
+  return `${recognitionStream}<section class="block">${sectionHead("CHERISH feedback", "Save a shoutout, project win, or private concern without leaving Field Mode.")}
     <form id="cherish-form" class="form">
       <label class="field">CHERISH value
         <select name="cherishValue" required>${valueOptions}</select>
@@ -489,7 +512,7 @@ function cherishView(): string {
       </label>
       ${cherishFeedback ? `<p class="${cherishFeedback.startsWith("Saved") || cherishFeedback.startsWith("Synced") ? "message-success" : "attachment-error"}" role="status">${escapeHtml(cherishFeedback)}</p>` : ""}
       <button class="primary" type="submit" ${syncingCherish ? "disabled" : ""}>${syncingCherish ? "Syncing" : online ? "Save and sync" : "Save for sync"}</button>
-    </form>`
+    </form></section>`
 }
 
 function settingsView(): string {
@@ -618,6 +641,7 @@ function bindEvents(): void {
   document.querySelector<HTMLButtonElement>("#open-live")?.addEventListener("click", openFullCompass)
   document.querySelector<HTMLButtonElement>("#open-live-empty")?.addEventListener("click", openFullCompass)
   document.querySelector<HTMLButtonElement>("#open-cherish")?.addEventListener("click", openCherish)
+  document.querySelector<HTMLButtonElement>("#today-cherish")?.addEventListener("click", openCherish)
   document.querySelector<HTMLButtonElement>("#sync-now")?.addEventListener("click", () => void resumePendingSync())
   document.querySelector<HTMLButtonElement>("#field-notifications")?.addEventListener("click", () => {
     activeTab = "notifications"
@@ -794,7 +818,11 @@ async function refreshFieldDataAfterNotification(): Promise<void> {
 
 async function refreshFieldDataAfterActivation(): Promise<void> {
   await refreshConnectivityAndSync()
-  if (packet && online) await refreshProjectPacket(false)
+  if (!online) return
+  await Promise.all([
+    packet ? refreshProjectPacket(false) : Promise.resolve(),
+    profile ? refreshCherishRecognition() : Promise.resolve(),
+  ])
 }
 
 function scheduleNotificationRefreshes(): void {
@@ -1169,6 +1197,51 @@ async function syncCherishOutbox(): Promise<void> {
     }
     syncingCherish = false
     render()
+    if (syncedCount > 0) void refreshCherishRecognition(true)
+  }
+}
+
+async function refreshCherishRecognition(force = false): Promise<void> {
+  if (!online || !profile || loadingCherishRecognitions) return
+  if (
+    !force &&
+    Date.now() - lastCherishRecognitionRefreshAt < 30_000
+  ) {
+    return
+  }
+
+  loadingCherishRecognitions = true
+  cherishRecognitionError = ""
+  if (activeTab === "cherish") render()
+  try {
+    const response = await CapacitorHttp.get({
+      url: `${LIVE_URL}/api/field/cherish?refresh=${Date.now()}`,
+      headers: {
+        "Cache-Control": "no-cache",
+        Pragma: "no-cache",
+      },
+      responseType: "json",
+    })
+    const result = nativeCherishStreamResponseSchema.safeParse(
+      responseData(response.data),
+    )
+    if (!result.success || !result.data.success || !result.data.items) {
+      throw new Error(
+        result.success
+          ? result.data.error ?? "Unable to load team recognition."
+          : "Unable to load team recognition.",
+      )
+    }
+    cherishRecognitions = result.data.items
+    lastCherishRecognitionRefreshAt = Date.now()
+  } catch (error) {
+    cherishRecognitionError =
+      error instanceof Error
+        ? error.message
+        : "Unable to load team recognition."
+  } finally {
+    loadingCherishRecognitions = false
+    if (activeTab === "cherish" || activeTab === "today") render()
   }
 }
 
@@ -1598,6 +1671,7 @@ function openFullCompass(): void {
 function openCherish(): void {
   activeTab = "cherish"
   render()
+  if (online) void refreshCherishRecognition()
 }
 
 async function resumePendingSync(): Promise<void> {
@@ -1722,6 +1796,7 @@ async function downloadNativeFieldState(projectId?: string): Promise<boolean> {
   activeTab = packet ? "today" : "projects"
   render()
   if (pushToken) void persistPushToken(pushToken)
+  void refreshCherishRecognition(true)
   return true
 }
 
@@ -2033,6 +2108,7 @@ async function initialize(): Promise<void> {
     await handleAppUrl(launchUrl.url)
   }
   if (online && packet) void refreshProjectPacket()
+  if (online && profile) void refreshCherishRecognition(true)
   void resumePendingSync()
 
   await Network.addListener("networkStatusChange", () => void refreshConnectivityAndSync())
@@ -2055,6 +2131,9 @@ async function refreshConnectivityAndSync(): Promise<void> {
   void resumePendingSync()
   if (!previousOnline && online && pushToken && pushStatus !== "enabled") {
     void persistPushToken(pushToken)
+  }
+  if (!previousOnline && online && profile) {
+    void refreshCherishRecognition(true)
   }
   if (!previousOnline && online && activeTab === "chat") {
     void refreshProjectPacket()

--- a/mobile-shell-src/styles.css
+++ b/mobile-shell-src/styles.css
@@ -122,6 +122,30 @@ button { cursor: pointer; }
 .auth-form { width: min(100%, 420px); margin-inline: auto; }
 .auth-error { color: #9b2c2c; }
 .block { margin-top: 28px; }
+.cherish-spotlight {
+  display: grid;
+  width: 100%;
+  gap: 5px;
+  margin-bottom: 20px;
+  border: 0;
+  border-left: 4px solid var(--green);
+  background: var(--green-light);
+  padding: 13px 14px;
+  color: inherit;
+  text-align: left;
+}
+.cherish-spotlight span { color: var(--green); font-size: 11px; font-weight: 850; letter-spacing: .04em; text-transform: uppercase; }
+.cherish-spotlight strong { font-size: 14px; line-height: 1.45; }
+.cherish-spotlight small { color: var(--muted); font-size: 11px; }
+.cherish-stream { margin-bottom: 28px; }
+.cherish-recognition-list { border-bottom: 1px solid var(--line); }
+.cherish-recognition { padding: 14px 0; border-bottom: 1px solid var(--line); }
+.cherish-recognition:last-child { border-bottom: 0; }
+.cherish-recognition > div { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.cherish-recognition span { color: var(--green); font-size: 11px; font-weight: 850; letter-spacing: .04em; text-transform: uppercase; }
+.cherish-recognition small, .cherish-recognition footer { color: var(--muted); font-size: 11px; }
+.cherish-recognition p { margin: 8px 0; white-space: pre-wrap; font-size: 14px; line-height: 1.5; }
+.cherish-stream-status { margin: 0; padding: 24px 0; border-bottom: 1px dashed var(--line); color: var(--muted); text-align: center; font-size: 13px; }
 .profile-list { margin: 0; }
 .profile-list div { display: grid; grid-template-columns: 6rem 1fr; gap: 12px; padding: 12px 0; border-bottom: 1px solid var(--line); font-size: 14px; }
 .profile-list dt { color: var(--muted); }

--- a/src/app/api/field/cherish/__tests__/route.test.ts
+++ b/src/app/api/field/cherish/__tests__/route.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  getCherishPulseTeamStream: vi.fn(),
+  submitCherishPulseResponse: vi.fn(),
+}))
+
+vi.mock("@/app/actions/cherish-pulse", () => ({
+  getCherishPulseTeamStream: mocks.getCherishPulseTeamStream,
+  submitCherishPulseResponse: mocks.submitCherishPulseResponse,
+}))
+
+import { GET } from "../route"
+
+describe("GET /api/field/cherish", () => {
+  beforeEach(() => {
+    mocks.getCherishPulseTeamStream.mockReset()
+  })
+
+  it("returns only crew-safe approved recognition without caching", async () => {
+    mocks.getCherishPulseTeamStream.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: "win-1",
+          cherishValue: "Excellence",
+          responseType: "win",
+          message: "The team passed inspection on the first visit.",
+          source: "compass_dashboard",
+          visibility: "team",
+          reviewStatus: "approved",
+          submittedByName: "Martine",
+          submittedByEmail: "martine@example.com",
+          weekStart: "2026-08-24",
+          createdAt: "2026-08-24T12:00:00.000Z",
+        },
+        {
+          id: "defense-in-depth",
+          cherishValue: "Integrity",
+          responseType: "concern",
+          message: "Private concern",
+          source: "compass_dashboard",
+          visibility: "private",
+          reviewStatus: "approved",
+          submittedByName: "Team member",
+          submittedByEmail: "private@example.com",
+          weekStart: "2026-08-24",
+          createdAt: "2026-08-24T13:00:00.000Z",
+        },
+      ],
+    })
+
+    const response = await GET()
+    const body: unknown = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("cache-control")).toBe("private, no-store")
+    expect(body).toEqual({
+      success: true,
+      items: [
+        {
+          id: "win-1",
+          cherishValue: "Excellence",
+          responseType: "win",
+          message: "The team passed inspection on the first visit.",
+          submittedByName: "Martine",
+          createdAt: "2026-08-24T12:00:00.000Z",
+        },
+      ],
+    })
+  })
+
+  it("keeps unauthorized users out of the team stream", async () => {
+    mocks.getCherishPulseTeamStream.mockResolvedValue({
+      success: false,
+      error: "Only internal team members can view CHERISH recognition.",
+    })
+
+    const response = await GET()
+
+    expect(response.status).toBe(403)
+  })
+})

--- a/src/app/api/field/cherish/route.ts
+++ b/src/app/api/field/cherish/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server"
 import { z } from "zod/v4"
 
-import { submitCherishPulseResponse } from "@/app/actions/cherish-pulse"
+import {
+  getCherishPulseTeamStream,
+  submitCherishPulseResponse,
+} from "@/app/actions/cherish-pulse"
+import { toFieldCherishRecognitions } from "@/lib/field/cherish-recognition"
 import {
   cherishResponseTypeSchema,
   cherishValueSchema,
@@ -13,6 +17,38 @@ const requestSchema = z.object({
   responseType: cherishResponseTypeSchema,
   message: z.string().trim().min(3).max(1_200),
 })
+
+export async function GET(): Promise<Response> {
+  try {
+    const result = await getCherishPulseTeamStream()
+    if (!result.success) {
+      return NextResponse.json(result, { status: 403 })
+    }
+
+    return NextResponse.json(
+      {
+        success: true,
+        items: toFieldCherishRecognitions(result.data),
+      },
+      {
+        headers: {
+          "Cache-Control": "private, no-store",
+        },
+      },
+    )
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unable to load CHERISH recognition.",
+      },
+      { status: 500 },
+    )
+  }
+}
 
 export async function POST(request: Request): Promise<Response> {
   try {

--- a/src/app/dashboard/field/page.tsx
+++ b/src/app/dashboard/field/page.tsx
@@ -1,8 +1,10 @@
 import { notFound } from "next/navigation"
 
-import { getCurrentUser } from "@/lib/auth"
-import { canUseAskCompass, canUseFieldDesk } from "@/lib/permissions"
+import { getCherishPulseTeamStream } from "@/app/actions/cherish-pulse"
 import { FieldDesk } from "@/components/field/field-desk"
+import { getCurrentUser } from "@/lib/auth"
+import { toFieldCherishRecognitions } from "@/lib/field/cherish-recognition"
+import { canUseAskCompass, canUseFieldDesk } from "@/lib/permissions"
 
 export default async function FieldDeskPage(): Promise<React.ReactElement> {
   const user = await getCurrentUser()
@@ -14,10 +16,17 @@ export default async function FieldDeskPage(): Promise<React.ReactElement> {
     notFound()
   }
 
+  const cherishResult = await getCherishPulseTeamStream()
+
   return (
     <FieldDesk
       offlineScopeKey={`${user.organizationId}:${user.id}`}
       displayName={user.displayName ?? user.firstName ?? "Team member"}
+      cherishRecognitions={
+        cherishResult.success
+          ? toFieldCherishRecognitions(cherishResult.data)
+          : []
+      }
     />
   )
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import type * as React from "react"
 import { redirect } from "next/navigation"
 
+import { getCherishPulseTeamStream } from "@/app/actions/cherish-pulse"
 import { getDashboardOverview } from "@/app/actions/dashboard-overview"
 import { getProjects } from "@/app/actions/projects"
 import {
@@ -15,6 +16,7 @@ import {
   canManageProjectRegistry,
   canUseExecutiveAdmin,
 } from "@/lib/permissions"
+import { toFieldCherishRecognitions } from "@/lib/field/cherish-recognition"
 
 export default async function Page(): Promise<React.ReactElement> {
   const currentUser = await getCurrentUser()
@@ -42,11 +44,13 @@ export default async function Page(): Promise<React.ReactElement> {
     presenceResult,
     teamAvailabilityResult,
     workCalendar,
+    cherishResult,
   ] = await Promise.all([
     getDashboardOverview(),
     getCurrentUserPresence(),
     getOrganizationTeamAvailability(),
     getWorkCalendar(undefined, { eventsOnly: true }).catch(() => null),
+    getCherishPulseTeamStream(),
   ])
   const sidebarUser = currentUser ? toSidebarUser(currentUser) : null
   const initialDeskStatusMessage = presenceResult.success
@@ -82,6 +86,11 @@ export default async function Page(): Promise<React.ReactElement> {
       officeProjectId={workCalendar?.defaultProjectId ?? null}
       canManageOfficeMaintenance={canManageProjectRegistry(currentUser)}
       canReviewCherish={canUseExecutiveAdmin(currentUser)}
+      cherishRecognitions={
+        cherishResult.success
+          ? toFieldCherishRecognitions(cherishResult.data)
+          : []
+      }
     />
   )
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1344,3 +1344,30 @@ em-emoji-picker {
     transform: translateX(410%);
   }
 }
+
+@keyframes cherish-recognition-scroll {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+.cherish-recognition-track {
+  animation: cherish-recognition-scroll 42s linear infinite;
+}
+
+.cherish-recognition-marquee:hover .cherish-recognition-track {
+  animation-play-state: paused;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cherish-recognition-track {
+    animation: none;
+  }
+
+  .cherish-recognition-marquee > div:last-child {
+    overflow-x: auto;
+  }
+}

--- a/src/components/cherish/cherish-recognition-ticker.tsx
+++ b/src/components/cherish/cherish-recognition-ticker.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import type * as React from "react"
+import { IconHeartHandshake } from "@tabler/icons-react"
+
+import type { FieldCherishRecognition } from "@/lib/field/types"
+import { cn } from "@/lib/utils"
+
+function recognitionLabel(item: FieldCherishRecognition): string {
+  return item.responseType === "win" ? "Project win" : "Shoutout"
+}
+
+function RecognitionItems({
+  items,
+  duplicate = false,
+}: {
+  readonly items: readonly FieldCherishRecognition[]
+  readonly duplicate?: boolean
+}): React.ReactElement {
+  return (
+    <div
+      className="flex shrink-0 items-center gap-8 pr-8"
+      aria-hidden={duplicate || undefined}
+    >
+      {items.map((item) => (
+        <div key={item.id} className="flex max-w-[42rem] items-center gap-3">
+          <span className="shrink-0 text-xs font-semibold uppercase tracking-wide text-[var(--department-primary)]">
+            {item.cherishValue}
+          </span>
+          <span className="text-sm text-foreground">{item.message}</span>
+          <span className="shrink-0 text-xs text-muted-foreground">
+            {recognitionLabel(item)} · {item.submittedByName ?? "Team member"}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function CherishRecognitionTicker({
+  items,
+  className,
+}: {
+  readonly items: readonly FieldCherishRecognition[]
+  readonly className?: string
+}): React.ReactElement | null {
+  if (items.length === 0) return null
+
+  return (
+    <section
+      className={cn(
+        "cherish-recognition-marquee flex min-w-0 items-center gap-4 border-y bg-muted/20 py-2.5",
+        className,
+      )}
+      aria-label="CHERISH team recognition"
+    >
+      <div className="flex shrink-0 items-center gap-2 border-r px-3 sm:px-4">
+        <IconHeartHandshake className="size-4 text-[var(--department-primary)]" />
+        <span className="text-xs font-semibold uppercase tracking-wide">
+          CHERISH
+        </span>
+      </div>
+      <div className="min-w-0 flex-1 overflow-hidden">
+        <div
+          className={cn(
+            "flex w-max items-center",
+            items.length > 1 && "cherish-recognition-track",
+          )}
+        >
+          <RecognitionItems items={items} />
+          {items.length > 1 ? (
+            <RecognitionItems items={items} duplicate />
+          ) : null}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/dashboard/dashboard-launchpad.tsx
+++ b/src/components/dashboard/dashboard-launchpad.tsx
@@ -46,6 +46,7 @@ import {
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { CherishPulseStream } from "@/components/dashboard/cherish-pulse-stream"
+import { CherishRecognitionTicker } from "@/components/cherish/cherish-recognition-ticker"
 import { OfficeMaintenanceDrawer } from "@/components/projects/office-maintenance-drawer"
 import {
   Dialog,
@@ -72,6 +73,7 @@ import {
 } from "@/components/ui/sheet"
 import { Textarea } from "@/components/ui/textarea"
 import type { SidebarUser } from "@/lib/auth"
+import type { FieldCherishRecognition } from "@/lib/field/types"
 import {
   DESK_STATUS_LABELS,
   deskStatusForPresenceMessage,
@@ -1307,6 +1309,7 @@ export function DashboardLaunchpad({
   officeProjectId,
   canManageOfficeMaintenance,
   canReviewCherish,
+  cherishRecognitions,
 }: {
   readonly overview: DashboardOverview
   readonly user: SidebarUser | null
@@ -1316,6 +1319,7 @@ export function DashboardLaunchpad({
   readonly officeProjectId: string | null
   readonly canManageOfficeMaintenance: boolean
   readonly canReviewCherish: boolean
+  readonly cherishRecognitions: readonly FieldCherishRecognition[]
 }): React.ReactElement {
   const [mode, setMode] = useState<DashboardMode>("office")
   const [deskStatus, setDeskStatus] = useState<DeskStatus>(() =>
@@ -1378,6 +1382,8 @@ export function DashboardLaunchpad({
           />
         </div>
       </div>
+
+      <CherishRecognitionTicker items={cherishRecognitions} />
 
       <div className="grid gap-4 xl:grid-cols-[minmax(20rem,0.72fr)_minmax(0,1.28fr)]">
         <DeskHero

--- a/src/components/field/field-desk.tsx
+++ b/src/components/field/field-desk.tsx
@@ -15,6 +15,7 @@ import {
   type CherishValue,
 } from "@/app/actions/cherish-pulse"
 import { useChatPanel } from "@/components/agent/chat-provider"
+import { CherishRecognitionTicker } from "@/components/cherish/cherish-recognition-ticker"
 import { Button } from "@/components/ui/button"
 import {
   Select,
@@ -30,6 +31,7 @@ import {
   FIELD_OUTBOX_CHANGED_EVENT,
   listFieldOutboxItems,
 } from "@/lib/field/offline-outbox"
+import type { FieldCherishRecognition } from "@/lib/field/types"
 import { cn } from "@/lib/utils"
 
 const CHERISH_VALUES: readonly CherishValue[] = [
@@ -54,9 +56,11 @@ const RESPONSE_TYPES: readonly {
 export function FieldDesk({
   offlineScopeKey,
   displayName,
+  cherishRecognitions,
 }: {
   readonly offlineScopeKey: string
   readonly displayName: string
+  readonly cherishRecognitions: readonly FieldCherishRecognition[]
 }): React.ReactElement {
   const chatPanel = useChatPanel()
   const [online, setOnline] = useState(true)
@@ -214,6 +218,11 @@ export function FieldDesk({
           </p>
         )}
       </header>
+
+      <CherishRecognitionTicker
+        items={cherishRecognitions}
+        className="mt-4"
+      />
 
       <section className="grid gap-3 border-b py-5 sm:grid-cols-[1fr_auto] sm:items-center">
         <div>

--- a/src/lib/field/__tests__/cherish-recognition.test.ts
+++ b/src/lib/field/__tests__/cherish-recognition.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import { toFieldCherishRecognitions } from "@/lib/field/cherish-recognition"
+
+describe("toFieldCherishRecognitions", () => {
+  it("keeps approved team recognition fields and excludes private concerns", () => {
+    const result = toFieldCherishRecognitions([
+      {
+        id: "shoutout-1",
+        cherishValue: "Camaraderie",
+        responseType: "shoutout",
+        message: "The framing crew helped another team finish safely.",
+        submittedByName: "Martine",
+        createdAt: "2026-08-24T12:00:00.000Z",
+      },
+      {
+        id: "concern-1",
+        cherishValue: "Integrity",
+        responseType: "concern",
+        message: "Leadership-only context.",
+        submittedByName: "Team member",
+        createdAt: "2026-08-24T13:00:00.000Z",
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        id: "shoutout-1",
+        cherishValue: "Camaraderie",
+        responseType: "shoutout",
+        message: "The framing crew helped another team finish safely.",
+        submittedByName: "Martine",
+        createdAt: "2026-08-24T12:00:00.000Z",
+      },
+    ])
+  })
+})

--- a/src/lib/field/__tests__/types.test.ts
+++ b/src/lib/field/__tests__/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { fieldOutboxSchema } from "../types"
+import { fieldCherishRecognitionSchema, fieldOutboxSchema } from "../types"
 
 describe("fieldOutboxSchema", () => {
   it("preserves daily log drafts queued by mobile builds before attachments", () => {
@@ -41,5 +41,30 @@ describe("fieldOutboxSchema", () => {
     ])
 
     expect(result.success).toBe(true)
+  })
+})
+
+describe("fieldCherishRecognitionSchema", () => {
+  it("accepts public recognition and rejects private concerns", () => {
+    const recognition = {
+      id: "recognition-1",
+      cherishValue: "Reliability",
+      message: "Thank you for keeping the delivery moving.",
+      submittedByName: "Martine",
+      createdAt: "2026-08-24T12:00:00.000Z",
+    }
+
+    expect(
+      fieldCherishRecognitionSchema.safeParse({
+        ...recognition,
+        responseType: "shoutout",
+      }).success,
+    ).toBe(true)
+    expect(
+      fieldCherishRecognitionSchema.safeParse({
+        ...recognition,
+        responseType: "concern",
+      }).success,
+    ).toBe(false)
   })
 })

--- a/src/lib/field/cherish-recognition.ts
+++ b/src/lib/field/cherish-recognition.ts
@@ -1,0 +1,37 @@
+import type {
+  FieldCherishRecognition,
+  FieldCherishResponseType,
+  FieldCherishValue,
+} from "@/lib/field/types"
+
+type CherishRecognitionSource = {
+  readonly id: string
+  readonly cherishValue: FieldCherishValue
+  readonly responseType: FieldCherishResponseType
+  readonly message: string
+  readonly submittedByName: string | null
+  readonly createdAt: string
+}
+
+/**
+ * Keep the crew-facing payload deliberately smaller than the review record.
+ * Private concerns are excluded even if a caller accidentally supplies one.
+ */
+export function toFieldCherishRecognitions(
+  items: readonly CherishRecognitionSource[],
+): readonly FieldCherishRecognition[] {
+  return items.flatMap((item) =>
+    item.responseType === "concern"
+      ? []
+      : [
+          {
+            id: item.id,
+            cherishValue: item.cherishValue,
+            responseType: item.responseType,
+            message: item.message,
+            submittedByName: item.submittedByName,
+            createdAt: item.createdAt,
+          },
+        ],
+  )
+}

--- a/src/lib/field/types.ts
+++ b/src/lib/field/types.ts
@@ -130,6 +130,15 @@ export const cherishResponseTypeSchema = z.enum([
   "concern",
 ])
 
+export const fieldCherishRecognitionSchema = z.object({
+  id: z.string(),
+  cherishValue: cherishValueSchema,
+  responseType: z.enum(["shoutout", "win"]),
+  message: z.string(),
+  submittedByName: z.string().nullable(),
+  createdAt: z.string(),
+})
+
 export const fieldOutboxItemSchema = z.discriminatedUnion("kind", [
   z.object({
     id: z.string(),
@@ -174,4 +183,7 @@ export type FieldOutboxItem = z.infer<typeof fieldOutboxItemSchema>
 export type FieldCherishValue = z.infer<typeof cherishValueSchema>
 export type FieldCherishResponseType = z.infer<
   typeof cherishResponseTypeSchema
+>
+export type FieldCherishRecognition = z.infer<
+  typeof fieldCherishRecognitionSchema
 >


### PR DESCRIPTION
## Summary

- add an approved CHERISH recognition ticker to the main dashboard and web Field Desk
- show the latest approved item on the native Field App Today view and the full stream in its CHERISH tab when online
- expose an authenticated crew-safe API response that excludes private concerns and reviewer-only fields

## Validation

- focused Vitest suite: 6 tests passed
- targeted ESLint passed
- native mobile shell compiled
- production Next.js build passed
- pre-push production build passed
