### PR TITLE
feat(estimates): price assembly cost items individually

### DIFF
--- a/drizzle/0136_estimate_line_cost_item_pricing.sql
+++ b/drizzle/0136_estimate_line_cost_item_pricing.sql
@@ -1,0 +1,71 @@
+ALTER TABLE `project_estimate_line_cost_items` ADD `direct_cost_cents` integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `project_estimate_line_cost_items` ADD `markup_rate_basis_points` integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `project_estimate_line_cost_items` ADD `markup_cents` integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `project_estimate_line_cost_items` ADD `taxable` integer DEFAULT false NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `project_estimate_line_cost_items` ADD `tax_entity_id` text REFERENCES `sage_tax_entities`(`id`) ON DELETE set null;
+--> statement-breakpoint
+ALTER TABLE `project_estimate_line_cost_items` ADD `tax_code` text;
+--> statement-breakpoint
+ALTER TABLE `project_estimate_line_cost_items` ADD `tax_name` text;
+--> statement-breakpoint
+ALTER TABLE `project_estimate_line_cost_items` ADD `tax_rate_basis_points` integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `project_estimate_line_cost_items` ADD `tax_cents` integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `project_estimate_line_cost_items` ADD `line_total_cents` integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+UPDATE `project_estimate_line_cost_items`
+SET `direct_cost_cents` = `total_cost_cents`;
+--> statement-breakpoint
+UPDATE `project_estimate_line_cost_items`
+SET `markup_rate_basis_points` = COALESCE((
+      SELECT `markup_rate_basis_points`
+      FROM `project_estimate_lines`
+      WHERE `project_estimate_lines`.`id` = `project_estimate_line_cost_items`.`estimate_line_id`
+    ), 0),
+    `taxable` = COALESCE((
+      SELECT `taxable`
+      FROM `project_estimate_lines`
+      WHERE `project_estimate_lines`.`id` = `project_estimate_line_cost_items`.`estimate_line_id`
+    ), false),
+    `tax_entity_id` = (
+      SELECT `tax_entity_id`
+      FROM `project_estimate_lines`
+      WHERE `project_estimate_lines`.`id` = `project_estimate_line_cost_items`.`estimate_line_id`
+    ),
+    `tax_code` = (
+      SELECT `tax_code`
+      FROM `project_estimate_lines`
+      WHERE `project_estimate_lines`.`id` = `project_estimate_line_cost_items`.`estimate_line_id`
+    ),
+    `tax_name` = (
+      SELECT `tax_name`
+      FROM `project_estimate_lines`
+      WHERE `project_estimate_lines`.`id` = `project_estimate_line_cost_items`.`estimate_line_id`
+    ),
+    `tax_rate_basis_points` = COALESCE((
+      SELECT `tax_rate_basis_points`
+      FROM `project_estimate_lines`
+      WHERE `project_estimate_lines`.`id` = `project_estimate_line_cost_items`.`estimate_line_id`
+    ), 0);
+--> statement-breakpoint
+UPDATE `project_estimate_line_cost_items`
+SET `markup_cents` = CAST(ROUND(
+  `direct_cost_cents` * `markup_rate_basis_points` / 10000.0
+) AS integer);
+--> statement-breakpoint
+UPDATE `project_estimate_line_cost_items`
+SET `tax_cents` = CASE
+  WHEN `taxable` THEN CAST(ROUND(
+    (`direct_cost_cents` + `markup_cents`) * `tax_rate_basis_points` / 10000.0
+  ) AS integer)
+  ELSE 0
+END;
+--> statement-breakpoint
+UPDATE `project_estimate_line_cost_items`
+SET `line_total_cents` = `direct_cost_cents` + `markup_cents` + `tax_cents`,
+    `total_cost_cents` = `direct_cost_cents` + `markup_cents` + `tax_cents`;

--- a/src/app/actions/project-estimates.ts
+++ b/src/app/actions/project-estimates.ts
@@ -31,8 +31,7 @@ import { getCloudflareContext } from "@/lib/db"
 import { rebuildProjectContractBudget } from "@/lib/financials/contract-budget-store"
 import {
   calculateEstimateLine,
-  calculateEstimateLineBreakdownSubtotal,
-  calculateEstimateLineCostItemTotal,
+  calculateEstimateLineBreakdownRollup,
   calculateEstimateTotals,
   estimateCanBeEdited,
   estimateSourceHash,
@@ -192,6 +191,16 @@ export type ProjectEstimateLineCostItem = {
   readonly quantity: number
   readonly unit: string
   readonly unitCostCents: number
+  readonly directCostCents: number
+  readonly markupRateBasisPoints: number
+  readonly markupCents: number
+  readonly taxable: boolean
+  readonly taxEntityId: string | null
+  readonly taxCode: string | null
+  readonly taxName: string | null
+  readonly taxRateBasisPoints: number
+  readonly taxCents: number
+  readonly lineTotalCents: number
   readonly totalCostCents: number
   readonly sortOrder: number
 }
@@ -348,6 +357,9 @@ export type ProjectEstimateLineCostItemInput = {
   readonly quantity: number | null
   readonly unit: string | null
   readonly unitCost: number | null
+  readonly markupPercent: number | null
+  readonly taxable: boolean
+  readonly taxEntityId: string | null
 }
 
 export type ProjectEstimateBuilderFeeInput = {
@@ -749,6 +761,16 @@ function estimateLineItem(
       quantity: item.quantity,
       unit: item.unit,
       unitCostCents: item.unitCostCents,
+      directCostCents: item.directCostCents,
+      markupRateBasisPoints: item.markupRateBasisPoints,
+      markupCents: item.markupCents,
+      taxable: item.taxable,
+      taxEntityId: item.taxEntityId,
+      taxCode: item.taxCode,
+      taxName: item.taxName,
+      taxRateBasisPoints: item.taxRateBasisPoints,
+      taxCents: item.taxCents,
+      lineTotalCents: item.lineTotalCents,
       totalCostCents: item.totalCostCents,
       sortOrder: item.sortOrder,
     })),
@@ -1421,14 +1443,21 @@ export async function duplicateProjectEstimate(
           `INSERT INTO project_estimate_line_cost_items (
              id, project_id, estimate_id, estimate_line_id, division_code,
              division_name, cost_code, cost_code_name, description, quantity,
-             unit, unit_cost_cents, total_cost_cents, sort_order, created_at,
-             updated_at
+             unit, unit_cost_cents, direct_cost_cents,
+             markup_rate_basis_points, markup_cents, taxable, tax_entity_id,
+             tax_code, tax_name, tax_rate_basis_points, tax_cents,
+             line_total_cents, total_cost_cents, sort_order, created_at, updated_at
            )
            SELECT lower(hex(randomblob(16))), cost_item.project_id, ?,
              copied_line.id, cost_item.division_code, cost_item.division_name,
              cost_item.cost_code, cost_item.cost_code_name,
              cost_item.description, cost_item.quantity, cost_item.unit,
-             cost_item.unit_cost_cents, cost_item.total_cost_cents,
+             cost_item.unit_cost_cents, cost_item.direct_cost_cents,
+             cost_item.markup_rate_basis_points, cost_item.markup_cents,
+             cost_item.taxable, cost_item.tax_entity_id, cost_item.tax_code,
+             cost_item.tax_name, cost_item.tax_rate_basis_points,
+             cost_item.tax_cents, cost_item.line_total_cents,
+             cost_item.total_cost_cents,
              cost_item.sort_order, ?, ?
            FROM project_estimate_line_cost_items AS cost_item
            INNER JOIN project_estimate_lines AS source_line
@@ -2348,13 +2377,29 @@ export async function saveProjectEstimateLine(
     const breakdownRows = lineId
       ? await access.db
           .select({
-            quantity: projectEstimateLineCostItems.quantity,
-            unitCostCents: projectEstimateLineCostItems.unitCostCents,
+            directCostCents: projectEstimateLineCostItems.directCostCents,
+            markupRateBasisPoints:
+              projectEstimateLineCostItems.markupRateBasisPoints,
+            markupCents: projectEstimateLineCostItems.markupCents,
+            taxable: projectEstimateLineCostItems.taxable,
+            taxEntityId: projectEstimateLineCostItems.taxEntityId,
+            taxCode: projectEstimateLineCostItems.taxCode,
+            taxName: projectEstimateLineCostItems.taxName,
+            taxRateBasisPoints:
+              projectEstimateLineCostItems.taxRateBasisPoints,
+            taxCents: projectEstimateLineCostItems.taxCents,
+            lineTotalCents: projectEstimateLineCostItems.lineTotalCents,
           })
           .from(projectEstimateLineCostItems)
           .where(eq(projectEstimateLineCostItems.estimateLineId, lineId))
       : []
-    const taxEntityId = cleanText(input.taxEntityId) ?? estimate.defaultTaxEntityId
+    const usesCostBreakdown = breakdownRows.length > 0
+    const breakdownRollup = usesCostBreakdown
+      ? calculateEstimateLineBreakdownRollup(breakdownRows)
+      : null
+    const taxEntityId = usesCostBreakdown
+      ? null
+      : cleanText(input.taxEntityId) ?? estimate.defaultTaxEntityId
     const taxRows = taxEntityId
       ? await access.db
           .select()
@@ -2363,22 +2408,25 @@ export async function saveProjectEstimateLine(
           .limit(1)
       : []
     const tax = taxRows[0]
-    if (input.taxable && !tax) {
+    if (!usesCostBreakdown && input.taxable && !tax) {
       throw new Error("Choose the Sage tax entity for a taxable line.")
     }
-    const usesCostBreakdown = breakdownRows.length > 0
     const quantity = usesCostBreakdown ? 1 : input.quantity ?? 1
     const unitCostCents = usesCostBreakdown
-      ? calculateEstimateLineBreakdownSubtotal(breakdownRows)
+      ? breakdownRollup?.directCostCents ?? 0
       : Math.round((input.unitCost ?? 0) * 100)
-    const markupRateBasisPoints = Math.round((input.markupPercent ?? 0) * 100)
-    const calculation = calculateEstimateLine({
-      quantity,
-      unitCostCents,
-      markupRateBasisPoints,
-      taxable: input.taxable,
-      taxRateBasisPoints: tax?.rateBasisPoints ?? 0,
-    })
+    const markupRateBasisPoints = usesCostBreakdown
+      ? breakdownRollup?.markupRateBasisPoints ?? 0
+      : rateBasisPoints(input.markupPercent, "Line markup")
+    const calculation =
+      breakdownRollup ??
+      calculateEstimateLine({
+        quantity,
+        unitCostCents,
+        markupRateBasisPoints,
+        taxable: input.taxable,
+        taxRateBasisPoints: tax?.rateBasisPoints ?? 0,
+      })
     if (calculation.lineTotalCents <= 0) {
       throw new Error("Enter a quantity and unit cost greater than zero.")
     }
@@ -2406,11 +2454,12 @@ export async function saveProjectEstimateLine(
       unitCostCents,
       ...calculation,
       markupRateBasisPoints,
-      taxable: input.taxable,
-      taxEntityId: tax?.id ?? null,
-      taxCode: tax?.code ?? null,
-      taxName: tax?.name ?? null,
-      taxRateBasisPoints: tax?.rateBasisPoints ?? 0,
+      taxable: breakdownRollup?.taxable ?? input.taxable,
+      taxEntityId: breakdownRollup?.taxEntityId ?? tax?.id ?? null,
+      taxCode: breakdownRollup?.taxCode ?? tax?.code ?? null,
+      taxName: breakdownRollup?.taxName ?? tax?.name ?? null,
+      taxRateBasisPoints:
+        breakdownRollup?.taxRateBasisPoints ?? tax?.rateBasisPoints ?? 0,
       ownerVisible: input.ownerVisible,
       includeInBuilderFee: input.includeInBuilderFee,
       updatedAt: now,
@@ -2486,8 +2535,17 @@ async function refreshEstimateLineFromCostItems(
       .limit(1),
     db
       .select({
-        quantity: projectEstimateLineCostItems.quantity,
-        unitCostCents: projectEstimateLineCostItems.unitCostCents,
+        directCostCents: projectEstimateLineCostItems.directCostCents,
+        markupRateBasisPoints:
+          projectEstimateLineCostItems.markupRateBasisPoints,
+        markupCents: projectEstimateLineCostItems.markupCents,
+        taxable: projectEstimateLineCostItems.taxable,
+        taxEntityId: projectEstimateLineCostItems.taxEntityId,
+        taxCode: projectEstimateLineCostItems.taxCode,
+        taxName: projectEstimateLineCostItems.taxName,
+        taxRateBasisPoints: projectEstimateLineCostItems.taxRateBasisPoints,
+        taxCents: projectEstimateLineCostItems.taxCents,
+        lineTotalCents: projectEstimateLineCostItems.lineTotalCents,
       })
       .from(projectEstimateLineCostItems)
       .where(
@@ -2512,20 +2570,13 @@ async function refreshEstimateLineFromCostItems(
       .run()
     return
   }
-  const directCostCents = calculateEstimateLineBreakdownSubtotal(costItems)
-  const calculation = calculateEstimateLine({
-    quantity: 1,
-    unitCostCents: directCostCents,
-    markupRateBasisPoints: line.markupRateBasisPoints,
-    taxable: line.taxable,
-    taxRateBasisPoints: line.taxRateBasisPoints,
-  })
+  const calculation = calculateEstimateLineBreakdownRollup(costItems)
   await db
     .update(projectEstimateLines)
     .set({
       quantity: 1,
       unit: "assembly",
-      unitCostCents: directCostCents,
+      unitCostCents: calculation.directCostCents,
       ...calculation,
       updatedAt: now,
     })
@@ -2542,7 +2593,11 @@ export async function saveProjectEstimateLineCostItem(
 ): Promise<ProjectEstimateActionResult> {
   try {
     const access = await estimateAccess(projectId, true)
-    await requireEditableEstimate(access.db, projectId, estimateId)
+    const estimate = await requireEditableEstimate(
+      access.db,
+      projectId,
+      estimateId
+    )
     const lineRows = await access.db
       .select({ id: projectEstimateLines.id })
       .from(projectEstimateLines)
@@ -2577,11 +2632,35 @@ export async function saveProjectEstimateLineCostItem(
       throw new Error("Unit cost cannot be negative.")
     }
     const unitCostCents = Math.round(unitCost * 100)
-    const totalCostCents = calculateEstimateLineCostItemTotal({
+    const markupRateBasisPoints = rateBasisPoints(
+      input.markupPercent,
+      "Cost item markup"
+    )
+    const taxEntityId = cleanText(input.taxEntityId) ?? estimate.defaultTaxEntityId
+    const taxRows = taxEntityId
+      ? await access.db
+          .select()
+          .from(sageTaxEntities)
+          .where(
+            and(
+              eq(sageTaxEntities.id, taxEntityId),
+              eq(sageTaxEntities.active, true)
+            )
+          )
+          .limit(1)
+      : []
+    const tax = taxRows[0]
+    if (input.taxable && !tax) {
+      throw new Error("Choose the Sage tax entity for a taxable cost item.")
+    }
+    const calculation = calculateEstimateLine({
       quantity,
       unitCostCents,
+      markupRateBasisPoints,
+      taxable: input.taxable,
+      taxRateBasisPoints: tax?.rateBasisPoints ?? 0,
     })
-    if (totalCostCents <= 0) {
+    if (calculation.lineTotalCents <= 0) {
       throw new Error("Enter a quantity and unit cost greater than zero.")
     }
     const unit = cleanText(input.unit) ?? ""
@@ -2600,7 +2679,14 @@ export async function saveProjectEstimateLineCostItem(
       quantity,
       unit,
       unitCostCents,
-      totalCostCents,
+      ...calculation,
+      markupRateBasisPoints,
+      taxable: input.taxable,
+      taxEntityId: tax?.id ?? null,
+      taxCode: tax?.code ?? null,
+      taxName: tax?.name ?? null,
+      taxRateBasisPoints: tax?.rateBasisPoints ?? 0,
+      totalCostCents: calculation.lineTotalCents,
       updatedAt: now,
     }
     if (costItemId) {
@@ -2710,13 +2796,26 @@ export async function applyProjectEstimateLineMarkup(
       .from(projectEstimateLines)
       .where(eq(projectEstimateLines.estimateId, estimateId))
     if (rows.length === 0) throw new Error("Add an estimate line first.")
+    const costItems = await access.db
+      .select()
+      .from(projectEstimateLineCostItems)
+      .where(eq(projectEstimateLineCostItems.estimateId, estimateId))
 
     const now = new Date().toISOString()
     const legacyAdjustmentCodes = new Set<string>(
       CONTRACT_ADJUSTMENT_COST_CODES.map((item) => item.value)
     )
-    const statements = rows
-      .filter((row) => !legacyAdjustmentCodes.has(row.costCode))
+    const eligibleRows = rows.filter(
+      (row) => !legacyAdjustmentCodes.has(row.costCode)
+    )
+    const eligibleLineIds = new Set(eligibleRows.map((row) => row.id))
+    const breakdownLineIds = new Set(
+      costItems
+        .filter((item) => eligibleLineIds.has(item.estimateLineId))
+        .map((item) => item.estimateLineId)
+    )
+    const lineStatements = eligibleRows
+      .filter((row) => !breakdownLineIds.has(row.id))
       .map((row) => {
         const calculation = calculateEstimateLine({
           quantity: row.quantity,
@@ -2745,6 +2844,38 @@ export async function applyProjectEstimateLineMarkup(
             projectId
           )
       })
+    const costItemStatements = costItems
+      .filter((item) => eligibleLineIds.has(item.estimateLineId))
+      .map((item) => {
+        const calculation = calculateEstimateLine({
+          quantity: item.quantity,
+          unitCostCents: item.unitCostCents,
+          markupRateBasisPoints,
+          taxable: item.taxable,
+          taxRateBasisPoints: item.taxRateBasisPoints,
+        })
+        return access.rawDb
+          .prepare(
+            `UPDATE project_estimate_line_cost_items
+             SET markup_rate_basis_points = ?, direct_cost_cents = ?,
+               markup_cents = ?, tax_cents = ?, line_total_cents = ?,
+               total_cost_cents = ?, updated_at = ?
+             WHERE id = ? AND estimate_id = ? AND project_id = ?`
+          )
+          .bind(
+            markupRateBasisPoints,
+            calculation.directCostCents,
+            calculation.markupCents,
+            calculation.taxCents,
+            calculation.lineTotalCents,
+            calculation.lineTotalCents,
+            now,
+            item.id,
+            estimateId,
+            projectId
+          )
+      })
+    const statements = [...lineStatements, ...costItemStatements]
     if (statements.length === 0) {
       throw new Error("Add a CSI cost-code line before applying markup.")
     }
@@ -2755,6 +2886,14 @@ export async function applyProjectEstimateLineMarkup(
       if (results.some((result) => !result.success)) {
         throw new Error("The line markup update did not complete.")
       }
+    }
+    for (const breakdownLineId of breakdownLineIds) {
+      await refreshEstimateLineFromCostItems(
+        access.db,
+        estimateId,
+        breakdownLineId,
+        now
+      )
     }
     await refreshEstimateTotals(access.db, estimateId, now)
     revalidateEstimate(projectId)

--- a/src/components/estimate-unit-input.tsx
+++ b/src/components/estimate-unit-input.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { Input } from "@/components/ui/input"
+
+const STANDARD_ESTIMATE_UNITS = [
+  { value: "EA", label: "Each" },
+  { value: "LS", label: "Lump sum" },
+  { value: "LOT", label: "Lot" },
+  { value: "LF", label: "Linear foot" },
+  { value: "SF", label: "Square foot" },
+  { value: "SY", label: "Square yard" },
+  { value: "CF", label: "Cubic foot" },
+  { value: "CY", label: "Cubic yard" },
+  { value: "AC", label: "Acre" },
+  { value: "IN", label: "Inch" },
+  { value: "FT", label: "Foot" },
+  { value: "YD", label: "Yard" },
+  { value: "MI", label: "Mile" },
+  { value: "BF", label: "Board foot" },
+  { value: "MBF", label: "Thousand board feet" },
+  { value: "LB", label: "Pound" },
+  { value: "TON", label: "Ton" },
+  { value: "GAL", label: "Gallon" },
+  { value: "HR", label: "Hour" },
+  { value: "DAY", label: "Day" },
+  { value: "WK", label: "Week" },
+  { value: "MO", label: "Month" },
+] as const
+
+export function EstimateUnitInput({
+  id,
+  name,
+  value,
+  disabled = false,
+  onValueChange,
+}: {
+  readonly id: string
+  readonly name?: string
+  readonly value: string
+  readonly disabled?: boolean
+  readonly onValueChange: (value: string) => void
+}): React.ReactElement {
+  const listId = `${id}-options`
+
+  return (
+    <>
+      <Input
+        id={id}
+        name={name}
+        list={listId}
+        value={value}
+        placeholder="Select or type a unit"
+        autoComplete="off"
+        disabled={disabled}
+        onChange={(event) => onValueChange(event.target.value)}
+      />
+      <datalist id={listId}>
+        {STANDARD_ESTIMATE_UNITS.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </datalist>
+      <p className="text-xs text-muted-foreground">
+        Choose a standard unit or type your own.
+      </p>
+    </>
+  )
+}

--- a/src/components/projects/project-estimate-line-breakdown.tsx
+++ b/src/components/projects/project-estimate-line-breakdown.tsx
@@ -17,9 +17,12 @@ import {
   type ProjectEstimateCostCodeOption,
   type ProjectEstimateLineCostItem,
   type ProjectEstimateLineItem,
+  type ProjectEstimateTaxOption,
 } from "@/app/actions/project-estimates"
 import { SearchableCombobox } from "@/components/searchable-combobox"
+import { EstimateUnitInput } from "@/components/estimate-unit-input"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import {
   Collapsible,
   CollapsibleContent,
@@ -34,6 +37,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { calculateEstimateLine } from "@/lib/financials/estimate-ledger"
 
 function money(cents: number): string {
   return new Intl.NumberFormat("en-US", {
@@ -48,6 +52,10 @@ function numericValue(value: string): number | null {
   return Number.isFinite(parsed) ? parsed : null
 }
 
+function percent(basisPoints: number): string {
+  return `${basisPoints / 100}%`
+}
+
 type CostCodeDraft = {
   readonly id: string | null
   readonly divisionCode: string
@@ -56,17 +64,23 @@ type CostCodeDraft = {
   readonly quantity: string
   readonly unit: string
   readonly unitCost: string
+  readonly markupPercent: string
+  readonly taxable: boolean
+  readonly taxEntityId: string
 }
 
-function emptyCostCode(divisionCode: string): CostCodeDraft {
+function emptyCostCode(line: ProjectEstimateLineItem): CostCodeDraft {
   return {
     id: null,
-    divisionCode,
+    divisionCode: line.divisionCode,
     costCode: "",
     description: "",
     quantity: "1",
     unit: "",
     unitCost: "",
+    markupPercent: String(line.markupRateBasisPoints / 100),
+    taxable: line.taxable,
+    taxEntityId: line.taxEntityId ?? "",
   }
 }
 
@@ -79,6 +93,9 @@ function costCodeDraft(item: ProjectEstimateLineCostItem): CostCodeDraft {
     quantity: String(item.quantity),
     unit: item.unit,
     unitCost: String(item.unitCostCents / 100),
+    markupPercent: String(item.markupRateBasisPoints / 100),
+    taxable: item.taxable,
+    taxEntityId: item.taxEntityId ?? "",
   }
 }
 
@@ -87,19 +104,23 @@ export function ProjectEstimateLineBreakdown({
   estimateId,
   line,
   costCodes,
+  taxEntities,
+  defaultTaxRateBasisPoints,
   editable,
 }: {
   readonly projectId: string
   readonly estimateId: string
   readonly line: ProjectEstimateLineItem
   readonly costCodes: readonly ProjectEstimateCostCodeOption[]
+  readonly taxEntities: readonly ProjectEstimateTaxOption[]
+  readonly defaultTaxRateBasisPoints: number
   readonly editable: boolean
 }): React.ReactElement | null {
   const router = useRouter()
   const [open, setOpen] = useState(false)
   const [isPending, startTransition] = useTransition()
   const [draft, setDraft] = useState<CostCodeDraft>(() =>
-    emptyCostCode(line.divisionCode)
+    emptyCostCode(line)
   )
   const divisions = useMemo(() => {
     const options = new Map<string, string>()
@@ -113,11 +134,33 @@ export function ProjectEstimateLineBreakdown({
   const availableCostCodes = costCodes.filter(
     (option) => option.divisionCode === draft.divisionCode
   )
+  const taxEntityOptions = useMemo(
+    () =>
+      taxEntities.map((option) => ({
+        value: option.value,
+        label: option.label,
+        selectedLabel: `${option.label} · ${percent(option.rateBasisPoints)}`,
+        description: `${percent(option.rateBasisPoints)} · Sage tax entity`,
+        keywords: `${option.code} ${option.rateBasisPoints / 100}`,
+      })),
+    [taxEntities]
+  )
   const previewQuantity = numericValue(draft.quantity) ?? 0
   const previewUnitCost = numericValue(draft.unitCost) ?? 0
-  const previewTotalCents = Math.round(
-    Math.max(0, previewQuantity) * Math.max(0, previewUnitCost) * 100
+  const previewMarkupRateBasisPoints = Math.round(
+    (numericValue(draft.markupPercent) ?? 0) * 100
   )
+  const selectedTaxEntity = taxEntities.find(
+    (option) => option.value === draft.taxEntityId
+  )
+  const preview = calculateEstimateLine({
+    quantity: previewQuantity,
+    unitCostCents: Math.round(Math.max(0, previewUnitCost) * 100),
+    markupRateBasisPoints: previewMarkupRateBasisPoints,
+    taxable: draft.taxable,
+    taxRateBasisPoints:
+      selectedTaxEntity?.rateBasisPoints ?? defaultTaxRateBasisPoints,
+  })
 
   if (!editable && line.costItems.length === 0) return null
 
@@ -135,6 +178,9 @@ export function ProjectEstimateLineBreakdown({
           quantity: numericValue(draft.quantity),
           unit: draft.unit,
           unitCost: numericValue(draft.unitCost),
+          markupPercent: numericValue(draft.markupPercent),
+          taxable: draft.taxable,
+          taxEntityId: draft.taxEntityId,
         }
       )
       if (!result.success) {
@@ -146,7 +192,7 @@ export function ProjectEstimateLineBreakdown({
           ? "Breakdown cost code updated"
           : "Breakdown cost code added"
       )
-      setDraft(emptyCostCode(line.divisionCode))
+      setDraft(emptyCostCode(line))
       setOpen(true)
       router.refresh()
     })
@@ -156,7 +202,7 @@ export function ProjectEstimateLineBreakdown({
     const finalItem = line.costItems.length === 1
     const confirmed = window.confirm(
       finalItem
-        ? `Delete ${item.costCode}? This removes the breakdown and returns the parent line to simple lump-sum pricing at its current direct cost.`
+        ? `Delete ${item.costCode}? This removes the breakdown and returns the parent line to simple lump-sum pricing at its current calculated amount.`
         : `Delete ${item.costCode} from this line's cost breakdown?`
     )
     if (!confirmed) return
@@ -172,7 +218,7 @@ export function ProjectEstimateLineBreakdown({
         return
       }
       if (draft.id === item.id) {
-        setDraft(emptyCostCode(line.divisionCode))
+        setDraft(emptyCostCode(line))
       }
       toast.success("Breakdown cost code deleted")
       router.refresh()
@@ -190,7 +236,7 @@ export function ProjectEstimateLineBreakdown({
           )}
           {line.costItems.length === 0
             ? "Build cost breakdown"
-            : `${line.costItems.length} breakdown ${line.costItems.length === 1 ? "cost code" : "cost codes"} · ${money(line.directCostCents)}`}
+            : `${line.costItems.length} breakdown ${line.costItems.length === 1 ? "cost code" : "cost codes"} · ${money(line.lineTotalCents)}`}
         </Button>
       </CollapsibleTrigger>
       <CollapsibleContent className="mt-2 border-t pt-3">
@@ -198,13 +244,14 @@ export function ProjectEstimateLineBreakdown({
           <div>
             <p className="text-sm font-medium">Line cost breakdown</p>
             <p className="mt-1 text-xs text-muted-foreground">
-              Choose CSI/Sage cost codes just like a parent estimate line. The
-              detailed subtotal becomes this line&apos;s direct cost; its markup,
-              tax, and builder-fee settings still apply at the parent level.
+              Choose CSI/Sage cost codes just like a parent estimate line. Set
+              the unit type, markup, and taxability for each item. The parent
+              line becomes a summary of those calculated amounts; builder-fee
+              eligibility remains on the parent line.
             </p>
           </div>
           <p className="text-sm font-semibold">
-            Direct cost {money(line.directCostCents)}
+            Line total {money(line.lineTotalCents)}
           </p>
         </div>
 
@@ -223,10 +270,17 @@ export function ProjectEstimateLineBreakdown({
                     {item.divisionCode} · {item.divisionName} · {item.quantity}{" "}
                     {item.unit} × {money(item.unitCostCents)}
                   </p>
+                  <p className="text-xs text-muted-foreground">
+                    Direct {money(item.directCostCents)} · Markup{" "}
+                    {percent(item.markupRateBasisPoints)} ({money(item.markupCents)}) ·{" "}
+                    {item.taxable
+                      ? `${item.taxName ?? item.taxCode ?? "Taxable"} ${percent(item.taxRateBasisPoints)} (${money(item.taxCents)})`
+                      : "Not taxable"}
+                  </p>
                 </div>
                 <div className="flex items-center justify-end gap-2">
                   <span className="text-sm font-medium">
-                    {money(item.totalCostCents)}
+                    {money(item.lineTotalCents)}
                   </span>
                   {editable && (
                     <>
@@ -270,7 +324,7 @@ export function ProjectEstimateLineBreakdown({
                   : "Add breakdown cost code"}
               </h4>
               <p className="text-xs text-muted-foreground">
-                Calculated amount {money(previewTotalCents)}
+                Calculated amount {money(preview.lineTotalCents)}
               </p>
             </div>
             <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
@@ -352,14 +406,13 @@ export function ProjectEstimateLineBreakdown({
                 />
               </div>
               <div className="space-y-1.5">
-                <Label htmlFor={`breakdown-unit-${line.id}`}>Unit</Label>
-                <Input
+                <Label htmlFor={`breakdown-unit-${line.id}`}>Unit type</Label>
+                <EstimateUnitInput
                   id={`breakdown-unit-${line.id}`}
                   value={draft.unit}
-                  onChange={(event) =>
-                    setDraft({ ...draft, unit: event.target.value })
+                  onValueChange={(value) =>
+                    setDraft({ ...draft, unit: value })
                   }
-                  placeholder="EA, SF, LF, HR..."
                 />
               </div>
               <div className="space-y-1.5">
@@ -379,12 +432,60 @@ export function ProjectEstimateLineBreakdown({
                   required
                 />
               </div>
+              <div className="space-y-1.5">
+                <Label htmlFor={`breakdown-markup-${line.id}`}>
+                  Markup %
+                </Label>
+                <Input
+                  id={`breakdown-markup-${line.id}`}
+                  type="number"
+                  inputMode="decimal"
+                  min="0"
+                  step="0.01"
+                  value={draft.markupPercent}
+                  onChange={(event) =>
+                    setDraft({ ...draft, markupPercent: event.target.value })
+                  }
+                />
+              </div>
+              <div className="space-y-1.5 md:col-span-2">
+                <Label>Tax entity</Label>
+                <SearchableCombobox
+                  value={draft.taxEntityId}
+                  onValueChange={(value) =>
+                    setDraft({ ...draft, taxEntityId: value })
+                  }
+                  disabled={!draft.taxable}
+                  options={[
+                    {
+                      value: "",
+                      label: "Use project tax entity",
+                      keywords: "default inherit clear",
+                    },
+                    ...taxEntityOptions,
+                  ]}
+                  ariaLabel="Breakdown cost item tax entity"
+                  placeholder="Use project tax entity"
+                  searchPlaceholder="Search Sage tax entities..."
+                  emptyMessage="No matching Sage tax entities."
+                  groupHeading="Active Sage tax entities"
+                />
+              </div>
+              <label className="flex items-center gap-2 text-sm">
+                <Checkbox
+                  checked={draft.taxable}
+                  onCheckedChange={(checked) =>
+                    setDraft({ ...draft, taxable: checked === true })
+                  }
+                />
+                Taxable cost item
+              </label>
               <div className="flex items-end justify-end gap-2">
                 {draft.id && (
                   <Button
                     type="button"
                     variant="ghost"
-                    onClick={() => setDraft(emptyCostCode(line.divisionCode))}
+                    onClick={() => setDraft(emptyCostCode(line))}
                   >
                     Cancel
                   </Button>
@@ -392,7 +493,7 @@ export function ProjectEstimateLineBreakdown({
                 <Button
                   type="submit"
                   disabled={
-                    isPending || !draft.costCode || previewTotalCents <= 0
+                    isPending || !draft.costCode || preview.lineTotalCents <= 0
                   }
                 >
                   {draft.id ? (

--- a/src/components/projects/project-estimate-workspace.tsx
+++ b/src/components/projects/project-estimate-workspace.tsx
@@ -48,6 +48,7 @@ import {
 import { uploadEstimateAcceptanceEvidence } from "@/components/projects/project-estimate-acceptance-upload"
 import { Badge } from "@/components/ui/badge"
 import { useDeveloperMode } from "@/components/developer-mode-provider"
+import { EstimateUnitInput } from "@/components/estimate-unit-input"
 import { ProjectEstimateClientReportSettings } from "@/components/projects/project-estimate-client-report-settings"
 import { ProjectEstimateLineBreakdown } from "@/components/projects/project-estimate-line-breakdown"
 import {
@@ -1333,12 +1334,8 @@ export function ProjectEstimateWorkspacePanel({
                             )}
                             <p className="text-xs text-muted-foreground">
                               {item.costItems.length > 0
-                                ? `${item.costItems.length} cost-code breakdown · direct cost ${money(item.directCostCents)}`
-                                : `${item.quantity} ${item.unit} × ${money(item.unitCostCents)}`}
-                              {` · markup ${percent(item.markupRateBasisPoints)}`}
-                              {item.taxable
-                                ? ` · ${item.taxCode ?? "tax"} ${percent(item.taxRateBasisPoints)}`
-                                : " · non-taxable"}
+                                ? `${item.costItems.length} cost-code breakdown · direct ${money(item.directCostCents)} · markup ${money(item.markupCents)} · tax ${money(item.taxCents)}`
+                                : `${item.quantity} ${item.unit} × ${money(item.unitCostCents)} · markup ${percent(item.markupRateBasisPoints)}${item.taxable ? ` · ${item.taxCode ?? "tax"} ${percent(item.taxRateBasisPoints)}` : " · non-taxable"}`}
                             </p>
                           </div>
                           <div className="flex items-center justify-end gap-2">
@@ -1387,6 +1384,10 @@ export function ProjectEstimateWorkspacePanel({
                           estimateId={estimate.id}
                           line={item}
                           costCodes={workspace.costCodes}
+                          taxEntities={workspace.taxEntities}
+                          defaultTaxRateBasisPoints={
+                            estimate.defaultTaxRateBasisPoints
+                          }
                           editable={editable}
                         />
                       </div>
@@ -1456,8 +1457,14 @@ export function ProjectEstimateWorkspacePanel({
                 />
               </div>
               <div className="space-y-1.5">
-                <Label htmlFor="estimateUnit">Unit</Label>
-                <Input id="estimateUnit" name="unit" value={line.unit} disabled={lineUsesCostBreakdown} onChange={(event) => setLine({ ...line, unit: event.target.value })} />
+                <Label htmlFor="estimateUnit">Unit type</Label>
+                <EstimateUnitInput
+                  id="estimateUnit"
+                  name="unit"
+                  value={line.unit}
+                  disabled={lineUsesCostBreakdown}
+                  onValueChange={(value) => setLine({ ...line, unit: value })}
+                />
               </div>
               <div className="space-y-1.5 md:col-span-2 xl:col-span-4">
                 <Label htmlFor="estimateDescription">Description</Label>
@@ -1477,7 +1484,7 @@ export function ProjectEstimateWorkspacePanel({
               </div>
               <div className="space-y-1.5">
                 <Label htmlFor="estimateMarkup">Line markup %</Label>
-                <Input id="estimateMarkup" name="markupPercent" inputMode="decimal" value={line.markupPercent} onChange={(event) => setLine({ ...line, markupPercent: event.target.value })} />
+                <Input id="estimateMarkup" name="markupPercent" inputMode="decimal" value={line.markupPercent} disabled={lineUsesCostBreakdown} onChange={(event) => setLine({ ...line, markupPercent: event.target.value })} />
               </div>
               <div className="space-y-1.5">
                 <Label>Tax entity</Label>
@@ -1486,7 +1493,7 @@ export function ProjectEstimateWorkspacePanel({
                   onValueChange={(value) =>
                     setLine({ ...line, taxEntityId: value })
                   }
-                  disabled={!line.taxable}
+                  disabled={!line.taxable || lineUsesCostBreakdown}
                   options={[
                     {
                       value: "",
@@ -1504,15 +1511,15 @@ export function ProjectEstimateWorkspacePanel({
               </div>
               {lineUsesCostBreakdown && (
                 <p className="text-xs text-muted-foreground md:col-span-2 xl:col-span-4">
-                  Quantity, unit, and unit cost are calculated from this line&apos;s
-                  expanded cost-code breakdown. Edit those values inside the
-                  breakdown above.
+                  Quantity, unit, unit cost, markup, and tax are calculated from
+                  this line&apos;s expanded cost-code breakdown. Edit those pricing
+                  values inside the breakdown above.
                 </p>
               )}
             </div>
             <div className="mt-3 flex flex-wrap items-center gap-5">
               <label className="flex items-center gap-2 text-sm">
-                <Checkbox checked={line.taxable} onCheckedChange={(checked) => setLine({ ...line, taxable: checked === true })} />
+                <Checkbox checked={line.taxable} disabled={lineUsesCostBreakdown} onCheckedChange={(checked) => setLine({ ...line, taxable: checked === true })} />
                 Taxable line
               </label>
               <label className="flex items-center gap-2 text-sm">

--- a/src/db/schema-estimates.ts
+++ b/src/db/schema-estimates.ts
@@ -339,6 +339,20 @@ export const projectEstimateLineCostItems = sqliteTable(
     quantity: real("quantity").notNull().default(1),
     unit: text("unit").notNull().default(""),
     unitCostCents: integer("unit_cost_cents").notNull().default(0),
+    directCostCents: integer("direct_cost_cents").notNull().default(0),
+    markupRateBasisPoints: integer("markup_rate_basis_points")
+      .notNull()
+      .default(0),
+    markupCents: integer("markup_cents").notNull().default(0),
+    taxable: integer("taxable", { mode: "boolean" }).notNull().default(false),
+    taxEntityId: text("tax_entity_id").references(() => sageTaxEntities.id, {
+      onDelete: "set null",
+    }),
+    taxCode: text("tax_code"),
+    taxName: text("tax_name"),
+    taxRateBasisPoints: integer("tax_rate_basis_points").notNull().default(0),
+    taxCents: integer("tax_cents").notNull().default(0),
+    lineTotalCents: integer("line_total_cents").notNull().default(0),
     totalCostCents: integer("total_cost_cents").notNull().default(0),
     sortOrder: integer("sort_order").notNull().default(0),
     createdAt: text("created_at").notNull(),

--- a/src/lib/financials/__tests__/estimate-ledger.test.ts
+++ b/src/lib/financials/__tests__/estimate-ledger.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   buildContractBudget,
   calculateEstimateLine,
+  calculateEstimateLineBreakdownRollup,
   calculateEstimateLineBreakdownSubtotal,
   calculateEstimateLineCostItemTotal,
   calculateEstimateTotals,
@@ -77,6 +78,57 @@ describe("estimate ledger", () => {
         { quantity: 12, unitCostCents: 2_560 },
       ])
     ).toBe(79_058)
+  })
+
+  it("rolls mixed taxable Fox items into the parent without taxing twice", () => {
+    const taxableFoxItem = calculateEstimateLine({
+      quantity: 1,
+      unitCostCents: 100_000,
+      markupRateBasisPoints: 1_000,
+      taxable: true,
+      taxRateBasisPoints: 513,
+    })
+    const nonTaxableFoxItem = calculateEstimateLine({
+      quantity: 1,
+      unitCostCents: 100_000,
+      markupRateBasisPoints: 0,
+      taxable: false,
+      taxRateBasisPoints: 0,
+    })
+
+    expect(
+      calculateEstimateLineBreakdownRollup([
+        {
+          ...taxableFoxItem,
+          markupRateBasisPoints: 1_000,
+          taxable: true,
+          taxEntityId: "littens-tax",
+          taxCode: "LITTEN",
+          taxName: "Litten tax district",
+          taxRateBasisPoints: 513,
+        },
+        {
+          ...nonTaxableFoxItem,
+          markupRateBasisPoints: 0,
+          taxable: false,
+          taxEntityId: null,
+          taxCode: null,
+          taxName: null,
+          taxRateBasisPoints: 0,
+        },
+      ])
+    ).toEqual({
+      directCostCents: 200_000,
+      markupRateBasisPoints: 0,
+      markupCents: 10_000,
+      taxable: true,
+      taxEntityId: "littens-tax",
+      taxCode: "LITTEN",
+      taxName: "Litten tax district",
+      taxRateBasisPoints: 513,
+      taxCents: 5_643,
+      lineTotalCents: 215_643,
+    })
   })
 
   it("rolls estimate totals once across all lines", () => {

--- a/src/lib/financials/estimate-ledger.ts
+++ b/src/lib/financials/estimate-ledger.ts
@@ -29,6 +29,24 @@ export type EstimateLineCostItemInput = {
   readonly unitCostCents: number
 }
 
+export type EstimateLineBreakdownItem = EstimateLineCalculation & {
+  readonly markupRateBasisPoints: number
+  readonly taxable: boolean
+  readonly taxEntityId: string | null
+  readonly taxCode: string | null
+  readonly taxName: string | null
+  readonly taxRateBasisPoints: number
+}
+
+export type EstimateLineBreakdownRollup = EstimateLineCalculation & {
+  readonly markupRateBasisPoints: number
+  readonly taxable: boolean
+  readonly taxEntityId: string | null
+  readonly taxCode: string | null
+  readonly taxName: string | null
+  readonly taxRateBasisPoints: number
+}
+
 export type EstimateLedgerLine = EstimateLineCalculation & {
   readonly id: string | null
   readonly divisionCode: string
@@ -140,6 +158,52 @@ export function calculateEstimateLineBreakdownSubtotal(
     (total, item) => total + calculateEstimateLineCostItemTotal(item),
     0
   )
+}
+
+export function calculateEstimateLineBreakdownRollup(
+  items: readonly EstimateLineBreakdownItem[]
+): EstimateLineBreakdownRollup {
+  const firstItem = items[0]
+  const commonMarkupRate = firstItem
+    ? items.every(
+        (item) =>
+          item.markupRateBasisPoints === firstItem.markupRateBasisPoints
+      )
+      ? firstItem.markupRateBasisPoints
+      : 0
+    : 0
+  const taxableItems = items.filter((item) => item.taxable)
+  const firstTaxableItem = taxableItems[0]
+  const commonTaxEntity = firstTaxableItem
+    ? taxableItems.every(
+        (item) =>
+          item.taxEntityId === firstTaxableItem.taxEntityId &&
+          item.taxCode === firstTaxableItem.taxCode &&
+          item.taxName === firstTaxableItem.taxName &&
+          item.taxRateBasisPoints === firstTaxableItem.taxRateBasisPoints
+      )
+    : false
+
+  return {
+    directCostCents: items.reduce(
+      (total, item) => total + item.directCostCents,
+      0
+    ),
+    markupRateBasisPoints: commonMarkupRate,
+    markupCents: items.reduce((total, item) => total + item.markupCents, 0),
+    taxable: taxableItems.length > 0,
+    taxEntityId: commonTaxEntity ? firstTaxableItem?.taxEntityId ?? null : null,
+    taxCode: commonTaxEntity ? firstTaxableItem?.taxCode ?? null : null,
+    taxName: commonTaxEntity ? firstTaxableItem?.taxName ?? null : null,
+    taxRateBasisPoints: commonTaxEntity
+      ? firstTaxableItem?.taxRateBasisPoints ?? 0
+      : 0,
+    taxCents: items.reduce((total, item) => total + item.taxCents, 0),
+    lineTotalCents: items.reduce(
+      (total, item) => total + item.lineTotalCents,
+      0
+    ),
+  }
 }
 
 export function calculateEstimateTotals(


### PR DESCRIPTION
## Summary
- add independent markup, taxability, Sage tax entity, and Unit Type controls to estimate assembly components
- roll child direct cost, markup, tax, and totals into the parent without double taxation
- preserve existing breakdown pricing during migration and keep bulk markup/revision duplication safe

## Verification
- bun test src/lib/financials/__tests__/estimate-ledger.test.ts
- bunx tsc --noEmit
- targeted ESLint on changed files
- production Next.js build
- SQLite execution of migration 0136 with a taxable Litten/Fox fixture