### PR TITLE
feat(estimates): add line cost-code breakdowns

### DIFF
--- a/drizzle/0135_estimate_line_cost_breakdowns.sql
+++ b/drizzle/0135_estimate_line_cost_breakdowns.sql
@@ -1,0 +1,25 @@
+CREATE TABLE `project_estimate_line_cost_items` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`estimate_id` text NOT NULL,
+	`estimate_line_id` text NOT NULL,
+	`division_code` text NOT NULL,
+	`division_name` text NOT NULL,
+	`cost_code` text NOT NULL,
+	`cost_code_name` text NOT NULL,
+	`description` text NOT NULL,
+	`quantity` real DEFAULT 1 NOT NULL,
+	`unit` text DEFAULT '' NOT NULL,
+	`unit_cost_cents` integer DEFAULT 0 NOT NULL,
+	`total_cost_cents` integer DEFAULT 0 NOT NULL,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`estimate_id`) REFERENCES `project_estimates`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`estimate_line_id`) REFERENCES `project_estimate_lines`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `project_estimate_line_cost_items_line_order_idx` ON `project_estimate_line_cost_items` (`estimate_line_id`,`sort_order`);
+--> statement-breakpoint
+CREATE INDEX `project_estimate_line_cost_items_estimate_idx` ON `project_estimate_line_cost_items` (`estimate_id`,`estimate_line_id`);

--- a/src/app/actions/project-estimates.ts
+++ b/src/app/actions/project-estimates.ts
@@ -17,6 +17,7 @@ import {
   estimateTermsTemplates,
   projectEstimateAcknowledgements,
   projectEstimateBasisDocuments,
+  projectEstimateLineCostItems,
   projectEstimateLines,
   projectEstimatePhaseDescriptions,
   projectEstimates,
@@ -30,6 +31,8 @@ import { getCloudflareContext } from "@/lib/db"
 import { rebuildProjectContractBudget } from "@/lib/financials/contract-budget-store"
 import {
   calculateEstimateLine,
+  calculateEstimateLineBreakdownSubtotal,
+  calculateEstimateLineCostItemTotal,
   calculateEstimateTotals,
   estimateCanBeEdited,
   estimateSourceHash,
@@ -175,6 +178,21 @@ export type ProjectEstimateLineItem = {
   readonly lineTotalCents: number
   readonly ownerVisible: boolean
   readonly includeInBuilderFee: boolean
+  readonly sortOrder: number
+  readonly costItems: readonly ProjectEstimateLineCostItem[]
+}
+
+export type ProjectEstimateLineCostItem = {
+  readonly id: string
+  readonly divisionCode: string
+  readonly divisionName: string
+  readonly costCode: string
+  readonly costCodeName: string
+  readonly description: string
+  readonly quantity: number
+  readonly unit: string
+  readonly unitCostCents: number
+  readonly totalCostCents: number
   readonly sortOrder: number
 }
 
@@ -322,6 +340,14 @@ export type ProjectEstimateLineInput = {
   readonly ownerVisible: boolean
   readonly includeInBuilderFee: boolean
   readonly insertAfterLineId: string | null
+}
+
+export type ProjectEstimateLineCostItemInput = {
+  readonly costCode: string | null
+  readonly description: string | null
+  readonly quantity: number | null
+  readonly unit: string | null
+  readonly unitCost: number | null
 }
 
 export type ProjectEstimateBuilderFeeInput = {
@@ -686,7 +712,8 @@ function estimateSummary(
 }
 
 function estimateLineItem(
-  row: typeof projectEstimateLines.$inferSelect
+  row: typeof projectEstimateLines.$inferSelect,
+  costItems: readonly (typeof projectEstimateLineCostItems.$inferSelect)[]
 ): ProjectEstimateLineItem {
   return {
     id: row.id,
@@ -712,6 +739,19 @@ function estimateLineItem(
     ownerVisible: row.ownerVisible,
     includeInBuilderFee: row.includeInBuilderFee,
     sortOrder: row.sortOrder,
+    costItems: costItems.map((item) => ({
+      id: item.id,
+      divisionCode: item.divisionCode,
+      divisionName: item.divisionName,
+      costCode: item.costCode,
+      costCodeName: item.costCodeName,
+      description: item.description,
+      quantity: item.quantity,
+      unit: item.unit,
+      unitCostCents: item.unitCostCents,
+      totalCostCents: item.totalCostCents,
+      sortOrder: item.sortOrder,
+    })),
   }
 }
 
@@ -960,6 +1000,7 @@ export async function getProjectEstimateWorkspace(
   const selected = activeEstimate(estimates, estimateId)
   const [
     lineRows,
+    costItemRows,
     basisRows,
     estimateCostCodes,
     taxRows,
@@ -977,6 +1018,16 @@ export async function getProjectEstimateWorkspace(
             .orderBy(
               asc(projectEstimateLines.divisionCode),
               asc(projectEstimateLines.sortOrder)
+            )
+        : Promise.resolve([]),
+      selected
+        ? access.db
+            .select()
+            .from(projectEstimateLineCostItems)
+            .where(eq(projectEstimateLineCostItems.estimateId, selected.id))
+            .orderBy(
+              asc(projectEstimateLineCostItems.estimateLineId),
+              asc(projectEstimateLineCostItems.sortOrder)
             )
         : Promise.resolve([]),
       selected
@@ -1051,6 +1102,16 @@ export async function getProjectEstimateWorkspace(
         ),
     ])
 
+  const costItemsByLine = new Map<
+    string,
+    (typeof projectEstimateLineCostItems.$inferSelect)[]
+  >()
+  for (const costItem of costItemRows) {
+    const items = costItemsByLine.get(costItem.estimateLineId) ?? []
+    items.push(costItem)
+    costItemsByLine.set(costItem.estimateLineId, items)
+  }
+
   const databaseTemplates = templateRows.flatMap(
     (row): readonly EstimateTextTemplateOption[] => {
       if (!isEstimateTextTemplateType(row.templateType)) return []
@@ -1093,7 +1154,9 @@ export async function getProjectEstimateWorkspace(
       selected?.clientReportMode ?? estimateClientReportMode(access.department),
     estimates,
     activeEstimate: selected,
-    lines: lineRows.map(estimateLineItem),
+    lines: lineRows.map((row) =>
+      estimateLineItem(row, costItemsByLine.get(row.id) ?? [])
+    ),
     basisDocuments: basisRows.map((row) => ({
       id: row.id,
       documentType: row.documentType,
@@ -1353,6 +1416,31 @@ export async function duplicateProjectEstimate(
            WHERE estimate_id = ? AND project_id = ?`
         )
         .bind(id, now, now, sourceEstimateId, projectId),
+      access.rawDb
+        .prepare(
+          `INSERT INTO project_estimate_line_cost_items (
+             id, project_id, estimate_id, estimate_line_id, division_code,
+             division_name, cost_code, cost_code_name, description, quantity,
+             unit, unit_cost_cents, total_cost_cents, sort_order, created_at,
+             updated_at
+           )
+           SELECT lower(hex(randomblob(16))), cost_item.project_id, ?,
+             copied_line.id, cost_item.division_code, cost_item.division_name,
+             cost_item.cost_code, cost_item.cost_code_name,
+             cost_item.description, cost_item.quantity, cost_item.unit,
+             cost_item.unit_cost_cents, cost_item.total_cost_cents,
+             cost_item.sort_order, ?, ?
+           FROM project_estimate_line_cost_items AS cost_item
+           INNER JOIN project_estimate_lines AS source_line
+             ON source_line.id = cost_item.estimate_line_id
+           INNER JOIN project_estimate_lines AS copied_line
+             ON copied_line.estimate_id = ?
+             AND copied_line.sort_order = source_line.sort_order
+             AND copied_line.cost_code = source_line.cost_code
+             AND copied_line.description = source_line.description
+           WHERE cost_item.estimate_id = ? AND cost_item.project_id = ?`
+        )
+        .bind(id, now, now, id, sourceEstimateId, projectId),
       access.rawDb
         .prepare(
           `INSERT INTO project_estimate_basis_documents (
@@ -2243,6 +2331,29 @@ export async function saveProjectEstimateLine(
     if (!cost) {
       throw new Error("Choose a verified CSI/Sage catalog cost code.")
     }
+    const existingRows = lineId
+      ? await access.db
+          .select({ id: projectEstimateLines.id })
+          .from(projectEstimateLines)
+          .where(
+            and(
+              eq(projectEstimateLines.id, lineId),
+              eq(projectEstimateLines.estimateId, estimateId)
+            )
+          )
+          .limit(1)
+      : []
+    const existing = existingRows[0]
+    if (lineId && !existing) throw new Error("Estimate line not found.")
+    const breakdownRows = lineId
+      ? await access.db
+          .select({
+            quantity: projectEstimateLineCostItems.quantity,
+            unitCostCents: projectEstimateLineCostItems.unitCostCents,
+          })
+          .from(projectEstimateLineCostItems)
+          .where(eq(projectEstimateLineCostItems.estimateLineId, lineId))
+      : []
     const taxEntityId = cleanText(input.taxEntityId) ?? estimate.defaultTaxEntityId
     const taxRows = taxEntityId
       ? await access.db
@@ -2255,8 +2366,11 @@ export async function saveProjectEstimateLine(
     if (input.taxable && !tax) {
       throw new Error("Choose the Sage tax entity for a taxable line.")
     }
-    const quantity = input.quantity ?? 1
-    const unitCostCents = Math.round((input.unitCost ?? 0) * 100)
+    const usesCostBreakdown = breakdownRows.length > 0
+    const quantity = usesCostBreakdown ? 1 : input.quantity ?? 1
+    const unitCostCents = usesCostBreakdown
+      ? calculateEstimateLineBreakdownSubtotal(breakdownRows)
+      : Math.round((input.unitCost ?? 0) * 100)
     const markupRateBasisPoints = Math.round((input.markupPercent ?? 0) * 100)
     const calculation = calculateEstimateLine({
       quantity,
@@ -2288,7 +2402,7 @@ export async function saveProjectEstimateLine(
       description: requiredText(input.description, "Description"),
       specifications: cleanText(input.specifications),
       quantity,
-      unit: cleanText(input.unit) ?? "LS",
+      unit: usesCostBreakdown ? "assembly" : cleanText(input.unit) ?? "LS",
       unitCostCents,
       ...calculation,
       markupRateBasisPoints,
@@ -2302,17 +2416,6 @@ export async function saveProjectEstimateLine(
       updatedAt: now,
     }
     if (lineId) {
-      const existing = await access.db
-        .select({ id: projectEstimateLines.id })
-        .from(projectEstimateLines)
-        .where(
-          and(
-            eq(projectEstimateLines.id, lineId),
-            eq(projectEstimateLines.estimateId, estimateId)
-          )
-        )
-        .limit(1)
-      if (!existing[0]) throw new Error("Estimate line not found.")
       await access.db
         .update(projectEstimateLines)
         .set(values)
@@ -2360,6 +2463,235 @@ export async function saveProjectEstimateLine(
       success: false,
       error:
         error instanceof Error ? error.message : "Unable to save estimate line.",
+    }
+  }
+}
+
+async function refreshEstimateLineFromCostItems(
+  db: CompassDb,
+  estimateId: string,
+  lineId: string,
+  now: string
+): Promise<void> {
+  const [lineRows, costItems] = await Promise.all([
+    db
+      .select()
+      .from(projectEstimateLines)
+      .where(
+        and(
+          eq(projectEstimateLines.id, lineId),
+          eq(projectEstimateLines.estimateId, estimateId)
+        )
+      )
+      .limit(1),
+    db
+      .select({
+        quantity: projectEstimateLineCostItems.quantity,
+        unitCostCents: projectEstimateLineCostItems.unitCostCents,
+      })
+      .from(projectEstimateLineCostItems)
+      .where(
+        and(
+          eq(projectEstimateLineCostItems.estimateId, estimateId),
+          eq(projectEstimateLineCostItems.estimateLineId, lineId)
+        )
+      ),
+  ])
+  const line = lineRows[0]
+  if (!line) throw new Error("Estimate line not found.")
+  if (costItems.length === 0) {
+    await db
+      .update(projectEstimateLines)
+      .set({
+        quantity: 1,
+        unit: "LS",
+        unitCostCents: line.directCostCents,
+        updatedAt: now,
+      })
+      .where(eq(projectEstimateLines.id, lineId))
+      .run()
+    return
+  }
+  const directCostCents = calculateEstimateLineBreakdownSubtotal(costItems)
+  const calculation = calculateEstimateLine({
+    quantity: 1,
+    unitCostCents: directCostCents,
+    markupRateBasisPoints: line.markupRateBasisPoints,
+    taxable: line.taxable,
+    taxRateBasisPoints: line.taxRateBasisPoints,
+  })
+  await db
+    .update(projectEstimateLines)
+    .set({
+      quantity: 1,
+      unit: "assembly",
+      unitCostCents: directCostCents,
+      ...calculation,
+      updatedAt: now,
+    })
+    .where(eq(projectEstimateLines.id, lineId))
+    .run()
+}
+
+export async function saveProjectEstimateLineCostItem(
+  projectId: string,
+  estimateId: string,
+  lineId: string,
+  costItemId: string | null,
+  input: ProjectEstimateLineCostItemInput
+): Promise<ProjectEstimateActionResult> {
+  try {
+    const access = await estimateAccess(projectId, true)
+    await requireEditableEstimate(access.db, projectId, estimateId)
+    const lineRows = await access.db
+      .select({ id: projectEstimateLines.id })
+      .from(projectEstimateLines)
+      .where(
+        and(
+          eq(projectEstimateLines.id, lineId),
+          eq(projectEstimateLines.estimateId, estimateId),
+          eq(projectEstimateLines.projectId, projectId)
+        )
+      )
+      .limit(1)
+    const line = lineRows[0]
+    if (!line) throw new Error("Estimate line not found.")
+
+    const costCode = requiredText(input.costCode, "Cost code")
+    const catalog = await loadProjectEstimateCostCodes(access.db)
+    const catalogItem = catalog.find((item) => item.code === costCode)
+    if (!catalogItem) {
+      throw new Error("Choose a verified CSI/Sage catalog cost code.")
+    }
+
+    const description = requiredText(input.description, "Description")
+    if (description.length > 500) {
+      throw new Error("Description must be 500 characters or fewer.")
+    }
+    const quantity = input.quantity ?? 1
+    const unitCost = input.unitCost ?? 0
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      throw new Error("Quantity must be greater than zero.")
+    }
+    if (!Number.isFinite(unitCost) || unitCost < 0) {
+      throw new Error("Unit cost cannot be negative.")
+    }
+    const unitCostCents = Math.round(unitCost * 100)
+    const totalCostCents = calculateEstimateLineCostItemTotal({
+      quantity,
+      unitCostCents,
+    })
+    if (totalCostCents <= 0) {
+      throw new Error("Enter a quantity and unit cost greater than zero.")
+    }
+    const unit = cleanText(input.unit) ?? ""
+    if (unit.length > 40) {
+      throw new Error("Unit must be 40 characters or fewer.")
+    }
+
+    const now = new Date().toISOString()
+    const id = costItemId ?? crypto.randomUUID()
+    const values = {
+      divisionCode: catalogItem.divisionCode,
+      divisionName: catalogItem.divisionDescription,
+      costCode: catalogItem.code,
+      costCodeName: catalogItem.description,
+      description,
+      quantity,
+      unit,
+      unitCostCents,
+      totalCostCents,
+      updatedAt: now,
+    }
+    if (costItemId) {
+      const existingRows = await access.db
+        .select({ id: projectEstimateLineCostItems.id })
+        .from(projectEstimateLineCostItems)
+        .where(
+          and(
+            eq(projectEstimateLineCostItems.id, costItemId),
+            eq(projectEstimateLineCostItems.estimateId, estimateId),
+            eq(projectEstimateLineCostItems.estimateLineId, lineId)
+          )
+        )
+        .limit(1)
+      if (!existingRows[0]) throw new Error("Cost item not found.")
+      await access.db
+        .update(projectEstimateLineCostItems)
+        .set(values)
+        .where(eq(projectEstimateLineCostItems.id, costItemId))
+        .run()
+    } else {
+      const priorRows = await access.db
+        .select({ sortOrder: projectEstimateLineCostItems.sortOrder })
+        .from(projectEstimateLineCostItems)
+        .where(eq(projectEstimateLineCostItems.estimateLineId, lineId))
+        .orderBy(desc(projectEstimateLineCostItems.sortOrder))
+        .limit(1)
+      await access.db.insert(projectEstimateLineCostItems).values({
+        id,
+        projectId,
+        estimateId,
+        estimateLineId: lineId,
+        ...values,
+        sortOrder: (priorRows[0]?.sortOrder ?? 0) + 1,
+        createdAt: now,
+      })
+    }
+
+    await refreshEstimateLineFromCostItems(access.db, estimateId, lineId, now)
+    await refreshEstimateTotals(access.db, estimateId, now)
+    revalidateEstimate(projectId)
+    return { success: true, id }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to save the line cost item.",
+    }
+  }
+}
+
+export async function deleteProjectEstimateLineCostItem(
+  projectId: string,
+  estimateId: string,
+  lineId: string,
+  costItemId: string
+): Promise<ProjectEstimateActionResult> {
+  try {
+    const access = await estimateAccess(projectId, true)
+    await requireEditableEstimate(access.db, projectId, estimateId)
+    const existingRows = await access.db
+      .select({ id: projectEstimateLineCostItems.id })
+      .from(projectEstimateLineCostItems)
+      .where(
+        and(
+          eq(projectEstimateLineCostItems.id, costItemId),
+          eq(projectEstimateLineCostItems.projectId, projectId),
+          eq(projectEstimateLineCostItems.estimateId, estimateId),
+          eq(projectEstimateLineCostItems.estimateLineId, lineId)
+        )
+      )
+      .limit(1)
+    if (!existingRows[0]) throw new Error("Cost item not found.")
+    await access.db
+      .delete(projectEstimateLineCostItems)
+      .where(eq(projectEstimateLineCostItems.id, costItemId))
+      .run()
+    const now = new Date().toISOString()
+    await refreshEstimateLineFromCostItems(access.db, estimateId, lineId, now)
+    await refreshEstimateTotals(access.db, estimateId, now)
+    revalidateEstimate(projectId)
+    return { success: true, id: costItemId }
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unable to delete the line cost item.",
     }
   }
 }

--- a/src/components/projects/project-estimate-line-breakdown.tsx
+++ b/src/components/projects/project-estimate-line-breakdown.tsx
@@ -1,0 +1,412 @@
+"use client"
+
+import { useMemo, useState, useTransition, type FormEvent } from "react"
+import { useRouter } from "next/navigation"
+import {
+  IconChevronDown,
+  IconChevronRight,
+  IconDeviceFloppy,
+  IconPlus,
+  IconTrash,
+} from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import {
+  deleteProjectEstimateLineCostItem,
+  saveProjectEstimateLineCostItem,
+  type ProjectEstimateCostCodeOption,
+  type ProjectEstimateLineCostItem,
+  type ProjectEstimateLineItem,
+} from "@/app/actions/project-estimates"
+import { SearchableCombobox } from "@/components/searchable-combobox"
+import { Button } from "@/components/ui/button"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+function money(cents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(cents / 100)
+}
+
+function numericValue(value: string): number | null {
+  const parsed = Number(value.replaceAll(",", ""))
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+type CostCodeDraft = {
+  readonly id: string | null
+  readonly divisionCode: string
+  readonly costCode: string
+  readonly description: string
+  readonly quantity: string
+  readonly unit: string
+  readonly unitCost: string
+}
+
+function emptyCostCode(divisionCode: string): CostCodeDraft {
+  return {
+    id: null,
+    divisionCode,
+    costCode: "",
+    description: "",
+    quantity: "1",
+    unit: "",
+    unitCost: "",
+  }
+}
+
+function costCodeDraft(item: ProjectEstimateLineCostItem): CostCodeDraft {
+  return {
+    id: item.id,
+    divisionCode: item.divisionCode,
+    costCode: item.costCode,
+    description: item.description,
+    quantity: String(item.quantity),
+    unit: item.unit,
+    unitCost: String(item.unitCostCents / 100),
+  }
+}
+
+export function ProjectEstimateLineBreakdown({
+  projectId,
+  estimateId,
+  line,
+  costCodes,
+  editable,
+}: {
+  readonly projectId: string
+  readonly estimateId: string
+  readonly line: ProjectEstimateLineItem
+  readonly costCodes: readonly ProjectEstimateCostCodeOption[]
+  readonly editable: boolean
+}): React.ReactElement | null {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [isPending, startTransition] = useTransition()
+  const [draft, setDraft] = useState<CostCodeDraft>(() =>
+    emptyCostCode(line.divisionCode)
+  )
+  const divisions = useMemo(() => {
+    const options = new Map<string, string>()
+    for (const option of costCodes) {
+      options.set(option.divisionCode, option.divisionLabel)
+    }
+    return [...options.entries()].sort((left, right) =>
+      left[0].localeCompare(right[0])
+    )
+  }, [costCodes])
+  const availableCostCodes = costCodes.filter(
+    (option) => option.divisionCode === draft.divisionCode
+  )
+  const previewQuantity = numericValue(draft.quantity) ?? 0
+  const previewUnitCost = numericValue(draft.unitCost) ?? 0
+  const previewTotalCents = Math.round(
+    Math.max(0, previewQuantity) * Math.max(0, previewUnitCost) * 100
+  )
+
+  if (!editable && line.costItems.length === 0) return null
+
+  function saveCostCode(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault()
+    startTransition(async () => {
+      const result = await saveProjectEstimateLineCostItem(
+        projectId,
+        estimateId,
+        line.id,
+        draft.id,
+        {
+          costCode: draft.costCode,
+          description: draft.description,
+          quantity: numericValue(draft.quantity),
+          unit: draft.unit,
+          unitCost: numericValue(draft.unitCost),
+        }
+      )
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      toast.success(
+        draft.id
+          ? "Breakdown cost code updated"
+          : "Breakdown cost code added"
+      )
+      setDraft(emptyCostCode(line.divisionCode))
+      setOpen(true)
+      router.refresh()
+    })
+  }
+
+  function removeCostCode(item: ProjectEstimateLineCostItem): void {
+    const finalItem = line.costItems.length === 1
+    const confirmed = window.confirm(
+      finalItem
+        ? `Delete ${item.costCode}? This removes the breakdown and returns the parent line to simple lump-sum pricing at its current direct cost.`
+        : `Delete ${item.costCode} from this line's cost breakdown?`
+    )
+    if (!confirmed) return
+    startTransition(async () => {
+      const result = await deleteProjectEstimateLineCostItem(
+        projectId,
+        estimateId,
+        line.id,
+        item.id
+      )
+      if (!result.success) {
+        toast.error(result.error)
+        return
+      }
+      if (draft.id === item.id) {
+        setDraft(emptyCostCode(line.divisionCode))
+      }
+      toast.success("Breakdown cost code deleted")
+      router.refresh()
+    })
+  }
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="mt-2">
+      <CollapsibleTrigger asChild>
+        <Button type="button" variant="ghost" size="sm" className="px-0">
+          {open ? (
+            <IconChevronDown className="size-4" />
+          ) : (
+            <IconChevronRight className="size-4" />
+          )}
+          {line.costItems.length === 0
+            ? "Build cost breakdown"
+            : `${line.costItems.length} breakdown ${line.costItems.length === 1 ? "cost code" : "cost codes"} · ${money(line.directCostCents)}`}
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2 border-t pt-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-sm font-medium">Line cost breakdown</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Choose CSI/Sage cost codes just like a parent estimate line. The
+              detailed subtotal becomes this line&apos;s direct cost; its markup,
+              tax, and builder-fee settings still apply at the parent level.
+            </p>
+          </div>
+          <p className="text-sm font-semibold">
+            Direct cost {money(line.directCostCents)}
+          </p>
+        </div>
+
+        {line.costItems.length > 0 ? (
+          <div className="mt-3 divide-y border-y">
+            {line.costItems.map((item) => (
+              <div
+                key={item.id}
+                className="grid gap-2 py-3 md:grid-cols-[minmax(0,1fr)_auto]"
+              >
+                <div>
+                  <p className="text-sm font-medium">
+                    {item.costCode} · {item.description}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {item.divisionCode} · {item.divisionName} · {item.quantity}{" "}
+                    {item.unit} × {money(item.unitCostCents)}
+                  </p>
+                </div>
+                <div className="flex items-center justify-end gap-2">
+                  <span className="text-sm font-medium">
+                    {money(item.totalCostCents)}
+                  </span>
+                  {editable && (
+                    <>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => setDraft(costCodeDraft(item))}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        aria-label={`Delete ${item.costCode}`}
+                        disabled={isPending}
+                        onClick={() => removeCostCode(item)}
+                      >
+                        <IconTrash className="size-4" />
+                      </Button>
+                    </>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="mt-3 border-y py-3 text-sm text-muted-foreground">
+            Add the first cost code to replace the parent line&apos;s simple
+            quantity × unit-cost calculation with a detailed subtotal.
+          </p>
+        )}
+
+        {editable && (
+          <form onSubmit={saveCostCode} className="mt-4 border-t pt-4">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <h4 className="text-sm font-semibold">
+                {draft.id
+                  ? "Edit breakdown cost code"
+                  : "Add breakdown cost code"}
+              </h4>
+              <p className="text-xs text-muted-foreground">
+                Calculated amount {money(previewTotalCents)}
+              </p>
+            </div>
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              <div className="space-y-1.5">
+                <Label>CSI division</Label>
+                <Select
+                  value={draft.divisionCode}
+                  onValueChange={(value) =>
+                    setDraft({
+                      ...draft,
+                      divisionCode: value,
+                      costCode: "",
+                      description: "",
+                    })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Choose division first" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {divisions.map(([value, label]) => (
+                      <SelectItem key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5 md:col-span-1 xl:col-span-3">
+                <Label>Cost code</Label>
+                <SearchableCombobox
+                  ariaLabel="Breakdown cost code"
+                  options={availableCostCodes}
+                  value={draft.costCode}
+                  onValueChange={(value) => {
+                    const option = costCodes.find(
+                      (candidate) => candidate.value === value
+                    )
+                    setDraft({
+                      ...draft,
+                      costCode: value,
+                      description: option?.description ?? draft.description,
+                    })
+                  }}
+                  disabled={!draft.divisionCode}
+                  placeholder="Choose cost code"
+                  searchPlaceholder="Search Sage cost codes..."
+                  emptyMessage="No matching Sage cost codes."
+                />
+              </div>
+              <div className="space-y-1.5 md:col-span-2 xl:col-span-4">
+                <Label htmlFor={`breakdown-description-${line.id}`}>
+                  Description
+                </Label>
+                <Input
+                  id={`breakdown-description-${line.id}`}
+                  value={draft.description}
+                  onChange={(event) =>
+                    setDraft({ ...draft, description: event.target.value })
+                  }
+                  required
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor={`breakdown-quantity-${line.id}`}>
+                  Quantity
+                </Label>
+                <Input
+                  id={`breakdown-quantity-${line.id}`}
+                  type="number"
+                  inputMode="decimal"
+                  min="0.0001"
+                  step="any"
+                  value={draft.quantity}
+                  onChange={(event) =>
+                    setDraft({ ...draft, quantity: event.target.value })
+                  }
+                  required
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor={`breakdown-unit-${line.id}`}>Unit</Label>
+                <Input
+                  id={`breakdown-unit-${line.id}`}
+                  value={draft.unit}
+                  onChange={(event) =>
+                    setDraft({ ...draft, unit: event.target.value })
+                  }
+                  placeholder="EA, SF, LF, HR..."
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor={`breakdown-unit-cost-${line.id}`}>
+                  Unit cost
+                </Label>
+                <Input
+                  id={`breakdown-unit-cost-${line.id}`}
+                  type="number"
+                  inputMode="decimal"
+                  min="0"
+                  step="0.01"
+                  value={draft.unitCost}
+                  onChange={(event) =>
+                    setDraft({ ...draft, unitCost: event.target.value })
+                  }
+                  required
+                />
+              </div>
+              <div className="flex items-end justify-end gap-2">
+                {draft.id && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => setDraft(emptyCostCode(line.divisionCode))}
+                  >
+                    Cancel
+                  </Button>
+                )}
+                <Button
+                  type="submit"
+                  disabled={
+                    isPending || !draft.costCode || previewTotalCents <= 0
+                  }
+                >
+                  {draft.id ? (
+                    <IconDeviceFloppy className="size-4" />
+                  ) : (
+                    <IconPlus className="size-4" />
+                  )}
+                  {draft.id ? "Save cost code" : "Add cost code"}
+                </Button>
+              </div>
+            </div>
+          </form>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/src/components/projects/project-estimate-workspace.tsx
+++ b/src/components/projects/project-estimate-workspace.tsx
@@ -49,6 +49,7 @@ import { uploadEstimateAcceptanceEvidence } from "@/components/projects/project-
 import { Badge } from "@/components/ui/badge"
 import { useDeveloperMode } from "@/components/developer-mode-provider"
 import { ProjectEstimateClientReportSettings } from "@/components/projects/project-estimate-client-report-settings"
+import { ProjectEstimateLineBreakdown } from "@/components/projects/project-estimate-line-breakdown"
 import {
   ProjectEstimateSignerPicker,
   type ProjectEstimateSignerValue,
@@ -273,6 +274,10 @@ export function ProjectEstimateWorkspacePanel({
   }, [workspace.costCodes])
   const availableCostCodes = workspace.costCodes.filter(
     (option) => option.divisionCode === line.divisionCode
+  )
+  const lineUsesCostBreakdown = Boolean(
+    line.id &&
+      workspace.lines.find((item) => item.id === line.id)?.costItems.length
   )
   const mappedCostCodes = useMemo(
     () =>
@@ -1310,69 +1315,80 @@ export function ProjectEstimateWorkspacePanel({
                   </div>
                   <div className="divide-y">
                     {items.map((item) => (
-                      <div key={item.id} className="grid gap-2 py-3 lg:grid-cols-[minmax(0,1fr)_auto]">
-                        <div>
-                          <p className="text-sm font-medium">
-                            {item.costCode} · {item.description}
-                          </p>
-                          {!mappedCostCodes.has(item.costCode) && (
-                            <Badge variant="outline" className="mt-1">
-                              Sage mapping required
-                            </Badge>
-                          )}
-                          {!item.includeInBuilderFee && (
-                            <Badge variant="outline" className="mt-1 ml-1">
-                              Builder fee excluded
-                            </Badge>
-                          )}
-                          <p className="text-xs text-muted-foreground">
-                            {item.quantity} {item.unit} × {money(item.unitCostCents)} ·
-                            markup {percent(item.markupRateBasisPoints)}
-                            {item.taxable
-                              ? ` · ${item.taxCode ?? "tax"} ${percent(item.taxRateBasisPoints)}`
-                              : " · non-taxable"}
-                          </p>
+                      <div key={item.id} className="py-3">
+                        <div className="grid gap-2 lg:grid-cols-[minmax(0,1fr)_auto]">
+                          <div>
+                            <p className="text-sm font-medium">
+                              {item.costCode} · {item.description}
+                            </p>
+                            {!mappedCostCodes.has(item.costCode) && (
+                              <Badge variant="outline" className="mt-1">
+                                Sage mapping required
+                              </Badge>
+                            )}
+                            {!item.includeInBuilderFee && (
+                              <Badge variant="outline" className="mt-1 ml-1">
+                                Builder fee excluded
+                              </Badge>
+                            )}
+                            <p className="text-xs text-muted-foreground">
+                              {item.costItems.length > 0
+                                ? `${item.costItems.length} cost-code breakdown · direct cost ${money(item.directCostCents)}`
+                                : `${item.quantity} ${item.unit} × ${money(item.unitCostCents)}`}
+                              {` · markup ${percent(item.markupRateBasisPoints)}`}
+                              {item.taxable
+                                ? ` · ${item.taxCode ?? "tax"} ${percent(item.taxRateBasisPoints)}`
+                                : " · non-taxable"}
+                            </p>
+                          </div>
+                          <div className="flex items-center justify-end gap-2">
+                            <span className="font-medium">{money(item.lineTotalCents)}</span>
+                            {editable && (
+                              <>
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={() => openLineEditor(lineDraft(item))}
+                                >
+                                  Edit
+                                </Button>
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="ghost"
+                                  onClick={() =>
+                                    openLineEditor(
+                                      {
+                                        ...EMPTY_LINE,
+                                        divisionCode: item.divisionCode,
+                                      },
+                                      item.id
+                                    )
+                                  }
+                                >
+                                  Insert below
+                                </Button>
+                                <Button
+                                  type="button"
+                                  size="icon"
+                                  variant="ghost"
+                                  aria-label={`Delete ${item.description}`}
+                                  onClick={() => removeLine(item.id)}
+                                >
+                                  <IconTrash className="size-4" />
+                                </Button>
+                              </>
+                            )}
+                          </div>
                         </div>
-                        <div className="flex items-center justify-end gap-2">
-                          <span className="font-medium">{money(item.lineTotalCents)}</span>
-                          {editable && (
-                            <>
-                              <Button
-                                type="button"
-                                size="sm"
-                                variant="outline"
-                                onClick={() => openLineEditor(lineDraft(item))}
-                              >
-                                Edit
-                              </Button>
-                              <Button
-                                type="button"
-                                size="sm"
-                                variant="ghost"
-                                onClick={() =>
-                                  openLineEditor(
-                                    {
-                                      ...EMPTY_LINE,
-                                      divisionCode: item.divisionCode,
-                                    },
-                                    item.id
-                                  )
-                                }
-                              >
-                                Insert below
-                              </Button>
-                              <Button
-                                type="button"
-                                size="icon"
-                                variant="ghost"
-                                aria-label={`Delete ${item.description}`}
-                                onClick={() => removeLine(item.id)}
-                              >
-                                <IconTrash className="size-4" />
-                              </Button>
-                            </>
-                          )}
-                        </div>
+                        <ProjectEstimateLineBreakdown
+                          projectId={projectId}
+                          estimateId={estimate.id}
+                          line={item}
+                          costCodes={workspace.costCodes}
+                          editable={editable}
+                        />
                       </div>
                     ))}
                   </div>
@@ -1441,7 +1457,7 @@ export function ProjectEstimateWorkspacePanel({
               </div>
               <div className="space-y-1.5">
                 <Label htmlFor="estimateUnit">Unit</Label>
-                <Input id="estimateUnit" name="unit" value={line.unit} onChange={(event) => setLine({ ...line, unit: event.target.value })} />
+                <Input id="estimateUnit" name="unit" value={line.unit} disabled={lineUsesCostBreakdown} onChange={(event) => setLine({ ...line, unit: event.target.value })} />
               </div>
               <div className="space-y-1.5 md:col-span-2 xl:col-span-4">
                 <Label htmlFor="estimateDescription">Description</Label>
@@ -1453,11 +1469,11 @@ export function ProjectEstimateWorkspacePanel({
               </div>
               <div className="space-y-1.5">
                 <Label htmlFor="estimateQuantity">Quantity</Label>
-                <Input id="estimateQuantity" name="quantity" inputMode="decimal" value={line.quantity} onChange={(event) => setLine({ ...line, quantity: event.target.value })} />
+                <Input id="estimateQuantity" name="quantity" inputMode="decimal" value={line.quantity} disabled={lineUsesCostBreakdown} onChange={(event) => setLine({ ...line, quantity: event.target.value })} />
               </div>
               <div className="space-y-1.5">
                 <Label htmlFor="estimateUnitCost">Unit cost</Label>
-                <Input id="estimateUnitCost" name="unitCost" inputMode="decimal" value={line.unitCost} onChange={(event) => setLine({ ...line, unitCost: event.target.value })} />
+                <Input id="estimateUnitCost" name="unitCost" inputMode="decimal" value={line.unitCost} disabled={lineUsesCostBreakdown} onChange={(event) => setLine({ ...line, unitCost: event.target.value })} />
               </div>
               <div className="space-y-1.5">
                 <Label htmlFor="estimateMarkup">Line markup %</Label>
@@ -1486,6 +1502,13 @@ export function ProjectEstimateWorkspacePanel({
                   groupHeading="Active Sage tax entities"
                 />
               </div>
+              {lineUsesCostBreakdown && (
+                <p className="text-xs text-muted-foreground md:col-span-2 xl:col-span-4">
+                  Quantity, unit, and unit cost are calculated from this line&apos;s
+                  expanded cost-code breakdown. Edit those values inside the
+                  breakdown above.
+                </p>
+              )}
             </div>
             <div className="mt-3 flex flex-wrap items-center gap-5">
               <label className="flex items-center gap-2 text-sm">

--- a/src/db/schema-estimates.ts
+++ b/src/db/schema-estimates.ts
@@ -318,6 +318,44 @@ export const projectEstimateLines = sqliteTable(
   ]
 )
 
+export const projectEstimateLineCostItems = sqliteTable(
+  "project_estimate_line_cost_items",
+  {
+    id: text("id").primaryKey(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    estimateId: text("estimate_id")
+      .notNull()
+      .references(() => projectEstimates.id, { onDelete: "cascade" }),
+    estimateLineId: text("estimate_line_id")
+      .notNull()
+      .references(() => projectEstimateLines.id, { onDelete: "cascade" }),
+    divisionCode: text("division_code").notNull(),
+    divisionName: text("division_name").notNull(),
+    costCode: text("cost_code").notNull(),
+    costCodeName: text("cost_code_name").notNull(),
+    description: text("description").notNull(),
+    quantity: real("quantity").notNull().default(1),
+    unit: text("unit").notNull().default(""),
+    unitCostCents: integer("unit_cost_cents").notNull().default(0),
+    totalCostCents: integer("total_cost_cents").notNull().default(0),
+    sortOrder: integer("sort_order").notNull().default(0),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (table) => [
+    index("project_estimate_line_cost_items_line_order_idx").on(
+      table.estimateLineId,
+      table.sortOrder
+    ),
+    index("project_estimate_line_cost_items_estimate_idx").on(
+      table.estimateId,
+      table.estimateLineId
+    ),
+  ]
+)
+
 export const projectEstimateBasisDocuments = sqliteTable(
   "project_estimate_basis_documents",
   {
@@ -473,6 +511,8 @@ export const projectContractBudgetAdjustments = sqliteTable(
 
 export type ProjectEstimate = typeof projectEstimates.$inferSelect
 export type ProjectEstimateLine = typeof projectEstimateLines.$inferSelect
+export type ProjectEstimateLineCostItem =
+  typeof projectEstimateLineCostItems.$inferSelect
 export type ProjectEstimateBasisDocument =
   typeof projectEstimateBasisDocuments.$inferSelect
 export type ProjectEstimatePhaseDescription =

--- a/src/lib/financials/__tests__/estimate-ledger.test.ts
+++ b/src/lib/financials/__tests__/estimate-ledger.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest"
 import {
   buildContractBudget,
   calculateEstimateLine,
+  calculateEstimateLineBreakdownSubtotal,
+  calculateEstimateLineCostItemTotal,
   calculateEstimateTotals,
   estimateCanBeAccepted,
   estimateCanBeEdited,
@@ -60,6 +62,21 @@ describe("estimate ledger", () => {
       taxCents: 51_850,
       lineTotalCents: 1_051_850,
     })
+  })
+
+  it("rolls detailed cost codes into a parent line subtotal", () => {
+    expect(
+      calculateEstimateLineCostItemTotal({
+        quantity: 37.5,
+        unitCostCents: 1_289,
+      })
+    ).toBe(48_338)
+    expect(
+      calculateEstimateLineBreakdownSubtotal([
+        { quantity: 37.5, unitCostCents: 1_289 },
+        { quantity: 12, unitCostCents: 2_560 },
+      ])
+    ).toBe(79_058)
   })
 
   it("rolls estimate totals once across all lines", () => {

--- a/src/lib/financials/estimate-ledger.ts
+++ b/src/lib/financials/estimate-ledger.ts
@@ -24,6 +24,11 @@ export type EstimateLineCalculation = {
   readonly lineTotalCents: number
 }
 
+export type EstimateLineCostItemInput = {
+  readonly quantity: number
+  readonly unitCostCents: number
+}
+
 export type EstimateLedgerLine = EstimateLineCalculation & {
   readonly id: string | null
   readonly divisionCode: string
@@ -116,6 +121,25 @@ export function calculateEstimateLine(
     taxCents,
     lineTotalCents: taxableSubtotal + taxCents,
   }
+}
+
+export function calculateEstimateLineCostItemTotal(
+  input: EstimateLineCostItemInput
+): number {
+  const quantity = Number.isFinite(input.quantity)
+    ? Math.max(0, input.quantity)
+    : 0
+  const unitCostCents = Math.max(0, safeInteger(input.unitCostCents))
+  return safeInteger(quantity * unitCostCents)
+}
+
+export function calculateEstimateLineBreakdownSubtotal(
+  items: readonly EstimateLineCostItemInput[]
+): number {
+  return items.reduce(
+    (total, item) => total + calculateEstimateLineCostItemTotal(item),
+    0
+  )
 }
 
 export function calculateEstimateTotals(


### PR DESCRIPTION
## Summary

- add expandable cost-code breakdowns beneath estimate parent lines
- let each child select from the same verified CSI/Sage cost-code catalog as its parent, including Fox-S600
- roll child quantity and unit-cost amounts into the parent direct cost while retaining parent-level markup, tax, and builder-fee settings
- preserve breakdowns when creating a new estimate revision and support permission-appropriate child editing and deletion

## Validation

- `bunx eslint src/app/actions/project-estimates.ts src/db/schema-estimates.ts src/components/projects/project-estimate-workspace.tsx src/components/projects/project-estimate-line-breakdown.tsx src/lib/financials/estimate-ledger.ts src/lib/financials/__tests__/estimate-ledger.test.ts`
- `bunx vitest run src/lib/financials/__tests__/estimate-ledger.test.ts src/lib/estimates/__tests__/project-cost-code-catalog.test.ts src/components/projects/__tests__/project-estimate-version-comparison.test.ts` (16 tests)
- `sqlite3 :memory: ".read drizzle/0135_estimate_line_cost_breakdowns.sql"`
- `git diff github/main...HEAD --check`

## Note

The repository-wide TypeScript check remains blocked by pre-existing errors in `src/components/__tests__/app-sidebar-navigation.test.ts`; the scoped feature files pass ESLint and focused tests.
