### PR TITLE
feat(sage): sync estimate tax catalog

### DIFF
--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -24,7 +24,8 @@ systemctl --user enable --now compass-sage-pay-application-poller.timer
 The secret broker must expose `HPS_SAGE_SQL_PASSWORD` and
 `SAGE_BRIDGE_SECRET`. The latter must match the Cloudflare Worker secret. The
 SQL account is read-only and the poller never sends SQL credentials to
-Compass.
+Compass. Each successful poll also sends a complete snapshot of Sage's
+combined tax districts so estimate selectors stay aligned with `dbo.taxdst`.
 
 Useful health checks:
 
@@ -34,4 +35,5 @@ journalctl --user -u compass-sage-pay-application-poller.service -n 50 --no-page
 ```
 
 The timer invokes a single, lock-protected poll each minute. A successful idle
-run reports `requested: 0` and `processed: 0`; that is a healthy state.
+run reports `requested: 0`, `processed: 0`, and the current `taxDistricts`
+count; that is a healthy state.

--- a/docs/wip/sage-api-bridge-2026-05-14.md
+++ b/docs/wip/sage-api-bridge-2026-05-14.md
@@ -90,6 +90,7 @@ units are in `deploy/systemd/`. The deployed process:
 - receives the SQL password and HMAC secret from the host secret broker;
 - connects with a dedicated read-only Sage identity;
 - claims bounded Compass requests once per minute;
+- reads Sage's complete `taxdst` catalog and refreshes the estimate selector;
 - reads only the latest AIA header and its G703 lines;
 - derives total earned less retainage from populated Sage header totals when
   Sage's `ttlern` field is empty;

--- a/scripts/sage_pay_application_poller.py
+++ b/scripts/sage_pay_application_poller.py
@@ -33,6 +33,7 @@ DEFAULT_SAGE_DATABASE = "High Performance Structures Inc"
 DEFAULT_SAGE_USERNAME = "hps_jarvis_readonly"
 REQUESTS_TARGET = "/api/integrations/sage/pay-applications/requests?limit=10"
 RESULTS_TARGET = "/api/integrations/sage/pay-applications/results"
+TAX_CATALOG_RESULTS_TARGET = "/api/integrations/sage/tax-catalog/results"
 LOCK_PATH = Path("/tmp/compass-sage-pay-application-poller.lock")
 SNAPSHOT_MAPPING_VERSION = "v2"
 
@@ -160,6 +161,35 @@ def normalized_cost_code(value: Any) -> str:
     if isinstance(value, Decimal):
         return format(value, "f")
     return text(value) or "Unassigned"
+
+
+def build_tax_catalog_snapshot(
+    rows: Sequence[Mapping[str, Any]], captured_at: str
+) -> dict[str, Any]:
+    if not rows:
+        raise PollerError("The Sage tax district catalog is empty")
+
+    districts: list[dict[str, Any]] = []
+    for row in rows:
+        source_record_id = text(row.get("recnum"))
+        name = text(row.get("dstnme"))
+        rate = row.get("sumrte")
+        if source_record_id is None or name is None or rate is None:
+            raise PollerError("Sage returned an incomplete tax district")
+        districts.append(
+            {
+                "sourceRecordId": source_record_id,
+                "code": source_record_id,
+                "name": name,
+                "ratePercent": float(Decimal(str(rate))),
+            }
+        )
+
+    return {
+        "capturedAt": captured_at,
+        "complete": True,
+        "taxDistricts": districts,
+    }
 
 
 def build_snapshot(
@@ -378,6 +408,17 @@ def fetch_latest_application(cursor: Any, sage_job: int) -> tuple[dict[str, Any]
     return dict(header), [dict(line) for line in cursor.fetchall()]
 
 
+def fetch_tax_catalog(cursor: Any) -> list[dict[str, Any]]:
+    cursor.execute(
+        """
+        SELECT recnum, dstnme, sumrte
+        FROM dbo.taxdst WITH (NOLOCK)
+        ORDER BY recnum
+        """
+    )
+    return [dict(row) for row in cursor.fetchall()]
+
+
 def connect_sage() -> Any:
     try:
         import pymssql
@@ -428,15 +469,48 @@ def process_requests(requests: Iterable[PollRequest], base_url: str, secret: str
     return processed
 
 
-def poll_once(base_url: str, secret: str) -> tuple[int, int]:
+def sync_tax_catalog(base_url: str, secret: str) -> int:
+    connection = connect_sage()
+    try:
+        cursor = connection.cursor(as_dict=True)
+        rows = fetch_tax_catalog(cursor)
+        captured_at = dt.datetime.now(dt.timezone.utc).isoformat()
+        snapshot = build_tax_catalog_snapshot(rows, captured_at)
+        signed_json_request(
+            base_url,
+            secret,
+            "POST",
+            TAX_CATALOG_RESULTS_TARGET,
+            snapshot,
+            timeout=45,
+        )
+        return len(rows)
+    finally:
+        connection.close()
+
+
+def sync_tax_catalog_safely(base_url: str, secret: str) -> tuple[int | None, str | None]:
+    try:
+        return sync_tax_catalog(base_url, secret), None
+    except PollerError as error:
+        return None, str(error)
+    except Exception as error:
+        # This ancillary sync must not take down the pay-application path.
+        # Report only the exception type so SQL or driver details cannot leak.
+        return None, f"Tax catalog sync failed: {type(error).__name__}"
+
+
+def poll_once(base_url: str, secret: str) -> tuple[int, int, int | None, str | None]:
+    # Catalog refresh is ancillary to pay applications. Run it before claiming
+    # work and contain expected failures so an invalid catalog cannot strand a
+    # claimed pay-application request.
+    tax_districts, tax_catalog_error = sync_tax_catalog_safely(base_url, secret)
     payload = signed_json_request(
         base_url, secret, "GET", REQUESTS_TARGET, timeout=30
     )
     requests = parse_poll_requests(payload)
-    if not requests:
-        return 0, 0
-    processed = process_requests(requests, base_url, secret)
-    return len(requests), processed
+    processed = process_requests(requests, base_url, secret) if requests else 0
+    return len(requests), processed, tax_districts, tax_catalog_error
 
 
 def acquire_lock() -> Any:
@@ -462,16 +536,20 @@ def main() -> int:
     lock = acquire_lock()
     try:
         while True:
-            requested, processed = poll_once(base_url, secret)
+            requested, processed, tax_districts, tax_catalog_error = poll_once(
+                base_url, secret
+            )
+            output = {
+                "status": "ok",
+                "requested": requested,
+                "processed": processed,
+                "taxDistricts": tax_districts,
+                "at": dt.datetime.now(dt.timezone.utc).isoformat(),
+            }
+            if tax_catalog_error is not None:
+                output["taxCatalogError"] = tax_catalog_error
             print(
-                json.dumps(
-                    {
-                        "status": "ok",
-                        "requested": requested,
-                        "processed": processed,
-                        "at": dt.datetime.now(dt.timezone.utc).isoformat(),
-                    }
-                ),
+                json.dumps(output),
                 flush=True,
             )
             if args.once:

--- a/scripts/test_sage_pay_application_poller.py
+++ b/scripts/test_sage_pay_application_poller.py
@@ -5,19 +5,63 @@ import sys
 import unittest
 from decimal import Decimal
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from sage_pay_application_poller import (
+    PollerError,
     PollRequest,
     build_snapshot,
+    build_tax_catalog_snapshot,
     parse_poll_requests,
     resolve_sage_job,
     signature,
+    sync_tax_catalog_safely,
 )
 
 
 class SagePayApplicationPollerTests(unittest.TestCase):
+    def test_build_tax_catalog_snapshot_preserves_sage_rate_precision(self) -> None:
+        snapshot = build_tax_catalog_snapshot(
+            [
+                {
+                    "recnum": 70206,
+                    "dstnme": "07-0206 Boulder County Combined",
+                    "sumrte": Decimal("5.1850"),
+                }
+            ],
+            "2026-08-25T18:00:00+00:00",
+        )
+
+        self.assertEqual(snapshot["complete"], True)
+        self.assertEqual(snapshot["taxDistricts"][0]["code"], "70206")
+        self.assertEqual(snapshot["taxDistricts"][0]["ratePercent"], 5.185)
+
+    def test_tax_catalog_failure_is_contained(self) -> None:
+        with mock.patch(
+            "sage_pay_application_poller.sync_tax_catalog",
+            side_effect=PollerError("catalog unavailable"),
+        ):
+            count, error = sync_tax_catalog_safely(
+                "https://compass.example", "a" * 32
+            )
+
+        self.assertIsNone(count)
+        self.assertEqual(error, "catalog unavailable")
+
+    def test_unexpected_tax_catalog_failure_is_contained_and_sanitized(self) -> None:
+        with mock.patch(
+            "sage_pay_application_poller.sync_tax_catalog",
+            side_effect=ValueError("sensitive driver detail"),
+        ):
+            count, error = sync_tax_catalog_safely(
+                "https://compass.example", "a" * 32
+            )
+
+        self.assertIsNone(count)
+        self.assertEqual(error, "Tax catalog sync failed: ValueError")
+
     def test_signature_matches_compass_contract(self) -> None:
         actual = signature(
             "a" * 32,

--- a/src/app/api/integrations/sage/tax-catalog/results/route.ts
+++ b/src/app/api/integrations/sage/tax-catalog/results/route.ts
@@ -1,0 +1,50 @@
+import { getCloudflareContext } from "@/lib/db"
+import {
+  getSageBridgeSecret,
+  readBoundedSageBridgeBody,
+  verifySageBridgeRequest,
+} from "@/lib/sage/bridge-auth"
+import { ingestSageTaxCatalog } from "@/lib/sage/tax-catalog-ingest"
+
+function unauthorized(error: string): Response {
+  return Response.json({ error }, { status: 401 })
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const { env } = await getCloudflareContext()
+  const secret = getSageBridgeSecret(env)
+  if (!secret) {
+    return Response.json(
+      { error: "Sage bridge is not configured" },
+      { status: 503 }
+    )
+  }
+  if (!request.headers.get("content-type")?.startsWith("application/json")) {
+    return Response.json(
+      { error: "Content-Type must be application/json" },
+      { status: 415 }
+    )
+  }
+  const body = await readBoundedSageBridgeBody(request)
+  if (!body.success) {
+    return Response.json({ error: body.error }, { status: 413 })
+  }
+  const verification = await verifySageBridgeRequest(
+    request,
+    secret,
+    body.rawBody
+  )
+  if (!verification.success) return unauthorized(verification.error)
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(body.rawBody)
+  } catch {
+    return Response.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+  const result = await ingestSageTaxCatalog(env, parsed)
+  if (!result.success) {
+    return Response.json({ error: result.error }, { status: 400 })
+  }
+  return Response.json(result)
+}

--- a/src/app/print/projects/[id]/estimate/page.tsx
+++ b/src/app/print/projects/[id]/estimate/page.tsx
@@ -25,7 +25,10 @@ function quantity(value: number): string {
 }
 
 function percent(basisPoints: number): string {
-  return `${(basisPoints / 100).toFixed(2)}%`
+  return `${(basisPoints / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  })}%`
 }
 
 function estimateDate(value: string | null, createdAt: string): string {

--- a/src/components/projects/project-estimate-workspace.tsx
+++ b/src/components/projects/project-estimate-workspace.tsx
@@ -85,7 +85,10 @@ function money(cents: number): string {
 }
 
 function percent(basisPoints: number): string {
-  return `${(basisPoints / 100).toFixed(2)}%`
+  return `${(basisPoints / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  })}%`
 }
 
 function SignatureRequiredMark(): React.ReactElement {

--- a/src/components/templates/estimate-template-editor.tsx
+++ b/src/components/templates/estimate-template-editor.tsx
@@ -102,7 +102,10 @@ function money(cents: number): string {
 }
 
 function percent(basisPoints: number): string {
-  return `${(basisPoints / 100).toFixed(2)}%`
+  return `${(basisPoints / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  })}%`
 }
 
 export function EstimateTemplateEditorPanel({

--- a/src/lib/__tests__/middleware-routes.test.ts
+++ b/src/lib/__tests__/middleware-routes.test.ts
@@ -26,12 +26,15 @@ describe("middleware public routes", () => {
     expect(isPublicPath("/api/integrations/other/events")).toBe(false)
   })
 
-  it("allows only the two HMAC-authenticated Sage bridge endpoints", () => {
+  it("allows only the HMAC-authenticated Sage bridge endpoints", () => {
     expect(
       isPublicPath("/api/integrations/sage/pay-applications/requests")
     ).toBe(true)
     expect(
       isPublicPath("/api/integrations/sage/pay-applications/results")
+    ).toBe(true)
+    expect(
+      isPublicPath("/api/integrations/sage/tax-catalog/results")
     ).toBe(true)
     expect(
       isPublicPath("/api/integrations/sage/client-project-writes/requests")

--- a/src/lib/contracts/packet-pdf.ts
+++ b/src/lib/contracts/packet-pdf.ts
@@ -60,7 +60,10 @@ function money(cents: number): string {
 }
 
 function percent(basisPoints: number): string {
-  return `${(basisPoints / 100).toFixed(2)}%`
+  return `${(basisPoints / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  })}%`
 }
 
 function displayDate(value: string | null): string {

--- a/src/lib/financials/__tests__/estimate-ledger.test.ts
+++ b/src/lib/financials/__tests__/estimate-ledger.test.ts
@@ -47,6 +47,21 @@ describe("estimate ledger", () => {
     })
   })
 
+  it("preserves fractional basis points from Sage tax districts", () => {
+    expect(
+      calculateEstimateLine({
+        quantity: 1,
+        unitCostCents: 1_000_000,
+        markupRateBasisPoints: 0,
+        taxable: true,
+        taxRateBasisPoints: 518.5,
+      })
+    ).toMatchObject({
+      taxCents: 51_850,
+      lineTotalCents: 1_051_850,
+    })
+  })
+
   it("rolls estimate totals once across all lines", () => {
     expect(
       calculateEstimateTotals([

--- a/src/lib/financials/estimate-ledger.ts
+++ b/src/lib/financials/estimate-ledger.ts
@@ -89,7 +89,7 @@ function safeInteger(value: number): number {
 
 function safeRate(value: number): number {
   if (!Number.isFinite(value)) return 0
-  return Math.min(1_000_000, Math.max(0, Math.round(value)))
+  return Math.min(1_000_000, Math.max(0, value))
 }
 
 export function calculateEstimateLine(

--- a/src/lib/public-paths.ts
+++ b/src/lib/public-paths.ts
@@ -22,6 +22,7 @@ const bridgePaths = [
 const sageBridgePaths = [
   "/api/integrations/sage/pay-applications/requests",
   "/api/integrations/sage/pay-applications/results",
+  "/api/integrations/sage/tax-catalog/results",
   "/api/integrations/sage/client-project-writes/requests",
   "/api/integrations/sage/client-project-writes/results",
 ]

--- a/src/lib/sage/__tests__/tax-catalog.test.ts
+++ b/src/lib/sage/__tests__/tax-catalog.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+
+import { parseSageTaxCatalog } from "@/lib/sage/tax-catalog"
+
+function catalog(): unknown {
+  return {
+    capturedAt: "2026-08-25T18:00:00.000Z",
+    complete: true,
+    taxDistricts: [
+      {
+        sourceRecordId: "70206",
+        code: "70206",
+        name: "07-0206 Boulder County Combined",
+        ratePercent: 5.185,
+      },
+      {
+        sourceRecordId: "40017",
+        code: "40017",
+        name: "04-0017 Colorado Springs Combined",
+        ratePercent: 8.2,
+      },
+    ],
+  }
+}
+
+describe("Sage tax catalog snapshots", () => {
+  it("normalizes exact Sage rate precision and stable numeric ordering", () => {
+    const result = parseSageTaxCatalog(catalog())
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        capturedAt: "2026-08-25T18:00:00.000Z",
+        taxDistricts: [
+          {
+            sourceRecordId: "40017",
+            code: "40017",
+            name: "04-0017 Colorado Springs Combined",
+            rateBasisPoints: 820,
+          },
+          {
+            sourceRecordId: "70206",
+            code: "70206",
+            name: "07-0206 Boulder County Combined",
+            rateBasisPoints: 518.5,
+          },
+        ],
+      },
+    })
+  })
+
+  it("rejects partial snapshots so missing rows cannot be deactivated", () => {
+    const input = catalog()
+    if (typeof input !== "object" || input === null) throw new Error("bad test")
+    Reflect.set(input, "complete", false)
+
+    expect(parseSageTaxCatalog(input)).toEqual({
+      success: false,
+      error: "Invalid Sage tax catalog snapshot.",
+    })
+  })
+
+  it("rejects duplicate source records or codes", () => {
+    const input = catalog()
+    if (typeof input !== "object" || input === null) throw new Error("bad test")
+    const districts = Reflect.get(input, "taxDistricts")
+    if (!Array.isArray(districts)) throw new Error("bad test")
+    districts.push({
+      sourceRecordId: "duplicate",
+      code: "40017",
+      name: "Duplicate",
+      ratePercent: 1,
+    })
+
+    expect(parseSageTaxCatalog(input)).toEqual({
+      success: false,
+      error: "Sage tax catalog contains duplicate identifiers.",
+    })
+  })
+})

--- a/src/lib/sage/tax-catalog-ingest.ts
+++ b/src/lib/sage/tax-catalog-ingest.ts
@@ -1,0 +1,128 @@
+import "server-only"
+
+import {
+  parseSageTaxCatalog,
+  type NormalizedSageTaxCatalog,
+} from "@/lib/sage/tax-catalog"
+
+type CurrentTaxDistrict = {
+  readonly sourceRecordId: string | null
+  readonly code: string
+  readonly name: string
+  readonly rateBasisPoints: number
+  readonly active: number
+}
+
+export type SageTaxCatalogIngestResult =
+  | {
+      readonly success: true
+      readonly changed: boolean
+      readonly taxDistrictCount: number
+    }
+  | { readonly success: false; readonly error: string }
+
+function catalogsMatch(
+  currentRows: readonly CurrentTaxDistrict[],
+  catalog: NormalizedSageTaxCatalog
+): boolean {
+  const activeRows = currentRows.filter((row) => row.active !== 0)
+  if (activeRows.length !== catalog.taxDistricts.length) return false
+
+  const currentByCode = new Map(activeRows.map((row) => [row.code, row]))
+  return catalog.taxDistricts.every((district) => {
+    const current = currentByCode.get(district.code)
+    return Boolean(
+      current &&
+        current.sourceRecordId === district.sourceRecordId &&
+        current.name === district.name &&
+        Math.abs(current.rateBasisPoints - district.rateBasisPoints) < 0.000_001
+    )
+  })
+}
+
+function heartbeatStatement(
+  env: CloudflareEnv,
+  capturedAt: string
+): D1PreparedStatement {
+  return env.DB.prepare(
+    `INSERT INTO sage_bridge_status (id, last_seen_at, updated_at)
+     VALUES ('tax-catalog-poller', ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       last_seen_at = excluded.last_seen_at,
+       updated_at = excluded.updated_at`
+  ).bind(capturedAt, capturedAt)
+}
+
+function upsertStatement(
+  env: CloudflareEnv,
+  catalog: NormalizedSageTaxCatalog,
+  index: number
+): D1PreparedStatement {
+  const district = catalog.taxDistricts[index]
+  if (!district) throw new Error("Missing normalized Sage tax district")
+  return env.DB.prepare(
+    `INSERT INTO sage_tax_entities (
+       id, source_record_id, code, name, rate_basis_points, active,
+       sync_status, last_synced_at, created_at, updated_at
+     ) VALUES (?, ?, ?, ?, ?, 1, 'synced', ?, ?, ?)
+     ON CONFLICT(code) DO UPDATE SET
+       source_record_id = excluded.source_record_id,
+       name = excluded.name,
+       rate_basis_points = excluded.rate_basis_points,
+       active = 1,
+       sync_status = 'synced',
+       last_synced_at = excluded.last_synced_at,
+       updated_at = excluded.updated_at`
+  ).bind(
+    `sage-taxdst-${district.code}`,
+    district.sourceRecordId,
+    district.code,
+    district.name,
+    district.rateBasisPoints,
+    catalog.capturedAt,
+    catalog.capturedAt,
+    catalog.capturedAt
+  )
+}
+
+export async function ingestSageTaxCatalog(
+  env: CloudflareEnv,
+  input: unknown
+): Promise<SageTaxCatalogIngestResult> {
+  const parsed = parseSageTaxCatalog(input)
+  if (!parsed.success) return parsed
+
+  const current = await env.DB.prepare(
+    `SELECT source_record_id AS sourceRecordId, code, name,
+            rate_basis_points AS rateBasisPoints, active
+     FROM sage_tax_entities`
+  ).all<CurrentTaxDistrict>()
+
+  if (catalogsMatch(current.results, parsed.data)) {
+    await heartbeatStatement(env, parsed.data.capturedAt).run()
+    return {
+      success: true,
+      changed: false,
+      taxDistrictCount: parsed.data.taxDistricts.length,
+    }
+  }
+
+  const statements: D1PreparedStatement[] = [
+    env.DB.prepare(
+      `UPDATE sage_tax_entities
+       SET active = 0, sync_status = 'inactive', updated_at = ?
+       WHERE active != 0`
+    ).bind(parsed.data.capturedAt),
+  ]
+  for (let index = 0; index < parsed.data.taxDistricts.length; index += 1) {
+    statements.push(upsertStatement(env, parsed.data, index))
+  }
+  statements.push(heartbeatStatement(env, parsed.data.capturedAt))
+  await env.DB.batch(statements)
+
+  return {
+    success: true,
+    changed: true,
+    taxDistrictCount: parsed.data.taxDistricts.length,
+  }
+}

--- a/src/lib/sage/tax-catalog.ts
+++ b/src/lib/sage/tax-catalog.ts
@@ -1,0 +1,75 @@
+import { z } from "zod/v4"
+
+const taxDistrictSchema = z.object({
+  sourceRecordId: z.string().trim().min(1).max(100),
+  code: z.string().trim().min(1).max(100),
+  name: z.string().trim().min(1).max(200),
+  ratePercent: z.number().finite().min(0).max(100),
+})
+
+export const sageTaxCatalogSchema = z.object({
+  capturedAt: z.iso.datetime({ offset: true }),
+  complete: z.literal(true),
+  taxDistricts: z.array(taxDistrictSchema).min(1).max(1_000),
+})
+
+export type NormalizedSageTaxDistrict = {
+  readonly sourceRecordId: string
+  readonly code: string
+  readonly name: string
+  readonly rateBasisPoints: number
+}
+
+export type NormalizedSageTaxCatalog = {
+  readonly capturedAt: string
+  readonly taxDistricts: readonly NormalizedSageTaxDistrict[]
+}
+
+export type SageTaxCatalogParseResult =
+  | { readonly success: true; readonly data: NormalizedSageTaxCatalog }
+  | { readonly success: false; readonly error: string }
+
+function normalizedBasisPoints(ratePercent: number): number {
+  return Math.round(ratePercent * 1_000_000) / 10_000
+}
+
+export function parseSageTaxCatalog(
+  input: unknown
+): SageTaxCatalogParseResult {
+  const parsed = sageTaxCatalogSchema.safeParse(input)
+  if (!parsed.success) {
+    return { success: false, error: "Invalid Sage tax catalog snapshot." }
+  }
+
+  const codes = new Set<string>()
+  const sourceRecordIds = new Set<string>()
+  const taxDistricts: NormalizedSageTaxDistrict[] = []
+  for (const row of parsed.data.taxDistricts) {
+    const normalizedCode = row.code.toUpperCase()
+    if (codes.has(normalizedCode) || sourceRecordIds.has(row.sourceRecordId)) {
+      return {
+        success: false,
+        error: "Sage tax catalog contains duplicate identifiers.",
+      }
+    }
+    codes.add(normalizedCode)
+    sourceRecordIds.add(row.sourceRecordId)
+    taxDistricts.push({
+      sourceRecordId: row.sourceRecordId,
+      code: row.code,
+      name: row.name,
+      rateBasisPoints: normalizedBasisPoints(row.ratePercent),
+    })
+  }
+
+  taxDistricts.sort((left, right) =>
+    left.code.localeCompare(right.code, undefined, { numeric: true })
+  )
+  return {
+    success: true,
+    data: {
+      capturedAt: parsed.data.capturedAt,
+      taxDistricts,
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- ingest the complete read-only Sage `dbo.taxdst` catalog through the authenticated bridge
- keep estimate tax selectors current while preserving Sage fractional rate precision
- isolate catalog failures from existing pay-application polling
- document and test the private poller behavior

## Validation

- `bun run test` — 228 files, 1,185 tests passed
- `python3 -m unittest scripts/test_sage_pay_application_poller.py` — 8 tests passed
- `bunx tsc --noEmit`
- `bun lint` — no errors (existing warnings only)
- `bun run build`
- `/Users/martine/.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean

## Production note

The 57 current Sage tax districts were imported as an immediate remediation. After the Worker route deploys, the private read-only poller will be updated and run once to establish recurring synchronization.
