### PR TITLE
fix(cherish): consolidate feedback navigation

### DIFF
--- a/mobile-shell-src/app.ts
+++ b/mobile-shell-src/app.ts
@@ -564,9 +564,10 @@ function render(): void {
     { value: "log", symbol: "L", label: "Log" },
     { value: "documents", symbol: "D", label: "Documents" },
     { value: "chat", symbol: "M", label: "Messages" },
+    { value: "cherish", symbol: "C", label: "Cherish" },
   ]
   const liveLabel = profile ? "Full Compass" : "Sign in"
-  app.innerHTML = `<div class="shell"><header class="shell-header"><div class="header-row"><div><p class="eyebrow">Field mode</p><h1 class="project-title">${escapeHtml(title)}</h1></div><div class="header-actions">${outbox.length > 0 && online ? `<button id="sync-now" class="icon-button" type="button" aria-label="Sync waiting work">${syncIcon()}</button>` : ""}<button id="field-notifications" class="notification-button" type="button" aria-label="Notifications">${bellIcon()}${unreadNotifications > 0 ? `<span>${unreadNotifications > 9 ? "9+" : unreadNotifications}</span>` : ""}</button><button id="open-cherish" class="settings-button" type="button" ${activeTab === "cherish" ? "aria-current=page" : ""}>CHERISH</button><button id="field-settings" class="settings-button" type="button" aria-label="Field settings">Settings</button><button id="open-live" class="live-button" ${online && !signingIn ? "" : "disabled"}>${liveLabel}</button></div></div><div class="sync-line"><span class="status-dot ${online ? "online" : ""}"></span>${syncing || syncingCherish || syncingDailyLogs ? "Syncing waiting work" : online ? "Connection available" : "Offline"}${escapeHtml(queued)}</div></header><main class="content">${view()}</main><nav class="tabbar">${tabs.map((tab) => `<button class="tab ${activeTab === tab.value ? "active" : ""}" data-tab="${tab.value}"><span class="tab-symbol">${tab.symbol}</span>${tab.label}</button>`).join("")}</nav></div>`
+  app.innerHTML = `<div class="shell"><header class="shell-header"><div class="header-row"><div><p class="eyebrow">Field mode</p><h1 class="project-title">${escapeHtml(title)}</h1></div><div class="header-actions">${outbox.length > 0 && online ? `<button id="sync-now" class="icon-button" type="button" aria-label="Sync waiting work">${syncIcon()}</button>` : ""}<button id="field-notifications" class="notification-button" type="button" aria-label="Notifications">${bellIcon()}${unreadNotifications > 0 ? `<span>${unreadNotifications > 9 ? "9+" : unreadNotifications}</span>` : ""}</button><button id="field-settings" class="settings-button" type="button" aria-label="Field settings">Settings</button><button id="open-live" class="live-button" ${online && !signingIn ? "" : "disabled"}>${liveLabel}</button></div></div><div class="sync-line"><span class="status-dot ${online ? "online" : ""}"></span>${syncing || syncingCherish || syncingDailyLogs ? "Syncing waiting work" : online ? "Connection available" : "Offline"}${escapeHtml(queued)}</div></header><main class="content">${view()}</main><nav class="tabbar">${tabs.map((tab) => `<button class="tab ${activeTab === tab.value ? "active" : ""}" data-tab="${tab.value}"><span class="tab-symbol">${tab.symbol}</span>${tab.label}</button>`).join("")}</nav></div>`
   bindEvents()
 }
 
@@ -618,6 +619,7 @@ function bindEvents(): void {
     if (isTab(button.dataset.tab)) activeTab = button.dataset.tab
     render()
     if (activeTab === "chat" && online) void refreshProjectPacket()
+    if (activeTab === "cherish" && online) void refreshCherishRecognition()
   }))
   document.querySelectorAll<HTMLButtonElement>("[data-project-id]").forEach((button) => button.addEventListener("click", () => void selectProject(button.dataset.projectId ?? "")))
   document.querySelector("#project-company-filter")?.addEventListener("change", (event) => {
@@ -640,7 +642,6 @@ function bindEvents(): void {
   })
   document.querySelector<HTMLButtonElement>("#open-live")?.addEventListener("click", openFullCompass)
   document.querySelector<HTMLButtonElement>("#open-live-empty")?.addEventListener("click", openFullCompass)
-  document.querySelector<HTMLButtonElement>("#open-cherish")?.addEventListener("click", openCherish)
   document.querySelector<HTMLButtonElement>("#today-cherish")?.addEventListener("click", openCherish)
   document.querySelector<HTMLButtonElement>("#sync-now")?.addEventListener("click", () => void resumePendingSync())
   document.querySelector<HTMLButtonElement>("#field-notifications")?.addEventListener("click", () => {

--- a/mobile-shell-src/styles.css
+++ b/mobile-shell-src/styles.css
@@ -208,7 +208,7 @@ button { cursor: pointer; }
   inset: auto 0 0;
   z-index: 20;
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(6, 1fr);
   min-height: calc(64px + env(safe-area-inset-bottom));
   padding-bottom: env(safe-area-inset-bottom);
   border-top: 1px solid var(--line);

--- a/src/app/actions/__tests__/cherish-pulse.test.ts
+++ b/src/app/actions/__tests__/cherish-pulse.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  canUseExecutiveAdmin: vi.fn(),
+  getCloudflareContext: vi.fn(),
+  getDb: vi.fn(),
+  requireAuth: vi.fn(),
+  revalidatePath: vi.fn(),
+}))
+
+vi.mock("next/cache", () => ({ revalidatePath: mocks.revalidatePath }))
+vi.mock("@/lib/auth", () => ({ requireAuth: mocks.requireAuth }))
+vi.mock("@/lib/db", () => ({ getCloudflareContext: mocks.getCloudflareContext }))
+vi.mock("@/db", () => ({ getDb: mocks.getDb }))
+vi.mock("@/lib/permissions", () => ({
+  canUseExecutiveAdmin: mocks.canUseExecutiveAdmin,
+  canUseFieldDesk: vi.fn(() => true),
+}))
+vi.mock("@/lib/user-roles", () => ({
+  isInternalStaffRole: vi.fn(() => true),
+}))
+
+import { reviewCherishPulseResponse } from "@/app/actions/cherish-pulse"
+
+describe("reviewCherishPulseResponse", () => {
+  beforeEach(() => {
+    mocks.requireAuth.mockResolvedValue({
+      id: "executive-1",
+      organizationId: "org-1",
+      email: "executive@example.com",
+    })
+    mocks.canUseExecutiveAdmin.mockReturnValue(true)
+    mocks.getCloudflareContext.mockResolvedValue({ env: { DB: {} } })
+    mocks.revalidatePath.mockReset()
+  })
+
+  it("archives an existing approved recognition and invalidates every stream", async () => {
+    const selectChain = { from: vi.fn(), where: vi.fn(), get: vi.fn() }
+    selectChain.from.mockReturnValue(selectChain)
+    selectChain.where.mockReturnValue(selectChain)
+    selectChain.get.mockResolvedValue({ id: "recognition-1" })
+
+    const updateChain = { set: vi.fn(), where: vi.fn(), run: vi.fn() }
+    updateChain.set.mockReturnValue(updateChain)
+    updateChain.where.mockReturnValue(updateChain)
+    updateChain.run.mockResolvedValue(undefined)
+    mocks.getDb.mockReturnValue({
+      select: vi.fn().mockReturnValue(selectChain),
+      update: vi.fn().mockReturnValue(updateChain),
+    })
+
+    const result = await reviewCherishPulseResponse({
+      id: "recognition-1",
+      decision: "archive",
+    })
+
+    expect(result).toEqual({
+      success: true,
+      data: { id: "recognition-1", reviewStatus: "archived" },
+    })
+    expect(updateChain.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reviewStatus: "archived",
+        publishedAt: null,
+      }),
+    )
+    expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard")
+    expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard/field")
+    expect(mocks.revalidatePath).toHaveBeenCalledWith(
+      "/dashboard/executive-admin/cherish",
+    )
+  })
+})

--- a/src/app/actions/cherish-pulse.ts
+++ b/src/app/actions/cherish-pulse.ts
@@ -490,6 +490,8 @@ export async function reviewCherishPulseResponse(
       .run()
 
     revalidatePath("/dashboard")
+    revalidatePath("/dashboard/cherish")
+    revalidatePath("/dashboard/field")
     revalidatePath("/dashboard/executive-admin/cherish")
 
     return {

--- a/src/app/dashboard/cherish/page.tsx
+++ b/src/app/dashboard/cherish/page.tsx
@@ -1,0 +1,36 @@
+import { redirect } from "next/navigation"
+import { IconHeartHandshake } from "@tabler/icons-react"
+
+import { CherishFeedbackForm } from "@/components/cherish/cherish-feedback-form"
+import { getCurrentUser } from "@/lib/auth"
+import { canUseFieldDesk } from "@/lib/permissions"
+
+export const dynamic = "force-dynamic"
+
+export default async function CherishPage(): Promise<React.ReactElement> {
+  const user = await getCurrentUser()
+  if (!canUseFieldDesk(user)) {
+    redirect("/dashboard/access-restricted?action=submit%20CHERISH%20feedback")
+  }
+
+  return (
+    <main className="mx-auto flex w-full max-w-4xl flex-1 flex-col overflow-y-auto px-4 py-6 sm:px-6">
+      <header className="border-b pb-5">
+        <div className="flex items-center gap-2">
+          <IconHeartHandshake className="size-6 text-primary" />
+          <h1 className="text-2xl font-semibold tracking-tight">
+            CHERISH feedback
+          </h1>
+        </div>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
+          Recognize a teammate, celebrate a project win, or privately let
+          leadership know where support is needed.
+        </p>
+      </header>
+
+      <section className="py-5" aria-label="Submit CHERISH feedback">
+        <CherishFeedbackForm />
+      </section>
+    </main>
+  )
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,7 +14,6 @@ import type { DashboardOfficeEvent } from "@/components/dashboard/dashboard-laun
 import { getCurrentUser, toSidebarUser } from "@/lib/auth"
 import {
   canManageProjectRegistry,
-  canUseExecutiveAdmin,
 } from "@/lib/permissions"
 import { toFieldCherishRecognitions } from "@/lib/field/cherish-recognition"
 
@@ -85,7 +84,6 @@ export default async function Page(): Promise<React.ReactElement> {
       officeCalendarEvents={officeCalendarEvents}
       officeProjectId={workCalendar?.defaultProjectId ?? null}
       canManageOfficeMaintenance={canManageProjectRegistry(currentUser)}
-      canReviewCherish={canUseExecutiveAdmin(currentUser)}
       cherishRecognitions={
         cherishResult.success
           ? toFieldCherishRecognitions(cherishResult.data)

--- a/src/components/__tests__/app-sidebar-navigation.test.ts
+++ b/src/components/__tests__/app-sidebar-navigation.test.ts
@@ -1,14 +1,23 @@
 import { describe, expect, it } from "vitest"
 
-import { buildMainNavigation } from "@/components/app-sidebar"
+import {
+  buildCherishNavigation,
+  buildMainNavigation,
+} from "@/components/app-sidebar"
+import type { NavGroupItem } from "@/components/nav-main"
 
-function officeNavigation(canUseExecutiveAdmin: boolean) {
+function officeNavigation(
+  canUseExecutiveAdmin: boolean,
+): NavGroupItem | undefined {
   return buildMainNavigation({
     activeProjectId: null,
     canViewActivity: true,
     canManageFeedback: false,
     canUseExecutiveAdmin,
-  }).find((item) => item.kind === "group" && item.title === "Office")
+  }).find(
+    (item): item is NavGroupItem =>
+      item.kind === "group" && item.title === "Office",
+  )
 }
 
 describe("Executive Admin sidebar navigation", () => {
@@ -39,5 +48,21 @@ describe("Executive Admin sidebar navigation", () => {
         (item) => item.kind === "subgroup" && item.title === "Executive Admin",
       ),
     ).toBe(false)
+  })
+})
+
+describe("CHERISH sidebar navigation", () => {
+  it("opens the dedicated full Compass page for eligible team members", () => {
+    expect(buildCherishNavigation(true)).toMatchObject([
+      {
+        kind: "link",
+        title: "CHERISH",
+        url: "/dashboard/cherish",
+      },
+    ])
+  })
+
+  it("remains hidden from users without Field Desk access", () => {
+    expect(buildCherishNavigation(false)).toEqual([])
   })
 })

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -517,6 +517,21 @@ export function buildMainNavigation({
   })
 }
 
+export function buildCherishNavigation(
+  canUseFieldDesk: boolean,
+): ReadonlyArray<NavLinkItem> {
+  return canUseFieldDesk
+    ? [
+        {
+          kind: "link",
+          title: "CHERISH",
+          url: "/dashboard/cherish",
+          icon: IconHeartHandshake,
+        },
+      ]
+    : []
+}
+
 function SidebarNav({
   canUseFieldDesk,
   canViewActivity,
@@ -558,16 +573,7 @@ function SidebarNav({
         },
       ]
     : []
-  const fieldNav: ReadonlyArray<NavLinkItem> = canUseFieldDesk
-    ? [
-        {
-          kind: "link",
-          title: "CHERISH",
-          url: "/dashboard/field",
-          icon: IconHeartHandshake,
-        },
-      ]
-    : []
+  const cherishNav = buildCherishNavigation(canUseFieldDesk)
   const persistentNav: ReadonlyArray<NavItem> = [
     DASHBOARD_NAV,
     ...staffMessageDeskNav,
@@ -577,7 +583,7 @@ function SidebarNav({
       icon: IconCalendarStats,
       items: projectScopedPlanningNav,
     },
-    ...fieldNav,
+    ...cherishNav,
   ]
 
   return (

--- a/src/components/cherish/cherish-feedback-form.tsx
+++ b/src/components/cherish/cherish-feedback-form.tsx
@@ -1,0 +1,187 @@
+"use client"
+
+import { useState, useTransition } from "react"
+
+import {
+  submitCherishPulseResponse,
+  type CherishPulseResponseType,
+  type CherishValue,
+} from "@/app/actions/cherish-pulse"
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+
+export const CHERISH_VALUES: readonly CherishValue[] = [
+  "Camaraderie",
+  "Honor",
+  "Excellence",
+  "Reliability",
+  "Integrity",
+  "Servitude",
+  "Humility",
+]
+
+export const CHERISH_RESPONSE_TYPES: readonly {
+  readonly value: CherishPulseResponseType
+  readonly label: string
+}[] = [
+  { value: "shoutout", label: "Shoutout" },
+  { value: "win", label: "Project win" },
+  { value: "concern", label: "Private concern" },
+]
+
+export function CherishFeedbackForm(): React.ReactElement {
+  const [cherishValue, setCherishValue] =
+    useState<CherishValue>("Reliability")
+  const [responseType, setResponseType] =
+    useState<CherishPulseResponseType>("shoutout")
+  const [message, setMessage] = useState("")
+  const [feedback, setFeedback] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function submitResponse(): void {
+    const trimmedMessage = message.trim()
+    if (trimmedMessage.length < 3) {
+      setFeedback("Add a little more detail before submitting.")
+      return
+    }
+
+    if (trimmedMessage.length > 1_200) {
+      setFeedback("Keep CHERISH responses under 1,200 characters.")
+      return
+    }
+
+    startTransition(async () => {
+      setFeedback(null)
+      const result = await submitCherishPulseResponse({
+        cherishValue,
+        responseType,
+        message: trimmedMessage,
+        source: "compass_dashboard",
+      })
+
+      if (!result.success) {
+        setFeedback(result.error)
+        return
+      }
+
+      setMessage("")
+      setFeedback(
+        responseType === "concern"
+          ? "Saved privately for leadership review."
+          : "Saved to the CHERISH review queue.",
+      )
+    })
+  }
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={(event) => {
+        event.preventDefault()
+        submitResponse()
+      }}
+    >
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label className="mb-1.5 block text-sm font-medium">
+            CHERISH value
+          </label>
+          <Select
+            value={cherishValue}
+            onValueChange={(value) => {
+              const nextValue = CHERISH_VALUES.find(
+                (candidate) => candidate === value,
+              )
+              if (nextValue) setCherishValue(nextValue)
+            }}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {CHERISH_VALUES.map((value) => (
+                <SelectItem key={value} value={value}>
+                  {value}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div>
+          <label className="mb-1.5 block text-sm font-medium">
+            Response type
+          </label>
+          <Select
+            value={responseType}
+            onValueChange={(value) => {
+              const nextType = CHERISH_RESPONSE_TYPES.find(
+                (candidate) => candidate.value === value,
+              )
+              if (nextType) setResponseType(nextType.value)
+            }}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {CHERISH_RESPONSE_TYPES.map((type) => (
+                <SelectItem key={type.value} value={type.value}>
+                  {type.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div>
+        <label className="mb-1.5 block text-sm font-medium">Message</label>
+        <Textarea
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          placeholder={
+            responseType === "concern"
+              ? "What should leadership know?"
+              : "What happened, and who helped?"
+          }
+          className="min-h-32 resize-y"
+          maxLength={1_200}
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-4">
+        <p
+          className={cn(
+            "text-sm",
+            feedback?.startsWith("Saved")
+              ? "text-muted-foreground"
+              : feedback
+                ? "text-destructive"
+                : "text-muted-foreground",
+          )}
+          role="status"
+        >
+          {feedback ??
+            (responseType === "concern"
+              ? "Private concerns are visible only to Executive Admin reviewers."
+              : "Team responses appear after Executive Admin approval.")}
+        </p>
+        <Button
+          type="submit"
+          disabled={isPending || message.trim().length < 3}
+        >
+          {isPending ? "Saving..." : "Submit CHERISH feedback"}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/dashboard/cherish-pulse-stream.tsx
+++ b/src/components/dashboard/cherish-pulse-stream.tsx
@@ -85,7 +85,15 @@ export function CherishPulseStream({
     }
 
     setReviewItems((current) => current.filter((entry) => entry.id !== item.id))
-    if (decision === "approve" && item.visibility === "team") {
+    if (decision === "archive") {
+      setTeamItems((current) => current.filter((entry) => entry.id !== item.id))
+      setPrivateItems((current) => current.filter((entry) => entry.id !== item.id))
+      setMessage(
+        item.reviewStatus === "approved" && item.visibility === "team"
+          ? "Archived and removed from the team CHERISH stream."
+          : "Archived from the CHERISH review queue.",
+      )
+    } else if (item.visibility === "team") {
       setTeamItems((current) => [
         { ...item, reviewStatus: "approved" },
         ...current.filter((entry) => entry.id !== item.id),
@@ -97,8 +105,6 @@ export function CherishPulseStream({
         ...current.filter((entry) => entry.id !== item.id),
       ])
       setMessage("Acknowledged and retained in the leadership-only history.")
-    } else {
-      setMessage("Archived from the CHERISH review queue.")
     }
     setReviewingId(null)
   }
@@ -234,6 +240,20 @@ export function CherishPulseStream({
               <p className="mt-2 text-[11px] text-muted-foreground">
                 Shared by {item.submittedByName ?? "a team member"}
               </p>
+              {canReview ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="mt-3"
+                  onClick={() => void review(item, "archive")}
+                  disabled={reviewingId !== null}
+                >
+                  {reviewingId === item.id
+                    ? "Archiving…"
+                    : "Archive from team stream"}
+                </Button>
+              ) : null}
             </article>
           ))}
         </div>

--- a/src/components/dashboard/dashboard-launchpad.tsx
+++ b/src/components/dashboard/dashboard-launchpad.tsx
@@ -26,19 +26,13 @@ import {
   IconMessageCircleQuestion,
   IconPhoto,
   IconPhotoEdit,
-  IconPlus,
   IconReceipt,
   IconSparkles,
-  IconUserHeart,
   IconUsers,
 } from "@tabler/icons-react"
 
 import type { DashboardOverview } from "@/app/actions/dashboard-overview"
 import { updateWorkspacePhoto } from "@/app/actions/profile"
-import {
-  submitCherishPulseResponse,
-  type CherishPulseResponseType,
-} from "@/app/actions/cherish-pulse"
 import {
   getOrganizationTeamAvailability,
   updatePresence,
@@ -48,14 +42,6 @@ import { Button } from "@/components/ui/button"
 import { CherishPulseStream } from "@/components/dashboard/cherish-pulse-stream"
 import { CherishRecognitionTicker } from "@/components/cherish/cherish-recognition-ticker"
 import { OfficeMaintenanceDrawer } from "@/components/projects/office-maintenance-drawer"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog"
 import {
   Select,
   SelectContent,
@@ -71,7 +57,6 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet"
-import { Textarea } from "@/components/ui/textarea"
 import type { SidebarUser } from "@/lib/auth"
 import type { FieldCherishRecognition } from "@/lib/field/types"
 import {
@@ -615,116 +600,6 @@ function DeskHero({
   )
 }
 
-function CherishComposer({
-  onSubmitted,
-}: {
-  readonly onSubmitted: () => void
-}): React.ReactElement {
-  const [open, setOpen] = useState(false)
-  const [responseType, setResponseType] =
-    useState<CherishPulseResponseType>("shoutout")
-  const [message, setMessage] = useState("")
-  const [resultMessage, setResultMessage] = useState<string | null>(null)
-  const [isPending, startTransition] = useTransition()
-  const isPrivate = responseType === "concern"
-
-  function handleSubmit(): void {
-    const trimmedMessage = message.trim()
-    if (trimmedMessage.length === 0) return
-
-    startTransition(async () => {
-      const result = await submitCherishPulseResponse({
-        cherishValue: "Reliability",
-        responseType,
-        message: trimmedMessage,
-        source: "compass_dashboard",
-      })
-
-      if (!result.success) {
-        setResultMessage(result.error)
-        return
-      }
-
-      setMessage("")
-      onSubmitted()
-      setResultMessage(
-        isPrivate
-          ? "Your private concern was sent for leadership review."
-          : "Your feedback was added to the CHERISH review queue."
-      )
-    })
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button size="sm" className="bg-[#2f5963] hover:bg-[#244750]">
-          <IconPlus className="size-4" />
-          Give CHERISH feedback
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Give CHERISH feedback</DialogTitle>
-          <DialogDescription>
-            Share team recognition or send a private concern to leadership.
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="grid grid-cols-2 border">
-          <button
-            type="button"
-            onClick={() => setResponseType("shoutout")}
-            className={cn(
-              "px-3 py-2 text-sm font-medium transition-colors",
-              responseType !== "concern" && "bg-[#2f5963] text-white"
-            )}
-          >
-            Team recognition
-          </button>
-          <button
-            type="button"
-            onClick={() => setResponseType("concern")}
-            className={cn(
-              "border-l px-3 py-2 text-sm font-medium transition-colors",
-              responseType === "concern" && "bg-[#9d832c] text-white"
-            )}
-          >
-            Private concern
-          </button>
-        </div>
-
-        <Textarea
-          value={message}
-          onChange={(event) => setMessage(event.target.value)}
-          placeholder={
-            isPrivate
-              ? "What should leadership know?"
-              : "Who deserves recognition, and what did they do?"
-          }
-          className="min-h-28"
-        />
-        <div className="flex items-center justify-between gap-3">
-          <p className="text-xs text-muted-foreground">
-            {isPrivate ? "Private to leadership" : "Team-visible after review"}
-          </p>
-          <Button
-            onClick={handleSubmit}
-            disabled={message.trim().length === 0 || isPending}
-          >
-            {isPending ? "Sending..." : "Send feedback"}
-          </Button>
-        </div>
-        {resultMessage ? (
-          <p className="border-l-2 border-emerald-700 pl-2 text-xs text-muted-foreground">
-            {resultMessage}
-          </p>
-        ) : null}
-      </DialogContent>
-    </Dialog>
-  )
-}
-
 function OfficeTaskList({
   overview,
   officeCalendarEvents,
@@ -1230,14 +1105,8 @@ function ProjectWorkspace({
 
 function TeamPulseDrawer({
   overview,
-  canReviewCherish,
-  cherishRefreshKey,
-  onCherishSubmitted,
 }: {
   readonly overview: DashboardOverview
-  readonly canReviewCherish: boolean
-  readonly cherishRefreshKey: number
-  readonly onCherishSubmitted: () => void
 }): React.ReactElement {
   return (
     <Sheet>
@@ -1255,23 +1124,7 @@ function TeamPulseDrawer({
           </SheetDescription>
         </SheetHeader>
         <div className="space-y-5 px-4 pb-6">
-          <div className="border-y py-4">
-            <div className="flex items-center gap-2">
-              <IconUserHeart className="size-5 text-emerald-700" />
-              <h3 className="text-sm font-semibold">CHERISH</h3>
-            </div>
-            <p className="mt-2 text-sm leading-6 text-muted-foreground">
-              Recognize a teammate or privately let leadership know where help
-              is needed.
-            </p>
-            <div className="mt-3">
-              <CherishComposer onSubmitted={onCherishSubmitted} />
-            </div>
-          </div>
-          <CherishPulseStream
-            canReview={canReviewCherish}
-            refreshKey={cherishRefreshKey}
-          />
+          <CherishPulseStream canReview={false} refreshKey={0} />
           <div>
             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               Today at a glance
@@ -1308,7 +1161,6 @@ export function DashboardLaunchpad({
   officeCalendarEvents,
   officeProjectId,
   canManageOfficeMaintenance,
-  canReviewCherish,
   cherishRecognitions,
 }: {
   readonly overview: DashboardOverview
@@ -1318,19 +1170,12 @@ export function DashboardLaunchpad({
   readonly officeCalendarEvents: readonly DashboardOfficeEvent[]
   readonly officeProjectId: string | null
   readonly canManageOfficeMaintenance: boolean
-  readonly canReviewCherish: boolean
   readonly cherishRecognitions: readonly FieldCherishRecognition[]
 }): React.ReactElement {
   const [mode, setMode] = useState<DashboardMode>("office")
   const [deskStatus, setDeskStatus] = useState<DeskStatus>(() =>
     deskStatusForPresenceMessage(initialDeskStatusMessage)
   )
-  const [cherishRefreshKey, setCherishRefreshKey] = useState(0)
-
-  function handleCherishSubmitted(): void {
-    setCherishRefreshKey((current) => current + 1)
-  }
-
   return (
     <main className="mx-auto w-full max-w-[1500px] space-y-4 p-3 sm:p-4 lg:p-5">
       <div className="flex flex-col gap-3 border-b pb-3 lg:grid lg:grid-cols-[1fr_auto_1fr] lg:items-center">
@@ -1373,13 +1218,7 @@ export function DashboardLaunchpad({
           {canManageOfficeMaintenance ? (
             <OfficeMaintenanceDrawer projects={overview.projects} />
           ) : null}
-          <CherishComposer onSubmitted={handleCherishSubmitted} />
-          <TeamPulseDrawer
-            overview={overview}
-            canReviewCherish={canReviewCherish}
-            cherishRefreshKey={cherishRefreshKey}
-            onCherishSubmitted={handleCherishSubmitted}
-          />
+          <TeamPulseDrawer overview={overview} />
         </div>
       </div>
 

--- a/src/components/dashboard/dashboard-launchpad.tsx
+++ b/src/components/dashboard/dashboard-launchpad.tsx
@@ -20,7 +20,6 @@ import {
   IconChecklist,
   IconClipboardText,
   IconFileInvoice,
-  IconHeartHandshake,
   IconHome2,
   IconMapPin,
   IconMessageCircleQuestion,
@@ -588,12 +587,11 @@ function DeskHero({
               ))}
             </SelectContent>
           </Select>
-          <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <IconHeartHandshake className="size-4 text-[#9d832c]" />
-            {isStatusPending
-              ? "Saving status..."
-              : statusMessage ?? "CHERISH notes will appear here"}
-          </span>
+          {isStatusPending || statusMessage ? (
+            <span className="text-xs text-muted-foreground">
+              {isStatusPending ? "Saving status..." : statusMessage}
+            </span>
+          ) : null}
         </div>
       </div>
     </section>


### PR DESCRIPTION
Summary
- make the sidebar CHERISH page the single full-Compass desktop submission experience
- preserve the Field App CHERISH workflow in its standard navigation and offline sync
- add executive archive controls for approved recognition
- remove the redundant dashboard placeholder beneath In Office

Validation
- production build
- TypeScript check
- focused Cherish and Field App tests
- ESLint (zero errors)