### PR TITLE
feat(estimates): search Sage tax entities

### DIFF
--- a/src/app/actions/project-estimates.ts
+++ b/src/app/actions/project-estimates.ts
@@ -1495,10 +1495,18 @@ export async function updateProjectEstimateHeader(
       ? await access.db
           .select()
           .from(sageTaxEntities)
-          .where(eq(sageTaxEntities.id, input.defaultTaxEntityId))
+          .where(
+            and(
+              eq(sageTaxEntities.id, input.defaultTaxEntityId),
+              eq(sageTaxEntities.active, true)
+            )
+          )
           .limit(1)
       : []
     const taxEntity = taxEntityRows[0]
+    if (input.defaultTaxEntityId && !taxEntity) {
+      throw new Error("Choose an active Sage tax entity.")
+    }
     const [termsTemplate, introductionTemplate, closingTemplate] =
       await Promise.all([
         loadEstimateTextTemplate({

--- a/src/components/projects/project-estimate-workspace.tsx
+++ b/src/components/projects/project-estimate-workspace.tsx
@@ -59,7 +59,10 @@ import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { SearchableCombobox } from "@/components/searchable-combobox"
+import {
+  SearchableCombobox,
+  SearchableComboboxField,
+} from "@/components/searchable-combobox"
 import {
   Select,
   SelectContent,
@@ -276,6 +279,17 @@ export function ProjectEstimateWorkspacePanel({
           .map((option) => option.value)
       ),
     [workspace.costCodes]
+  )
+  const taxEntityOptions = useMemo(
+    () =>
+      workspace.taxEntities.map((option) => ({
+        value: option.value,
+        label: option.label,
+        selectedLabel: `${option.label} · ${percent(option.rateBasisPoints)}`,
+        description: `${percent(option.rateBasisPoints)} · Sage tax entity`,
+        keywords: `${option.code} ${option.rateBasisPoints / 100}`,
+      })),
+    [workspace.taxEntities]
   )
   const groupedLines = useMemo(() => {
     const groups = new Map<string, ProjectEstimateLineItem[]>()
@@ -670,21 +684,23 @@ export function ProjectEstimateWorkspacePanel({
                     ))}
                   </SelectContent>
                 </Select>
-                <Select
+                <SearchableCombobox
                   value={startTaxEntityId}
                   onValueChange={setStartTaxEntityId}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Project tax entity, if applicable" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {workspace.taxEntities.map((tax) => (
-                      <SelectItem key={tax.value} value={tax.value}>
-                        {tax.label} · {percent(tax.rateBasisPoints)}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  options={[
+                    {
+                      value: "",
+                      label: "No project tax entity",
+                      keywords: "none clear non-taxable",
+                    },
+                    ...taxEntityOptions,
+                  ]}
+                  ariaLabel="Project tax entity for the new estimate"
+                  placeholder="Project tax entity, if applicable"
+                  searchPlaceholder="Search Sage tax entities..."
+                  emptyMessage="No matching Sage tax entities."
+                  groupHeading="Active Sage tax entities"
+                />
                 {selectedStartTemplate?.requiresProjectTaxEntity && (
                   <p className="text-xs text-amber-700 dark:text-amber-300">
                     This template contains taxable lines. Select the project’s
@@ -1005,22 +1021,25 @@ export function ProjectEstimateWorkspacePanel({
           </div>
           <div className="space-y-1.5 md:col-span-2">
             <Label htmlFor="defaultTaxEntityId">Project tax entity</Label>
-            <Select
+            <SearchableComboboxField
               name="defaultTaxEntityId"
+              id="defaultTaxEntityId"
               defaultValue={estimate.defaultTaxEntityId ?? undefined}
               disabled={!editable}
-            >
-              <SelectTrigger id="defaultTaxEntityId">
-                <SelectValue placeholder="Select a tax entity" />
-              </SelectTrigger>
-              <SelectContent>
-                {workspace.taxEntities.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label} · {percent(option.rateBasisPoints)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              options={[
+                {
+                  value: "",
+                  label: "No project tax entity",
+                  keywords: "none clear non-taxable",
+                },
+                ...taxEntityOptions,
+              ]}
+              ariaLabel="Project tax entity"
+              placeholder="Select a Sage tax entity"
+              searchPlaceholder="Search Sage tax entities..."
+              emptyMessage="No matching Sage tax entities."
+              groupHeading="Active Sage tax entities"
+            />
           </div>
           <div className="space-y-1.5 md:col-span-2">
             <Label htmlFor="termsTemplateId">Contract terms template</Label>
@@ -1443,14 +1462,26 @@ export function ProjectEstimateWorkspacePanel({
               </div>
               <div className="space-y-1.5">
                 <Label>Tax entity</Label>
-                <Select value={line.taxEntityId} onValueChange={(value) => setLine({ ...line, taxEntityId: value })} disabled={!line.taxable}>
-                  <SelectTrigger><SelectValue placeholder="Project default" /></SelectTrigger>
-                  <SelectContent>
-                    {workspace.taxEntities.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>{option.label} · {percent(option.rateBasisPoints)}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <SearchableCombobox
+                  value={line.taxEntityId}
+                  onValueChange={(value) =>
+                    setLine({ ...line, taxEntityId: value })
+                  }
+                  disabled={!line.taxable}
+                  options={[
+                    {
+                      value: "",
+                      label: "Use project tax entity",
+                      keywords: "default inherit clear",
+                    },
+                    ...taxEntityOptions,
+                  ]}
+                  ariaLabel="Estimate line tax entity"
+                  placeholder="Use project tax entity"
+                  searchPlaceholder="Search Sage tax entities..."
+                  emptyMessage="No matching Sage tax entities."
+                  groupHeading="Active Sage tax entities"
+                />
               </div>
             </div>
             <div className="mt-3 flex flex-wrap items-center gap-5">


### PR DESCRIPTION
## Summary

- replace estimate tax entity selects with searchable Sage-backed comboboxes
- support explicit project-default and no-tax-entity choices
- reject inactive Sage tax entity IDs when saving estimate headers

## Validation

- `bunx eslint src/components/projects/project-estimate-workspace.tsx src/app/actions/project-estimates.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit --pretty false`
- `bun run test` (227 files, 1,181 tests)
- `bun run build`
- autoreview clean: no accepted/actionable findings
